### PR TITLE
feat(ai): Phase 1 — DataExchange.AI, Extraction, Querying.AI, VectorData

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,7 @@
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.*" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.*" />
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.*" />
+    <PackageVersion Include="Microsoft.Extensions.VectorData.Abstractions" Version="10.*" />
     <PackageVersion Include="OllamaSharp" Version="5.*" />
   </ItemGroup>
   <ItemGroup Label="ASP.NET Core">

--- a/Granit.slnx
+++ b/Granit.slnx
@@ -11,6 +11,7 @@
     <Project Path="src/Granit.AI.Anthropic/Granit.AI.Anthropic.csproj" />
     <Project Path="src/Granit.AI.AzureOpenAI/Granit.AI.AzureOpenAI.csproj" />
     <Project Path="src/Granit.AI.EntityFrameworkCore/Granit.AI.EntityFrameworkCore.csproj" />
+    <Project Path="src/Granit.AI.Extraction/Granit.AI.Extraction.csproj" />
     <Project Path="src/Granit.AI.Ollama/Granit.AI.Ollama.csproj" />
     <Project Path="src/Granit.AI.OpenAI/Granit.AI.OpenAI.csproj" />
     <Project Path="src/Granit.ApiDocumentation/Granit.ApiDocumentation.csproj" />
@@ -47,6 +48,7 @@
     <Project Path="src/Granit.Cookies/Granit.Cookies.csproj" />
     <Project Path="src/Granit.Core/Granit.Core.csproj" />
     <Project Path="src/Granit.Cors/Granit.Cors.csproj" />
+    <Project Path="src/Granit.DataExchange.AI/Granit.DataExchange.AI.csproj" />
     <Project Path="src/Granit.DataExchange.Csv/Granit.DataExchange.Csv.csproj" />
     <Project Path="src/Granit.DataExchange.Endpoints/Granit.DataExchange.Endpoints.csproj" />
     <Project Path="src/Granit.DataExchange.EntityFrameworkCore/Granit.DataExchange.EntityFrameworkCore.csproj" />
@@ -165,6 +167,7 @@
     <Project Path="tests/Granit.AI.Anthropic.Tests/Granit.AI.Anthropic.Tests.csproj" />
     <Project Path="tests/Granit.AI.AzureOpenAI.Tests/Granit.AI.AzureOpenAI.Tests.csproj" />
     <Project Path="tests/Granit.AI.EntityFrameworkCore.Tests/Granit.AI.EntityFrameworkCore.Tests.csproj" />
+    <Project Path="tests/Granit.AI.Extraction.Tests/Granit.AI.Extraction.Tests.csproj" />
     <Project Path="tests/Granit.AI.Ollama.Tests/Granit.AI.Ollama.Tests.csproj" />
     <Project Path="tests/Granit.AI.OpenAI.Tests/Granit.AI.OpenAI.Tests.csproj" />
     <Project Path="tests/Granit.Authentication.ApiKeys.Endpoints.Tests/Granit.Authentication.ApiKeys.Endpoints.Tests.csproj" />
@@ -201,6 +204,7 @@
     <Project Path="tests/Granit.Cookies.Tests/Granit.Cookies.Tests.csproj" />
     <Project Path="tests/Granit.Core.Tests/Granit.Core.Tests.csproj" />
     <Project Path="tests/Granit.Cors.Tests/Granit.Cors.Tests.csproj" />
+    <Project Path="tests/Granit.DataExchange.AI.Tests/Granit.DataExchange.AI.Tests.csproj" />
     <Project Path="tests/Granit.DataExchange.Csv.Tests/Granit.DataExchange.Csv.Tests.csproj" />
     <Project Path="tests/Granit.DataExchange.Endpoints.Tests/Granit.DataExchange.Endpoints.Tests.csproj" />
     <Project Path="tests/Granit.DataExchange.EntityFrameworkCore.Tests/Granit.DataExchange.EntityFrameworkCore.Tests.csproj" />

--- a/Granit.slnx
+++ b/Granit.slnx
@@ -14,6 +14,7 @@
     <Project Path="src/Granit.AI.Extraction/Granit.AI.Extraction.csproj" />
     <Project Path="src/Granit.AI.Ollama/Granit.AI.Ollama.csproj" />
     <Project Path="src/Granit.AI.OpenAI/Granit.AI.OpenAI.csproj" />
+    <Project Path="src/Granit.AI.VectorData/Granit.AI.VectorData.csproj" />
     <Project Path="src/Granit.ApiDocumentation/Granit.ApiDocumentation.csproj" />
     <Project Path="src/Granit.ApiVersioning/Granit.ApiVersioning.csproj" />
     <Project Path="src/Granit.Authentication.ApiKeys.Endpoints/Granit.Authentication.ApiKeys.Endpoints.csproj" />
@@ -111,6 +112,7 @@
     <Project Path="src/Granit.Querying.Endpoints/Granit.Querying.Endpoints.csproj" />
     <Project Path="src/Granit.Querying.EntityFrameworkCore/Granit.Querying.EntityFrameworkCore.csproj" />
     <Project Path="src/Granit.Querying/Granit.Querying.csproj" />
+    <Project Path="src/Granit.Querying.AI/Granit.Querying.AI.csproj" />
     <Project Path="src/Granit.RateLimiting/Granit.RateLimiting.csproj" />
     <Project Path="src/Granit.ReferenceData.Endpoints/Granit.ReferenceData.Endpoints.csproj" />
     <Project Path="src/Granit.ReferenceData.EntityFrameworkCore/Granit.ReferenceData.EntityFrameworkCore.csproj" />
@@ -169,6 +171,7 @@
     <Project Path="tests/Granit.AI.EntityFrameworkCore.Tests/Granit.AI.EntityFrameworkCore.Tests.csproj" />
     <Project Path="tests/Granit.AI.Extraction.Tests/Granit.AI.Extraction.Tests.csproj" />
     <Project Path="tests/Granit.AI.Ollama.Tests/Granit.AI.Ollama.Tests.csproj" />
+    <Project Path="tests/Granit.AI.VectorData.Tests/Granit.AI.VectorData.Tests.csproj" />
     <Project Path="tests/Granit.AI.OpenAI.Tests/Granit.AI.OpenAI.Tests.csproj" />
     <Project Path="tests/Granit.Authentication.ApiKeys.Endpoints.Tests/Granit.Authentication.ApiKeys.Endpoints.Tests.csproj" />
     <Project Path="tests/Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests/Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests.csproj" />
@@ -266,6 +269,7 @@
     <Project Path="tests/Granit.Privacy.Tests/Granit.Privacy.Tests.csproj" />
     <Project Path="tests/Granit.Querying.Endpoints.Tests.Integration/Granit.Querying.Endpoints.Tests.Integration.csproj" />
     <Project Path="tests/Granit.Querying.Endpoints.Tests/Granit.Querying.Endpoints.Tests.csproj" />
+    <Project Path="tests/Granit.Querying.AI.Tests/Granit.Querying.AI.Tests.csproj" />
     <Project Path="tests/Granit.Querying.EntityFrameworkCore.Tests/Granit.Querying.EntityFrameworkCore.Tests.csproj" />
     <Project Path="tests/Granit.Querying.Tests/Granit.Querying.Tests.csproj" />
     <Project Path="tests/Granit.RateLimiting.Tests/Granit.RateLimiting.Tests.csproj" />

--- a/src/Granit.AI.Anthropic/Internal/AnthropicProviderFactory.cs
+++ b/src/Granit.AI.Anthropic/Internal/AnthropicProviderFactory.cs
@@ -12,24 +12,29 @@ namespace Granit.AI.Anthropic.Internal;
 /// <remarks>
 /// Creates <see cref="IChatClient"/> instances backed by the Anthropic SDK.
 /// Embedding generation is not supported by Anthropic and always returns <c>null</c>.
+/// The underlying <see cref="AnthropicClient"/> is created once and reused for the
+/// lifetime of the factory. It is disposed when the factory is disposed.
 /// </remarks>
-internal sealed class AnthropicProviderFactory(IOptions<AnthropicProviderOptions> options) : IAIProviderFactory
+internal sealed class AnthropicProviderFactory(IOptions<AnthropicProviderOptions> options)
+    : IAIProviderFactory, IDisposable
 {
+    private readonly AnthropicClient _client = new() { ApiKey = options.Value.ApiKey };
+
     /// <inheritdoc />
     public string ProviderName => "Anthropic";
 
     /// <inheritdoc />
     public IChatClient CreateChatClient(AIWorkspace workspace)
     {
-        AnthropicProviderOptions opts = options.Value;
-        AnthropicClient client = new() { ApiKey = opts.ApiKey };
-        string model = workspace.Model ?? opts.DefaultModel;
-
-        return client.AsIChatClient(model);
+        string model = workspace.Model ?? options.Value.DefaultModel;
+        return _client.AsIChatClient(model);
     }
 
     /// <inheritdoc />
     /// <returns>Always <c>null</c>. Anthropic does not support embedding generation.</returns>
     public IEmbeddingGenerator<string, Embedding<float>>? CreateEmbeddingGenerator(AIWorkspace workspace) =>
         null;
+
+    /// <inheritdoc />
+    public void Dispose() => _client.Dispose();
 }

