### PR TITLE
fix(webhooks): register EfWebhookSubscriptionStore as Scoped

### DIFF
--- a/src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksEfCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksEfCoreHostApplicationBuilderExtensions.cs
@@ -35,11 +35,11 @@ public static class WebhooksEfCoreHostApplicationBuilderExtensions
     {
         builder.Services.AddGranitDbContext<WebhooksDbContext>(configure);
 
-        builder.Services.AddSingleton<EfWebhookSubscriptionStore>();
+        builder.Services.AddScoped<EfWebhookSubscriptionStore>();
         builder.Services.Replace(
-            ServiceDescriptor.Singleton<IWebhookSubscriptionReader>(sp => sp.GetRequiredService<EfWebhookSubscriptionStore>()));
+            ServiceDescriptor.Scoped<IWebhookSubscriptionReader>(sp => sp.GetRequiredService<EfWebhookSubscriptionStore>()));
         builder.Services.Replace(
-            ServiceDescriptor.Singleton<IWebhookSubscriptionWriter>(sp => sp.GetRequiredService<EfWebhookSubscriptionStore>()));
+            ServiceDescriptor.Scoped<IWebhookSubscriptionWriter>(sp => sp.GetRequiredService<EfWebhookSubscriptionStore>()));
 
         builder.Services.Replace(
             ServiceDescriptor.Scoped<IWebhookDeliveryWriter, EfWebhookDeliveryStore>());


### PR DESCRIPTION
## Summary

- `EfWebhookSubscriptionStore` was registered as Singleton while `IDbContextFactory<WebhooksDbContext>` is Scoped (intentional — multi-tenant interceptor isolation via `AddGranitDbContext`)
- The DI validator rejects a Singleton consuming a Scoped dependency, causing a startup crash
- `EfWebhookDeliveryStore` in the same file was already Scoped — this aligns `EfWebhookSubscriptionStore` with the same lifetime

## Context

`AddGranitDbContext` explicitly passes `ServiceLifetime.Scoped` to `AddDbContextFactory` so that interceptors (`AuditedEntityInterceptor`, `SoftDeleteInterceptor`) can resolve Scoped services like `ICurrentTenant` per request. All EF-backed stores must therefore be Scoped.

Consumers (`WebhookFanoutHandler`, `RetryWebhookHandler`) are Wolverine handlers — Scoped by nature.

## Test plan

- [ ] `dotnet build` passes
- [ ] DI validation at startup no longer throws for Webhooks stores
