### PR TITLE
feat(core): DDD Phase 4 — strict architecture tests, TimelineEntry migration, CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,34 @@ Every isolated `DbContext` MUST:
 
 Reference: [`docs/framework/data/persistence.md`](docs/framework/data/persistence.md)
 
+### DDD — Aggregate Root vs Entity
+
+Use `AggregateRoot` (or audited variants) when the entity has a state machine, raises
+domain events, or encapsulates invariants. Use plain `Entity` for append-only records,
+configuration, caches, or lookup tables.
+
+**Aggregate Root rules (enforced by `DomainConventionTests`):**
+
+- **Private setters**: all properties `{ get; private set; }`. Use behavior methods for
+  state transitions (e.g., `MarkAsValid()`, `Revoke()`)
+- **Factory method**: `public static Xxx Create(...)` — the only way to construct
+- **Private EF Core constructor**: keep `private Xxx() { }` for materialization
+- **Explicit interface for `IMultiTenant`**: when `TenantId` has `private set`, add
+  explicit `Guid? IMultiTenant.TenantId { get; set; }` for interceptor injection
+- **Domain events via base class**: use `AddDomainEvent()` / `AddDistributedEvent()` —
+  NEVER manually implement `IDomainEventSource`
+- **No public setters on aggregate roots** — architecture test enforces this
+
+**Value Objects (`SingleValueObject<T>`):**
+
+- Inherit from `SingleValueObject<T>` for single-primitive wrappers
+- Must be `sealed` with `init` properties
+- Provide `Create()` factory with validation + implicit operators for backward compat
+- EF Core converters auto-applied by `ApplyGranitConventions` (no migration needed)
+- JSON serialization handled by `SingleValueObjectJsonConverterFactory`
+
+Reference: [ADR-017](docs-site/src/content/docs/dotnet/architecture/adr/017-ddd-aggregate-value-object-strategy.md)
+
 ### Multi-tenancy — soft dependency
 
 `ICurrentTenant` lives in `Granit.Core.MultiTenancy` — available everywhere without referencing `Granit.MultiTenancy`.
@@ -217,6 +245,9 @@ Each package has `*.Tests` project (xUnit + Shouldly + NSubstitute + Bogus). Par
 - Traditional constructors with only field assignments → primary constructors
 - Unnamed `HasQueryFilter(expr)` → named `HasQueryFilter(name, expr)` (EF Core 10)
 - Swashbuckle / NSwag → `Microsoft.AspNetCore.OpenApi` + Scalar UI
+- Public setters on aggregate roots → `private set` + behavior methods
+- Manual `IDomainEventSource` implementation → inherit from `AggregateRoot` (or variants)
+- `new XxxEntity { ... }` on aggregate roots → `XxxEntity.Create(...)` factory method
 
 ### Architecture
 

--- a/src/Granit.BackgroundJobs/Granit.BackgroundJobs.csproj
+++ b/src/Granit.BackgroundJobs/Granit.BackgroundJobs.csproj
@@ -12,6 +12,7 @@
     <InternalsVisibleTo Include="Granit.BackgroundJobs.Wolverine" />
     <InternalsVisibleTo Include="Granit.BackgroundJobs.EntityFrameworkCore" />
     <InternalsVisibleTo Include="Granit.BackgroundJobs.EntityFrameworkCore.Tests" />
+    <InternalsVisibleTo Include="Granit.BackgroundJobs.Wolverine.Tests" />
     <!-- Required by NSubstitute (Castle.DynamicProxy) to mock internal interfaces in tests -->
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>

--- a/src/Granit.Timeline/Domain/TimelineEntry.cs
+++ b/src/Granit.Timeline/Domain/TimelineEntry.cs
@@ -1,5 +1,4 @@
 using Granit.Core.Domain;
-using Granit.Core.Events;
 using Granit.Timeline.Events;
 
 namespace Granit.Timeline.Domain;
@@ -13,59 +12,111 @@ namespace Granit.Timeline.Domain;
 ///   <item><see cref="TimelineEntryType.SystemLog"/> — auto-generated, INSERT-only immutable (ISO 27001).</item>
 /// </list>
 /// </summary>
