### PR TITLE
fix(persistence): guard EnsureProgressTableAsync against non-relational providers

### DIFF
--- a/src/Granit.Persistence.Migrations/Internal/MigrationStartupService.cs
+++ b/src/Granit.Persistence.Migrations/Internal/MigrationStartupService.cs
@@ -132,6 +132,12 @@ internal sealed partial class MigrationStartupService(
     /// </remarks>
     private static async Task EnsureProgressTableAsync(MigrationProgressDbContext db, CancellationToken ct)
     {
+        if (!db.Database.IsRelational())
+        {
+            // Non-relational providers (e.g. InMemory) don't need table creation.
+            return;
+        }
+
         IRelationalDatabaseCreator creator = db.GetService<IRelationalDatabaseCreator>();
 
         if (!await creator.HasTablesAsync(ct).ConfigureAwait(false))


### PR DESCRIPTION
## Summary

- `EnsureProgressTableAsync` called `GetService<IRelationalDatabaseCreator>()` which throws with non-relational providers (InMemory), causing `ResumeAsync` to silently abort before dispatching any migration batch commands.
- Added an early `db.Database.IsRelational()` guard to skip table creation for non-relational providers.
- Fixes 4 failing `MigrationStartupServiceTests` introduced by #404.

## Test plan

- [x] `dotnet test tests/Granit.Persistence.Migrations.Tests` — 41/41 pass (was 37 pass, 4 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)