### PR TITLE
fix(ci): pin wrangler-action to correct SHA for v3.14.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,7 +438,7 @@ jobs:
         run: pnpm astro build
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@da0e0235f40ea0de66c4e1e8e25a0fdd569c0a54 # v3
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

- Fixes the docs deploy job which was failing with `Unable to find action`
- Previous SHA `da0e0235f40ea0de66c4e1e8e25a0fdd569c0a54` was invalid
- Updated to correct SHA `da0e0dfe58b7a431659754fdf3f186c529afbe65` (v3.14.1)

## Test plan

- [ ] Docs CI job passes on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)