### PR TITLE
feat(http-resilience): add Granit.HttpResilience with centralized outbound HTTP resilience

### DIFF
--- a/docs-site/src/content/docs/dotnet/api/http-resilience.mdx
+++ b/docs-site/src/content/docs/dotnet/api/http-resilience.mdx
@@ -1,0 +1,120 @@
+---
+title: HTTP Resilience
+description: Standardized outbound HTTP resilience for Granit modules — retry, circuit breaker, and per-client appsettings configuration via AddGranitHttpClient()
+sidebar:
+  order: 95
+---
+
+import { Aside, Code } from '@astrojs/starlight/components';
+
+## Overview
+
+`Granit.HttpResilience` wraps [`Microsoft.Extensions.Http.Resilience`](https://learn.microsoft.com/en-us/dotnet/core/resilience/http-resilience)
+(built on Polly v8) and exposes a single `AddGranitHttpClient()` extension that replaces
+bare `AddHttpClient()` calls across all Granit modules. Every outbound HTTP call
+automatically benefits from retry with exponential back-off, circuit breaking, and
+per-request timeouts.
+
+## Default pipeline
+
+| Stage | Default |
+|-------|---------|
+| Total timeout | 30 s |
+| Retry | 3 attempts, exponential back-off (2 s base) |
+| Circuit breaker | Opens after 10 failures in 30 s, stays open for 1 min |
+| Per-attempt timeout | 10 s |
+
+These defaults come from `AddStandardResilienceHandler()` and apply to every client
+registered via `AddGranitHttpClient()`.
+
+## Registration
+
+```csharp
+// Drop-in replacement for AddHttpClient()
+services.AddGranitHttpClient("granit-webhooks", (sp, client) =>
+{
+    client.BaseAddress = new Uri("https://webhook-receiver.example.com/");
+    client.Timeout = TimeSpan.FromSeconds(10);
+});
+```
+
+The returned `IHttpClientBuilder` can be chained for further customization.
+
+## Per-client configuration
+
+Override pipeline settings per named client in `appsettings.json` without redeploying:
+
+```json
+{
+  "HttpResilience": {
+    "granit-webhooks": {
+      "Retry": { "MaxRetryAttempts": 5 },
+      "CircuitBreaker": {
+        "SamplingDuration": "00:01:00",
+        "MinimumThroughput": 20
+      }
+    },
+    "KeycloakAdmin": {
+      "Retry": { "MaxRetryAttempts": 1 }
+    }
+  }
+}
+```
+
+Settings from `HttpResilience:{clientName}` are applied on top of the defaults at
+runtime via `IPostConfigureOptions<HttpStandardResilienceOptions>`.
+
+## Affected modules
+
+All Granit modules that register outbound `HttpClient` instances declare
+`[DependsOn(typeof(GranitHttpResilienceModule))]` and call `AddGranitHttpClient()`:
+
+| Module | Client name | Notes |
+|--------|-------------|-------|
+| `Granit.Webhooks` | `granit-webhook-delivery` | Webhook delivery |
+| `Granit.Notifications.Twilio` | `Twilio` | SMS + WhatsApp |
+| `Granit.Notifications.Brevo` | `Brevo` | Email + SMS + WhatsApp |
+| `Granit.Notifications.Zulip` | `Zulip` | Chat |
+| `Granit.Notifications.Email.SendGrid` | `SendGrid` | Email |
+| `Granit.Notifications.Email.Scaleway` | `Scaleway` | Email |
+| `Granit.Notifications.MobilePush.GoogleFcm` | `GoogleFcmPush` | Mobile push |
+| `Granit.Identity.Keycloak` | `KeycloakAdmin` | Admin API |
+| `Granit.Identity.EntraId` | `MicrosoftGraph` | Graph API |
+| `Granit.AI.Ollama` | `GranitAIOllamaHealthCheck` | Health check |
+
+<Aside type="tip">
+For identity providers (Keycloak, Entra ID), lower the retry count to avoid amplifying load
+on an already-struggling auth server:
+
+```json
+"HttpResilience": {
+  "KeycloakAdmin": { "Retry": { "MaxRetryAttempts": 1 } },
+  "MicrosoftGraph": { "Retry": { "MaxRetryAttempts": 1 } }
+}
+```
+</Aside>
+
+## Architecture
+
+```mermaid
+graph TD
+    GHR[Granit.HttpResilience] --> MEHR[Microsoft.Extensions.Http.Resilience]
+    MEHR --> POLLY[Polly v8]
+    GHR --> WEBHOOKS[Granit.Webhooks]
+    GHR --> NOTIF[Granit.Notifications.*]
+    GHR --> IDENTITY[Granit.Identity.*]
+    GHR --> AI[Granit.AI.Ollama]
+```
+
+## Compliance
+
+- **ISO 27001 A.17.1** — service continuity: circuit breaking prevents cascade failures
+  when a downstream dependency is unavailable
+- **GDPR Article 32** — availability: resilience policies reduce data-processing downtime
+  caused by transient network or API errors
+
+## Further reading
+
+- [Webhooks](/dotnet/api/webhooks/) — uses `granit-webhook-delivery` client
+- [Notifications](/dotnet/api/notifications/) — notification provider clients
+- [Microsoft.Extensions.Http.Resilience docs](https://learn.microsoft.com/en-us/dotnet/core/resilience/http-resilience)

--- a/docs-site/src/data/constants.ts
+++ b/docs-site/src/data/constants.ts
@@ -1,5 +1,5 @@
 /** Single source of truth for documentation-wide constants. */
-export const PACKAGE_COUNT = 161;
+export const PACKAGE_COUNT = 162;
 export const FRONTEND_PACKAGE_COUNT = 49;
 export const CULTURE_COUNT = 17;
 export const BASE_LANGUAGE_COUNT = 14;

--- a/src/Granit.HttpResilience/Extensions/HttpResilienceServiceCollectionExtensions.cs
+++ b/src/Granit.HttpResilience/Extensions/HttpResilienceServiceCollectionExtensions.cs
@@ -1,0 +1,68 @@
+using Granit.HttpResilience.Options;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
+using Microsoft.Extensions.Options;
+
+namespace Granit.HttpResilience.Extensions;
+
+/// <summary>
+/// Extension methods for registering resilient named <see cref="HttpClient"/> instances.
+/// </summary>
+public static class HttpResilienceServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds a named <see cref="HttpClient"/> with the standard Granit resilience pipeline applied:
+    /// retry with exponential back-off, circuit breaker, and per-request timeout.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="name">The logical name of the <see cref="HttpClient"/>.</param>
+    /// <param name="configure">Optional per-client configuration callback.</param>
+    /// <returns>The <see cref="IHttpClientBuilder"/> for further chaining.</returns>
+    /// <remarks>
+    /// Per-client pipeline settings are read at runtime from the
+    /// <c>HttpResilience:{name}</c> configuration section, allowing operators to tune
+    /// retry counts, circuit-breaker thresholds, and timeouts per named client via
+    /// <c>appsettings.json</c> without redeploying.
+    /// </remarks>
+    public static IHttpClientBuilder AddGranitHttpClient(
+        this IServiceCollection services,
+        string name,
+        Action<IServiceProvider, HttpClient>? configure = null)
+    {
+        IHttpClientBuilder clientBuilder = configure is null
+            ? services.AddHttpClient(name)
+            : services.AddHttpClient(name, configure);
+
+        clientBuilder.AddStandardResilienceHandler();
+
+        // Per-client override: HttpResilience:{name}:* → HttpStandardResilienceOptions.
+        // AddStandardResilienceHandler uses named options key "{name}-standard".
+        // IPostConfigureOptions runs after all IConfigureOptions, guaranteeing user
+        // settings override the pipeline defaults.
+        services.AddTransient<IPostConfigureOptions<HttpStandardResilienceOptions>>(sp =>
+        {
+            IConfiguration config = sp.GetRequiredService<IConfiguration>();
+            return new PostConfigureOptions<HttpStandardResilienceOptions>(
+                $"{name}-standard",
+                opts => config
+                    .GetSection($"{HttpResilienceOptions.SectionName}:{name}")
+                    .Bind(opts));
+        });
+
+        return clientBuilder;
+    }
+
+    /// <summary>
+    /// Adds a named <see cref="HttpClient"/> with the standard Granit resilience pipeline applied.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="name">The logical name of the <see cref="HttpClient"/>.</param>
+    /// <param name="configure">Per-client configuration callback.</param>
+    /// <returns>The <see cref="IHttpClientBuilder"/> for further chaining.</returns>
+    public static IHttpClientBuilder AddGranitHttpClient(
+        this IServiceCollection services,
+        string name,
+        Action<HttpClient> configure)
+        => services.AddGranitHttpClient(name, (_, client) => configure(client));
+}

--- a/src/Granit.HttpResilience/Granit.HttpResilience.csproj
+++ b/src/Granit.HttpResilience/Granit.HttpResilience.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Granit.HttpResilience</PackageId>
+    <Description>Standardized outbound HTTP resilience for Granit modules. Wraps Microsoft.Extensions.Http.Resilience to provide a single AddGranitHttpClient() extension that applies retry, circuit breaker, and timeout to named HttpClient instances, with per-client configuration via appsettings.json.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Granit.HttpResilience.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Granit.Core\Granit.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Granit.HttpResilience/GranitHttpResilienceModule.cs
+++ b/src/Granit.HttpResilience/GranitHttpResilienceModule.cs
@@ -1,0 +1,16 @@
+using Granit.Core.Modularity;
+
+namespace Granit.HttpResilience;
+
+/// <summary>
+/// Granit module for standardized outbound HTTP resilience.
+/// </summary>
+/// <remarks>
+/// Exposes <c>AddGranitHttpClient()</c> which applies a standard resilience pipeline
+/// (retry with exponential back-off, circuit breaker, per-request timeout) to named
+/// <see cref="System.Net.Http.HttpClient"/> instances via
+/// <c>Microsoft.Extensions.Http.Resilience</c>.
+/// Per-client settings are overridable from <c>HttpResilience:{clientName}:*</c> in
+/// <c>appsettings.json</c>.
+/// </remarks>
+public sealed class GranitHttpResilienceModule : GranitModule;

--- a/src/Granit.HttpResilience/Options/HttpResilienceOptions.cs
+++ b/src/Granit.HttpResilience/Options/HttpResilienceOptions.cs
@@ -1,0 +1,22 @@
+namespace Granit.HttpResilience.Options;
+
+/// <summary>
+/// Global HTTP resilience configuration.
+/// Per-client pipeline overrides are read from <c>HttpResilience:{clientName}:*</c>
+/// in <c>appsettings.json</c> and applied on top of the
+/// <c>AddStandardResilienceHandler</c> defaults.
+/// </summary>
+/// <remarks>
+/// Default pipeline (from <c>AddStandardResilienceHandler</c>):
+/// <list type="bullet">
+///   <item><description>Total timeout: 30 s</description></item>
+///   <item><description>Retry: 3 attempts, exponential back-off (2 s base)</description></item>
+///   <item><description>Circuit breaker: opens after 10 failures in 30 s, stays open for 1 min</description></item>
+///   <item><description>Per-attempt timeout: 10 s</description></item>
+/// </list>
+/// </remarks>
+public sealed class HttpResilienceOptions
+{
+    /// <summary>The root appsettings section under which per-client overrides are nested.</summary>
+    public const string SectionName = "HttpResilience";
+}

--- a/src/Granit.HttpResilience/packages.lock.json
+++ b/src/Granit.HttpResilience/packages.lock.json
@@ -8,18 +8,6 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
-      "Microsoft.Extensions.Diagnostics.HealthChecks": {
-        "type": "Direct",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "REdt95QXHscGdtw/UUgyCW2lF9DJcAOJxmebKW2IkgUjuCAdMODIi2HNOWg5utW98nm8ekgV0Gjqs/sljwwqMw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5"
-        }
-      },
       "Microsoft.Extensions.Http": {
         "type": "Direct",
         "requested": "[10.*, )",
@@ -32,6 +20,27 @@
           "Microsoft.Extensions.Logging": "10.0.5",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
           "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.4.0",
+        "contentHash": "HbkUsPUC7vLy2TaDbdA9aooW64n9yX4sUppRuiJ1cOzzU1FUW+MVEotm6kYVq6AuUI9xwFSBhRFzA03blmk3VA==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Diagnostics": "10.4.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.4",
+          "Microsoft.Extensions.Resilience": "10.4.0"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
@@ -126,17 +135,12 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4"
         }
       },
