### PR TITLE
fix(wolverine-postgresql): use GranitWolverineOptionsHolder to pass WolverineOptions to provider packages

### DIFF
--- a/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
@@ -98,7 +98,7 @@ public static class WolverinePostgresqlHostApplicationBuilderExtensions
     }
 
     /// <summary>
-    /// Shared core setup: options binding, connection string resolution, and <c>UseWolverine</c>.
+    /// Shared core setup: options binding, connection string resolution, and PostgreSQL Wolverine configuration.
     /// </summary>
     private static IHostApplicationBuilder AddGranitWolverineWithPostgresqlCore(
         IHostApplicationBuilder builder,
@@ -125,17 +125,19 @@ public static class WolverinePostgresqlHostApplicationBuilderExtensions
         //
         // Path A — AddGranitWolverine() was called first (production via [DependsOn] module ordering):
         //   UseWolverine() can only be called once; calling it again throws.
-        //   WolverineOptions is registered as a singleton instance — retrieve it from the service
-        //   descriptors and extend it directly. The container is not yet built so
-        //   options.Services.AddSingleton() inside PersistMessagesWithPostgresql is still valid.
+        //   Wolverine 5.20+ registers WolverineOptions via a factory (ImplementationFactory),
+        //   not as an ImplementationInstance. Invoke the factory with null — the lambda is
+        //   always `_ => options` and ignores the IServiceProvider argument.
+        //   The container is not yet built so options.Services.AddSingleton() inside
+        //   PersistMessagesWithPostgresql is still valid.
         //
         // Path B — called standalone without AddGranitWolverine() (integration tests, manual wiring):
         //   UseWolverine() hasn't been called yet — it is safe to call it once here.
         WolverineOptions? existing = builder.Services
             .Where(sd => sd.ServiceType == typeof(WolverineOptions))
-            .Select(sd => sd.ImplementationInstance)
-            .OfType<WolverineOptions>()
-            .FirstOrDefault();
+            .Select(sd => sd.ImplementationInstance as WolverineOptions
+                          ?? sd.ImplementationFactory?.Invoke(null!) as WolverineOptions)
+            .FirstOrDefault(x => x is not null);
 
         if (existing is not null)
         {

--- a/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Granit.Persistence.Extensions;
 using Granit.Persistence.MultiTenancy;
+using Granit.Wolverine.Internal;
 using Granit.Wolverine.Postgresql.Internal;
 using Granit.Wolverine.Postgresql.Options;
 using Microsoft.EntityFrameworkCore;
@@ -125,18 +126,19 @@ public static class WolverinePostgresqlHostApplicationBuilderExtensions
         //
         // Path A — AddGranitWolverine() was called first (production via [DependsOn] module ordering):
         //   UseWolverine() can only be called once; calling it again throws.
-        //   Wolverine 5.20+ registers WolverineOptions via a factory (ImplementationFactory),
-        //   not as an ImplementationInstance. Invoke the factory with null — the lambda is
-        //   always `_ => options` and ignores the IServiceProvider argument.
+        //   AddGranitWolverine() captures the WolverineOptions from inside the UseWolverine lambda
+        //   (invoked synchronously) and registers it via GranitWolverineOptionsHolder.
+        //   Wolverine 5.20+ registers WolverineOptions via an IServiceProvider-dependent factory —
+        //   it cannot be retrieved via ImplementationInstance before the container is built.
         //   The container is not yet built so options.Services.AddSingleton() inside
         //   PersistMessagesWithPostgresql is still valid.
         //
         // Path B — called standalone without AddGranitWolverine() (integration tests, manual wiring):
-        //   UseWolverine() hasn't been called yet — it is safe to call it once here.
+        //   GranitWolverineOptionsHolder is absent — UseWolverine() hasn't been called yet — safe to
+        //   call it once here.
         WolverineOptions? existing = builder.Services
-            .Where(sd => sd.ServiceType == typeof(WolverineOptions))
-            .Select(sd => sd.ImplementationInstance as WolverineOptions
-                          ?? sd.ImplementationFactory?.Invoke(null!) as WolverineOptions)
+            .Where(sd => sd.ServiceType == typeof(GranitWolverineOptionsHolder))
+            .Select(sd => (sd.ImplementationInstance as GranitWolverineOptionsHolder)?.Options)
             .FirstOrDefault(x => x is not null);
 
         if (existing is not null)

--- a/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
@@ -77,8 +77,17 @@ public static class WolverineHostApplicationBuilderExtensions
         // Modules without Wolverine handlers must still register manually.
         builder.Services.AddGranitValidatorsFromWolverineHandlerModules();
 
+        // Capture the WolverineOptions instance for downstream packages (e.g. Granit.Wolverine.Postgresql).
+        // Wolverine 5.20+ registers WolverineOptions via an IServiceProvider-dependent factory, making
+        // it impossible to retrieve the instance from the service collection before the DI container is
+        // built. We capture it here (the configure lambda is invoked synchronously by UseWolverine) and
+        // register a holder as a plain ImplementationInstance singleton so it is always readable.
+        WolverineOptions? captured = null;
+
         builder.UseWolverine(opts =>
         {
+            captured = opts;
+
             // Auto-discover assemblies decorated with [assembly: WolverineHandlerModule].
             // Application modules mark themselves, eliminating centralized IncludeAssembly() calls.
             opts.Discovery.IncludeHandlerModules = true;
@@ -111,6 +120,14 @@ public static class WolverineHostApplicationBuilderExtensions
 
             configure?.Invoke(opts);
         });
+
+        // Register the captured WolverineOptions as an ImplementationInstance singleton so that
+        // Granit.Wolverine.Postgresql (and other Granit provider packages) can find it via the
+        // service descriptors before the DI container is built — without going through the factory.
+        if (captured is not null)
+        {
+            builder.Services.AddSingleton(new GranitWolverineOptionsHolder(captured));
+        }
 
         return builder;
     }

--- a/src/Granit.Wolverine/Internal/GranitWolverineOptionsHolder.cs
+++ b/src/Granit.Wolverine/Internal/GranitWolverineOptionsHolder.cs
@@ -1,0 +1,20 @@
+using Wolverine;
+
+namespace Granit.Wolverine.Internal;
+
+/// <summary>
+/// Internal marker registered by <c>AddGranitWolverine()</c> so that
+/// <c>AddGranitWolverineWithPostgresql()</c> can retrieve the live
+/// <see cref="WolverineOptions"/> instance before the DI container is built.
+/// </summary>
+/// <remarks>
+/// Wolverine 5.20+ registers <see cref="WolverineOptions"/> via a factory that
+/// requires a built <see cref="IServiceProvider"/>, making it impossible to retrieve
+/// the instance through the service collection before the container is built.
+/// This holder is registered as an <c>ImplementationInstance</c> singleton — safe to
+/// read via <see cref="ServiceDescriptor.ImplementationInstance"/> at any time.
+/// </remarks>
+public sealed class GranitWolverineOptionsHolder(WolverineOptions options)
+{
+    public WolverineOptions Options { get; } = options;
+}


### PR DESCRIPTION
## Problem

Wolverine 5.20+ registers `WolverineOptions` via an `IServiceProvider`-dependent factory (`ImplementationFactory`), not as an `ImplementationInstance`. This makes it impossible to retrieve the live instance from the service collection before the DI container is built — which is exactly when `AddGranitWolverineWithPostgresql()` needs to extend it.

PR #351 attempted a two-path detection using `sd.ImplementationInstance`, but since Wolverine uses a factory, the detection always returns `null`, causing `AddGranitWolverineWithPostgresqlCore()` to fall through to Path B and call `builder.UseWolverine()` a second time — which throws since Wolverine 3.0+.

## Solution

`AddGranitWolverine()` now captures the `WolverineOptions` from inside the `UseWolverine` lambda (which is invoked **synchronously**) and registers it as a `GranitWolverineOptionsHolder` singleton (`ImplementationInstance` — always readable before the container is built).

`AddGranitWolverineWithPostgresqlCore()` detects `GranitWolverineOptionsHolder` to apply `PersistMessagesWithPostgresql()` without calling `UseWolverine()` a second time.

Path B (standalone / integration tests without `AddGranitWolverine`) is preserved: when the holder is absent, `UseWolverine()` is called once as before.

## Test plan

- [x] 21/21 `Granit.Wolverine.Postgresql.Tests` pass (Path B — standalone, no prior `AddGranitWolverine`)
- [x] 92/92 `Granit.Wolverine.Tests` pass
- [x] Local patch applied to `granit-microservice-template` AppHost — CatalogService, NotificationService start without `UseWolverine() can only be called once` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
