### PR TITLE
fix(http-idempotency): add in-memory fallback store when Redis is unavailable

### DIFF
--- a/src/Granit.Http.Idempotency/Extensions/IdempotencyServiceCollectionExtensions.cs
+++ b/src/Granit.Http.Idempotency/Extensions/IdempotencyServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Microsoft.IO;
+using StackExchange.Redis;
 
 namespace Granit.Http.Idempotency.Extensions;
 
@@ -54,7 +55,23 @@ public static class IdempotencyServiceCollectionExtensions
     private static IServiceCollection AddGranitIdempotencyCore(this IServiceCollection services)
     {
         services.AddSingleton<IValidateOptions<IdempotencyOptions>, IdempotencyOptionsValidator>();
-        services.AddScoped<IIdempotencyStore, RedisIdempotencyStore>();
+
+        // Resolve at runtime: Redis-backed store when IConnectionMultiplexer is available,
+        // otherwise fall back to an in-memory store (dev / single-instance deployments).
+        // Using a factory delegate avoids order-dependent service.Any() checks at registration time.
+        services.TryAddScoped<IIdempotencyStore>(sp =>
+        {
+            IConnectionMultiplexer? redis = sp.GetService<IConnectionMultiplexer>();
+            if (redis is not null)
+            {
+                return ActivatorUtilities.CreateInstance<RedisIdempotencyStore>(sp);
+            }
+
+            // Singleton fallback — resolved from the root scope to avoid multiple instances.
+            return sp.GetRequiredService<InMemoryIdempotencyStore>();
+        });
+
+        services.TryAddSingleton<InMemoryIdempotencyStore>();
 
         // RecyclableMemoryStreamManager is thread-safe and should be a singleton
         services.TryAddSingleton<RecyclableMemoryStreamManager>();

--- a/src/Granit.Http.Idempotency/Internal/InMemoryIdempotencyStore.cs
+++ b/src/Granit.Http.Idempotency/Internal/InMemoryIdempotencyStore.cs
@@ -1,0 +1,71 @@
+using System.Collections.Concurrent;
+using Granit.Http.Idempotency.Abstractions;
+using Granit.Http.Idempotency.Models;
+
+namespace Granit.Http.Idempotency.Internal;
+
+/// <summary>
+/// In-memory fallback implementation of <see cref="IIdempotencyStore"/> used when
+/// no <c>IConnectionMultiplexer</c> (Redis) is registered in the container.
+/// </summary>
+/// <remarks>
+/// This store is suitable for development and single-instance deployments only.
+/// It does not survive process restarts and does not provide cross-instance deduplication.
+/// TTL expiration is checked lazily on read; a background cleanup is not implemented.
+/// </remarks>
+internal sealed class InMemoryIdempotencyStore(TimeProvider timeProvider) : IIdempotencyStore
+{
+    private readonly ConcurrentDictionary<string, (IdempotencyEntry Entry, DateTimeOffset ExpiresAt)> _store = new();
+
+    /// <inheritdoc/>
+    public Task<bool> TryAcquireAsync(string key, IdempotencyEntry entry, TimeSpan ttl, CancellationToken cancellationToken)
+    {
+        Cleanup();
+        DateTimeOffset expiresAt = timeProvider.GetUtcNow() + ttl;
+        bool acquired = _store.TryAdd(key, (entry, expiresAt));
+        return Task.FromResult(acquired);
+    }
+
+    /// <inheritdoc/>
+    public Task<IdempotencyEntry?> GetAsync(string key, CancellationToken cancellationToken)
+    {
+        if (_store.TryGetValue(key, out (IdempotencyEntry Entry, DateTimeOffset ExpiresAt) tuple))
+        {
+            if (timeProvider.GetUtcNow() < tuple.ExpiresAt)
+            {
+                return Task.FromResult<IdempotencyEntry?>(tuple.Entry);
+            }
+
+            _store.TryRemove(key, out _);
+        }
+
+        return Task.FromResult<IdempotencyEntry?>(null);
+    }
+
+    /// <inheritdoc/>
+    public Task SetCompletedAsync(string key, IdempotencyEntry entry, TimeSpan ttl, CancellationToken cancellationToken)
+    {
+        DateTimeOffset expiresAt = timeProvider.GetUtcNow() + ttl;
+        _store.AddOrUpdate(key, (entry, expiresAt), (_, _) => (entry, expiresAt));
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task DeleteAsync(string key, CancellationToken cancellationToken)
+    {
+        _store.TryRemove(key, out _);
+        return Task.CompletedTask;
+    }
+
+    private void Cleanup()
+    {
+        DateTimeOffset now = timeProvider.GetUtcNow();
+        foreach (KeyValuePair<string, (IdempotencyEntry Entry, DateTimeOffset ExpiresAt)> kvp in _store)
+        {
+            if (now >= kvp.Value.ExpiresAt)
+            {
+                _store.TryRemove(kvp.Key, out _);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the hard-wired `AddScoped<IIdempotencyStore, RedisIdempotencyStore>` with a runtime factory delegate
- Falls back to `InMemoryIdempotencyStore` when no `IConnectionMultiplexer` is registered in the container
- Enables local development and single-instance deployments without requiring Redis

## Motivation

`guava-backend` does not register `IConnectionMultiplexer` in its dev environment, causing a startup crash:
> `Unable to resolve service for type 'StackExchange.Redis.IConnectionMultiplexer'`

## Test plan

- [ ] Dev environment without Redis: app starts, idempotency middleware uses in-memory store
- [ ] Prod environment with Redis (`IConnectionMultiplexer` registered): `RedisIdempotencyStore` is used
- [ ] `InMemoryIdempotencyStore` is Singleton — thread-safe via `ConcurrentDictionary`, TTL enforced lazily on read