-      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "NrIMTy7dpqxAvA6kHAYH8cXID/YgeNOy0OqFKpLtkPu5X4WS/basX91UszANzVrMNRAICJ2GOnGiRxJtsRyEQw=="
-      },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
+        "resolved": "10.0.4",
+        "contentHash": "3hLXFZ1E/Kj3obIcb9iMCC95MpW2e8EkWxpXKgUfgGBfm+yn507pHAjPaHoi2U3GlSHIm/21DPCDLumwlMowjw==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.5"
+          "Microsoft.Extensions.Primitives": "10.0.4"
         }
       },
       "Microsoft.Extensions.Http.Diagnostics": {
@@ -251,37 +255,6 @@
       "granit.core": {
         "type": "Project"
       },
-      "granit.httpresilience": {
-        "type": "Project",
-        "dependencies": {
-          "Granit.Core": "[0.1.0-dev, )",
-          "Microsoft.Extensions.Http": "[10.*, )",
-          "Microsoft.Extensions.Http.Resilience": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
-      "granit.identity": {
-        "type": "Project",
-        "dependencies": {
-          "Granit.Core": "[0.1.0-dev, )",
-          "Granit.Querying": "[0.1.0-dev, )"
-        }
-      },
-      "granit.querying": {
-        "type": "Project",
-        "dependencies": {
-          "Granit.Core": "[0.1.0-dev, )"
-        }
-      },
-      "granit.timing": {
-        "type": "Project",
-        "dependencies": {
-          "Granit.Core": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )"
-        }
-      },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -301,25 +274,14 @@
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "resolved": "10.0.4",
+        "contentHash": "+5mQrqlBhqNUaPyDmFSNM/qiWStvE9LMxZW1MRF0NhEbO781xNeKryXNR9gGDJ0PmYFDAVoMT9ffX+I15LPFTw==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Http.Resilience": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "HbkUsPUC7vLy2TaDbdA9aooW64n9yX4sUppRuiJ1cOzzU1FUW+MVEotm6kYVq6AuUI9xwFSBhRFzA03blmk3VA==",
-        "dependencies": {
-          "Microsoft.Extensions.Http.Diagnostics": "10.4.0",
-          "Microsoft.Extensions.ObjectPool": "10.0.4",
-          "Microsoft.Extensions.Resilience": "10.4.0"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.4",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.4"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -329,16 +291,6 @@
         "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Options": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
         }
       }
     }

--- a/src/Granit.Identity.EntraId/Extensions/IdentityEntraIdServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.EntraId/Extensions/IdentityEntraIdServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Core.Diagnostics;
+using Granit.HttpResilience.Extensions;
 using Granit.Identity.EntraId.HealthChecks;
 using Granit.Identity.EntraId.Internal;
 using Granit.Identity.EntraId.Options;
@@ -6,7 +7,6 @@ using Granit.Identity.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 
 namespace Granit.Identity.EntraId.Extensions;
@@ -47,13 +47,12 @@ public static class IdentityEntraIdServiceCollectionExtensions
             .ValidateDataAnnotations()
             .ValidateOnStart();
 
-        services.AddHttpClient("MicrosoftGraph", (sp, client) =>
-            {
-                EntraIdAdminOptions opts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<EntraIdAdminOptions>>().Value;
-                client.BaseAddress = new Uri(opts.GraphBaseUrl);
-                client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
-            })
-            .AddStandardResilienceHandler();
+        services.AddGranitHttpClient("MicrosoftGraph", (sp, client) =>
+        {
+            EntraIdAdminOptions opts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<EntraIdAdminOptions>>().Value;
+            client.BaseAddress = new Uri(opts.GraphBaseUrl);
+            client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
+        });
 
         services.TryAddSingleton<EntraIdAdminTokenService>();
         services.TryAddScoped<IPasswordResetNotifier, NullPasswordResetNotifier>();

--- a/src/Granit.Identity.EntraId/Granit.Identity.EntraId.csproj
+++ b/src/Granit.Identity.EntraId/Granit.Identity.EntraId.csproj
@@ -14,11 +14,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.Http" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.HttpResilience\Granit.HttpResilience.csproj" />
     <ProjectReference Include="..\Granit.Identity\Granit.Identity.csproj" />
     <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />
   </ItemGroup>

