### PR TITLE
fix(style): IDE0008 var violations from #370

### DIFF
--- a/tests/Granit.Notifications.Wolverine.Tests/GranitNotificationsWolverineModuleTests.cs
+++ b/tests/Granit.Notifications.Wolverine.Tests/GranitNotificationsWolverineModuleTests.cs
@@ -62,13 +62,13 @@ public sealed class GranitNotificationsWolverineModuleTests
         module.ConfigureServices(context);
 
         // Assert — invoke all registered IWolverineExtension to cover lambda bodies
-        var extensions = builder.Services
+        IEnumerable<IWolverineExtension?> extensions = builder.Services
             .Where(d => d.ServiceType == typeof(IWolverineExtension))
             .Select(d => d.ImplementationInstance as IWolverineExtension)
             .Where(e => e is not null);
 
         WolverineOptions opts = new();
-        foreach (var ext in extensions)
+        foreach (IWolverineExtension? ext in extensions)
         {
             ext!.Configure(opts);
         }

--- a/tests/Granit.Notifications.Wolverine.Tests/WolverineNotificationPublisherTests.cs
+++ b/tests/Granit.Notifications.Wolverine.Tests/WolverineNotificationPublisherTests.cs
@@ -98,7 +98,7 @@ public sealed class WolverineNotificationPublisherTests
     public async Task PublishAsync_DataIsSerializedToJsonElement()
     {
         TestNotificationType notifType = new();
-        var data = new TestData("serialized-value");
+        TestData data = new("serialized-value");
 
         await _sut.PublishAsync(notifType, data, ["user-1"], TestContext.Current.CancellationToken);
 


### PR DESCRIPTION
## Summary

- Fix IDE0008 `var` → explicit type violations introduced in #370
- LINQ chain results and `foreach` iterators require explicit types (type not apparent)

## Test plan

- [x] `dotnet build -warnaserror` passes on both affected test projects
- [x] No other IDE0007/IDE0008 violations in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)