### PR TITLE
feat(wolverine-pg): add TransportConnectionStringName for Aspire integration

### DIFF
--- a/docs-site/src/content/docs/404.md
+++ b/docs-site/src/content/docs/404.md
@@ -1,0 +1,12 @@
+---
+title: Page not found
+template: splash
+editUrl: false
+hero:
+  title: "404"
+  tagline: The page you're looking for doesn't exist or has been moved.
+  actions:
+    - text: Go to homepage
+      link: /
+      icon: right-arrow
+---

--- a/src/Granit.AI/Internal/LlmResponseHelper.cs
+++ b/src/Granit.AI/Internal/LlmResponseHelper.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+
+namespace Granit.AI.Internal;
+
+/// <summary>
+/// Shared utilities for parsing LLM responses across AI modules.
+/// </summary>
+internal static class LlmResponseHelper
+{
+    /// <summary>
+    /// Strips optional Markdown code fences (```json ... ```) from an LLM response.
+    /// </summary>
+    public static string StripMarkdownCodeFences(string text)
+    {
+        ReadOnlySpan<char> span = text.AsSpan().Trim();
+
+        if (span.StartsWith("```json", StringComparison.OrdinalIgnoreCase))
+        {
+            span = span["```json".Length..];
+        }
+        else if (span.StartsWith("```", StringComparison.Ordinal))
+        {
+            span = span["```".Length..];
+        }
+
+        if (span.EndsWith("```", StringComparison.Ordinal))
+        {
+            span = span[..^"```".Length];
+        }
+
+        return span.Trim().ToString();
+    }
+}

--- a/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
@@ -67,9 +67,11 @@ public static class WolverinePostgresqlHostApplicationBuilderExtensions
             .GetSection(WolverinePostgresqlOptions.SectionName)
             .Bind(options);
 
+        string connectionString = ResolveConnectionString(builder.Configuration, options);
+
         builder.Services.ConfigureWolverine(opts =>
         {
-            opts.PersistMessagesWithPostgresql(options.TransportConnectionString);
+            opts.PersistMessagesWithPostgresql(connectionString);
             opts.UseEntityFrameworkCoreTransactions(options.TransactionMode);
             opts.Policies.AutoApplyTransactions();
 
@@ -130,6 +132,8 @@ public static class WolverinePostgresqlHostApplicationBuilderExtensions
             .GetSection(WolverinePostgresqlOptions.SectionName)
             .Bind(options);
 
+        string connectionString = ResolveConnectionString(builder.Configuration, options);
+
         // Register the per-tenant factory and DbContext as Scoped via Granit.Persistence.
         // TryAdd semantics preserve any existing registration (e.g., overrides from integration tests).
         builder.Services.AddTenantPerDatabaseDbContext<TContext>(
@@ -137,7 +141,7 @@ public static class WolverinePostgresqlHostApplicationBuilderExtensions
 
         builder.Services.ConfigureWolverine(opts =>
         {
-            opts.PersistMessagesWithPostgresql(options.TransportConnectionString);
+            opts.PersistMessagesWithPostgresql(connectionString);
             opts.UseEntityFrameworkCoreTransactions(options.TransactionMode);
             opts.Policies.AutoApplyTransactions();
 
@@ -145,5 +149,26 @@ public static class WolverinePostgresqlHostApplicationBuilderExtensions
         });
 
         return builder;
+    }
+
+    /// <summary>
+    /// Resolves the transport connection string from explicit value or <c>ConnectionStrings:{name}</c> fallback.
+    /// </summary>
+    private static string ResolveConnectionString(IConfiguration configuration, WolverinePostgresqlOptions options)
+    {
+        if (!string.IsNullOrWhiteSpace(options.TransportConnectionString))
+        {
+            return options.TransportConnectionString;
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.TransportConnectionStringName))
+        {
+            return configuration.GetConnectionString(options.TransportConnectionStringName)
+                ?? throw new InvalidOperationException(
+                    $"Connection string '{options.TransportConnectionStringName}' not found in ConnectionStrings configuration. " +
+                    "Ensure the Aspire resource name matches TransportConnectionStringName.");
+        }
+
+        return string.Empty;
     }
 }