--- a/src/Granit.Identity.EntraId/GranitIdentityEntraIdModule.cs
+++ b/src/Granit.Identity.EntraId/GranitIdentityEntraIdModule.cs
@@ -1,4 +1,5 @@
 using Granit.Core.Modularity;
+using Granit.HttpResilience;
 using Granit.Identity.EntraId.Extensions;
 using Granit.Timing;
 
@@ -9,6 +10,7 @@ namespace Granit.Identity.EntraId;
 /// <see cref="IIdentityProvider"/> implementation.
 /// </summary>
 [DependsOn(
+    typeof(GranitHttpResilienceModule),
     typeof(GranitIdentityModule),
     typeof(GranitTimingModule))]
 public sealed class GranitIdentityEntraIdModule : GranitModule

--- a/src/Granit.Identity.Keycloak/Extensions/IdentityKeycloakServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.Keycloak/Extensions/IdentityKeycloakServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Core.Diagnostics;
+using Granit.HttpResilience.Extensions;
 using Granit.Identity.Extensions;
 using Granit.Identity.Keycloak.HealthChecks;
 using Granit.Identity.Keycloak.Internal;
@@ -6,7 +7,6 @@ using Granit.Identity.Keycloak.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Http.Resilience;
 
 namespace Granit.Identity.Keycloak.Extensions;
 
@@ -44,12 +44,11 @@ public static class IdentityKeycloakServiceCollectionExtensions
             .ValidateDataAnnotations()
             .ValidateOnStart();
 
-        services.AddHttpClient("KeycloakAdmin", (sp, client) =>
-            {
-                KeycloakAdminOptions opts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<KeycloakAdminOptions>>().Value;
-                client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
-            })
-            .AddStandardResilienceHandler();
+        services.AddGranitHttpClient("KeycloakAdmin", (sp, client) =>
+        {
+            KeycloakAdminOptions opts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<KeycloakAdminOptions>>().Value;
+            client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
+        });
 
         services.TryAddSingleton<KeycloakAdminTokenService>();
         services.TryAddTransient<KeycloakUserTokenExchangeService>();

--- a/src/Granit.Identity.Keycloak/Granit.Identity.Keycloak.csproj
+++ b/src/Granit.Identity.Keycloak/Granit.Identity.Keycloak.csproj
@@ -14,11 +14,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.Http" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.HttpResilience\Granit.HttpResilience.csproj" />
     <ProjectReference Include="..\Granit.Identity\Granit.Identity.csproj" />
     <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />
   </ItemGroup>

--- a/src/Granit.Identity.Keycloak/GranitIdentityKeycloakModule.cs
+++ b/src/Granit.Identity.Keycloak/GranitIdentityKeycloakModule.cs
@@ -1,4 +1,5 @@
 using Granit.Core.Modularity;
+using Granit.HttpResilience;
 using Granit.Identity.Keycloak.Extensions;
 using Granit.Timing;
 
@@ -9,6 +10,7 @@ namespace Granit.Identity.Keycloak;
 /// <see cref="IIdentityProvider"/> implementation.
 /// </summary>
 [DependsOn(
+    typeof(GranitHttpResilienceModule),
     typeof(GranitIdentityModule),
     typeof(GranitTimingModule))]
 public sealed class GranitIdentityKeycloakModule : GranitModule

--- a/src/Granit.Identity.Keycloak/packages.lock.json
+++ b/src/Granit.Identity.Keycloak/packages.lock.json
@@ -34,17 +34,6 @@
           "Microsoft.Extensions.Options": "10.0.5"
         }
       },
-      "Microsoft.Extensions.Http.Resilience": {
-        "type": "Direct",
-        "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "HbkUsPUC7vLy2TaDbdA9aooW64n9yX4sUppRuiJ1cOzzU1FUW+MVEotm6kYVq6AuUI9xwFSBhRFzA03blmk3VA==",
-        "dependencies": {
-          "Microsoft.Extensions.Http.Diagnostics": "10.4.0",
-          "Microsoft.Extensions.ObjectPool": "10.0.4",
-          "Microsoft.Extensions.Resilience": "10.4.0"
-        }
-      },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Direct",
         "requested": "[10.*, )",
@@ -262,6 +251,16 @@
       "granit.core": {
         "type": "Project"
       },