--- a/src/Granit.AI.Anthropic/README.md
+++ b/src/Granit.AI.Anthropic/README.md
@@ -1,0 +1,19 @@
+# Granit.AI.Anthropic
+
+Anthropic (Claude) provider for Granit.AI. Chat completion via Claude Opus, Sonnet, and Haiku models.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.AI.Anthropic
+```
+
+## Dependencies
+
+- `Granit.AI`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.AI.AzureOpenAI/README.md
+++ b/src/Granit.AI.AzureOpenAI/README.md
@@ -1,0 +1,19 @@
+# Granit.AI.AzureOpenAI
+
+Azure OpenAI provider for Granit.AI. Chat completion and embedding generation with API key or Managed Identity authentication.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.AI.AzureOpenAI
+```
+
+## Dependencies
+
+- `Granit.AI`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.AI.EntityFrameworkCore/README.md
+++ b/src/Granit.AI.EntityFrameworkCore/README.md
@@ -1,0 +1,20 @@
+# Granit.AI.EntityFrameworkCore
+
+EF Core persistence layer for Granit.AI. Isolated AIDbContext for workspace configurations and usage tracking.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.AI.EntityFrameworkCore
+```
+
+## Dependencies
+
+- `Granit.AI`
+- `Granit.Persistence`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.AI.Extraction/Extensions/AIExtractionServiceCollectionExtensions.cs
+++ b/src/Granit.AI.Extraction/Extensions/AIExtractionServiceCollectionExtensions.cs
@@ -1,0 +1,44 @@
+using System.Diagnostics.CodeAnalysis;
+using Granit.AI.Extraction.Internal;
+using Granit.AI.Extraction.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+
+namespace Granit.AI.Extraction.Extensions;
+
+/// <summary>
+/// Extension methods for registering Granit AI extraction services.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public static class AIExtractionServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds Granit AI extraction core services and binds <see cref="ExtractionOptions"/>
+    /// from the <c>AI:Extraction</c> configuration section.
+    /// </summary>
+    /// <param name="builder">The host application builder.</param>
+    /// <returns>The builder for chaining.</returns>
+    public static IHostApplicationBuilder AddGranitAIExtraction(this IHostApplicationBuilder builder)
+    {
+        builder.Services
+            .AddOptions<ExtractionOptions>()
+            .BindConfiguration(ExtractionOptions.SectionName);
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers <see cref="IDocumentExtractor{TResult}"/> for the specified result type
+    /// using the default LLM-based implementation.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the structured data to extract.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddDocumentExtractor<TResult>(this IServiceCollection services)
+        where TResult : class
+    {
+        services.TryAddScoped<IDocumentExtractor<TResult>, DefaultDocumentExtractor<TResult>>();
+        return services;
+    }
+}

--- a/src/Granit.AI.Extraction/ExtractionResult.cs
+++ b/src/Granit.AI.Extraction/ExtractionResult.cs
@@ -1,0 +1,89 @@
+namespace Granit.AI.Extraction;
+
+/// <summary>
+/// Factory methods for creating <see cref="ExtractionResult{TResult}"/> instances.
+/// </summary>
+public static class ExtractionResult
+{
+    /// <summary>
+    /// Creates a successful extraction result.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the extracted data.</typeparam>
+    /// <param name="data">The extracted data.</param>
+    /// <param name="confidence">Confidence score between 0.0 and 1.0.</param>
+    /// <param name="warnings">Optional warnings.</param>
+    /// <returns>A successful <see cref="ExtractionResult{TResult}"/>.</returns>
+    public static ExtractionResult<TResult> Success<TResult>(TResult data, double confidence, IReadOnlyList<string>? warnings = null)
+        where TResult : class =>
+        new()
+        {
+            Status = ExtractionStatus.Succeeded,
+            Data = data,
+            ConfidenceScore = confidence,
+            Warnings = warnings ?? [],
+        };
+
+    /// <summary>
+    /// Creates a failed extraction result.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the extracted data.</typeparam>
+    /// <param name="errorMessage">Description of the failure.</param>
+    /// <returns>A failed <see cref="ExtractionResult{TResult}"/>.</returns>
+    public static ExtractionResult<TResult> Failed<TResult>(string errorMessage)
+        where TResult : class =>
+        new()
+        {
+            Status = ExtractionStatus.Failed,
+            ErrorMessage = errorMessage,
+        };
+
+    /// <summary>
+    /// Creates an extraction result that needs manual review due to low confidence or warnings.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the extracted data.</typeparam>
+    /// <param name="data">The extracted data.</param>
+    /// <param name="confidence">Confidence score between 0.0 and 1.0.</param>
+    /// <param name="warnings">Warnings explaining why review is needed.</param>
+    /// <returns>A <see cref="ExtractionResult{TResult}"/> with <see cref="ExtractionStatus.NeedsReview"/> status.</returns>
+    public static ExtractionResult<TResult> NeedsReview<TResult>(TResult data, double confidence, IReadOnlyList<string> warnings)
+        where TResult : class =>
+        new()
+        {
+            Status = ExtractionStatus.NeedsReview,
+            Data = data,
+            ConfidenceScore = confidence,
+            Warnings = warnings,
+        };
+}
+
+/// <summary>
+/// Result of a document extraction operation containing typed data, confidence score, and status.
+/// </summary>
+/// <typeparam name="TResult">The type of the extracted data.</typeparam>
+public sealed record ExtractionResult<TResult> where TResult : class
+{
+    /// <summary>
+    /// Status of the extraction operation.
+    /// </summary>
+    public required ExtractionStatus Status { get; init; }
+
+    /// <summary>
+    /// Extracted data. <c>null</c> when <see cref="Status"/> is <see cref="ExtractionStatus.Failed"/>.
+    /// </summary>
+    public TResult? Data { get; init; }
+
+    /// <summary>
+    /// Confidence score between 0.0 and 1.0, if available.
+    /// </summary>
+    public double? ConfidenceScore { get; init; }
+
+    /// <summary>
+    /// Error message when <see cref="Status"/> is <see cref="ExtractionStatus.Failed"/>.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// Warnings produced during extraction (e.g. missing optional fields, low-confidence fields).
+    /// </summary>
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+}

--- a/src/Granit.AI.Extraction/ExtractionStatus.cs
+++ b/src/Granit.AI.Extraction/ExtractionStatus.cs
@@ -1,0 +1,22 @@
+namespace Granit.AI.Extraction;
+
+/// <summary>
+/// Status of a document extraction operation.
+/// </summary>
+public enum ExtractionStatus
+{
+    /// <summary>
+    /// Extraction completed successfully with high confidence.
+    /// </summary>
+    Succeeded,
+
+    /// <summary>
+    /// Extraction completed but with low confidence or validation warnings — manual review recommended.
+    /// </summary>
+    NeedsReview,
+
+    /// <summary>
+    /// Extraction failed — no usable data could be extracted.
+    /// </summary>
+    Failed,
+}

--- a/src/Granit.AI.Extraction/Granit.AI.Extraction.csproj
+++ b/src/Granit.AI.Extraction/Granit.AI.Extraction.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Granit.AI.Extraction</PackageId>
+    <Description>Structured document extraction for Granit.AI. Extract typed C# objects from documents (PDF, text) using LLM with JSON Schema output. Supports confidence scoring and FluentValidation integration.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Granit.AI.Extraction.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Granit.AI\Granit.AI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Granit.AI.Extraction/GranitAIExtractionModule.cs
+++ b/src/Granit.AI.Extraction/GranitAIExtractionModule.cs
@@ -1,0 +1,15 @@
+using Granit.AI;
+using Granit.Core.Modularity;
+
+namespace Granit.AI.Extraction;
+
+/// <summary>
+/// Granit module for AI-powered structured document extraction.
+/// </summary>
+/// <remarks>
+/// Provides <see cref="IDocumentExtractor{TResult}"/> for extracting typed C# objects
+/// from document text using LLM with JSON structured output. Requires a registered
+/// AI provider (e.g. <c>Granit.AI.OpenAI</c>) to function.
+/// </remarks>
+[DependsOn(typeof(GranitAIModule))]
+public sealed class GranitAIExtractionModule : GranitModule;

--- a/src/Granit.AI.Extraction/IDocumentExtractor.cs
+++ b/src/Granit.AI.Extraction/IDocumentExtractor.cs
@@ -1,0 +1,23 @@
+namespace Granit.AI.Extraction;
+
+/// <summary>
+/// Extracts structured data of type <typeparamref name="TResult"/> from document text using LLM.
+/// </summary>
+/// <typeparam name="TResult">The type of the structured data to extract.</typeparam>
+/// <remarks>
+/// Takes <c>string</c> content (not <c>Stream</c>) because document-to-text conversion
+/// (PDF parsing, OCR) is a separate concern. This keeps the extraction module focused
+/// on LLM-based structured extraction.
+/// </remarks>
+public interface IDocumentExtractor<TResult> where TResult : class
+{
+    /// <summary>
+    /// Extracts structured data from a document.
+    /// </summary>
+    /// <param name="content">Document text content (already extracted from PDF/image).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Extraction result with typed data, confidence score, and status.</returns>
+    Task<ExtractionResult<TResult>> ExtractAsync(
+        string content,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.AI.Extraction/Internal/DefaultDocumentExtractor.cs
+++ b/src/Granit.AI.Extraction/Internal/DefaultDocumentExtractor.cs
@@ -1,0 +1,210 @@
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using Granit.AI.Extraction.Options;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Granit.AI.Extraction.Internal;
+
+/// <summary>
+/// Default implementation of <see cref="IDocumentExtractor{TResult}"/> that uses an LLM
+/// via <see cref="IAIChatClientFactory"/> to extract structured data from document text.
+/// </summary>
+internal sealed partial class DefaultDocumentExtractor<TResult>(
+    IAIChatClientFactory chatClientFactory,
+    IOptions<ExtractionOptions> options,
+    ILogger<DefaultDocumentExtractor<TResult>> logger) : IDocumentExtractor<TResult>
+    where TResult : class
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    /// <inheritdoc />
+    public async Task<ExtractionResult<TResult>> ExtractAsync(
+        string content,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        ExtractionOptions extractionOptions = options.Value;
+
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(extractionOptions.TimeoutSeconds));
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+        try
+        {
+            IChatClient chatClient = await chatClientFactory
+                .CreateAsync(extractionOptions.WorkspaceName, linkedCts.Token)
+                .ConfigureAwait(false);
+
+            string schemaDescription = BuildSchemaDescription();
+            string prompt = BuildPrompt(schemaDescription, content);
+
+            var messages = new List<ChatMessage>
+            {
+                new(ChatRole.User, prompt),
+            };
+
+            ChatResponse response = await chatClient
+                .GetResponseAsync(messages, cancellationToken: linkedCts.Token)
+                .ConfigureAwait(false);
+
+            string responseText = response.Text ?? string.Empty;
+
+            // Strip markdown code fences if present
+            responseText = StripMarkdownCodeFences(responseText);
+
+            TResult? data = JsonSerializer.Deserialize<TResult>(responseText, SerializerOptions);
+
+            if (data is null)
+            {
+                LogDeserializationNull(typeof(TResult).Name);
+                return ExtractionResult.Failed<TResult>("Deserialization returned null.");
+            }
+
+            double confidence = EstimateConfidence(response);
+            var warnings = new List<string>();
+
+            if (confidence < extractionOptions.ReviewThreshold)
+            {
+                warnings.Add($"Confidence score ({confidence:F2}) is below the review threshold ({extractionOptions.ReviewThreshold:F2}).");
+                LogLowConfidence(typeof(TResult).Name, confidence, extractionOptions.ReviewThreshold);
+                return ExtractionResult.NeedsReview(data, confidence, warnings);
+            }
+
+            LogExtractionSucceeded(typeof(TResult).Name, confidence);
+            return ExtractionResult.Success(data, confidence);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+        {
+            LogExtractionTimeout(typeof(TResult).Name, extractionOptions.TimeoutSeconds);
+            return ExtractionResult.Failed<TResult>(
+                $"Extraction timed out after {extractionOptions.TimeoutSeconds} seconds.");
+        }
+        catch (JsonException ex)
+        {
+            LogDeserializationFailed(typeof(TResult).Name, ex.Message);
+            return ExtractionResult.Failed<TResult>($"Failed to deserialize LLM response: {ex.Message}");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogExtractionFailed(typeof(TResult).Name, ex.Message);
+            return ExtractionResult.Failed<TResult>($"Extraction failed: {ex.Message}");
+        }
+    }
+
+    private static string BuildSchemaDescription()
+    {
+        var sb = new StringBuilder();
+        PropertyInfo[] properties = typeof(TResult).GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+        foreach (PropertyInfo property in properties)
+        {
+            string typeName = GetFriendlyTypeName(property.PropertyType);
+            sb.AppendLine($"- \"{property.Name}\": {typeName}");
+        }
+
+        return sb.ToString();
+    }
+
+    private static string GetFriendlyTypeName(Type type)
+    {
+        Type underlying = Nullable.GetUnderlyingType(type) ?? type;
+        string name = underlying switch
+        {
+            _ when underlying == typeof(string) => "string",
+            _ when underlying == typeof(int) => "integer",
+            _ when underlying == typeof(long) => "integer",
+            _ when underlying == typeof(decimal) => "number",
+            _ when underlying == typeof(double) => "number",
+            _ when underlying == typeof(float) => "number",
+            _ when underlying == typeof(bool) => "boolean",
+            _ when underlying == typeof(DateTime) => "date-time string (ISO 8601)",
+            _ when underlying == typeof(DateOnly) => "date string (yyyy-MM-dd)",
+            _ when underlying == typeof(Guid) => "UUID string",
+            _ => underlying.Name,
+        };
+
+        return Nullable.GetUnderlyingType(type) is not null ? $"{name} (nullable)" : name;
+    }
+
+    private static string BuildPrompt(string schemaDescription, string content) =>
+        $"""
+         Extract structured data from the following document.
+         Return a JSON object matching this schema:
+         {schemaDescription}
+         Document:
+         ---
+         {content}
+         ---
+
+         Return ONLY valid JSON, no markdown, no explanation.
+         """;
+
+    private static string StripMarkdownCodeFences(string text)
+    {
+        ReadOnlySpan<char> span = text.AsSpan().Trim();
+
+        if (span.StartsWith("```json", StringComparison.OrdinalIgnoreCase))
+        {
+            span = span["```json".Length..];
+        }
+        else if (span.StartsWith("```", StringComparison.Ordinal))
+        {
+            span = span["```".Length..];
+        }
+
+        if (span.EndsWith("```", StringComparison.Ordinal))
+        {
+            span = span[..^"```".Length];
+        }
+
+        return span.Trim().ToString();
+    }
+
+    private static double EstimateConfidence(ChatResponse response)
+    {
+        // Check for provider-supplied confidence in additional properties
+        if (response.AdditionalProperties?.TryGetValue("confidence", out object? confidenceValue) is true
+            && confidenceValue is double confidence)
+        {
+            return confidence;
+        }
+
+        // Check finish reason as a heuristic
+        if (response.FinishReason == ChatFinishReason.Stop)
+        {
+            return 0.85;
+        }
+
+        // Default moderate confidence when no signal is available
+        return 0.75;
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Extraction succeeded for {TypeName} with confidence {Confidence:F2}")]
+    private partial void LogExtractionSucceeded(string typeName, double confidence);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Low confidence extraction for {TypeName}: {Confidence:F2} < threshold {Threshold:F2}")]
+    private partial void LogLowConfidence(string typeName, double confidence, double threshold);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Extraction failed for {TypeName}: {ErrorMessage}")]
+    private partial void LogExtractionFailed(string typeName, string errorMessage);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Extraction timed out for {TypeName} after {TimeoutSeconds}s")]
+    private partial void LogExtractionTimeout(string typeName, int timeoutSeconds);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Deserialization returned null for {TypeName}")]
+    private partial void LogDeserializationNull(string typeName);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to deserialize LLM response for {TypeName}: {ErrorMessage}")]
+    private partial void LogDeserializationFailed(string typeName, string errorMessage);
+}

--- a/src/Granit.AI.Extraction/Options/ExtractionOptions.cs
+++ b/src/Granit.AI.Extraction/Options/ExtractionOptions.cs
@@ -1,0 +1,31 @@
+namespace Granit.AI.Extraction.Options;
+
+/// <summary>
+/// Configuration options for AI document extraction.
+/// </summary>
+/// <remarks>
+/// Bound to the <c>AI:Extraction</c> configuration section.
+/// </remarks>
+public sealed class ExtractionOptions
+{
+    /// <summary>
+    /// Configuration section name in appsettings.json.
+    /// </summary>
+    public const string SectionName = "AI:Extraction";
+
+    /// <summary>
+    /// AI workspace name to use for extraction. Defaults to <c>"default"</c>.
+    /// </summary>
+    public string WorkspaceName { get; set; } = "default";
+
+    /// <summary>
+    /// Confidence threshold below which the extraction status is set to
+    /// <see cref="ExtractionStatus.NeedsReview"/>. Defaults to <c>0.7</c>.
+    /// </summary>
+    public double ReviewThreshold { get; set; } = 0.7;
+
+    /// <summary>
+    /// Maximum time in seconds to wait for an extraction to complete. Defaults to <c>30</c>.
+    /// </summary>
+    public int TimeoutSeconds { get; set; } = 30;
+}

--- a/src/Granit.AI.Extraction/README.md
+++ b/src/Granit.AI.Extraction/README.md
@@ -1,0 +1,19 @@
+# Granit.AI.Extraction
+
+Structured document extraction for Granit.AI. Extract typed C# objects from documents using LLM with JSON output.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.AI.Extraction
+```
+
+## Dependencies
+
+- `Granit.AI`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.AI.Extraction/packages.lock.json
+++ b/src/Granit.AI.Extraction/packages.lock.json
@@ -1,0 +1,149 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
+      },
+      "granit.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.core": {
+        "type": "Project"
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.4.0",
+        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      }
+    }
+  }
+}

--- a/src/Granit.AI.Ollama/HealthChecks/OllamaHealthCheck.cs
+++ b/src/Granit.AI.Ollama/HealthChecks/OllamaHealthCheck.cs
@@ -48,7 +48,7 @@ internal sealed class OllamaHealthCheck(
         {
             return HealthCheckResult.Unhealthy("Ollama server unreachable");
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is TimeoutException or IOException or InvalidOperationException)
         {
             // Sanitize: never expose endpoint URLs or internal details in the message
             return HealthCheckResult.Unhealthy($"Ollama health check failed: {ex.GetType().Name}");

--- a/src/Granit.AI.Ollama/README.md
+++ b/src/Granit.AI.Ollama/README.md
@@ -1,0 +1,19 @@
+# Granit.AI.Ollama
+
+Ollama provider for Granit.AI. Run AI models locally for development, on-premise, and GDPR-compliant scenarios. Zero API key required.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.AI.Ollama
+```
+
+## Dependencies
+
+- `Granit.AI`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.AI.VectorData/Extensions/VectorDataHostApplicationBuilderExtensions.cs
+++ b/src/Granit.AI.VectorData/Extensions/VectorDataHostApplicationBuilderExtensions.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics.CodeAnalysis;
+using Granit.AI.VectorData.Internal;
+using Granit.AI.VectorData.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+
+namespace Granit.AI.VectorData.Extensions;
+
+/// <summary>
+/// Extension methods for registering Granit.AI.VectorData services.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public static class VectorDataHostApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Adds the Granit AI vector data services, including <see cref="ISemanticSearchService"/>.
+    /// </summary>
+    /// <remarks>
+    /// A concrete <see cref="IVectorCollectionFactory"/> implementation must be registered
+    /// by a provider package (e.g. <c>Granit.AI.VectorData.PgVector</c>).
+    /// An <see cref="IEmbeddingGeneratorFactory"/> must also be registered
+    /// by an AI provider package.
+    /// </remarks>
+    /// <param name="builder">The host application builder.</param>
+    /// <returns>The host application builder for chaining.</returns>
+    public static IHostApplicationBuilder AddGranitAIVectorData(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddOptions<VectorDataOptions>()
+            .BindConfiguration(VectorDataOptions.SectionName);
+
+        builder.Services.TryAddSingleton<ISemanticSearchService, DefaultSemanticSearchService>();
+
+        return builder;
+    }
+}

--- a/src/Granit.AI.VectorData/Granit.AI.VectorData.csproj
+++ b/src/Granit.AI.VectorData/Granit.AI.VectorData.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Granit.AI.VectorData</PackageId>
+    <Description>Multi-tenant vector storage abstractions for Granit.AI. Enables semantic search (RAG), similarity matching, and recommendation via provider-agnostic vector collections. Built on Microsoft.Extensions.VectorData when available.</Description>
+    <IsPackable>true</IsPackable>
+    <!-- CA1711: IVectorCollection is a domain concept, not a BCL collection -->
+    <NoWarn>$(NoWarn);CA1711</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Granit.AI.VectorData.Tests" />
+    <InternalsVisibleTo Include="Granit.AI.VectorData.PgVector" />
+    <InternalsVisibleTo Include="Granit.AI.VectorData.PgVector.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <PackageReference Include="Microsoft.Extensions.VectorData.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Granit.AI\Granit.AI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Granit.AI.VectorData/GranitAIVectorDataModule.cs
+++ b/src/Granit.AI.VectorData/GranitAIVectorDataModule.cs
@@ -1,0 +1,15 @@
+using Granit.AI;
+using Granit.Core.Modularity;
+
+namespace Granit.AI.VectorData;
+
+/// <summary>
+/// Granit module for multi-tenant vector storage abstractions.
+/// </summary>
+/// <remarks>
+/// Defines the <see cref="IVectorCollection{TRecord}"/>, <see cref="IVectorCollectionFactory"/>,
+/// and <see cref="ISemanticSearchService"/> abstractions.
+/// Register a concrete provider (e.g. <c>Granit.AI.VectorData.PgVector</c>) alongside this module.
+/// </remarks>
+[DependsOn(typeof(GranitAIModule))]
+public sealed class GranitAIVectorDataModule : GranitModule;

