### PR TITLE
feat(persistence): add Configure*Module() + DbProperties to all 20 EF Core modules

### DIFF
--- a/docs-site/src/content/docs/dotnet/data/interceptors.mdx
+++ b/docs-site/src/content/docs/dotnet/data/interceptors.mdx
@@ -1,0 +1,209 @@
+---
+title: "Interceptors — Audit, Soft Delete, Concurrency, Events"
+description: Five EF Core SaveChanges interceptors that automate ISO 27001 audit trails, GDPR soft delete, optimistic concurrency, domain event dispatch, and entity versioning.
+sidebar:
+  label: Interceptors
+  order: 3
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+Five interceptors execute on every `SaveChanges` call, in this order:
+
+| Order | Interceptor | Behavior |
+|-------|-------------|----------|
+| 1 | `AuditedEntityInterceptor` | Populates `CreatedAt`, `CreatedBy`, `ModifiedAt`, `ModifiedBy`, auto-generates `Id`, injects `TenantId` |
+| 2 | `VersioningInterceptor` | Sets `BusinessId` and `Version` on `IVersioned` entities |
+| 3 | `ConcurrencyStampInterceptor` | Regenerates `ConcurrencyStamp` on `IConcurrencyAware` entities |
+| 4 | `DomainEventDispatcherInterceptor` | Collects domain events before save, dispatches after commit |
+| 5 | `SoftDeleteInterceptor` | Converts `DELETE` to `UPDATE` for `ISoftDeletable` entities |
+
+:::note
+SoftDeleteInterceptor must be last — it changes `EntityState.Deleted` to
+`EntityState.Modified`, which would prevent earlier interceptors from seeing
+the original state.
+:::
+
+## AuditedEntityInterceptor
+
+Resolves audit data from DI:
+
+- **Who:** `ICurrentUserService.UserId` (falls back to `"system"`)
+- **When:** `IClock.Now` (never `DateTime.UtcNow`)
+- **Id:** `IGuidGenerator` (sequential GUIDs for clustered indexes)
+
+| Entity state | Action |
+|-------------|--------|
+| `Added` | Sets `CreatedAt`, `CreatedBy`. Auto-generates `Id` if `Guid.Empty`. Injects `TenantId` if `IMultiTenant` and null. |
+| `Modified` | Protects `CreatedAt`/`CreatedBy` from overwrite. Sets `ModifiedAt`, `ModifiedBy`. |
+
+:::caution[ExecuteUpdate bypasses this interceptor]
+`ExecuteUpdate()` and `ExecuteUpdateAsync()` emit a raw SQL `UPDATE` and never
+reach `AuditedEntityInterceptor`. Set `ModifiedAt`, `ModifiedBy`, and `TenantId`
+explicitly in the `setPropertyCalls` expression, or use the change tracker.
+
+```csharp
+// ❌ Bypasses interceptor — audit fields not set
+await db.Patients
+    .Where(p => p.TenantId == tenantId)
+    .ExecuteUpdateAsync(s => s.SetProperty(p => p.Status, status), ct);
+
+// ✅ Correct — include audit fields explicitly
+await db.Patients
+    .Where(p => p.TenantId == tenantId)
+    .ExecuteUpdateAsync(s => s
+        .SetProperty(p => p.Status, status)
+        .SetProperty(p => p.ModifiedAt, clock.Now)
+        .SetProperty(p => p.ModifiedBy, currentUser.UserId), ct);
+```
+
+:::
+
+## SoftDeleteInterceptor
+
+Converts physical DELETE to soft delete:
+
+```text
+DELETE FROM Patients WHERE Id = @id
+  ↓ intercepted ↓
+UPDATE Patients SET IsDeleted = true, DeletedAt = @now, DeletedBy = @userId WHERE Id = @id
+```
+
+Only applies to entities implementing `ISoftDeletable`.
+
+:::caution[ExecuteDelete bypasses this interceptor]
+`ExecuteDelete()` and `ExecuteDeleteAsync()` emit a raw SQL `DELETE` and never
+reach `SoftDeleteInterceptor`. Use `ExecuteUpdate()` with explicit `IsDeleted`,
+`DeletedAt`, and `DeletedBy` assignments instead, or load the entity and call
+`DbContext.Remove()`.
+
+```csharp
+// ❌ Bypasses interceptor — performs a physical DELETE
+await db.Patients.Where(p => p.Id == id).ExecuteDeleteAsync(ct);
+
+// ✅ Correct — soft delete via interceptor
+var patient = await db.Patients.FindAsync(id, ct);
+db.Remove(patient!);
+await db.SaveChangesAsync(ct);
+
+// ✅ Also correct — explicit soft delete via ExecuteUpdate
+await db.Patients
+    .Where(p => p.Id == id)
+    .ExecuteUpdateAsync(s => s
+        .SetProperty(p => p.IsDeleted, true)
+        .SetProperty(p => p.DeletedAt, clock.Now)
+        .SetProperty(p => p.DeletedBy, currentUser.UserId), ct);
+```
+
+:::
+
+## DomainEventDispatcherInterceptor
+
+Collects and dispatches domain events transactionally:
+
+1. **SavingChanges** — scans change tracker for `IDomainEventSource` entities, collects events, clears event lists
+2. **SavedChanges** — dispatches events after commit via `IDomainEventDispatcher`
+3. **SaveChangesFailed** — discards events (transaction rolled back)
+
+Uses `AsyncLocal<List<IDomainEvent>>` for thread safety across concurrent
+`SaveChanges` calls in the same async flow.
+
+Default dispatcher is `NullDomainEventDispatcher` (no-op). `Granit.Wolverine`
+replaces it with real message bus dispatch.
+
+## VersioningInterceptor
+
+For `IVersioned` entities on `EntityState.Added`:
+
+- Generates `BusinessId` if empty (first version of a new entity)
+- Determines `Version` from change tracker (starting at 1)
+- Modified entities are untouched — versioning is explicit (create a new entity with same `BusinessId`)
+
+## ConcurrencyStampInterceptor
+
+Prevents silent data loss from concurrent writes. When two users load the same
+entity and both save changes, the second write fails instead of overwriting the first.
+
+Targets entities implementing `IConcurrencyAware`:
+
+```csharp
+public class Order : AuditedEntity, IConcurrencyAware
+{
+    public string Reference { get; set; } = string.Empty;
+    public OrderStatus Status { get; set; }
+    public string ConcurrencyStamp { get; set; } = string.Empty;
+}
+```
+
+| Entity state | Action |
+|-------------|--------|
+| `Added` | Sets `ConcurrencyStamp` to a new GUID string |
+| `Modified` | Regenerates `ConcurrencyStamp` with a new GUID string |
+
+`ApplyGranitConventions` auto-discovers `IConcurrencyAware` entities and configures
+`ConcurrencyStamp` as an EF Core concurrency token (`VARCHAR(36)`,
+`.IsConcurrencyToken()`). No manual Fluent API configuration needed.
+
+EF Core includes the stamp in the `WHERE` clause on update:
+
+```sql
+UPDATE Orders
+SET Status = @newStatus, ConcurrencyStamp = @newStamp
+WHERE Id = @id AND ConcurrencyStamp = @originalStamp
+```
+
+If the stamp in the database differs from the original value loaded by the entity,
+EF Core throws `DbUpdateConcurrencyException` — mapped to **HTTP 409 Conflict**
+by `EfCoreExceptionStatusCodeMapper`.
+
+### Connected vs disconnected updates
+
+**Connected** — entity loaded from the same `DbContext`. EF Core tracks
+`OriginalValue` automatically; nothing extra to do:
+
+```csharp
+var order = await db.Orders.FindAsync(orderId, ct);
+order!.Status = OrderStatus.Confirmed;
+await db.SaveChangesAsync(ct); // stamp checked automatically
+```
+
+**Disconnected** (CQRS command, new `DbContext`) — the frontend sends the stamp it
+received in the GET response. You must set `OriginalValue` explicitly before saving:
+
+```csharp
+var order = await db.Orders.FindAsync(request.Id, ct);
+order!.Status = request.NewStatus;
+
+// Tell EF Core what the client believes the current stamp is
+db.Entry(order).Property(e => e.ConcurrencyStamp).OriginalValue = request.ConcurrencyStamp;
+
+await db.SaveChangesAsync(ct); // throws DbUpdateConcurrencyException on mismatch
+```
+
+Use `IConcurrencyStampRequest` as a DTO convention:
+
+```csharp
+public sealed record UpdateOrderStatusRequest(
+    Guid Id,
+    OrderStatus NewStatus,
+    string ConcurrencyStamp) : IConcurrencyStampRequest;
+```
+
+:::caution[ExecuteUpdate bypasses this interceptor]
+`ExecuteUpdateAsync()` emits raw SQL and never reaches `ConcurrencyStampInterceptor`.
+The concurrency stamp is **not** regenerated and **not** checked. Use the change
+tracker for entities that need optimistic concurrency protection.
+:::
+
+:::tip[When to use IConcurrencyAware]
+Add `IConcurrencyAware` to entities where concurrent modifications are likely and
+data loss is unacceptable: orders, payments, appointments, inventory, shared
+configuration. For read-heavy entities that rarely conflict, the overhead is
+negligible but unnecessary.
+:::
+
+## See also
+
+- [Persistence overview](./persistence/) — setup, isolated DbContext, host-owned migrations
+- [Query filters](./query-filters/) — named filters, runtime bypass, translations
+- [Zero-downtime migrations](./migrations/) — Expand & Contract pattern

--- a/docs-site/src/content/docs/dotnet/data/migrations.mdx
+++ b/docs-site/src/content/docs/dotnet/data/migrations.mdx
@@ -1,0 +1,195 @@
+---
+title: "Migrations — Standard EF Core & Zero-Downtime Expand & Contract"
+description: Two migration strategies for Granit applications — standard EF Core migrations for single-instance apps, and Expand & Contract with batch processing for zero-downtime K8s deployments.
+sidebar:
+  label: Migrations
+  order: 5
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+Granit supports two migration strategies. Which one you need depends on a single
+question: **can your application tolerate a brief downtime during deployment?**
+
+| | Standard migrations | Expand & Contract |
+|---|---|---|
+| **When** | Single instance, maintenance window OK | Multiple replicas, zero downtime required |
+| **How** | One migration, one deploy | Three phases across multiple deploys |
+| **Complexity** | Low — standard EF Core workflow | Higher — requires batch backfill logic |
+| **Package** | EF Core (built-in) | `Granit.Persistence.Migrations` |
+
+Most applications start with standard migrations. Move to Expand & Contract only
+when you need zero-downtime deployments with breaking schema changes.
+
+## Standard migrations
+
+This is the default EF Core migration workflow. One migration file per schema
+change, applied at startup or via CI/CD.
+
+### Creating a migration
+
+```bash
+dotnet ef migrations add AddPatientFullName \
+    --project src/MyApp.Host \
+    --context AppDbContext
+```
+
+EF Core compares the current model (from `OnModelCreating`) with the last snapshot
+and generates the diff.
+
+### Applying migrations
+
+<Tabs>
+<TabItem label="At startup (dev / staging)">
+
+```csharp
+// Program.cs — after builder.Build()
+await using var scope = app.Services.CreateAsyncScope();
+var factory = scope.ServiceProvider
+    .GetRequiredService<IDbContextFactory<AppDbContext>>();
+await using var db = await factory.CreateDbContextAsync();
+await db.Database.MigrateAsync();
+```
+
+Simple, works with Testcontainers in integration tests, but blocks app startup
+until migrations complete.
+
+</TabItem>
+<TabItem label="CI/CD (production)">
+
+Generate an idempotent SQL script and apply it before deploying the new version:
+
+```bash
+dotnet ef migrations script --idempotent -o migrate.sql \
+    --project src/MyApp.Host \
+    --context AppDbContext
+```
+
+The `--idempotent` flag wraps each migration in an `IF NOT EXISTS` check — safe
+to run multiple times.
+
+</TabItem>
+</Tabs>
+
+### When standard migrations are enough
+
+Standard migrations handle most schema changes without issues:
+
+- Adding a new table or column (nullable or with a default)
+- Adding or removing an index
+- Changing column constraints (max length, nullability)
+- Dropping an unused column or table
+
+These changes are **backwards-compatible** — the old application version can still
+run against the new schema. A brief restart is all you need.
+
+### When standard migrations break
+
+Some changes require the old and new application versions to coexist during
+deployment (rolling updates, blue/green, canary). Standard migrations fail here:
+
+- **Renaming a column** — old code still references the old name
+- **Changing a column type** — old code expects the old type
+- **Splitting a column** — old code writes to the original, new code writes to the split
+- **Backfilling computed data** — millions of rows cannot be updated in one transaction
+
+These are the cases where Expand & Contract is necessary.
+
+## Expand & Contract migrations
+
+`Granit.Persistence.Migrations` implements the **Expand & Contract** pattern:
+split a breaking change into three safe, backwards-compatible phases deployed
+separately.
+
+### Three phases
+
+```mermaid
+stateDiagram-v2
+    [*] --> Expand: Add new column (nullable/default)
+    Expand --> Migrate: Background batch backfill
+    Migrate --> Contract: Remove old column
+    Contract --> [*]
+```
+
+| Phase | What happens | Application behavior |
+|-------|-------------|---------------------|
+| **Expand** | `ALTER TABLE ADD COLUMN` (nullable) | Writes to both old and new columns |
+| **Migrate** | Background batch backfill | Reads from new column with fallback to old |
+| **Contract** | `ALTER TABLE DROP COLUMN` (old) | Reads/writes new column only |
+
+Each phase is a separate EF Core migration, deployed independently. At no point
+does the schema become incompatible with running application instances.
+
+### Annotating migrations
+
+```csharp
+[MigrationCycle(MigrationPhase.Expand, "patient-fullname-v2")]
+public partial class AddPatientFullName : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            "FullName", "Patients", nullable: true);
+    }
+}
+```
+
+### Batch processing
+
+Register a batch delegate that backfills data in chunks:
+
+```csharp
+registry.Register<AppDbContext>(
+    "patient-fullname-v2",
+    async (context, batch, ct) =>
+{
+    var patients = await context.Set<Patient>()
+        .Where(p => p.FullName == null)
+        .OrderBy(p => p.Id)
+        .Take(batch.Size)
+        .ToListAsync(ct)
+        .ConfigureAwait(false);
+
+    foreach (var p in patients)
+        p.FullName = $"{p.FirstName} {p.LastName}";
+
+    await context.SaveChangesAsync(ct).ConfigureAwait(false);
+
+    return new MigrationBatchResult(
+        patients.Count,
+        patients.Count < batch.Size
+            ? null
+            : patients[^1].Id.ToString());
+});
+```
+
+Batch delegates must be **idempotent** — re-running over already-migrated rows
+must have no side effects.
+
+### Configuration
+
+```json
+{
+  "GranitMigrations": {
+    "DefaultBatchSize": 500,
+    "BatchExecutionTimeout": "00:05:00"
+  }
+}
+```
+
+### Channel vs Wolverine dispatch
+
+| | `Granit.Persistence.Migrations` | `+ .Wolverine` |
+|---|---|---|
+| Dispatch | In-memory `Channel<T>` | Durable outbox |
+| Restart safety | Lost batches on crash | Survives restarts |
+| Multi-instance | Single node only | Distributed |
+
+Use `Granit.Persistence.Migrations.Wolverine` when batch processing must survive
+application restarts or run across multiple nodes.
+
+## See also
+
+- [Persistence overview](./persistence/) — setup, isolated DbContext, host-owned migrations
+- [Interceptors](./interceptors/) — audit, soft delete, concurrency, events
+- [Query filters](./query-filters/) — named filters, runtime bypass, translations

--- a/docs-site/src/content/docs/dotnet/data/migrations.mdx
+++ b/docs-site/src/content/docs/dotnet/data/migrations.mdx
@@ -71,6 +71,54 @@ to run multiple times.
 </TabItem>
 </Tabs>
 
+### EF Core CLI reference
+
+Common commands for working with migrations. When your solution has multiple
+DbContexts, always specify `--context` to target the right one.
+
+```bash
+# Add a migration to a specific DbContext
+dotnet ef migrations add AddSchedulingTables \
+    --project src/MyApp.Host \
+    --context AppDbContext \
+    --output-dir Migrations/App
+
+# Add a migration to a secondary DbContext
+dotnet ef migrations add AddSecurityTables \
+    --project src/MyApp.Host \
+    --context SecurityDbContext \
+    --output-dir Migrations/Security
+
+# Apply pending migrations (specific context)
+dotnet ef database update \
+    --project src/MyApp.Host \
+    --context AppDbContext
+
+# Generate idempotent SQL script for CI/CD
+dotnet ef migrations script --idempotent \
+    --project src/MyApp.Host \
+    --context AppDbContext \
+    -o migrations/app.sql
+
+# List pending migrations
+dotnet ef migrations list \
+    --project src/MyApp.Host \
+    --context AppDbContext
+
+# Remove the last unapplied migration
+dotnet ef migrations remove \
+    --project src/MyApp.Host \
+    --context AppDbContext
+```
+
+:::tip[Multiple DbContexts]
+Use `--output-dir` to keep migrations organized per DbContext. A typical
+Granit application might have:
+
+- `Migrations/App/` — business entities + Granit modules (Settings, Workflow, etc.)
+- `Migrations/Security/` — Authorization, Identity, ApiKeys
+:::
+
 ### When standard migrations are enough
 
 Standard migrations handle most schema changes without issues:

--- a/docs-site/src/content/docs/dotnet/data/persistence.mdx
+++ b/docs-site/src/content/docs/dotnet/data/persistence.mdx
@@ -1,12 +1,12 @@
 ---
-title: "Persistence \u2014 EF Core 10 & Isolated DbContexts"
-description: EF Core 10 isolated DbContexts with automatic audit trails, GDPR soft delete, multi-tenant query filters, domain event dispatch, and zero-downtime migration support.
+title: "Persistence — EF Core 10, Isolated DbContexts & Host-Owned Migrations"
+description: How Granit structures EF Core persistence — isolated DbContexts per module, host-owned migrations via Configure*Module(), configurable table prefixes, and automatic interceptor wiring.
 sidebar:
   label: Persistence
   order: 2
 ---
 
-import { Tabs, TabItem, FileTree, Badge } from "@astrojs/starlight/components";
+import { Tabs, TabItem, FileTree } from "@astrojs/starlight/components";
 
 Granit.Persistence provides the data access layer for the framework. It automates
 ISO 27001 audit trails, GDPR-compliant soft delete, optimistic concurrency control,