+      "granit.httpresilience": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Http": "[10.*, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {
@@ -310,6 +309,17 @@
           "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.4.0",
+        "contentHash": "HbkUsPUC7vLy2TaDbdA9aooW64n9yX4sUppRuiJ1cOzzU1FUW+MVEotm6kYVq6AuUI9xwFSBhRFzA03blmk3VA==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Diagnostics": "10.4.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.4",
+          "Microsoft.Extensions.Resilience": "10.4.0"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {

--- a/src/Granit.Notifications.Brevo/Extensions/BrevoNotificationsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Brevo/Extensions/BrevoNotificationsServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.HttpResilience.Extensions;
 using Granit.Notifications.Brevo.HealthChecks;
 using Granit.Notifications.Brevo.Internal;
 using Granit.Notifications.Brevo.Options;
@@ -6,7 +7,6 @@ using Granit.Notifications.Sms;
 using Granit.Notifications.WhatsApp;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Http.Resilience;
 
 namespace Granit.Notifications.Brevo.Extensions;
 
@@ -32,15 +32,14 @@ public static class BrevoNotificationsServiceCollectionExtensions
             services.Configure(configure);
         }
 
-        services.AddHttpClient(ProviderKey, (sp, client) =>
-            {
-                BrevoOptions opts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<BrevoOptions>>().Value;
-                client.BaseAddress = new Uri(string.Concat(opts.BaseUrl.TrimEnd('/'), "/"));
-                client.DefaultRequestHeaders.Add("api-key", opts.ApiKey);
-                client.DefaultRequestHeaders.Add("Accept", "application/json");
-                client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
-            })
-            .AddStandardResilienceHandler();
+        services.AddGranitHttpClient(ProviderKey, (sp, client) =>
+        {
+            BrevoOptions opts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<BrevoOptions>>().Value;
+            client.BaseAddress = new Uri(string.Concat(opts.BaseUrl.TrimEnd('/'), "/"));
+            client.DefaultRequestHeaders.Add("api-key", opts.ApiKey);
+            client.DefaultRequestHeaders.Add("Accept", "application/json");
+            client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
+        });
 
         services.AddSingleton<BrevoNotificationProvider>();
         services.AddKeyedSingleton<IEmailSender>(

--- a/src/Granit.Notifications.Brevo/Granit.Notifications.Brevo.csproj
+++ b/src/Granit.Notifications.Brevo/Granit.Notifications.Brevo.csproj
@@ -15,12 +15,12 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.HttpResilience\Granit.HttpResilience.csproj" />
     <ProjectReference Include="..\Granit.Notifications.Email\Granit.Notifications.Email.csproj" />
     <ProjectReference Include="..\Granit.Notifications.Sms\Granit.Notifications.Sms.csproj" />
     <ProjectReference Include="..\Granit.Notifications.WhatsApp\Granit.Notifications.WhatsApp.csproj" />

--- a/src/Granit.Notifications.Brevo/GranitNotificationsBrevoModule.cs
+++ b/src/Granit.Notifications.Brevo/GranitNotificationsBrevoModule.cs
@@ -1,4 +1,5 @@
 using Granit.Core.Modularity;
+using Granit.HttpResilience;
 using Granit.Notifications.Email;
 using Granit.Notifications.Sms;
 using Granit.Notifications.WhatsApp;
@@ -13,6 +14,7 @@ namespace Granit.Notifications.Brevo;
 /// Registers <c>BrevoNotificationProvider</c> as a keyed service for email, SMS and WhatsApp channels.
 /// </remarks>
 [DependsOn(
+    typeof(GranitHttpResilienceModule),
     typeof(GranitNotificationsEmailModule),
     typeof(GranitNotificationsSmsModule),
     typeof(GranitNotificationsWhatsAppModule))]

--- a/src/Granit.Notifications.Brevo/packages.lock.json
+++ b/src/Granit.Notifications.Brevo/packages.lock.json
@@ -40,17 +40,6 @@
           "Microsoft.Extensions.Options": "10.0.5"
         }
       },
-      "Microsoft.Extensions.Http.Resilience": {
-        "type": "Direct",
-        "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "HbkUsPUC7vLy2TaDbdA9aooW64n9yX4sUppRuiJ1cOzzU1FUW+MVEotm6kYVq6AuUI9xwFSBhRFzA03blmk3VA==",
-        "dependencies": {
-          "Microsoft.Extensions.Http.Diagnostics": "10.4.0",
-          "Microsoft.Extensions.ObjectPool": "10.0.4",
-          "Microsoft.Extensions.Resilience": "10.4.0"
-        }
-      },
       "Microsoft.Extensions.Options": {
         "type": "Direct",
         "requested": "[10.*, )",
@@ -286,6 +275,16 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "granit.httpresilience": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Http": "[10.*, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
       "granit.notifications": {
         "type": "Project",
         "dependencies": {
@@ -360,6 +359,17 @@
           "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.4.0",
+        "contentHash": "HbkUsPUC7vLy2TaDbdA9aooW64n9yX4sUppRuiJ1cOzzU1FUW+MVEotm6kYVq6AuUI9xwFSBhRFzA03blmk3VA==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Diagnostics": "10.4.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.4",
+          "Microsoft.Extensions.Resilience": "10.4.0"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {

--- a/src/Granit.Notifications.Email.Scaleway/Extensions/ScalewayEmailServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Email.Scaleway/Extensions/ScalewayEmailServiceCollectionExtensions.cs
@@ -1,10 +1,10 @@
+using Granit.HttpResilience.Extensions;
 using Granit.Notifications.Email.Scaleway.Diagnostics;
 using Granit.Notifications.Email.Scaleway.HealthChecks;
 using Granit.Notifications.Email.Scaleway.Internal;
 using Granit.Notifications.Email.Scaleway.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Http.Resilience;
 
 namespace Granit.Notifications.Email.Scaleway.Extensions;
 
@@ -28,17 +28,16 @@ public static class ScalewayEmailServiceCollectionExtensions
             services.Configure(configure);
         }
 
-        services.AddHttpClient(ProviderKey, (sp, client) =>
-            {
-                ScalewayEmailOptions opts = sp
-                    .GetRequiredService<Microsoft.Extensions.Options.IOptions<ScalewayEmailOptions>>().Value;
-                client.BaseAddress = new Uri(string.Concat(
-                    opts.BaseUrl.TrimEnd('/'), "/regions/", opts.Region.TrimEnd('/'), "/"));
-                client.DefaultRequestHeaders.Add("X-Auth-Token", opts.SecretKey);
-                client.DefaultRequestHeaders.Add("Accept", "application/json");
-                client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
-            })
-            .AddStandardResilienceHandler();
+        services.AddGranitHttpClient(ProviderKey, (sp, client) =>
+        {
+            ScalewayEmailOptions opts = sp
+                .GetRequiredService<Microsoft.Extensions.Options.IOptions<ScalewayEmailOptions>>().Value;
+            client.BaseAddress = new Uri(string.Concat(
+                opts.BaseUrl.TrimEnd('/'), "/regions/", opts.Region.TrimEnd('/'), "/"));
+            client.DefaultRequestHeaders.Add("X-Auth-Token", opts.SecretKey);
+            client.DefaultRequestHeaders.Add("Accept", "application/json");
+            client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
+        });
 
         services.AddSingleton<ScalewayEmailSender>();
         services.AddKeyedSingleton<IEmailSender>(

--- a/src/Granit.Notifications.Email.Scaleway/Granit.Notifications.Email.Scaleway.csproj
+++ b/src/Granit.Notifications.Email.Scaleway/Granit.Notifications.Email.Scaleway.csproj
@@ -15,12 +15,12 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.HttpResilience\Granit.HttpResilience.csproj" />
     <ProjectReference Include="..\Granit.Notifications.Email\Granit.Notifications.Email.csproj" />
   </ItemGroup>
 

--- a/src/Granit.Notifications.Email.Scaleway/GranitNotificationsEmailScalewayModule.cs
+++ b/src/Granit.Notifications.Email.Scaleway/GranitNotificationsEmailScalewayModule.cs
@@ -1,10 +1,13 @@
 using Granit.Core.Modularity;
+using Granit.HttpResilience;
 using Granit.Notifications.Email.Scaleway.Extensions;
 
 namespace Granit.Notifications.Email.Scaleway;
 
 /// <summary>Module for Scaleway Transactional Email provider.</summary>
-[DependsOn(typeof(GranitNotificationsEmailModule))]
+[DependsOn(
+    typeof(GranitHttpResilienceModule),
+    typeof(GranitNotificationsEmailModule))]
 public sealed class GranitNotificationsEmailScalewayModule : GranitModule
 {
     /// <inheritdoc />

--- a/src/Granit.Notifications.Email.Scaleway/packages.lock.json
+++ b/src/Granit.Notifications.Email.Scaleway/packages.lock.json
@@ -40,17 +40,6 @@
           "Microsoft.Extensions.Options": "10.0.5"
         }
       },
-      "Microsoft.Extensions.Http.Resilience": {
-        "type": "Direct",
-        "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "HbkUsPUC7vLy2TaDbdA9aooW64n9yX4sUppRuiJ1cOzzU1FUW+MVEotm6kYVq6AuUI9xwFSBhRFzA03blmk3VA==",
-        "dependencies": {
-          "Microsoft.Extensions.Http.Diagnostics": "10.4.0",
-          "Microsoft.Extensions.ObjectPool": "10.0.4",
-          "Microsoft.Extensions.Resilience": "10.4.0"
-        }
-      },
       "Microsoft.Extensions.Options": {
         "type": "Direct",
         "requested": "[10.*, )",
@@ -286,6 +275,16 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "granit.httpresilience": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Http": "[10.*, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
       "granit.notifications": {
         "type": "Project",
         "dependencies": {
@@ -342,6 +341,17 @@
           "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.4.0",
+        "contentHash": "HbkUsPUC7vLy2TaDbdA9aooW64n9yX4sUppRuiJ1cOzzU1FUW+MVEotm6kYVq6AuUI9xwFSBhRFzA03blmk3VA==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Diagnostics": "10.4.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.4",
+          "Microsoft.Extensions.Resilience": "10.4.0"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {

--- a/src/Granit.Notifications.Email.SendGrid/Extensions/SendGridEmailServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Email.SendGrid/Extensions/SendGridEmailServiceCollectionExtensions.cs
@@ -1,10 +1,10 @@
+using Granit.HttpResilience.Extensions;
 using Granit.Notifications.Email.SendGrid.Diagnostics;
 using Granit.Notifications.Email.SendGrid.HealthChecks;
 using Granit.Notifications.Email.SendGrid.Internal;
 using Granit.Notifications.Email.SendGrid.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Http.Resilience;
 
 namespace Granit.Notifications.Email.SendGrid.Extensions;
 
@@ -28,16 +28,15 @@ public static class SendGridEmailServiceCollectionExtensions
             services.Configure(configure);
         }
 
-        services.AddHttpClient(ProviderKey, (sp, client) =>
-            {
-                SendGridEmailOptions opts = sp
-                    .GetRequiredService<Microsoft.Extensions.Options.IOptions<SendGridEmailOptions>>().Value;
-                client.BaseAddress = new Uri(string.Concat(opts.BaseUrl.TrimEnd('/'), "/"));
-                client.DefaultRequestHeaders.Add("Authorization", $"Bearer {opts.ApiKey}");
-                client.DefaultRequestHeaders.Add("Accept", "application/json");
-                client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
-            })
-            .AddStandardResilienceHandler();
+        services.AddGranitHttpClient(ProviderKey, (sp, client) =>
+        {
+            SendGridEmailOptions opts = sp
+                .GetRequiredService<Microsoft.Extensions.Options.IOptions<SendGridEmailOptions>>().Value;
+            client.BaseAddress = new Uri(string.Concat(opts.BaseUrl.TrimEnd('/'), "/"));
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {opts.ApiKey}");
+            client.DefaultRequestHeaders.Add("Accept", "application/json");
+            client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
+        });
 
         services.AddSingleton<SendGridEmailSender>();
         services.AddKeyedSingleton<IEmailSender>(

--- a/src/Granit.Notifications.Email.SendGrid/Granit.Notifications.Email.SendGrid.csproj
+++ b/src/Granit.Notifications.Email.SendGrid/Granit.Notifications.Email.SendGrid.csproj
@@ -15,12 +15,12 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.HttpResilience\Granit.HttpResilience.csproj" />
     <ProjectReference Include="..\Granit.Notifications.Email\Granit.Notifications.Email.csproj" />
   </ItemGroup>
 

--- a/src/Granit.Notifications.Email.SendGrid/GranitNotificationsEmailSendGridModule.cs
+++ b/src/Granit.Notifications.Email.SendGrid/GranitNotificationsEmailSendGridModule.cs
@@ -1,10 +1,13 @@
 using Granit.Core.Modularity;
+using Granit.HttpResilience;
 using Granit.Notifications.Email.SendGrid.Extensions;
 
 namespace Granit.Notifications.Email.SendGrid;
 
 /// <summary>Module for SendGrid email provider.</summary>
-[DependsOn(typeof(GranitNotificationsEmailModule))]
+[DependsOn(
+    typeof(GranitHttpResilienceModule),
+    typeof(GranitNotificationsEmailModule))]
 public sealed class GranitNotificationsEmailSendGridModule : GranitModule
 {
     /// <inheritdoc />

--- a/src/Granit.Notifications.Email.SendGrid/packages.lock.json
+++ b/src/Granit.Notifications.Email.SendGrid/packages.lock.json
@@ -40,17 +40,6 @@
           "Microsoft.Extensions.Options": "10.0.5"
         }
       },
-      "Microsoft.Extensions.Http.Resilience": {
-        "type": "Direct",
-        "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "HbkUsPUC7vLy2TaDbdA9aooW64n9yX4sUppRuiJ1cOzzU1FUW+MVEotm6kYVq6AuUI9xwFSBhRFzA03blmk3VA==",
-        "dependencies": {
-          "Microsoft.Extensions.Http.Diagnostics": "10.4.0",
-          "Microsoft.Extensions.ObjectPool": "10.0.4",
-          "Microsoft.Extensions.Resilience": "10.4.0"
-        }
-      },
       "Microsoft.Extensions.Options": {
         "type": "Direct",
         "requested": "[10.*, )",
@@ -286,6 +275,16 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "granit.httpresilience": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Http": "[10.*, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
       "granit.notifications": {
         "type": "Project",
         "dependencies": {
@@ -342,6 +341,17 @@
           "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.4.0",
+        "contentHash": "HbkUsPUC7vLy2TaDbdA9aooW64n9yX4sUppRuiJ1cOzzU1FUW+MVEotm6kYVq6AuUI9xwFSBhRFzA03blmk3VA==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Diagnostics": "10.4.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.4",
+          "Microsoft.Extensions.Resilience": "10.4.0"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {

--- a/src/Granit.Notifications.MobilePush.GoogleFcm/Extensions/GoogleFcmMobilePushServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.MobilePush.GoogleFcm/Extensions/GoogleFcmMobilePushServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.HttpResilience.Extensions;
 using Granit.Notifications.MobilePush.GoogleFcm.Internal;
 using Granit.Notifications.MobilePush.GoogleFcm.Options;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,13 +26,12 @@ public static class GoogleFcmMobilePushServiceCollectionExtensions
             services.Configure(configure);
         }
 
-        services.AddHttpClient(HttpClientName, (sp, client) =>
-            {
-                GoogleFcmOptions opts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<GoogleFcmOptions>>().Value;
-                client.BaseAddress = new Uri(opts.BaseAddress);
-                client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
-            })
-            .AddStandardResilienceHandler();
+        services.AddGranitHttpClient(HttpClientName, (sp, client) =>
+        {
+            GoogleFcmOptions opts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<GoogleFcmOptions>>().Value;
+            client.BaseAddress = new Uri(opts.BaseAddress);
+            client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
+        });
 
         services.AddKeyedSingleton<IMobilePushSender, GoogleFcmMobilePushSender>(ProviderKey);
         return services;

--- a/src/Granit.Notifications.MobilePush.GoogleFcm/Granit.Notifications.MobilePush.GoogleFcm.csproj
+++ b/src/Granit.Notifications.MobilePush.GoogleFcm/Granit.Notifications.MobilePush.GoogleFcm.csproj
@@ -14,13 +14,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.HttpResilience\Granit.HttpResilience.csproj" />
     <ProjectReference Include="..\Granit.Notifications.MobilePush\Granit.Notifications.MobilePush.csproj" />
   </ItemGroup>
 

--- a/src/Granit.Notifications.MobilePush.GoogleFcm/GranitNotificationsMobilePushGoogleFcmModule.cs
+++ b/src/Granit.Notifications.MobilePush.GoogleFcm/GranitNotificationsMobilePushGoogleFcmModule.cs
@@ -1,4 +1,5 @@
 using Granit.Core.Modularity;
+using Granit.HttpResilience;
 using Granit.Notifications.MobilePush;
 
 namespace Granit.Notifications.MobilePush.GoogleFcm;
@@ -10,5 +11,7 @@ namespace Granit.Notifications.MobilePush.GoogleFcm;
 /// Registration is done via <c>AddGranitNotificationsMobilePushGoogleFcm()</c>.
 /// Registers <c>GoogleFcmMobilePushSender</c> as a keyed <c>IMobilePushSender</c> implementation.
 /// </remarks>
-[DependsOn(typeof(GranitNotificationsMobilePushModule))]
+[DependsOn(
+    typeof(GranitHttpResilienceModule),
+    typeof(GranitNotificationsMobilePushModule))]
 public sealed class GranitNotificationsMobilePushGoogleFcmModule : GranitModule;

--- a/src/Granit.Notifications.MobilePush.GoogleFcm/packages.lock.json
+++ b/src/Granit.Notifications.MobilePush.GoogleFcm/packages.lock.json
@@ -28,17 +28,6 @@
           "Microsoft.Extensions.Options": "10.0.5"
         }
       },
-      "Microsoft.Extensions.Http.Resilience": {
-        "type": "Direct",
-        "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "HbkUsPUC7vLy2TaDbdA9aooW64n9yX4sUppRuiJ1cOzzU1FUW+MVEotm6kYVq6AuUI9xwFSBhRFzA03blmk3VA==",
-        "dependencies": {
-          "Microsoft.Extensions.Http.Diagnostics": "10.4.0",
-          "Microsoft.Extensions.ObjectPool": "10.0.4",
-          "Microsoft.Extensions.Resilience": "10.4.0"
-        }
-      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Direct",
         "requested": "[10.*, )",
@@ -278,6 +267,16 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "granit.httpresilience": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Http": "[10.*, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
       "granit.notifications": {
         "type": "Project",
         "dependencies": {
@@ -335,6 +334,17 @@
           "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.4.0",
+        "contentHash": "HbkUsPUC7vLy2TaDbdA9aooW64n9yX4sUppRuiJ1cOzzU1FUW+MVEotm6kYVq6AuUI9xwFSBhRFzA03blmk3VA==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Diagnostics": "10.4.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.4",
+          "Microsoft.Extensions.Resilience": "10.4.0"
         }
       }
     }

--- a/src/Granit.Notifications.Twilio/Extensions/TwilioNotificationsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Twilio/Extensions/TwilioNotificationsServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Headers;
 using System.Text;
+using Granit.HttpResilience.Extensions;
 using Granit.Notifications.Sms;
 using Granit.Notifications.Twilio.HealthChecks;
 using Granit.Notifications.Twilio.Internal;
@@ -7,7 +8,6 @@ using Granit.Notifications.Twilio.Options;
 using Granit.Notifications.WhatsApp;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Http.Resilience;
 
 namespace Granit.Notifications.Twilio.Extensions;
 
@@ -33,16 +33,15 @@ public static class TwilioNotificationsServiceCollectionExtensions
             services.Configure(configure);
         }
 
-        services.AddHttpClient(ProviderKey, (sp, client) =>
-            {
-                TwilioOptions opts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<TwilioOptions>>().Value;
-                client.BaseAddress = new Uri(string.Concat(opts.BaseUrl.TrimEnd('/'), "/"));
-                string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{opts.AccountSid}:{opts.AuthToken}"));
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
-                client.DefaultRequestHeaders.Add("Accept", "application/json");
-                client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
-            })
-            .AddStandardResilienceHandler();
+        services.AddGranitHttpClient(ProviderKey, (sp, client) =>
+        {
+            TwilioOptions opts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<TwilioOptions>>().Value;
+            client.BaseAddress = new Uri(string.Concat(opts.BaseUrl.TrimEnd('/'), "/"));
+            string credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{opts.AccountSid}:{opts.AuthToken}"));
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+            client.DefaultRequestHeaders.Add("Accept", "application/json");
+            client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
+        });
 
         services.AddSingleton<TwilioNotificationProvider>();
         services.AddKeyedSingleton<ISmsSender>(

--- a/src/Granit.Notifications.Twilio/Granit.Notifications.Twilio.csproj
+++ b/src/Granit.Notifications.Twilio/Granit.Notifications.Twilio.csproj
@@ -15,12 +15,12 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.HttpResilience\Granit.HttpResilience.csproj" />
     <ProjectReference Include="..\Granit.Notifications.Sms\Granit.Notifications.Sms.csproj" />
     <ProjectReference Include="..\Granit.Notifications.WhatsApp\Granit.Notifications.WhatsApp.csproj" />
   </ItemGroup>

--- a/src/Granit.Notifications.Twilio/GranitNotificationsTwilioModule.cs
+++ b/src/Granit.Notifications.Twilio/GranitNotificationsTwilioModule.cs
@@ -1,4 +1,5 @@
 using Granit.Core.Modularity;
+using Granit.HttpResilience;
 using Granit.Notifications.Sms;
 using Granit.Notifications.WhatsApp;
 
@@ -12,6 +13,7 @@ namespace Granit.Notifications.Twilio;
 /// Registers <c>TwilioNotificationProvider</c> as a keyed service for SMS and WhatsApp channels.
 /// </remarks>
 [DependsOn(
+    typeof(GranitHttpResilienceModule),
     typeof(GranitNotificationsSmsModule),
     typeof(GranitNotificationsWhatsAppModule))]
 public sealed class GranitNotificationsTwilioModule : GranitModule;

--- a/src/Granit.Notifications.Twilio/packages.lock.json
+++ b/src/Granit.Notifications.Twilio/packages.lock.json
@@ -40,17 +40,6 @@
           "Microsoft.Extensions.Options": "10.0.5"
         }
       },
-      "Microsoft.Extensions.Http.Resilience": {
-        "type": "Direct",
-        "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "HbkUsPUC7vLy2TaDbdA9aooW64n9yX4sUppRuiJ1cOzzU1FUW+MVEotm6kYVq6AuUI9xwFSBhRFzA03blmk3VA==",
-        "dependencies": {
-          "Microsoft.Extensions.Http.Diagnostics": "10.4.0",
-          "Microsoft.Extensions.ObjectPool": "10.0.4",
-          "Microsoft.Extensions.Resilience": "10.4.0"
-        }
-      },
       "Microsoft.Extensions.Options": {
         "type": "Direct",
         "requested": "[10.*, )",
@@ -286,6 +275,16 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "granit.httpresilience": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Http": "[10.*, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
       "granit.notifications": {
         "type": "Project",
         "dependencies": {
@@ -351,6 +350,17 @@
           "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.4.0",
+        "contentHash": "HbkUsPUC7vLy2TaDbdA9aooW64n9yX4sUppRuiJ1cOzzU1FUW+MVEotm6kYVq6AuUI9xwFSBhRFzA03blmk3VA==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Diagnostics": "10.4.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.4",
+          "Microsoft.Extensions.Resilience": "10.4.0"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {

--- a/src/Granit.Notifications.Zulip/Extensions/ZulipNotificationsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Zulip/Extensions/ZulipNotificationsServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.HttpResilience.Extensions;
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Zulip.HealthChecks;
 using Granit.Notifications.Zulip.Internal;
@@ -36,13 +37,12 @@ public static class ZulipNotificationsServiceCollectionExtensions
             services.Configure(configureBot);
         }
 
-        services.AddHttpClient(ZulipBotSender.HttpClientName, (sp, client) =>
-            {
-                ZulipBotOptions opts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<ZulipBotOptions>>().Value;
-                client.BaseAddress = new Uri(string.Concat(opts.BaseUrl.TrimEnd('/'), "/"));
-                client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
-            })
-            .AddStandardResilienceHandler();
+        services.AddGranitHttpClient(ZulipBotSender.HttpClientName, (sp, client) =>
+        {
+            ZulipBotOptions opts = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<ZulipBotOptions>>().Value;
+            client.BaseAddress = new Uri(string.Concat(opts.BaseUrl.TrimEnd('/'), "/"));
+            client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
+        });
 
         services.AddSingleton<IZulipSender, ZulipBotSender>();
         services.AddScoped<INotificationChannel, ZulipNotificationChannel>();

--- a/src/Granit.Notifications.Zulip/Granit.Notifications.Zulip.csproj
+++ b/src/Granit.Notifications.Zulip/Granit.Notifications.Zulip.csproj
@@ -15,13 +15,13 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Http" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.HttpResilience\Granit.HttpResilience.csproj" />
     <ProjectReference Include="..\Granit.Notifications\Granit.Notifications.csproj" />
   </ItemGroup>
 

--- a/src/Granit.Notifications.Zulip/GranitNotificationsZulipModule.cs
+++ b/src/Granit.Notifications.Zulip/GranitNotificationsZulipModule.cs
@@ -1,4 +1,5 @@
 using Granit.Core.Modularity;
+using Granit.HttpResilience;
 
 namespace Granit.Notifications.Zulip;
 
@@ -9,5 +10,7 @@ namespace Granit.Notifications.Zulip;
 /// Registration is done via <c>AddGranitNotificationsZulip()</c>.
 /// Includes its own <c>ZulipBotSender</c> implementation.
 /// </remarks>
-[DependsOn(typeof(GranitNotificationsModule))]
+[DependsOn(
+    typeof(GranitHttpResilienceModule),
+    typeof(GranitNotificationsModule))]
 public sealed class GranitNotificationsZulipModule : GranitModule;

--- a/src/Granit.Notifications.Zulip/packages.lock.json
+++ b/src/Granit.Notifications.Zulip/packages.lock.json
@@ -40,17 +40,6 @@
           "Microsoft.Extensions.Options": "10.0.5"
         }
       },
-      "Microsoft.Extensions.Http.Resilience": {
-        "type": "Direct",
-        "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "HbkUsPUC7vLy2TaDbdA9aooW64n9yX4sUppRuiJ1cOzzU1FUW+MVEotm6kYVq6AuUI9xwFSBhRFzA03blmk3VA==",
-        "dependencies": {
-          "Microsoft.Extensions.Http.Diagnostics": "10.4.0",
-          "Microsoft.Extensions.ObjectPool": "10.0.4",
-          "Microsoft.Extensions.Resilience": "10.4.0"
-        }
-      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Direct",
         "requested": "[10.*, )",
@@ -295,6 +284,16 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "granit.httpresilience": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Http": "[10.*, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
       "granit.notifications": {
         "type": "Project",
         "dependencies": {
@@ -342,6 +341,17 @@
           "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.4.0",
+        "contentHash": "HbkUsPUC7vLy2TaDbdA9aooW64n9yX4sUppRuiJ1cOzzU1FUW+MVEotm6kYVq6AuUI9xwFSBhRFzA03blmk3VA==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Diagnostics": "10.4.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.4",
+          "Microsoft.Extensions.Resilience": "10.4.0"
         }
       }
     }

--- a/src/Granit.Webhooks/Extensions/WebhooksHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Webhooks/Extensions/WebhooksHostApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System.Threading.Channels;
 using Granit.Core.Diagnostics;
+using Granit.HttpResilience.Extensions;
 using Granit.Webhooks.Abstractions;
 using Granit.Webhooks.Endpoints;
 using Granit.Webhooks.Handlers;
@@ -46,8 +47,8 @@ public static class WebhooksHostApplicationBuilderExtensions
             .Bind(options);
         configure?.Invoke(options);
 
-        // Named HttpClient for webhook delivery — strict timeout to avoid blocking workers.
-        builder.Services.AddHttpClient(WebhooksConstants.HttpClientName, client =>
+        // Named HttpClient for webhook delivery — resilience pipeline + strict timeout.
+        builder.Services.AddGranitHttpClient(WebhooksConstants.HttpClientName, client =>
         {
             client.Timeout = TimeSpan.FromSeconds(options.HttpTimeoutSeconds);
             client.DefaultRequestHeaders.Add(

--- a/src/Granit.Webhooks/Granit.Webhooks.csproj
+++ b/src/Granit.Webhooks/Granit.Webhooks.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Granit.Core\Granit.Core.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
+    <ProjectReference Include="..\Granit.HttpResilience\Granit.HttpResilience.csproj" />
     <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />
   </ItemGroup>
 

--- a/src/Granit.Webhooks/GranitWebhooksModule.cs
+++ b/src/Granit.Webhooks/GranitWebhooksModule.cs
@@ -1,4 +1,5 @@
 using Granit.Core.Modularity;
+using Granit.HttpResilience;
 using Granit.Timing;
 using Granit.Webhooks.Extensions;
 
@@ -13,7 +14,9 @@ namespace Granit.Webhooks;
 /// <c>Granit.Webhooks.Wolverine</c> for durable outbox dispatch and call
 /// <c>AddGranitWebhooksEntityFrameworkCore()</c> for persistent stores.
 /// </remarks>
-[DependsOn(typeof(GranitTimingModule))]
+[DependsOn(
+    typeof(GranitHttpResilienceModule),
+    typeof(GranitTimingModule))]
 public sealed class GranitWebhooksModule : GranitModule
 {
     /// <inheritdoc/>

--- a/src/Granit.Webhooks/packages.lock.json
+++ b/src/Granit.Webhooks/packages.lock.json
@@ -8,6 +8,84 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.Extensions.AmbientMetadata.Application": {
+        "type": "Transitive",
+        "resolved": "10.4.0",
+        "contentHash": "bovnONzrr/JIc+w343i857rJEb7cQH9UzEjbV5n67agWBEYICGQb8xiqYz5+GoFXp6mKEKLwYCQGttMU1p5yXQ=="
+      },
+      "Microsoft.Extensions.Compliance.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.4.0",
+        "contentHash": "4WkknDbVrHNf+S6fwSt1OAXlGJ/G/QrtJlqx4aNzOLmeT3GRyxpGLZn+Q3UV+RMRAF6FfsijEZBg2ZAW8bTAkg=="
+      },
+      "Microsoft.Extensions.DependencyInjection.AutoActivation": {
+        "type": "Transitive",
+        "resolved": "10.4.0",
+        "contentHash": "ksmUG2SFTcXzYdyoLOdeSM/qYLRGN6qbbSzYVkwMK9xsctfR1hYkUayeOpFCMd7L+QSlYX72mK9wxwdgQxyS4g=="
+      },
+      "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
+        "type": "Transitive",
+        "resolved": "10.4.0",
+        "contentHash": "1/hQmONMWxRTKXuN0pQShQN9QsqIRTS1G4fdmKW0O9phuVZjyzIROQD9Fbfwyn2t+yvP8SzjatGAPX4jDRfgHg=="
+      },
+      "Microsoft.Extensions.Http.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.4.0",
+        "contentHash": "ybx2QcCWROCnUCbSj/IyHXn1c58brjjHzTTbueKgBl/qHsWk69mu25mjQ3oaMsO1I0+EcS6AhVuhIopL2q3IDw==",
+        "dependencies": {
+          "Microsoft.Extensions.Telemetry": "10.4.0"
+        }
+      },
+      "Microsoft.Extensions.Resilience": {
+        "type": "Transitive",
+        "resolved": "10.4.0",
+        "contentHash": "41CCbJJPsDWU6NsmKfANHkfT/+KCBlZZqQ1eBoQhhW0xqGCiWmUlMdi2BoaM/GcwKHX5WiQL/IESROmgk0Owfw==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.4.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.4.0",
+          "Polly.Extensions": "8.4.2",
+          "Polly.RateLimiting": "8.4.2"
+        }
+      },
+      "Microsoft.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "10.4.0",
+        "contentHash": "AbHleTzdpGPjA6RpOjKVHEYx7SoBRnJ2bwAbbPa3aGB7HiVwBmeTJhBGhtIBiuIW0VpKDS8x+bV5iWqpBRIf4w==",
+        "dependencies": {
+          "Microsoft.Extensions.AmbientMetadata.Application": "10.4.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.4.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.4.0"
+        }
+      },
+      "Microsoft.Extensions.Telemetry.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.4.0",
+        "contentHash": "3b2uVa4voJfLLg39BPCKQS0ZgnpEZFkKf7YmnMVlM5FQJYBPOuePIQdnEK1/Oxd+w3GscxGYuE7IMOXDwixZtQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Compliance.Abstractions": "10.4.0"
+        }
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "BpE2I6HBYYA5tF0Vn4eoQOGYTYIK1BlF5EXVgkWGn3mqUUjbXAr13J6fZVbp7Q3epRR8yshacBMlsHMhpOiV3g=="
+      },
+      "Polly.Extensions": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "GZ9vRVmR0jV2JtZavt+pGUsQ1O1cuRKG7R7VOZI6ZDy9y6RNPvRvXK1tuS4ffUrv8L0FTea59oEuQzgS0R7zSA==",
+        "dependencies": {
+          "Polly.Core": "8.4.2"
+        }
+      },
+      "Polly.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "ehTImQ/eUyO07VYW2WvwSmU9rRH200SKJ/3jku9rOkyWE0A2JxNFmAVms8dSn49QLSjmjFRRSgfNyOgr/2PSmA==",
+        "dependencies": {
+          "Polly.Core": "8.4.2"
+        }
+      },
       "granit.core": {
         "type": "Project"
       },
@@ -17,10 +95,27 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
+      "granit.httpresilience": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Http.Resilience": "[10.*, )"
+        }
+      },
       "granit.timing": {
         "type": "Project",
         "dependencies": {
           "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.4.0",
+        "contentHash": "HbkUsPUC7vLy2TaDbdA9aooW64n9yX4sUppRuiJ1cOzzU1FUW+MVEotm6kYVq6AuUI9xwFSBhRFzA03blmk3VA==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Diagnostics": "10.4.0",
+          "Microsoft.Extensions.Resilience": "10.4.0"
         }
       }
     }

--- a/tests/Granit.HttpResilience.Tests/Granit.HttpResilience.Tests.csproj
+++ b/tests/Granit.HttpResilience.Tests/Granit.HttpResilience.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.HttpResilience\Granit.HttpResilience.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.HttpResilience.Tests/GranitHttpResilienceModuleTests.cs
+++ b/tests/Granit.HttpResilience.Tests/GranitHttpResilienceModuleTests.cs
@@ -1,0 +1,110 @@
+// =============================================================================
+// Tests - GranitHttpResilienceModule
+// =============================================================================
+// Verifies module inheritance, that AddGranitHttpClient() registers services
+// without throwing, and that IHttpClientFactory is resolvable.
+// =============================================================================
+
+using Granit.Core.Modularity;
+using Granit.HttpResilience.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace Granit.HttpResilience.Tests;
+
+public sealed class GranitHttpResilienceModuleTests
+{
+    [Fact]
+    public void GranitHttpResilienceModule_IsGranitModule() =>
+        typeof(GranitHttpResilienceModule).IsAssignableTo(typeof(GranitModule)).ShouldBeTrue();
+
+    [Fact]
+    public void GranitHttpResilienceModule_IsSealed() =>
+        typeof(GranitHttpResilienceModule).IsSealed.ShouldBeTrue();
+
+    [Fact]
+    public void GranitHttpResilienceModule_HasNoDependsOn()
+    {
+        var attributes = (DependsOnAttribute[])
+            typeof(GranitHttpResilienceModule).GetCustomAttributes(typeof(DependsOnAttribute), inherit: false);
+
+        attributes.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void AddGranitHttpClient_DoesNotThrow()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+
+        Should.NotThrow(() => builder.Services.AddGranitHttpClient("test-client"));
+    }
+
+    [Fact]
+    public void AddGranitHttpClient_WithConfigureCallback_DoesNotThrow()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+
+        Should.NotThrow(() => builder.Services.AddGranitHttpClient("test-client",
+            (_, client) => client.Timeout = TimeSpan.FromSeconds(5)));
+    }
+
+    [Fact]
+    public void AddGranitHttpClient_WithSimpleCallback_DoesNotThrow()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+
+        Should.NotThrow(() => builder.Services.AddGranitHttpClient("test-client",
+            client => client.Timeout = TimeSpan.FromSeconds(5)));
+    }
+
+    [Fact]
+    public void AddGranitHttpClient_RegistersIHttpClientFactory()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.Services.AddGranitHttpClient("test-client");
+
+        builder.Services.ShouldContain(d =>
+            d.ServiceType == typeof(IHttpClientFactory));
+    }
+
+    [Fact]
+    public void AddGranitHttpClient_MultipleClients_DoesNotThrow()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+
+        Should.NotThrow(() =>
+        {
+            builder.Services.AddGranitHttpClient("client-one");
+            builder.Services.AddGranitHttpClient("client-two");
+            builder.Services.AddGranitHttpClient("client-three");
+        });
+    }
+
+    [Fact]
+    public void AddGranitHttpClient_BuildsServiceProvider_WithoutErrors()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.Services.AddGranitHttpClient("granit-webhooks");
+
+        using IHost host = builder.Build();
+
+        IHttpClientFactory factory = host.Services.GetRequiredService<IHttpClientFactory>();
+        factory.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AddGranitHttpClient_CreatesNamedClient()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.Services.AddGranitHttpClient("granit-test");
+
+        using IHost host = builder.Build();
+
+        IHttpClientFactory factory = host.Services.GetRequiredService<IHttpClientFactory>();
+        HttpClient client = factory.CreateClient("granit-test");
+
+        client.ShouldNotBeNull();
+    }
+}