--- a/src/Granit.AI.VectorData/ISemanticSearchService.cs
+++ b/src/Granit.AI.VectorData/ISemanticSearchService.cs
@@ -1,0 +1,34 @@
+namespace Granit.AI.VectorData;
+
+/// <summary>
+/// High-level semantic search service combining embedding generation and vector search.
+/// </summary>
+/// <remarks>
+/// Uses <see cref="IVectorCollectionFactory"/> for vector storage and
+/// <see cref="Granit.AI.IEmbeddingGeneratorFactory"/> for generating embeddings from text.
+/// </remarks>
+public interface ISemanticSearchService
+{
+    /// <summary>
+    /// Indexes a text document by generating its embedding and storing it in a vector collection.
+    /// </summary>
+    /// <param name="collectionName">The logical name of the vector collection.</param>
+    /// <param name="key">The unique key for the document.</param>
+    /// <param name="text">The text content to embed and index.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task IndexAsync(string collectionName, string key, string text, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Searches for documents similar to the given query text.
+    /// </summary>
+    /// <param name="collectionName">The logical name of the vector collection.</param>
+    /// <param name="query">The natural language query to search for.</param>
+    /// <param name="limit">Maximum number of results.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of semantic search results ordered by descending relevance.</returns>
+    Task<IReadOnlyList<SemanticSearchResult>> SearchAsync(
+        string collectionName,
+        string query,
+        int limit = 10,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.AI.VectorData/IVectorCollection.cs
+++ b/src/Granit.AI.VectorData/IVectorCollection.cs
@@ -1,0 +1,34 @@
+namespace Granit.AI.VectorData;
+
+/// <summary>
+/// A tenant-scoped collection of vector records for semantic search.
+/// </summary>
+/// <typeparam name="TRecord">The record type stored in this collection.</typeparam>
+public interface IVectorCollection<TRecord> where TRecord : class
+{
+    /// <summary>
+    /// Upserts a record with its embedding vector.
+    /// </summary>
+    /// <param name="record">The record to upsert.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task UpsertAsync(TRecord record, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a record by key.
+    /// </summary>
+    /// <param name="key">The unique key of the record to delete.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task DeleteAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Searches for records similar to the given vector.
+    /// </summary>
+    /// <param name="vector">Query embedding vector.</param>
+    /// <param name="limit">Maximum number of results.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of search results ordered by descending similarity score.</returns>
+    Task<IReadOnlyList<VectorSearchResult<TRecord>>> SearchAsync(
+        ReadOnlyMemory<float> vector,
+        int limit = 10,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.AI.VectorData/IVectorCollectionFactory.cs
+++ b/src/Granit.AI.VectorData/IVectorCollectionFactory.cs
@@ -1,0 +1,16 @@
+namespace Granit.AI.VectorData;
+
+/// <summary>
+/// Factory for creating tenant-scoped vector collections.
+/// </summary>
+public interface IVectorCollectionFactory
+{
+    /// <summary>
+    /// Gets or creates a vector collection for the specified name.
+    /// The collection is automatically scoped to the current tenant.
+    /// </summary>
+    /// <typeparam name="TRecord">The record type stored in the collection.</typeparam>
+    /// <param name="collectionName">The logical name of the vector collection.</param>
+    /// <returns>A tenant-scoped vector collection instance.</returns>
+    IVectorCollection<TRecord> GetCollection<TRecord>(string collectionName) where TRecord : class;
+}

--- a/src/Granit.AI.VectorData/Internal/DefaultSemanticSearchService.cs
+++ b/src/Granit.AI.VectorData/Internal/DefaultSemanticSearchService.cs
@@ -1,0 +1,97 @@
+using Granit.AI.VectorData.Options;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Granit.AI.VectorData.Internal;
+
+/// <summary>
+/// Default implementation of <see cref="ISemanticSearchService"/> that combines
+/// embedding generation via <see cref="IAIEmbeddingGeneratorFactory"/> with
+/// vector storage via <see cref="IVectorCollectionFactory"/>.
+/// </summary>
+internal sealed partial class DefaultSemanticSearchService(
+    IAIEmbeddingGeneratorFactory embeddingGeneratorFactory,
+    IVectorCollectionFactory vectorCollectionFactory,
+    IOptions<VectorDataOptions> options,
+    ILogger<DefaultSemanticSearchService> logger) : ISemanticSearchService
+{
+    /// <inheritdoc />
+    public async Task IndexAsync(
+        string collectionName,
+        string key,
+        string text,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(collectionName);
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(text);
+
+        LogIndexing(collectionName, key);
+
+        IEmbeddingGenerator<string, Embedding<float>> generator =
+            await embeddingGeneratorFactory.CreateAsync(options.Value.EmbeddingWorkspace, cancellationToken).ConfigureAwait(false);
+
+        GeneratedEmbeddings<Embedding<float>> embeddings =
+            await generator.GenerateAsync([text], cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var record = new TextVectorRecord
+        {
+            Key = key,
+            Text = text,
+            Vector = embeddings[0].Vector,
+        };
+
+        IVectorCollection<TextVectorRecord> collection =
+            vectorCollectionFactory.GetCollection<TextVectorRecord>(collectionName);
+
+        await collection.UpsertAsync(record, cancellationToken).ConfigureAwait(false);
+
+        LogIndexed(collectionName, key);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SemanticSearchResult>> SearchAsync(
+        string collectionName,
+        string query,
+        int limit = 10,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(collectionName);
+        ArgumentNullException.ThrowIfNull(query);
+
+        int effectiveLimit = limit > 0 ? limit : options.Value.DefaultSearchLimit;
+
+        LogSearching(collectionName, effectiveLimit);
+
+        IEmbeddingGenerator<string, Embedding<float>> generator =
+            await embeddingGeneratorFactory.CreateAsync(options.Value.EmbeddingWorkspace, cancellationToken).ConfigureAwait(false);
+
+        GeneratedEmbeddings<Embedding<float>> embeddings =
+            await generator.GenerateAsync([query], cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        IVectorCollection<TextVectorRecord> collection =
+            vectorCollectionFactory.GetCollection<TextVectorRecord>(collectionName);
+
+        IReadOnlyList<VectorSearchResult<TextVectorRecord>> results =
+            await collection.SearchAsync(embeddings[0].Vector, effectiveLimit, cancellationToken).ConfigureAwait(false);
+
+        LogSearchCompleted(collectionName, results.Count);
+
+        return results
+            .Select(r => new SemanticSearchResult(r.Record.Key, r.Score, r.Record.Text))
+            .ToList();
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Indexing document in collection '{CollectionName}' with key '{Key}'")]
+    private partial void LogIndexing(string collectionName, string key);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Indexed document in collection '{CollectionName}' with key '{Key}'")]
+    private partial void LogIndexed(string collectionName, string key);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Searching collection '{CollectionName}' with limit {Limit}")]
+    private partial void LogSearching(string collectionName, int limit);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Search completed in collection '{CollectionName}', found {Count} results")]
+    private partial void LogSearchCompleted(string collectionName, int count);
+}

--- a/src/Granit.AI.VectorData/Internal/TextVectorRecord.cs
+++ b/src/Granit.AI.VectorData/Internal/TextVectorRecord.cs
@@ -1,0 +1,22 @@
+namespace Granit.AI.VectorData.Internal;
+
+/// <summary>
+/// Internal record used by <see cref="DefaultSemanticSearchService"/> for text-based vector storage.
+/// </summary>
+internal sealed class TextVectorRecord
+{
+    /// <summary>
+    /// The unique key of the document.
+    /// </summary>
+    public required string Key { get; init; }
+
+    /// <summary>
+    /// The original text content of the document.
+    /// </summary>
+    public string? Text { get; init; }
+
+    /// <summary>
+    /// The embedding vector for the document.
+    /// </summary>
+    public required ReadOnlyMemory<float> Vector { get; init; }
+}

--- a/src/Granit.AI.VectorData/Options/VectorDataOptions.cs
+++ b/src/Granit.AI.VectorData/Options/VectorDataOptions.cs
@@ -1,0 +1,23 @@
+namespace Granit.AI.VectorData.Options;
+
+/// <summary>
+/// Configuration options for the Granit AI vector data module.
+/// </summary>
+public sealed class VectorDataOptions
+{
+    /// <summary>
+    /// The configuration section name (<c>AI:VectorData</c>).
+    /// </summary>
+    public const string SectionName = "AI:VectorData";
+
+    /// <summary>
+    /// The logical name of the embedding workspace.
+    /// Used to resolve the correct <see cref="Granit.AI.IEmbeddingGeneratorFactory"/> instance.
+    /// </summary>
+    public string EmbeddingWorkspace { get; set; } = "default";
+
+    /// <summary>
+    /// The default maximum number of results returned by search operations.
+    /// </summary>
+    public int DefaultSearchLimit { get; set; } = 10;
+}

--- a/src/Granit.AI.VectorData/README.md
+++ b/src/Granit.AI.VectorData/README.md
@@ -1,0 +1,19 @@
+# Granit.AI.VectorData
+
+Multi-tenant vector storage abstractions for Granit.AI. Semantic search (RAG), similarity matching via provider-agnostic vector collections.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.AI.VectorData
+```
+
+## Dependencies
+
+- `Granit.AI`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.AI.VectorData/SemanticSearchResult.cs
+++ b/src/Granit.AI.VectorData/SemanticSearchResult.cs
@@ -1,0 +1,9 @@
+namespace Granit.AI.VectorData;
+
+/// <summary>
+/// A result from a semantic search operation.
+/// </summary>
+/// <param name="Key">The unique key of the matched document.</param>
+/// <param name="Score">The similarity score (higher is more similar).</param>
+/// <param name="Text">The text content of the matched document, if available.</param>
+public sealed record SemanticSearchResult(string Key, double Score, string? Text);

--- a/src/Granit.AI.VectorData/VectorSearchResult.cs
+++ b/src/Granit.AI.VectorData/VectorSearchResult.cs
@@ -1,0 +1,9 @@
+namespace Granit.AI.VectorData;
+
+/// <summary>
+/// A search result from vector similarity search.
+/// </summary>
+/// <typeparam name="TRecord">The record type stored in the vector collection.</typeparam>
+/// <param name="Record">The matched record.</param>
+/// <param name="Score">The similarity score (higher is more similar).</param>
+public sealed record VectorSearchResult<TRecord>(TRecord Record, double Score) where TRecord : class;

--- a/src/Granit.AI.VectorData/packages.lock.json
+++ b/src/Granit.AI.VectorData/packages.lock.json
@@ -1,0 +1,158 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.VectorData.Abstractions": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.1",
+        "contentHash": "1vsHJaRET/Q8aldtGiaAP4BKXBrVA9Y1brgYbpWyQQsr6HN7fN5+Qw74sC8g+JSHiZONJ4134pPQd1mk7fGlQw==",
+        "dependencies": {
+          "Microsoft.Extensions.AI.Abstractions": "10.3.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
+      },
+      "granit.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.core": {
+        "type": "Project"
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.4.0",
+        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      }
+    }
+  }
+}

--- a/src/Granit.AI/Internal/DefaultAIWorkspaceProvider.cs
+++ b/src/Granit.AI/Internal/DefaultAIWorkspaceProvider.cs
@@ -39,14 +39,7 @@ internal sealed class DefaultAIWorkspaceProvider(
         var systemNames = _systemWorkspaces.Value.Keys.ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         List<AIWorkspace> merged = new(_systemWorkspaces.Value.Values);
-
-        foreach (AIWorkspace workspace in dynamicWorkspaces)
-        {
-            if (!systemNames.Contains(workspace.Name))
-            {
-                merged.Add(workspace);
-            }
-        }
+        merged.AddRange(dynamicWorkspaces.Where(w => !systemNames.Contains(w.Name)));
 
         return merged;
     }

--- a/src/Granit.AI/README.md
+++ b/src/Granit.AI/README.md
@@ -1,0 +1,20 @@
+# Granit.AI
+
+Provider-agnostic AI module for Granit. Workspace management, IChatClient/IEmbeddingGenerator factory, usage tracking, and ISO 27001 audit trail. Built on Microsoft.Extensions.AI.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.AI
+```
+
+## Dependencies
+
+- `Granit.Core`
+- `Granit.Guids`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.DataExchange.AI/Extensions/DataExchangeAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.DataExchange.AI/Extensions/DataExchangeAIHostApplicationBuilderExtensions.cs
@@ -1,0 +1,42 @@
+using System.Diagnostics.CodeAnalysis;
+using Granit.DataExchange.AI.Internal;
+using Granit.DataExchange.AI.Options;
+using Granit.DataExchange.Extensions;
+using Granit.DataExchange.Import.Mapping;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Granit.DataExchange.AI.Extensions;
+
+/// <summary>
+/// Extension methods for registering AI-powered semantic mapping services.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public static class DataExchangeAIHostApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Adds the AI-powered semantic mapping service for data exchange.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Replaces the default <c>NullSemanticMappingService</c> with <see cref="AISemanticMappingService"/>
+    /// which uses an LLM via <c>IAIChatClientFactory</c> to suggest column-to-property mappings.
+    /// </para>
+    /// <para>
+    /// Requires <c>Granit.AI</c> to be configured with at least one provider and a workspace
+    /// matching <see cref="DataExchangeAIOptions.WorkspaceName"/>.
+    /// </para>
+    /// </remarks>
+    /// <param name="builder">The host application builder.</param>
+    /// <returns>The builder for chaining.</returns>
+    public static IHostApplicationBuilder AddGranitDataExchangeAI(this IHostApplicationBuilder builder)
+    {
+        builder.Services
+            .AddOptions<DataExchangeAIOptions>()
+            .BindConfiguration(DataExchangeAIOptions.SectionName);
+
+        builder.Services.AddSemanticMappingService<AISemanticMappingService>();
+
+        return builder;
+    }
+}

--- a/src/Granit.DataExchange.AI/Granit.DataExchange.AI.csproj
+++ b/src/Granit.DataExchange.AI/Granit.DataExchange.AI.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Granit.DataExchange.AI</PackageId>
+    <Description>AI-powered column mapping for Granit.DataExchange. Uses LLM (via Microsoft.Extensions.AI) to semantically match imported file columns to entity properties when exact and fuzzy matching fail.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Granit.DataExchange.AI.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Granit.AI\Granit.AI.csproj" />
+    <ProjectReference Include="..\Granit.DataExchange\Granit.DataExchange.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Granit.DataExchange.AI/GranitDataExchangeAIModule.cs
+++ b/src/Granit.DataExchange.AI/GranitDataExchangeAIModule.cs
@@ -1,0 +1,21 @@
+using Granit.AI;
+using Granit.Core.Modularity;
+using Granit.DataExchange;
+
+namespace Granit.DataExchange.AI;
+
+/// <summary>
+/// Granit module that provides AI-powered semantic column mapping for data exchange.
+/// </summary>
+/// <remarks>
+/// When this module is installed, the default <c>NullSemanticMappingService</c> is replaced
+/// with an LLM-backed implementation that uses <see cref="IAIChatClientFactory"/> to suggest
+/// column-to-property mappings during CSV/Excel import.
+/// <para>
+/// Only column headers and field metadata are sent to the LLM — never business data (GDPR safe).
+/// </para>
+/// </remarks>
+[DependsOn(
+    typeof(GranitAIModule),
+    typeof(GranitDataExchangeModule))]
+public sealed class GranitDataExchangeAIModule : GranitModule;

--- a/src/Granit.DataExchange.AI/Internal/AISemanticMappingService.cs
+++ b/src/Granit.DataExchange.AI/Internal/AISemanticMappingService.cs
@@ -1,0 +1,192 @@
+using System.Text;
+using System.Text.Json;
+using Granit.AI;
+using Granit.DataExchange.AI.Options;
+using Granit.DataExchange.Import.Mapping;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Granit.DataExchange.AI.Internal;
+
+/// <summary>
+/// AI-powered implementation of <see cref="ISemanticMappingService"/> that uses
+/// an LLM via <see cref="IAIChatClientFactory"/> to suggest column-to-property mappings.
+/// </summary>
+/// <remarks>
+/// Only column headers and field metadata are sent to the LLM — never business data (GDPR safe).
+/// On failure, gracefully degrades to an empty result set.
+/// </remarks>
+internal sealed partial class AISemanticMappingService(
+    IAIChatClientFactory chatClientFactory,
+    IOptions<DataExchangeAIOptions> options,
+    ILogger<AISemanticMappingService> logger) : ISemanticMappingService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <inheritdoc/>
+    public bool IsAvailable => true;
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<SemanticMappingSuggestion>> SuggestSemanticMappingsAsync(
+        IReadOnlyList<string> headers,
+        IReadOnlyList<ImportFieldMetadata> targetFields,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(headers);
+        ArgumentNullException.ThrowIfNull(targetFields);
+
+        if (headers.Count == 0 || targetFields.Count == 0)
+        {
+            return [];
+        }
+
+        DataExchangeAIOptions opts = options.Value;
+
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(opts.TimeoutSeconds));
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+        try
+        {
+            IChatClient chatClient = await chatClientFactory
+                .CreateAsync(opts.WorkspaceName, linkedCts.Token)
+                .ConfigureAwait(false);
+
+            string prompt = BuildPrompt(headers, targetFields, opts.MinConfidenceScore);
+
+            ChatResponse response = await chatClient
+                .GetResponseAsync(prompt, cancellationToken: linkedCts.Token)
+                .ConfigureAwait(false);
+
+            string responseText = response.Text ?? string.Empty;
+
+            LogLlmResponseReceived(responseText.Length);
+
+            IReadOnlyList<SemanticMappingSuggestion> suggestions = ParseSuggestions(responseText);
+
+            var filtered = suggestions
+                .Where(s => s.Score >= opts.MinConfidenceScore)
+                .OrderByDescending(s => s.Score)
+                .ToList();
+
+            LogSuggestionsFiltered(suggestions.Count, filtered.Count, opts.MinConfidenceScore);
+
+            return filtered;
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            LogSemanticMappingFailed(ex);
+            return [];
+        }
+    }
+
+    internal static string BuildPrompt(
+        IReadOnlyList<string> headers,
+        IReadOnlyList<ImportFieldMetadata> targetFields,
+        double minConfidenceScore)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("You are a data mapping assistant. Match source CSV/Excel columns to target entity properties.");
+        sb.AppendLine();
+        sb.Append("Source columns: ");
+        sb.AppendJoin(", ", headers);
+        sb.AppendLine();
+        sb.AppendLine();
+        sb.AppendLine("Target properties:");
+        sb.AppendLine("| Property | Type | Display Name | Description | Required |");
+        sb.AppendLine("|----------|------|-------------|-------------|----------|");
+
+        foreach (ImportFieldMetadata field in targetFields)
+        {
+            sb.Append("| ");
+            sb.Append(field.PropertyPath);
+            sb.Append(" | ");
+            sb.Append(field.ClrTypeName);
+            sb.Append(" | ");
+            sb.Append(field.DisplayName ?? "-");
+            sb.Append(" | ");
+            sb.Append(field.Description ?? "-");
+            sb.Append(" | ");
+            sb.Append(field.IsRequired ? "Yes" : "No");
+            sb.AppendLine(" |");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("Return a JSON array of mappings. Each mapping has:");
+        sb.AppendLine("""- "source": exact source column name""");
+        sb.AppendLine("""- "target": exact target property path""");
+        sb.AppendLine("""- "score": confidence score 0.0 to 1.0""");
+        sb.AppendLine();
+        sb.Append($"Only include confident matches (score >= {minConfidenceScore:F1}). ");
+        sb.AppendLine("Return [] if no good matches found.");
+        sb.AppendLine("Return ONLY the JSON array, no markdown fences or extra text.");
+
+        return sb.ToString();
+    }
+
+    internal static IReadOnlyList<SemanticMappingSuggestion> ParseSuggestions(string responseText)
+    {
+        string trimmed = responseText.Trim();
+
+        // Strip markdown code fences if present
+        if (trimmed.StartsWith("```", StringComparison.Ordinal))
+        {
+            int firstNewline = trimmed.IndexOf('\n');
+            if (firstNewline >= 0)
+            {
+                trimmed = trimmed[(firstNewline + 1)..];
+            }
+
+            if (trimmed.EndsWith("```", StringComparison.Ordinal))
+            {
+                trimmed = trimmed[..^3].TrimEnd();
+            }
+        }
+
+        // Find the JSON array boundaries
+        int startIndex = trimmed.IndexOf('[');
+        int endIndex = trimmed.LastIndexOf(']');
+
+        if (startIndex < 0 || endIndex < 0 || endIndex <= startIndex)
+        {
+            return [];
+        }
+
+        string jsonArray = trimmed[startIndex..(endIndex + 1)];
+
+        List<MappingDto>? dtos = JsonSerializer.Deserialize<List<MappingDto>>(jsonArray, JsonOptions);
+
+        if (dtos is null)
+        {
+            return [];
+        }
+
+        return dtos
+            .Where(d => d.Source is not null && d.Target is not null)
+            .Select(d => new SemanticMappingSuggestion(d.Source!, d.Target!, d.Score))
+            .ToList();
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "LLM response received for semantic mapping ({ResponseLength} chars)")]
+    private partial void LogLlmResponseReceived(int responseLength);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Semantic mapping: {TotalCount} suggestions from LLM, {FilteredCount} after filtering (min score: {MinScore:F2})")]
+    private partial void LogSuggestionsFiltered(int totalCount, int filteredCount, double minScore);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "AI semantic mapping failed, returning empty suggestions (graceful degradation)")]
+    private partial void LogSemanticMappingFailed(Exception exception);
+
+    /// <summary>
+    /// Internal DTO for deserializing the LLM JSON response.
+    /// </summary>
+    internal sealed class MappingDto
+    {
+        public string? Source { get; set; }
+        public string? Target { get; set; }
+        public double Score { get; set; }
+    }
+}

--- a/src/Granit.DataExchange.AI/Internal/AISemanticMappingService.cs
+++ b/src/Granit.DataExchange.AI/Internal/AISemanticMappingService.cs
@@ -31,9 +31,17 @@ internal sealed partial class AISemanticMappingService(
     public bool IsAvailable => true;
 
     /// <inheritdoc/>
+    public Task<IReadOnlyList<SemanticMappingSuggestion>> SuggestSemanticMappingsAsync(
+        IReadOnlyList<string> headers,
+        IReadOnlyList<ImportFieldMetadata> targetFields,
+        CancellationToken cancellationToken = default)
+        => SuggestSemanticMappingsAsync(headers, targetFields, previewRows: null, cancellationToken);
+
+    /// <inheritdoc/>
     public async Task<IReadOnlyList<SemanticMappingSuggestion>> SuggestSemanticMappingsAsync(
         IReadOnlyList<string> headers,
         IReadOnlyList<ImportFieldMetadata> targetFields,
+        IReadOnlyList<string[]>? previewRows,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(headers);
@@ -46,6 +54,9 @@ internal sealed partial class AISemanticMappingService(
 
         DataExchangeAIOptions opts = options.Value;
 
+        // Only include preview rows if the option is explicitly enabled (GDPR opt-in)
+        IReadOnlyList<string[]>? effectivePreview = opts.IncludePreviewRows ? previewRows : null;
+
         using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(opts.TimeoutSeconds));
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
 
@@ -55,7 +66,7 @@ internal sealed partial class AISemanticMappingService(
                 .CreateAsync(opts.WorkspaceName, linkedCts.Token)
                 .ConfigureAwait(false);
 
-            string prompt = BuildPrompt(headers, targetFields, opts.MinConfidenceScore);
+            string prompt = BuildPrompt(headers, targetFields, opts.MinConfidenceScore, effectivePreview);
 
             ChatResponse response = await chatClient
                 .GetResponseAsync(prompt, cancellationToken: linkedCts.Token)
@@ -86,7 +97,8 @@ internal sealed partial class AISemanticMappingService(
     internal static string BuildPrompt(
         IReadOnlyList<string> headers,
         IReadOnlyList<ImportFieldMetadata> targetFields,
-        double minConfidenceScore)
+        double minConfidenceScore,
+        IReadOnlyList<string[]>? previewRows = null)
     {
         var sb = new StringBuilder();
 
@@ -95,6 +107,28 @@ internal sealed partial class AISemanticMappingService(
         sb.Append("Source columns: ");
         sb.AppendJoin(", ", headers);
         sb.AppendLine();
+
+        // Include preview rows when provided (opt-in, caller is responsible for GDPR compliance)
+        if (previewRows is { Count: > 0 })
+        {
+            sb.AppendLine();
+            sb.AppendLine("Sample data (first rows):");
+            sb.AppendLine("| " + string.Join(" | ", headers) + " |");
+            sb.AppendLine("| " + string.Join(" | ", headers.Select(_ => "---")) + " |");
+
+            foreach (string[] row in previewRows)
+            {
+                sb.Append("| ");
+                for (int i = 0; i < headers.Count; i++)
+                {
+                    sb.Append(i < row.Length ? row[i] : "-");
+                    sb.Append(i < headers.Count - 1 ? " | " : " |");
+                }
+
+                sb.AppendLine();
+            }
+        }
+
         sb.AppendLine();
         sb.AppendLine("Target properties:");
         sb.AppendLine("| Property | Type | Display Name | Description | Required |");

--- a/src/Granit.DataExchange.AI/Options/DataExchangeAIOptions.cs
+++ b/src/Granit.DataExchange.AI/Options/DataExchangeAIOptions.cs
@@ -34,4 +34,24 @@ public sealed class DataExchangeAIOptions
     /// Suggestions with a score below this threshold are discarded.
     /// </remarks>
     public double MinConfidenceScore { get; set; } = 0.6;
+
+    /// <summary>
+    /// When <c>true</c>, the AI mapping service includes a preview of the first data rows
+    /// in the prompt to improve mapping accuracy for headerless files or cryptic column names.
+    /// </summary>
+    /// <remarks>
+    /// <b>GDPR warning</b>: preview rows may contain PII. Only enable when:
+    /// <list type="bullet">
+    ///   <item>The data is known to be non-sensitive, OR</item>
+    ///   <item>The AI provider has a Data Processing Agreement (e.g. Azure OpenAI), OR</item>
+    ///   <item>A local model is used (Ollama)</item>
+    /// </list>
+    /// Default: <c>false</c> (headers-only mode, GDPR-safe).
+    /// </remarks>
+    public bool IncludePreviewRows { get; set; }
+
+    /// <summary>
+    /// Number of preview rows to include when <see cref="IncludePreviewRows"/> is <c>true</c>.
+    /// </summary>
+    public int PreviewRowCount { get; set; } = 5;
 }

--- a/src/Granit.DataExchange.AI/Options/DataExchangeAIOptions.cs
+++ b/src/Granit.DataExchange.AI/Options/DataExchangeAIOptions.cs
@@ -1,0 +1,37 @@
+namespace Granit.DataExchange.AI.Options;
+
+/// <summary>
+/// Configuration options for the AI-powered semantic mapping service.
+/// </summary>
+/// <remarks>
+/// Bound to the <c>AI:DataExchange</c> configuration section.
+/// </remarks>
+public sealed class DataExchangeAIOptions
+{
+    /// <summary>
+    /// Configuration section name in appsettings.json.
+    /// </summary>
+    public const string SectionName = "AI:DataExchange";
+
+    /// <summary>
+    /// Name of the AI workspace to use for mapping suggestions.
+    /// </summary>
+    /// <remarks>
+    /// Must correspond to a workspace configured in the <c>AI:Workspaces</c> section.
+    /// Defaults to <c>"default"</c>.
+    /// </remarks>
+    public string WorkspaceName { get; set; } = "default";
+
+    /// <summary>
+    /// Timeout in seconds for the LLM call.
+    /// </summary>
+    public int TimeoutSeconds { get; set; } = 10;
+
+    /// <summary>
+    /// Minimum confidence score (0.0 to 1.0) to accept a mapping suggestion.
+    /// </summary>
+    /// <remarks>
+    /// Suggestions with a score below this threshold are discarded.
+    /// </remarks>
+    public double MinConfidenceScore { get; set; } = 0.6;
+}

--- a/src/Granit.DataExchange.AI/README.md
+++ b/src/Granit.DataExchange.AI/README.md
@@ -1,0 +1,20 @@
+# Granit.DataExchange.AI
+
+AI-powered column mapping for Granit.DataExchange. Uses LLM to semantically match imported file columns to entity properties.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.DataExchange.AI
+```
+
+## Dependencies
+
+- `Granit.AI`
+- `Granit.DataExchange`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.DataExchange.AI/packages.lock.json
+++ b/src/Granit.DataExchange.AI/packages.lock.json
@@ -1,0 +1,258 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "xKobiPRPVkK/bD/oLUTF1OnilG3N+4o0u/T8YWqHq+E97zWgCRr8Zhk9N6OZeLBSNHC7imT53QkH/yv9MaXkew=="
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
+      },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
+      "granit.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.core": {
+        "type": "Project"
+      },
+      "granit.dataexchange": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.querying": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.validation": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.*, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.*, )",
+          "Granit.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
+        }
+      },
+      "FluentValidation": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.4.0",
+        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "k/QDdQ94/0Shi0KfU+e12m73jfQo+3JpErTtgpZfsCIqkvdEEO0XIx6R+iTbN55rNPaNhOqNY4/sB+jZ8XxVPw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "jUEXmkBUPdOS/MP9areK/sbKhdklq9+tEhvwfxGalZVnmyLUO5rrheNNutUBtvbZ7J8ECkG7/r2KXi/IFC06cA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "Co/URpVB1P1WbvswTumphjYZcvqTA2piSTLVOVtN6qLNrK6pg0OjZ/9SzigI+7NYGS2UpxVMydk/n45VvWZvOg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      }
+    }
+  }
+}

--- a/src/Granit.DataExchange.Endpoints/Internal/Import/ImportDefinitionResolver.cs
+++ b/src/Granit.DataExchange.Endpoints/Internal/Import/ImportDefinitionResolver.cs
@@ -22,7 +22,7 @@ internal static class ImportDefinitionResolver
     }
 
     /// <summary>
-    /// Invokes <see cref="IMappingSuggestionService.SuggestMappingsAsync{TEntity}"/> via reflection,
+    /// Invokes <c>IMappingSuggestionService.SuggestMappingsAsync</c> via reflection,
     /// using the entity type discovered at runtime from the definition descriptor.
     /// </summary>
     internal static async Task<IReadOnlyList<ImportColumnMapping>> SuggestMappingsAsync(

--- a/src/Granit.DataExchange/Import/Internal/MappingSuggestionService.cs
+++ b/src/Granit.DataExchange/Import/Internal/MappingSuggestionService.cs
@@ -18,8 +18,15 @@ internal sealed class MappingSuggestionService(
     IOptions<ImportOptions> options) : IMappingSuggestionService
 {
     /// <inheritdoc/>
+    public Task<IReadOnlyList<ImportColumnMapping>> SuggestMappingsAsync<TEntity>(
+        IReadOnlyList<string> headers,
+        CancellationToken cancellationToken = default) where TEntity : class
+        => SuggestMappingsAsync<TEntity>(headers, previewRows: null, cancellationToken);
+
+    /// <inheritdoc/>
     public async Task<IReadOnlyList<ImportColumnMapping>> SuggestMappingsAsync<TEntity>(
         IReadOnlyList<string> headers,
+        IReadOnlyList<string[]>? previewRows,
         CancellationToken cancellationToken = default) where TEntity : class
     {
         ImportDefinition<TEntity> definition = serviceProvider.GetRequiredService<ImportDefinition<TEntity>>();
@@ -51,7 +58,7 @@ internal sealed class MappingSuggestionService(
         {
             IReadOnlyList<ImportFieldMetadata> targetFields = definition.GetFieldMetadata();
             IReadOnlyList<SemanticMappingSuggestion> semanticSuggestions =
-                await semanticMappingService.SuggestSemanticMappingsAsync(unmappedHeaders, targetFields, cancellationToken).ConfigureAwait(false);
+                await semanticMappingService.SuggestSemanticMappingsAsync(unmappedHeaders, targetFields, previewRows, cancellationToken).ConfigureAwait(false);
 
             foreach (SemanticMappingSuggestion suggestion in semanticSuggestions
                 .Where(s => !suggestions.ContainsKey(s.SourceColumn) &&

--- a/src/Granit.DataExchange/Import/Mapping/IMappingSuggestionService.cs
+++ b/src/Granit.DataExchange/Import/Mapping/IMappingSuggestionService.cs
@@ -23,4 +23,21 @@ public interface IMappingSuggestionService
     Task<IReadOnlyList<ImportColumnMapping>> SuggestMappingsAsync<TEntity>(
         IReadOnlyList<string> headers,
         CancellationToken cancellationToken = default) where TEntity : class;
+
+    /// <summary>
+    /// Suggests column-to-property mappings with optional preview rows for the AI tier.
+    /// </summary>
+    /// <typeparam name="TEntity">The target entity type.</typeparam>
+    /// <param name="headers">Column headers extracted from the file.</param>
+    /// <param name="previewRows">
+    /// Optional preview of the first data rows for AI-assisted mapping.
+    /// Each element is one row as an array of cell values, aligned with <paramref name="headers"/>.
+    /// <b>GDPR warning</b>: may contain PII. Only provide when safe (see <c>DataExchangeAIOptions.IncludePreviewRows</c>).
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<ImportColumnMapping>> SuggestMappingsAsync<TEntity>(
+        IReadOnlyList<string> headers,
+        IReadOnlyList<string[]>? previewRows,
+        CancellationToken cancellationToken = default) where TEntity : class
+        => SuggestMappingsAsync<TEntity>(headers, cancellationToken);
 }

--- a/src/Granit.DataExchange/Import/Mapping/ISemanticMappingService.cs
+++ b/src/Granit.DataExchange/Import/Mapping/ISemanticMappingService.cs
@@ -32,4 +32,24 @@ public interface ISemanticMappingService
         IReadOnlyList<string> headers,
         IReadOnlyList<ImportFieldMetadata> targetFields,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Suggests column-to-property mappings using semantic analysis of headers, field metadata,
+    /// and optionally a preview of the first data rows.
+    /// </summary>
+    /// <param name="headers">Column headers from the imported file.</param>
+    /// <param name="targetFields">Schema metadata for the target entity.</param>
+    /// <param name="previewRows">
+    /// Optional preview of the first data rows. Each element is one row as an array of cell values.
+    /// <b>GDPR warning</b>: preview rows may contain PII. Only provide when the data is non-sensitive,
+    /// the AI provider has a DPA, or a local model (Ollama) is used.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of semantic mapping suggestions ordered by confidence score.</returns>
+    Task<IReadOnlyList<SemanticMappingSuggestion>> SuggestSemanticMappingsAsync(
+        IReadOnlyList<string> headers,
+        IReadOnlyList<ImportFieldMetadata> targetFields,
+        IReadOnlyList<string[]>? previewRows,
+        CancellationToken cancellationToken = default)
+        => SuggestSemanticMappingsAsync(headers, targetFields, cancellationToken);
 }

--- a/src/Granit.Querying.AI/Extensions/QueryingAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Querying.AI/Extensions/QueryingAIHostApplicationBuilderExtensions.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics.CodeAnalysis;
+using Granit.Querying.AI.Internal;
+using Granit.Querying.AI.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+
+namespace Granit.Querying.AI.Extensions;
+
+/// <summary>
+/// Extension methods for registering Granit.Querying.AI services.
+/// </summary>
+// DI wiring only — no logic to unit test.
+[ExcludeFromCodeCoverage]
+public static class QueryingAIHostApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Adds the AI-powered natural language query translator to the application.
+    /// </summary>
+    /// <param name="builder">The host application builder.</param>
+    /// <returns>The builder for chaining.</returns>
+    public static IHostApplicationBuilder AddGranitQueryingAI(this IHostApplicationBuilder builder)
+    {
+        builder.Services
+            .AddOptions<QueryingAIOptions>()
+            .BindConfiguration(QueryingAIOptions.SectionName);
+
+        builder.Services.TryAddSingleton<INaturalLanguageQueryTranslator, LlmNaturalLanguageQueryTranslator>();
+
+        return builder;
+    }
+}

--- a/src/Granit.Querying.AI/Granit.Querying.AI.csproj
+++ b/src/Granit.Querying.AI/Granit.Querying.AI.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Granit.Querying.AI</PackageId>
+    <Description>Natural Language Query (NLQ) for Granit.Querying. Translates natural language phrases into structured QueryRequest objects using LLM. The LLM only receives query metadata (column names, filter types), never business data.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Granit.Querying.AI.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Granit.AI\Granit.AI.csproj" />
+    <ProjectReference Include="..\Granit.Querying\Granit.Querying.csproj" />
+    <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Granit.Querying.AI/GranitQueryingAIModule.cs
+++ b/src/Granit.Querying.AI/GranitQueryingAIModule.cs
@@ -1,0 +1,18 @@
+using Granit.AI;
+using Granit.Core.Modularity;
+using Granit.Querying;
+
+namespace Granit.Querying.AI;
+
+/// <summary>
+/// Granit module for Natural Language Query (NLQ) translation.
+/// </summary>
+/// <remarks>
+/// Translates user natural language phrases into structured <see cref="QueryRequest"/> objects
+/// using an LLM via <see cref="IAIChatClientFactory"/>. Only query metadata (column names,
+/// filter types, operator codes) is sent to the LLM — never business data.
+/// </remarks>
+[DependsOn(
+    typeof(GranitAIModule),
+    typeof(GranitQueryingModule))]
+public sealed class GranitQueryingAIModule : GranitModule;

--- a/src/Granit.Querying.AI/INaturalLanguageQueryTranslator.cs
+++ b/src/Granit.Querying.AI/INaturalLanguageQueryTranslator.cs
@@ -1,0 +1,22 @@
+using Granit.Querying.Meta;
+
+namespace Granit.Querying.AI;
+
+/// <summary>
+/// Translates natural language queries into structured <see cref="QueryRequest"/> objects.
+/// </summary>
+public interface INaturalLanguageQueryTranslator
+{
+    /// <summary>
+    /// Translates a natural language phrase into a <see cref="QueryRequest"/> using the query metadata
+    /// as schema context for the LLM.
+    /// </summary>
+    /// <param name="naturalLanguage">User's query in natural language.</param>
+    /// <param name="metadata">Query metadata describing available columns, filters, sorts.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A structured <see cref="QueryRequest"/>, or <c>null</c> if the phrase cannot be translated.</returns>
+    Task<QueryRequest?> TranslateAsync(
+        string naturalLanguage,
+        QueryMetadata metadata,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Querying.AI/Internal/LlmNaturalLanguageQueryTranslator.cs
+++ b/src/Granit.Querying.AI/Internal/LlmNaturalLanguageQueryTranslator.cs
@@ -1,0 +1,238 @@
+using System.Text;
+using System.Text.Json;
+using Granit.AI;
+using Granit.Querying.AI.Options;
+using Granit.Querying.Meta;
+using Granit.Timing;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Querying.AI.Internal;
+
+/// <summary>
+/// LLM-backed implementation of <see cref="INaturalLanguageQueryTranslator"/>.
+/// Sends query metadata to the LLM as schema context and parses the structured JSON response.
+/// </summary>
+internal sealed partial class LlmNaturalLanguageQueryTranslator(
+    IAIChatClientFactory chatClientFactory,
+    IOptions<QueryingAIOptions> options,
+    ILogger<LlmNaturalLanguageQueryTranslator> logger,
+    IClock clock) : INaturalLanguageQueryTranslator
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <inheritdoc/>
+    public async Task<QueryRequest?> TranslateAsync(
+        string naturalLanguage,
+        QueryMetadata metadata,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(naturalLanguage))
+        {
+            return null;
+        }
+
+        try
+        {
+            QueryingAIOptions opts = options.Value;
+
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(opts.TimeoutSeconds));
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+            IChatClient chatClient = await chatClientFactory
+                .CreateAsync(opts.WorkspaceName, linkedCts.Token)
+                .ConfigureAwait(false);
+
+            string systemPrompt = BuildSystemPrompt(metadata);
+
+            List<ChatMessage> messages =
+            [
+                new(ChatRole.System, systemPrompt),
+                new(ChatRole.User, naturalLanguage),
+            ];
+
+            ChatResponse response = await chatClient
+                .GetResponseAsync(messages, cancellationToken: linkedCts.Token)
+                .ConfigureAwait(false);
+
+            string rawJson = response.Text ?? string.Empty;
+            string json = StripMarkdownFences(rawJson);
+
+            QueryRequestDto? dto = JsonSerializer.Deserialize<QueryRequestDto>(json, JsonOptions);
+            if (dto is null)
+            {
+                LogInvalidResponse(logger, naturalLanguage);
+                return null;
+            }
+
+            return ToQueryRequest(dto);
+        }
+        catch (OperationCanceledException)
+        {
+            LogTimeout(logger, naturalLanguage);
+            return null;
+        }
+        catch (JsonException ex)
+        {
+            LogJsonParseError(logger, naturalLanguage, ex);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            LogTranslationError(logger, naturalLanguage, ex);
+            return null;
+        }
+    }
+
+    internal string BuildSystemPrompt(QueryMetadata metadata)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("You are a query translator. Convert the user's natural language phrase into a JSON object matching this schema:");
+        sb.AppendLine();
+        sb.AppendLine("```json");
+        sb.AppendLine("{");
+        sb.AppendLine("  \"page\": <int or null>,");
+        sb.AppendLine("  \"pageSize\": <int or null>,");
+        sb.AppendLine("  \"sort\": \"<comma-separated fields, prefix - for desc>\" or null,");
+        sb.AppendLine("  \"filter\": { \"<field.operator>\": \"<value>\", ... } or null,");
+        sb.AppendLine("  \"quickFilters\": [\"<name>\", ...] or null,");
+        sb.AppendLine("  \"groupBy\": \"<field>\" or null");
+        sb.AppendLine("}");
+        sb.AppendLine("```");
+        sb.AppendLine();
+
+        // Filterable fields
+        if (metadata.FilterableFields.Count > 0)
+        {
+            sb.AppendLine("Available filterable fields:");
+
+            foreach (FilterableField field in metadata.FilterableFields)
+            {
+                string operators = string.Join(", ", field.Operators.Select(static op => op.ToString().ToLowerInvariant()));
+                sb.AppendLine($"  - {field.Name} (type: {field.Type}, operators: {operators})");
+            }
+
+            sb.AppendLine();
+        }
+
+        // Sortable fields
+        if (metadata.SortableFields.Count > 0)
+        {
+            sb.AppendLine("Available sortable fields:");
+
+            foreach (SortableField field in metadata.SortableFields)
+            {
+                sb.AppendLine($"  - {field.Name}");
+            }
+
+            sb.AppendLine("Sort format: comma-separated field names. Prefix with - for descending (e.g. \"-createdAt,lastName\").");
+            sb.AppendLine();
+        }
+
+        // Quick filters
+        if (metadata.QuickFilters.Count > 0)
+        {
+            sb.AppendLine("Available quick filters:");
+
+            foreach (QuickFilterMeta qf in metadata.QuickFilters)
+            {
+                sb.AppendLine($"  - \"{qf.Name}\" (label: {qf.Label})");
+            }
+
+            sb.AppendLine();
+        }
+
+        // Date filters
+        if (metadata.DateFilters.Count > 0)
+        {
+            sb.AppendLine("Available date filter fields:");
+
+            foreach (DateFilterMeta df in metadata.DateFilters)
+            {
+                string periods = string.Join(", ", df.AvailablePeriods.Select(static p => p.ToString()));
+                sb.AppendLine($"  - {df.Name} (periods: {periods})");
+            }
+
+            sb.AppendLine();
+        }
+
+        // Group by
+        if (metadata.GroupByFields.Count > 0)
+        {
+            sb.AppendLine("Available group-by fields:");
+
+            foreach (GroupByField field in metadata.GroupByFields)
+            {
+                sb.AppendLine($"  - {field.Name}");
+            }
+
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("Filter key format: \"fieldName.operator\" (e.g. \"status.eq\", \"amount.gte\", \"name.contains\").");
+        sb.AppendLine($"Current date: {clock.Now:yyyy-MM-dd}. Use this for relative date references (\"this week\", \"last month\").");
+        sb.AppendLine();
+        sb.AppendLine("Rules:");
+        sb.AppendLine("- Return ONLY valid JSON, no explanation.");
+        sb.AppendLine("- Use only the fields and operators listed above.");
+        sb.AppendLine("- Omit properties that are not needed (use null).");
+        sb.AppendLine("- For date ranges, use gte/lte operators with ISO 8601 dates.");
+
+        return sb.ToString();
+    }
+
+    internal static string StripMarkdownFences(string text)
+    {
+        string trimmed = text.Trim();
+
+        if (trimmed.StartsWith("```", StringComparison.Ordinal))
+        {
+            // Remove opening fence (```json or ```)
+            int firstNewline = trimmed.IndexOf('\n');
+            if (firstNewline >= 0)
+            {
+                trimmed = trimmed[(firstNewline + 1)..];
+            }
+
+            // Remove closing fence
+            if (trimmed.EndsWith("```", StringComparison.Ordinal))
+            {
+                trimmed = trimmed[..^3].TrimEnd();
+            }
+        }
+
+        return trimmed;
+    }
+
+    private static QueryRequest ToQueryRequest(QueryRequestDto dto) =>
+        new()
+        {
+            Page = dto.Page,
+            PageSize = dto.PageSize,
+            Sort = dto.Sort,
+            Filter = dto.Filter is { Count: > 0 }
+                ? new Dictionary<string, string>(dto.Filter)
+                : null,
+            QuickFilters = dto.QuickFilters is { Count: > 0 }
+                ? dto.QuickFilters.AsReadOnly()
+                : null,
+            GroupBy = dto.GroupBy,
+        };
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "NLQ translation returned invalid response for input: {NaturalLanguage}")]
+    private static partial void LogInvalidResponse(ILogger logger, string naturalLanguage);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "NLQ translation timed out for input: {NaturalLanguage}")]
+    private static partial void LogTimeout(ILogger logger, string naturalLanguage);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "NLQ translation failed to parse JSON for input: {NaturalLanguage}")]
+    private static partial void LogJsonParseError(ILogger logger, string naturalLanguage, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "NLQ translation failed for input: {NaturalLanguage}")]
+    private static partial void LogTranslationError(ILogger logger, string naturalLanguage, Exception exception);
+}

