### PR TITLE
fix(wolverine-postgresql): replace ConfigureWolverine with UseWolverine

### DIFF
--- a/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
@@ -61,7 +61,7 @@ public static class WolverinePostgresqlHostApplicationBuilderExtensions
             WolverinePostgresqlOptionsValidator>();
 
         // Read options directly from IConfiguration: the DI container is not yet
-        // built at this point, so IOptions<> is not resolvable inside ConfigureWolverine().
+        // built at this point, so IOptions<> is not resolvable inside UseWolverine().
         WolverinePostgresqlOptions options = new();
         builder.Configuration
             .GetSection(WolverinePostgresqlOptions.SectionName)
@@ -69,7 +69,11 @@ public static class WolverinePostgresqlHostApplicationBuilderExtensions
 
         string connectionString = ResolveConnectionString(builder.Configuration, options);
 
-        builder.Services.ConfigureWolverine(opts =>
+        // UseWolverine runs eagerly before the DI container is built.
+        // ConfigureWolverine must NOT be used here: it registers a late-bound IWolverineExtension
+        // in DI that runs after the container is locked, and PersistMessagesWithPostgresql
+        // tries to add singletons to the read-only service collection (Wolverine 3.0+ breaking change).
+        builder.UseWolverine(opts =>
         {
             opts.PersistMessagesWithPostgresql(connectionString);
             opts.UseEntityFrameworkCoreTransactions(options.TransactionMode);
@@ -126,7 +130,7 @@ public static class WolverinePostgresqlHostApplicationBuilderExtensions
             WolverinePostgresqlOptionsValidator>();
 
         // Read options directly from IConfiguration: the DI container is not yet
-        // built at this point, so IOptions<> is not resolvable inside ConfigureWolverine().
+        // built at this point, so IOptions<> is not resolvable inside UseWolverine().
         WolverinePostgresqlOptions options = new();
         builder.Configuration
             .GetSection(WolverinePostgresqlOptions.SectionName)
@@ -139,7 +143,11 @@ public static class WolverinePostgresqlHostApplicationBuilderExtensions
         builder.Services.AddTenantPerDatabaseDbContext<TContext>(
             static (opts, connectionString) => opts.UseNpgsql(connectionString));
 
-        builder.Services.ConfigureWolverine(opts =>
+        // UseWolverine runs eagerly before the DI container is built.
+        // ConfigureWolverine must NOT be used here: it registers a late-bound IWolverineExtension
+        // in DI that runs after the container is locked, and PersistMessagesWithPostgresql
+        // tries to add singletons to the read-only service collection (Wolverine 3.0+ breaking change).
+        builder.UseWolverine(opts =>
         {
             opts.PersistMessagesWithPostgresql(connectionString);
             opts.UseEntityFrameworkCoreTransactions(options.TransactionMode);


### PR DESCRIPTION
## Summary

- `AddGranitWolverineWithPostgresql` and `AddGranitWolverineWithPostgresqlPerTenant` used `builder.Services.ConfigureWolverine()` to configure the PostgreSQL outbox
- `ConfigureWolverine` registers a late-bound `IWolverineExtension` in the DI container that is applied **after** the container is built (read-only)
- `PersistMessagesWithPostgresql` calls `services.AddSingleton(...)` internally, which throws as of **Wolverine 3.0**:
  ```
  As of Wolverine 3.0, it's no longer supported to alter IoC service registrations
  through Wolverine extensions that are themselves registered in the IoC container
  ```
- Fix: replace `builder.Services.ConfigureWolverine(...)` with `builder.UseWolverine(...)`, which runs eagerly before the container is built — the same pattern already used by `AddGranitWolverine` in `Granit.Wolverine`

## Test plan

- [x] `Granit.Wolverine.Postgresql.Tests` — 21 tests pass
- [ ] Run `granit-microservice-template` AppHost end-to-end — services should start without the `InvalidOperationException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