--- a/src/Granit.Wolverine.Postgresql/Internal/WolverinePostgresqlOptionsValidator.cs
+++ b/src/Granit.Wolverine.Postgresql/Internal/WolverinePostgresqlOptionsValidator.cs
@@ -11,11 +11,13 @@ internal sealed class WolverinePostgresqlOptionsValidator : IValidateOptions<Wol
     /// <inheritdoc/>
     public ValidateOptionsResult Validate(string? name, WolverinePostgresqlOptions options)
     {
-        if (string.IsNullOrWhiteSpace(options.TransportConnectionString))
+        if (string.IsNullOrWhiteSpace(options.TransportConnectionString) &&
+            string.IsNullOrWhiteSpace(options.TransportConnectionStringName))
         {
             return ValidateOptionsResult.Fail(
-                $"{nameof(options.TransportConnectionString)} must be non-empty. " +
-                "A valid PostgreSQL connection string is required for the Wolverine Outbox (ISO 27001 compliance).");
+                $"Either {nameof(options.TransportConnectionString)} or {nameof(options.TransportConnectionStringName)} " +
+                "must be configured. A valid PostgreSQL connection string is required for the Wolverine Outbox (ISO 27001 compliance). " +
+                "Use TransportConnectionStringName for Aspire integration (e.g., \"catalog-db\").");
         }
 
         return ValidateOptionsResult.Success;

--- a/src/Granit.Wolverine.Postgresql/Options/WolverinePostgresqlOptions.cs
+++ b/src/Granit.Wolverine.Postgresql/Options/WolverinePostgresqlOptions.cs
@@ -24,11 +24,29 @@ public sealed class WolverinePostgresqlOptions
     public const string SectionName = "WolverinePostgresql";
 
     /// <summary>
-    /// PostgreSQL connection string for the Wolverine Outbox tables.
-    /// Must be non-empty. Required for ISO 27001-compliant durable messaging.
+    /// Explicit PostgreSQL connection string for the Wolverine Outbox tables.
+    /// Takes priority over <see cref="TransportConnectionStringName"/>.
+    /// Required (either this or <see cref="TransportConnectionStringName"/>) for ISO 27001-compliant durable messaging.
     /// </summary>
-    [Required]
-    public string TransportConnectionString { get; set; } = string.Empty;
+    public string? TransportConnectionString { get; set; }
+
+    /// <summary>
+    /// Name of the connection string in the <c>ConnectionStrings</c> configuration section.
+    /// Used as fallback when <see cref="TransportConnectionString"/> is null or empty.
+    /// Enables seamless integration with .NET Aspire service discovery.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// // appsettings.json
+    /// {
+    ///   "WolverinePostgresql": {
+    ///     "TransportConnectionStringName": "catalog-db"
+    ///   }
+    /// }
+    /// // Aspire injects ConnectionStrings:catalog-db → Wolverine reads it automatically.
+    /// </code>
+    /// </example>
+    public string? TransportConnectionStringName { get; set; }
 
     /// <summary>
     /// EF Core transaction wrapping mode for Wolverine handlers.

--- a/tests/Granit.Wolverine.Postgresql.Tests/WolverinePostgresqlOptionsTests.cs
+++ b/tests/Granit.Wolverine.Postgresql.Tests/WolverinePostgresqlOptionsTests.cs
@@ -25,8 +25,12 @@ public sealed class WolverinePostgresqlOptionsTests
         WolverinePostgresqlOptions.SectionName.ShouldBe("WolverinePostgresql");
 
     [Fact]
-    public void DefaultTransportConnectionString_IsEmpty() =>
-        new WolverinePostgresqlOptions().TransportConnectionString.ShouldBeEmpty();
+    public void DefaultTransportConnectionString_IsNull() =>
+        new WolverinePostgresqlOptions().TransportConnectionString.ShouldBeNull();
+
+    [Fact]
+    public void DefaultTransportConnectionStringName_IsNull() =>
+        new WolverinePostgresqlOptions().TransportConnectionStringName.ShouldBeNull();
 
     [Fact]
     public void DefaultTransactionMode_IsEager() =>
