### PR TITLE
feat(persistence): add optimistic concurrency via IConcurrencyAware

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -159,6 +159,13 @@ export default defineConfig({
                         { label: "Use with AI Assistants", link: "/dotnet/guides/use-with-ai-assistants/" },
                       ],
                     },
+                    {
+                      label: "Testing",
+                      collapsed: true,
+                      items: [
+                        { label: "Testing Infrastructure", link: "/dotnet/guides/testing/" },
+                      ],
+                    },
                   ],
                 },
                 {

--- a/docs-site/src/components/ArchDiagram.astro
+++ b/docs-site/src/components/ArchDiagram.astro
@@ -105,7 +105,7 @@ const layers: Layer[] = [
     label: "Data",
     color: "data",
     modules: [
-      { name: "Persistence",     pkg: "Granit.Persistence",     href: "/dotnet/data/persistence/",     tip: "EF Core interceptors, soft delete, audit, multi-tenancy filters" },
+      { name: "Persistence",     pkg: "Granit.Persistence",     href: "/dotnet/data/persistence/",     tip: "EF Core interceptors, soft delete, audit, optimistic concurrency, multi-tenancy filters" },
       { name: "Caching",         pkg: "Granit.Caching",         href: "/dotnet/data/caching/",         tip: "HybridCache: in-process + distributed (Redis, SQL)" },
       { name: "BlobStorage",     pkg: "Granit.BlobStorage",     href: "/dotnet/data/blob-storage/",    tip: "Multi-provider: S3, Azure Blob, GCS, FileSystem, Database" },
       { name: "Imaging",         pkg: "Granit.Imaging",         href: "/dotnet/data/imaging/",         tip: "Image processing pipeline: resize, crop, convert, watermark" },

--- a/docs-site/src/content/docs/dotnet/data/concurrency.mdx
+++ b/docs-site/src/content/docs/dotnet/data/concurrency.mdx
@@ -1,0 +1,301 @@
+---
+title: Optimistic Concurrency
+description: Prevent silent data loss from concurrent writes with IConcurrencyAware, ConcurrencyStampInterceptor, and automatic HTTP 409 Conflict responses
+sidebar:
+  order: 3
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+Two users open the same order. Both change the status. Both click Save. Without
+concurrency control, the last write wins and the first change is silently lost.
+With `IConcurrencyAware`, the second save fails with HTTP 409 Conflict — the user
+can review the updated data and retry.
+
+## How it works
+
+```mermaid
+sequenceDiagram
+    participant A as User A
+    participant API as API
+    participant DB as Database
+    participant B as User B
+
+    A->>API: GET /orders/42
+    API->>DB: SELECT ... WHERE Id = 42
+    DB-->>API: Order (stamp = "abc")
+    API-->>A: { status: "Pending", stamp: "abc" }
+
+    B->>API: GET /orders/42
+    API->>DB: SELECT ... WHERE Id = 42
+    DB-->>API: Order (stamp = "abc")
+    API-->>B: { status: "Pending", stamp: "abc" }
+
+    A->>API: PUT /orders/42 { status: "Confirmed", stamp: "abc" }
+    API->>DB: UPDATE ... SET Status='Confirmed', Stamp='def' WHERE Id=42 AND Stamp='abc'
+    DB-->>API: 1 row affected
+    API-->>A: 200 OK { stamp: "def" }
+
+    B->>API: PUT /orders/42 { status: "Cancelled", stamp: "abc" }
+    API->>DB: UPDATE ... SET Status='Cancelled', Stamp='ghi' WHERE Id=42 AND Stamp='abc'
+    DB-->>API: 0 rows affected (stamp is now "def")
+    API-->>B: 409 Conflict
+```
+
+EF Core includes the `ConcurrencyStamp` in the `WHERE` clause of every `UPDATE`.
+If the stamp in the database differs from the value EF loaded, zero rows are affected
+and EF throws `DbUpdateConcurrencyException`. Granit maps this to HTTP 409 Conflict
+automatically.
+
+## Setup
+
+No additional registration needed. `IConcurrencyAware` support is built into
+`Granit.Persistence` — already activated by `AddGranitPersistence()` and
+`ApplyGranitConventions()`.
+
+The three components:
+
+| Component | Role | Package |
+|-----------|------|---------|
+| `IConcurrencyAware` | Entity interface with `ConcurrencyStamp` property | `Granit.Core` |
+| `ConcurrencyStampInterceptor` | Regenerates stamp on every `SaveChanges` | `Granit.Persistence` |
+| `ApplyGranitConventions()` | Configures `.IsConcurrencyToken()` automatically | `Granit.Persistence` |
+| `EfCoreExceptionStatusCodeMapper` | Maps `DbUpdateConcurrencyException` to 409 | `Granit.Persistence` |
+
+## Adding concurrency to an entity
+
+Implement `IConcurrencyAware` on any entity that needs protection:
+
+```csharp
+public class Order : AuditedEntity, IConcurrencyAware
+{
+    public string Reference { get; set; } = string.Empty;
+    public OrderStatus Status { get; set; }
+    public decimal TotalAmount { get; set; }
+
+    // Auto-managed by ConcurrencyStampInterceptor
+    public string ConcurrencyStamp { get; set; } = string.Empty;
+}
+```
+
+That's it. No Fluent API, no attributes, no manual interceptor wiring.
+`ApplyGranitConventions()` auto-discovers all `IConcurrencyAware` entities and
+configures `ConcurrencyStamp` as `VARCHAR(36)` with `.IsConcurrencyToken()`.
+
+## Interceptor pipeline
+
+`ConcurrencyStampInterceptor` runs in the standard pipeline:
+
+| Order | Interceptor | Action |
+|-------|-------------|--------|
+| 1 | `AuditedEntityInterceptor` | Sets audit fields |
+| 2 | `VersioningInterceptor` | Sets version number |
+| **3** | **`ConcurrencyStampInterceptor`** | **Regenerates `ConcurrencyStamp`** |
+| 4 | `DomainEventDispatcherInterceptor` | Collects domain events |
+| 5 | `SoftDeleteInterceptor` | Converts DELETE to soft delete |
+
+On `EntityState.Added`: sets the initial stamp (new GUID string).
+On `EntityState.Modified`: regenerates the stamp (new GUID string).
+
+## Endpoint patterns
+
+### Response DTO — include the stamp
+
+```csharp
+public sealed record OrderResponse(
+    Guid Id,
+    string Reference,
+    OrderStatus Status,
+    decimal TotalAmount,
+    string ConcurrencyStamp);
+```
+
+### Request DTO — accept the stamp back
+
+Use `IConcurrencyStampRequest` as a convention:
+
+```csharp
+public sealed record UpdateOrderRequest(
+    OrderStatus Status,
+    string ConcurrencyStamp) : IConcurrencyStampRequest;
+```
+
+### Connected update (same DbContext)
+
+When the entity is loaded from the same `DbContext`, EF Core tracks `OriginalValue`
+automatically:
+
+```csharp
+app.MapPut("/orders/{id:guid}", async (
+    Guid id,
+    UpdateOrderRequest request,
+    AppDbContext db,
+    CancellationToken ct) =>
+{
+    Order? order = await db.Orders.FindAsync([id], ct);
+    if (order is null)
+        return TypedResults.NotFound();
+
+    order.Status = request.Status;
+    await db.SaveChangesAsync(ct); // stamp checked automatically
+    return TypedResults.Ok(order.ToResponse());
+})
+.Produces<OrderResponse>()
+.ProducesProblem(StatusCodes.Status409Conflict);
+```
+
+### Disconnected update (CQRS / new DbContext)
+
+When the entity was not loaded by the current `DbContext`, you must set the
+`OriginalValue` explicitly so EF Core knows what the client believes the stamp is:
+
+```csharp
+app.MapPut("/orders/{id:guid}", async (
+    Guid id,
+    UpdateOrderRequest request,
+    AppDbContext db,
+    CancellationToken ct) =>
+{
+    Order? order = await db.Orders.FindAsync([id], ct);
+    if (order is null)
+        return TypedResults.NotFound();
+
+    order.Status = request.Status;
+
+    // Tell EF Core what the client believes the current stamp is
+    db.Entry(order).Property(e => e.ConcurrencyStamp).OriginalValue
+        = request.ConcurrencyStamp;
+
+    await db.SaveChangesAsync(ct);
+    return TypedResults.Ok(order.ToResponse());
+})
+.Produces<OrderResponse>()
+.ProducesProblem(StatusCodes.Status409Conflict);
+```
+
+:::caution[Always set OriginalValue in disconnected scenarios]
+Without setting `OriginalValue`, EF Core compares the stamp against itself (current
+DB value = original value) and the check always passes. The concurrency protection
+is silently disabled.
+:::
+
+## Error handling
+
+`EfCoreExceptionStatusCodeMapper` automatically maps `DbUpdateConcurrencyException`
+to HTTP 409 Conflict with RFC 7807 `ProblemDetails`:
+
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.8",
+  "title": "Conflict",
+  "status": 409,
+  "detail": "The resource was modified by another request. Reload and retry."
+}
+```
+
+No custom exception handling needed — the Granit exception middleware handles it.
+
+### Client-side retry guidance
+
+API consumers should implement this pattern:
+
+1. **GET** the resource (receive `ConcurrencyStamp` in response)
+2. **PUT/PATCH** with the stamp
+3. If **409**: re-GET, show updated data to the user, let them retry
+4. If **200**: success, update the local stamp
+
+:::tip[Automated retry for non-interactive operations]
+For background jobs or automated integrations, implement exponential backoff:
+re-fetch, re-apply changes, re-submit. Limit to 3 retries.
+:::
+
+## When to use IConcurrencyAware
+
+| Use case | Recommendation |
+|----------|---------------|
+| Orders, payments, invoices | **Yes** — financial data loss is unacceptable |
+| Appointments, bookings | **Yes** — double-booking from concurrent edits |
+| Shared configuration | **Yes** — admin panels with multiple operators |
+| Inventory, stock levels | **Yes** — concurrent decrements cause overselling |
+| User profiles | **Maybe** — low conflict probability, but protects against rare edge cases |
+| Read-only / append-only entities | **No** — no concurrent writes to conflict |
+| Audit log entries | **No** — immutable, never updated |
+
+The overhead is negligible: one `VARCHAR(36)` column and one `WHERE` clause
+parameter per update.
+
+## Testing
+
+Use SQLite for concurrency tests — the EF Core InMemory provider does not enforce
+concurrency tokens.
+
+```csharp
+[Fact]
+public async Task Concurrent_update_throws_DbUpdateConcurrencyException()
+{
+    // Arrange — create entity via context1
+    using var factory = new SqliteDbContextFactory<OrderDbContext>();
+    using OrderDbContext context1 = factory.CreateContext();
+    Order order = new() { Reference = "ORD-001" };
+    context1.Orders.Add(order);
+    await context1.SaveChangesAsync();
+
+    // Load same entity in context2 (EF tracks OriginalValue automatically)
+    using OrderDbContext context2 = factory.CreateContext(ensureCreated: false);
+    Order? sameOrder = await context2.Orders.FindAsync(order.Id);
+
+    // Modify and save via context1 — stamp changes in DB
+    order.Status = OrderStatus.Confirmed;
+    await context1.SaveChangesAsync();
+
+    // Act — context2 still has the old stamp
+    sameOrder!.Status = OrderStatus.Cancelled;
+
+    // Assert
+    await Should.ThrowAsync<DbUpdateConcurrencyException>(
+        () => context2.SaveChangesAsync());
+}
+```
+
+:::caution[EF Core InMemory does not work]
+`UseInMemoryDatabase()` silently ignores `.IsConcurrencyToken()`. Concurrency
+conflict tests always pass (false positive). Always use `SqliteDbContextFactory`
+or Testcontainers for PostgreSQL.
+:::
+
+## Common pitfalls
+
+:::caution[ExecuteUpdate bypasses the interceptor]
+`ExecuteUpdateAsync()` emits raw SQL — `ConcurrencyStampInterceptor` is never
+called. The stamp is not regenerated and not checked. Use the change tracker for
+entities that need concurrency protection.
+:::
+
+:::caution[Forgetting ConcurrencyStamp in the response DTO]
+If the response doesn't include the stamp, the frontend cannot send it back on
+update. The concurrency check silently passes because `OriginalValue` matches the
+DB value.
+:::
+
+:::caution[Bulk operations]
+`SaveChanges` with multiple modified `IConcurrencyAware` entities checks each stamp
+independently. If entity A conflicts but entity B doesn't, the entire
+`SaveChangesAsync` fails. Design your endpoints to modify one concurrency-aware
+entity per save, or handle partial failures.
+:::
+
+## Public API summary
+
+| Category | Type | Package |
+|----------|------|---------|
+| Entity interface | `IConcurrencyAware` | `Granit.Core` |
+| DTO convention | `IConcurrencyStampRequest` | `Granit.Core` |
+| Interceptor | `ConcurrencyStampInterceptor` | `Granit.Persistence` |
+| Auto-config | `ApplyGranitConventions()` | `Granit.Persistence` |
+| Exception mapping | `EfCoreExceptionStatusCodeMapper` | `Granit.Persistence` |
+
+## See also
+
+- [Persistence](/dotnet/data/persistence/) — full interceptor pipeline, query filters, isolated DbContext
+- [Exception Handling](/dotnet/api/exception-handling/) — RFC 7807 ProblemDetails, global error mapping
+- [Idempotency](/dotnet/api/idempotency/) — complementary pattern for preventing duplicate requests

--- a/docs-site/src/content/docs/dotnet/data/persistence.mdx
+++ b/docs-site/src/content/docs/dotnet/data/persistence.mdx
@@ -1,6 +1,6 @@
 ---
 title: Persistence
-description: EF Core interceptors, audit trail, soft delete, data seeding, zero-downtime migrations
+description: EF Core interceptors, audit trail, soft delete, optimistic concurrency, data seeding, zero-downtime migrations
 sidebar:
   order: 2
 ---
@@ -8,9 +8,10 @@ sidebar:
 import { Tabs, TabItem, FileTree, Badge } from "@astrojs/starlight/components";
 
 Granit.Persistence provides the data access layer for the framework. It automates
-ISO 27001 audit trails, GDPR-compliant soft delete, domain event dispatching,
-entity versioning, and multi-tenant query filtering — all through EF Core interceptors
-and conventions. No manual `WHERE` clauses, no forgotten audit fields.
+ISO 27001 audit trails, GDPR-compliant soft delete, optimistic concurrency control,
+domain event dispatching, entity versioning, and multi-tenant query filtering — all
+through EF Core interceptors and conventions. No manual `WHERE` clauses, no forgotten
+audit fields, no silent data overwrites.
 
 ## Package structure
 
@@ -50,7 +51,7 @@ graph TD
 public class AppModule : GranitModule { }
 ```
 
-Registers all four interceptors and `IDataFilter`.
+Registers all five interceptors and `IDataFilter`.
 
 </TabItem>
 <TabItem label="With migrations">
@@ -130,14 +131,15 @@ Manual filters cause duplicates or conflicts.
 
 ## Interceptors
 
-Four interceptors execute on every `SaveChanges` call, in this order:
+Five interceptors execute on every `SaveChanges` call, in this order:
 
 | Order | Interceptor | Behavior |
 |-------|-------------|----------|
 | 1 | `AuditedEntityInterceptor` | Populates `CreatedAt`, `CreatedBy`, `ModifiedAt`, `ModifiedBy`, auto-generates `Id`, injects `TenantId` |
 | 2 | `VersioningInterceptor` | Sets `BusinessId` and `Version` on `IVersioned` entities |
-| 3 | `DomainEventDispatcherInterceptor` | Collects domain events before save, dispatches after commit |
-| 4 | `SoftDeleteInterceptor` | Converts `DELETE` to `UPDATE` for `ISoftDeletable` entities |
+| 3 | `ConcurrencyStampInterceptor` | Regenerates `ConcurrencyStamp` on `IConcurrencyAware` entities |
+| 4 | `DomainEventDispatcherInterceptor` | Collects domain events before save, dispatches after commit |
+| 5 | `SoftDeleteInterceptor` | Converts `DELETE` to `UPDATE` for `ISoftDeletable` entities |
 
 :::note
 SoftDeleteInterceptor must be last — it changes `EntityState.Deleted` to
@@ -235,6 +237,89 @@ For `IVersioned` entities on `EntityState.Added`:
 - Generates `BusinessId` if empty (first version of a new entity)
 - Determines `Version` from change tracker (starting at 1)
 - Modified entities are untouched — versioning is explicit (create a new entity with same `BusinessId`)
+
+### ConcurrencyStampInterceptor
+
+Prevents silent data loss from concurrent writes. When two users load the same
+entity and both save changes, the second write fails instead of overwriting the first.
+
+Targets entities implementing `IConcurrencyAware`:
+
+```csharp
+public class Order : AuditedEntity, IConcurrencyAware
+{
+    public string Reference { get; set; } = string.Empty;
+    public OrderStatus Status { get; set; }
+    public string ConcurrencyStamp { get; set; } = string.Empty;
+}
+```
+
+| Entity state | Action |
+|-------------|--------|
+| `Added` | Sets `ConcurrencyStamp` to a new GUID string |
+| `Modified` | Regenerates `ConcurrencyStamp` with a new GUID string |
+
+`ApplyGranitConventions` auto-discovers `IConcurrencyAware` entities and configures
+`ConcurrencyStamp` as an EF Core concurrency token (`VARCHAR(36)`,
+`.IsConcurrencyToken()`). No manual Fluent API configuration needed.
+
+EF Core includes the stamp in the `WHERE` clause on update:
+
+```sql
+UPDATE Orders
+SET Status = @newStatus, ConcurrencyStamp = @newStamp
+WHERE Id = @id AND ConcurrencyStamp = @originalStamp
+```
+
+If the stamp in the database differs from the original value loaded by the entity,
+EF Core throws `DbUpdateConcurrencyException` — mapped to **HTTP 409 Conflict**
+by `EfCoreExceptionStatusCodeMapper`.
+
+#### Connected vs disconnected updates
+
+**Connected** — entity loaded from the same `DbContext`. EF Core tracks
+`OriginalValue` automatically; nothing extra to do:
+
+```csharp
+var order = await db.Orders.FindAsync(orderId, ct);
+order!.Status = OrderStatus.Confirmed;
+await db.SaveChangesAsync(ct); // stamp checked automatically
+```
+
+**Disconnected** (CQRS command, new `DbContext`) — the frontend sends the stamp it
+received in the GET response. You must set `OriginalValue` explicitly before saving:
+
+```csharp
+var order = await db.Orders.FindAsync(request.Id, ct);
+order!.Status = request.NewStatus;
+
+// Tell EF Core what the client believes the current stamp is
+db.Entry(order).Property(e => e.ConcurrencyStamp).OriginalValue = request.ConcurrencyStamp;
+
+await db.SaveChangesAsync(ct); // throws DbUpdateConcurrencyException on mismatch
+```
+
+Use `IConcurrencyStampRequest` as a DTO convention:
+
+```csharp
+public sealed record UpdateOrderStatusRequest(
+    Guid Id,
+    OrderStatus NewStatus,
+    string ConcurrencyStamp) : IConcurrencyStampRequest;
+```
+
+:::caution[ExecuteUpdate bypasses this interceptor]
+`ExecuteUpdateAsync()` emits raw SQL and never reaches `ConcurrencyStampInterceptor`.
+The concurrency stamp is **not** regenerated and **not** checked. Use the change
+tracker for entities that need optimistic concurrency protection.
+:::
+
+:::tip[When to use IConcurrencyAware]
+Add `IConcurrencyAware` to entities where concurrent modifications are likely and
+data loss is unacceptable: orders, payments, appointments, inventory, shared
+configuration. For read-heavy entities that rarely conflict, the overhead is
+negligible but unnecessary.
+:::
 
 ## Query filters
 
@@ -483,7 +568,7 @@ to cascade to the next batch via the durable outbox.
 | Category | Key types | Package |
 |----------|-----------|---------|
 | Module | `GranitPersistenceModule` | `Granit.Persistence` |
-| Interceptors | `AuditedEntityInterceptor`, `SoftDeleteInterceptor`, `DomainEventDispatcherInterceptor`, `VersioningInterceptor` | `Granit.Persistence` |
+| Interceptors | `AuditedEntityInterceptor`, `VersioningInterceptor`, `ConcurrencyStampInterceptor`, `DomainEventDispatcherInterceptor`, `SoftDeleteInterceptor` | `Granit.Persistence` |
 | Extensions | `AddGranitPersistence()`, `AddGranitDbContext<T>()`, `UseGranitInterceptors()`, `ApplyGranitConventions()` | `Granit.Persistence` |
 | Data seeding | `IDataSeeder`, `IDataSeedContributor`, `DataSeedContext` | `Granit.Persistence` |
 | Purging | `ISoftDeletePurgeTarget`, `PurgeSoftDeletedBeforeAsync()` | `Granit.Persistence` |
@@ -550,6 +635,34 @@ public async Task Soft_deleted_entities_are_filtered_out()
     // Assert — visible when filter is disabled
     var all = await context.Patients.IgnoreQueryFilters().ToListAsync();
     all.Count.ShouldBe(1);
+}
+```
+
+For concurrency conflict tests, use SQLite (the InMemory provider does not enforce
+concurrency tokens):
+
+```csharp
+[Fact]
+public async Task Concurrent_modification_throws_DbUpdateConcurrencyException()
+{
+    // Arrange — create entity via context1
+    await using var context1 = CreateSqliteContext<OrderDbContext>();
+    var order = new Order { Reference = "ORD-001" };
+    context1.Orders.Add(order);
+    await context1.SaveChangesAsync();
+
+    // Load the same entity in context2
+    await using var context2 = CreateSqliteContext<OrderDbContext>(ensureCreated: false);
+    var sameOrder = await context2.Orders.FindAsync(order.Id);
+
+    // Modify and save via context1 — stamp changes in DB
+    order.Status = OrderStatus.Confirmed;
+    await context1.SaveChangesAsync();
+
+    // Act — context2 still has the old stamp
+    sameOrder!.Status = OrderStatus.Cancelled;
+    await Should.ThrowAsync<DbUpdateConcurrencyException>(
+        () => context2.SaveChangesAsync());
 }
 ```
 

--- a/src/Granit.Core/Domain/IConcurrencyAware.cs
+++ b/src/Granit.Core/Domain/IConcurrencyAware.cs
@@ -1,0 +1,33 @@
+namespace Granit.Core.Domain;
+
+/// <summary>
+/// Interface for entities with optimistic concurrency control.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The <see cref="ConcurrencyStamp"/> is automatically regenerated on every
+/// <c>SaveChanges</c>/<c>SaveChangesAsync</c> by <c>ConcurrencyStampInterceptor</c>
+/// and configured as an EF Core concurrency token by
+/// <c>ModelBuilderExtensions.ApplyGranitConventions()</c>.
+/// </para>
+/// <para>
+/// When a concurrent update is detected (stamp mismatch in the <c>WHERE</c> clause),
+/// EF Core throws <see cref="Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException"/>,
+/// which is mapped to HTTP 409 Conflict by <c>EfCoreExceptionStatusCodeMapper</c>.
+/// </para>
+/// <para>
+/// <b>Disconnected updates (CQRS):</b> when the entity is not loaded from the same
+/// <c>DbContext</c>, set the original stamp received from the client before saving:
+/// <code>
+/// dbContext.Entry(entity).Property(e =&gt; e.ConcurrencyStamp).OriginalValue = request.ConcurrencyStamp;
+/// </code>
+/// </para>
+/// </remarks>
+public interface IConcurrencyAware
+{
+    /// <summary>
+    /// Opaque concurrency stamp (GUID string, 36 characters).
+    /// Automatically regenerated on every save by <c>ConcurrencyStampInterceptor</c>.
+    /// </summary>
+    string ConcurrencyStamp { get; set; }
+}

--- a/src/Granit.Core/Domain/IConcurrencyStampRequest.cs
+++ b/src/Granit.Core/Domain/IConcurrencyStampRequest.cs
@@ -1,0 +1,34 @@
+namespace Granit.Core.Domain;
+
+/// <summary>
+/// Optional convention for request DTOs that carry a concurrency stamp
+/// for optimistic concurrency control on <see cref="IConcurrencyAware"/> entities.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Endpoints handling <see cref="IConcurrencyAware"/> entities should include
+/// the stamp in the response DTO and accept it back in the update request DTO.
+/// The endpoint maps it to the entity before saving:
+/// </para>
+/// <code>
+/// // Connected scenario (entity loaded from same DbContext):
+/// entity.Name = request.Name; // EF Core already knows OriginalValue
+///
+/// // Disconnected scenario (CQRS command, new DbContext):
+/// dbContext.Entry(entity).Property(e =&gt; e.ConcurrencyStamp).OriginalValue = request.ConcurrencyStamp;
+/// </code>
+/// <para>
+/// If the stamp in the database differs from the original value, EF Core throws
+/// <see cref="Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException"/>,
+/// mapped to HTTP 409 Conflict by <c>EfCoreExceptionStatusCodeMapper</c>.
+/// </para>
+/// </remarks>
+public interface IConcurrencyStampRequest
+{
+    /// <summary>
+    /// Concurrency stamp from the last read, used for optimistic locking.
+    /// Must match the current <see cref="IConcurrencyAware.ConcurrencyStamp"/>
+    /// in the database; otherwise, the save throws a concurrency conflict.
+    /// </summary>
+    string ConcurrencyStamp { get; }
+}

--- a/src/Granit.Persistence/Extensions/DbContextOptionsBuilderExtensions.cs
+++ b/src/Granit.Persistence/Extensions/DbContextOptionsBuilderExtensions.cs
@@ -19,6 +19,7 @@ public static class DbContextOptionsBuilderExtensions
     /// <list type="number">
     ///   <item><see cref="AuditedEntityInterceptor"/> — ISO 27001 audit fields (created/modified by/at, tenant, GUID).</item>
     ///   <item><see cref="VersioningInterceptor"/> — auto-assigns <c>BusinessId</c> and <c>Version</c> on <c>IVersioned</c> entities.</item>
+    ///   <item><see cref="ConcurrencyStampInterceptor"/> — regenerates <c>ConcurrencyStamp</c> on <c>IConcurrencyAware</c> entities.</item>
     ///   <item><see cref="DomainEventDispatcherInterceptor"/> — collects and dispatches domain events after save.</item>
     ///   <item><see cref="SoftDeleteInterceptor"/> — converts physical deletes to soft deletes for <c>ISoftDeletable</c> entities.</item>
     /// </list>
@@ -49,11 +50,12 @@ public static class DbContextOptionsBuilderExtensions
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(serviceProvider);
 
-        // Order matters: Audit → Versioning → DomainEvents → SoftDelete.
+        // Order matters: Audit → Versioning → ConcurrencyStamp → DomainEvents → SoftDelete.
         // SoftDelete must be last because it converts Deleted → Modified,
         // which would prevent other interceptors from seeing the original state.
         AddInterceptorIfRegistered<AuditedEntityInterceptor>(options, serviceProvider);
         AddInterceptorIfRegistered<VersioningInterceptor>(options, serviceProvider);
+        AddInterceptorIfRegistered<ConcurrencyStampInterceptor>(options, serviceProvider);
         AddInterceptorIfRegistered<DomainEventDispatcherInterceptor>(options, serviceProvider);
         AddInterceptorIfRegistered<SoftDeleteInterceptor>(options, serviceProvider);
 

--- a/src/Granit.Persistence/Extensions/ModelBuilderExtensions.cs
+++ b/src/Granit.Persistence/Extensions/ModelBuilderExtensions.cs
@@ -17,6 +17,10 @@ public static class ModelBuilderExtensions
         typeof(ModelBuilderExtensions)
             .GetMethod(nameof(SetEntityFilter), BindingFlags.Static | BindingFlags.NonPublic)!; // NOSONAR S3011 - intentional: generic EF Core filter pattern requires reflection on private generic method
 
+    private static readonly MethodInfo ConfigureConcurrencyStampMethod =
+        typeof(ModelBuilderExtensions)
+            .GetMethod(nameof(ConfigureConcurrencyStamp), BindingFlags.Static | BindingFlags.NonPublic)!; // NOSONAR S3011 - intentional: generic EF Core property configuration requires reflection
+
     /// <summary>
     /// Applies Granit conventions to all entity types in the model:
     /// <list type="bullet">
@@ -75,6 +79,20 @@ public static class ModelBuilderExtensions
             SetEntityFilterMethod // NOSONAR S3011 - intentional: generic EF Core filter pattern requires reflection
                 .MakeGenericMethod(clrType)
                 .Invoke(null, [modelBuilder, currentTenant, proxy]);
+        }
+
+        // --- Concurrency token conventions ---
+        // Detects IConcurrencyAware implementations and configures:
+        //   - ConcurrencyStamp as a concurrency token (IsConcurrencyToken)
+        //   - VARCHAR(36) max length
+        foreach (Type clrType in modelBuilder.Model.GetEntityTypes().Select(entityType => entityType.ClrType))
+        {
+            if (typeof(IConcurrencyAware).IsAssignableFrom(clrType))
+            {
+                ConfigureConcurrencyStampMethod // NOSONAR S3011 - intentional: generic EF Core property configuration requires reflection
+                    .MakeGenericMethod(clrType)
+                    .Invoke(null, [modelBuilder]);
+            }
         }
 
         // --- Translation conventions ---
@@ -194,6 +212,16 @@ public static class ModelBuilderExtensions
             builder.HasQueryFilter(GranitFilterNames.Publishable,
                 Expression.Lambda<Func<TEntity, bool>>(Expression.OrElse(bypass, isPublished), param));
         }
+    }
+
+    // Configures the ConcurrencyStamp property as a concurrency token with VARCHAR(36).
+    private static void ConfigureConcurrencyStamp<TEntity>(ModelBuilder modelBuilder)
+        where TEntity : class, IConcurrencyAware
+    {
+        modelBuilder.Entity<TEntity>()
+            .Property(e => e.ConcurrencyStamp)
+            .HasMaxLength(36)
+            .IsConcurrencyToken();
     }
 
     // Internal wrapper: EF Core evaluates simple property access on a ConstantExpression

--- a/src/Granit.Persistence/Extensions/PersistenceServiceCollectionExtensions.cs
+++ b/src/Granit.Persistence/Extensions/PersistenceServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ public static class PersistenceServiceCollectionExtensions
     /// <list type="bullet">
     ///   <item>ISO 27001 audit interceptor (<see cref="AuditedEntityInterceptor"/>)</item>
     ///   <item>Versioning interceptor (<see cref="VersioningInterceptor"/>)</item>
+    ///   <item>Optimistic concurrency interceptor (<see cref="ConcurrencyStampInterceptor"/>)</item>
     ///   <item>GDPR soft delete interceptor (<see cref="SoftDeleteInterceptor"/>)</item>
     ///   <item>
     ///     Data filter service (<see cref="IDataFilter"/>) for runtime filter control.
@@ -43,6 +44,7 @@ public static class PersistenceServiceCollectionExtensions
     {
         services.AddScoped<AuditedEntityInterceptor>();
         services.AddScoped<VersioningInterceptor>();
+        services.AddScoped<ConcurrencyStampInterceptor>();
         services.AddScoped<SoftDeleteInterceptor>();
         services.AddScoped<DomainEventDispatcherInterceptor>();
         services.TryAddSingleton<IDomainEventDispatcher, NullDomainEventDispatcher>();

--- a/src/Granit.Persistence/Interceptors/ConcurrencyStampInterceptor.cs
+++ b/src/Granit.Persistence/Interceptors/ConcurrencyStampInterceptor.cs
@@ -1,0 +1,71 @@
+using Granit.Core.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Granit.Persistence.Interceptors;
+
+/// <summary>
+/// EF Core interceptor that auto-generates a new <see cref="IConcurrencyAware.ConcurrencyStamp"/>
+/// on every <c>SaveChanges</c>/<c>SaveChangesAsync</c> for entities implementing
+/// <see cref="IConcurrencyAware"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// On <c>EntityState.Added</c> and <c>EntityState.Modified</c>:
+/// <list type="bullet">
+///   <item>Sets <see cref="IConcurrencyAware.ConcurrencyStamp"/> to a new <see cref="Guid"/>
+///         string (36 characters).</item>
+/// </list>
+/// </para>
+/// <para>
+/// The stamp is configured as an EF Core concurrency token by
+/// <see cref="Extensions.ModelBuilderExtensions.ApplyGranitConventions"/>
+/// (<c>.IsConcurrencyToken()</c>). EF Core includes it in the <c>WHERE</c> clause
+/// on update — if the stored value differs from the original, a
+/// <see cref="DbUpdateConcurrencyException"/> is thrown.
+/// </para>
+/// <para>
+/// Registered as Scoped. Must be ordered after <see cref="VersioningInterceptor"/>
+/// and before <see cref="DomainEventDispatcherInterceptor"/>.
+/// </para>
+/// </remarks>
+public sealed class ConcurrencyStampInterceptor : SaveChangesInterceptor
+{
+    /// <inheritdoc/>
+    public override InterceptionResult<int> SavingChanges(
+        DbContextEventData eventData,
+        InterceptionResult<int> result)
+    {
+        ApplyConcurrencyStamp(eventData.Context);
+        return base.SavingChanges(eventData, result);
+    }
+
+    /// <inheritdoc/>
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        ApplyConcurrencyStamp(eventData.Context);
+        return base.SavingChangesAsync(eventData, result, cancellationToken);
+    }
+
+    private static void ApplyConcurrencyStamp(DbContext? context)
+    {
+        if (context is null)
+        {
+            return;
+        }
+
+        foreach (EntityEntry<IConcurrencyAware> entry in context.ChangeTracker.Entries<IConcurrencyAware>())
+        {
+            if (entry.State is EntityState.Added or EntityState.Modified)
+            {
+#pragma warning disable GRSEC002 // Concurrency stamp is opaque, not a business identifier — no UUIDv7 needed
+                entry.Entity.ConcurrencyStamp = Guid.NewGuid().ToString();
+#pragma warning restore GRSEC002
+            }
+        }
+    }
+}

--- a/src/Granit.Testing.EntityFrameworkCore/Extensions/TestDbContextServiceCollectionExtensions.cs
+++ b/src/Granit.Testing.EntityFrameworkCore/Extensions/TestDbContextServiceCollectionExtensions.cs
@@ -43,10 +43,11 @@ public static class TestDbContextServiceCollectionExtensions
 
             AuditedEntityInterceptor auditInterceptor = new(user, clock, guidGenerator, tenant);
             VersioningInterceptor versioningInterceptor = new(guidGenerator);
+            ConcurrencyStampInterceptor concurrencyStampInterceptor = new();
             SoftDeleteInterceptor softDeleteInterceptor = new(user, clock);
 
             options.UseInMemoryDatabase(guidGenerator.Create().ToString())
-                .AddInterceptors(auditInterceptor, versioningInterceptor, softDeleteInterceptor);
+                .AddInterceptors(auditInterceptor, versioningInterceptor, concurrencyStampInterceptor, softDeleteInterceptor);
         });
 
         return services;

--- a/src/Granit.Testing.EntityFrameworkCore/InMemoryDbContextFactory.cs
+++ b/src/Granit.Testing.EntityFrameworkCore/InMemoryDbContextFactory.cs
@@ -63,18 +63,19 @@ public sealed class InMemoryDbContextFactory<TContext>
 
     /// <summary>
     /// Creates a new <typeparamref name="TContext"/> instance with Granit interceptors
-    /// (audit, versioning, soft-delete) wired to the fakes.
+    /// (audit, versioning, concurrency stamp, soft-delete) wired to the fakes.
     /// </summary>
     /// <returns>A configured <typeparamref name="TContext"/> instance.</returns>
     public TContext CreateContext()
     {
         AuditedEntityInterceptor auditInterceptor = new(_user, _clock, _guidGenerator, _tenant);
         VersioningInterceptor versioningInterceptor = new(_guidGenerator);
+        ConcurrencyStampInterceptor concurrencyStampInterceptor = new();
         SoftDeleteInterceptor softDeleteInterceptor = new(_user, _clock);
 
         DbContextOptionsBuilder<TContext> optionsBuilder = new DbContextOptionsBuilder<TContext>()
             .UseInMemoryDatabase(_databaseName)
-            .AddInterceptors(auditInterceptor, versioningInterceptor, softDeleteInterceptor);
+            .AddInterceptors(auditInterceptor, versioningInterceptor, concurrencyStampInterceptor, softDeleteInterceptor);
 
         _configureOptions?.Invoke(optionsBuilder);
 

--- a/src/Granit.Testing.EntityFrameworkCore/SqliteDbContextFactory.cs
+++ b/src/Granit.Testing.EntityFrameworkCore/SqliteDbContextFactory.cs
@@ -65,7 +65,7 @@ public sealed class SqliteDbContextFactory<TContext> : IDisposable
 
     /// <summary>
     /// Creates a new <typeparamref name="TContext"/> instance with Granit interceptors
-    /// (audit, versioning, soft-delete) wired to the fakes.
+    /// (audit, versioning, concurrency stamp, soft-delete) wired to the fakes.
     /// </summary>
     /// <param name="ensureCreated">
     /// When <c>true</c> (default), calls <see cref="DatabaseFacade.EnsureCreated"/>
@@ -79,11 +79,12 @@ public sealed class SqliteDbContextFactory<TContext> : IDisposable
 
         AuditedEntityInterceptor auditInterceptor = new(_user, _clock, _guidGenerator, _tenant);
         VersioningInterceptor versioningInterceptor = new(_guidGenerator);
+        ConcurrencyStampInterceptor concurrencyStampInterceptor = new();
         SoftDeleteInterceptor softDeleteInterceptor = new(_user, _clock);
 
         DbContextOptionsBuilder<TContext> optionsBuilder = new DbContextOptionsBuilder<TContext>()
             .UseSqlite(_connection)
-            .AddInterceptors(auditInterceptor, versioningInterceptor, softDeleteInterceptor);
+            .AddInterceptors(auditInterceptor, versioningInterceptor, concurrencyStampInterceptor, softDeleteInterceptor);
 
         _configureOptions?.Invoke(optionsBuilder);
 

--- a/tests/Granit.Persistence.Tests/ConcurrencyStampInterceptorTests.cs
+++ b/tests/Granit.Persistence.Tests/ConcurrencyStampInterceptorTests.cs
@@ -1,0 +1,257 @@
+using Granit.Core.Domain;
+using Granit.Persistence.Interceptors;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Persistence.Tests;
+
+public sealed class ConcurrencyStampInterceptorTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+
+    public ConcurrencyStampInterceptorTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+    }
+
+    // ========================================================================
+    // Initial stamp on new entity
+    // ========================================================================
+
+    [Fact]
+    public async Task SaveChangesAsync_NewEntity_SetsInitialConcurrencyStamp()
+    {
+        // Arrange
+        using TestDbContext context = CreateContext();
+        TestConcurrencyEntity entity = new()
+        {
+            Id = Guid.NewGuid(),
+            Name = "New entity",
+        };
+        context.Entities.Add(entity);
+
+        // Act
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        entity.ConcurrencyStamp.ShouldNotBeNullOrEmpty();
+        Guid.TryParse(entity.ConcurrencyStamp, out _).ShouldBeTrue("stamp must be a valid GUID string");
+    }
+
+    // ========================================================================
+    // Stamp regeneration on modify
+    // ========================================================================
+
+    [Fact]
+    public async Task SaveChangesAsync_ModifiedEntity_RegeneratesStamp()
+    {
+        // Arrange
+        using TestDbContext context = CreateContext();
+        TestConcurrencyEntity entity = new()
+        {
+            Id = Guid.NewGuid(),
+            Name = "Original",
+        };
+        context.Entities.Add(entity);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        string initialStamp = entity.ConcurrencyStamp;
+
+        // Act — modify the entity
+        entity.Name = "Updated";
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Assert — stamp must be different
+        entity.ConcurrencyStamp.ShouldNotBe(initialStamp);
+        entity.ConcurrencyStamp.ShouldNotBeNullOrEmpty();
+    }
+
+    // ========================================================================
+    // Sync variant
+    // ========================================================================
+
+    [Fact]
+    public void SaveChanges_Sync_SetsConcurrencyStamp()
+    {
+        // Arrange
+        using TestDbContext context = CreateContext();
+        TestConcurrencyEntity entity = new()
+        {
+            Id = Guid.NewGuid(),
+            Name = "Sync test",
+        };
+        context.Entities.Add(entity);
+
+        // Act
+        context.SaveChanges();
+
+        // Assert
+        entity.ConcurrencyStamp.ShouldNotBeNullOrEmpty();
+    }
+
+    // ========================================================================
+    // Non-IConcurrencyAware entities — should be ignored
+    // ========================================================================
+
+    [Fact]
+    public async Task SaveChangesAsync_NonConcurrencyAwareEntity_IsIgnored()
+    {
+        // Arrange
+        using TestDbContext context = CreateContext();
+        TestPlainEntity entity = new()
+        {
+            Id = Guid.NewGuid(),
+            Label = "Not concurrency-aware",
+        };
+        context.PlainEntities.Add(entity);
+
+        // Act — should not throw
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        entity.Label.ShouldBe("Not concurrency-aware");
+    }
+
+    // ========================================================================
+    // Concurrent modification — connected scenario (same DB, two contexts)
+    // ========================================================================
+
+    [Fact]
+    public async Task SaveChangesAsync_ConcurrentModification_ThrowsDbUpdateConcurrencyException()
+    {
+        // Arrange — create entity via context1
+        var entityId = Guid.NewGuid();
+        using TestDbContext context1 = CreateContext();
+        TestConcurrencyEntity entity1 = new()
+        {
+            Id = entityId,
+            Name = "Original",
+        };
+        context1.Entities.Add(entity1);
+        await context1.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Load the same entity in context2 (EF tracks OriginalValue automatically)
+        using TestDbContext context2 = CreateContext(ensureCreated: false);
+        TestConcurrencyEntity entity2 = (await context2.Entities.FindAsync([entityId], TestContext.Current.CancellationToken))!;
+        entity2.ShouldNotBeNull();
+
+        // Modify and save via context1 (stamp changes in DB)
+        entity1.Name = "Updated by context1";
+        await context1.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Act — modify and save via context2 (still has old stamp) → should throw
+        entity2.Name = "Updated by context2";
+
+        // Assert
+        await Should.ThrowAsync<DbUpdateConcurrencyException>(
+            () => context2.SaveChangesAsync(TestContext.Current.CancellationToken));
+    }
+
+    // ========================================================================
+    // Disconnected update — OriginalValue pattern for CQRS
+    // ========================================================================
+
+    [Fact]
+    public async Task SaveChangesAsync_DisconnectedUpdate_WithStaleStamp_ThrowsDbUpdateConcurrencyException()
+    {
+        // Arrange — create entity and capture its initial stamp
+        var entityId = Guid.NewGuid();
+        using TestDbContext context1 = CreateContext();
+        TestConcurrencyEntity entity = new()
+        {
+            Id = entityId,
+            Name = "Original",
+        };
+        context1.Entities.Add(entity);
+        await context1.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        string staleStamp = entity.ConcurrencyStamp;
+
+        // Modify and save — stamp rotates
+        entity.Name = "Updated once";
+        await context1.SaveChangesAsync(TestContext.Current.CancellationToken);
+        entity.ConcurrencyStamp.ShouldNotBe(staleStamp, "stamp must have rotated");
+
+        // Simulate a disconnected update: load entity in context2, set stale OriginalValue
+        using TestDbContext context2 = CreateContext(ensureCreated: false);
+        TestConcurrencyEntity disconnected = (await context2.Entities.FindAsync([entityId], TestContext.Current.CancellationToken))!;
+
+        // Force the OriginalValue to the stale stamp (simulating a frontend sending an old stamp)
+        context2.Entry(disconnected).Property(e => e.ConcurrencyStamp).OriginalValue = staleStamp;
+
+        // Act — modify and save with stale stamp
+        disconnected.Name = "Disconnected update";
+
+        // Assert — EF Core detects mismatch between OriginalValue and DB value
+        await Should.ThrowAsync<DbUpdateConcurrencyException>(
+            () => context2.SaveChangesAsync(TestContext.Current.CancellationToken));
+    }
+
+    // ========================================================================
+    // Test infrastructure
+    // ========================================================================
+
+    private TestDbContext CreateContext(bool ensureCreated = true)
+    {
+        ConcurrencyStampInterceptor interceptor = new();
+
+        DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseSqlite(_connection)
+            .AddInterceptors(interceptor)
+            .Options;
+
+        var context = new TestDbContext(options);
+
+        if (ensureCreated)
+        {
+            context.Database.EnsureCreated();
+        }
+
+        return context;
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    // --- Test entities ---
+
+    private sealed class TestConcurrencyEntity : Entity, IConcurrencyAware
+    {
+        public string Name { get; set; } = string.Empty;
+        public string ConcurrencyStamp { get; set; } = string.Empty;
+    }
+
+    private sealed class TestPlainEntity : Entity
+    {
+        public string Label { get; set; } = string.Empty;
+    }
+
+    // --- Test DbContext ---
+
+    private sealed class TestDbContext(DbContextOptions<TestDbContext> options)
+        : DbContext(options)
+    {
+        public DbSet<TestConcurrencyEntity> Entities => Set<TestConcurrencyEntity>();
+        public DbSet<TestPlainEntity> PlainEntities => Set<TestPlainEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<TestConcurrencyEntity>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedNever();
+                b.Property(e => e.ConcurrencyStamp).HasMaxLength(36).IsConcurrencyToken();
+            });
+
+            modelBuilder.Entity<TestPlainEntity>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedNever();
+            });
+        }
+    }
+}

--- a/tests/Granit.Persistence.Tests/DbContextOptionsBuilderExtensionsTests.cs
+++ b/tests/Granit.Persistence.Tests/DbContextOptionsBuilderExtensionsTests.cs
@@ -28,7 +28,7 @@ public sealed class DbContextOptionsBuilderExtensionsTests
         // Act
         builder.UseGranitInterceptors(scope.ServiceProvider);
 
-        // Assert — all 4 interceptors should be present
+        // Assert — all 5 interceptors should be present
         DbContextOptions options = builder.Options;
         IEnumerable<IInterceptor> interceptors = options.Extensions
             .OfType<Microsoft.EntityFrameworkCore.Infrastructure.CoreOptionsExtension>()
@@ -36,6 +36,7 @@ public sealed class DbContextOptionsBuilderExtensionsTests
 
         interceptors.ShouldContain(i => i is AuditedEntityInterceptor);
         interceptors.ShouldContain(i => i is VersioningInterceptor);
+        interceptors.ShouldContain(i => i is ConcurrencyStampInterceptor);
         interceptors.ShouldContain(i => i is DomainEventDispatcherInterceptor);
         interceptors.ShouldContain(i => i is SoftDeleteInterceptor);
     }

--- a/tests/Granit.Persistence.Tests/Granit.Persistence.Tests.csproj
+++ b/tests/Granit.Persistence.Tests/Granit.Persistence.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Bogus" />
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Granit.Persistence.Tests/ModelBuilderExtensionsTests.cs
+++ b/tests/Granit.Persistence.Tests/ModelBuilderExtensionsTests.cs
@@ -545,6 +545,42 @@ public sealed class ModelBuilderExtensionsTests
     }
 
     // -------------------------------------------------------------------------
+    // IConcurrencyAware — concurrency token property configuration
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void ApplyGranitConventions_ConcurrencyAware_ConfiguresConcurrencyToken()
+    {
+        using TestDbContextWithConcurrencyAware context = CreateContextWithConcurrencyAware();
+
+        Microsoft.EntityFrameworkCore.Metadata.IEntityType? entityType =
+            context.Model.FindEntityType(typeof(TestConcurrencyAwareEntity));
+
+        entityType.ShouldNotBeNull();
+        Microsoft.EntityFrameworkCore.Metadata.IProperty? property =
+            entityType!.FindProperty(nameof(IConcurrencyAware.ConcurrencyStamp));
+
+        property.ShouldNotBeNull("ConcurrencyStamp property must exist on the model");
+        property!.IsConcurrencyToken.ShouldBeTrue("ConcurrencyStamp must be configured as a concurrency token");
+        property.GetMaxLength().ShouldBe(36, "ConcurrencyStamp must be VARCHAR(36)");
+    }
+
+    [Fact]
+    public void ApplyGranitConventions_NonConcurrencyAware_NoConcurrencyToken()
+    {
+        using TestDbContext context = CreateContext();
+
+        Microsoft.EntityFrameworkCore.Metadata.IEntityType? entityType =
+            context.Model.FindEntityType(typeof(TestCategory));
+
+        entityType.ShouldNotBeNull();
+        Microsoft.EntityFrameworkCore.Metadata.IProperty? property =
+            entityType!.FindProperty("ConcurrencyStamp");
+
+        property.ShouldBeNull("non-IConcurrencyAware entity must not have ConcurrencyStamp");
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 
@@ -626,6 +662,16 @@ public sealed class ModelBuilderExtensionsTests
                 .Options;
 
         return new TestDbContextWithCombinedSdPr(options, SharedDataFilter);
+    }
+
+    private static TestDbContextWithConcurrencyAware CreateContextWithConcurrencyAware()
+    {
+        DbContextOptions<TestDbContextWithConcurrencyAware> options =
+            new DbContextOptionsBuilder<TestDbContextWithConcurrencyAware>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .Options;
+
+        return new TestDbContextWithConcurrencyAware(options);
     }
 
     // Always uses SharedTenant and SharedDataFilter — same reason as above.
@@ -854,6 +900,21 @@ internal sealed class TestDbContextWithCombinedSdPr(
 
     protected override void OnModelCreating(ModelBuilder modelBuilder) =>
         modelBuilder.ApplyGranitConventions(dataFilter: _dataFilter);
+}
+
+internal sealed class TestConcurrencyAwareEntity : IConcurrencyAware
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string ConcurrencyStamp { get; set; } = string.Empty;
+}
+
+internal sealed class TestDbContextWithConcurrencyAware(DbContextOptions<TestDbContextWithConcurrencyAware> options) : DbContext(options)
+{
+    public DbSet<TestConcurrencyAwareEntity> ConcurrencyAwareEntities => Set<TestConcurrencyAwareEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+        modelBuilder.ApplyGranitConventions();
 }
 
 #endregion

--- a/tests/Granit.Persistence.Tests/PersistenceServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Persistence.Tests/PersistenceServiceCollectionExtensionsTests.cs
@@ -77,6 +77,23 @@ public sealed class PersistenceServiceCollectionExtensionsTests
     }
 
     [Fact]
+    public void AddGranitPersistence_RegistersConcurrencyStampInterceptor()
+    {
+        // Arrange
+        ServiceCollection services = new();
+
+        // Act
+        services.AddGranitPersistence();
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        using IServiceScope scope = sp.CreateScope();
+
+        // Assert
+        ConcurrencyStampInterceptor? interceptor = scope.ServiceProvider.GetService<ConcurrencyStampInterceptor>();
+        interceptor.ShouldNotBeNull();
+    }
+
+    [Fact]
     public void AddGranitPersistence_InterceptorsAreScoped()
     {
         // Arrange
@@ -91,6 +108,9 @@ public sealed class PersistenceServiceCollectionExtensionsTests
 
         ServiceDescriptor versioningDescriptor = services.First(d => d.ServiceType == typeof(VersioningInterceptor));
         versioningDescriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+
+        ServiceDescriptor concurrencyStampDescriptor = services.First(d => d.ServiceType == typeof(ConcurrencyStampInterceptor));
+        concurrencyStampDescriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
 
         ServiceDescriptor softDeleteDescriptor = services.First(d => d.ServiceType == typeof(SoftDeleteInterceptor));
         softDeleteDescriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);

--- a/tests/Granit.Persistence.Tests/packages.lock.json
+++ b/tests/Granit.Persistence.Tests/packages.lock.json
@@ -37,6 +37,21 @@
           "Microsoft.Extensions.Logging": "10.0.5"
         }
       },
+      "Microsoft.EntityFrameworkCore.Sqlite": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "lxeRviglTkkmzYJVJ600yb6gJjnf5za9v7uH+0byuSXTGv7U8cT6hz7qRTmiGSOfLcl86QFdy2BBKaUFd6NQug==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.5",
+          "Microsoft.Extensions.Caching.Memory": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyModel": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
@@ -118,6 +133,14 @@
         "resolved": "18.3.0",
         "contentHash": "23BNy/vziREC20Wwhb50K7+kZe0m07KlLWDQv4qjJ9tt3QjpDpDIqJFrhYHmMEo9xDkuSp55U/8h4bMF7MiB+g=="
       },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "jFYXnh7s0RShCw6Vkf+ReGCw+mVi7ISg1YaEzYCJcXnUifmbW+aqvCsRJuSRj2ZuQ+oqetpjxlZtbpMmk5FKqQ==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.5",
@@ -127,6 +150,20 @@
         "type": "Transitive",
         "resolved": "10.0.5",
         "contentHash": "ipC4u1VojgEfoIZhtbS2Sx5IluJTP/Jf1hz3yGsxGBgSukYY/CquI6rAjxn5H58CZgVn36qcuPPtNMwZ0AUzMg=="
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "rVH43bcUyZiMn0SnCpVnvFpl4PFxT4GwmuVVLcT4JL0NtzuHY9ymKV+Llb5cjuJ+6+gEl4eixy2rE8nxOPcBSA==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "10.0.5",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.5",
+          "Microsoft.Extensions.Caching.Memory": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyModel": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
@@ -143,6 +180,11 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
         }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "xA4kkL+QS6KCAOKz/O0oquHs44Ob8J7zpBCNt3wjkBWDg5aCqfwG8rWWLsg5V86AM0sB849g9JjPjIdksTCIKg=="
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
@@ -234,6 +276,33 @@
         "type": "Transitive",
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "DC4nA7yWnf4UZdgJDF+9Mus4/cb0Y3Sfgi3gDnAoKNAIBwzkskNAbNbyu+u4atT0ruVlZNJfwZmwiEwE5oz9LQ==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.11"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "PK0GLFkfhZzLQeR3PJf71FmhtHox+U3vcY6ZtswoMjrefkB9k6ErNJEnwXqc5KgXDSjige2XXrezqS39gkpQKA=="
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Ev2ytaXiOlWZ4b3R67GZBsemTINslLD1DCJr2xiacpn4tbapu0Q4dHEzSvZSMnVWeE5nlObU3VZN2p81q3XOYQ=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Y/0ZkR+r0Cg3DQFuCl1RBnv/tmxpIZRU3HUvelPw6MVaKHwYYR8YNvgs0vuNuXCMvlyJ+Fh88U1D4tah1tt6qw==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
       },
       "System.CodeDom": {
         "type": "Transitive",


### PR DESCRIPTION
## Summary

- Add `IConcurrencyAware` interface + `ConcurrencyStampInterceptor` following the existing interceptor pattern (AuditedEntity, SoftDelete, Versioning)
- Auto-discovery via `ApplyGranitConventions()` — entities implementing `IConcurrencyAware` get `.IsConcurrencyToken()` configured automatically
- `DbUpdateConcurrencyException` → HTTP 409 Conflict was already implemented in `EfCoreExceptionStatusCodeMapper`
- `IConcurrencyStampRequest` DTO convention for PUT/PATCH endpoints (connected + disconnected update patterns)
- Dedicated docs page with Mermaid sequence diagram, endpoint patterns, testing guide, and common pitfalls

### Files created (5)

| File | Purpose |
|------|---------|
| `src/Granit.Core/Domain/IConcurrencyAware.cs` | Entity interface with `ConcurrencyStamp` property |
| `src/Granit.Core/Domain/IConcurrencyStampRequest.cs` | DTO convention for request DTOs |
| `src/Granit.Persistence/Interceptors/ConcurrencyStampInterceptor.cs` | Auto-regenerates stamp on Added/Modified |
| `tests/Granit.Persistence.Tests/ConcurrencyStampInterceptorTests.cs` | 6 tests (SQLite): stamp gen, conflict detection, disconnected update |
| `docs-site/src/content/docs/dotnet/data/concurrency.mdx` | Dedicated documentation page |

### Files modified (14)

- `ModelBuilderExtensions.cs` — concurrency token auto-config loop
- `PersistenceServiceCollectionExtensions.cs` — DI registration
- `DbContextOptionsBuilderExtensions.cs` — pipeline: Audit → Versioning → **ConcurrencyStamp** → DomainEvents → SoftDelete
- 3 Testing factory files — wire `ConcurrencyStampInterceptor`
- 4 test files — DI, pipeline, ModelBuilder assertions
- `persistence.mdx` — interceptor table + ConcurrencyStampInterceptor section
- `ArchDiagram.astro` — Persistence tooltip updated
- `astro.config.mjs` — Testing guide added to sidebar (fixes CI error)

### Stories

- Closes #289 — Auto-detect IConcurrencyAware and enforce optimistic concurrency
- Closes #291 — ConcurrencyStamp convention for request/response DTOs
- #290 was already implemented (`EfCoreExceptionStatusCodeMapper`)

## Test plan

- [x] `dotnet test tests/Granit.Persistence.Tests` — 170 tests pass (8 new)
- [x] `dotnet format --verify-no-changes` — clean
- [x] `npx astro build` — builds (only pre-existing link error in output-caching)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