@@ -130,284 +130,145 @@ Never call `HasQueryFilter` manually in entity configurations.
 Manual filters cause duplicates or conflicts.
 :::
 
-## Interceptors
+## Host-owned migrations
 
-Five interceptors execute on every `SaveChanges` call, in this order:
+Granit modules ship **entity configurations**, not migrations. Why? Because the host
+application — not the framework — decides how to organize its database:
 
-| Order | Interceptor | Behavior |
-|-------|-------------|----------|
-| 1 | `AuditedEntityInterceptor` | Populates `CreatedAt`, `CreatedBy`, `ModifiedAt`, `ModifiedBy`, auto-generates `Id`, injects `TenantId` |
-| 2 | `VersioningInterceptor` | Sets `BusinessId` and `Version` on `IVersioned` entities |
-| 3 | `ConcurrencyStampInterceptor` | Regenerates `ConcurrencyStamp` on `IConcurrencyAware` entities |
-| 4 | `DomainEventDispatcherInterceptor` | Collects domain events before save, dispatches after commit |
-| 5 | `SoftDeleteInterceptor` | Converts `DELETE` to `UPDATE` for `ISoftDeletable` entities |
+- **Which modules share a DbContext?** A simple app might put everything in one
+  `AppDbContext`. A larger system might split `SecurityDbContext` and `BusinessDbContext`.
+- **When do migrations run?** At startup (`MigrateAsync`) for dev/staging, or via
+  idempotent SQL scripts in CI/CD for production.
+- **How do schema changes deploy?** Simple `ALTER TABLE` for single-instance apps,
+  or [Expand & Contract](./migrations/) for zero-downtime K8s deployments.
 
-:::note
-SoftDeleteInterceptor must be last — it changes `EntityState.Deleted` to
-`EntityState.Modified`, which would prevent earlier interceptors from seeing
-the original state.
-:::
+The framework cannot make these decisions — only the host can. So Granit modules
+expose their entity configurations via `Configure{Module}Module()` and let the host
+generate and own all migration files.
 
-### AuditedEntityInterceptor
+### How it works
 
-Resolves audit data from DI:
-- **Who:** `ICurrentUserService.UserId` (falls back to `"system"`)
-- **When:** `IClock.Now` (never `DateTime.UtcNow`)
-- **Id:** `IGuidGenerator` (sequential GUIDs for clustered indexes)
-
-| Entity state | Action |
-|-------------|--------|
-| `Added` | Sets `CreatedAt`, `CreatedBy`. Auto-generates `Id` if `Guid.Empty`. Injects `TenantId` if `IMultiTenant` and null. |
-| `Modified` | Protects `CreatedAt`/`CreatedBy` from overwrite. Sets `ModifiedAt`, `ModifiedBy`. |
-
-:::caution[ExecuteUpdate bypasses this interceptor]
-`ExecuteUpdate()` and `ExecuteUpdateAsync()` emit a raw SQL `UPDATE` and never
-reach `AuditedEntityInterceptor`. Set `ModifiedAt`, `ModifiedBy`, and `TenantId`
-explicitly in the `setPropertyCalls` expression, or use the change tracker.
+Every `*.EntityFrameworkCore` module exposes a public `ModelBuilder` extension.
+The host calls these in its own DbContext's `OnModelCreating`:
 
 ```csharp
-// ❌ Bypasses interceptor — audit fields not set
-await db.Patients
-    .Where(p => p.TenantId == tenantId)
-    .ExecuteUpdateAsync(s => s.SetProperty(p => p.Status, status), ct);
-
-// ✅ Correct — include audit fields explicitly
-await db.Patients
-    .Where(p => p.TenantId == tenantId)
-    .ExecuteUpdateAsync(s => s
-        .SetProperty(p => p.Status, status)
-        .SetProperty(p => p.ModifiedAt, clock.Now)
-        .SetProperty(p => p.ModifiedBy, currentUser.UserId), ct);
-```
-:::
-
-### SoftDeleteInterceptor
-
-Converts physical DELETE to soft delete:
-
-```
-DELETE FROM Patients WHERE Id = @id
-  ↓ intercepted ↓
-UPDATE Patients SET IsDeleted = true, DeletedAt = @now, DeletedBy = @userId WHERE Id = @id
-```
-
-Only applies to entities implementing `ISoftDeletable`.
-
-:::caution[ExecuteDelete bypasses this interceptor]
-`ExecuteDelete()` and `ExecuteDeleteAsync()` emit a raw SQL `DELETE` and never
-reach `SoftDeleteInterceptor`. Use `ExecuteUpdate()` with explicit `IsDeleted`,
-`DeletedAt`, and `DeletedBy` assignments instead, or load the entity and call
-`DbContext.Remove()`.
-
-```csharp
-// ❌ Bypasses interceptor — performs a physical DELETE
-await db.Patients.Where(p => p.Id == id).ExecuteDeleteAsync(ct);
-
-// ✅ Correct — soft delete via interceptor
-var patient = await db.Patients.FindAsync(id, ct);
-db.Remove(patient!);
-await db.SaveChangesAsync(ct);
-
-// ✅ Also correct — explicit soft delete via ExecuteUpdate
-await db.Patients
-    .Where(p => p.Id == id)
-    .ExecuteUpdateAsync(s => s
-        .SetProperty(p => p.IsDeleted, true)
-        .SetProperty(p => p.DeletedAt, clock.Now)
-        .SetProperty(p => p.DeletedBy, currentUser.UserId), ct);
-```
-:::
-
-### DomainEventDispatcherInterceptor
-
-Collects and dispatches domain events transactionally:
-
-1. **SavingChanges** — scans change tracker for `IDomainEventSource` entities, collects events, clears event lists
-2. **SavedChanges** — dispatches events after commit via `IDomainEventDispatcher`
-3. **SaveChangesFailed** — discards events (transaction rolled back)
-
-Uses `AsyncLocal<List<IDomainEvent>>` for thread safety across concurrent
-`SaveChanges` calls in the same async flow.
-
-Default dispatcher is `NullDomainEventDispatcher` (no-op). `Granit.Wolverine`
-replaces it with real message bus dispatch.
-
-### VersioningInterceptor
-
-For `IVersioned` entities on `EntityState.Added`:
-- Generates `BusinessId` if empty (first version of a new entity)
-- Determines `Version` from change tracker (starting at 1)
-- Modified entities are untouched — versioning is explicit (create a new entity with same `BusinessId`)
-
-### ConcurrencyStampInterceptor
-
-Prevents silent data loss from concurrent writes. When two users load the same
-entity and both save changes, the second write fails instead of overwriting the first.
-
-Targets entities implementing `IConcurrencyAware`:
-
-```csharp
-public class Order : AuditedEntity, IConcurrencyAware
+public class AppDbContext(
+    DbContextOptions<AppDbContext> options,
+    ICurrentTenant? currentTenant = null,
+    IDataFilter? dataFilter = null)
+    : DbContext(options)
 {
-    public string Reference { get; set; } = string.Empty;
-    public OrderStatus Status { get; set; }
-    public string ConcurrencyStamp { get; set; } = string.Empty;
-}
-```
-
-| Entity state | Action |
-|-------------|--------|
-| `Added` | Sets `ConcurrencyStamp` to a new GUID string |
-| `Modified` | Regenerates `ConcurrencyStamp` with a new GUID string |
-
-`ApplyGranitConventions` auto-discovers `IConcurrencyAware` entities and configures
-`ConcurrencyStamp` as an EF Core concurrency token (`VARCHAR(36)`,
-`.IsConcurrencyToken()`). No manual Fluent API configuration needed.
-
-EF Core includes the stamp in the `WHERE` clause on update:
-
-```sql
-UPDATE Orders
-SET Status = @newStatus, ConcurrencyStamp = @newStamp
-WHERE Id = @id AND ConcurrencyStamp = @originalStamp
-```
-
-If the stamp in the database differs from the original value loaded by the entity,
-EF Core throws `DbUpdateConcurrencyException` — mapped to **HTTP 409 Conflict**
-by `EfCoreExceptionStatusCodeMapper`.
-
-#### Connected vs disconnected updates
-
-**Connected** — entity loaded from the same `DbContext`. EF Core tracks
-`OriginalValue` automatically; nothing extra to do:
-
-```csharp
-var order = await db.Orders.FindAsync(orderId, ct);
-order!.Status = OrderStatus.Confirmed;
-await db.SaveChangesAsync(ct); // stamp checked automatically
-```
-
-**Disconnected** (CQRS command, new `DbContext`) — the frontend sends the stamp it
-received in the GET response. You must set `OriginalValue` explicitly before saving:
-
-```csharp
-var order = await db.Orders.FindAsync(request.Id, ct);
-order!.Status = request.NewStatus;
-
-// Tell EF Core what the client believes the current stamp is
-db.Entry(order).Property(e => e.ConcurrencyStamp).OriginalValue = request.ConcurrencyStamp;
-
-await db.SaveChangesAsync(ct); // throws DbUpdateConcurrencyException on mismatch
-```
-
-Use `IConcurrencyStampRequest` as a DTO convention:
-
-```csharp
-public sealed record UpdateOrderStatusRequest(
-    Guid Id,
-    OrderStatus NewStatus,
-    string ConcurrencyStamp) : IConcurrencyStampRequest;
-```
-
-:::caution[ExecuteUpdate bypasses this interceptor]
-`ExecuteUpdateAsync()` emits raw SQL and never reaches `ConcurrencyStampInterceptor`.
-The concurrency stamp is **not** regenerated and **not** checked. Use the change
-tracker for entities that need optimistic concurrency protection.
-:::
-
-:::tip[When to use IConcurrencyAware]
-Add `IConcurrencyAware` to entities where concurrent modifications are likely and
-data loss is unacceptable: orders, payments, appointments, inventory, shared
-configuration. For read-heavy entities that rarely conflict, the overhead is
-negligible but unnecessary.
-:::
-
-## Query filters
-
-`ApplyGranitConventions` registers one **named** `HasQueryFilter` per applicable
-interface on each entity type (EF Core 10). Filters are independent — bypass one
-without affecting the others.
-
-| Interface | Filter key (`GranitFilterNames`) | Filter expression | Default |
-|-----------|----------------------------------|------------------|---------|
-| `ISoftDeletable` | `SoftDelete` | `!e.IsDeleted` | Enabled |
-| `IActive` | `Active` | `e.IsActive` | Enabled |
-| `IProcessingRestrictable` | `ProcessingRestrictable` | `!e.IsProcessingRestricted` | Enabled |
-| `IMultiTenant` | `MultiTenant` | `e.TenantId == currentTenant.Id` | Enabled |
-| `IPublishable` | `Publishable` | `e.IsPublished` | Enabled |
-
-Filters are re-evaluated per query via `DataFilter`'s `AsyncLocal` state — EF Core
-extracts `FilterProxy` boolean properties as parameterized expressions.
-
-### Runtime filter control — service scope
-
-Use `IDataFilter` to bypass a filter for all queries in the current async flow:
-
-```csharp
-public class PatientAdminService(IDataFilter dataFilter, AppDbContext db)
-{
-    public async Task<List<Patient>> GetAllIncludingDeletedAsync(
-        CancellationToken cancellationToken)
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        using (dataFilter.Disable<ISoftDeletable>())
-        {
-            return await db.Patients
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
-        }
-        // Filter re-enabled automatically
+        base.OnModelCreating(modelBuilder);
+
+        // Include Granit module tables in this DbContext
+        modelBuilder.ConfigureSettingsModule();
+        modelBuilder.ConfigureBackgroundJobsModule();
+        modelBuilder.ConfigureNotificationsModule();
+        modelBuilder.ConfigureWorkflowModule();
+
+        // MANDATORY — always call last
+        modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }
 }
 ```
 
-Scopes nest correctly — inner `Enable`/`Disable` calls restore the outer state
-on disposal.
+The module's internal DbContext (used at runtime by module services) calls the
+**same** `Configure{Module}Module()` method — guaranteeing that migration-time and
+runtime EF models are always identical.
 
-### Per-query bypass (EF Core 10)
+### DbProperties — table naming control
 
-Use `IgnoreQueryFilters` with one or more filter keys to bypass specific filters
-for a single query, without affecting other queries in the same flow:
-
-```csharp
-// Bypass only soft delete — multi-tenant and other filters still apply
-var deletedPatients = await db.Patients
-    .IgnoreQueryFilters([GranitFilterNames.SoftDelete])
-    .Where(p => p.IsDeleted)
-    .ToListAsync(cancellationToken)
-    .ConfigureAwait(false);
-
-// Bypass all named filters (equivalent to IgnoreQueryFilters() without args)
-var allPatients = await db.Patients
-    .IgnoreQueryFilters([
-        GranitFilterNames.SoftDelete,
-        GranitFilterNames.MultiTenant])
-    .ToListAsync(cancellationToken)
-    .ConfigureAwait(false);
-```
-
-### Translation conventions
-
-For entities implementing `ITranslatable<T>`, `ApplyGranitConventions` automatically
-configures:
-- Foreign key: `Translation.ParentId → Parent.Id` with cascade delete
-- Unique index: `(ParentId, Culture)`
-- Culture column: max length 20 (BCP 47)
-
-Query extensions for translated entities:
+Each module defines a `Granit{Module}DbProperties` static class with configurable
+table prefix and schema:
 
 ```csharp
-// Eager load translations for a culture
-var patients = await db.Patients
-    .IncludeTranslations<Patient, PatientTranslation>("fr")
-    .ToListAsync(cancellationToken)
-    .ConfigureAwait(false);
-
-// Filter by translation property
-var results = await db.Patients
-    .WhereTranslation<Patient, PatientTranslation>("fr", t => t.DisplayName.Contains("Jean"))
-    .ToListAsync(cancellationToken)
-    .ConfigureAwait(false);
+// Override before ConfigureServices — EF Core caches the model after first use
+GranitBackgroundJobsDbProperties.DbTablePrefix = "scheduling_";
+GranitBackgroundJobsDbProperties.DbSchema = "core";
 ```
+
+Default prefixes follow the convention **package name in snake\_case + `_`**:
+
+| Module | Default prefix | Example table |
+|--------|---------------|---------------|
+| `BackgroundJobs` | `scheduling_` | `scheduling_background_jobs` |
+| `Settings` | `core_` | `core_setting_records` |
+| `Workflow` | `workflow_` | `workflow_transition_records` |
+| `AuditLog` | `audit_` | `audit_log_entries` |
+| `Notifications` | `notification_` | `notification_user_notifications` |
+| `Webhooks` | `webhook_` | `webhook_subscriptions` |
+| `BlobStorage` | `blob_storage_` | `blob_storage_descriptors` |
+| `Features` | `feature_` | `feature_overrides` |
+| `Localization` | `localization_` | `localization_overrides` |
+| `AI` | `ai_` | `ai_workspaces` |
+| `ApiKeys` | `auth_` | `auth_api_keys` |
+| `Authorization` | `auth_` | `auth_permission_grants` |
+| `Identity` | `identity_` | `identity_user_cache_entries` |
+| `DataExchange` | `data_exchange_` | `data_exchange_import_jobs` |
+| `Querying` | `querying_` | `querying_saved_views` |
+| `Templating` | `templating_` | `templating_revisions` |
+| `Timeline` | `timeline_` | `timeline_entries` |
+
+### Generating and applying migrations
+
+Two approaches, depending on your deployment model:
+
+<Tabs>
+<TabItem label="Simple — MigrateAsync at startup">
+
+Best for single-instance apps, dev, and staging environments. The application
+creates or updates the schema on boot:
+
+```csharp
+// Program.cs — after builder.Build()
+await using var scope = app.Services.CreateAsyncScope();
+var factory = scope.ServiceProvider
+    .GetRequiredService<IDbContextFactory<AppDbContext>>();
+await using var db = await factory.CreateDbContextAsync();
+await db.Database.MigrateAsync();
+```
+
+This also works with `WebApplicationFactory` + Testcontainers in integration tests.
+
+</TabItem>
+<TabItem label="Production — CI/CD SQL scripts">
+
+For zero-downtime K8s deployments, generate an idempotent SQL script and apply it
+**before** the new pods start. This decouples schema changes from application
+startup — critical when running multiple replicas:
+
+```bash
+# Generate idempotent SQL script
+dotnet ef migrations script --idempotent -o migrate.sql \
+    --project src/MyApp.Host \
+    --context AppDbContext
+
+# Apply via CI/CD pipeline (e.g., Flyway, psql, sqlcmd)
+psql -h $DB_HOST -U $DB_USER -d $DB_NAME -f migrate.sql
+```
+
+Combine with [Expand & Contract](./migrations/) for column renames, type changes,
+and other breaking schema changes that require data backfill.
+
+</TabItem>
+<TabItem label="Adding a new migration">
+
+```bash
+dotnet ef migrations add AddBackgroundJobsTables \
+    --project src/MyApp.Host \
+    --context AppDbContext
+```
+
+</TabItem>
+</Tabs>
+
+:::caution[Never mix EnsureCreated with migrations]
+`EnsureCreatedAsync()` creates the schema without a migration history table.
+Once used, `MigrateAsync()` will fail because it cannot determine which
+migrations have already been applied. Pick one approach and stick with it.
+:::
 
 ## Data seeding
 
@@ -482,88 +343,6 @@ retain the previous tenant's schema — failing to reset is a data isolation
 breach (ISO 27001).
 :::
 