--- a/src/Granit.Querying.AI/Internal/QueryRequestDto.cs
+++ b/src/Granit.Querying.AI/Internal/QueryRequestDto.cs
@@ -1,0 +1,20 @@
+namespace Granit.Querying.AI.Internal;
+
+/// <summary>
+/// Internal DTO for JSON deserialization of the LLM response.
+/// Maps to <see cref="QueryRequest"/> after validation.
+/// </summary>
+internal sealed class QueryRequestDto
+{
+    public int? Page { get; set; }
+
+    public int? PageSize { get; set; }
+
+    public string? Sort { get; set; }
+
+    public Dictionary<string, string>? Filter { get; set; }
+
+    public List<string>? QuickFilters { get; set; }
+
+    public string? GroupBy { get; set; }
+}

--- a/src/Granit.Querying.AI/Options/QueryingAIOptions.cs
+++ b/src/Granit.Querying.AI/Options/QueryingAIOptions.cs
@@ -1,0 +1,22 @@
+namespace Granit.Querying.AI.Options;
+
+/// <summary>
+/// Configuration options for the AI-powered natural language query translator.
+/// </summary>
+public sealed class QueryingAIOptions
+{
+    /// <summary>
+    /// Configuration section name (<c>"AI:Querying"</c>).
+    /// </summary>
+    public const string SectionName = "AI:Querying";
+
+    /// <summary>
+    /// AI workspace name used to create the <c>IChatClient</c>. Defaults to <c>"default"</c>.
+    /// </summary>
+    public string WorkspaceName { get; set; } = "default";
+
+    /// <summary>
+    /// Timeout in seconds for the LLM call. NLQ should be fast. Defaults to <c>5</c>.
+    /// </summary>
+    public int TimeoutSeconds { get; set; } = 5;
+}