@@ -51,6 +55,35 @@ public sealed class WolverinePostgresqlOptionsTests
     }
 
     [Fact]
+    public void Validate_ValidConnectionStringName_Succeeds()
+    {
+        WolverinePostgresqlOptionsValidator validator = new();
+        WolverinePostgresqlOptions options = new()
+        {
+            TransportConnectionStringName = "catalog-db",
+        };
+
+        ValidateOptionsResult result = validator.Validate(null, options);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_BothConnectionStringAndName_Succeeds()
+    {
+        WolverinePostgresqlOptionsValidator validator = new();
+        WolverinePostgresqlOptions options = new()
+        {
+            TransportConnectionString = "Host=localhost;Database=test",
+            TransportConnectionStringName = "catalog-db",
+        };
+
+        ValidateOptionsResult result = validator.Validate(null, options);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
     public void Validate_LightweightMode_Succeeds()
     {
         WolverinePostgresqlOptionsValidator validator = new();
@@ -66,23 +99,24 @@ public sealed class WolverinePostgresqlOptionsTests
     }
 
     // -----------------------------------------------------------------------
-    // WolverinePostgresqlOptionsValidator — TransportConnectionString failures
+    // WolverinePostgresqlOptionsValidator — failures
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void Validate_NullConnectionString_Fails()
+    public void Validate_NeitherConnectionStringNorName_Fails()
     {
         WolverinePostgresqlOptionsValidator validator = new();
-        WolverinePostgresqlOptions options = new() { TransportConnectionString = null! };
+        WolverinePostgresqlOptions options = new();
 
         ValidateOptionsResult result = validator.Validate(null, options);
 
         result.Failed.ShouldBeTrue();
         result.Failures.ShouldContain(x => x.Contains("TransportConnectionString"));
+        result.Failures.ShouldContain(x => x.Contains("TransportConnectionStringName"));
     }
 
     [Fact]
-    public void Validate_EmptyConnectionString_Fails()
+    public void Validate_EmptyConnectionStringAndNoName_Fails()
     {
         WolverinePostgresqlOptionsValidator validator = new();
         WolverinePostgresqlOptions options = new() { TransportConnectionString = string.Empty };
@@ -90,11 +124,10 @@ public sealed class WolverinePostgresqlOptionsTests
         ValidateOptionsResult result = validator.Validate(null, options);
 
         result.Failed.ShouldBeTrue();
-        result.Failures.ShouldContain(x => x.Contains("TransportConnectionString"));
     }
 
     [Fact]
-    public void Validate_WhitespaceConnectionString_Fails()
+    public void Validate_WhitespaceConnectionStringAndNoName_Fails()
     {
         WolverinePostgresqlOptionsValidator validator = new();
         WolverinePostgresqlOptions options = new() { TransportConnectionString = "   " };
@@ -102,6 +135,5 @@ public sealed class WolverinePostgresqlOptionsTests
         ValidateOptionsResult result = validator.Validate(null, options);
 
         result.Failed.ShouldBeTrue();
-        result.Failures.ShouldContain(x => x.Contains("ISO 27001"));
     }
 }


### PR DESCRIPTION
## Summary

- Add `TransportConnectionStringName` property to `WolverinePostgresqlOptions`
- Resolves connection string from `ConnectionStrings:{name}` when `TransportConnectionString` is null
- Enables seamless .NET Aspire integration without manual mapping in `Program.cs`
- Priority: `TransportConnectionString` (explicit) > `ConnectionStrings:{TransportConnectionStringName}` (Aspire)

## Usage

```json
{
  "WolverinePostgresql": {
    "TransportConnectionStringName": "catalog-db"
  }
}
```

Aspire injects `ConnectionStrings:catalog-db` automatically — Wolverine reads it via the fallback.

## Test plan

- [x] 21/21 Wolverine PostgreSQL tests passing
- [x] Validator accepts either `TransportConnectionString` or `TransportConnectionStringName`
- [x] Validator rejects when neither is set
- [ ] End-to-end with Aspire AppHost (granit-microservice-template)

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)