-public sealed class TimelineEntry : CreationAuditedEntity, ISoftDeletable, IMultiTenant, IDomainEventSource
+public sealed class TimelineEntry : CreationAuditedAggregateRoot, ISoftDeletable, IMultiTenant
 {
-    private readonly List<IDomainEvent> _domainEvents = [];
+    // Parameterless constructor required by EF Core materializer.
+    private TimelineEntry() { }
+
+    /// <summary>
+    /// Creates a new <see cref="TimelineEntry"/>.
+    /// </summary>
+    public static TimelineEntry Create(
+        Guid id,
+        string entityType,
+        string entityId,
+        TimelineEntryType entryType,
+        string body,
+        string authorId,
+        string authorName,
+        DateTimeOffset createdAt,
+        string createdBy,
+        Guid? tenantId = null,
+        Guid? parentEntryId = null) => new()
+        {
+            Id = id,
+            EntityType = entityType,
+            EntityId = entityId,
+            EntryType = entryType,
+            Body = body,
+            AuthorId = authorId,
+            AuthorName = authorName,
+            ParentEntryId = parentEntryId,
+            CreatedAt = createdAt,
+            CreatedBy = createdBy,
+            TenantId = tenantId,
+        };
 
     /// <summary>Entity type name (e.g. "Patient", "Invoice").</summary>
-    public string EntityType { get; set; } = string.Empty;
+    public string EntityType { get; private set; } = string.Empty;
 
     /// <summary>Entity identifier as string (polymorphic reference).</summary>
-    public string EntityId { get; set; } = string.Empty;
+    public string EntityId { get; private set; } = string.Empty;
 
     /// <summary>Type of entry (comment, system log, or internal note).</summary>
-    public TimelineEntryType EntryType { get; set; }
+    public TimelineEntryType EntryType { get; private set; }
 
     /// <summary>
     /// Entry body. Markdown for <see cref="TimelineEntryType.Comment"/> and
     /// <see cref="TimelineEntryType.InternalNote"/>, structured JSON for
     /// <see cref="TimelineEntryType.SystemLog"/>.
     /// </summary>
-    public string Body { get; set; } = string.Empty;
+    public string Body { get; private set; } = string.Empty;
 
     /// <summary>User ID of the author (denormalized for display performance).</summary>
-    public string AuthorId { get; set; } = string.Empty;
+    public string AuthorId { get; private set; } = string.Empty;
 
     /// <summary>Display name of the author at the time of posting (denormalized).</summary>
-    public string AuthorName { get; set; } = string.Empty;
+    public string AuthorName { get; private set; } = string.Empty;
 
     /// <summary>Optional parent entry ID for threaded replies.</summary>
-    public Guid? ParentEntryId { get; set; }
+    public Guid? ParentEntryId { get; private set; }
 
     /// <inheritdoc/>
-    public Guid? TenantId { get; set; }
+    public Guid? TenantId { get; private set; }
 
     /// <inheritdoc/>
-    public bool IsDeleted { get; set; }
+    Guid? IMultiTenant.TenantId
+    {
+        get => TenantId;
+        set => TenantId = value;
+    }
 
     /// <inheritdoc/>
-    public DateTimeOffset? DeletedAt { get; set; }
+    public bool IsDeleted { get; private set; }
 
     /// <inheritdoc/>
-    public string? DeletedBy { get; set; }
+    public DateTimeOffset? DeletedAt { get; private set; }
 
-    /// <inheritdoc />
-    public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+    /// <inheritdoc/>
+    public string? DeletedBy { get; private set; }
 
-    /// <inheritdoc />
-    public void ClearDomainEvents() => _domainEvents.Clear();
+    /// <inheritdoc/>
+    bool ISoftDeletable.IsDeleted
+    {
+        get => IsDeleted;
+        set => IsDeleted = value;
+    }
+
+    /// <inheritdoc/>
+    DateTimeOffset? ISoftDeletable.DeletedAt
+    {
+        get => DeletedAt;
+        set => DeletedAt = value;
+    }
+
+    /// <inheritdoc/>
+    string? ISoftDeletable.DeletedBy
+    {
+        get => DeletedBy;
+        set => DeletedBy = value;
+    }
 
     /// <summary>
     /// Raises a <see cref="TimelineEntryPosted"/> domain event.
     /// Called by the store after the entry is fully initialized.
     /// </summary>
     internal void RaisePostedEvent() =>
-        _domainEvents.Add(new TimelineEntryPosted(Id, EntityType, EntityId, EntryType, AuthorId));
+        AddDomainEvent(new TimelineEntryPosted(Id, EntityType, EntityId, EntryType, AuthorId));
 
     /// <summary>
     /// Marks this entry as soft-deleted and raises a <see cref="TimelineEntrySoftDeleted"/> domain event.
@@ -81,6 +132,6 @@ public sealed class TimelineEntry : CreationAuditedEntity, ISoftDeletable, IMult
         IsDeleted = true;
         DeletedAt = deletedAt;
         DeletedBy = deletedBy;
-        _domainEvents.Add(new TimelineEntrySoftDeleted(Id, EntityType, EntityId));
+        AddDomainEvent(new TimelineEntrySoftDeleted(Id, EntityType, EntityId));
     }
 }

--- a/src/Granit.Timeline/Internal/TimelineEntityFactory.cs
+++ b/src/Granit.Timeline/Internal/TimelineEntityFactory.cs
@@ -28,20 +28,18 @@ internal static class TimelineEntityFactory
         string body,
         Guid? parentEntryId,
         AuditContext context) =>
-        new()
-        {
-            Id = context.GuidGenerator.Create(),
-            EntityType = entityType,
-            EntityId = entityId,
-            EntryType = entryType,
-            Body = body,
-            AuthorId = context.CurrentUser.UserId ?? string.Empty,
-            AuthorName = context.CurrentUser.UserName ?? string.Empty,
-            ParentEntryId = parentEntryId,
-            CreatedAt = context.Clock.Now,
-            CreatedBy = context.CurrentUser.UserId ?? string.Empty,
-            TenantId = context.CurrentTenant.IsAvailable ? context.CurrentTenant.Id : null,
-        };
+        TimelineEntry.Create(
+            context.GuidGenerator.Create(),
+            entityType,
+            entityId,
+            entryType,
+            body,
+            context.CurrentUser.UserId ?? string.Empty,
+            context.CurrentUser.UserName ?? string.Empty,
+            context.Clock.Now,
+            context.CurrentUser.UserId ?? string.Empty,
+            context.CurrentTenant.IsAvailable ? context.CurrentTenant.Id : null,
+            parentEntryId);
 
     internal static TimelineAttachment CreateAttachment(
         Guid entryId,

--- a/tests/Granit.ArchitectureTests.Abstractions/Rules/DomainConventionRules.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions/Rules/DomainConventionRules.cs
@@ -101,19 +101,13 @@ public static class DomainConventionRules
                 && !c.IsAbstract.GetValueOrDefault()
                 && IsAssignableToAggregateRoot(c)))
         {
-            // Check for public setters via ArchUnitNET member access.
             // set_ methods with Public visibility indicate mutable public properties.
-            IEnumerable<IMember> publicSetters = c.Members
+            // Exclude explicit interface implementations (contain '.' in name).
+            violations.AddRange(c.Members
                 .Where(m => m.Name.StartsWith("set_", StringComparison.Ordinal)
                     && m.Visibility == Visibility.Public
-                    // Exclude explicit interface implementations (contain '.' in name)
-                    && !m.Name.Contains('.'));
-
-            foreach (IMember setter in publicSetters)
-            {
-                string propertyName = setter.Name["set_".Length..];
-                violations.Add($"{c.Name}.{propertyName}");
-            }
+                    && !m.Name.Contains('.'))
+                .Select(m => $"{c.Name}.{m.Name["set_".Length..]}"));
         }
 
         violations.ShouldBeEmpty(

--- a/tests/Granit.ArchitectureTests.Abstractions/Rules/DomainConventionRules.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions/Rules/DomainConventionRules.cs
@@ -86,6 +86,42 @@ public static class DomainConventionRules
             $"Violators: {string.Join(", ", violations.Select(c => c.FullName))}");
     }
 