--- a/src/Granit.Querying.AI/README.md
+++ b/src/Granit.Querying.AI/README.md
@@ -1,0 +1,20 @@
+# Granit.Querying.AI
+
+Natural Language Query (NLQ) for Granit.Querying. Translates natural language into structured QueryRequest objects using LLM.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.Querying.AI
+```
+
+## Dependencies
+
+- `Granit.AI`
+- `Granit.Querying`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.Querying.AI/packages.lock.json
+++ b/src/Granit.Querying.AI/packages.lock.json
@@ -1,0 +1,155 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
+      },
+      "granit.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.core": {
+        "type": "Project"
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.querying": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.4.0",
+        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      }
+    }
+  }
+}

--- a/tests/Granit.AI.Extraction.Tests/DefaultDocumentExtractorTests.cs
+++ b/tests/Granit.AI.Extraction.Tests/DefaultDocumentExtractorTests.cs
@@ -1,0 +1,187 @@
+using Granit.AI.Extraction;
+using Granit.AI.Extraction.Internal;
+using Granit.AI.Extraction.Options;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+
+namespace Granit.AI.Extraction.Tests;
+
+public sealed record InvoiceData
+{
+    public string? Supplier { get; init; }
+    public decimal Amount { get; init; }
+    public string? Currency { get; init; }
+}
+
+public sealed class DefaultDocumentExtractorTests
+{
+    private readonly IAIChatClientFactory _chatClientFactory = Substitute.For<IAIChatClientFactory>();
+    private readonly IChatClient _chatClient = Substitute.For<IChatClient>();
+    private readonly IOptions<ExtractionOptions> _options = Microsoft.Extensions.Options.Options.Create(new ExtractionOptions
+    {
+        WorkspaceName = "test",
+        ReviewThreshold = 0.7,
+        TimeoutSeconds = 30,
+    });
+
+    private readonly DefaultDocumentExtractor<InvoiceData> _sut;
+
+    public DefaultDocumentExtractorTests()
+    {
+        _chatClientFactory
+            .CreateAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(_chatClient);
+
+        _sut = new DefaultDocumentExtractor<InvoiceData>(
+            _chatClientFactory,
+            _options,
+            NullLogger<DefaultDocumentExtractor<InvoiceData>>.Instance);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ValidResponse_ReturnsSuccess()
+    {
+        // Arrange
+        const string jsonResponse = """{"supplier":"Acme Corp","amount":1500.50,"currency":"EUR"}""";
+
+        _chatClient
+            .GetResponseAsync(
+                Arg.Any<IEnumerable<ChatMessage>>(),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ChatResponse(new ChatMessage(ChatRole.Assistant, jsonResponse))
+            {
+                FinishReason = ChatFinishReason.Stop,
+            });
+
+        // Act
+        ExtractionResult<InvoiceData> result = await _sut.ExtractAsync("Invoice from Acme Corp, total 1500.50 EUR", TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.ShouldBe(ExtractionStatus.Succeeded);
+        result.Data.ShouldNotBeNull();
+        result.Data.Supplier.ShouldBe("Acme Corp");
+        result.Data.Amount.ShouldBe(1500.50m);
+        result.Data.Currency.ShouldBe("EUR");
+        result.ConfidenceScore.ShouldNotBeNull();
+        result.ConfidenceScore.Value.ShouldBeGreaterThanOrEqualTo(0.7);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_LowConfidence_ReturnsNeedsReview()
+    {
+        // Arrange
+        const string jsonResponse = """{"supplier":"Unknown","amount":0,"currency":"USD"}""";
+
+        // No FinishReason.Stop and no confidence metadata -> default 0.75
+        // But we need below threshold, so set threshold high
+        IOptions<ExtractionOptions> highThresholdOptions = Microsoft.Extensions.Options.Options.Create(new ExtractionOptions
+        {
+            WorkspaceName = "test",
+            ReviewThreshold = 0.9,
+            TimeoutSeconds = 30,
+        });
+
+        var extractor = new DefaultDocumentExtractor<InvoiceData>(
+            _chatClientFactory,
+            highThresholdOptions,
+            NullLogger<DefaultDocumentExtractor<InvoiceData>>.Instance);
+
+        _chatClient
+            .GetResponseAsync(
+                Arg.Any<IEnumerable<ChatMessage>>(),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ChatResponse(new ChatMessage(ChatRole.Assistant, jsonResponse)));
+
+        // Act
+        ExtractionResult<InvoiceData> result = await extractor.ExtractAsync("Some ambiguous document", TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.ShouldBe(ExtractionStatus.NeedsReview);
+        result.Data.ShouldNotBeNull();
+        result.Data.Supplier.ShouldBe("Unknown");
+        result.Warnings.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_LLMFailure_ReturnsFailed()
+    {
+        // Arrange
+        _chatClient
+            .GetResponseAsync(
+                Arg.Any<IEnumerable<ChatMessage>>(),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Provider unavailable"));
+
+        // Act
+        ExtractionResult<InvoiceData> result = await _sut.ExtractAsync("Some document content", TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.ShouldBe(ExtractionStatus.Failed);
+        result.Data.ShouldBeNull();
+        result.ErrorMessage.ShouldNotBeNull();
+        result.ErrorMessage.ShouldContain("Provider unavailable");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_InvalidJson_ReturnsFailed()
+    {
+        // Arrange
+        _chatClient
+            .GetResponseAsync(
+                Arg.Any<IEnumerable<ChatMessage>>(),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ChatResponse(new ChatMessage(ChatRole.Assistant, "not valid json")));
+
+        // Act
+        ExtractionResult<InvoiceData> result = await _sut.ExtractAsync("Some document", TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.ShouldBe(ExtractionStatus.Failed);
+        result.ErrorMessage.ShouldNotBeNull();
+        result.ErrorMessage.ShouldContain("deserialize");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_MarkdownCodeFences_StripsAndParses()
+    {
+        // Arrange
+        const string jsonWithFences = """
+            ```json
+            {"supplier":"Fenced Corp","amount":200,"currency":"GBP"}
+            ```
+            """;
+
+        _chatClient
+            .GetResponseAsync(
+                Arg.Any<IEnumerable<ChatMessage>>(),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ChatResponse(new ChatMessage(ChatRole.Assistant, jsonWithFences))
+            {
+                FinishReason = ChatFinishReason.Stop,
+            });
+
+        // Act
+        ExtractionResult<InvoiceData> result = await _sut.ExtractAsync("Document with fenced response", TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.ShouldBe(ExtractionStatus.Succeeded);
+        result.Data.ShouldNotBeNull();
+        result.Data.Supplier.ShouldBe("Fenced Corp");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_NullContent_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        await Should.ThrowAsync<ArgumentNullException>(() => _sut.ExtractAsync(null!, TestContext.Current.CancellationToken));
+    }
+}

--- a/tests/Granit.AI.Extraction.Tests/ExtractionResultTests.cs
+++ b/tests/Granit.AI.Extraction.Tests/ExtractionResultTests.cs
@@ -1,0 +1,76 @@
+using Granit.AI.Extraction;
+using Shouldly;
+
+namespace Granit.AI.Extraction.Tests;
+
+public sealed class ExtractionResultTests
+{
+    private sealed record SampleData
+    {
+        public string? Name { get; init; }
+        public int Value { get; init; }
+    }
+
+    [Fact]
+    public void Success_SetsCorrectProperties()
+    {
+        // Arrange
+        var data = new SampleData { Name = "Test", Value = 42 };
+        List<string> warnings = ["minor warning"];
+
+        // Act
+        var result = ExtractionResult.Success(data, 0.95, warnings);
+
+        // Assert
+        result.Status.ShouldBe(ExtractionStatus.Succeeded);
+        result.Data.ShouldBe(data);
+        result.ConfidenceScore.ShouldBe(0.95);
+        result.ErrorMessage.ShouldBeNull();
+        result.Warnings.ShouldBe(warnings);
+    }
+
+    [Fact]
+    public void Success_WithoutWarnings_DefaultsToEmptyList()
+    {
+        // Arrange
+        var data = new SampleData { Name = "Test", Value = 1 };
+
+        // Act
+        var result = ExtractionResult.Success(data, 0.9);
+
+        // Assert
+        result.Warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Failed_SetsCorrectProperties()
+    {
+        // Act
+        var result = ExtractionResult.Failed<SampleData>("Something went wrong");
+
+        // Assert
+        result.Status.ShouldBe(ExtractionStatus.Failed);
+        result.Data.ShouldBeNull();
+        result.ConfidenceScore.ShouldBeNull();
+        result.ErrorMessage.ShouldBe("Something went wrong");
+        result.Warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void NeedsReview_SetsCorrectProperties()
+    {
+        // Arrange
+        var data = new SampleData { Name = "Uncertain", Value = 0 };
+        List<string> warnings = ["Low confidence on Name field"];
+
+        // Act
+        var result = ExtractionResult.NeedsReview(data, 0.55, warnings);
+
+        // Assert
+        result.Status.ShouldBe(ExtractionStatus.NeedsReview);
+        result.Data.ShouldBe(data);
+        result.ConfidenceScore.ShouldBe(0.55);
+        result.ErrorMessage.ShouldBeNull();
+        result.Warnings.ShouldBe(warnings);
+    }
+}

--- a/tests/Granit.AI.Extraction.Tests/GlobalUsings.cs
+++ b/tests/Granit.AI.Extraction.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Granit.AI.Extraction.Tests/Granit.AI.Extraction.Tests.csproj
+++ b/tests/Granit.AI.Extraction.Tests/Granit.AI.Extraction.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.AI.Extraction\Granit.AI.Extraction.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.AI.Extraction.Tests/packages.lock.json
+++ b/tests/Granit.AI.Extraction.Tests/packages.lock.json
@@ -1,0 +1,389 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[8.*, )",
+        "resolved": "8.0.0",
+        "contentHash": "EMkj/2F6n6IVPrvGYkqzGJs6phuGGkq6N+E7KW9rNyzNxXbwQ1KfMqWyXNf9nCNEQOA6IjFwmOLvkriwKE7Orw=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.*, )",
+        "resolved": "18.3.0",
+        "contentHash": "xW3kXuWRQtgoxJp4J+gdhHSQyK+6Wb/AZDSd7lMvuMRYlZ1tnpkojyfZlWilB5G4dmZ0Y0ZxU/M23TlubndNkw==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.3.0",
+          "Microsoft.TestPlatform.TestHost": "18.3.0"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.*, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "23BNy/vziREC20Wwhb50K7+kZe0m07KlLWDQv4qjJ9tt3QjpDpDIqJFrhYHmMEo9xDkuSp55U/8h4bMF7MiB+g=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "AEIEX2aWdPO9XbtR96eBaJxmXRD9vaI9uQ1T/JbPEKlTAZwYx0ZrMzKyULMdh/HH9Sg03kXCoN7LszQ90o6nPQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "twmsoelXnp1uWMU3VGip9f0Jr1mZ0PZqgJdF35CIrdYgYrkHIJMV1m8uKyhcdjLdsQDESHAgkR7KhS9i1qpJag==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.3.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "granit.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.ai.extraction": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.AI": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.core": {
+        "type": "Project"
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.4.0",
+        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      }
+    }
+  }
+}

--- a/tests/Granit.AI.VectorData.Tests/DefaultSemanticSearchServiceTests.cs
+++ b/tests/Granit.AI.VectorData.Tests/DefaultSemanticSearchServiceTests.cs
@@ -1,0 +1,124 @@
+using Granit.AI;
+using Granit.AI.VectorData;
+using Granit.AI.VectorData.Internal;
+using Granit.AI.VectorData.Options;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+
+namespace Granit.AI.VectorData.Tests;
+
+public sealed class DefaultSemanticSearchServiceTests
+{
+    private readonly IAIEmbeddingGeneratorFactory _embeddingGeneratorFactory = Substitute.For<IAIEmbeddingGeneratorFactory>();
+    private readonly IVectorCollectionFactory _vectorCollectionFactory = Substitute.For<IVectorCollectionFactory>();
+    private readonly IOptions<VectorDataOptions> _options = Microsoft.Extensions.Options.Options.Create(new VectorDataOptions());
+    private readonly IEmbeddingGenerator<string, Embedding<float>> _embeddingGenerator = Substitute.For<IEmbeddingGenerator<string, Embedding<float>>>();
+    private readonly IVectorCollection<TextVectorRecord> _vectorCollection = Substitute.For<IVectorCollection<TextVectorRecord>>();
+    private readonly DefaultSemanticSearchService _sut;
+
+    public DefaultSemanticSearchServiceTests()
+    {
+        _embeddingGeneratorFactory.CreateAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(_embeddingGenerator);
+        _vectorCollectionFactory.GetCollection<TextVectorRecord>(Arg.Any<string>()).Returns(_vectorCollection);
+
+        _sut = new DefaultSemanticSearchService(
+            _embeddingGeneratorFactory,
+            _vectorCollectionFactory,
+            _options,
+            NullLogger<DefaultSemanticSearchService>.Instance);
+    }
+
+    [Fact]
+    public async Task IndexAsync_GeneratesEmbeddingAndUpsertsRecord()
+    {
+        float[] vector = [0.1f, 0.2f, 0.3f];
+        var embedding = new Embedding<float>(vector);
+        var embeddings = new GeneratedEmbeddings<Embedding<float>>([embedding]);
+
+        _embeddingGenerator
+            .GenerateAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<EmbeddingGenerationOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(embeddings);
+
+        await _sut.IndexAsync("test-collection", "doc-1", "Hello world", TestContext.Current.CancellationToken);
+
+        await _embeddingGeneratorFactory.Received(1).CreateAsync("default", Arg.Any<CancellationToken>());
+        await _vectorCollection.Received(1).UpsertAsync(
+            Arg.Is<TextVectorRecord>(r => r.Key == "doc-1" && r.Text == "Hello world"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SearchAsync_GeneratesEmbeddingAndSearchesCollection()
+    {
+        float[] vector = [0.4f, 0.5f, 0.6f];
+        var embedding = new Embedding<float>(vector);
+        var embeddings = new GeneratedEmbeddings<Embedding<float>>([embedding]);
+
+        _embeddingGenerator
+            .GenerateAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<EmbeddingGenerationOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(embeddings);
+
+        List<VectorSearchResult<TextVectorRecord>> searchResults =
+        [
+            new(new TextVectorRecord { Key = "doc-1", Text = "Hello world", Vector = new float[] { 0.1f, 0.2f, 0.3f } }, 0.95),
+            new(new TextVectorRecord { Key = "doc-2", Text = "Goodbye world", Vector = new float[] { 0.4f, 0.5f, 0.6f } }, 0.80),
+        ];
+
+        _vectorCollection
+            .SearchAsync(Arg.Any<ReadOnlyMemory<float>>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(searchResults);
+
+        IReadOnlyList<SemanticSearchResult> results = await _sut.SearchAsync("test-collection", "search query", 5, TestContext.Current.CancellationToken);
+
+        results.Count.ShouldBe(2);
+        results[0].Key.ShouldBe("doc-1");
+        results[0].Score.ShouldBe(0.95);
+        results[0].Text.ShouldBe("Hello world");
+
+        await _embeddingGeneratorFactory.Received(1).CreateAsync("default", Arg.Any<CancellationToken>());
+        await _vectorCollection.Received(1).SearchAsync(
+            Arg.Any<ReadOnlyMemory<float>>(),
+            5,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SearchAsync_UsesDefaultLimitFromOptionsWhenLimitIsZero()
+    {
+        float[] vector = [0.1f, 0.2f, 0.3f];
+        var embedding = new Embedding<float>(vector);
+        var embeddings = new GeneratedEmbeddings<Embedding<float>>([embedding]);
+
+        _embeddingGenerator
+            .GenerateAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<EmbeddingGenerationOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(embeddings);
+
+        _vectorCollection
+            .SearchAsync(Arg.Any<ReadOnlyMemory<float>>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new List<VectorSearchResult<TextVectorRecord>>());
+
+        await _sut.SearchAsync("test-collection", "query", limit: 0, TestContext.Current.CancellationToken);
+
+        await _vectorCollection.Received(1).SearchAsync(
+            Arg.Any<ReadOnlyMemory<float>>(),
+            10,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task IndexAsync_ThrowsOnNullCollectionName()
+    {
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => _sut.IndexAsync(null!, "key", "text", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task SearchAsync_ThrowsOnNullQuery()
+    {
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => _sut.SearchAsync("collection", null!, cancellationToken: TestContext.Current.CancellationToken));
+    }
+}

--- a/tests/Granit.AI.VectorData.Tests/GlobalUsings.cs
+++ b/tests/Granit.AI.VectorData.Tests/GlobalUsings.cs
@@ -1,0 +1,3 @@
+global using NSubstitute;
+global using Shouldly;
+global using Xunit;

--- a/tests/Granit.AI.VectorData.Tests/Granit.AI.VectorData.Tests.csproj
+++ b/tests/Granit.AI.VectorData.Tests/Granit.AI.VectorData.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.AI.VectorData\Granit.AI.VectorData.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.AI.VectorData.Tests/packages.lock.json
+++ b/tests/Granit.AI.VectorData.Tests/packages.lock.json
@@ -1,0 +1,400 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[8.*, )",
+        "resolved": "8.0.0",
+        "contentHash": "EMkj/2F6n6IVPrvGYkqzGJs6phuGGkq6N+E7KW9rNyzNxXbwQ1KfMqWyXNf9nCNEQOA6IjFwmOLvkriwKE7Orw=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.*, )",
+        "resolved": "18.3.0",
+        "contentHash": "xW3kXuWRQtgoxJp4J+gdhHSQyK+6Wb/AZDSd7lMvuMRYlZ1tnpkojyfZlWilB5G4dmZ0Y0ZxU/M23TlubndNkw==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.3.0",
+          "Microsoft.TestPlatform.TestHost": "18.3.0"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.*, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "23BNy/vziREC20Wwhb50K7+kZe0m07KlLWDQv4qjJ9tt3QjpDpDIqJFrhYHmMEo9xDkuSp55U/8h4bMF7MiB+g=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "AEIEX2aWdPO9XbtR96eBaJxmXRD9vaI9uQ1T/JbPEKlTAZwYx0ZrMzKyULMdh/HH9Sg03kXCoN7LszQ90o6nPQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "twmsoelXnp1uWMU3VGip9f0Jr1mZ0PZqgJdF35CIrdYgYrkHIJMV1m8uKyhcdjLdsQDESHAgkR7KhS9i1qpJag==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.3.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "granit.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.ai.vectordata": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.AI": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "Microsoft.Extensions.VectorData.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.core": {
+        "type": "Project"
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.4.0",
+        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.VectorData.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.1",
+        "contentHash": "1vsHJaRET/Q8aldtGiaAP4BKXBrVA9Y1brgYbpWyQQsr6HN7fN5+Qw74sC8g+JSHiZONJ4134pPQd1mk7fGlQw==",
+        "dependencies": {
+          "Microsoft.Extensions.AI.Abstractions": "10.3.0"
+        }
+      }
+    }
+  }
+}

--- a/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
+++ b/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
@@ -34,6 +34,7 @@
     <ProjectReference Include="..\..\src\Granit.AI.Anthropic\Granit.AI.Anthropic.csproj" />
     <ProjectReference Include="..\..\src\Granit.AI.AzureOpenAI\Granit.AI.AzureOpenAI.csproj" />
     <ProjectReference Include="..\..\src\Granit.AI.EntityFrameworkCore\Granit.AI.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\src\Granit.AI.Extraction\Granit.AI.Extraction.csproj" />
     <ProjectReference Include="..\..\src\Granit.AI.Ollama\Granit.AI.Ollama.csproj" />
     <ProjectReference Include="..\..\src\Granit.AI.OpenAI\Granit.AI.OpenAI.csproj" />
     <ProjectReference Include="..\..\src\Granit.ApiDocumentation\Granit.ApiDocumentation.csproj" />
@@ -70,6 +71,7 @@
     <ProjectReference Include="..\..\src\Granit.Core\Granit.Core.csproj" />
     <ProjectReference Include="..\..\src\Granit.Cors\Granit.Cors.csproj" />
     <ProjectReference Include="..\..\src\Granit.DataExchange\Granit.DataExchange.csproj" />
+    <ProjectReference Include="..\..\src\Granit.DataExchange.AI\Granit.DataExchange.AI.csproj" />
     <ProjectReference Include="..\..\src\Granit.DataExchange.Csv\Granit.DataExchange.Csv.csproj" />
     <ProjectReference Include="..\..\src\Granit.DataExchange.Endpoints\Granit.DataExchange.Endpoints.csproj" />
     <ProjectReference Include="..\..\src\Granit.DataExchange.EntityFrameworkCore\Granit.DataExchange.EntityFrameworkCore.csproj" />

--- a/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
+++ b/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
@@ -36,6 +36,7 @@
     <ProjectReference Include="..\..\src\Granit.AI.EntityFrameworkCore\Granit.AI.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\src\Granit.AI.Extraction\Granit.AI.Extraction.csproj" />
     <ProjectReference Include="..\..\src\Granit.AI.Ollama\Granit.AI.Ollama.csproj" />
+    <ProjectReference Include="..\..\src\Granit.AI.VectorData\Granit.AI.VectorData.csproj" />
     <ProjectReference Include="..\..\src\Granit.AI.OpenAI\Granit.AI.OpenAI.csproj" />
     <ProjectReference Include="..\..\src\Granit.ApiDocumentation\Granit.ApiDocumentation.csproj" />
     <ProjectReference Include="..\..\src\Granit.ApiVersioning\Granit.ApiVersioning.csproj" />
@@ -132,6 +133,7 @@
     <ProjectReference Include="..\..\src\Granit.Privacy\Granit.Privacy.csproj" />
     <ProjectReference Include="..\..\src\Granit.Querying\Granit.Querying.csproj" />
     <ProjectReference Include="..\..\src\Granit.RateLimiting\Granit.RateLimiting.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Querying.AI\Granit.Querying.AI.csproj" />
     <ProjectReference Include="..\..\src\Granit.Querying.Endpoints\Granit.Querying.Endpoints.csproj" />
     <ProjectReference Include="..\..\src\Granit.Querying.EntityFrameworkCore\Granit.Querying.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\src\Granit.ReferenceData\Granit.ReferenceData.csproj" />

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1218,6 +1218,12 @@
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
         }
       },
+      "granit.ai.extraction": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.AI": "[0.1.0-dev, )"
+        }
+      },
       "granit.ai.ollama": {
         "type": "Project",
         "dependencies": {
@@ -1503,6 +1509,13 @@
           "Granit.Querying": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dataexchange.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.AI": "[0.1.0-dev, )",
+          "Granit.DataExchange": "[0.1.0-dev, )"
         }
       },
       "granit.dataexchange.csv": {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1238,6 +1238,13 @@
           "Microsoft.Extensions.AI.OpenAI": "[10.*, )"
         }
       },
+      "granit.ai.vectordata": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.AI": "[0.1.0-dev, )",
+          "Microsoft.Extensions.VectorData.Abstractions": "[10.*, )"
+        }
+      },
       "granit.apidocumentation": {
         "type": "Project",
         "dependencies": {
@@ -1958,6 +1965,14 @@
           "Granit.Core": "[0.1.0-dev, )"
         }
       },
+      "granit.querying.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.AI": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
       "granit.querying.endpoints": {
         "type": "Project",
         "dependencies": {
@@ -2673,6 +2688,15 @@
         "dependencies": {
           "Microsoft.Extensions.Http.Diagnostics": "10.4.0",
           "Microsoft.Extensions.Resilience": "10.4.0"
+        }
+      },
+      "Microsoft.Extensions.VectorData.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.1",
+        "contentHash": "1vsHJaRET/Q8aldtGiaAP4BKXBrVA9Y1brgYbpWyQQsr6HN7fN5+Qw74sC8g+JSHiZONJ4134pPQd1mk7fGlQw==",
+        "dependencies": {
+          "Microsoft.Extensions.AI.Abstractions": "10.3.0"
         }
       },
       "Microsoft.IO.RecyclableMemoryStream": {

--- a/tests/Granit.DataExchange.AI.Tests/AISemanticMappingServiceTests.cs
+++ b/tests/Granit.DataExchange.AI.Tests/AISemanticMappingServiceTests.cs
@@ -1,0 +1,207 @@
+using Granit.AI;
+using Granit.DataExchange.AI.Internal;
+using Granit.DataExchange.AI.Options;
+using Granit.DataExchange.Import.Mapping;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+
+namespace Granit.DataExchange.AI.Tests;
+
+public sealed class AISemanticMappingServiceTests
+{
+    private readonly IAIChatClientFactory _chatClientFactory = Substitute.For<IAIChatClientFactory>();
+    private readonly IChatClient _chatClient = Substitute.For<IChatClient>();
+    private readonly ILogger<AISemanticMappingService> _logger = NullLogger<AISemanticMappingService>.Instance;
+
+    private readonly DataExchangeAIOptions _options = new()
+    {
+        WorkspaceName = "test-workspace",
+        TimeoutSeconds = 10,
+        MinConfidenceScore = 0.6,
+    };
+
+    private readonly IReadOnlyList<string> _headers = ["Email", "Full Name", "Phone Number"];
+
+    private readonly IReadOnlyList<ImportFieldMetadata> _targetFields =
+    [
+        new("Email", "String", "Email Address", "The user's email", true),
+        new("FullName", "String", "Full Name", "The user's full name", true),
+        new("PhoneNumber", "String", "Phone", "Contact phone number", false),
+    ];
+
+    private AISemanticMappingService CreateService() =>
+        new(_chatClientFactory, Microsoft.Extensions.Options.Options.Create(_options), _logger);
+
+    private void SetupChatClient(string jsonResponse)
+    {
+        _chatClientFactory
+            .CreateAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(_chatClient);
+
+        var response = new ChatResponse(new ChatMessage(ChatRole.Assistant, jsonResponse));
+        _chatClient
+            .GetResponseAsync(
+                Arg.Any<IEnumerable<ChatMessage>>(),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+    }
+
+    [Fact]
+    public void IsAvailable_ReturnsTrue()
+    {
+        AISemanticMappingService service = CreateService();
+
+        service.IsAvailable.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task SuggestSemanticMappingsAsync_WithValidResponse_ReturnsMappings()
+    {
+        const string jsonResponse = """
+            [
+                {"source": "Email", "target": "Email", "score": 0.95},
+                {"source": "Full Name", "target": "FullName", "score": 0.90},
+                {"source": "Phone Number", "target": "PhoneNumber", "score": 0.85}
+            ]
+            """;
+
+        SetupChatClient(jsonResponse);
+
+        AISemanticMappingService service = CreateService();
+
+        IReadOnlyList<SemanticMappingSuggestion> result = await service
+            .SuggestSemanticMappingsAsync(_headers, _targetFields, TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(3);
+        result[0].SourceColumn.ShouldBe("Email");
+        result[0].TargetProperty.ShouldBe("Email");
+        result[0].Score.ShouldBe(0.95);
+        result[1].SourceColumn.ShouldBe("Full Name");
+        result[1].TargetProperty.ShouldBe("FullName");
+        result[2].SourceColumn.ShouldBe("Phone Number");
+        result[2].TargetProperty.ShouldBe("PhoneNumber");
+
+        // Should be sorted by score descending
+        result[0].Score.ShouldBeGreaterThanOrEqualTo(result[1].Score);
+        result[1].Score.ShouldBeGreaterThanOrEqualTo(result[2].Score);
+    }
+
+    [Fact]
+    public async Task SuggestSemanticMappingsAsync_WithLLMFailure_ReturnsEmptyList()
+    {
+        _chatClientFactory
+            .CreateAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("LLM provider unavailable"));
+
+        AISemanticMappingService service = CreateService();
+
+        IReadOnlyList<SemanticMappingSuggestion> result = await service
+            .SuggestSemanticMappingsAsync(_headers, _targetFields, TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task SuggestSemanticMappingsAsync_FiltersLowConfidence()
+    {
+        const string jsonResponse = """
+            [
+                {"source": "Email", "target": "Email", "score": 0.95},
+                {"source": "Full Name", "target": "FullName", "score": 0.40},
+                {"source": "Phone Number", "target": "PhoneNumber", "score": 0.55}
+            ]
+            """;
+
+        SetupChatClient(jsonResponse);
+
+        AISemanticMappingService service = CreateService();
+
+        IReadOnlyList<SemanticMappingSuggestion> result = await service
+            .SuggestSemanticMappingsAsync(_headers, _targetFields, TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(1);
+        result[0].SourceColumn.ShouldBe("Email");
+        result[0].Score.ShouldBe(0.95);
+    }
+
+    [Fact]
+    public async Task SuggestSemanticMappingsAsync_WithEmptyHeaders_ReturnsEmptyList()
+    {
+        AISemanticMappingService service = CreateService();
+
+        IReadOnlyList<SemanticMappingSuggestion> result = await service
+            .SuggestSemanticMappingsAsync([], _targetFields, TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task SuggestSemanticMappingsAsync_WithEmptyTargetFields_ReturnsEmptyList()
+    {
+        AISemanticMappingService service = CreateService();
+
+        IReadOnlyList<SemanticMappingSuggestion> result = await service
+            .SuggestSemanticMappingsAsync(_headers, [], TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task SuggestSemanticMappingsAsync_WithMarkdownFencedResponse_ParsesCorrectly()
+    {
+        const string jsonResponse = """
+            ```json
+            [
+                {"source": "Email", "target": "Email", "score": 0.95}
+            ]
+            ```
+            """;
+
+        SetupChatClient(jsonResponse);
+
+        AISemanticMappingService service = CreateService();
+
+        IReadOnlyList<SemanticMappingSuggestion> result = await service
+            .SuggestSemanticMappingsAsync(_headers, _targetFields, TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(1);
+        result[0].SourceColumn.ShouldBe("Email");
+    }
+
+    [Fact]
+    public void BuildPrompt_ContainsHeadersAndFields()
+    {
+        string prompt = AISemanticMappingService.BuildPrompt(_headers, _targetFields, 0.6);
+
+        prompt.ShouldContain("Email, Full Name, Phone Number");
+        prompt.ShouldContain("Email Address");
+        prompt.ShouldContain("The user's email");
+        prompt.ShouldContain("FullName");
+        prompt.ShouldContain("PhoneNumber");
+        prompt.ShouldContain("0.6");
+    }
+
+    [Fact]
+    public void ParseSuggestions_WithInvalidJson_ReturnsEmptyList()
+    {
+        IReadOnlyList<SemanticMappingSuggestion> result =
+            AISemanticMappingService.ParseSuggestions("not valid json");
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ParseSuggestions_WithEmptyArray_ReturnsEmptyList()
+    {
+        IReadOnlyList<SemanticMappingSuggestion> result =
+            AISemanticMappingService.ParseSuggestions("[]");
+
+        result.ShouldBeEmpty();
+    }
+}

--- a/tests/Granit.DataExchange.AI.Tests/AISemanticMappingServiceTests.cs
+++ b/tests/Granit.DataExchange.AI.Tests/AISemanticMappingServiceTests.cs
@@ -188,6 +188,78 @@ public sealed class AISemanticMappingServiceTests
     }
 
     [Fact]
+    public void BuildPrompt_WithPreviewRows_IncludesSampleData()
+    {
+        IReadOnlyList<string[]> previewRows =
+        [
+            ["john@example.com", "John Doe", "+32 123 456"],
+            ["jane@example.com", "Jane Smith", "+32 789 012"],
+        ];
+
+        string prompt = AISemanticMappingService.BuildPrompt(_headers, _targetFields, 0.6, previewRows);
+
+        prompt.ShouldContain("Sample data (first rows):");
+        prompt.ShouldContain("john@example.com");
+        prompt.ShouldContain("Jane Smith");
+    }
+
+    [Fact]
+    public void BuildPrompt_WithoutPreviewRows_DoesNotContainSampleData()
+    {
+        string prompt = AISemanticMappingService.BuildPrompt(_headers, _targetFields, 0.6, previewRows: null);
+
+        prompt.ShouldNotContain("Sample data");
+    }
+
+    [Fact]
+    public async Task SuggestSemanticMappingsAsync_WithPreviewRows_IgnoredWhenOptionDisabled()
+    {
+        _options.IncludePreviewRows = false;
+
+        const string jsonResponse = """[{"source": "COL1", "target": "Email", "score": 0.9}]""";
+        SetupChatClient(jsonResponse);
+
+        AISemanticMappingService service = CreateService();
+        IReadOnlyList<string[]> previewRows = [["john@example.com"]];
+
+        IReadOnlyList<SemanticMappingSuggestion> result = await service
+            .SuggestSemanticMappingsAsync(["COL1"], _targetFields, previewRows, TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(1);
+
+        // Verify the prompt does NOT contain sample data (option is disabled)
+        await _chatClient.Received(1).GetResponseAsync(
+            Arg.Is<IEnumerable<ChatMessage>>(msgs =>
+                !string.Join("", msgs.Select(m => m.Text)).Contains("Sample data")),
+            Arg.Any<ChatOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SuggestSemanticMappingsAsync_WithPreviewRows_IncludedWhenOptionEnabled()
+    {
+        _options.IncludePreviewRows = true;
+
+        const string jsonResponse = """[{"source": "COL1", "target": "Email", "score": 0.9}]""";
+        SetupChatClient(jsonResponse);
+
+        AISemanticMappingService service = CreateService();
+        IReadOnlyList<string[]> previewRows = [["john@example.com"]];
+
+        IReadOnlyList<SemanticMappingSuggestion> result = await service
+            .SuggestSemanticMappingsAsync(["COL1"], _targetFields, previewRows, TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(1);
+
+        // Verify the prompt DOES contain sample data
+        await _chatClient.Received(1).GetResponseAsync(
+            Arg.Is<IEnumerable<ChatMessage>>(msgs =>
+                string.Join("", msgs.Select(m => m.Text)).Contains("Sample data")),
+            Arg.Any<ChatOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public void ParseSuggestions_WithInvalidJson_ReturnsEmptyList()
     {
         IReadOnlyList<SemanticMappingSuggestion> result =

--- a/tests/Granit.DataExchange.AI.Tests/GlobalUsings.cs
+++ b/tests/Granit.DataExchange.AI.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Granit.DataExchange.AI.Tests/Granit.DataExchange.AI.Tests.csproj
+++ b/tests/Granit.DataExchange.AI.Tests/Granit.DataExchange.AI.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.DataExchange.AI\Granit.DataExchange.AI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.DataExchange.AI.Tests/packages.lock.json
+++ b/tests/Granit.DataExchange.AI.Tests/packages.lock.json
@@ -1,0 +1,499 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[8.*, )",
+        "resolved": "8.0.0",
+        "contentHash": "EMkj/2F6n6IVPrvGYkqzGJs6phuGGkq6N+E7KW9rNyzNxXbwQ1KfMqWyXNf9nCNEQOA6IjFwmOLvkriwKE7Orw=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.*, )",
+        "resolved": "18.3.0",
+        "contentHash": "xW3kXuWRQtgoxJp4J+gdhHSQyK+6Wb/AZDSd7lMvuMRYlZ1tnpkojyfZlWilB5G4dmZ0Y0ZxU/M23TlubndNkw==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.3.0",
+          "Microsoft.TestPlatform.TestHost": "18.3.0"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.*, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "23BNy/vziREC20Wwhb50K7+kZe0m07KlLWDQv4qjJ9tt3QjpDpDIqJFrhYHmMEo9xDkuSp55U/8h4bMF7MiB+g=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "xKobiPRPVkK/bD/oLUTF1OnilG3N+4o0u/T8YWqHq+E97zWgCRr8Zhk9N6OZeLBSNHC7imT53QkH/yv9MaXkew=="
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "AEIEX2aWdPO9XbtR96eBaJxmXRD9vaI9uQ1T/JbPEKlTAZwYx0ZrMzKyULMdh/HH9Sg03kXCoN7LszQ90o6nPQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "twmsoelXnp1uWMU3VGip9f0Jr1mZ0PZqgJdF35CIrdYgYrkHIJMV1m8uKyhcdjLdsQDESHAgkR7KhS9i1qpJag==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.3.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
+      "granit.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.core": {
+        "type": "Project"
+      },
+      "granit.dataexchange": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.dataexchange.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.AI": "[0.1.0-dev, )",
+          "Granit.DataExchange": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.querying": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.validation": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.*, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.*, )",
+          "Granit.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
+        }
+      },
+      "FluentValidation": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.4.0",
+        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "k/QDdQ94/0Shi0KfU+e12m73jfQo+3JpErTtgpZfsCIqkvdEEO0XIx6R+iTbN55rNPaNhOqNY4/sB+jZ8XxVPw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "jUEXmkBUPdOS/MP9areK/sbKhdklq9+tEhvwfxGalZVnmyLUO5rrheNNutUBtvbZ7J8ECkG7/r2KXi/IFC06cA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "Co/URpVB1P1WbvswTumphjYZcvqTA2piSTLVOVtN6qLNrK6pg0OjZ/9SzigI+7NYGS2UpxVMydk/n45VvWZvOg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      }
+    }
+  }
+}

--- a/tests/Granit.Querying.AI.Tests/GlobalUsings.cs
+++ b/tests/Granit.Querying.AI.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Granit.Querying.AI.Tests/Granit.Querying.AI.Tests.csproj
+++ b/tests/Granit.Querying.AI.Tests/Granit.Querying.AI.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Querying.AI\Granit.Querying.AI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.Querying.AI.Tests/LlmNaturalLanguageQueryTranslatorTests.cs
+++ b/tests/Granit.Querying.AI.Tests/LlmNaturalLanguageQueryTranslatorTests.cs
@@ -1,0 +1,258 @@
+using Granit.AI;
+using Granit.Querying.AI.Internal;
+using Granit.Querying.AI.Options;
+using Granit.Querying.Filtering;
+using Granit.Querying.Meta;
+using Granit.Timing;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+
+namespace Granit.Querying.AI.Tests;
+
+public sealed class LlmNaturalLanguageQueryTranslatorTests
+{
+    private readonly IAIChatClientFactory _chatClientFactory = Substitute.For<IAIChatClientFactory>();
+    private readonly IChatClient _chatClient = Substitute.For<IChatClient>();
+    private readonly IOptions<QueryingAIOptions> _options = Microsoft.Extensions.Options.Options.Create(new QueryingAIOptions());
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly LlmNaturalLanguageQueryTranslator _sut;
+
+    public LlmNaturalLanguageQueryTranslatorTests()
+    {
+        _chatClientFactory
+            .CreateAsync(Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(_chatClient);
+
+        _clock.Now.Returns(new DateTimeOffset(2026, 3, 16, 0, 0, 0, TimeSpan.Zero));
+
+        _sut = new LlmNaturalLanguageQueryTranslator(
+            _chatClientFactory,
+            _options,
+            NullLogger<LlmNaturalLanguageQueryTranslator>.Instance,
+            _clock);
+    }
+
+    [Fact]
+    public async Task TranslateAsync_ValidResponse_ReturnsQueryRequest()
+    {
+        // Arrange
+        const string jsonText = """
+            {
+                "sort": "-createdAt",
+                "filter": {
+                    "status.eq": "active",
+                    "amount.gte": "1000"
+                }
+            }
+            """;
+
+        var response = new ChatResponse(new ChatMessage(ChatRole.Assistant, jsonText));
+        _chatClient
+            .GetResponseAsync(
+                Arg.Any<IEnumerable<ChatMessage>>(),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        QueryMetadata metadata = CreateTestMetadata();
+
+        // Act
+        QueryRequest? result = await _sut.TranslateAsync(
+            "show active items over 1000, newest first",
+            metadata,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Sort.ShouldBe("-createdAt");
+        result.Filter.ShouldNotBeNull();
+        result.Filter.Count.ShouldBe(2);
+        result.Filter["status.eq"].ShouldBe("active");
+        result.Filter["amount.gte"].ShouldBe("1000");
+    }
+
+    [Fact]
+    public async Task TranslateAsync_LLMFailure_ReturnsNull()
+    {
+        // Arrange
+        _chatClient
+            .GetResponseAsync(
+                Arg.Any<IEnumerable<ChatMessage>>(),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("LLM unavailable"));
+
+        QueryMetadata metadata = CreateTestMetadata();
+
+        // Act
+        QueryRequest? result = await _sut.TranslateAsync(
+            "show all items",
+            metadata,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task TranslateAsync_InvalidJson_ReturnsNull()
+    {
+        // Arrange
+        var response = new ChatResponse(new ChatMessage(ChatRole.Assistant, "this is not valid json at all"));
+        _chatClient
+            .GetResponseAsync(
+                Arg.Any<IEnumerable<ChatMessage>>(),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        QueryMetadata metadata = CreateTestMetadata();
+
+        // Act
+        QueryRequest? result = await _sut.TranslateAsync(
+            "show all items",
+            metadata,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task TranslateAsync_EmptyInput_ReturnsNull()
+    {
+        // Arrange
+        QueryMetadata metadata = CreateTestMetadata();
+
+        // Act
+        QueryRequest? result = await _sut.TranslateAsync(
+            "",
+            metadata,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task TranslateAsync_MarkdownFencedResponse_ParsesCorrectly()
+    {
+        // Arrange
+        const string jsonText = """
+            ```json
+            {
+                "sort": "name",
+                "filter": { "name.contains": "alice" }
+            }
+            ```
+            """;
+
+        var response = new ChatResponse(new ChatMessage(ChatRole.Assistant, jsonText));
+        _chatClient
+            .GetResponseAsync(
+                Arg.Any<IEnumerable<ChatMessage>>(),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        QueryMetadata metadata = CreateTestMetadata();
+
+        // Act
+        QueryRequest? result = await _sut.TranslateAsync(
+            "find alice",
+            metadata,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Sort.ShouldBe("name");
+        result.Filter.ShouldNotBeNull();
+        result.Filter["name.contains"].ShouldBe("alice");
+    }
+
+    [Fact]
+    public async Task TranslateAsync_WhitespaceInput_ReturnsNull()
+    {
+        // Arrange
+        QueryMetadata metadata = CreateTestMetadata();
+
+        // Act
+        QueryRequest? result = await _sut.TranslateAsync(
+            "   ",
+            metadata,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildSystemPrompt_IncludesFilterableFields()
+    {
+        // Arrange
+        QueryMetadata metadata = CreateTestMetadata();
+
+        // Act
+        string prompt = _sut.BuildSystemPrompt(metadata);
+
+        // Assert
+        prompt.ShouldContain("status");
+        prompt.ShouldContain("amount");
+        prompt.ShouldContain("eq");
+        prompt.ShouldContain("gte");
+    }
+
+    [Fact]
+    public void StripMarkdownFences_RemovesFences()
+    {
+        const string input = """
+            ```json
+            {"sort": "name"}
+            ```
+            """;
+
+        string result = LlmNaturalLanguageQueryTranslator.StripMarkdownFences(input);
+
+        result.ShouldBe("{\"sort\": \"name\"}");
+    }
+
+    [Fact]
+    public void StripMarkdownFences_PlainJsonUnchanged()
+    {
+        const string input = """{"sort": "name"}""";
+
+        string result = LlmNaturalLanguageQueryTranslator.StripMarkdownFences(input);
+
+        result.ShouldBe("{\"sort\": \"name\"}");
+    }
+
+    private static QueryMetadata CreateTestMetadata() =>
+        new()
+        {
+            FilterableFields =
+            [
+                new FilterableField("status", "string", [FilterOperator.Eq, FilterOperator.Contains]),
+                new FilterableField("amount", "decimal", [FilterOperator.Gte, FilterOperator.Lte]),
+                new FilterableField("name", "string", [FilterOperator.Contains]),
+            ],
+            SortableFields =
+            [
+                new SortableField("name"),
+                new SortableField("createdAt"),
+                new SortableField("amount"),
+            ],
+            QuickFilters =
+            [
+                new QuickFilterMeta("active", "Active Items", false),
+            ],
+            DateFilters = [],
+            GroupByFields = [],
+            Columns = [],
+            PresetFilterGroups = [],
+            Pagination = new PaginationMeta(25, 100, false),
+        };
+}

--- a/tests/Granit.Querying.AI.Tests/packages.lock.json
+++ b/tests/Granit.Querying.AI.Tests/packages.lock.json
@@ -1,0 +1,397 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[8.*, )",
+        "resolved": "8.0.0",
+        "contentHash": "EMkj/2F6n6IVPrvGYkqzGJs6phuGGkq6N+E7KW9rNyzNxXbwQ1KfMqWyXNf9nCNEQOA6IjFwmOLvkriwKE7Orw=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.*, )",
+        "resolved": "18.3.0",
+        "contentHash": "xW3kXuWRQtgoxJp4J+gdhHSQyK+6Wb/AZDSd7lMvuMRYlZ1tnpkojyfZlWilB5G4dmZ0Y0ZxU/M23TlubndNkw==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.3.0",
+          "Microsoft.TestPlatform.TestHost": "18.3.0"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.*, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "23BNy/vziREC20Wwhb50K7+kZe0m07KlLWDQv4qjJ9tt3QjpDpDIqJFrhYHmMEo9xDkuSp55U/8h4bMF7MiB+g=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "AEIEX2aWdPO9XbtR96eBaJxmXRD9vaI9uQ1T/JbPEKlTAZwYx0ZrMzKyULMdh/HH9Sg03kXCoN7LszQ90o6nPQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "twmsoelXnp1uWMU3VGip9f0Jr1mZ0PZqgJdF35CIrdYgYrkHIJMV1m8uKyhcdjLdsQDESHAgkR7KhS9i1qpJag==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.3.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "granit.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.core": {
+        "type": "Project"
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.querying": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.querying.ai": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.AI": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.4.0",
+        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 builds on Phase 0 (#40) with 4 new modules that plug AI into existing Granit modules via soft dependency:

### Phase 1a — ROI immédiat
- **Granit.DataExchange.AI** — AI-powered `ISemanticMappingService` for CSV/Excel import. LLM suggests column-to-property mappings when exact/fuzzy matching fails. Opt-in preview rows support for headerless files (GDPR opt-in). 14 tests.
- **Granit.AI.Extraction** — Generic `IDocumentExtractor<T>` for structured data extraction from documents (PDF text → typed C# object). Async-first (Wolverine handler pattern). 10 tests.

### Phase 1b — Recherche intelligente
- **Granit.Querying.AI** — `INaturalLanguageQueryTranslator` converts natural language ("unpaid invoices from last week for Belgian clients") into structured `QueryRequest`. Only metadata sent to LLM, never data. 9 tests.
- **Granit.AI.VectorData** — Multi-tenant vector storage abstractions (`IVectorCollection<T>`, `ISemanticSearchService`). Combines embedding generation + vector search for RAG. 5 tests.

### Fixes
- Anthropic: reuse single `AnthropicClient`, implement `IDisposable`
- `DefaultAIWorkspaceProvider`: use `.Where()` instead of foreach+if
- `OllamaHealthCheck`: narrow generic catch to specific types
- Fix ambiguous cref in `DataExchange.Endpoints`
- Add README.md for all 9 AI packages

### Numbers
- 4 new packages (10 total AI packages)
- 38 new tests (87 total)
- All format checks clean
- Architecture tests pass

Closes #33, closes #34, closes #35, closes #36

## Test plan

- [x] `dotnet test` passes for all 4 new test projects
- [x] `dotnet format --verify-no-changes` clean
- [x] Architecture tests build and pass (README check)
- [ ] Review LLM prompt engineering (DataExchange.AI, Querying.AI)
- [ ] Review VectorData abstractions for future PgVector provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)