### PR TITLE
fix: resolve SonarCloud code smells and add coverage tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      microsoft:
+        patterns:
+          - "Microsoft.*"
+          - "System.*"
+      testing:
+        patterns:
+          - "xunit*"
+          - "Shouldly"
+          - "NSubstitute"
+          - "Bogus"
+          - "coverlet*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+
+  - package-ecosystem: npm
+    directory: /docs-site
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docs"

--- a/src/Granit.Analyzers.CodeFixes/CrossModuleReferenceCodeFixProvider.cs
+++ b/src/Granit.Analyzers.CodeFixes/CrossModuleReferenceCodeFixProvider.cs
@@ -173,7 +173,7 @@ public sealed class CrossModuleReferenceCodeFixProvider : CodeFixProvider
         return document.WithSyntaxRoot(root!);
     }
 
-    private static string? GetUsingForNode(CompilationUnitSyntax compilationUnit, SyntaxNode node)
+    private static string? GetUsingForNode(CompilationUnitSyntax compilationUnit, SyntaxNode _)
     {
         // Try to find which using directive brought the type into scope.
         // Heuristic: look for a using that contains ".Modules." but not ".Contracts".

--- a/src/Granit.Analyzers/CrossModuleReferenceAnalyzer.cs
+++ b/src/Granit.Analyzers/CrossModuleReferenceAnalyzer.cs
@@ -194,18 +194,8 @@ public sealed class CrossModuleReferenceAnalyzer : DiagnosticAnalyzer
         return (moduleName, isContracts);
     }
 
-    private static bool HasModulesNamespace(INamespaceSymbol globalNamespace)
-    {
-        foreach (INamespaceSymbol member in globalNamespace.GetNamespaceMembers())
-        {
-            if (HasModulesNamespaceRecursive(member))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+    private static bool HasModulesNamespace(INamespaceSymbol globalNamespace) =>
+        globalNamespace.GetNamespaceMembers().Any(HasModulesNamespaceRecursive);
 
     private static bool HasModulesNamespaceRecursive(INamespaceSymbol ns)
     {
@@ -214,12 +204,9 @@ public sealed class CrossModuleReferenceAnalyzer : DiagnosticAnalyzer
             return true;
         }
 
-        foreach (INamespaceSymbol child in ns.GetNamespaceMembers())
+        if (ns.GetNamespaceMembers().Any(HasModulesNamespaceRecursive))
         {
-            if (HasModulesNamespaceRecursive(child))
-            {
-                return true;
-            }
+            return true;
         }
 
         return false;

--- a/src/Granit.Notifications.MobilePush.GoogleFcm/Internal/GoogleFcmMobilePushSender.cs
+++ b/src/Granit.Notifications.MobilePush.GoogleFcm/Internal/GoogleFcmMobilePushSender.cs
@@ -111,7 +111,7 @@ internal sealed partial class GoogleFcmMobilePushSender(
 }
 
 /// <summary>Thrown when a device token is no longer registered with FCM.</summary>
-internal sealed class FcmTokenUnregisteredException(string token)
+public sealed class FcmTokenUnregisteredException(string token)
     : Exception($"FCM token is unregistered: {token}");
 
 internal sealed record FcmPayload

--- a/src/Granit.Persistence/Extensions/DbContextOptionsBuilderExtensions.cs
+++ b/src/Granit.Persistence/Extensions/DbContextOptionsBuilderExtensions.cs
@@ -68,7 +68,7 @@ public static class DbContextOptionsBuilderExtensions
         T? interceptor = serviceProvider.GetService<T>();
         if (interceptor is not null)
         {
-            options.AddInterceptors([interceptor]);
+            options.AddInterceptors(new[] { interceptor });
         }
     }
 }

--- a/src/Granit.Validation.Europe/Internal/EuropeanVatAlgorithm.cs
+++ b/src/Granit.Validation.Europe/Internal/EuropeanVatAlgorithm.cs
@@ -85,7 +85,7 @@ internal static partial class EuropeanVatAlgorithm
             "FR" => FrenchVatAlgorithm.IsValid(normalized),
             "BE" => ValidateBelgianVat(normalized),
             "DE" => true, // DE USt-IdNr is 9 digits — regex-validated; no public check digit algo.
-            "NL" => ValidateDutchVat(normalized),
+            "NL" => true, // NL VAT: regex-validated (NL\d{9}B\d{2}); no public check digit algo.
             "ES" => ValidateSpanishVat(normalized),
             "IT" => PartitaIvaAlgorithm.IsValid(normalized[2..]),
             "LU" => ValidateLuxembourgVat(normalized),
@@ -106,12 +106,6 @@ internal static partial class EuropeanVatAlgorithm
 
         return BceAlgorithm.IsValid(digits);
     }
-
-    // Dutch VAT: NL + 9 digits + B + 2 digits. The 9 digits are not a BSN
-    // (different structure), so we validate format only beyond the regex.
-    // The "B" at position 12 distinguishes sub-entities.
-    private static bool ValidateDutchVat(string normalized) =>
-        true; // Regex already validated the format NL\d{9}B\d{2}.
 
     private static bool ValidateSpanishVat(string normalized)
     {


### PR DESCRIPTION
## Summary

- Remove unused `node` param in `CrossModuleReferenceCodeFixProvider`
- Simplify foreach loops to LINQ `Any()` in `CrossModuleReferenceAnalyzer`
- Make `FcmTokenUnregisteredException` public (SonarCloud API design rule)
- Use explicit `new[]` for `AddInterceptors` IEnumerable overload
- Inline `ValidateDutchVat` (regex-only, remove dead method)
- Add GoogleFcm options and DI registration tests (coverage quick-win)
- Pin trivy-action to full SHA, enforce HTTPS for curl (security hotspots)

## Test plan

- [x] Analyzers: 82/82 passed
- [x] Persistence: 160/160 passed
- [x] Validation.Europe: 297/297 passed
- [x] GoogleFcm: 9/9 passed
- [x] `dotnet format --verify-no-changes` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)