-## Zero-downtime migrations
-
-`Granit.Persistence.Migrations` implements the **Expand & Contract** pattern for
-schema changes that would otherwise require downtime.
-
-### Three phases
-
-```mermaid
-stateDiagram-v2
-    [*] --> Expand: Add new column (nullable/default)
-    Expand --> Migrate: Background batch backfill
-    Migrate --> Contract: Remove old column
-    Contract --> [*]
-```
-
-| Phase | EF Migration | Application |
-|-------|-------------|-------------|
-| **Expand** | `ALTER TABLE ADD COLUMN` (nullable) | Writes to both old and new columns |
-| **Migrate** | Batch job backfills new column | Reads from new column with fallback |
-| **Contract** | `ALTER TABLE DROP COLUMN` (old) | Reads/writes new column only |
-
-### Annotating migrations
-
-```csharp
-[MigrationCycle(MigrationPhase.Expand, "patient-fullname-v2")]
-public partial class AddPatientFullName : Migration
-{
-    protected override void Up(MigrationBuilder migrationBuilder)
-    {
-        migrationBuilder.AddColumn<string>("FullName", "Patients", nullable: true);
-    }
-}
-```
-
-### Batch processing
-
-```csharp
-registry.Register<AppDbContext>("patient-fullname-v2", async (context, batch, ct) =>
-{
-    var patients = await context.Set<Patient>()
-        .Where(p => p.FullName == null)
-        .OrderBy(p => p.Id)
-        .Take(batch.Size)
-        .ToListAsync(ct)
-        .ConfigureAwait(false);
-
-    foreach (var p in patients)
-        p.FullName = $"{p.FirstName} {p.LastName}";
-
-    await context.SaveChangesAsync(ct).ConfigureAwait(false);
-
-    return new MigrationBatchResult(
-        patients.Count,
-        patients.Count < batch.Size ? null : patients[^1].Id.ToString());
-});
-```
-
-Batch delegates must be **idempotent** — re-running over already-migrated rows
-must have no side effects.
-
-### Configuration
-
-```json
-{
-  "GranitMigrations": {
-    "DefaultBatchSize": 500,
-    "BatchExecutionTimeout": "00:05:00"
-  }
-}
-```
-
-### Channel vs Wolverine dispatch
-
-| | `Granit.Persistence.Migrations` | `+ .Wolverine` |
-|---|---|---|
-| Dispatch | In-memory `Channel<T>` | Durable outbox |
-| Restart safety | Lost batches on crash | Survives restarts |
-| Multi-instance | Single node only | Distributed |
-
-With Wolverine, the handler returns `object[]` — empty to stop, or `[nextCommand]`
-to cascade to the next batch via the durable outbox.
-
 ## Public API summary
 
 | Category | Key types | Package |
@@ -575,41 +354,9 @@ to cascade to the next batch via the durable outbox.
 | Purging | `ISoftDeletePurgeTarget`, `PurgeSoftDeletedBeforeAsync()` | `Granit.Persistence` |
 | Query extensions | `IncludeTranslations()`, `WhereTranslation()`, `OrderByTranslation()` | `Granit.Persistence` |
 | Multi-tenancy | `TenantIsolationStrategy`, `ITenantSchemaProvider`, `ITenantConnectionStringProvider`, `ITenantSchemaActivator` | `Granit.Persistence` |
+| Host migrations | `Configure{Module}Module()`, `Granit{Module}DbProperties` | Each `*.EntityFrameworkCore` package |
 | Migrations | `MigrationPhase`, `MigrationCycleAttribute`, `IMigrationCycleRegistry`, `BatchMigrationDelegate` | `Granit.Persistence.Migrations` |
-| Migration dispatch | `IMigrationBatchDispatcher`, `RunMigrationBatchCommand` | `Granit.Persistence.Migrations` |
 | Wolverine dispatch | `GranitPersistenceMigrationsWolverineModule` | `Granit.Persistence.Migrations.Wolverine` |
-
-## Common pitfalls
-
-:::caution[Forgetting `ApplyGranitConventions`]
-If your `DbContext.OnModelCreating` does not call `modelBuilder.ApplyGranitConventions(...)`,
-**no query filters** (soft delete, multi-tenancy, active, publishable) are applied.
-Entities will appear unfiltered — including soft-deleted and other-tenant data. This is
-the #1 cause of "I see deleted records" bugs.
-:::
-
-:::caution[`ExecuteUpdate` / `ExecuteDelete` bypass interceptors]
-EF Core bulk operations (`ExecuteUpdateAsync`, `ExecuteDeleteAsync`) bypass
-`SaveChangesInterceptor`. This means:
-- `SoftDeleteInterceptor` is **not** called — records are **hard-deleted**
-- `AuditedEntityInterceptor` is **not** called — `ModifiedAt`/`ModifiedBy` are not set
-- Domain events are **not** dispatched
-
-Use these operations only for data migrations or batch cleanup, never for business logic.
-:::
-
-:::caution[EF InMemory does not apply value converters]
-`UseInMemoryDatabase()` ignores `HasConversion<>()` — this affects `[Encrypted]` fields,
-enum-to-string conversions, and JSON columns. Always use SQLite or Testcontainers
-(PostgreSQL) for tests that depend on converters or query filters.
-:::
-
-:::caution[Named vs unnamed query filters]
-Never use `HasQueryFilter(expr)` (unnamed) — it silently **replaces** any existing
-filter on the entity. Always use `HasQueryFilter(name, expr)` (EF Core 10 named
-filters) so filters compose instead of overwriting. `ApplyGranitConventions` already
-registers standard filters with names from `GranitFilterNames`.
-:::
 
 ## Testing persistence
 