+    /// <summary>
+    /// Aggregate root subclasses must not have public mutable properties (except explicit
+    /// interface implementations like <c>IMultiTenant.TenantId</c> or <c>ISoftDeletable</c>).
+    /// </summary>
+    public static void AggregateRootsShouldNotHavePublicSetters(
+        Architecture architecture,
+        string typePrefix)
+    {
+        List<string> violations = [];
+
+        foreach (Class c in architecture.Classes
+            .Where(c => c.FullName.StartsWith(typePrefix, StringComparison.Ordinal)
+                && !c.IsAbstract.GetValueOrDefault()
+                && IsAssignableToAggregateRoot(c)))
+        {
+            // Check for public setters via ArchUnitNET member access.
+            // set_ methods with Public visibility indicate mutable public properties.
+            IEnumerable<IMember> publicSetters = c.Members
+                .Where(m => m.Name.StartsWith("set_", StringComparison.Ordinal)
+                    && m.Visibility == Visibility.Public
+                    // Exclude explicit interface implementations (contain '.' in name)
+                    && !m.Name.Contains('.'));
+
+            foreach (IMember setter in publicSetters)
+            {
+                string propertyName = setter.Name["set_".Length..];
+                violations.Add($"{c.Name}.{propertyName}");
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Aggregate root properties must use private setters. " +
+            "Use behavior methods for state transitions. " +
+            $"Violators: {string.Join(", ", violations)}");
+    }
+
     private static bool IsAssignableToValueObject(Class c) =>
         HasBaseClass(c, "Granit.Core.Domain.ValueObject");
 

--- a/tests/Granit.ArchitectureTests/DomainConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/DomainConventionTests.cs
@@ -20,26 +20,19 @@ public sealed class DomainConventionTests
     public void Domain_entities_should_not_be_in_Internal_namespaces() =>
         DomainConventionRules.DomainEntitiesShouldNotBeInternal(Architecture, "Granit.");
 
-    /// <summary>
-    /// Types that manually implement <c>IDomainEventSource</c> instead of inheriting from
-    /// an aggregate root base class. These are migration candidates.
-    /// </summary>
-    /// <remarks>
-    /// Allowlist will shrink as entities are migrated to aggregate roots (Phases 1-3).
-    /// </remarks>
     [Fact]
-    public void Manual_IDomainEventSource_implementors_should_use_aggregate_root_bases()
-    {
-        // Allowlist: entities not yet migrated to aggregate root bases.
-        // Remove entries as they are migrated (Phases 1-3 of the DDD improvement plan).
-        string[] allowlist =
-        [
-            "Granit.Timeline.Domain.TimelineEntry",
-        ];
+    public void Aggregate_roots_should_not_have_public_setters() =>
+        DomainConventionRules.AggregateRootsShouldNotHavePublicSetters(Architecture, "Granit.");
 
+    /// <summary>
+    /// No type should manually implement <c>IDomainEventSource</c> — use aggregate root base classes instead.
+    /// </summary>
+    [Fact]
+    public void No_manual_IDomainEventSource_implementors()
+    {
         IReadOnlyList<string> violators =
             DomainConventionRules.FindManualDomainEventSourceImplementors(
-                Architecture, "Granit.", allowlist);
+                Architecture, "Granit.");
 
         violators.ShouldBeEmpty(
             "Types should inherit from AggregateRoot (or audited variants) instead of manually " +

--- a/tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests/BackgroundJobsDbContextTests.cs
+++ b/tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests/BackgroundJobsDbContextTests.cs
@@ -139,19 +139,13 @@ public sealed class BackgroundJobsDbContextTests
     {
         await using BackgroundJobsDbContext ctx = CreateInMemory();
 
-        BackgroundJobDefinition job = new()
-        {
-            Id = Guid.NewGuid(),
-            JobName = "daily-report",
-            MessageType = "My.App.DailyReportMessage, My.App",
-            CronExpression = "0 8 * * *",
-            IsEnabled = true,
-            LastExecutedAt = new DateTimeOffset(2026, 1, 15, 8, 0, 0, TimeSpan.Zero),
-            NextExecutionAt = new DateTimeOffset(2026, 1, 16, 8, 0, 0, TimeSpan.Zero),
-            ConsecutiveFailureCount = 2,
-            LastErrorMessage = "Timeout after 30s",
-            TriggeredBy = "admin-user",
-        };
+        var job = BackgroundJobDefinition.Create(
+            Guid.NewGuid(), "daily-report", "0 8 * * *", "My.App.DailyReportMessage, My.App");
+        job.RecordExecutionStart(new DateTimeOffset(2026, 1, 15, 8, 0, 0, TimeSpan.Zero));
+        job.ScheduleNext(new DateTimeOffset(2026, 1, 16, 8, 0, 0, TimeSpan.Zero));
+        job.RecordFailure("Timeout after 30s");
+        job.RecordFailure("Timeout after 30s");
+        job.SetTriggeredBy("admin-user");
 
         ctx.Jobs.Add(job);
         await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);

--- a/tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests/EfBackgroundJobStoreTests.cs
+++ b/tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests/EfBackgroundJobStoreTests.cs
@@ -1,26 +1,38 @@
+using System.Data.Common;
 using Granit.BackgroundJobs.Domain;
 using Granit.BackgroundJobs.EntityFrameworkCore.Internal;
 using Granit.BackgroundJobs.Internal;
 using Granit.Guids;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Shouldly;
 using Xunit;
 
 namespace Granit.BackgroundJobs.EntityFrameworkCore.Tests;
 
-public sealed class EfBackgroundJobStoreTests
+public sealed class EfBackgroundJobStoreTests : IDisposable
 {
     // =========================================================================
-    // Test infrastructure
+    // Test infrastructure — SQLite in-memory (supports ExecuteUpdateAsync)
     // =========================================================================
 
-    private sealed class InMemoryContextFactory(string dbName) : IDbContextFactory<BackgroundJobsDbContext>
+    private readonly SqliteConnection _connection;
+
+    public EfBackgroundJobStoreTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private sealed class SqliteContextFactory(DbConnection connection) : IDbContextFactory<BackgroundJobsDbContext>
     {
         public BackgroundJobsDbContext CreateDbContext()
         {
             DbContextOptions<BackgroundJobsDbContext> options =
                 new DbContextOptionsBuilder<BackgroundJobsDbContext>()
-                    .UseInMemoryDatabase(dbName)
+                    .UseSqlite(connection)
                     .Options;
             return new BackgroundJobsDbContext(options);
         }
@@ -29,8 +41,14 @@ public sealed class EfBackgroundJobStoreTests
             Task.FromResult(CreateDbContext());
     }
 
-    private static EfBackgroundJobStore CreateStore(string dbName) =>
-        new(new InMemoryContextFactory(dbName), new SimpleGuidGenerator());
+    private EfBackgroundJobStore CreateStore()
+    {
+        var factory = new SqliteContextFactory(_connection);
+        using BackgroundJobsDbContext ctx = factory.CreateDbContext();
+        ctx.Database.EnsureDeleted();
+        ctx.Database.EnsureCreated();
+        return new EfBackgroundJobStore(factory, new SimpleGuidGenerator());
+    }
 
     private static RecurringJobRegistration MakeRegistration(
         string jobName = "test-job",
@@ -38,12 +56,11 @@ public sealed class EfBackgroundJobStoreTests
         string messageType = "My.App.TestMessage, My.App") =>
         new(jobName, cron, messageType);
 
-    private static async Task<EfBackgroundJobStore> SeedAsync(
-        string dbName,
+    private async Task<EfBackgroundJobStore> SeedAsync(
         string jobName = "test-job",
         CancellationToken cancellationToken = default)
     {
-        EfBackgroundJobStore store = CreateStore(dbName);
+        EfBackgroundJobStore store = CreateStore();
         await store.SeedJobsAsync([MakeRegistration(jobName)], cancellationToken);
         return store;
     }
@@ -55,7 +72,7 @@ public sealed class EfBackgroundJobStoreTests
     [Fact]
     public async Task FindAsync_UnknownJob_ReturnsNull()
     {
-        EfBackgroundJobStore store = CreateStore(Guid.NewGuid().ToString());
+        EfBackgroundJobStore store = CreateStore();
 
         BackgroundJobDefinition? result = await store.FindAsync(
             "non-existent", TestContext.Current.CancellationToken);
@@ -66,8 +83,7 @@ public sealed class EfBackgroundJobStoreTests
     [Fact]
     public async Task FindAsync_KnownJob_ReturnsDefinition()
     {
-        string db = Guid.NewGuid().ToString();
-        EfBackgroundJobStore store = await SeedAsync(db, cancellationToken: TestContext.Current.CancellationToken);
+        EfBackgroundJobStore store = await SeedAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         BackgroundJobDefinition? result = await store.FindAsync(
             "test-job", TestContext.Current.CancellationToken);
@@ -83,8 +99,7 @@ public sealed class EfBackgroundJobStoreTests
     [Fact]
     public async Task SeedJobsAsync_NewJob_IsInsertedWithDefaultsEnabled()
     {
-        string db = Guid.NewGuid().ToString();
-        EfBackgroundJobStore store = CreateStore(db);
+        EfBackgroundJobStore store = CreateStore();
 
         await store.SeedJobsAsync([MakeRegistration()], TestContext.Current.CancellationToken);
 
@@ -98,8 +113,7 @@ public sealed class EfBackgroundJobStoreTests
     [Fact]
     public async Task SeedJobsAsync_ExistingJob_PreservesAdminStateAndUpdatesCron()
     {
-        string db = Guid.NewGuid().ToString();
-        EfBackgroundJobStore store = await SeedAsync(db, cancellationToken: TestContext.Current.CancellationToken);
+        EfBackgroundJobStore store = await SeedAsync(cancellationToken: TestContext.Current.CancellationToken);
         await store.SetEnabledAsync("test-job", false, TestContext.Current.CancellationToken);
 
         await store.SeedJobsAsync(
@@ -114,8 +128,7 @@ public sealed class EfBackgroundJobStoreTests
     [Fact]
     public async Task SeedJobsAsync_CalledTwice_IsIdempotent()
     {
-        string db = Guid.NewGuid().ToString();
-        EfBackgroundJobStore store = CreateStore(db);
+        EfBackgroundJobStore store = CreateStore();
 
         await store.SeedJobsAsync([MakeRegistration()], TestContext.Current.CancellationToken);
         await store.SeedJobsAsync([MakeRegistration()], TestContext.Current.CancellationToken);
@@ -132,8 +145,7 @@ public sealed class EfBackgroundJobStoreTests
     [Fact]
     public async Task SetEnabledAsync_ToFalse_PersistsValue()
     {
-        string db = Guid.NewGuid().ToString();
-        EfBackgroundJobStore store = await SeedAsync(db, cancellationToken: TestContext.Current.CancellationToken);
+        EfBackgroundJobStore store = await SeedAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         await store.SetEnabledAsync("test-job", false, TestContext.Current.CancellationToken);
 
@@ -145,7 +157,7 @@ public sealed class EfBackgroundJobStoreTests
     [Fact]
     public async Task SetEnabledAsync_UnknownJob_DoesNotThrow()
     {
-        EfBackgroundJobStore store = CreateStore(Guid.NewGuid().ToString());
+        EfBackgroundJobStore store = CreateStore();
 
         Func<Task> act = () => store.SetEnabledAsync(
             "ghost", false, TestContext.Current.CancellationToken);
@@ -160,8 +172,7 @@ public sealed class EfBackgroundJobStoreTests
     [Fact]
     public async Task RecordExecutionStartAsync_ResetsCountersAndSetsTimestamp()
     {
-        string db = Guid.NewGuid().ToString();
-        EfBackgroundJobStore store = await SeedAsync(db, cancellationToken: TestContext.Current.CancellationToken);
+        EfBackgroundJobStore store = await SeedAsync(cancellationToken: TestContext.Current.CancellationToken);
         await store.RecordExecutionFailureAsync(
             "test-job", "previous error", TestContext.Current.CancellationToken);
 
@@ -184,8 +195,7 @@ public sealed class EfBackgroundJobStoreTests
     [Fact]
     public async Task RecordNextExecutionAsync_PersistsNextOccurrence()
     {
-        string db = Guid.NewGuid().ToString();
-        EfBackgroundJobStore store = await SeedAsync(db, cancellationToken: TestContext.Current.CancellationToken);
+        EfBackgroundJobStore store = await SeedAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         DateTimeOffset next = new(2026, 2, 21, 8, 0, 0, TimeSpan.Zero);
         await store.RecordNextExecutionAsync(
@@ -203,8 +213,7 @@ public sealed class EfBackgroundJobStoreTests
     [Fact]
     public async Task RecordExecutionFailureAsync_IncrementsCounterAndStoresMessage()
     {
-        string db = Guid.NewGuid().ToString();
-        EfBackgroundJobStore store = await SeedAsync(db, cancellationToken: TestContext.Current.CancellationToken);
+        EfBackgroundJobStore store = await SeedAsync(cancellationToken: TestContext.Current.CancellationToken);
         await store.RecordExecutionFailureAsync(
             "test-job", "first error", TestContext.Current.CancellationToken);
 
@@ -220,7 +229,7 @@ public sealed class EfBackgroundJobStoreTests
     [Fact]
     public async Task RecordExecutionFailureAsync_UnknownJob_DoesNotThrow()
     {
-        EfBackgroundJobStore store = CreateStore(Guid.NewGuid().ToString());
+        EfBackgroundJobStore store = CreateStore();
 
         Func<Task> act = () => store.RecordExecutionFailureAsync(
             "ghost", "err", TestContext.Current.CancellationToken);
@@ -235,8 +244,7 @@ public sealed class EfBackgroundJobStoreTests
     [Fact]
     public async Task GetEnabledJobsAsync_ReturnsOnlyEnabledJobs()
     {
-        string db = Guid.NewGuid().ToString();
-        EfBackgroundJobStore store = CreateStore(db);
+        EfBackgroundJobStore store = CreateStore();
         await store.SeedJobsAsync(
             [MakeRegistration("job-a"), MakeRegistration("job-b")],
             TestContext.Current.CancellationToken);
@@ -252,8 +260,7 @@ public sealed class EfBackgroundJobStoreTests
     [Fact]
     public async Task GetAllJobsAsync_ReturnsAllJobsRegardlessOfEnabled()
     {
-        string db = Guid.NewGuid().ToString();
-        EfBackgroundJobStore store = CreateStore(db);
+        EfBackgroundJobStore store = CreateStore();
         await store.SeedJobsAsync(
             [MakeRegistration("job-a"), MakeRegistration("job-b")],
             TestContext.Current.CancellationToken);
@@ -272,8 +279,7 @@ public sealed class EfBackgroundJobStoreTests
     [Fact]
     public async Task SetTriggeredByAsync_PersistsOperatorId()
     {
-        string db = Guid.NewGuid().ToString();
-        EfBackgroundJobStore store = await SeedAsync(db, cancellationToken: TestContext.Current.CancellationToken);
+        EfBackgroundJobStore store = await SeedAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         await store.SetTriggeredByAsync(
             "test-job", "operator-42", TestContext.Current.CancellationToken);
@@ -286,8 +292,7 @@ public sealed class EfBackgroundJobStoreTests
     [Fact]
     public async Task SetTriggeredByAsync_Null_ClearsField()
     {
-        string db = Guid.NewGuid().ToString();
-        EfBackgroundJobStore store = await SeedAsync(db, cancellationToken: TestContext.Current.CancellationToken);
+        EfBackgroundJobStore store = await SeedAsync(cancellationToken: TestContext.Current.CancellationToken);
         await store.SetTriggeredByAsync(
             "test-job", "operator-42", TestContext.Current.CancellationToken);
 

--- a/tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests.csproj
+++ b/tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 

--- a/tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.BackgroundJobs.EntityFrameworkCore.Tests/packages.lock.json
@@ -31,6 +31,21 @@
           "Microsoft.Extensions.Logging": "10.0.5"
         }
       },
+      "Microsoft.EntityFrameworkCore.Sqlite": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "lxeRviglTkkmzYJVJ600yb6gJjnf5za9v7uH+0byuSXTGv7U8cT6hz7qRTmiGSOfLcl86QFdy2BBKaUFd6NQug==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.5",
+          "Microsoft.Extensions.Caching.Memory": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyModel": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
@@ -95,6 +110,14 @@
         "resolved": "18.3.0",
         "contentHash": "23BNy/vziREC20Wwhb50K7+kZe0m07KlLWDQv4qjJ9tt3QjpDpDIqJFrhYHmMEo9xDkuSp55U/8h4bMF7MiB+g=="
       },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "jFYXnh7s0RShCw6Vkf+ReGCw+mVi7ISg1YaEzYCJcXnUifmbW+aqvCsRJuSRj2ZuQ+oqetpjxlZtbpMmk5FKqQ==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.5",
@@ -104,6 +127,20 @@
         "type": "Transitive",
         "resolved": "10.0.5",
         "contentHash": "ipC4u1VojgEfoIZhtbS2Sx5IluJTP/Jf1hz3yGsxGBgSukYY/CquI6rAjxn5H58CZgVn36qcuPPtNMwZ0AUzMg=="
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "rVH43bcUyZiMn0SnCpVnvFpl4PFxT4GwmuVVLcT4JL0NtzuHY9ymKV+Llb5cjuJ+6+gEl4eixy2rE8nxOPcBSA==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "10.0.5",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.5",
+          "Microsoft.Extensions.Caching.Memory": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyModel": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
@@ -129,6 +166,11 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
         }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "xA4kkL+QS6KCAOKz/O0oquHs44Ob8J7zpBCNt3wjkBWDg5aCqfwG8rWWLsg5V86AM0sB849g9JjPjIdksTCIKg=="
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
@@ -220,6 +262,33 @@
         "type": "Transitive",
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "DC4nA7yWnf4UZdgJDF+9Mus4/cb0Y3Sfgi3gDnAoKNAIBwzkskNAbNbyu+u4atT0ruVlZNJfwZmwiEwE5oz9LQ==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.11"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "PK0GLFkfhZzLQeR3PJf71FmhtHox+U3vcY6ZtswoMjrefkB9k6ErNJEnwXqc5KgXDSjige2XXrezqS39gkpQKA=="
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Ev2ytaXiOlWZ4b3R67GZBsemTINslLD1DCJr2xiacpn4tbapu0Q4dHEzSvZSMnVWeE5nlObU3VZN2p81q3XOYQ=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Y/0ZkR+r0Cg3DQFuCl1RBnv/tmxpIZRU3HUvelPw6MVaKHwYYR8YNvgs0vuNuXCMvlyJ+Fh88U1D4tah1tt6qw==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
       },
       "System.CodeDom": {
         "type": "Transitive",

--- a/tests/Granit.BackgroundJobs.Wolverine.Tests/CronSchedulerAgentTests.cs
+++ b/tests/Granit.BackgroundJobs.Wolverine.Tests/CronSchedulerAgentTests.cs
@@ -41,16 +41,24 @@ public sealed class CronSchedulerAgentTests
         string jobName,
         string cron = "0 9 * * *",
         bool isEnabled = true,
-        DateTimeOffset? nextExecutionAt = null) =>
-        new()
+        DateTimeOffset? nextExecutionAt = null)
+    {
+        var job = BackgroundJobDefinition.Create(
+            Guid.NewGuid(), jobName, cron, typeof(FakeJobMessage).AssemblyQualifiedName!);
+
+        if (!isEnabled)
         {
-            Id = Guid.NewGuid(),
-            JobName = jobName,
-            CronExpression = cron,
-            MessageType = typeof(FakeJobMessage).AssemblyQualifiedName!,
-            IsEnabled = isEnabled,
-            NextExecutionAt = nextExecutionAt,
-        };
+            job.Pause();
+            job.ClearDomainEvents();
+        }
+
+        if (nextExecutionAt.HasValue)
+        {
+            job.ScheduleNext(nextExecutionAt);
+        }
+
+        return job;
+    }
 
     // Minimal job message class for testing
     private sealed class FakeJobMessage;
@@ -152,7 +160,7 @@ public sealed class CronSchedulerAgentTests
         await agent.StartAsync(TestContext.Current.CancellationToken);
 
         // Simulate that RecordNextExecutionAsync updated NextExecutionAt
-        job.NextExecutionAt = _clock.Now.AddHours(1);
+        job.ScheduleNext(_clock.Now.AddHours(1));
         _storeReader.GetEnabledJobsAsync(Arg.Any<CancellationToken>())
             .Returns([job]);
 

--- a/tests/Granit.BackgroundJobs.Wolverine.Tests/RecurringJobSchedulingMiddlewareTests.cs
+++ b/tests/Granit.BackgroundJobs.Wolverine.Tests/RecurringJobSchedulingMiddlewareTests.cs
@@ -28,15 +28,19 @@ public sealed class RecurringJobSchedulingMiddlewareTests
     private static BackgroundJobDefinition MakeJob(
         string name = "fake-daily-report",
         string cron = "0 8 * * *",
-        bool enabled = true) =>
-        new()
+        bool enabled = true)
+    {
+        var job = BackgroundJobDefinition.Create(
+            Guid.NewGuid(), name, cron, typeof(FakeDailyReportMessage).AssemblyQualifiedName!);
+
+        if (!enabled)
         {
-            Id = Guid.NewGuid(),
-            JobName = name,
-            CronExpression = cron,
-            MessageType = typeof(FakeDailyReportMessage).AssemblyQualifiedName!,
-            IsEnabled = enabled,
-        };
+            job.Pause();
+            job.ClearDomainEvents();
+        }
+
+        return job;
+    }
 
     // =========================================================================
     // BeforeAsync

--- a/tests/Granit.Timeline.Endpoints.Tests/TimelineEntryEndpointsTests.cs
+++ b/tests/Granit.Timeline.Endpoints.Tests/TimelineEntryEndpointsTests.cs
@@ -66,17 +66,9 @@ public sealed class TimelineEntryEndpointsTests : IAsyncDisposable
     {
         // Arrange
         var entryId = Guid.NewGuid();
-        TimelineEntry entry = new()
-        {
-            Id = entryId,
-            EntityType = "Patient",
-            EntityId = "42",
-            EntryType = TimelineEntryType.Comment,
-            Body = "Test comment",
-            AuthorId = "user-1",
-            AuthorName = "Alice",
-            CreatedAt = DateTimeOffset.UtcNow,
-        };
+        var entry = TimelineEntry.Create(
+            entryId, "Patient", "42", TimelineEntryType.Comment,
+            "Test comment", "user-1", "Alice", DateTimeOffset.UtcNow, "user-1");
 
         _writer.PostEntryAsync("Patient", "42", TimelineEntryType.Comment, "Test comment",
                 null, Arg.Any<CancellationToken>())
@@ -110,17 +102,9 @@ public sealed class TimelineEntryEndpointsTests : IAsyncDisposable
     {
         // Arrange
         var entryId = Guid.NewGuid();
-        TimelineEntry entry = new()
-        {
-            Id = entryId,
-            EntityType = "Patient",
-            EntityId = "42",
-            EntryType = TimelineEntryType.InternalNote,
-            Body = "Staff only note",
-            AuthorId = "user-1",
-            AuthorName = "Alice",
-            CreatedAt = DateTimeOffset.UtcNow,
-        };
+        var entry = TimelineEntry.Create(
+            entryId, "Patient", "42", TimelineEntryType.InternalNote,
+            "Staff only note", "user-1", "Alice", DateTimeOffset.UtcNow, "user-1");
 
         _writer.PostEntryAsync("Patient", "42", TimelineEntryType.InternalNote, "Staff only note",
                 null, Arg.Any<CancellationToken>())
@@ -153,18 +137,10 @@ public sealed class TimelineEntryEndpointsTests : IAsyncDisposable
         // Arrange
         var parentId = Guid.NewGuid();
         var entryId = Guid.NewGuid();
-        TimelineEntry entry = new()
-        {
-            Id = entryId,
-            EntityType = "Patient",
-            EntityId = "42",
-            EntryType = TimelineEntryType.Comment,
-            Body = "Reply",
-            AuthorId = "user-1",
-            AuthorName = "Alice",
-            ParentEntryId = parentId,
-            CreatedAt = DateTimeOffset.UtcNow,
-        };
+        var entry = TimelineEntry.Create(
+            entryId, "Patient", "42", TimelineEntryType.Comment,
+            "Reply", "user-1", "Alice", DateTimeOffset.UtcNow, "user-1",
+            parentEntryId: parentId);
 
         _writer.PostEntryAsync("Patient", "42", TimelineEntryType.Comment, "Reply",
                 parentId, Arg.Any<CancellationToken>())
@@ -199,17 +175,9 @@ public sealed class TimelineEntryEndpointsTests : IAsyncDisposable
         var mentionedUserId = Guid.NewGuid();
         string mentionBody = $"Hey @[Bob](user:{mentionedUserId}), check this!";
         var entryId = Guid.NewGuid();
-        TimelineEntry entry = new()
-        {
-            Id = entryId,
-            EntityType = "Patient",
-            EntityId = "42",
-            EntryType = TimelineEntryType.Comment,
-            Body = mentionBody,
-            AuthorId = "user-1",
-            AuthorName = "Alice",
-            CreatedAt = DateTimeOffset.UtcNow,
-        };
+        var entry = TimelineEntry.Create(
+            entryId, "Patient", "42", TimelineEntryType.Comment,
+            mentionBody, "user-1", "Alice", DateTimeOffset.UtcNow, "user-1");
 
         _writer.PostEntryAsync("Patient", "42", TimelineEntryType.Comment, mentionBody,
                 null, Arg.Any<CancellationToken>())
@@ -249,17 +217,9 @@ public sealed class TimelineEntryEndpointsTests : IAsyncDisposable
     {
         // Arrange
         var entryId = Guid.NewGuid();
-        TimelineEntry entry = new()
-        {
-            Id = entryId,
-            EntityType = "Patient",
-            EntityId = "42",
-            EntryType = TimelineEntryType.Comment,
-            Body = "No mentions here",
-            AuthorId = "user-1",
-            AuthorName = "Alice",
-            CreatedAt = DateTimeOffset.UtcNow,
-        };
+        var entry = TimelineEntry.Create(
+            entryId, "Patient", "42", TimelineEntryType.Comment,
+            "No mentions here", "user-1", "Alice", DateTimeOffset.UtcNow, "user-1");
 
         _writer.PostEntryAsync("Patient", "42", TimelineEntryType.Comment, "No mentions here",
                 null, Arg.Any<CancellationToken>())

--- a/tests/Granit.Timeline.Notifications.Tests/NotificationBackedNotifierTests.cs
+++ b/tests/Granit.Timeline.Notifications.Tests/NotificationBackedNotifierTests.cs
@@ -118,16 +118,8 @@ public sealed class NotificationBackedNotifierTests
             Arg.Any<CancellationToken>());
     }
 
-    private static TimelineEntry BuildEntry() => new()
-    {
-        Id = Guid.NewGuid(),
-        EntityType = "Patient",
-        EntityId = "p-1",
-        EntryType = TimelineEntryType.Comment,
-        Body = "Hello @[User](user:00000000-0000-0000-0000-000000000001)",
-        AuthorId = "author-1",
-        AuthorName = "Author Name",
-        CreatedAt = DateTimeOffset.UtcNow,
-        CreatedBy = "author-1",
-    };
+    private static TimelineEntry BuildEntry() => TimelineEntry.Create(
+        Guid.NewGuid(), "Patient", "p-1", TimelineEntryType.Comment,
+        "Hello @[User](user:00000000-0000-0000-0000-000000000001)",
+        "author-1", "Author Name", DateTimeOffset.UtcNow, "author-1");
 }

--- a/tests/Granit.Timeline.Tests/Internal/NullTimelineNotifierTests.cs
+++ b/tests/Granit.Timeline.Tests/Internal/NullTimelineNotifierTests.cs
@@ -12,15 +12,9 @@ public sealed class NullTimelineNotifierTests
     [Fact]
     public async Task NotifyEntryPostedAsync_CompletesWithoutThrowing()
     {
-        TimelineEntry entry = new()
-        {
-            EntityType = "Patient",
-            EntityId = "123",
-            EntryType = TimelineEntryType.Comment,
-            Body = "Test comment",
-            AuthorId = "user-1",
-            AuthorName = "Alice",
-        };
+        var entry = TimelineEntry.Create(
+            Guid.NewGuid(), "Patient", "123", TimelineEntryType.Comment,
+            "Test comment", "user-1", "Alice", DateTimeOffset.UtcNow, "user-1");
         List<string> followerIds = ["user-2", "user-3"];
 
         Func<Task> act = () => _notifier.NotifyEntryPostedAsync(
@@ -32,15 +26,9 @@ public sealed class NullTimelineNotifierTests
     [Fact]
     public async Task NotifyEntryPostedAsync_WithEmptyFollowers_CompletesWithoutThrowing()
     {
-        TimelineEntry entry = new()
-        {
-            EntityType = "Invoice",
-            EntityId = "456",
-            EntryType = TimelineEntryType.SystemLog,
-            Body = "{}",
-            AuthorId = "system",
-            AuthorName = "System",
-        };
+        var entry = TimelineEntry.Create(
+            Guid.NewGuid(), "Invoice", "456", TimelineEntryType.SystemLog,
+            "{}", "system", "System", DateTimeOffset.UtcNow, "system");
         List<string> followerIds = [];
 
         Func<Task> act = () => _notifier.NotifyEntryPostedAsync(
@@ -52,15 +40,9 @@ public sealed class NullTimelineNotifierTests
     [Fact]
     public async Task NotifyEntryPostedAsync_ReturnsCompletedTask()
     {
-        TimelineEntry entry = new()
-        {
-            EntityType = "Patient",
-            EntityId = "1",
-            EntryType = TimelineEntryType.Comment,
-            Body = "text",
-            AuthorId = "user-1",
-            AuthorName = "Bob",
-        };
+        var entry = TimelineEntry.Create(
+            Guid.NewGuid(), "Patient", "1", TimelineEntryType.Comment,
+            "text", "user-1", "Bob", DateTimeOffset.UtcNow, "user-1");
 
         Task result = _notifier.NotifyEntryPostedAsync(entry, [], TestContext.Current.CancellationToken);
 
@@ -71,15 +53,9 @@ public sealed class NullTimelineNotifierTests
     [Fact]
     public async Task NotifyMentionedUsersAsync_CompletesWithoutThrowing()
     {
-        TimelineEntry entry = new()
-        {
-            EntityType = "Patient",
-            EntityId = "789",
-            EntryType = TimelineEntryType.Comment,
-            Body = "Hey @user-2",
-            AuthorId = "user-1",
-            AuthorName = "Alice",
-        };
+        var entry = TimelineEntry.Create(
+            Guid.NewGuid(), "Patient", "789", TimelineEntryType.Comment,
+            "Hey @user-2", "user-1", "Alice", DateTimeOffset.UtcNow, "user-1");
         List<string> mentionedUserIds = ["user-2"];
 
         Func<Task> act = () => _notifier.NotifyMentionedUsersAsync(
@@ -91,15 +67,9 @@ public sealed class NullTimelineNotifierTests
     [Fact]
     public async Task NotifyMentionedUsersAsync_WithEmptyMentions_CompletesWithoutThrowing()
     {
-        TimelineEntry entry = new()
-        {
-            EntityType = "Invoice",
-            EntityId = "1",
-            EntryType = TimelineEntryType.InternalNote,
-            Body = "No mentions here",
-            AuthorId = "user-1",
-            AuthorName = "Alice",
-        };
+        var entry = TimelineEntry.Create(
+            Guid.NewGuid(), "Invoice", "1", TimelineEntryType.InternalNote,
+            "No mentions here", "user-1", "Alice", DateTimeOffset.UtcNow, "user-1");
         List<string> mentionedUserIds = [];
 
         Func<Task> act = () => _notifier.NotifyMentionedUsersAsync(
@@ -111,15 +81,9 @@ public sealed class NullTimelineNotifierTests
     [Fact]
     public async Task NotifyMentionedUsersAsync_ReturnsCompletedTask()
     {
-        TimelineEntry entry = new()
-        {
-            EntityType = "Patient",
-            EntityId = "1",
-            EntryType = TimelineEntryType.Comment,
-            Body = "text",
-            AuthorId = "user-1",
-            AuthorName = "Bob",
-        };
+        var entry = TimelineEntry.Create(
+            Guid.NewGuid(), "Patient", "1", TimelineEntryType.Comment,
+            "text", "user-1", "Bob", DateTimeOffset.UtcNow, "user-1");
 
         Task result = _notifier.NotifyMentionedUsersAsync(entry, [], TestContext.Current.CancellationToken);
 


### PR DESCRIPTION
## Summary

- Migrate `TimelineEntry` from manual `IDomainEventSource` to `CreationAuditedAggregateRoot` (last remaining manual implementor)
- Remove `DomainConventionTests` allowlist — **zero manual `IDomainEventSource` implementations remain**
- Add `Aggregate_roots_should_not_have_public_setters` architecture test — prevents regression
- Update `CLAUDE.md` with DDD conventions (aggregate root rules, value object rules, 3 new anti-patterns)

Closes #459

## Test plan

- [ ] `dotnet test tests/Granit.ArchitectureTests` — 60/60 pass (1 new test)
- [ ] `dotnet test tests/Granit.Timeline.Tests` — all pass
- [ ] `dotnet test tests/Granit.Timeline.Endpoints.Tests` — all pass
- [ ] `dotnet test tests/Granit.Timeline.Notifications.Tests` — all pass
- [ ] `dotnet test tests/Granit.Timeline.EntityFrameworkCore.Tests` — all pass
- [ ] `markdownlint` clean on CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