--- a/tests/Granit.HttpResilience.Tests/packages.lock.json
+++ b/tests/Granit.HttpResilience.Tests/packages.lock.json
@@ -2,50 +2,104 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[8.*, )",
+        "resolved": "8.0.0",
+        "contentHash": "EMkj/2F6n6IVPrvGYkqzGJs6phuGGkq6N+E7KW9rNyzNxXbwQ1KfMqWyXNf9nCNEQOA6IjFwmOLvkriwKE7Orw=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",
         "requested": "[3.*, )",
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
-      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+      "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "REdt95QXHscGdtw/UUgyCW2lF9DJcAOJxmebKW2IkgUjuCAdMODIi2HNOWg5utW98nm8ekgV0Gjqs/sljwwqMw==",
+        "requested": "[18.*, )",
+        "resolved": "18.3.0",
+        "contentHash": "xW3kXuWRQtgoxJp4J+gdhHSQyK+6Wb/AZDSd7lMvuMRYlZ1tnpkojyfZlWilB5G4dmZ0Y0ZxU/M23TlubndNkw==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5"
+          "Microsoft.CodeCoverage": "18.3.0",
+          "Microsoft.TestPlatform.TestHost": "18.3.0"
         }
       },
-      "Microsoft.Extensions.Http": {
+      "NSubstitute": {
         "type": "Direct",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "AiFvHYM8nP0wPC7bGPI3NHQlSYSLqjjT7DMJUuuxhd+7pz3O89iu2gdQfgACy5DxsXENiok5i1bMacJL7KR8jA==",
+        "requested": "[5.*, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Diagnostics": "10.0.5",
-          "Microsoft.Extensions.Logging": "10.0.5",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5"
+          "Castle.Core": "5.1.1"
         }
       },
