### PR TITLE
fix(ci): add build step before pack, deploy docs on develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,7 @@ jobs:
             /d:sonar.host.url="https://sonarcloud.io" \
             /d:sonar.token="${SONAR_TOKEN}" \
             /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml" \
-            /d:sonar.exclusions=".nuget/**" \
+            /d:sonar.exclusions=".nuget/**,docs-site/**" \
             /d:sonar.coverage.exclusions="**/Tests/**,**/test/**,**/*HostApplicationBuilderExtensions.cs,**/Granit*Module.cs" \
             /d:sonar.issue.ignore.multicriteria="e1,e2,e3,e4" \
             /d:sonar.issue.ignore.multicriteria.e1.ruleKey="csharpsquid:S6608" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,17 +411,11 @@ jobs:
           --skip-duplicate
 
   # ---------------------------------------------------------------------------
-  # DOCS (Astro Starlight → GitHub Pages)
+  # DOCS (Astro Starlight → Cloudflare Pages)
   # ---------------------------------------------------------------------------
   docs:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/develop'
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
+    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6
 
@@ -443,11 +437,9 @@ jobs:
         working-directory: docs-site
         run: pnpm astro build
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@da0e0235f40ea0de66c4e1e8e25a0fdd569c0a54 # v3
         with:
-          path: docs-site/dist
-
-      - name: Deploy to GitHub Pages
-        id: deploy
-        uses: actions/deploy-pages@v4
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy docs-site/dist --project-name=granit-docs --branch=${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,7 +415,7 @@ jobs:
   # ---------------------------------------------------------------------------
   docs:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/develop'
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,8 +342,11 @@ jobs:
             echo "version=0.1.0-dev.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Build
+        run: dotnet build -c $CONFIGURATION
+
       - name: Pack
-        run: dotnet pack -c $CONFIGURATION -p:PackageVersion=${{ steps.version.outputs.version }} -o ./nupkgs
+        run: dotnet pack -c $CONFIGURATION --no-build -p:PackageVersion=${{ steps.version.outputs.version }} -o ./nupkgs
 
       - name: Upload packages
         uses: actions/upload-artifact@v7
@@ -412,7 +415,7 @@ jobs:
   # ---------------------------------------------------------------------------
   docs:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,7 +415,7 @@ jobs:
   # ---------------------------------------------------------------------------
   docs:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
+    if: github.ref == 'refs/heads/main'
     permissions:
       pages: write
       id-token: write

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@
   .NET 10 · C# 14 · EF Core 10 · CQRS · Vertical Slicing · Modular Architecture
 </p>
 
+<p align="center">
+  <a href="https://github.com/granit-fx/granit-dotnet/actions/workflows/ci.yml"><img src="https://github.com/granit-fx/granit-dotnet/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI"></a>
+  <a href="https://sonarcloud.io/summary/new_code?id=granit-fx_granit-dotnet"><img src="https://sonarcloud.io/api/project_badges/measure?project=granit-fx_granit-dotnet&metric=alert_status" alt="Quality Gate Status"></a>
+  <a href="https://sonarcloud.io/summary/new_code?id=granit-fx_granit-dotnet"><img src="https://sonarcloud.io/api/project_badges/measure?project=granit-fx_granit-dotnet&metric=coverage" alt="Coverage"></a>
+  <a href="https://github.com/granit-fx/granit-dotnet/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="License"></a>
+</p>
+
 ---
 
 Granit is a rock-solid, production-ready modular framework for .NET and React.

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -14,6 +14,9 @@ import { remarkVariables } from "./src/plugins/remark-variables.mjs";
 
 export default defineConfig({
   site: "https://granit-fx.dev",
+  build: {
+    assets: "assets",
+  },
   markdown: {
     remarkPlugins: [remarkVariables],
     rehypePlugins: [

--- a/docs-site/public/_routes.json
+++ b/docs-site/public/_routes.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "include": [],
+  "exclude": ["/*"]
+}

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -83,6 +83,9 @@ const programHtml = hl(`var builder = WebApplication.CreateBuilder(args);\n\nbui
   headings={[]}
 >
   <style is:global>
+    /* Override starlight-blog hiding the first content-panel */
+    .content-panel:first-of-type { display: block !important; }
+
     /* ── Layout ── */
     .lp { margin-inline: auto; max-width: 72rem; padding-inline: 1.5rem; }
 

--- a/tests/Granit.Identity.EntraId.Tests/IdentityEntraIdActivitySourceTests.cs
+++ b/tests/Granit.Identity.EntraId.Tests/IdentityEntraIdActivitySourceTests.cs
@@ -92,9 +92,10 @@ public sealed class IdentityEntraIdActivitySourceTests : IDisposable
 
         await _provider.GetUserAsync("u1", TestContext.Current.CancellationToken);
 
-        Activity? activity = _activities.Find(a => a.OperationName == IdentityEntraIdActivitySource.GetUser);
+        Activity? activity = _activities.Find(a =>
+            a.OperationName == IdentityEntraIdActivitySource.GetUser
+            && a.GetTagItem("identity.user_id") is "u1");
         activity.ShouldNotBeNull();
-        activity.GetTagItem("identity.user_id").ShouldBe("u1");
     }
 
     [Fact]
@@ -118,9 +119,10 @@ public sealed class IdentityEntraIdActivitySourceTests : IDisposable
 
         await _provider.SetUserEnabledAsync("u1", true, TestContext.Current.CancellationToken);
 
-        Activity? activity = _activities.Find(a => a.OperationName == IdentityEntraIdActivitySource.SetUserEnabled);
+        Activity? activity = _activities.Find(a =>
+            a.OperationName == IdentityEntraIdActivitySource.SetUserEnabled
+            && a.GetTagItem("identity.user_id") is "u1");
         activity.ShouldNotBeNull();
-        activity.GetTagItem("identity.user_id").ShouldBe("u1");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Fix pack failure: Analyzers target `netstandard2.0` and need an explicit `dotnet build` before `dotnet pack --no-build`
- Deploy docs site on both `main` and `develop` branches

## Test plan

- [ ] `pack` job succeeds
- [ ] `docs` job deploys on develop push

🤖 Generated with [Claude Code](https://claude.com/claude-code)