### PR TITLE
feat(docs): add AI showcase section to homepage

### DIFF
--- a/docs-site/src/content/docs/dotnet/index.md
+++ b/docs-site/src/content/docs/dotnet/index.md
@@ -1,41 +1,44 @@
 ---
-title: Reference
-description: Complete reference documentation for all 97 Granit packages
+title: Backend (.NET)
+description: Granit .NET framework — modular, production-ready modules for authentication, persistence, messaging, AI, and GDPR/ISO 27001 compliance.
 sidebar:
+  label: Overview
   order: 0
 ---
 
-This section provides detailed reference documentation for every Granit module.
+Granit is a modular .NET 10 framework providing production-ready building blocks
+for enterprise applications. Each module follows the same layered anatomy
+(abstractions, EF Core, endpoints, providers) and wires into the
+dependency injection system via `[DependsOn]`.
 
-Each module page documents the full package family (abstractions, providers,
-EF Core integration, endpoints), configuration options, public API surface,
-and provider comparison.
+## Module groups
 
-## Module categories
+| Group | Modules | Purpose |
+|-------|---------|---------|
+| [Core](/dotnet/core/module-system/) | Module System, Utilities, Analyzers | Foundation types, module lifecycle, Roslyn analyzers |
+| [Data](/dotnet/data/persistence/) | Persistence, Caching, Storage, Querying, Reference Data | EF Core interceptors, HybridCache, multi-provider storage |
+| [Security & Compliance](/dotnet/security/authentication/) | Authentication, Authorization, Security, Identity, Privacy, Vault & Encryption | JWT Bearer, RBAC, GDPR, key management |
+| [API](/dotnet/api/api/) | API & Web, Webhooks | Versioning, OpenAPI, idempotency, HMAC-signed webhooks |
+| [Infrastructure](/dotnet/infrastructure/wolverine/) | Wolverine, Notifications, Background Jobs, Localization, Settings, Multi-Tenancy, Features | Message bus, 6-channel notifications, i18n (17 cultures), time zones, SaaS enablement |
+| [Observability](/dotnet/observability/observability-otlp/) | Observability & Diagnostics | Serilog, OpenTelemetry, health checks |
+| [Business Features](/dotnet/business/workflow/) | Workflow, Data Exchange, Templating, Timeline | FSM engine, import/export, PDF generation, activity stream |
 
-| Category | Modules | Description |
-|----------|---------|-------------|
-| Core & Utilities | [Core & Utilities](./modules/core/) | Foundation types, module system, Timing, Guids, Validation |
-| Security | [Security & Identity](./modules/security/), [Privacy](./modules/privacy/), [Vault & Encryption](./modules/vault-encryption/) | Authentication, authorization, encryption, GDPR |
-| Identity | [Identity](./modules/identity/) | Keycloak/EntraID/Cognito integration, user cache |
-| Data & Persistence | [Persistence](./modules/persistence/), [Caching](./modules/caching/), [Multi-Tenancy](./modules/multi-tenancy/) | EF Core interceptors, HybridCache, tenant isolation |
-| Settings & Features | [Settings & Features](./modules/settings-features/) | Application settings, feature flags, reference data |
-| API & Web | [API & Web](./modules/api-web/) | Versioning, OpenAPI docs, idempotency, CORS, cookies |
-| Messaging | [Wolverine](./modules/wolverine/), [Webhooks](./modules/webhooks/), [Notifications](./modules/notifications/) | Message bus, outbox, webhooks, 6-channel notifications |
-| Audit | [Timeline](./modules/timeline/) | Entity activity stream (chatter), follow/notify |
-| Documents | [Templating & DocumentGeneration](./modules/templating/) | Scriban templates, HTML-to-PDF, Excel generation |
-| Data Exchange | [DataExchange](./modules/data-exchange/) | Import pipeline (CSV, Excel), export presets |
-| Workflow | [Workflow](./modules/workflow/) | FSM engine, publication lifecycle |
-| Diagnostics | [Observability & Diagnostics](./modules/observability/) | Serilog, OpenTelemetry, health checks |
-| Storage | [BlobStorage & Imaging](./modules/blob-storage/) | Multi-provider storage (S3, Azure, FileSystem, Database), image processing |
-| Scheduling | [BackgroundJobs](./modules/background-jobs/) | Recurring and delayed jobs (Wolverine + Cronos) |
-| Localization | [Localization](./modules/localization/) | i18n (17 cultures), source-generated keys |
+## AI
 
