### PR TITLE
fix(di-lifetime): fix Scoped IDbContextFactory consumers broken by #738

### DIFF
--- a/src/Granit.DataExchange.EntityFrameworkCore/GranitDataExchangeEntityFrameworkCoreModule.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/GranitDataExchangeEntityFrameworkCoreModule.cs
@@ -23,7 +23,11 @@ public sealed class GranitDataExchangeEntityFrameworkCoreModule : GranitModule
     /// <inheritdoc />
     public override async Task OnApplicationInitializationAsync(ApplicationInitializationContext context)
     {
-        IDbContextFactory<DataExchangeDbContext> factory = context.ServiceProvider
+        // IDbContextFactory<T> is Scoped (multi-tenant interceptor isolation).
+        // OnApplicationInitializationAsync runs against the root provider — a scope is required.
+        await using AsyncServiceScope scope = context.ServiceProvider.CreateAsyncScope();
+
+        IDbContextFactory<DataExchangeDbContext> factory = scope.ServiceProvider
             .GetRequiredService<IDbContextFactory<DataExchangeDbContext>>();
 
         await using DataExchangeDbContext dbContext = await factory

--- a/src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksEfCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksEfCoreHostApplicationBuilderExtensions.cs
@@ -35,11 +35,11 @@ public static class WebhooksEfCoreHostApplicationBuilderExtensions
     {
         builder.Services.AddGranitDbContext<WebhooksDbContext>(configure);
 
-        builder.Services.AddSingleton<EfWebhookSubscriptionStore>();
+        builder.Services.AddScoped<EfWebhookSubscriptionStore>();
         builder.Services.Replace(
-            ServiceDescriptor.Singleton<IWebhookSubscriptionReader>(sp => sp.GetRequiredService<EfWebhookSubscriptionStore>()));
+            ServiceDescriptor.Scoped<IWebhookSubscriptionReader>(sp => sp.GetRequiredService<EfWebhookSubscriptionStore>()));
         builder.Services.Replace(
-            ServiceDescriptor.Singleton<IWebhookSubscriptionWriter>(sp => sp.GetRequiredService<EfWebhookSubscriptionStore>()));
+            ServiceDescriptor.Scoped<IWebhookSubscriptionWriter>(sp => sp.GetRequiredService<EfWebhookSubscriptionStore>()));
 
         builder.Services.Replace(
             ServiceDescriptor.Scoped<IWebhookDeliveryWriter, EfWebhookDeliveryStore>());


### PR DESCRIPTION
## Summary

Two fixes introduced by `#738` (`AddGranitDbContext` centralization, March 12) which switched `IDbContextFactory<T>` from Singleton to Scoped to support `ICurrentUserService`/`ICurrentTenant` in `AuditedEntityInterceptor`.

- **Webhooks**: `EfWebhookSubscriptionStore` was still Singleton — cannot consume a Scoped `IDbContextFactory<WebhooksDbContext>`. Registered as Scoped to align with `EfWebhookDeliveryStore` in the same file and all other EF-backed stores.
- **DataExchange**: `GranitDataExchangeEntityFrameworkCoreModule.OnApplicationInitializationAsync` resolved `IDbContextFactory<DataExchangeDbContext>` directly from the root provider. Wrapped in `CreateAsyncScope()` to resolve the Scoped factory from a child scope.

## Root cause

`AddGranitDbContext<T>()` passes `ServiceLifetime.Scoped` to `AddDbContextFactory` so that `AuditedEntityInterceptor` can inject Scoped services (`ICurrentUserService`, `ICurrentTenant`) per request. All consumers of `IDbContextFactory<T>` must therefore be Scoped or use `IServiceScopeFactory`.

## Audit

Checked all `AddSingleton` store registrations across `src/`:
- EF-backed stores: all now Scoped ✅
- `EfCoreSettingStore`: Singleton via `IServiceScopeFactory` (correct — documented pattern) ✅
- Remaining Singletons: static config stores, blob clients, HTTP clients — no `IDbContextFactory` dependency ✅

## Test plan

- [ ] `dotnet build` passes
- [ ] `guava-backend` starts without DI validation errors
- [ ] Settings, BlobStorage, Localization stores unaffected