@@ -639,42 +386,15 @@ public async Task Soft_deleted_entities_are_filtered_out()
 }
 ```
 
-For concurrency conflict tests, use SQLite (the InMemory provider does not enforce
-concurrency tokens):
-
-```csharp
-[Fact]
-public async Task Concurrent_modification_throws_DbUpdateConcurrencyException()
-{
-    // Arrange — create entity via context1
-    await using var context1 = CreateSqliteContext<OrderDbContext>();
-    var order = new Order { Reference = "ORD-001" };
-    context1.Orders.Add(order);
-    await context1.SaveChangesAsync();
-
-    // Load the same entity in context2
-    await using var context2 = CreateSqliteContext<OrderDbContext>(ensureCreated: false);
-    var sameOrder = await context2.Orders.FindAsync(order.Id);
-
-    // Modify and save via context1 — stamp changes in DB
-    order.Status = OrderStatus.Confirmed;
-    await context1.SaveChangesAsync();
-
-    // Act — context2 still has the old stamp
-    sameOrder!.Status = OrderStatus.Cancelled;
-    await Should.ThrowAsync<DbUpdateConcurrencyException>(
-        () => context2.SaveChangesAsync());
-}
-```
-
 For integration tests with real PostgreSQL, use Testcontainers to get full fidelity
 (JSON columns, concurrent transactions, schema isolation).
 
 ## See also
 
-- [Adding Persistence guide](/dotnet/getting-started/adding-persistence/) — step-by-step tutorial for new projects
+- [Interceptors](./interceptors/) — audit, soft delete, concurrency, domain events, versioning
+- [Query filters](./query-filters/) — named filters, runtime bypass, translations
+- [Zero-downtime migrations](./migrations/) — Expand & Contract pattern
+- [Adding Persistence guide](/dotnet/getting-started/adding-persistence/) — step-by-step tutorial
 - [Core module](../core/module-system/) — domain base types, filter interfaces, `IDataFilter`
 - [Multi-tenancy concept](../../concepts/multi-tenancy.md) — isolation strategies in depth
-- [Security module](./authentication/) — `ICurrentUserService` that feeds audit fields
 - [Wolverine module](/dotnet/infrastructure/wolverine/) — domain event dispatch and durable messaging
-- [API Reference](/api/Granit.Persistence.html) (auto-generated from XML docs)

--- a/docs-site/src/content/docs/dotnet/data/query-filters.mdx
+++ b/docs-site/src/content/docs/dotnet/data/query-filters.mdx
@@ -1,0 +1,121 @@
+---
+title: "Query Filters — Soft Delete, Multi-Tenant, Active"
+description: Named EF Core 10 query filters for soft delete, multi-tenancy, active state, publishable state, and GDPR processing restriction — with runtime bypass and translation conventions.
+sidebar:
+  label: Query Filters
+  order: 4
+---
+
+`ApplyGranitConventions` registers one **named** `HasQueryFilter` per applicable
+interface on each entity type (EF Core 10). Filters are independent — bypass one
+without affecting the others.
+
+| Interface | Filter key (`GranitFilterNames`) | Filter expression | Default |
+|-----------|----------------------------------|------------------|---------|
+| `ISoftDeletable` | `SoftDelete` | `!e.IsDeleted` | Enabled |
+| `IActive` | `Active` | `e.IsActive` | Enabled |
+| `IProcessingRestrictable` | `ProcessingRestrictable` | `!e.IsProcessingRestricted` | Enabled |
+| `IMultiTenant` | `MultiTenant` | `e.TenantId == currentTenant.Id` | Enabled |
+| `IPublishable` | `Publishable` | `e.IsPublished` | Enabled |
+
+Filters are re-evaluated per query via `DataFilter`'s `AsyncLocal` state — EF Core
+extracts `FilterProxy` boolean properties as parameterized expressions.
+
+## Runtime filter control — service scope
+
+Use `IDataFilter` to bypass a filter for all queries in the current async flow:
+
+```csharp
+public class PatientAdminService(IDataFilter dataFilter, AppDbContext db)
+{
+    public async Task<List<Patient>> GetAllIncludingDeletedAsync(
+        CancellationToken cancellationToken)
+    {
+        using (dataFilter.Disable<ISoftDeletable>())
+        {
+            return await db.Patients
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+        // Filter re-enabled automatically
+    }
+}
+```
+
+Scopes nest correctly — inner `Enable`/`Disable` calls restore the outer state
+on disposal.
+
+## Per-query bypass (EF Core 10)
+
+Use `IgnoreQueryFilters` with one or more filter keys to bypass specific filters
+for a single query, without affecting other queries in the same flow:
+
+```csharp
+// Bypass only soft delete — multi-tenant and other filters still apply
+var deletedPatients = await db.Patients
+    .IgnoreQueryFilters([GranitFilterNames.SoftDelete])
+    .Where(p => p.IsDeleted)
+    .ToListAsync(cancellationToken)
+    .ConfigureAwait(false);
+
+// Bypass all named filters (equivalent to IgnoreQueryFilters() without args)
+var allPatients = await db.Patients
+    .IgnoreQueryFilters([
+        GranitFilterNames.SoftDelete,
+        GranitFilterNames.MultiTenant])
+    .ToListAsync(cancellationToken)
+    .ConfigureAwait(false);
+```
+
+## Translation conventions
+
+For entities implementing `ITranslatable<T>`, `ApplyGranitConventions` automatically
+configures:
+
+- Foreign key: `Translation.ParentId → Parent.Id` with cascade delete
+- Unique index: `(ParentId, Culture)`
+- Culture column: max length 20 (BCP 47)
+
+Query extensions for translated entities:
+
+```csharp
+// Eager load translations for a culture
+var patients = await db.Patients
+    .IncludeTranslations<Patient, PatientTranslation>("fr")
+    .ToListAsync(cancellationToken)
+    .ConfigureAwait(false);
+
+// Filter by translation property
+var results = await db.Patients
+    .WhereTranslation<Patient, PatientTranslation>("fr", t => t.DisplayName.Contains("Jean"))
+    .ToListAsync(cancellationToken)
+    .ConfigureAwait(false);
+```
+
+## Common pitfalls
+
+:::caution[Forgetting `ApplyGranitConventions`]
+If your `DbContext.OnModelCreating` does not call `modelBuilder.ApplyGranitConventions(...)`,
+**no query filters** (soft delete, multi-tenancy, active, publishable) are applied.
+Entities will appear unfiltered — including soft-deleted and other-tenant data. This is
+the #1 cause of "I see deleted records" bugs.
+:::
+
+:::caution[Named vs unnamed query filters]
+Never use `HasQueryFilter(expr)` (unnamed) — it silently **replaces** any existing
+filter on the entity. Always use `HasQueryFilter(name, expr)` (EF Core 10 named
+filters) so filters compose instead of overwriting. `ApplyGranitConventions` already
+registers standard filters with names from `GranitFilterNames`.
+:::
+
+:::caution[EF InMemory does not apply value converters]
+`UseInMemoryDatabase()` ignores `HasConversion<>()` — this affects `[Encrypted]` fields,
+enum-to-string conversions, and JSON columns. Always use SQLite or Testcontainers
+(PostgreSQL) for tests that depend on converters or query filters.
+:::
+
+## See also
+
+- [Persistence overview](./persistence/) — setup, isolated DbContext, host-owned migrations
+- [Interceptors](./interceptors/) — audit, soft delete, concurrency, events
+- [Zero-downtime migrations](./migrations/) — Expand & Contract pattern

--- a/src/Granit.AI.EntityFrameworkCore/Extensions/AIModelBuilderExtensions.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Extensions/AIModelBuilderExtensions.cs
@@ -1,0 +1,23 @@
+using Granit.AI.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.AI.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// <see cref="ModelBuilder"/> extensions for including Granit AI entity
+/// configurations in a host-owned <see cref="DbContext"/>.
+/// </summary>
+public static class AIModelBuilderExtensions
+{
+    /// <summary>
+    /// Applies all entity configurations for the Granit AI module.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder.</param>
+    /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
+    public static ModelBuilder ConfigureAIModule(this ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new AIWorkspaceEntityConfiguration());
+        modelBuilder.ApplyConfiguration(new AIUsageRecordEntityConfiguration());
+        return modelBuilder;
+    }
+}

--- a/src/Granit.AI.EntityFrameworkCore/GranitAIDbProperties.cs
+++ b/src/Granit.AI.EntityFrameworkCore/GranitAIDbProperties.cs
@@ -1,0 +1,30 @@
+namespace Granit.AI.EntityFrameworkCore;
+
+/// <summary>
+/// Provides configurable table-naming properties for the AI EF Core module.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These properties control the table prefix and schema used by all entity configurations
+/// in <c>Granit.AI.EntityFrameworkCore</c>. Both the internal
+/// <c>AIDbContext</c> and the host's <c>Configure*Module()</c> call read
+/// the same static values, ensuring migration-time and runtime SQL stay in sync.
+/// </para>
+/// <para>
+/// <b>Important:</b> Set these properties at application startup, before
+/// <c>ConfigureServices</c> completes. EF Core caches the compiled <see cref="Microsoft.EntityFrameworkCore.Metadata.IModel"/>
+/// after first use — later mutations have no effect.
+/// </para>
+/// </remarks>
+public static class GranitAIDbProperties
+{
+    /// <summary>
+    /// Table name prefix for all AI tables. Default: <c>"ai_"</c>.
+    /// </summary>
+    public static string DbTablePrefix { get; set; } = "ai_";
+
+    /// <summary>
+    /// Database schema for all AI tables. Default: <c>null</c> (provider default schema).
+    /// </summary>
+    public static string? DbSchema { get; set; }
+}

--- a/src/Granit.AI.EntityFrameworkCore/Internal/AIDbContext.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/AIDbContext.cs
@@ -1,3 +1,4 @@
+using Granit.AI.EntityFrameworkCore.Extensions;
 using Granit.Core.DataFiltering;
 using Granit.Core.MultiTenancy;
 using Granit.Persistence.Extensions;
@@ -28,8 +29,7 @@ internal sealed class AIDbContext(
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
-        modelBuilder.ApplyConfiguration(new AIWorkspaceEntityConfiguration());
-        modelBuilder.ApplyConfiguration(new AIUsageRecordEntityConfiguration());
+        modelBuilder.ConfigureAIModule();
         modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }
 }

--- a/src/Granit.AI.EntityFrameworkCore/Internal/AIUsageRecordEntityConfiguration.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/AIUsageRecordEntityConfiguration.cs
@@ -12,7 +12,9 @@ internal sealed class AIUsageRecordEntityConfiguration : IEntityTypeConfiguratio
     /// <inheritdoc/>
     public void Configure(EntityTypeBuilder<AIUsageRecordEntity> builder)
     {
-        builder.ToTable("ai_usage_records");
+        builder.ToTable(
+            GranitAIDbProperties.DbTablePrefix + "usage_records",
+            GranitAIDbProperties.DbSchema);
 
         builder.HasKey(e => e.Id);
 
@@ -53,10 +55,10 @@ internal sealed class AIUsageRecordEntityConfiguration : IEntityTypeConfiguratio
 
         // Tenant-scoped queries by workspace and time range (billing, dashboards).
         builder.HasIndex(e => new { e.TenantId, e.WorkspaceName, e.CreatedAt })
-            .HasDatabaseName("ix_ai_usage_records_tenant_workspace_date");
+            .HasDatabaseName($"ix_{GranitAIDbProperties.DbTablePrefix}usage_records_tenant_workspace_date");
 
         // Cost aggregation queries by provider/model.
         builder.HasIndex(e => new { e.TenantId, e.Provider, e.Model })
-            .HasDatabaseName("ix_ai_usage_records_tenant_provider_model");
+            .HasDatabaseName($"ix_{GranitAIDbProperties.DbTablePrefix}usage_records_tenant_provider_model");
     }
 }

--- a/src/Granit.AI.EntityFrameworkCore/Internal/AIWorkspaceEntityConfiguration.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/AIWorkspaceEntityConfiguration.cs
@@ -12,7 +12,9 @@ internal sealed class AIWorkspaceEntityConfiguration : IEntityTypeConfiguration<
     /// <inheritdoc/>
     public void Configure(EntityTypeBuilder<AIWorkspaceEntity> builder)
     {
-        builder.ToTable("ai_workspaces");
+        builder.ToTable(
+            GranitAIDbProperties.DbTablePrefix + "workspaces",
+            GranitAIDbProperties.DbSchema);
 
         builder.HasKey(e => e.Id);
 
@@ -65,6 +67,6 @@ internal sealed class AIWorkspaceEntityConfiguration : IEntityTypeConfiguration<
         // Workspace name is unique per tenant.
         builder.HasIndex(e => new { e.TenantId, e.Name })
             .IsUnique()
-            .HasDatabaseName("uq_ai_workspaces_tenant_name");
+            .HasDatabaseName($"uq_{GranitAIDbProperties.DbTablePrefix}workspaces_tenant_name");
     }
 }

--- a/src/Granit.AuditLog.EntityFrameworkCore/Extensions/AuditLogModelBuilderExtensions.cs
+++ b/src/Granit.AuditLog.EntityFrameworkCore/Extensions/AuditLogModelBuilderExtensions.cs
@@ -1,0 +1,24 @@
+using Granit.AuditLog.EntityFrameworkCore.Internal.Configurations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.AuditLog.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// <see cref="ModelBuilder"/> extensions for including Granit audit log entity
+/// configurations in a host-owned <see cref="DbContext"/>.
+/// </summary>
+public static class AuditLogModelBuilderExtensions
+{
+    /// <summary>
+    /// Applies all entity configurations for the Granit AuditLog module.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder.</param>
+    /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
+    public static ModelBuilder ConfigureAuditLogModule(this ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new AuditLogEntryConfiguration());
+        modelBuilder.ApplyConfiguration(new AuditEntityChangeConfiguration());
+        modelBuilder.ApplyConfiguration(new AuditPropertyChangeConfiguration());
+        return modelBuilder;
+    }
+}

--- a/src/Granit.AuditLog.EntityFrameworkCore/GranitAuditLogDbProperties.cs
+++ b/src/Granit.AuditLog.EntityFrameworkCore/GranitAuditLogDbProperties.cs
@@ -1,0 +1,30 @@
+namespace Granit.AuditLog.EntityFrameworkCore;
+
+/// <summary>
+/// Provides configurable table-naming properties for the AuditLog EF Core module.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These properties control the table prefix and schema used by all entity configurations
+/// in <c>Granit.AuditLog.EntityFrameworkCore</c>. Both the internal
+/// <c>AuditLogDbContext</c> and the host's <c>Configure*Module()</c> call read
+/// the same static values, ensuring migration-time and runtime SQL stay in sync.
+/// </para>
+/// <para>
+/// <b>Important:</b> Set these properties at application startup, before
+/// <c>ConfigureServices</c> completes. EF Core caches the compiled <see cref="Microsoft.EntityFrameworkCore.Metadata.IModel"/>
+/// after first use — later mutations have no effect.
+/// </para>
+/// </remarks>
+public static class GranitAuditLogDbProperties
+{
+    /// <summary>
+    /// Table name prefix for all audit log tables. Default: <c>"audit_"</c>.
+    /// </summary>
+    public static string DbTablePrefix { get; set; } = "audit_";
+
+    /// <summary>
+    /// Database schema for all audit log tables. Default: <c>null</c> (provider default schema).
+    /// </summary>
+    public static string? DbSchema { get; set; }
+}

--- a/src/Granit.AuditLog.EntityFrameworkCore/Internal/AuditLogDbContext.cs
+++ b/src/Granit.AuditLog.EntityFrameworkCore/Internal/AuditLogDbContext.cs
@@ -1,5 +1,5 @@
 using Granit.AuditLog.Domain;
-using Granit.AuditLog.EntityFrameworkCore.Internal.Configurations;
+using Granit.AuditLog.EntityFrameworkCore.Extensions;
 using Granit.Core.DataFiltering;
 using Granit.Core.MultiTenancy;
 using Granit.Persistence.Extensions;
@@ -39,9 +39,7 @@ internal sealed class AuditLogDbContext(
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
-        modelBuilder.ApplyConfiguration(new AuditLogEntryConfiguration());
-        modelBuilder.ApplyConfiguration(new AuditEntityChangeConfiguration());
-        modelBuilder.ApplyConfiguration(new AuditPropertyChangeConfiguration());
+        modelBuilder.ConfigureAuditLogModule();
         modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }
 }

--- a/src/Granit.AuditLog.EntityFrameworkCore/Internal/Configurations/AuditEntityChangeConfiguration.cs
+++ b/src/Granit.AuditLog.EntityFrameworkCore/Internal/Configurations/AuditEntityChangeConfiguration.cs
@@ -13,7 +13,9 @@ internal sealed class AuditEntityChangeConfiguration : IEntityTypeConfiguration<
     /// <inheritdoc/>
     public void Configure(EntityTypeBuilder<AuditEntityChange> builder)
     {
-        builder.ToTable("audit_entity_changes");
+        builder.ToTable(
+            GranitAuditLogDbProperties.DbTablePrefix + "entity_changes",
+            GranitAuditLogDbProperties.DbSchema);
 
         builder.HasKey(e => e.Id);
 
@@ -31,7 +33,7 @@ internal sealed class AuditEntityChangeConfiguration : IEntityTypeConfiguration<
             .IsRequired();
 
         builder.HasIndex(e => new { e.EntityType, e.EntityId })
-            .HasDatabaseName("ix_audit_entity_changes_type_id");
+            .HasDatabaseName($"ix_{GranitAuditLogDbProperties.DbTablePrefix}entity_changes_type_id");
 
         builder.HasMany(e => e.PropertyChanges)
             .WithOne()

--- a/src/Granit.AuditLog.EntityFrameworkCore/Internal/Configurations/AuditLogEntryConfiguration.cs
+++ b/src/Granit.AuditLog.EntityFrameworkCore/Internal/Configurations/AuditLogEntryConfiguration.cs
@@ -13,7 +13,9 @@ internal sealed class AuditLogEntryConfiguration : IEntityTypeConfiguration<Audi
     /// <inheritdoc/>
     public void Configure(EntityTypeBuilder<AuditLogEntry> builder)
     {
-        builder.ToTable("audit_log_entries");
+        builder.ToTable(
+            GranitAuditLogDbProperties.DbTablePrefix + "log_entries",
+            GranitAuditLogDbProperties.DbSchema);
 
         builder.HasKey(e => e.Id);
 
@@ -45,13 +47,13 @@ internal sealed class AuditLogEntryConfiguration : IEntityTypeConfiguration<Audi
 
         // Indexes for common query patterns.
         builder.HasIndex(e => e.Timestamp)
-            .HasDatabaseName("ix_audit_log_entries_timestamp");
+            .HasDatabaseName($"ix_{GranitAuditLogDbProperties.DbTablePrefix}log_entries_timestamp");
 
         builder.HasIndex(e => new { e.UserId, e.Timestamp })
-            .HasDatabaseName("ix_audit_log_entries_user_timestamp");
+            .HasDatabaseName($"ix_{GranitAuditLogDbProperties.DbTablePrefix}log_entries_user_timestamp");
 
         builder.HasIndex(e => new { e.TenantId, e.Timestamp })
-            .HasDatabaseName("ix_audit_log_entries_tenant_timestamp");
+            .HasDatabaseName($"ix_{GranitAuditLogDbProperties.DbTablePrefix}log_entries_tenant_timestamp");
 
         builder.HasMany(e => e.EntityChanges)
             .WithOne()

--- a/src/Granit.AuditLog.EntityFrameworkCore/Internal/Configurations/AuditPropertyChangeConfiguration.cs
+++ b/src/Granit.AuditLog.EntityFrameworkCore/Internal/Configurations/AuditPropertyChangeConfiguration.cs
@@ -13,7 +13,9 @@ internal sealed class AuditPropertyChangeConfiguration : IEntityTypeConfiguratio
     /// <inheritdoc/>
     public void Configure(EntityTypeBuilder<AuditPropertyChange> builder)
     {
-        builder.ToTable("audit_property_changes");
+        builder.ToTable(
+            GranitAuditLogDbProperties.DbTablePrefix + "property_changes",
+            GranitAuditLogDbProperties.DbSchema);
 
         builder.HasKey(e => e.Id);
 

--- a/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/EntityConfigurations/ApiKeyEntryConfiguration.cs
+++ b/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/EntityConfigurations/ApiKeyEntryConfiguration.cs
@@ -13,18 +13,20 @@ internal sealed class ApiKeyEntryConfiguration : IEntityTypeConfiguration<ApiKey
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        builder.ToTable("ApiKeys");
+        builder.ToTable(
+            GranitApiKeysDbProperties.DbTablePrefix + "api_keys",
+            GranitApiKeysDbProperties.DbSchema);
 
         builder.HasKey(e => e.Id);
 
         // Unique index on HashedKey for O(1) lookups
         builder.HasIndex(e => e.HashedKey)
             .IsUnique()
-            .HasDatabaseName("IX_ApiKeys_HashedKey");
+            .HasDatabaseName($"uq_{GranitApiKeysDbProperties.DbTablePrefix}api_keys_hashed_key");
 
         // Index on TenantId for multi-tenant queries
         builder.HasIndex(e => e.TenantId)
-            .HasDatabaseName("IX_ApiKeys_TenantId");
+            .HasDatabaseName($"ix_{GranitApiKeysDbProperties.DbTablePrefix}api_keys_tenant_id");
 
         builder.Property(e => e.Name).HasMaxLength(200).IsRequired();
         builder.Property(e => e.HashedKey).HasMaxLength(64).IsRequired(); // SHA-256 hex = 64 chars

--- a/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Extensions/ApiKeysModelBuilderExtensions.cs
+++ b/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Extensions/ApiKeysModelBuilderExtensions.cs
@@ -1,0 +1,22 @@
+using Granit.Authentication.ApiKeys.EntityFrameworkCore.EntityConfigurations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Authentication.ApiKeys.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// <see cref="ModelBuilder"/> extensions for including Granit API key entity
+/// configurations in a host-owned <see cref="DbContext"/>.
+/// </summary>
+public static class ApiKeysModelBuilderExtensions
+{
+    /// <summary>
+    /// Applies all entity configurations for the Granit ApiKeys module.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder.</param>
+    /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
+    public static ModelBuilder ConfigureApiKeysModule(this ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new ApiKeyEntryConfiguration());
+        return modelBuilder;
+    }
+}

--- a/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/GranitApiKeysDbProperties.cs
+++ b/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/GranitApiKeysDbProperties.cs
@@ -1,0 +1,30 @@
+namespace Granit.Authentication.ApiKeys.EntityFrameworkCore;
+
+/// <summary>
+/// Provides configurable table-naming properties for the ApiKeys EF Core module.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These properties control the table prefix and schema used by all entity configurations
+/// in <c>Granit.Authentication.ApiKeys.EntityFrameworkCore</c>. Both the internal
+/// <c>ApiKeysDbContext</c> and the host's <c>Configure*Module()</c> call read
+/// the same static values, ensuring migration-time and runtime SQL stay in sync.
+/// </para>
+/// <para>
+/// <b>Important:</b> Set these properties at application startup, before
+/// <c>ConfigureServices</c> completes. EF Core caches the compiled <see cref="Microsoft.EntityFrameworkCore.Metadata.IModel"/>
+/// after first use — later mutations have no effect.
+/// </para>
+/// </remarks>
+public static class GranitApiKeysDbProperties
+{
+    /// <summary>
+    /// Table name prefix for all API key tables. Default: <c>"auth_"</c>.
+    /// </summary>
+    public static string DbTablePrefix { get; set; } = "auth_";
+
+    /// <summary>
+    /// Database schema for all API key tables. Default: <c>null</c> (provider default schema).
+    /// </summary>
+    public static string? DbSchema { get; set; }
+}

--- a/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Internal/ApiKeysDbContext.cs
+++ b/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Internal/ApiKeysDbContext.cs
@@ -1,5 +1,5 @@
 using Granit.Authentication.ApiKeys.Domain;
-using Granit.Authentication.ApiKeys.EntityFrameworkCore.EntityConfigurations;
+using Granit.Authentication.ApiKeys.EntityFrameworkCore.Extensions;
 using Granit.Core.DataFiltering;
 using Granit.Core.MultiTenancy;
 using Granit.Persistence.Extensions;
@@ -26,7 +26,7 @@ internal sealed class ApiKeysDbContext(
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);
         base.OnModelCreating(modelBuilder);
-        modelBuilder.ApplyConfiguration(new ApiKeyEntryConfiguration());
+        modelBuilder.ConfigureApiKeysModule();
         modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }
 }

--- a/src/Granit.Authorization.EntityFrameworkCore/DbContext/IPermissionGrantDbContext.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/DbContext/IPermissionGrantDbContext.cs
@@ -6,7 +6,7 @@ namespace Granit.Authorization.EntityFrameworkCore.DbContext;
 /// <summary>
 /// Implement this interface on the host application's <see cref="Microsoft.EntityFrameworkCore.DbContext"/>
 /// to enable Granit.Authorization.EntityFrameworkCore persistence.
-/// Call <see cref="PermissionGrantModelBuilderExtensions.ConfigurePermissionGrants"/> in <c>OnModelCreating</c>.
+/// Call <see cref="PermissionGrantModelBuilderExtensions.ConfigureAuthorizationModule"/> in <c>OnModelCreating</c>.
 /// </summary>
 public interface IPermissionGrantDbContext
 {

--- a/src/Granit.Authorization.EntityFrameworkCore/DbContext/PermissionGrantModelBuilderExtensions.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/DbContext/PermissionGrantModelBuilderExtensions.cs
@@ -3,25 +3,30 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Authorization.EntityFrameworkCore.DbContext;
 
-/// <summary>EF Core model builder extensions for the permission grants schema.</summary>
+/// <summary>EF Core model builder extensions for the Authorization module.</summary>
 public static class PermissionGrantModelBuilderExtensions
 {
     /// <summary>
+    /// Applies all entity configurations for the Granit Authorization module.
+    /// </summary>
+    /// <remarks>
     /// Configures the <see cref="PermissionGrant"/> entity: table name, column constraints,
     /// and unique composite index on (TenantId, Name, RoleName).
     /// Call this from <c>OnModelCreating</c> in the host application's DbContext.
-    /// </summary>
-    public static ModelBuilder ConfigurePermissionGrants(this ModelBuilder builder)
+    /// </remarks>
+    public static ModelBuilder ConfigureAuthorizationModule(this ModelBuilder builder)
     {
         builder.Entity<PermissionGrant>(entity =>
         {
-            entity.ToTable("security_permission_grants");
+            entity.ToTable(
+                GranitAuthorizationDbProperties.DbTablePrefix + "permission_grants",
+                GranitAuthorizationDbProperties.DbSchema);
             entity.HasKey(e => e.Id);
             entity.Property(e => e.Name).HasMaxLength(256).IsRequired();
             entity.Property(e => e.RoleName).HasMaxLength(256).IsRequired();
             entity.HasIndex(e => new { e.TenantId, e.Name, e.RoleName })
                   .IsUnique()
-                  .HasDatabaseName("uq_security_permission_grants_tenant_name_role");
+                  .HasDatabaseName($"uq_{GranitAuthorizationDbProperties.DbTablePrefix}permission_grants_tenant_name_role");
         });
 
         return builder;

--- a/src/Granit.Authorization.EntityFrameworkCore/GranitAuthorizationDbProperties.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/GranitAuthorizationDbProperties.cs
@@ -1,0 +1,22 @@
+namespace Granit.Authorization.EntityFrameworkCore;
+
+/// <summary>
+/// Provides configurable table-naming properties for the Authorization EF Core module.
+/// </summary>
+/// <remarks>
+/// <b>Important:</b> Set these properties at application startup, before
+/// <c>ConfigureServices</c> completes. EF Core caches the compiled model
+/// after first use — later mutations have no effect.
+/// </remarks>
+public static class GranitAuthorizationDbProperties
+{
+    /// <summary>
+    /// Table name prefix for all authorization tables. Default: <c>"auth_"</c>.
+    /// </summary>
+    public static string DbTablePrefix { get; set; } = "auth_";
+
+    /// <summary>
+    /// Database schema for all authorization tables. Default: <c>null</c> (provider default schema).
+    /// </summary>
+    public static string? DbSchema { get; set; }
+}

--- a/src/Granit.BackgroundJobs.EntityFrameworkCore/Extensions/BackgroundJobsModelBuilderExtensions.cs
+++ b/src/Granit.BackgroundJobs.EntityFrameworkCore/Extensions/BackgroundJobsModelBuilderExtensions.cs
@@ -1,0 +1,29 @@
+using Granit.BackgroundJobs.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.BackgroundJobs.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// <see cref="ModelBuilder"/> extensions for including Granit background job entity
+/// configurations in a host-owned <see cref="DbContext"/>.
+/// </summary>
+/// <remarks>
+/// Call <see cref="ConfigureBackgroundJobsModule"/> inside the host's
+/// <c>OnModelCreating</c> so that EF Core migrations include the background job tables.
+/// Optionally set <see cref="GranitBackgroundJobsDbProperties.DbTablePrefix"/> and
+/// <see cref="GranitBackgroundJobsDbProperties.DbSchema"/> before calling this method
+/// to customise table naming.
+/// </remarks>
+public static class BackgroundJobsModelBuilderExtensions
+{
+    /// <summary>
+    /// Applies all entity configurations for the Granit Background Jobs module.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder.</param>
+    /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
+    public static ModelBuilder ConfigureBackgroundJobsModule(this ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new BackgroundJobDefinitionConfiguration());
+        return modelBuilder;
+    }
+}

--- a/src/Granit.BackgroundJobs.EntityFrameworkCore/GranitBackgroundJobsDbProperties.cs
+++ b/src/Granit.BackgroundJobs.EntityFrameworkCore/GranitBackgroundJobsDbProperties.cs
@@ -1,0 +1,30 @@
+namespace Granit.BackgroundJobs.EntityFrameworkCore;
+
+/// <summary>
+/// Provides configurable table-naming properties for the Background Jobs EF Core module.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These properties control the table prefix and schema used by all entity configurations
+/// in <c>Granit.BackgroundJobs.EntityFrameworkCore</c>. Both the internal
+/// <c>BackgroundJobsDbContext</c> and the host's <c>Configure*Module()</c> call read
+/// the same static values, ensuring migration-time and runtime SQL stay in sync.
+/// </para>
+/// <para>
+/// <b>Important:</b> Set these properties at application startup, before
+/// <c>ConfigureServices</c> completes. EF Core caches the compiled <see cref="Microsoft.EntityFrameworkCore.Metadata.IModel"/>
+/// after first use — later mutations have no effect.
+/// </para>
+/// </remarks>
+public static class GranitBackgroundJobsDbProperties
+{
+    /// <summary>
+    /// Table name prefix for all background job tables. Default: <c>"scheduling_"</c>.
+    /// </summary>
+    public static string DbTablePrefix { get; set; } = "scheduling_";
+
+    /// <summary>
+    /// Database schema for all background job tables. Default: <c>null</c> (provider default schema).
+    /// </summary>
+    public static string? DbSchema { get; set; }
+}

--- a/src/Granit.BackgroundJobs.EntityFrameworkCore/Internal/BackgroundJobDefinitionConfiguration.cs
+++ b/src/Granit.BackgroundJobs.EntityFrameworkCore/Internal/BackgroundJobDefinitionConfiguration.cs
@@ -14,7 +14,9 @@ internal sealed class BackgroundJobDefinitionConfiguration
     /// <inheritdoc/>
     public void Configure(EntityTypeBuilder<BackgroundJobDefinition> builder)
     {
-        builder.ToTable("scheduling_background_jobs");
+        builder.ToTable(
+            GranitBackgroundJobsDbProperties.DbTablePrefix + "background_jobs",
+            GranitBackgroundJobsDbProperties.DbSchema);
 
         builder.HasKey(e => e.Id);
 
@@ -50,6 +52,6 @@ internal sealed class BackgroundJobDefinitionConfiguration
 
         builder.HasIndex(e => e.JobName)
             .IsUnique()
-            .HasDatabaseName("uq_scheduling_background_jobs_name");
+            .HasDatabaseName($"uq_{GranitBackgroundJobsDbProperties.DbTablePrefix}background_jobs_name");
     }
 }

--- a/src/Granit.BackgroundJobs.EntityFrameworkCore/Internal/BackgroundJobsDbContext.cs
+++ b/src/Granit.BackgroundJobs.EntityFrameworkCore/Internal/BackgroundJobsDbContext.cs
@@ -1,4 +1,5 @@
 using Granit.BackgroundJobs.Domain;
+using Granit.BackgroundJobs.EntityFrameworkCore.Extensions;
 using Granit.Core.DataFiltering;
 using Granit.Core.MultiTenancy;
 using Granit.Persistence.Extensions;
@@ -32,7 +33,7 @@ internal sealed class BackgroundJobsDbContext(
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
-        modelBuilder.ApplyConfiguration(new BackgroundJobDefinitionConfiguration());
+        modelBuilder.ConfigureBackgroundJobsModule();
         modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }
 }

--- a/src/Granit.BlobStorage.EntityFrameworkCore/Extensions/BlobStorageModelBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.EntityFrameworkCore/Extensions/BlobStorageModelBuilderExtensions.cs
@@ -1,0 +1,22 @@
+using Granit.BlobStorage.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.BlobStorage.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// <see cref="ModelBuilder"/> extensions for including Granit blob storage entity
+/// configurations in a host-owned <see cref="DbContext"/>.
+/// </summary>
+public static class BlobStorageModelBuilderExtensions
+{
+    /// <summary>
+    /// Applies all entity configurations for the Granit BlobStorage module.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder.</param>
+    /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
+    public static ModelBuilder ConfigureBlobStorageModule(this ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new BlobDescriptorConfiguration());
+        return modelBuilder;
+    }
+}

--- a/src/Granit.BlobStorage.EntityFrameworkCore/GranitBlobStorageDbProperties.cs
+++ b/src/Granit.BlobStorage.EntityFrameworkCore/GranitBlobStorageDbProperties.cs
@@ -1,0 +1,30 @@
+namespace Granit.BlobStorage.EntityFrameworkCore;
+
+/// <summary>
+/// Provides configurable table-naming properties for the BlobStorage EF Core module.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These properties control the table prefix and schema used by all entity configurations
+/// in <c>Granit.BlobStorage.EntityFrameworkCore</c>. Both the internal
+/// <c>BlobStorageDbContext</c> and the host's <c>Configure*Module()</c> call read
+/// the same static values, ensuring migration-time and runtime SQL stay in sync.
+/// </para>
+/// <para>
+/// <b>Important:</b> Set these properties at application startup, before
+/// <c>ConfigureServices</c> completes. EF Core caches the compiled <see cref="Microsoft.EntityFrameworkCore.Metadata.IModel"/>
+/// after first use — later mutations have no effect.
+/// </para>
+/// </remarks>
+public static class GranitBlobStorageDbProperties
+{
+    /// <summary>
+    /// Table name prefix for all blob storage tables. Default: <c>"blob_storage_"</c>.
+    /// </summary>
+    public static string DbTablePrefix { get; set; } = "blob_storage_";
+
+    /// <summary>
+    /// Database schema for all blob storage tables. Default: <c>null</c> (provider default schema).
+    /// </summary>
+    public static string? DbSchema { get; set; }
+}

--- a/src/Granit.BlobStorage.EntityFrameworkCore/Internal/BlobDescriptorConfiguration.cs
+++ b/src/Granit.BlobStorage.EntityFrameworkCore/Internal/BlobDescriptorConfiguration.cs
@@ -13,7 +13,9 @@ internal sealed class BlobDescriptorConfiguration : IEntityTypeConfiguration<Blo
     /// <inheritdoc/>
     public void Configure(EntityTypeBuilder<BlobDescriptor> builder)
     {
-        builder.ToTable("storage_blob_descriptors");
+        builder.ToTable(
+            GranitBlobStorageDbProperties.DbTablePrefix + "descriptors",
+            GranitBlobStorageDbProperties.DbSchema);
 
         builder.HasKey(e => e.Id);
 
@@ -66,11 +68,11 @@ internal sealed class BlobDescriptorConfiguration : IEntityTypeConfiguration<Blo
 
         // Composite index for tenant-scoped queries by container.
         builder.HasIndex(e => new { e.TenantId, e.ContainerName })
-            .HasDatabaseName("ix_storage_blob_descriptors_tenant_container");
+            .HasDatabaseName($"ix_{GranitBlobStorageDbProperties.DbTablePrefix}descriptors_tenant_container");
 
         // The S3 object key is globally unique across all tenants.
         builder.HasIndex(e => e.ObjectKey)
             .IsUnique()
-            .HasDatabaseName("uq_storage_blob_descriptors_object_key");
+            .HasDatabaseName($"uq_{GranitBlobStorageDbProperties.DbTablePrefix}descriptors_object_key");
     }
 }

--- a/src/Granit.BlobStorage.EntityFrameworkCore/Internal/BlobStorageDbContext.cs
+++ b/src/Granit.BlobStorage.EntityFrameworkCore/Internal/BlobStorageDbContext.cs
@@ -1,4 +1,5 @@
 using Granit.BlobStorage.Domain;
+using Granit.BlobStorage.EntityFrameworkCore.Extensions;
 using Granit.Core.DataFiltering;
 using Granit.Core.MultiTenancy;
 using Granit.Persistence.Extensions;
@@ -31,7 +32,7 @@ internal sealed class BlobStorageDbContext(
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
-        modelBuilder.ApplyConfiguration(new BlobDescriptorConfiguration());
+        modelBuilder.ConfigureBlobStorageModule();
         modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }
 }

--- a/src/Granit.DataExchange.EntityFrameworkCore/Extensions/DataExchangeModelBuilderExtensions.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Extensions/DataExchangeModelBuilderExtensions.cs
@@ -1,0 +1,27 @@
+using Granit.DataExchange.EntityFrameworkCore.Internal.Export.Configurations;
+using Granit.DataExchange.EntityFrameworkCore.Internal.Import.Configurations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.DataExchange.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// <see cref="ModelBuilder"/> extensions for including Granit data exchange entity
+/// configurations in a host-owned <see cref="DbContext"/>.
+/// </summary>
+public static class DataExchangeModelBuilderExtensions
+{
+    /// <summary>
+    /// Applies all entity configurations for the Granit DataExchange module.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder.</param>
+    /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
+    public static ModelBuilder ConfigureDataExchangeModule(this ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new ImportJobConfiguration());
+        modelBuilder.ApplyConfiguration(new SavedMappingEntityConfiguration());
+        modelBuilder.ApplyConfiguration(new ExternalIdMappingEntityConfiguration());
+        modelBuilder.ApplyConfiguration(new ExportJobConfiguration());
+        modelBuilder.ApplyConfiguration(new ExportPresetEntityConfiguration());
+        return modelBuilder;
+    }
+}

--- a/src/Granit.DataExchange.EntityFrameworkCore/GranitDataExchangeDbProperties.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/GranitDataExchangeDbProperties.cs
@@ -1,0 +1,22 @@
+namespace Granit.DataExchange.EntityFrameworkCore;
+
+/// <summary>
+/// Provides configurable table-naming properties for the DataExchange EF Core module.
+/// </summary>
+/// <remarks>
+/// <b>Important:</b> Set these properties at application startup, before
+/// <c>ConfigureServices</c> completes. EF Core caches the compiled model
+/// after first use — later mutations have no effect.
+/// </remarks>
+public static class GranitDataExchangeDbProperties
+{
+    /// <summary>
+    /// Table name prefix for all data exchange tables. Default: <c>"data_exchange_"</c>.
+    /// </summary>
+    public static string DbTablePrefix { get; set; } = "data_exchange_";
+
+    /// <summary>
+    /// Database schema for all data exchange tables. Default: <c>null</c> (provider default schema).
+    /// </summary>
+    public static string? DbSchema { get; set; }
+}

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/DataExchangeDbContext.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/DataExchangeDbContext.cs
@@ -1,8 +1,7 @@
 using Granit.Core.DataFiltering;
 using Granit.Core.MultiTenancy;
-using Granit.DataExchange.EntityFrameworkCore.Internal.Export.Configurations;
+using Granit.DataExchange.EntityFrameworkCore.Extensions;
 using Granit.DataExchange.EntityFrameworkCore.Internal.Export.Entities;
-using Granit.DataExchange.EntityFrameworkCore.Internal.Import.Configurations;
 using Granit.DataExchange.EntityFrameworkCore.Internal.Import.Entities;
 using Granit.DataExchange.Export;
 using Granit.DataExchange.Export.Domain;
@@ -32,11 +31,7 @@ internal sealed class DataExchangeDbContext(
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
-        modelBuilder.ApplyConfiguration(new ImportJobConfiguration());
-        modelBuilder.ApplyConfiguration(new SavedMappingEntityConfiguration());
-        modelBuilder.ApplyConfiguration(new ExternalIdMappingEntityConfiguration());
-        modelBuilder.ApplyConfiguration(new ExportJobConfiguration());
-        modelBuilder.ApplyConfiguration(new ExportPresetEntityConfiguration());
+        modelBuilder.ConfigureDataExchangeModule();
         modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }
 }

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/Configurations/ExportJobConfiguration.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/Configurations/ExportJobConfiguration.cs
@@ -12,7 +12,9 @@ internal sealed class ExportJobConfiguration : IEntityTypeConfiguration<ExportJo
 {
     public void Configure(EntityTypeBuilder<ExportJob> builder)
     {
-        builder.ToTable("data_import_export_jobs");
+        builder.ToTable(
+            GranitDataExchangeDbProperties.DbTablePrefix + "export_jobs",
+            GranitDataExchangeDbProperties.DbSchema);
         builder.HasKey(e => e.Id);
 
         builder.Property(e => e.DefinitionName).HasMaxLength(200).IsRequired();
@@ -33,9 +35,9 @@ internal sealed class ExportJobConfiguration : IEntityTypeConfiguration<ExportJo
         builder.Property(e => e.ModifiedBy).HasMaxLength(200);
 
         builder.HasIndex(e => e.TenantId)
-            .HasDatabaseName("ix_export_jobs_tenant");
+            .HasDatabaseName($"ix_{GranitDataExchangeDbProperties.DbTablePrefix}export_jobs_tenant");
 
         builder.HasIndex(e => e.Status)
-            .HasDatabaseName("ix_export_jobs_status");
+            .HasDatabaseName($"ix_{GranitDataExchangeDbProperties.DbTablePrefix}export_jobs_status");
     }
 }

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/Configurations/ExportPresetEntityConfiguration.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/Configurations/ExportPresetEntityConfiguration.cs
@@ -12,7 +12,9 @@ internal sealed class ExportPresetEntityConfiguration : IEntityTypeConfiguration
 {
     public void Configure(EntityTypeBuilder<ExportPresetEntity> builder)
     {
-        builder.ToTable("data_import_export_presets");
+        builder.ToTable(
+            GranitDataExchangeDbProperties.DbTablePrefix + "export_presets",
+            GranitDataExchangeDbProperties.DbSchema);
         builder.HasKey(e => e.Id);
 
         builder.Property(e => e.DefinitionName).HasMaxLength(200).IsRequired();
@@ -26,6 +28,6 @@ internal sealed class ExportPresetEntityConfiguration : IEntityTypeConfiguration
 
         builder.HasIndex(e => new { e.DefinitionName, e.PresetName, e.TenantId })
             .IsUnique()
-            .HasDatabaseName("ix_export_presets_def_name_tenant");
+            .HasDatabaseName($"uq_{GranitDataExchangeDbProperties.DbTablePrefix}export_presets_def_name_tenant");
     }
 }

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Configurations/ExternalIdMappingEntityConfiguration.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Configurations/ExternalIdMappingEntityConfiguration.cs
@@ -12,7 +12,9 @@ internal sealed class ExternalIdMappingEntityConfiguration : IEntityTypeConfigur
 {
     public void Configure(EntityTypeBuilder<ExternalIdMappingEntity> builder)
     {
-        builder.ToTable("data_import_external_id_mappings");
+        builder.ToTable(
+            GranitDataExchangeDbProperties.DbTablePrefix + "external_id_mappings",
+            GranitDataExchangeDbProperties.DbSchema);
         builder.HasKey(e => e.Id);
 
         builder.Property(e => e.DefinitionName).HasMaxLength(200).IsRequired();
@@ -23,6 +25,6 @@ internal sealed class ExternalIdMappingEntityConfiguration : IEntityTypeConfigur
 
         builder.HasIndex(e => new { e.DefinitionName, e.ExternalId, e.TenantId })
             .IsUnique()
-            .HasDatabaseName("ix_ext_id_def_ext_tenant");
+            .HasDatabaseName($"uq_{GranitDataExchangeDbProperties.DbTablePrefix}external_id_mappings_def_ext_tenant");
     }
 }

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Configurations/ImportJobConfiguration.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Configurations/ImportJobConfiguration.cs
@@ -11,7 +11,9 @@ internal sealed class ImportJobConfiguration : IEntityTypeConfiguration<ImportJo
 {
     public void Configure(EntityTypeBuilder<ImportJob> builder)
     {
-        builder.ToTable("data_import_jobs");
+        builder.ToTable(
+            GranitDataExchangeDbProperties.DbTablePrefix + "import_jobs",
+            GranitDataExchangeDbProperties.DbSchema);
         builder.HasKey(e => e.Id);
 
         builder.Property(e => e.DefinitionName).HasMaxLength(200).IsRequired();
@@ -38,6 +40,6 @@ internal sealed class ImportJobConfiguration : IEntityTypeConfiguration<ImportJo
         builder.Property(e => e.ModifiedBy).HasMaxLength(200);
 
         builder.HasIndex(e => new { e.DefinitionName, e.Status })
-            .HasDatabaseName("ix_data_import_jobs_definition_status");
+            .HasDatabaseName($"ix_{GranitDataExchangeDbProperties.DbTablePrefix}import_jobs_definition_status");
     }
 }

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Configurations/SavedMappingEntityConfiguration.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Configurations/SavedMappingEntityConfiguration.cs
@@ -12,7 +12,9 @@ internal sealed class SavedMappingEntityConfiguration : IEntityTypeConfiguration
 {
     public void Configure(EntityTypeBuilder<SavedMappingEntity> builder)
     {
-        builder.ToTable("data_import_saved_mappings");
+        builder.ToTable(
+            GranitDataExchangeDbProperties.DbTablePrefix + "saved_mappings",
+            GranitDataExchangeDbProperties.DbSchema);
         builder.HasKey(e => e.Id);
 
         builder.Property(e => e.DefinitionName).HasMaxLength(200).IsRequired();
@@ -23,6 +25,6 @@ internal sealed class SavedMappingEntityConfiguration : IEntityTypeConfiguration
 
         builder.HasIndex(e => new { e.DefinitionName, e.TenantId })
             .IsUnique()
-            .HasDatabaseName("ix_saved_mappings_def_tenant");
+            .HasDatabaseName($"uq_{GranitDataExchangeDbProperties.DbTablePrefix}saved_mappings_def_tenant");
     }
 }

--- a/src/Granit.Features.EntityFrameworkCore/Extensions/FeaturesModelBuilderExtensions.cs
+++ b/src/Granit.Features.EntityFrameworkCore/Extensions/FeaturesModelBuilderExtensions.cs
@@ -1,0 +1,22 @@
+using Granit.Features.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Features.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// <see cref="ModelBuilder"/> extensions for including Granit feature override entity
+/// configurations in a host-owned <see cref="DbContext"/>.
+/// </summary>
+public static class FeaturesModelBuilderExtensions
+{
+    /// <summary>
+    /// Applies all entity configurations for the Granit Features module.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder.</param>
+    /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
+    public static ModelBuilder ConfigureFeaturesModule(this ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new TenantFeatureOverrideConfiguration());
+        return modelBuilder;
+    }
+}

--- a/src/Granit.Features.EntityFrameworkCore/GranitFeaturesDbProperties.cs
+++ b/src/Granit.Features.EntityFrameworkCore/GranitFeaturesDbProperties.cs
@@ -1,0 +1,30 @@
+namespace Granit.Features.EntityFrameworkCore;
+
+/// <summary>
+/// Provides configurable table-naming properties for the Features EF Core module.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These properties control the table prefix and schema used by all entity configurations
+/// in <c>Granit.Features.EntityFrameworkCore</c>. Both the internal
+/// <c>FeaturesDbContext</c> and the host's <c>Configure*Module()</c> call read
+/// the same static values, ensuring migration-time and runtime SQL stay in sync.
+/// </para>
+/// <para>
+/// <b>Important:</b> Set these properties at application startup, before
+/// <c>ConfigureServices</c> completes. EF Core caches the compiled <see cref="Microsoft.EntityFrameworkCore.Metadata.IModel"/>
+/// after first use — later mutations have no effect.
+/// </para>
+/// </remarks>
+public static class GranitFeaturesDbProperties
+{
+    /// <summary>
+    /// Table name prefix for all features tables. Default: <c>"feature_"</c>.
+    /// </summary>
+    public static string DbTablePrefix { get; set; } = "feature_";
+
+    /// <summary>
+    /// Database schema for all features tables. Default: <c>null</c> (provider default schema).
+    /// </summary>
+    public static string? DbSchema { get; set; }
+}

--- a/src/Granit.Features.EntityFrameworkCore/Internal/GranitFeaturesDbContext.cs
+++ b/src/Granit.Features.EntityFrameworkCore/Internal/GranitFeaturesDbContext.cs
@@ -1,5 +1,6 @@
 using Granit.Core.DataFiltering;
 using Granit.Core.MultiTenancy;
+using Granit.Features.EntityFrameworkCore.Extensions;
 using Granit.Persistence.Extensions;
 using Microsoft.EntityFrameworkCore;
 
@@ -31,7 +32,7 @@ internal sealed class GranitFeaturesDbContext(
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
-        modelBuilder.ApplyConfiguration(new TenantFeatureOverrideConfiguration());
+        modelBuilder.ConfigureFeaturesModule();
         modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }
 }

--- a/src/Granit.Features.EntityFrameworkCore/Internal/TenantFeatureOverrideConfiguration.cs
+++ b/src/Granit.Features.EntityFrameworkCore/Internal/TenantFeatureOverrideConfiguration.cs
@@ -5,7 +5,7 @@ namespace Granit.Features.EntityFrameworkCore.Internal;
 
 /// <summary>
 /// EF Core Fluent API configuration for <see cref="TenantFeatureOverride"/>.
-/// Table: <c>saas_feature_overrides</c>.
+/// Table: <c>feature_overrides</c>.
 /// </summary>
 internal sealed class TenantFeatureOverrideConfiguration
     : IEntityTypeConfiguration<TenantFeatureOverride>
@@ -13,7 +13,9 @@ internal sealed class TenantFeatureOverrideConfiguration
     /// <inheritdoc/>
     public void Configure(EntityTypeBuilder<TenantFeatureOverride> builder)
     {
-        builder.ToTable("saas_feature_overrides");
+        builder.ToTable(
+            GranitFeaturesDbProperties.DbTablePrefix + "overrides",
+            GranitFeaturesDbProperties.DbSchema);
 
         builder.HasKey(e => e.Id);
 
@@ -46,6 +48,6 @@ internal sealed class TenantFeatureOverrideConfiguration
         // Unique composite index: one override per (tenant, feature)
         builder.HasIndex(e => new { e.TenantId, e.FeatureName })
                .IsUnique()
-               .HasDatabaseName("uq_saas_feature_overrides_tenant_feature");
+               .HasDatabaseName($"uq_{GranitFeaturesDbProperties.DbTablePrefix}overrides_tenant_feature");
     }
 }

--- a/src/Granit.Identity.EntityFrameworkCore/DbContext/IUserCacheDbContext.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/DbContext/IUserCacheDbContext.cs
@@ -6,7 +6,7 @@ namespace Granit.Identity.EntityFrameworkCore.DbContext;
 /// <summary>
 /// Implement this interface on the host application's <see cref="Microsoft.EntityFrameworkCore.DbContext"/>
 /// to enable Granit.Identity.EntityFrameworkCore persistence.
-/// Call <see cref="UserCacheModelBuilderExtensions.ConfigureIdentityUserCache"/> in <c>OnModelCreating</c>.
+/// Call <see cref="UserCacheModelBuilderExtensions.ConfigureIdentityModule"/> in <c>OnModelCreating</c>.
 /// </summary>
 public interface IUserCacheDbContext
 {

--- a/src/Granit.Identity.EntityFrameworkCore/DbContext/UserCacheModelBuilderExtensions.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/DbContext/UserCacheModelBuilderExtensions.cs
@@ -3,19 +3,24 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Identity.EntityFrameworkCore.DbContext;
 
-/// <summary>EF Core model builder extensions for the identity user cache schema.</summary>
+/// <summary>EF Core model builder extensions for the Identity module.</summary>
 public static class UserCacheModelBuilderExtensions
 {
     /// <summary>
+    /// Applies all entity configurations for the Granit Identity module.
+    /// </summary>
+    /// <remarks>
     /// Configures the <see cref="UserCacheEntry"/> entity: table name, column constraints,
     /// and indexes for efficient lookup and search.
     /// Call this from <c>OnModelCreating</c> in the host application's DbContext.
-    /// </summary>
-    public static ModelBuilder ConfigureIdentityUserCache(this ModelBuilder builder)
+    /// </remarks>
+    public static ModelBuilder ConfigureIdentityModule(this ModelBuilder builder)
     {
         builder.Entity<UserCacheEntry>(entity =>
         {
-            entity.ToTable("identity_user_cache_entries");
+            entity.ToTable(
+                GranitIdentityDbProperties.DbTablePrefix + "user_cache_entries",
+                GranitIdentityDbProperties.DbSchema);
             entity.HasKey(e => e.Id);
 
             entity.Property(e => e.ExternalUserId).HasMaxLength(256).IsRequired();
@@ -27,17 +32,17 @@ public static class UserCacheModelBuilderExtensions
             // Unique: one cache entry per user per tenant
             entity.HasIndex(e => new { e.TenantId, e.ExternalUserId })
                   .IsUnique()
-                  .HasDatabaseName("uq_identity_user_cache_tenant_external_id");
+                  .HasDatabaseName($"uq_{GranitIdentityDbProperties.DbTablePrefix}user_cache_tenant_external_id");
 
             // Search indexes
             entity.HasIndex(e => new { e.TenantId, e.Username })
-                  .HasDatabaseName("ix_identity_user_cache_tenant_username");
+                  .HasDatabaseName($"ix_{GranitIdentityDbProperties.DbTablePrefix}user_cache_tenant_username");
 
             entity.HasIndex(e => new { e.TenantId, e.Email })
-                  .HasDatabaseName("ix_identity_user_cache_tenant_email");
+                  .HasDatabaseName($"ix_{GranitIdentityDbProperties.DbTablePrefix}user_cache_tenant_email");
 
             entity.HasIndex(e => new { e.TenantId, e.LastName, e.FirstName })
-                  .HasDatabaseName("ix_identity_user_cache_tenant_name");
+                  .HasDatabaseName($"ix_{GranitIdentityDbProperties.DbTablePrefix}user_cache_tenant_name");
         });
 
         return builder;

--- a/src/Granit.Identity.EntityFrameworkCore/GranitIdentityDbProperties.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/GranitIdentityDbProperties.cs
@@ -1,0 +1,22 @@
+namespace Granit.Identity.EntityFrameworkCore;
+
+/// <summary>
+/// Provides configurable table-naming properties for the Identity EF Core module.
+/// </summary>
+/// <remarks>
+/// <b>Important:</b> Set these properties at application startup, before
+/// <c>ConfigureServices</c> completes. EF Core caches the compiled model
+/// after first use — later mutations have no effect.
+/// </remarks>
+public static class GranitIdentityDbProperties
+{
+    /// <summary>
+    /// Table name prefix for all identity tables. Default: <c>"identity_"</c>.
+    /// </summary>
+    public static string DbTablePrefix { get; set; } = "identity_";
+
+    /// <summary>
+    /// Database schema for all identity tables. Default: <c>null</c> (provider default schema).
+    /// </summary>
+    public static string? DbSchema { get; set; }
+}

--- a/src/Granit.Localization.EntityFrameworkCore/Extensions/LocalizationModelBuilderExtensions.cs
+++ b/src/Granit.Localization.EntityFrameworkCore/Extensions/LocalizationModelBuilderExtensions.cs
@@ -1,0 +1,22 @@
+using Granit.Localization.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Localization.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// <see cref="ModelBuilder"/> extensions for including Granit localization entity
+/// configurations in a host-owned <see cref="DbContext"/>.
+/// </summary>
+public static class LocalizationModelBuilderExtensions
+{
+    /// <summary>
+    /// Applies all entity configurations for the Granit Localization module.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder.</param>
+    /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
+    public static ModelBuilder ConfigureLocalizationModule(this ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new LocalizationOverrideConfiguration());
+        return modelBuilder;
+    }
+}

--- a/src/Granit.Localization.EntityFrameworkCore/GranitLocalizationDbProperties.cs
+++ b/src/Granit.Localization.EntityFrameworkCore/GranitLocalizationDbProperties.cs
@@ -1,0 +1,30 @@
+namespace Granit.Localization.EntityFrameworkCore;
+
+/// <summary>
+/// Provides configurable table-naming properties for the Localization EF Core module.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These properties control the table prefix and schema used by all entity configurations
+/// in <c>Granit.Localization.EntityFrameworkCore</c>. Both the internal
+/// <c>LocalizationDbContext</c> and the host's <c>Configure*Module()</c> call read
+/// the same static values, ensuring migration-time and runtime SQL stay in sync.
+/// </para>
+/// <para>
+/// <b>Important:</b> Set these properties at application startup, before
+/// <c>ConfigureServices</c> completes. EF Core caches the compiled <see cref="Microsoft.EntityFrameworkCore.Metadata.IModel"/>
+/// after first use — later mutations have no effect.
+/// </para>
+/// </remarks>
+public static class GranitLocalizationDbProperties
+{
+    /// <summary>
+    /// Table name prefix for all localization tables. Default: <c>"localization_"</c>.
+    /// </summary>
+    public static string DbTablePrefix { get; set; } = "localization_";
+
+    /// <summary>
+    /// Database schema for all localization tables. Default: <c>null</c> (provider default schema).
+    /// </summary>
+    public static string? DbSchema { get; set; }
+}

--- a/src/Granit.Localization.EntityFrameworkCore/Internal/GranitLocalizationOverridesDbContext.cs
+++ b/src/Granit.Localization.EntityFrameworkCore/Internal/GranitLocalizationOverridesDbContext.cs
@@ -1,6 +1,7 @@
 using Granit.Core.DataFiltering;
 using Granit.Core.MultiTenancy;
 using Granit.Localization.EntityFrameworkCore.Entities;
+using Granit.Localization.EntityFrameworkCore.Extensions;
 using Granit.Persistence.Extensions;
 using Microsoft.EntityFrameworkCore;
 
@@ -32,7 +33,7 @@ internal sealed class GranitLocalizationOverridesDbContext(
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
-        modelBuilder.ApplyConfiguration(new LocalizationOverrideConfiguration());
+        modelBuilder.ConfigureLocalizationModule();
         modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }
 }

--- a/src/Granit.Localization.EntityFrameworkCore/Internal/LocalizationOverrideConfiguration.cs
+++ b/src/Granit.Localization.EntityFrameworkCore/Internal/LocalizationOverrideConfiguration.cs
@@ -14,7 +14,9 @@ internal sealed class LocalizationOverrideConfiguration
     /// <inheritdoc/>
     public void Configure(EntityTypeBuilder<LocalizationOverride> builder)
     {
-        builder.ToTable("i18n_localization_overrides");
+        builder.ToTable(
+            GranitLocalizationDbProperties.DbTablePrefix + "overrides",
+            GranitLocalizationDbProperties.DbSchema);
 
         builder.HasKey(e => e.Id);
 
@@ -52,10 +54,10 @@ internal sealed class LocalizationOverrideConfiguration
         // Unique composite index: one override per (tenant, resource, culture, key)
         builder.HasIndex(e => new { e.TenantId, e.ResourceName, e.CultureName, e.Key })
                .IsUnique()
-               .HasDatabaseName("uq_i18n_localization_overrides_tenant_resource_culture_key");
+               .HasDatabaseName($"uq_{GranitLocalizationDbProperties.DbTablePrefix}overrides_tenant_resource_culture_key");
 
         // Non-unique index to speed up bulk reads per (tenant, resource, culture)
         builder.HasIndex(e => new { e.TenantId, e.ResourceName, e.CultureName })
-               .HasDatabaseName("ix_i18n_localization_overrides_tenant_resource_culture");
+               .HasDatabaseName($"ix_{GranitLocalizationDbProperties.DbTablePrefix}overrides_tenant_resource_culture");
     }
 }

--- a/src/Granit.Notifications.Email.AwsSes/GranitNotificationsEmailAwsSesModule.cs
+++ b/src/Granit.Notifications.Email.AwsSes/GranitNotificationsEmailAwsSesModule.cs
@@ -4,7 +4,7 @@ using Granit.Notifications.Email.AwsSes.Extensions;
 namespace Granit.Notifications.Email.AwsSes;
 
 /// <summary>Module for Amazon SES email provider.</summary>
-public class GranitNotificationsEmailAwsSesModule : GranitModule
+public sealed class GranitNotificationsEmailAwsSesModule : GranitModule
 {
     /// <inheritdoc />
     public override void ConfigureServices(ServiceConfigurationContext context) =>

--- a/src/Granit.Notifications.EntityFrameworkCore/Configurations/MobilePushTokenConfiguration.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Configurations/MobilePushTokenConfiguration.cs
@@ -8,7 +8,9 @@ internal sealed class MobilePushTokenConfiguration : IEntityTypeConfiguration<Mo
 {
     public void Configure(EntityTypeBuilder<MobilePushTokenEntity> builder)
     {
-        builder.ToTable("mobile_push_tokens");
+        builder.ToTable(
+            GranitNotificationsDbProperties.DbTablePrefix + "mobile_push_tokens",
+            GranitNotificationsDbProperties.DbSchema);
         builder.HasKey(x => x.Id);
 
         builder.Property(x => x.UserId).HasMaxLength(256).IsRequired();
@@ -19,10 +21,10 @@ internal sealed class MobilePushTokenConfiguration : IEntityTypeConfiguration<Mo
         // Unique constraint: one device token per tenant
         builder.HasIndex(x => new { x.DeviceToken, x.TenantId })
             .IsUnique()
-            .HasDatabaseName("ix_mobile_push_tokens_device_tenant");
+            .HasDatabaseName($"uq_{GranitNotificationsDbProperties.DbTablePrefix}mobile_push_tokens_device_tenant");
 
         // Lookup by user + tenant
         builder.HasIndex(x => new { x.UserId, x.TenantId })
-            .HasDatabaseName("ix_mobile_push_tokens_user_tenant");
+            .HasDatabaseName($"ix_{GranitNotificationsDbProperties.DbTablePrefix}mobile_push_tokens_user_tenant");
     }
 }

--- a/src/Granit.Notifications.EntityFrameworkCore/Configurations/NotificationDeliveryAttemptConfiguration.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Configurations/NotificationDeliveryAttemptConfiguration.cs
@@ -8,7 +8,9 @@ internal sealed class NotificationDeliveryAttemptConfiguration : IEntityTypeConf
 {
     public void Configure(EntityTypeBuilder<NotificationDeliveryAttempt> builder)
     {
-        builder.ToTable("notification_delivery_attempts");
+        builder.ToTable(
+            GranitNotificationsDbProperties.DbTablePrefix + "delivery_attempts",
+            GranitNotificationsDbProperties.DbSchema);
         builder.HasKey(x => x.Id);
 
         builder.Property(x => x.NotificationTypeName).HasMaxLength(256).IsRequired();
@@ -17,10 +19,10 @@ internal sealed class NotificationDeliveryAttemptConfiguration : IEntityTypeConf
         builder.Property(x => x.ErrorMessage).HasMaxLength(2048);
 
         builder.HasIndex(x => new { x.NotificationId, x.ChannelName })
-            .HasDatabaseName("ix_notification_delivery_attempts_notification");
+            .HasDatabaseName($"ix_{GranitNotificationsDbProperties.DbTablePrefix}delivery_attempts_notification");
 
         builder.HasIndex(x => new { x.TenantId, x.OccurredAt })
             .IsDescending(false, true)
-            .HasDatabaseName("ix_notification_delivery_attempts_audit");
+            .HasDatabaseName($"ix_{GranitNotificationsDbProperties.DbTablePrefix}delivery_attempts_audit");
     }
 }

--- a/src/Granit.Notifications.EntityFrameworkCore/Configurations/NotificationPreferenceConfiguration.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Configurations/NotificationPreferenceConfiguration.cs
@@ -8,7 +8,9 @@ internal sealed class NotificationPreferenceConfiguration : IEntityTypeConfigura
 {
     public void Configure(EntityTypeBuilder<NotificationPreference> builder)
     {
-        builder.ToTable("notification_preferences");
+        builder.ToTable(
+            GranitNotificationsDbProperties.DbTablePrefix + "preferences",
+            GranitNotificationsDbProperties.DbSchema);
         builder.HasKey(x => x.Id);
 
         builder.Property(x => x.UserId).HasMaxLength(256).IsRequired();
@@ -19,6 +21,6 @@ internal sealed class NotificationPreferenceConfiguration : IEntityTypeConfigura
 
         builder.HasIndex(x => new { x.UserId, x.NotificationTypeName, x.ChannelName, x.TenantId })
             .IsUnique()
-            .HasDatabaseName("ix_notification_preferences_unique");
+            .HasDatabaseName($"uq_{GranitNotificationsDbProperties.DbTablePrefix}preferences_user_type_channel_tenant");
     }
 }

--- a/src/Granit.Notifications.EntityFrameworkCore/Configurations/NotificationSubscriptionConfiguration.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Configurations/NotificationSubscriptionConfiguration.cs
@@ -8,7 +8,9 @@ internal sealed class NotificationSubscriptionConfiguration : IEntityTypeConfigu
 {
     public void Configure(EntityTypeBuilder<NotificationSubscription> builder)
     {
-        builder.ToTable("notification_subscriptions");
+        builder.ToTable(
+            GranitNotificationsDbProperties.DbTablePrefix + "subscriptions",
+            GranitNotificationsDbProperties.DbSchema);
         builder.HasKey(x => x.Id);
 
         builder.Property(x => x.UserId).HasMaxLength(256).IsRequired();
@@ -19,10 +21,10 @@ internal sealed class NotificationSubscriptionConfiguration : IEntityTypeConfigu
 
         // Global subscription
         builder.HasIndex(x => new { x.UserId, x.NotificationTypeName, x.TenantId })
-            .HasDatabaseName("ix_notification_subscriptions_global");
+            .HasDatabaseName($"ix_{GranitNotificationsDbProperties.DbTablePrefix}subscriptions_global");
 
         // Entity followers
         builder.HasIndex(x => new { x.EntityType, x.EntityId, x.TenantId })
-            .HasDatabaseName("ix_notification_subscriptions_entity");
+            .HasDatabaseName($"ix_{GranitNotificationsDbProperties.DbTablePrefix}subscriptions_entity");
     }
 }

--- a/src/Granit.Notifications.EntityFrameworkCore/Configurations/UserNotificationConfiguration.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Configurations/UserNotificationConfiguration.cs
@@ -10,7 +10,9 @@ internal sealed class UserNotificationConfiguration : IEntityTypeConfiguration<U
 {
     public void Configure(EntityTypeBuilder<UserNotification> builder)
     {
-        builder.ToTable("notification_user_notifications");
+        builder.ToTable(
+            GranitNotificationsDbProperties.DbTablePrefix + "user_notifications",
+            GranitNotificationsDbProperties.DbSchema);
         builder.HasKey(x => x.Id);
 
         builder.Property(x => x.NotificationTypeName).HasMaxLength(256).IsRequired();
@@ -27,11 +29,11 @@ internal sealed class UserNotificationConfiguration : IEntityTypeConfiguration<U
         // Paginated inbox
         builder.HasIndex(x => new { x.RecipientUserId, x.TenantId, x.State, x.CreatedAt })
             .IsDescending(false, false, false, true)
-            .HasDatabaseName("ix_notification_user_notifications_inbox");
+            .HasDatabaseName($"ix_{GranitNotificationsDbProperties.DbTablePrefix}user_notifications_inbox");
 
         // Activity feed: per-entity notification history
         builder.HasIndex(x => new { x.RelatedEntityType, x.RelatedEntityId, x.TenantId, x.CreatedAt })
             .IsDescending(false, false, false, true)
-            .HasDatabaseName("ix_notification_user_notifications_entity_feed");
+            .HasDatabaseName($"ix_{GranitNotificationsDbProperties.DbTablePrefix}user_notifications_entity_feed");
     }
 }

--- a/src/Granit.Notifications.EntityFrameworkCore/Extensions/NotificationsModelBuilderExtensions.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Extensions/NotificationsModelBuilderExtensions.cs
@@ -1,0 +1,26 @@
+using Granit.Notifications.EntityFrameworkCore.Configurations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Notifications.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// <see cref="ModelBuilder"/> extensions for including Granit notification entity
+/// configurations in a host-owned <see cref="DbContext"/>.
+/// </summary>
+public static class NotificationsModelBuilderExtensions
+{
+    /// <summary>
+    /// Applies all entity configurations for the Granit Notifications module.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder.</param>
+    /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
+    public static ModelBuilder ConfigureNotificationsModule(this ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new UserNotificationConfiguration());
+        modelBuilder.ApplyConfiguration(new NotificationSubscriptionConfiguration());
+        modelBuilder.ApplyConfiguration(new NotificationPreferenceConfiguration());
+        modelBuilder.ApplyConfiguration(new NotificationDeliveryAttemptConfiguration());
+        modelBuilder.ApplyConfiguration(new MobilePushTokenConfiguration());
+        return modelBuilder;
+    }
+}

--- a/src/Granit.Notifications.EntityFrameworkCore/GranitNotificationsDbProperties.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/GranitNotificationsDbProperties.cs
@@ -1,0 +1,30 @@
+namespace Granit.Notifications.EntityFrameworkCore;
+
+/// <summary>
+/// Provides configurable table-naming properties for the Notifications EF Core module.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These properties control the table prefix and schema used by all entity configurations
+/// in <c>Granit.Notifications.EntityFrameworkCore</c>. Both the internal
+/// <c>NotificationsDbContext</c> and the host's <c>Configure*Module()</c> call read
+/// the same static values, ensuring migration-time and runtime SQL stay in sync.
+/// </para>
+/// <para>
+/// <b>Important:</b> Set these properties at application startup, before
+/// <c>ConfigureServices</c> completes. EF Core caches the compiled <see cref="Microsoft.EntityFrameworkCore.Metadata.IModel"/>
+/// after first use — later mutations have no effect.
+/// </para>
+/// </remarks>
+public static class GranitNotificationsDbProperties
+{
+    /// <summary>
+    /// Table name prefix for all notification tables. Default: <c>"notification_"</c>.
+    /// </summary>
+    public static string DbTablePrefix { get; set; } = "notification_";
+
+    /// <summary>
+    /// Database schema for all notification tables. Default: <c>null</c> (provider default schema).
+    /// </summary>
+    public static string? DbSchema { get; set; }
+}

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/NotificationDbContext.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/NotificationDbContext.cs
@@ -2,6 +2,7 @@ using Granit.Core.DataFiltering;
 using Granit.Core.MultiTenancy;
 using Granit.Notifications.Domain;
 using Granit.Notifications.EntityFrameworkCore.Entities;
+using Granit.Notifications.EntityFrameworkCore.Extensions;
 using Granit.Persistence.Extensions;
 using Microsoft.EntityFrameworkCore;
 
@@ -35,7 +36,7 @@ internal sealed class NotificationDbContext(
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
-        modelBuilder.ApplyConfigurationsFromAssembly(typeof(NotificationDbContext).Assembly);
+        modelBuilder.ConfigureNotificationsModule();
         modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }
 }

--- a/src/Granit.Querying.EntityFrameworkCore/Extensions/QueryingModelBuilderExtensions.cs
+++ b/src/Granit.Querying.EntityFrameworkCore/Extensions/QueryingModelBuilderExtensions.cs
@@ -1,0 +1,22 @@
+using Granit.Querying.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Querying.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// <see cref="ModelBuilder"/> extensions for including Granit querying entity
+/// configurations in a host-owned <see cref="DbContext"/>.
+/// </summary>
+public static class QueryingModelBuilderExtensions
+{
+    /// <summary>
+    /// Applies all entity configurations for the Granit Querying module.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder.</param>
+    /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
+    public static ModelBuilder ConfigureQueryingModule(this ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new SavedViewEntityConfiguration());
+        return modelBuilder;
+    }
+}

--- a/src/Granit.Querying.EntityFrameworkCore/GranitQueryingDbProperties.cs
+++ b/src/Granit.Querying.EntityFrameworkCore/GranitQueryingDbProperties.cs
@@ -1,0 +1,22 @@
+namespace Granit.Querying.EntityFrameworkCore;
+
+/// <summary>
+/// Provides configurable table-naming properties for the Querying EF Core module.
+/// </summary>
+/// <remarks>
+/// <b>Important:</b> Set these properties at application startup, before
+/// <c>ConfigureServices</c> completes. EF Core caches the compiled model
+/// after first use — later mutations have no effect.
+/// </remarks>
+public static class GranitQueryingDbProperties
+{
+    /// <summary>
+    /// Table name prefix for all querying tables. Default: <c>"querying_"</c>.
+    /// </summary>
+    public static string DbTablePrefix { get; set; } = "querying_";
+
+    /// <summary>
+    /// Database schema for all querying tables. Default: <c>null</c> (provider default schema).
+    /// </summary>
+    public static string? DbSchema { get; set; }
+}

--- a/src/Granit.Querying.EntityFrameworkCore/Internal/QueryingDbContext.cs
+++ b/src/Granit.Querying.EntityFrameworkCore/Internal/QueryingDbContext.cs
@@ -1,6 +1,7 @@
 using Granit.Core.DataFiltering;
 using Granit.Core.MultiTenancy;
 using Granit.Persistence.Extensions;
+using Granit.Querying.EntityFrameworkCore.Extensions;
 using Granit.Querying.SavedViews;
 using Granit.Querying.SavedViews.Domain;
 using Microsoft.EntityFrameworkCore;
@@ -22,7 +23,7 @@ internal sealed class QueryingDbContext(
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
-        modelBuilder.ApplyConfiguration(new SavedViewEntityConfiguration());
+        modelBuilder.ConfigureQueryingModule();
         modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }
 }

--- a/src/Granit.Querying.EntityFrameworkCore/Internal/SavedViewEntityConfiguration.cs
+++ b/src/Granit.Querying.EntityFrameworkCore/Internal/SavedViewEntityConfiguration.cs
@@ -12,7 +12,9 @@ internal sealed class SavedViewEntityConfiguration : IEntityTypeConfiguration<Sa
 {
     public void Configure(EntityTypeBuilder<SavedView> builder)
     {
-        builder.ToTable("querying_saved_views");
+        builder.ToTable(
+            GranitQueryingDbProperties.DbTablePrefix + "saved_views",
+            GranitQueryingDbProperties.DbSchema);
         builder.HasKey(e => e.Id);
 
         builder.Property(e => e.EntityType).HasMaxLength(200).IsRequired();
@@ -34,6 +36,6 @@ internal sealed class SavedViewEntityConfiguration : IEntityTypeConfiguration<Sa
 
         builder.HasIndex(e => new { e.EntityType, e.UserId, e.Name, e.TenantId })
             .IsUnique()
-            .HasDatabaseName("ix_querying_saved_views_entity_user_name_tenant");
+            .HasDatabaseName($"uq_{GranitQueryingDbProperties.DbTablePrefix}saved_views_entity_user_name_tenant");
     }
 }

--- a/src/Granit.Settings.EntityFrameworkCore/GranitSettingsDbProperties.cs
+++ b/src/Granit.Settings.EntityFrameworkCore/GranitSettingsDbProperties.cs
@@ -1,0 +1,22 @@
+namespace Granit.Settings.EntityFrameworkCore;
+
+/// <summary>
+/// Provides configurable table-naming properties for the Settings EF Core module.
+/// </summary>
+/// <remarks>
+/// <b>Important:</b> Set these properties at application startup, before
+/// <c>ConfigureServices</c> completes. EF Core caches the compiled model
+/// after first use — later mutations have no effect.
+/// </remarks>
+public static class GranitSettingsDbProperties
+{
+    /// <summary>
+    /// Table name prefix for all settings tables. Default: <c>"core_"</c>.
+    /// </summary>
+    public static string DbTablePrefix { get; set; } = "core_";
+
+    /// <summary>
+    /// Database schema for all settings tables. Default: <c>null</c> (provider default schema).
+    /// </summary>
+    public static string? DbSchema { get; set; }
+}

--- a/src/Granit.Settings.EntityFrameworkCore/Internal/SettingRecordConfiguration.cs
+++ b/src/Granit.Settings.EntityFrameworkCore/Internal/SettingRecordConfiguration.cs
@@ -13,7 +13,9 @@ internal sealed class SettingRecordConfiguration : IEntityTypeConfiguration<Sett
     /// <inheritdoc/>
     public void Configure(EntityTypeBuilder<SettingRecord> builder)
     {
-        builder.ToTable("core_setting_records");
+        builder.ToTable(
+            GranitSettingsDbProperties.DbTablePrefix + "setting_records",
+            GranitSettingsDbProperties.DbSchema);
 
         builder.HasKey(e => e.Id);
 
@@ -46,6 +48,6 @@ internal sealed class SettingRecordConfiguration : IEntityTypeConfiguration<Sett
         // Unique composite index: one record per (Name, ProviderName, ProviderKey)
         builder.HasIndex(e => new { e.Name, e.ProviderName, e.ProviderKey })
                .IsUnique()
-               .HasDatabaseName("uq_core_setting_records_name_provider");
+               .HasDatabaseName($"uq_{GranitSettingsDbProperties.DbTablePrefix}setting_records_name_provider");
     }
 }

--- a/src/Granit.Templating.EntityFrameworkCore/Extensions/TemplatingModelBuilderExtensions.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Extensions/TemplatingModelBuilderExtensions.cs
@@ -1,0 +1,23 @@
+using Granit.Templating.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Templating.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// <see cref="ModelBuilder"/> extensions for including Granit templating entity
+/// configurations in a host-owned <see cref="DbContext"/>.
+/// </summary>
+public static class TemplatingModelBuilderExtensions
+{
+    /// <summary>
+    /// Applies all entity configurations for the Granit Templating module.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder.</param>
+    /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
+    public static ModelBuilder ConfigureTemplatingModule(this ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new TemplateRevisionEntityConfiguration());
+        modelBuilder.ApplyConfiguration(new TemplateCategoryEntityConfiguration());
+        return modelBuilder;
+    }
+}

--- a/src/Granit.Templating.EntityFrameworkCore/GranitTemplatingDbProperties.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/GranitTemplatingDbProperties.cs
@@ -1,0 +1,22 @@
+namespace Granit.Templating.EntityFrameworkCore;
+
+/// <summary>
+/// Provides configurable table-naming properties for the Templating EF Core module.
+/// </summary>
+/// <remarks>
+/// <b>Important:</b> Set these properties at application startup, before
+/// <c>ConfigureServices</c> completes. EF Core caches the compiled model
+/// after first use — later mutations have no effect.
+/// </remarks>
+public static class GranitTemplatingDbProperties
+{
+    /// <summary>
+    /// Table name prefix for all templating tables. Default: <c>"templating_"</c>.
+    /// </summary>
+    public static string DbTablePrefix { get; set; } = "templating_";
+
+    /// <summary>
+    /// Database schema for all templating tables. Default: <c>null</c> (provider default schema).
+    /// </summary>
+    public static string? DbSchema { get; set; }
+}

--- a/src/Granit.Templating.EntityFrameworkCore/Internal/TemplateCategoryEntityConfiguration.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Internal/TemplateCategoryEntityConfiguration.cs
@@ -13,7 +13,9 @@ internal sealed class TemplateCategoryEntityConfiguration
     /// <inheritdoc/>
     public void Configure(EntityTypeBuilder<TemplateCategoryEntity> builder)
     {
-        builder.ToTable("templating_categories");
+        builder.ToTable(
+            GranitTemplatingDbProperties.DbTablePrefix + "categories",
+            GranitTemplatingDbProperties.DbSchema);
 
         builder.HasKey(e => e.Id);
 
@@ -40,10 +42,10 @@ internal sealed class TemplateCategoryEntityConfiguration
         // Unique constraint on Name for business rule enforcement.
         builder.HasIndex(e => e.Name)
             .IsUnique()
-            .HasDatabaseName("ix_templating_categories_name");
+            .HasDatabaseName($"uq_{GranitTemplatingDbProperties.DbTablePrefix}categories_name");
 
         // Sort index for default ordering (SortOrder, Name).
         builder.HasIndex(e => new { e.SortOrder, e.Name })
-            .HasDatabaseName("ix_templating_categories_sort");
+            .HasDatabaseName($"ix_{GranitTemplatingDbProperties.DbTablePrefix}categories_sort");
     }
 }

--- a/src/Granit.Templating.EntityFrameworkCore/Internal/TemplateRevisionEntityConfiguration.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Internal/TemplateRevisionEntityConfiguration.cs
@@ -14,7 +14,9 @@ internal sealed class TemplateRevisionEntityConfiguration
     /// <inheritdoc/>
     public void Configure(EntityTypeBuilder<TemplateRevisionEntity> builder)
     {
-        builder.ToTable("templating_revisions");
+        builder.ToTable(
+            GranitTemplatingDbProperties.DbTablePrefix + "revisions",
+            GranitTemplatingDbProperties.DbSchema);
 
         builder.HasKey(e => e.RevisionId);
 
@@ -59,11 +61,11 @@ internal sealed class TemplateRevisionEntityConfiguration
 
         // Composite index for lifecycle queries: find draft/published by (name, culture, status)
         builder.HasIndex(e => new { e.TemplateName, e.Culture, e.Status })
-            .HasDatabaseName("ix_templating_revisions_name_culture_status");
+            .HasDatabaseName($"ix_{GranitTemplatingDbProperties.DbTablePrefix}revisions_name_culture_status");
 
         // Index for history queries: all revisions for a given key
         builder.HasIndex(e => new { e.TemplateName, e.Culture })
-            .HasDatabaseName("ix_templating_revisions_name_culture");
+            .HasDatabaseName($"ix_{GranitTemplatingDbProperties.DbTablePrefix}revisions_name_culture");
 
         // Optional FK to template category.
         builder.Property(e => e.CategoryId);

--- a/src/Granit.Templating.EntityFrameworkCore/Internal/TemplatingDbContext.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Internal/TemplatingDbContext.cs
@@ -1,6 +1,7 @@
 using Granit.Core.DataFiltering;
 using Granit.Core.MultiTenancy;
 using Granit.Persistence.Extensions;
+using Granit.Templating.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Templating.EntityFrameworkCore.Internal;
@@ -28,8 +29,7 @@ internal sealed class TemplatingDbContext(
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
-        modelBuilder.ApplyConfiguration(new TemplateRevisionEntityConfiguration());
-        modelBuilder.ApplyConfiguration(new TemplateCategoryEntityConfiguration());
+        modelBuilder.ConfigureTemplatingModule();
         modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }
 }

--- a/src/Granit.Timeline.EntityFrameworkCore/Configurations/TimelineAttachmentConfiguration.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/Configurations/TimelineAttachmentConfiguration.cs
@@ -12,7 +12,9 @@ internal sealed class TimelineAttachmentConfiguration : IEntityTypeConfiguration
 {
     public void Configure(EntityTypeBuilder<TimelineAttachment> builder)
     {
-        builder.ToTable("timeline_attachments");
+        builder.ToTable(
+            GranitTimelineDbProperties.DbTablePrefix + "attachments",
+            GranitTimelineDbProperties.DbSchema);
         builder.HasKey(x => x.Id);
 
         builder.Property(x => x.FileName).HasMaxLength(512).IsRequired();
@@ -22,6 +24,6 @@ internal sealed class TimelineAttachmentConfiguration : IEntityTypeConfiguration
 
         // Lookup attachments for a given entry
         builder.HasIndex(x => x.EntryId)
-            .HasDatabaseName("ix_timeline_attachments_entry");
+            .HasDatabaseName($"ix_{GranitTimelineDbProperties.DbTablePrefix}attachments_entry");
     }
 }

--- a/src/Granit.Timeline.EntityFrameworkCore/Configurations/TimelineEntryConfiguration.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/Configurations/TimelineEntryConfiguration.cs
@@ -12,7 +12,9 @@ internal sealed class TimelineEntryConfiguration : IEntityTypeConfiguration<Time
 {
     public void Configure(EntityTypeBuilder<TimelineEntry> builder)
     {
-        builder.ToTable("timeline_entries");
+        builder.ToTable(
+            GranitTimelineDbProperties.DbTablePrefix + "entries",
+            GranitTimelineDbProperties.DbSchema);
         builder.HasKey(x => x.Id);
 
         builder.Property(x => x.EntityType).HasMaxLength(256).IsRequired();
@@ -27,10 +29,10 @@ internal sealed class TimelineEntryConfiguration : IEntityTypeConfiguration<Time
         // Primary stream query: all entries for an entity, newest first
         builder.HasIndex(x => new { x.EntityType, x.EntityId, x.TenantId, x.CreatedAt })
             .IsDescending(false, false, false, true)
-            .HasDatabaseName("ix_timeline_entries_entity_stream");
+            .HasDatabaseName($"ix_{GranitTimelineDbProperties.DbTablePrefix}entries_entity_stream");
 
         // Self-referencing for threaded replies (no navigation property)
         builder.HasIndex(x => x.ParentEntryId)
-            .HasDatabaseName("ix_timeline_entries_parent");
+            .HasDatabaseName($"ix_{GranitTimelineDbProperties.DbTablePrefix}entries_parent");
     }
 }

--- a/src/Granit.Timeline.EntityFrameworkCore/Extensions/TimelineModelBuilderExtensions.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/Extensions/TimelineModelBuilderExtensions.cs
@@ -1,0 +1,23 @@
+using Granit.Timeline.EntityFrameworkCore.Configurations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Timeline.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// <see cref="ModelBuilder"/> extensions for including Granit timeline entity
+/// configurations in a host-owned <see cref="DbContext"/>.
+/// </summary>
+public static class TimelineModelBuilderExtensions
+{
+    /// <summary>
+    /// Applies all entity configurations for the Granit Timeline module.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder.</param>
+    /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
+    public static ModelBuilder ConfigureTimelineModule(this ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new TimelineEntryConfiguration());
+        modelBuilder.ApplyConfiguration(new TimelineAttachmentConfiguration());
+        return modelBuilder;
+    }
+}

--- a/src/Granit.Timeline.EntityFrameworkCore/GranitTimelineDbProperties.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/GranitTimelineDbProperties.cs
@@ -1,0 +1,22 @@
+namespace Granit.Timeline.EntityFrameworkCore;
+
+/// <summary>
+/// Provides configurable table-naming properties for the Timeline EF Core module.
+/// </summary>
+/// <remarks>
+/// <b>Important:</b> Set these properties at application startup, before
+/// <c>ConfigureServices</c> completes. EF Core caches the compiled model
+/// after first use — later mutations have no effect.
+/// </remarks>
+public static class GranitTimelineDbProperties
+{
+    /// <summary>
+    /// Table name prefix for all timeline tables. Default: <c>"timeline_"</c>.
+    /// </summary>
+    public static string DbTablePrefix { get; set; } = "timeline_";
+
+    /// <summary>
+    /// Database schema for all timeline tables. Default: <c>null</c> (provider default schema).
+    /// </summary>
+    public static string? DbSchema { get; set; }
+}

--- a/src/Granit.Timeline.EntityFrameworkCore/Internal/TimelineDbContext.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/Internal/TimelineDbContext.cs
@@ -2,6 +2,7 @@ using Granit.Core.DataFiltering;
 using Granit.Core.MultiTenancy;
 using Granit.Persistence.Extensions;
 using Granit.Timeline.Domain;
+using Granit.Timeline.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Timeline.EntityFrameworkCore.Internal;
@@ -29,7 +30,7 @@ internal sealed class TimelineDbContext(
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
-        modelBuilder.ApplyConfigurationsFromAssembly(typeof(TimelineDbContext).Assembly);
+        modelBuilder.ConfigureTimelineModule();
         modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }
 }

--- a/src/Granit.Webhooks.EntityFrameworkCore/Configurations/WebhookDeliveryAttemptConfiguration.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Configurations/WebhookDeliveryAttemptConfiguration.cs
@@ -19,7 +19,9 @@ internal sealed class WebhookDeliveryAttemptConfiguration : IEntityTypeConfigura
     /// <inheritdoc/>
     public void Configure(EntityTypeBuilder<WebhookDeliveryAttempt> builder)
     {
-        builder.ToTable("webhook_delivery_attempts");
+        builder.ToTable(
+            GranitWebhooksDbProperties.DbTablePrefix + "delivery_attempts",
+            GranitWebhooksDbProperties.DbSchema);
 
         builder.HasKey(e => e.Id);
 
@@ -65,15 +67,15 @@ internal sealed class WebhookDeliveryAttemptConfiguration : IEntityTypeConfigura
 
         // Delivery lookup by subscription (e.g., history view).
         builder.HasIndex(e => new { e.SubscriptionId, e.OccurredAt })
-            .HasDatabaseName("ix_webhook_delivery_attempts_subscriptionid_occurredat");
+            .HasDatabaseName($"ix_{GranitWebhooksDbProperties.DbTablePrefix}delivery_attempts_subscriptionid_occurredat");
 
         // RGPD: enables bulk export and erasure by tenant.
         builder.HasIndex(e => new { e.TenantId, e.OccurredAt })
-            .HasDatabaseName("ix_webhook_delivery_attempts_tenantid_occurredat");
+            .HasDatabaseName($"ix_{GranitWebhooksDbProperties.DbTablePrefix}delivery_attempts_tenantid_occurredat");
 
         // Unique index on DeliveryId for deduplication.
         builder.HasIndex(e => e.DeliveryId)
             .IsUnique()
-            .HasDatabaseName("uq_webhook_delivery_attempts_deliveryid");
+            .HasDatabaseName($"uq_{GranitWebhooksDbProperties.DbTablePrefix}delivery_attempts_deliveryid");
     }
 }

--- a/src/Granit.Webhooks.EntityFrameworkCore/Configurations/WebhookSubscriptionConfiguration.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Configurations/WebhookSubscriptionConfiguration.cs
@@ -13,7 +13,9 @@ internal sealed class WebhookSubscriptionConfiguration : IEntityTypeConfiguratio
     /// <inheritdoc/>
     public void Configure(EntityTypeBuilder<WebhookSubscription> builder)
     {
-        builder.ToTable("webhook_subscriptions");
+        builder.ToTable(
+            GranitWebhooksDbProperties.DbTablePrefix + "subscriptions",
+            GranitWebhooksDbProperties.DbSchema);
 
         builder.HasKey(e => e.Id);
 
@@ -58,6 +60,6 @@ internal sealed class WebhookSubscriptionConfiguration : IEntityTypeConfiguratio
 
         // Hot path: fan-out query filters on (EventType, TenantId, Status).
         builder.HasIndex(e => new { e.EventType, e.TenantId, e.Status })
-            .HasDatabaseName("ix_webhook_subscriptions_eventtype_tenantid_status");
+            .HasDatabaseName($"ix_{GranitWebhooksDbProperties.DbTablePrefix}subscriptions_eventtype_tenantid_status");
     }
 }

--- a/src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksModelBuilderExtensions.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksModelBuilderExtensions.cs
@@ -1,0 +1,23 @@
+using Granit.Webhooks.EntityFrameworkCore.Configurations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Webhooks.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// <see cref="ModelBuilder"/> extensions for including Granit webhook entity
+/// configurations in a host-owned <see cref="DbContext"/>.
+/// </summary>
+public static class WebhooksModelBuilderExtensions
+{
+    /// <summary>
+    /// Applies all entity configurations for the Granit Webhooks module.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder.</param>
+    /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
+    public static ModelBuilder ConfigureWebhooksModule(this ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new WebhookSubscriptionConfiguration());
+        modelBuilder.ApplyConfiguration(new WebhookDeliveryAttemptConfiguration());
+        return modelBuilder;
+    }
+}

--- a/src/Granit.Webhooks.EntityFrameworkCore/GranitWebhooksDbProperties.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/GranitWebhooksDbProperties.cs
@@ -1,0 +1,30 @@
+namespace Granit.Webhooks.EntityFrameworkCore;
+
+/// <summary>
+/// Provides configurable table-naming properties for the Webhooks EF Core module.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These properties control the table prefix and schema used by all entity configurations
+/// in <c>Granit.Webhooks.EntityFrameworkCore</c>. Both the internal
+/// <c>WebhooksDbContext</c> and the host's <c>Configure*Module()</c> call read
+/// the same static values, ensuring migration-time and runtime SQL stay in sync.
+/// </para>
+/// <para>
+/// <b>Important:</b> Set these properties at application startup, before
+/// <c>ConfigureServices</c> completes. EF Core caches the compiled <see cref="Microsoft.EntityFrameworkCore.Metadata.IModel"/>
+/// after first use — later mutations have no effect.
+/// </para>
+/// </remarks>
+public static class GranitWebhooksDbProperties
+{
+    /// <summary>
+    /// Table name prefix for all webhook tables. Default: <c>"webhook_"</c>.
+    /// </summary>
+    public static string DbTablePrefix { get; set; } = "webhook_";
+
+    /// <summary>
+    /// Database schema for all webhook tables. Default: <c>null</c> (provider default schema).
+    /// </summary>
+    public static string? DbSchema { get; set; }
+}

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/WebhooksDbContext.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/WebhooksDbContext.cs
@@ -2,7 +2,7 @@ using Granit.Core.DataFiltering;
 using Granit.Core.MultiTenancy;
 using Granit.Persistence.Extensions;
 using Granit.Webhooks.Domain;
-using Granit.Webhooks.EntityFrameworkCore.Configurations;
+using Granit.Webhooks.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Webhooks.EntityFrameworkCore.Internal;
@@ -29,8 +29,7 @@ internal sealed class WebhooksDbContext(
     /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        modelBuilder.ApplyConfiguration(new WebhookSubscriptionConfiguration());
-        modelBuilder.ApplyConfiguration(new WebhookDeliveryAttemptConfiguration());
+        modelBuilder.ConfigureWebhooksModule();
         modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }
 }

--- a/src/Granit.Workflow.EntityFrameworkCore/Configurations/WorkflowTransitionRecordConfiguration.cs
+++ b/src/Granit.Workflow.EntityFrameworkCore/Configurations/WorkflowTransitionRecordConfiguration.cs
@@ -17,7 +17,9 @@ internal sealed class WorkflowTransitionRecordConfiguration
 {
     public void Configure(EntityTypeBuilder<WorkflowTransitionRecord> builder)
     {
-        builder.ToTable("workflow_transition_records");
+        builder.ToTable(
+            GranitWorkflowDbProperties.DbTablePrefix + "transition_records",
+            GranitWorkflowDbProperties.DbSchema);
 
         builder.HasKey(e => e.Id);
 
@@ -51,14 +53,14 @@ internal sealed class WorkflowTransitionRecordConfiguration
 
         // Hot path: query transition history for a specific entity
         builder.HasIndex(e => new { e.EntityType, e.EntityId, e.TransitionedAt })
-            .HasDatabaseName("ix_workflow_transition_records_entity_type_id_at");
+            .HasDatabaseName($"ix_{GranitWorkflowDbProperties.DbTablePrefix}transition_records_entity_type_id_at");
 
         // RGPD: enables bulk export and erasure by tenant
         builder.HasIndex(e => new { e.TenantId, e.TransitionedAt })
-            .HasDatabaseName("ix_workflow_transition_records_tenantid_at");
+            .HasDatabaseName($"ix_{GranitWorkflowDbProperties.DbTablePrefix}transition_records_tenantid_at");
 
         // Audit query: all transitions by a specific user
         builder.HasIndex(e => new { e.TransitionedBy, e.TransitionedAt })
-            .HasDatabaseName("ix_workflow_transition_records_by_user_at");
+            .HasDatabaseName($"ix_{GranitWorkflowDbProperties.DbTablePrefix}transition_records_by_user_at");
     }
 }

--- a/src/Granit.Workflow.EntityFrameworkCore/GranitWorkflowDbProperties.cs
+++ b/src/Granit.Workflow.EntityFrameworkCore/GranitWorkflowDbProperties.cs
@@ -1,0 +1,22 @@
+namespace Granit.Workflow.EntityFrameworkCore;
+
+/// <summary>
+/// Provides configurable table-naming properties for the Workflow EF Core module.
+/// </summary>
+/// <remarks>
+/// <b>Important:</b> Set these properties at application startup, before
+/// <c>ConfigureServices</c> completes. EF Core caches the compiled model
+/// after first use — later mutations have no effect.
+/// </remarks>
+public static class GranitWorkflowDbProperties
+{
+    /// <summary>
+    /// Table name prefix for all workflow tables. Default: <c>"workflow_"</c>.
+    /// </summary>
+    public static string DbTablePrefix { get; set; } = "workflow_";
+
+    /// <summary>
+    /// Database schema for all workflow tables. Default: <c>null</c> (provider default schema).
+    /// </summary>
+    public static string? DbSchema { get; set; }
+}

--- a/tests/Granit.Authorization.EntityFrameworkCore.Tests/TestDbContext.cs
+++ b/tests/Granit.Authorization.EntityFrameworkCore.Tests/TestDbContext.cs
@@ -15,5 +15,5 @@ internal sealed class TestDbContext(DbContextOptions<TestDbContext> options)
     public DbSet<PermissionGrant> PermissionGrants => Set<PermissionGrant>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder) =>
-        modelBuilder.ConfigurePermissionGrants();
+        modelBuilder.ConfigureAuthorizationModule();
 }

--- a/tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests/BackgroundJobsModelBuilderExtensionsTests.cs
+++ b/tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests/BackgroundJobsModelBuilderExtensionsTests.cs
@@ -1,0 +1,100 @@
+using Granit.BackgroundJobs.Domain;
+using Granit.BackgroundJobs.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BackgroundJobs.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// Tests for <see cref="BackgroundJobsModelBuilderExtensions.ConfigureBackgroundJobsModule"/>
+/// and <see cref="GranitBackgroundJobsDbProperties"/> — verifies that the host-owned
+/// migration extension produces the expected EF Core model.
+/// </summary>
+public sealed class BackgroundJobsModelBuilderExtensionsTests
+{
+    /// <summary>
+    /// Simulates a host-owned DbContext that calls <c>ConfigureBackgroundJobsModule()</c>.
+    /// </summary>
+    private sealed class HostDbContext(DbContextOptions<HostDbContext> options)
+        : DbContext(options)
+    {
+        public DbSet<BackgroundJobDefinition> Jobs { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.ConfigureBackgroundJobsModule();
+        }
+    }
+
+    private static IModel BuildModel()
+    {
+        DbContextOptions<HostDbContext> options =
+            new DbContextOptionsBuilder<HostDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+        using HostDbContext context = new(options);
+        return context.Model;
+    }
+
+    // =========================================================================
+    // Default DbProperties
+    // =========================================================================
+
+    [Fact]
+    public void ConfigureBackgroundJobsModule_MapsToDefaultTable()
+    {
+        IModel model = BuildModel();
+        IEntityType entity = model.FindEntityType(typeof(BackgroundJobDefinition))!;
+
+        entity.GetTableName().ShouldBe("scheduling_background_jobs");
+    }
+
+    [Fact]
+    public void ConfigureBackgroundJobsModule_HasPrimaryKeyOnId()
+    {
+        IModel model = BuildModel();
+        IEntityType entity = model.FindEntityType(typeof(BackgroundJobDefinition))!;
+
+        IKey pk = entity.FindPrimaryKey()!;
+        pk.Properties.ShouldContain(p => p.Name == nameof(BackgroundJobDefinition.Id));
+    }
+
+    [Fact]
+    public void ConfigureBackgroundJobsModule_HasUniqueIndexOnJobName()
+    {
+        IModel model = BuildModel();
+        IEntityType entity = model.FindEntityType(typeof(BackgroundJobDefinition))!;
+
+        IIndex? uniqueIndex = entity.GetIndexes()
+            .FirstOrDefault(i =>
+                i.IsUnique &&
+                i.Properties.Any(p => p.Name == nameof(BackgroundJobDefinition.JobName)));
+
+        uniqueIndex.ShouldNotBeNull("a unique index on JobName must be configured");
+    }
+
+    [Fact]
+    public void ConfigureBackgroundJobsModule_JobName_HasMaxLength200()
+    {
+        IModel model = BuildModel();
+        IEntityType entity = model.FindEntityType(typeof(BackgroundJobDefinition))!;
+
+        IProperty property = entity.FindProperty(nameof(BackgroundJobDefinition.JobName))!;
+
+        property.GetMaxLength().ShouldBe(200);
+        property.IsNullable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ConfigureBackgroundJobsModule_DefaultSchema_IsNull()
+    {
+        IModel model = BuildModel();
+        IEntityType entity = model.FindEntityType(typeof(BackgroundJobDefinition))!;
+
+        entity.GetSchema().ShouldBeNull();
+    }
+}

--- a/tests/Granit.Features.EntityFrameworkCore.Tests/GranitFeaturesDbContextTests.cs
+++ b/tests/Granit.Features.EntityFrameworkCore.Tests/GranitFeaturesDbContextTests.cs
@@ -41,7 +41,7 @@ public sealed class GranitFeaturesDbContextTests
             .FindEntityType(typeof(TenantFeatureOverride))!
             .GetTableName();
 
-        tableName.ShouldBe("saas_feature_overrides");
+        tableName.ShouldBe("feature_overrides");
     }
 
     [Fact]

--- a/tests/Granit.Features.EntityFrameworkCore.Tests/TenantFeatureOverrideConfigurationTests.cs
+++ b/tests/Granit.Features.EntityFrameworkCore.Tests/TenantFeatureOverrideConfigurationTests.cs
@@ -83,7 +83,7 @@ public sealed class TenantFeatureOverrideConfigurationTests
             i.Properties.Any(p => p.Name == nameof(TenantFeatureOverride.FeatureName)));
 
         index.ShouldNotBeNull();
-        index.GetDatabaseName().ShouldBe("uq_saas_feature_overrides_tenant_feature");
+        index.GetDatabaseName().ShouldBe("uq_feature_overrides_tenant_feature");
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Granit.Identity.EntityFrameworkCore.Tests/TestDbContext.cs
+++ b/tests/Granit.Identity.EntityFrameworkCore.Tests/TestDbContext.cs
@@ -14,5 +14,5 @@ internal sealed class TestDbContext(DbContextOptions<TestDbContext> options)
     public DbSet<UserCacheEntry> UserCacheEntries => Set<UserCacheEntry>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder) =>
-        modelBuilder.ConfigureIdentityUserCache();
+        modelBuilder.ConfigureIdentityModule();
 }

--- a/tests/Granit.Notifications.Email.AwsSes.Tests/GranitNotificationsEmailAwsSesModuleTests.cs
+++ b/tests/Granit.Notifications.Email.AwsSes.Tests/GranitNotificationsEmailAwsSesModuleTests.cs
@@ -14,8 +14,8 @@ public sealed class GranitNotificationsEmailAwsSesModuleTests
         typeof(GranitNotificationsEmailAwsSesModule).IsAssignableTo(typeof(GranitModule)).ShouldBeTrue();
 
     [Fact]
-    public void IsNotSealed() =>
-        typeof(GranitNotificationsEmailAwsSesModule).IsSealed.ShouldBeFalse();
+    public void IsSealed() =>
+        typeof(GranitNotificationsEmailAwsSesModule).IsSealed.ShouldBeTrue();
 
     [Fact]
     public void ConfigureServices_RegistersKeyedEmailSender()


### PR DESCRIPTION
## Summary

- Every `*.EntityFrameworkCore` module now exposes `Configure{Module}Module()` on `ModelBuilder` and `Granit{Module}DbProperties` for configurable table prefix/schema
- Internal DbContexts call `Configure*Module()` instead of applying configurations directly — single source of truth between migration-time and runtime EF models
- Renamed `ConfigurePermissionGrants()` → `ConfigureAuthorizationModule()`, `ConfigureIdentityUserCache()` → `ConfigureIdentityModule()`
- Normalized table prefixes: `ApiKeys` → `auth_api_keys`, `saas_` → `feature_`, `security_` → `auth_`, `storage_` → `blob_storage_`, `i18n_` → `localization_`
- Split `persistence.mdx` into 4 focused pages: persistence overview, interceptors, query filters, migrations
- Added host-owned migration strategy documentation with EF Core CLI reference

## Motivation

Host applications (e.g., guava-backend) could not generate EF Core migrations for Granit module tables because 14 of 20 modules had internal-only entity configurations. This caused runtime crashes (`42P01: relation does not exist`) when tables were never created.

Closes #364, #365, #366, #367, #368

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] All 531 EF Core tests pass (21 test projects)
- [x] Architecture tests pass
- [x] Markdownlint passes (only pre-existing MD033/MD060 for Astro components)
- [ ] Verify in guava-backend: add `Configure*Module()` calls to host DbContext and generate migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