-## Cross-cutting references
+Granit.AI adds provider-agnostic LLM capabilities (OpenAI, Azure, Anthropic, Ollama)
+via Microsoft.Extensions.AI. See the [AI section](/dotnet/ai/) for setup, NLQ,
+semantic search, document extraction, and more.
 
-- [Configuration Keys](./configuration-keys/) -- all appsettings sections and Options classes
-- [HTTP Conventions](./http-conventions/) -- status codes, Problem Details, DTO naming
-- [Dependency Graph](./dependency-graph/) -- package relationships and module dependencies
-- [Cloud Providers](./cloud-providers/) -- packages by cloud provider (AWS, Azure, Google Cloud)
-- [Provider Compatibility](./provider-compatibility/) -- database, cache, storage support matrix
-- [Tech Stack](./tech-stack/) -- third-party libraries, licenses, and ADR links
+## Architecture
+
+- [HTTP Conventions](/dotnet/architecture/http-conventions/) — status codes, Problem Details, DTO naming
+- [Dependency Graph](/dotnet/architecture/dependency-graph/) — package relationships
+- [Tech Stack](/dotnet/architecture/tech-stack/) — third-party libraries and licenses
+- [Design Patterns](/dotnet/architecture/patterns/) — 43 patterns documented
+- [ADRs](/dotnet/architecture/adr/) — architecture decision records
+
+## Reference
+
+- [Configuration Keys](/dotnet/configuration-keys/) — all appsettings sections and Options classes
+- [Cloud Providers](/dotnet/cloud-providers/) — packages by cloud provider (AWS, Azure, Google Cloud)
+- [Provider Compatibility](/dotnet/provider-compatibility/) — database, cache, storage support matrix

