### PR TITLE
fix(wolverine): make GranitWolverineOptionsHolder internal to satisfy architecture test

### DIFF
--- a/src/Granit.Wolverine/Internal/GranitWolverineOptionsHolder.cs
+++ b/src/Granit.Wolverine/Internal/GranitWolverineOptionsHolder.cs
@@ -14,7 +14,7 @@ namespace Granit.Wolverine.Internal;
 /// This holder is registered as an <c>ImplementationInstance</c> singleton — safe to
 /// read via <see cref="ServiceDescriptor.ImplementationInstance"/> at any time.
 /// </remarks>
-public sealed class GranitWolverineOptionsHolder(WolverineOptions options)
+internal sealed class GranitWolverineOptionsHolder(WolverineOptions options)
 {
-    public WolverineOptions Options { get; } = options;
+    internal WolverineOptions Options { get; } = options;
 }


### PR DESCRIPTION
## Summary

- Makes `GranitWolverineOptionsHolder` `internal` so it no longer violates the Granit architecture rule that public types must not reside in `*.Internal.*` namespaces.
- `InternalsVisibleTo("Granit.Wolverine.Postgresql")` is already declared in the `.csproj`, so cross-assembly access from the provider package is unaffected.

## Test plan

- [ ] `dotnet test tests/Granit.ArchitectureTests` — no public-type-in-internal-namespace violations
- [ ] `dotnet build src/Granit.Wolverine` — builds clean
- [ ] `dotnet build src/Granit.Wolverine.Postgresql` — still compiles (InternalsVisibleTo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