-      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+      "Shouldly": {
         "type": "Direct",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
         }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "23BNy/vziREC20Wwhb50K7+kZe0m07KlLWDQv4qjJ9tt3QjpDpDIqJFrhYHmMEo9xDkuSp55U/8h4bMF7MiB+g=="
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
@@ -126,17 +180,12 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4"
         }
       },
-      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "NrIMTy7dpqxAvA6kHAYH8cXID/YgeNOy0OqFKpLtkPu5X4WS/basX91UszANzVrMNRAICJ2GOnGiRxJtsRyEQw=="
-      },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
+        "resolved": "10.0.4",
+        "contentHash": "3hLXFZ1E/Kj3obIcb9iMCC95MpW2e8EkWxpXKgUfgGBfm+yn507pHAjPaHoi2U3GlSHIm/21DPCDLumwlMowjw==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.5"
+          "Microsoft.Extensions.Primitives": "10.0.4"
         }
       },
       "Microsoft.Extensions.Http.Diagnostics": {
@@ -219,6 +268,60 @@
           "Microsoft.Extensions.Options": "10.0.4"
         }
       },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "AEIEX2aWdPO9XbtR96eBaJxmXRD9vaI9uQ1T/JbPEKlTAZwYx0ZrMzKyULMdh/HH9Sg03kXCoN7LszQ90o6nPQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "twmsoelXnp1uWMU3VGip9f0Jr1mZ0PZqgJdF35CIrdYgYrkHIJMV1m8uKyhcdjLdsQDESHAgkR7KhS9i1qpJag==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.3.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
       "Polly.Core": {
         "type": "Transitive",
         "resolved": "8.4.2",
@@ -243,10 +346,95 @@
           "System.Threading.RateLimiting": "8.0.0"
         }
       },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
       "System.Threading.RateLimiting": {
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "7mu9v0QDv66ar3DpGSZHg9NuNcxDaaAcnMULuZlaTpP9+hwXhrxNGsF5GmLkSHxFdb5bBc1TzeujsRgTrPWi+Q=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
       },
       "granit.core": {
         "type": "Project"
@@ -259,27 +447,6 @@
           "Microsoft.Extensions.Http.Resilience": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
-      "granit.identity": {
-        "type": "Project",
-        "dependencies": {
-          "Granit.Core": "[0.1.0-dev, )",
-          "Granit.Querying": "[0.1.0-dev, )"
-        }
-      },
-      "granit.querying": {
-        "type": "Project",
-        "dependencies": {
-          "Granit.Core": "[0.1.0-dev, )"
-        }
-      },
-      "granit.timing": {
-        "type": "Project",
-        "dependencies": {
-          "Granit.Core": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
@@ -301,14 +468,28 @@
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
+        "resolved": "10.0.4",
+        "contentHash": "+5mQrqlBhqNUaPyDmFSNM/qiWStvE9LMxZW1MRF0NhEbO781xNeKryXNR9gGDJ0PmYFDAVoMT9ffX+I15LPFTw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.4",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Http": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
         "resolved": "10.0.5",
-        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "contentHash": "AiFvHYM8nP0wPC7bGPI3NHQlSYSLqjjT7DMJUuuxhd+7pz3O89iu2gdQfgACy5DxsXENiok5i1bMacJL7KR8jA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+          "Microsoft.Extensions.Diagnostics": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
         }
       },
       "Microsoft.Extensions.Http.Resilience": {
@@ -338,6 +519,19 @@
         "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
           "Microsoft.Extensions.Primitives": "10.0.5"
         }
       }


