### PR TITLE
docs: rewrite dotnet/ overview page for new structure

### DIFF
--- a/docs-site/src/content/docs/dotnet/index.md
+++ b/docs-site/src/content/docs/dotnet/index.md
@@ -14,7 +14,7 @@ dependency injection system via `[DependsOn]`.
 ## Module groups
 
 | Group | Modules | Purpose |
-|-------|---------|---------|
+| ----- | ------- | ------- |
 | [Core](/dotnet/core/module-system/) | Module System, Utilities, Analyzers | Foundation types, module lifecycle, Roslyn analyzers |
 | [Data](/dotnet/data/persistence/) | Persistence, Caching, Storage, Querying, Reference Data | EF Core interceptors, HybridCache, multi-provider storage |
 | [Security & Compliance](/dotnet/security/authentication/) | Authentication, Authorization, Security, Identity, Privacy, Vault & Encryption | JWT Bearer, RBAC, GDPR, key management |


### PR DESCRIPTION
## Summary

- Rewrites `dotnet/index.md` with a clearer intro and better structure
- Groups modules into 7 categories with absolute links matching the current sidebar
- Adds an AI section pointing to `/dotnet/ai/`
- Fixes cross-cutting references links (absolute paths)
- Fixes markdownlint MD060 table column style error

## Test plan

- [ ] Docs site builds without errors (`npx astro build`)
- [ ] Links in module groups table resolve correctly