--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -315,6 +315,86 @@ const programHtml = hl(`var builder = WebApplication.CreateBuilder(args);\n\nbui
       margin-top: 0.125rem;
     }
 
+    /* ── AI showcase ── */
+    .lp-ai-card {
+      border-radius: 0.75rem;
+      border: 1px solid color-mix(in srgb, var(--sl-color-accent) 45%, transparent);
+      background: color-mix(in srgb, var(--sl-color-accent) 5%, var(--sl-color-bg));
+      padding: 2.5rem;
+    }
+    .lp-ai-layout {
+      display: grid; gap: 2.5rem; align-items: center;
+    }
+    @media (min-width: 960px) {
+      .lp-ai-layout { grid-template-columns: 1fr 1.5fr; }
+    }
+    .lp-ai-eyebrow {
+      display: flex; align-items: center; gap: 0.5rem;
+      font-size: 0.8125rem; font-weight: 700; text-transform: uppercase;
+      letter-spacing: 0.07em; color: var(--sl-color-accent);
+      margin-bottom: 1rem;
+    }
+    .lp-ai-eyebrow svg { width: 1rem; height: 1rem; flex-shrink: 0; }
+    .lp-ai-h2 {
+      font-size: clamp(1.375rem, 2.5vw, 1.875rem);
+      font-weight: 800; color: var(--sl-color-white);
+      margin: 0 0 0.75rem; line-height: 1.2;
+    }
+    .lp-ai-sub {
+      font-size: 0.9375rem; color: var(--sl-color-gray-2);
+      line-height: 1.6; margin: 0 0 1.5rem;
+    }
+    .lp-ai-sub code {
+      font-size: 0.875rem; color: var(--sl-color-accent-high);
+      background: color-mix(in srgb, var(--sl-color-accent) 12%, transparent);
+      padding: 0.125rem 0.375rem; border-radius: 0.25rem;
+      font-family: var(--sl-font-mono);
+    }
+    .lp-ai-providers {
+      display: flex; flex-wrap: wrap; gap: 0.5rem;
+      margin-bottom: 1.75rem; align-items: center;
+    }
+    .lp-ai-providers-label {
+      font-size: 0.75rem; color: var(--sl-color-gray-4);
+      margin-right: 0.125rem;
+    }
+    .lp-ai-provider {
+      font-size: 0.75rem; font-weight: 600;
+      padding: 0.1875rem 0.625rem; border-radius: 9999px;
+      border: 1px solid var(--sl-color-gray-5);
+      color: var(--sl-color-gray-3); white-space: nowrap;
+    }
+    .lp-ai-caps {
+      display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.625rem;
+    }
+    @media (max-width: 480px) {
+      .lp-ai-caps { grid-template-columns: repeat(2, 1fr); }
+    }
+    .lp-ai-cap {
+      background: var(--sl-color-bg);
+      border: 1px solid var(--sl-color-gray-5);
+      border-radius: 0.625rem; padding: 0.875rem;
+      display: flex; flex-direction: column; gap: 0.25rem;
+      text-decoration: none;
+      transition: border-color 0.15s, transform 0.15s;
+    }
+    .lp-ai-cap:hover {
+      border-color: var(--sl-color-accent); transform: translateY(-1px);
+    }
+    .lp-ai-cap-icon {
+      width: 1.125rem; height: 1.125rem;
+      color: var(--sl-color-accent); flex-shrink: 0; margin-bottom: 0.25rem;
+    }
+    .lp-ai-cap-icon svg { width: 100%; height: 100%; }
+    .lp-ai-cap-title {
+      font-size: 0.8125rem; font-weight: 700;
+      color: var(--sl-color-white); margin: 0;
+    }
+    .lp-ai-cap-desc {
+      font-size: 0.75rem; color: var(--sl-color-gray-3);
+      line-height: 1.4; margin: 0;
+    }
+
     /* ── Compliance ── */
     .lp-compliance {
       display: grid; gap: 2.5rem; align-items: center;
@@ -481,6 +561,84 @@ const programHtml = hl(`var builder = WebApplication.CreateBuilder(args);\n\nbui
       </a>
     </div>
   </div>
+
+  <!-- ════════ AI showcase ════════ -->
+  <section class="lp" style="padding-bottom:4rem">
+    <div class="lp-ai-card">
+      <div class="lp-ai-layout">
+
+        <!-- Left: intro -->
+        <div>
+          <div class="lp-ai-eyebrow">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z" />
+            </svg>
+            AI-powered
+            <span class="lp-eyebrow-badge">New</span>
+          </div>
+          <h2 class="lp-ai-h2">Your modules,<br/>intelligently enhanced.</h2>
+          <p class="lp-ai-sub">
+            Add one <code>.AI</code> package and the LLM plugs into your existing
+            module — no rewrites, no coupling. Provider-agnostic by design.
+          </p>
+          <div class="lp-ai-providers">
+            <span class="lp-ai-providers-label">Works with</span>
+            <span class="lp-ai-provider">OpenAI</span>
+            <span class="lp-ai-provider">Azure OpenAI</span>
+            <span class="lp-ai-provider">Anthropic</span>
+            <span class="lp-ai-provider">Ollama</span>
+          </div>
+          <a href="/dotnet/ai/" class="lp-btn lp-btn-outline" style="display:inline-flex;gap:0.5rem">
+            Explore AI modules
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" style="width:1rem;height:1rem" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
+            </svg>
+          </a>
+        </div>
+
+        <!-- Right: capability grid -->
+        <div class="lp-ai-caps">
+
+          <a href="/dotnet/ai/natural-language-query/" class="lp-ai-cap">
+            <div class="lp-ai-cap-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" /></svg></div>
+            <div class="lp-ai-cap-title">Natural Language Query</div>
+            <div class="lp-ai-cap-desc">Type a question, get a typed QueryRequest.</div>
+          </a>
+
+          <a href="/dotnet/ai/workflow-ai/" class="lp-ai-cap">
+            <div class="lp-ai-cap-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" /></svg></div>
+            <div class="lp-ai-cap-title">Workflow decisions</div>
+            <div class="lp-ai-cap-desc">Score risk. Let safe transitions approve themselves.</div>
+          </a>
+
+          <a href="/dotnet/ai/timeline-ai/" class="lp-ai-cap">
+            <div class="lp-ai-cap-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" /></svg></div>
+            <div class="lp-ai-cap-title">Audit summaries</div>
+            <div class="lp-ai-cap-desc">300 log entries → one readable paragraph.</div>
+          </a>
+
+          <a href="/dotnet/ai/notifications-ai/" class="lp-ai-cap">
+            <div class="lp-ai-cap-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" /></svg></div>
+            <div class="lp-ai-cap-title">Smart notifications</div>
+            <div class="lp-ai-cap-desc">LLM writes content in the recipient's language.</div>
+          </a>
+
+          <a href="/dotnet/ai/import-mapping/" class="lp-ai-cap">
+            <div class="lp-ai-cap-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" /></svg></div>
+            <div class="lp-ai-cap-title">Intelligent import</div>
+            <div class="lp-ai-cap-desc">AI maps CSV headers to your entity properties.</div>
+          </a>
+
+          <a href="/dotnet/ai/privacy-ai/" class="lp-ai-cap">
+            <div class="lp-ai-cap-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 11c0 3.517-1.009 6.799-2.753 9.571m-3.44-2.04l.054-.09A13.916 13.916 0 008 11a4 4 0 118 0c0 1.017-.07 2.019-.203 3m-2.118 6.844A21.88 21.88 0 0015.171 17m3.839 1.132c.645-2.266.99-4.659.99-7.132A8 8 0 008 4.07M3 15.364c.64-1.319 1-2.8 1-4.364 0-1.457.39-2.823 1.07-4" /></svg></div>
+            <div class="lp-ai-cap-title">PII detection</div>
+            <div class="lp-ai-cap-desc">Scan free text for personal data before storage.</div>
+          </a>
+
+        </div>
+      </div>
+    </div>
+  </section>
 
   <!-- ════════ Interactive builder ════════ -->
   <section class="lp lp-section">


### PR DESCRIPTION
## Summary

Adds an "AI-powered" showcase section to the homepage, positioned between the stats bar and the interactive module builder.

### Visual design
- Accent-colored border card with subtle tinted background (distinct from the solid accent banner above and the gray compliance card below)
- 2-column layout on desktop: intro text on the left, 6 capability cards on the right
- Responsive: stacks vertically on mobile, 2-col capability grid on small screens

### Content
- Eyebrow: sparkles icon + "AI-powered" + "New" badge
- Heading: "Your modules, intelligently enhanced."
- Tagline: emphasizes the soft-dependency model (one `.AI` package, no rewrites)
- Provider chips: OpenAI · Azure OpenAI · Anthropic · Ollama
- 6 clickable capability cards → each links to the corresponding AI docs page:
  - Natural Language Query
  - Workflow decisions
  - Audit summaries
  - Smart notifications
  - Intelligent import
  - PII detection
- "Explore AI modules →" CTA → `/dotnet/ai/`

## Test plan

- [ ] `astro build` passes (0 errors, all links valid)
- [ ] Section renders correctly in dark and light mode
- [ ] Capability cards are clickable and link to correct pages
- [ ] Responsive layout works on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)