### PR TITLE
feat(http-resilience): add auth token propagation for inter-service calls

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -404,7 +404,7 @@ export default defineConfig({
         ),
         starlightLinksValidator({
           errorOnRelativeLinks: false,
-          exclude: ["/api/**", "/blog/**"],
+          exclude: ["/", "/api/**", "/blog/**"],
         }),
         starlightImageZoom(),
         starlightLlmsTxt(),

--- a/docs-site/src/content/docs/dotnet/api/http-resilience.mdx
+++ b/docs-site/src/content/docs/dotnet/api/http-resilience.mdx
@@ -40,6 +40,32 @@ services.AddGranitHttpClient("granit-webhooks", (sp, client) =>
 
 The returned `IHttpClientBuilder` can be chained for further customization.
 
+## Auth token propagation
+
+In microservice architectures, downstream services often need the same JWT token that
+the incoming request carries. `AddAuthTokenPropagation()` adds a `DelegatingHandler`
+that reads the `Authorization` header from the current `HttpContext` and sets it on
+every outgoing request automatically.
+
+```csharp
+services.AddGranitHttpClient("catalog-service")
+    .AddAuthTokenPropagation();
+```
+
+<Aside type="note">
+If the outgoing request already contains an `Authorization` header, the handler leaves
+it untouched — explicit overrides always win. Calls made outside an HTTP request pipeline
+(e.g. background jobs) will not propagate any token.
+</Aside>
+
+Combine with Aspire service discovery for zero-configuration inter-service calls:
+
+```csharp
+services.AddGranitHttpClient("catalog-service",
+    client => client.BaseAddress = new Uri("https+http://catalog-service"))
+    .AddAuthTokenPropagation();
+```
+
 ## Per-client configuration
 
 Override pipeline settings per named client in `appsettings.json` without redeploying:

--- a/docs-site/src/content/docs/dotnet/api/output-caching.mdx
+++ b/docs-site/src/content/docs/dotnet/api/output-caching.mdx
@@ -204,5 +204,5 @@ Tagged `readiness` and `startup` for Kubernetes probes.
 
 - [Caching](/dotnet/data/caching/) — distributed caching with `ICacheService<T>`
 - [CORS](/dotnet/api/cors/) — must be registered before output caching
-- [Multi-tenancy](/dotnet/core/multi-tenancy/) — tenant context used for cache isolation
+- [Multi-tenancy](/dotnet/concepts/multi-tenancy/) — tenant context used for cache isolation
 - [ASP.NET Core Output Caching](https://learn.microsoft.com/en-us/aspnet/core/performance/caching/output) — upstream documentation

--- a/src/Granit.Http.Resilience/Extensions/HttpResilienceServiceCollectionExtensions.cs
+++ b/src/Granit.Http.Resilience/Extensions/HttpResilienceServiceCollectionExtensions.cs
@@ -1,6 +1,9 @@
+using Granit.Http.Resilience.Handlers;
 using Granit.Http.Resilience.Options;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 
@@ -65,4 +68,25 @@ public static class HttpResilienceServiceCollectionExtensions
         string name,
         Action<HttpClient> configure)
         => services.AddGranitHttpClient(name, (_, client) => configure(client));
+
+    /// <summary>
+    /// Adds automatic propagation of the incoming <c>Authorization</c> header to outgoing
+    /// requests made by this <see cref="HttpClient"/>, enabling transparent token forwarding
+    /// for inter-service communication in microservice architectures.
+    /// </summary>
+    /// <param name="builder">The HTTP client builder.</param>
+    /// <returns>The <see cref="IHttpClientBuilder"/> for further chaining.</returns>
+    /// <remarks>
+    /// The handler only forwards the token when the outgoing request does not already
+    /// contain an <c>Authorization</c> header, allowing explicit overrides when needed.
+    /// Requires an active <see cref="HttpContext"/> — calls made outside an HTTP request
+    /// pipeline (e.g. background jobs) will not propagate any token.
+    /// </remarks>
+    public static IHttpClientBuilder AddAuthTokenPropagation(this IHttpClientBuilder builder)
+    {
+        builder.Services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+        builder.Services.TryAddTransient<AuthTokenPropagationHandler>();
+        builder.AddHttpMessageHandler<AuthTokenPropagationHandler>();
+        return builder;
+    }
 }

--- a/src/Granit.Http.Resilience/Granit.Http.Resilience.csproj
+++ b/src/Granit.Http.Resilience/Granit.Http.Resilience.csproj
@@ -12,10 +12,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
-    <PackageReference Include="Microsoft.Extensions.Options" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.Http.Resilience/Handlers/AuthTokenPropagationHandler.cs
+++ b/src/Granit.Http.Resilience/Handlers/AuthTokenPropagationHandler.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+
+namespace Granit.Http.Resilience.Handlers;
+
+/// <summary>
+/// Propagates the incoming <c>Authorization</c> header to outgoing HTTP requests,
+/// enabling transparent token forwarding for inter-service communication.
+/// </summary>
+/// <remarks>
+/// The handler only forwards the token when the outgoing request does not already
+/// contain an <c>Authorization</c> header, allowing explicit overrides when needed.
+/// </remarks>
+internal sealed class AuthTokenPropagationHandler(
+    IHttpContextAccessor httpContextAccessor) : DelegatingHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        if (!request.Headers.Contains("Authorization"))
+        {
+            HttpContext? context = httpContextAccessor.HttpContext;
+            if (context is not null)
+            {
+                StringValues authHeader = context.Request.Headers.Authorization;
+                if (!StringValues.IsNullOrEmpty(authHeader))
+                {
+                    request.Headers.TryAddWithoutValidation("Authorization", (string?)authHeader);
+                }
+            }
+        }
+
+        return base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/Granit.Http.Resilience/README.md
+++ b/src/Granit.Http.Resilience/README.md
@@ -12,6 +12,43 @@ Part of the [granit](https://granit-fx.dev) framework.
 dotnet add package Granit.Http.Resilience
 ```
 
+## Usage
+
+### Resilient HTTP client
+
+```csharp
+services.AddGranitHttpClient("catalog-service",
+    client => client.BaseAddress = new Uri("https://catalog-api"));
+```
+
+The standard pipeline applies: retry (3 attempts, exponential back-off), circuit breaker,
+and per-request timeout. Override per-client via `appsettings.json`:
+
+```json
+{
+  "HttpResilience": {
+    "catalog-service": {
+      "Retry": { "MaxRetryAttempts": 5 },
+      "TotalRequestTimeout": { "Timeout": "00:01:00" }
+    }
+  }
+}
+```
+
+### Auth token propagation
+
+For microservice architectures where the incoming JWT token must be forwarded to
+downstream services:
+
+```csharp
+services.AddGranitHttpClient("catalog-service")
+    .AddAuthTokenPropagation();
+```
+
+The handler reads the `Authorization` header from the current `HttpContext` and sets it
+on every outgoing request. If the outgoing request already has an `Authorization` header,
+it is left untouched (explicit overrides are respected).
+
 ## Dependencies
 
 - `Granit.Core`

--- a/src/Granit.Http.Resilience/packages.lock.json
+++ b/src/Granit.Http.Resilience/packages.lock.json
@@ -8,20 +8,6 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
-      "Microsoft.Extensions.Http": {
-        "type": "Direct",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "AiFvHYM8nP0wPC7bGPI3NHQlSYSLqjjT7DMJUuuxhd+7pz3O89iu2gdQfgACy5DxsXENiok5i1bMacJL7KR8jA==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Diagnostics": "10.0.5",
-          "Microsoft.Extensions.Logging": "10.0.5",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5"
-        }
-      },
       "Microsoft.Extensions.Http.Resilience": {
         "type": "Direct",
         "requested": "[10.*, )",
@@ -29,172 +15,43 @@
         "contentHash": "HbkUsPUC7vLy2TaDbdA9aooW64n9yX4sUppRuiJ1cOzzU1FUW+MVEotm6kYVq6AuUI9xwFSBhRFzA03blmk3VA==",
         "dependencies": {
           "Microsoft.Extensions.Http.Diagnostics": "10.4.0",
-          "Microsoft.Extensions.ObjectPool": "10.0.4",
           "Microsoft.Extensions.Resilience": "10.4.0"
-        }
-      },
-      "Microsoft.Extensions.Options": {
-        "type": "Direct",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Options.ConfigurationExtensions": {
-        "type": "Direct",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
         }
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
         "resolved": "10.4.0",
-        "contentHash": "bovnONzrr/JIc+w343i857rJEb7cQH9UzEjbV5n67agWBEYICGQb8xiqYz5+GoFXp6mKEKLwYCQGttMU1p5yXQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.4",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.4",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.4"
-        }
+        "contentHash": "bovnONzrr/JIc+w343i857rJEb7cQH9UzEjbV5n67agWBEYICGQb8xiqYz5+GoFXp6mKEKLwYCQGttMU1p5yXQ=="
       },
       "Microsoft.Extensions.Compliance.Abstractions": {
         "type": "Transitive",
         "resolved": "10.4.0",
-        "contentHash": "4WkknDbVrHNf+S6fwSt1OAXlGJ/G/QrtJlqx4aNzOLmeT3GRyxpGLZn+Q3UV+RMRAF6FfsijEZBg2ZAW8bTAkg==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4",
-          "Microsoft.Extensions.ObjectPool": "10.0.4"
-        }
-      },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Configuration.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "v1SVsowG6YE1YnHVGmLWz57YTRCQRx9pH5ebIESXfm5isI9gA3QaMyg/oMTzPpXYZwSAVDzYItGJKfmV+pqXkQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
-        }
+        "contentHash": "4WkknDbVrHNf+S6fwSt1OAXlGJ/G/QrtJlqx4aNzOLmeT3GRyxpGLZn+Q3UV+RMRAF6FfsijEZBg2ZAW8bTAkg=="
       },
       "Microsoft.Extensions.DependencyInjection.AutoActivation": {
         "type": "Transitive",
         "resolved": "10.4.0",
-        "contentHash": "ksmUG2SFTcXzYdyoLOdeSM/qYLRGN6qbbSzYVkwMK9xsctfR1hYkUayeOpFCMd7L+QSlYX72mK9wxwdgQxyS4g==",
-        "dependencies": {
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.4"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "vAJHd4yOpmKoK+jBuYV7a3y+Ab9U4ARCc29b6qvMy276RgJFw9LFs0DdsPqOL3ahwzyrX7tM+i4cCxU/RX0qAg==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.5",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5"
-        }
+        "contentHash": "ksmUG2SFTcXzYdyoLOdeSM/qYLRGN6qbbSzYVkwMK9xsctfR1hYkUayeOpFCMd7L+QSlYX72mK9wxwdgQxyS4g=="
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",
         "resolved": "10.4.0",
-        "contentHash": "1/hQmONMWxRTKXuN0pQShQN9QsqIRTS1G4fdmKW0O9phuVZjyzIROQD9Fbfwyn2t+yvP8SzjatGAPX4jDRfgHg==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4"
-        }
-      },
-      "Microsoft.Extensions.FileProviders.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.4",
-        "contentHash": "3hLXFZ1E/Kj3obIcb9iMCC95MpW2e8EkWxpXKgUfgGBfm+yn507pHAjPaHoi2U3GlSHIm/21DPCDLumwlMowjw==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.4"
-        }
+        "contentHash": "1/hQmONMWxRTKXuN0pQShQN9QsqIRTS1G4fdmKW0O9phuVZjyzIROQD9Fbfwyn2t+yvP8SzjatGAPX4jDRfgHg=="
       },
       "Microsoft.Extensions.Http.Diagnostics": {
         "type": "Transitive",
         "resolved": "10.4.0",
         "contentHash": "ybx2QcCWROCnUCbSj/IyHXn1c58brjjHzTTbueKgBl/qHsWk69mu25mjQ3oaMsO1I0+EcS6AhVuhIopL2q3IDw==",
         "dependencies": {
-          "Microsoft.Extensions.Http": "10.0.4",
           "Microsoft.Extensions.Telemetry": "10.4.0"
         }
-      },
-      "Microsoft.Extensions.Logging": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "+XTMKQyDWg4ODoNHU/BN3BaI1jhGO7VCS+BnzT/4IauiG6y2iPAte7MyD7rHKS+hNP0TkFkjrae8DFjDUxtcxg==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.5",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Logging.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.4",
-        "contentHash": "XPXoOpUnWEh0pV7Vl2DK2wj47y73Krhrve5OkPrvGIWdZ4U2r47WO8hEdv+wKn65Kh4pmDdiWm7Ibo5pZX+vig==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.4",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.4",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4",
-          "Microsoft.Extensions.Logging": "10.0.4",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.4",
-          "Microsoft.Extensions.Options": "10.0.4",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.4"
-        }
-      },
-      "Microsoft.Extensions.ObjectPool": {
-        "type": "Transitive",
-        "resolved": "10.0.4",
-        "contentHash": "2pufIFOgNl/yWTOoIC9XgBnO9VxgfAjdRCnVwpE2+ICfcroGnjuEAGzJ5lTdZeAe0HvA31vMBWXtcmGB7TOq3g=="
-      },
-      "Microsoft.Extensions.Primitives": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
       },
       "Microsoft.Extensions.Resilience": {
         "type": "Transitive",
         "resolved": "10.4.0",
         "contentHash": "41CCbJJPsDWU6NsmKfANHkfT/+KCBlZZqQ1eBoQhhW0xqGCiWmUlMdi2BoaM/GcwKHX5WiQL/IESROmgk0Owfw==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics": "10.0.4",
           "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.4.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.4",
           "Microsoft.Extensions.Telemetry.Abstractions": "10.4.0",
           "Polly.Extensions": "8.4.2",
           "Polly.RateLimiting": "8.4.2"
@@ -207,8 +64,6 @@
         "dependencies": {
           "Microsoft.Extensions.AmbientMetadata.Application": "10.4.0",
           "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.4.0",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.4",
-          "Microsoft.Extensions.ObjectPool": "10.0.4",
           "Microsoft.Extensions.Telemetry.Abstractions": "10.4.0"
         }
       },
@@ -217,10 +72,7 @@
         "resolved": "10.4.0",
         "contentHash": "3b2uVa4voJfLLg39BPCKQS0ZgnpEZFkKf7YmnMVlM5FQJYBPOuePIQdnEK1/Oxd+w3GscxGYuE7IMOXDwixZtQ==",
         "dependencies": {
-          "Microsoft.Extensions.Compliance.Abstractions": "10.4.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.4",
-          "Microsoft.Extensions.ObjectPool": "10.0.4",
-          "Microsoft.Extensions.Options": "10.0.4"
+          "Microsoft.Extensions.Compliance.Abstractions": "10.4.0"
         }
       },
       "Polly.Core": {
@@ -233,8 +85,6 @@
         "resolved": "8.4.2",
         "contentHash": "GZ9vRVmR0jV2JtZavt+pGUsQ1O1cuRKG7R7VOZI6ZDy9y6RNPvRvXK1tuS4ffUrv8L0FTea59oEuQzgS0R7zSA==",
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Options": "8.0.0",
           "Polly.Core": "8.4.2"
         }
       },
@@ -243,55 +93,11 @@
         "resolved": "8.4.2",
         "contentHash": "ehTImQ/eUyO07VYW2WvwSmU9rRH200SKJ/3jku9rOkyWE0A2JxNFmAVms8dSn49QLSjmjFRRSgfNyOgr/2PSmA==",
         "dependencies": {
-          "Polly.Core": "8.4.2",
-          "System.Threading.RateLimiting": "8.0.0"
+          "Polly.Core": "8.4.2"
         }
-      },
-      "System.Threading.RateLimiting": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "7mu9v0QDv66ar3DpGSZHg9NuNcxDaaAcnMULuZlaTpP9+hwXhrxNGsF5GmLkSHxFdb5bBc1TzeujsRgTrPWi+Q=="
       },
       "granit.core": {
         "type": "Project"
-      },
-      "Microsoft.Extensions.Configuration.Binder": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.5",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
-      },
-      "Microsoft.Extensions.Hosting.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.4",
-        "contentHash": "+5mQrqlBhqNUaPyDmFSNM/qiWStvE9LMxZW1MRF0NhEbO781xNeKryXNR9gGDJ0PmYFDAVoMT9ffX+I15LPFTw==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.4",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.4",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.4"
-        }
-      },
-      "Microsoft.Extensions.Logging.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
-        }
       }
     }
   }

--- a/tests/Granit.Http.Resilience.Tests/AuthTokenPropagationHandlerTests.cs
+++ b/tests/Granit.Http.Resilience.Tests/AuthTokenPropagationHandlerTests.cs
@@ -1,0 +1,133 @@
+using Granit.Http.Resilience.Extensions;
+using Granit.Http.Resilience.Handlers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Http.Resilience.Tests;
+
+public sealed class AuthTokenPropagationHandlerTests
+{
+    [Fact]
+    public void AddAuthTokenPropagation_DoesNotThrow()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+
+        Should.NotThrow(() => builder.Services
+            .AddGranitHttpClient("test-client")
+            .AddAuthTokenPropagation());
+    }
+
+    [Fact]
+    public void AddAuthTokenPropagation_RegistersIHttpContextAccessor()
+    {
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.Services
+            .AddGranitHttpClient("test-client")
+            .AddAuthTokenPropagation();
+
+        builder.Services.ShouldContain(d =>
+            d.ServiceType == typeof(IHttpContextAccessor));
+    }
+
+    [Fact]
+    public async Task SendAsync_PropagatesAuthorizationHeader()
+    {
+        DefaultHttpContext httpContext = new();
+        httpContext.Request.Headers.Authorization = "Bearer test-token-123";
+
+        IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(httpContext);
+
+        using AuthTokenPropagationHandler handler = CreateHandler(accessor);
+        using HttpClient client = new(handler) { BaseAddress = new Uri("https://localhost") };
+
+        HttpRequestMessage? capturedRequest = null;
+        handler.InnerHandler = new CapturingHandler(req => capturedRequest = req);
+
+        await client.GetAsync("/api/test", TestContext.Current.CancellationToken);
+
+        capturedRequest.ShouldNotBeNull();
+        capturedRequest.Headers.Authorization.ShouldNotBeNull();
+        capturedRequest.Headers.Authorization.Scheme.ShouldBe("Bearer");
+        capturedRequest.Headers.Authorization.Parameter.ShouldBe("test-token-123");
+    }
+
+    [Fact]
+    public async Task SendAsync_DoesNotOverrideExistingAuthorizationHeader()
+    {
+        DefaultHttpContext httpContext = new();
+        httpContext.Request.Headers.Authorization = "Bearer incoming-token";
+
+        IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(httpContext);
+
+        using AuthTokenPropagationHandler handler = CreateHandler(accessor);
+        using HttpClient client = new(handler) { BaseAddress = new Uri("https://localhost") };
+
+        HttpRequestMessage? capturedRequest = null;
+        handler.InnerHandler = new CapturingHandler(req => capturedRequest = req);
+
+        using HttpRequestMessage request = new(HttpMethod.Get, "/api/test");
+        request.Headers.Authorization = new("Bearer", "explicit-token");
+        await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        capturedRequest.ShouldNotBeNull();
+        capturedRequest.Headers.Authorization!.Parameter.ShouldBe("explicit-token");
+    }
+
+    [Fact]
+    public async Task SendAsync_NoHttpContext_DoesNotSetHeader()
+    {
+        IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns((HttpContext?)null);
+
+        using AuthTokenPropagationHandler handler = CreateHandler(accessor);
+        using HttpClient client = new(handler) { BaseAddress = new Uri("https://localhost") };
+
+        HttpRequestMessage? capturedRequest = null;
+        handler.InnerHandler = new CapturingHandler(req => capturedRequest = req);
+
+        await client.GetAsync("/api/test", TestContext.Current.CancellationToken);
+
+        capturedRequest.ShouldNotBeNull();
+        capturedRequest.Headers.Authorization.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SendAsync_NoAuthorizationHeader_DoesNotSetHeader()
+    {
+        DefaultHttpContext httpContext = new();
+
+        IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(httpContext);
+
+        using AuthTokenPropagationHandler handler = CreateHandler(accessor);
+        using HttpClient client = new(handler) { BaseAddress = new Uri("https://localhost") };
+
+        HttpRequestMessage? capturedRequest = null;
+        handler.InnerHandler = new CapturingHandler(req => capturedRequest = req);
+
+        await client.GetAsync("/api/test", TestContext.Current.CancellationToken);
+
+        capturedRequest.ShouldNotBeNull();
+        capturedRequest.Headers.Authorization.ShouldBeNull();
+    }
+
+    private static AuthTokenPropagationHandler CreateHandler(IHttpContextAccessor accessor) =>
+        new(accessor) { InnerHandler = new CapturingHandler(_ => { }) };
+
+    private sealed class CapturingHandler(Action<HttpRequestMessage> capture) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            capture(request);
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+        }
+    }
+}

--- a/tests/Granit.Http.Resilience.Tests/Granit.Http.Resilience.Tests.csproj
+++ b/tests/Granit.Http.Resilience.Tests/Granit.Http.Resilience.Tests.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />


### PR DESCRIPTION
## Summary

- Adds `AddAuthTokenPropagation()` extension on `IHttpClientBuilder` that forwards the incoming `Authorization` header to outgoing HTTP requests
- Enables transparent JWT propagation in microservice architectures (prerequisite for `granit-fx/granit-microservice-template`)
- Updates README, Astro docs, and fixes 2 pre-existing broken links in docs-site

## Changes

### `Granit.Http.Resilience`
- `AuthTokenPropagationHandler` — `DelegatingHandler` that reads `Authorization` from `HttpContext` and sets it on outgoing requests (skips if already present)
- `AddAuthTokenPropagation()` extension on `IHttpClientBuilder`
- Added `FrameworkReference` to `Microsoft.AspNetCore.App` (needed for `IHttpContextAccessor`), removed now-redundant package references

### Documentation
- Updated `README.md` with usage examples
- Added "Auth token propagation" section to `http-resilience.mdx` (Astro docs)
- Fixed broken link `/dotnet/core/multi-tenancy/` → `/dotnet/concepts/multi-tenancy/` in `output-caching.mdx`
- Excluded `/` from link validator (custom Astro landing page)

## Test plan

- [x] 6 new unit tests in `AuthTokenPropagationHandlerTests` (propagation, no-override, null context, no header, registration)
- [x] All 16 tests pass in `Granit.Http.Resilience.Tests`
- [x] `dotnet format --verify-no-changes` passes
- [x] `pnpm astro build` passes with 0 link errors

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)