### PR DESCRIPTION
## Summary

- Adds `Granit.HttpResilience` — a new package wrapping `Microsoft.Extensions.Http.Resilience` (Polly v8) that exposes `AddGranitHttpClient()` as a drop-in replacement for `AddHttpClient().AddStandardResilienceHandler()`
- Every registered client automatically gets retry (3 attempts, exponential back-off), circuit breaker (10 failures/30 s → 1 min open), total timeout (30 s), and per-attempt timeout (10 s)
- Per-client pipeline overrides are bound from `HttpResilience:{clientName}` in `appsettings.json` at runtime via `IPostConfigureOptions<HttpStandardResilienceOptions>` — no redeployment needed
- Migrates 10 modules to `AddGranitHttpClient()`: Webhooks, Notifications.Twilio, Notifications.Brevo, Notifications.Zulip, Notifications.Email.SendGrid, Notifications.Email.Scaleway, Notifications.MobilePush.GoogleFcm, Identity.Keycloak, Identity.EntraId, AI.Ollama

## Test plan

- [x] `Granit.HttpResilience.Tests` — 10 unit tests covering module contract, DI registration, named clients, multi-client scenarios
- [x] `dotnet build` — all 10 migrated modules build with 0 errors
- [x] `dotnet format --verify-no-changes` — no style regressions
- [x] `PACKAGE_COUNT` updated 161 → 162 in `docs-site/src/data/constants.ts`
- [x] Docs page added at `docs-site/src/content/docs/dotnet/api/http-resilience.mdx`

Closes #162, #163, #168, #171, #174, #176, #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)
