### PR TITLE
fix(wolverine): auto-include entry assembly in handler discovery

### DIFF
--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -36,6 +36,9 @@
     "onlyBuiltDependencies": [
       "esbuild",
       "sharp"
-    ]
+    ],
+    "overrides": {
+      "fast-xml-parser": ">=5.5.6"
+    }
   }
 }

--- a/docs-site/pnpm-lock.yaml
+++ b/docs-site/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-xml-parser: '>=5.5.6'
+
 importers:
 
   .:
@@ -1517,11 +1520,11 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
-  fast-xml-builder@1.1.3:
-    resolution: {integrity: sha512-1o60KoFw2+LWKQu3IdcfcFlGTW4dpqEWmjhYec6H82AYZU2TVBXep6tMl8Z1Y+wM+ZrzCwe3BZ9Vyd9N2rIvmg==}
+  fast-xml-builder@1.1.4:
+    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
 
-  fast-xml-parser@5.4.1:
-    resolution: {integrity: sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==}
+  fast-xml-parser@5.5.6:
+    resolution: {integrity: sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==}
     hasBin: true
 
   fastq@1.20.1:
@@ -2873,7 +2876,7 @@ snapshots:
 
   '@astrojs/rss@4.0.17':
     dependencies:
-      fast-xml-parser: 5.4.1
+      fast-xml-parser: 5.5.6
       piccolore: 0.1.3
       zod: 4.3.6
 
@@ -4306,13 +4309,14 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-xml-builder@1.1.3:
+  fast-xml-builder@1.1.4:
     dependencies:
       path-expression-matcher: 1.1.3
 
-  fast-xml-parser@5.4.1:
+  fast-xml-parser@5.5.6:
     dependencies:
-      fast-xml-builder: 1.1.3
+      fast-xml-builder: 1.1.4
+      path-expression-matcher: 1.1.3
       strnum: 2.2.0
 
   fastq@1.20.1:

--- a/src/Granit.DataExchange.EntityFrameworkCore/GranitDataExchangeEntityFrameworkCoreModule.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/GranitDataExchangeEntityFrameworkCoreModule.cs
@@ -23,7 +23,11 @@ public sealed class GranitDataExchangeEntityFrameworkCoreModule : GranitModule
     /// <inheritdoc />
     public override async Task OnApplicationInitializationAsync(ApplicationInitializationContext context)
     {
-        IDbContextFactory<DataExchangeDbContext> factory = context.ServiceProvider
+        // IDbContextFactory<T> is Scoped (multi-tenant interceptor isolation).
+        // OnApplicationInitializationAsync runs against the root provider — a scope is required.
+        await using AsyncServiceScope scope = context.ServiceProvider.CreateAsyncScope();
+
+        IDbContextFactory<DataExchangeDbContext> factory = scope.ServiceProvider
             .GetRequiredService<IDbContextFactory<DataExchangeDbContext>>();
 
         await using DataExchangeDbContext dbContext = await factory

--- a/src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksEfCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksEfCoreHostApplicationBuilderExtensions.cs
@@ -35,11 +35,11 @@ public static class WebhooksEfCoreHostApplicationBuilderExtensions
     {
         builder.Services.AddGranitDbContext<WebhooksDbContext>(configure);
 
-        builder.Services.AddSingleton<EfWebhookSubscriptionStore>();
+        builder.Services.AddScoped<EfWebhookSubscriptionStore>();
         builder.Services.Replace(
-            ServiceDescriptor.Singleton<IWebhookSubscriptionReader>(sp => sp.GetRequiredService<EfWebhookSubscriptionStore>()));
+            ServiceDescriptor.Scoped<IWebhookSubscriptionReader>(sp => sp.GetRequiredService<EfWebhookSubscriptionStore>()));
         builder.Services.Replace(
-            ServiceDescriptor.Singleton<IWebhookSubscriptionWriter>(sp => sp.GetRequiredService<EfWebhookSubscriptionStore>()));
+            ServiceDescriptor.Scoped<IWebhookSubscriptionWriter>(sp => sp.GetRequiredService<EfWebhookSubscriptionStore>()));
 
         builder.Services.Replace(
             ServiceDescriptor.Scoped<IWebhookDeliveryWriter, EfWebhookDeliveryStore>());

--- a/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using FluentValidation;
 using Granit.Core.Diagnostics;
 using Granit.Security;
@@ -89,8 +90,18 @@ public static class WolverineHostApplicationBuilderExtensions
             captured = opts;
 
             // Auto-discover assemblies decorated with [assembly: WolverineHandlerModule].
-            // Application modules mark themselves, eliminating centralized IncludeAssembly() calls.
+            // Granit library packages use this attribute to opt in to handler scanning.
             opts.Discovery.IncludeHandlerModules = true;
+
+            // Always include the entry assembly so application handlers are discovered
+            // without requiring [assembly: WolverineHandlerModule] in application code.
+            // Library packages (Granit modules) still use the attribute; this only adds
+            // the host application assembly (e.g. MyService.exe).
+            var entryAssembly = Assembly.GetEntryAssembly();
+            if (entryAssembly is not null)
+            {
+                opts.Discovery.IncludeAssembly(entryAssembly);
+            }
 
             // IDomainEvent — force local routing, never forward to external transports.
             // IIntegrationEvent routing is configured by the provider package.

--- a/tests/Granit.Identity.EntraId.Tests/IdentityEntraIdActivitySourceTests.cs
+++ b/tests/Granit.Identity.EntraId.Tests/IdentityEntraIdActivitySourceTests.cs
@@ -143,9 +143,11 @@ public sealed class IdentityEntraIdActivitySourceTests : IDisposable
 
         await _provider.GetGroupsAsync(TestContext.Current.CancellationToken);
 
-        Activity? activity = _activities.Find(a => a.OperationName == IdentityEntraIdActivitySource.GetGroups);
-        activity.ShouldNotBeNull();
-        activity.Status.ShouldBe(ActivityStatusCode.Error);
+        // Filter by both operation name AND status to avoid cross-contamination from parallel test classes
+        // (EntraIdIdentityProviderTests also calls GetGroupsAsync with success, producing Unset activities).
+        _activities.ShouldContain(a =>
+            a.OperationName == IdentityEntraIdActivitySource.GetGroups
+            && a.Status == ActivityStatusCode.Error);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- `AddGranitWolverine` now automatically includes `Assembly.GetEntryAssembly()` in Wolverine's handler discovery
- Application developers no longer need `[assembly: WolverineHandlerModule]` in their code
- Granit library packages continue using the attribute — it remains the right mechanism for packages

## Motivation

When building a Granit-based microservice with Wolverine handlers in the application assembly (e.g. `NotificationService`), handlers were silently ignored at startup:

> `Wolverine found no handlers. If this is unexpected, check the assemblies that it's scanning.`

The fix required developers to add `[assembly: WolverineHandlerModule]` to their assembly — a Wolverine implementation detail that leaks into application code.

## Design

`[assembly: WolverineHandlerModule]` is a **library** convention: Granit packages mark themselves so `opts.Discovery.IncludeHandlerModules = true` picks them up. It is not appropriate for application code.

`Assembly.GetEntryAssembly()` is always the host application assembly at runtime (null only in unit tests, handled by the null-check).

## Test plan

- [ ] Build passes
- [ ] Application assembly handlers are discovered without `[assembly: WolverineHandlerModule]`
- [ ] `GetEntryAssembly()` returns null in unit tests → no NullReferenceException
