### PR TITLE
refactor(events): standardize event naming — *Event for domain, *Eto for integration

### DIFF
--- a/docs-site/src/content/docs/blog/gdpr-by-design.md
+++ b/docs-site/src/content/docs/blog/gdpr-by-design.md
@@ -100,7 +100,7 @@ Soft delete is not erasure. GDPR Article 17 requires actual deletion when there 
 
 ```
 User -> API: DELETE /privacy/my-data
-API -> Saga: PersonalDataDeletionRequestedEvent
+API -> Saga: PersonalDataDeletionRequestedEto
 Saga -> Identity: DeleteByIdAsync (hard delete)
 Saga -> BlobStorage: Delete user blobs
 Saga -> Notifications: Delete delivery records

--- a/docs-site/src/content/docs/contributing/module-structure.md
+++ b/docs-site/src/content/docs/contributing/module-structure.md
@@ -121,7 +121,7 @@ Granit.Example.EntityFrameworkCore/
 | Module class | **Module root** | `GranitBlobStorageModule.cs` |
 | Domain entity | **`Domain/`** | `Domain/ExportJob.cs` |
 | Business exception | **`Exceptions/`** | `Exceptions/BlobNotFoundException.cs` |
-| Wolverine event | **`Events/`** | `Events/BlobDeleted.cs` |
+| Wolverine event | **`Events/`** | `Events/BlobDeletedEvent.cs` |
 | Internal implementation | **`Internal/`** | `Internal/DefaultBlobStorage.cs` |
 | Options class | **`Options/`** | `Options/BlobStorageOptions.cs` |
 | DI extension | **`Extensions/`** | `Extensions/BlobStorageServiceCollectionExtensions.cs` |

--- a/docs-site/src/content/docs/dotnet/api/webhooks.mdx
+++ b/docs-site/src/content/docs/dotnet/api/webhooks.mdx
@@ -163,8 +163,8 @@ When consecutive failures exceed the threshold, the subscription transitions:
 | Failures | Status | Domain event |
 |----------|--------|-------------|
 | 0 | `Active` | — |
-| Threshold reached | `Suspended` | `WebhookSubscriptionSuspended` |
-| Non-retriable (4xx) | `Deactivated` | `WebhookSubscriptionDeactivated` |
+| Threshold reached | `Suspended` | `WebhookSubscriptionSuspendedEvent` |
+| Non-retriable (4xx) | `Deactivated` | `WebhookSubscriptionDeactivatedEvent` |
 
 Suspension records `SuspendedAt` and `SuspendedBy` for ISO 27001 audit compliance.
 
@@ -206,7 +206,7 @@ against GDPR data-minimization requirements.
 | Publisher | `IWebhookPublisher` (`PublishAsync<TPayload>`) | `Granit.Webhooks` |
 | Subscriptions | `IWebhookSubscriptionReader`, `IWebhookSubscriptionWriter`, `WebhookSubscription` | `Granit.Webhooks` |
 | Delivery | `WebhookDeliveryAttempt`, `WebhookEnvelope`, `IWebhookDeliveryReader`, `IWebhookDeliveryWriter` | `Granit.Webhooks` |
-| Events | `WebhookSubscriptionSuspended`, `WebhookSubscriptionDeactivated` | `Granit.Webhooks` |
+| Events | `WebhookSubscriptionSuspendedEvent`, `WebhookSubscriptionDeactivatedEvent` | `Granit.Webhooks` |
 | Options | `WebhooksOptions` | `Granit.Webhooks` |
 | Extensions | `AddGranitWebhooks()`, `AddGranitWebhooksEntityFrameworkCore()` | — |
 
@@ -235,7 +235,7 @@ it, or ensure the webhook database is encrypted and has a retention policy.
 
 :::caution[Subscription suspension]
 After repeated delivery failures (configurable), a subscription is automatically
-**suspended**. A `WebhookSubscriptionSuspended` event is published, but if no handler
+**suspended**. A `WebhookSubscriptionSuspendedEvent` event is published, but if no handler
 re-activates or alerts an admin, the subscription stays silent forever. Monitor this
 event in production.
 :::

--- a/docs-site/src/content/docs/dotnet/architecture/adr/017-ddd-aggregate-value-object-strategy.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/017-ddd-aggregate-value-object-strategy.md
@@ -76,7 +76,7 @@ public void MarkAsValid(string contentType, long size, DateTimeOffset at)
     SizeBytes = size;
     ValidatedAt = at;
 
-    AddDomainEvent(new BlobValidated(Id, ContainerName, contentType, size));
+    AddDomainEvent(new BlobValidatedEvent(Id, ContainerName, contentType, size));
 }
 ```
 

--- a/docs-site/src/content/docs/dotnet/architecture/patterns/ddd-aggregate-roots.md
+++ b/docs-site/src/content/docs/dotnet/architecture/patterns/ddd-aggregate-roots.md
@@ -117,7 +117,7 @@ public sealed class BlobDescriptor : AggregateRoot, IMultiTenant
         SizeBytes = sizeBytes;
         ValidatedAt = at;
 
-        AddDomainEvent(new BlobValidated(Id, ContainerName, contentType, sizeBytes));
+        AddDomainEvent(new BlobValidatedEvent(Id, ContainerName, contentType, sizeBytes));
     }
 }
 ```

--- a/docs-site/src/content/docs/dotnet/architecture/patterns/event-driven.md
+++ b/docs-site/src/content/docs/dotnet/architecture/patterns/event-driven.md
@@ -15,10 +15,10 @@ Granit distinguishes two categories of events with fundamentally different
 guarantees:
 
 - **IDomainEvent**: in-process, synchronous, same transaction. Never crosses
-  the Outbox. Naming convention: `XxxOccurred`.
+  the Outbox. Naming convention: `*Event` suffix.
 - **IIntegrationEvent**: cross-module, durable via Wolverine Outbox,
   dispatched only after the transaction commits. Naming convention:
-  `XxxEvent`. Flat DTOs only (never EF Core entities).
+  `*Eto` suffix (Event Transfer Object). Flat DTOs only (never EF Core entities).
 
 ## Diagram
 
@@ -41,7 +41,7 @@ sequenceDiagram
 
     Note over H,IH: IIntegrationEvent -- via Outbox
     H->>DB: Modify entity
-    H->>OB: Publish BedReleasedEvent
+    H->>OB: Publish BedReleasedEto
     H->>DB: SaveChangesAsync() -- atomic commit (data + Outbox)
     OB->>TX: Post-commit dispatch
     TX->>IH: Guaranteed delivery (retry, DLQ)
@@ -100,7 +100,7 @@ public sealed class PatientDischargedOccurred : IDomainEvent
 }
 
 // 2. Define an integration event (durable, cross-module)
-public sealed class BedReleasedEvent : IIntegrationEvent
+public sealed class BedReleasedEto : IIntegrationEvent
 {
     public required Guid BedId { get; init; }
     public required Guid WardId { get; init; }
@@ -127,7 +127,7 @@ public static class DischargePatientHandler
         };
 
         // Integration event -- persisted in the Outbox, dispatched after commit
-        yield return new BedReleasedEvent
+        yield return new BedReleasedEto
         {
             BedId = patient.BedId,
             WardId = patient.WardId,

--- a/docs-site/src/content/docs/dotnet/architecture/patterns/saga-process-manager.md
+++ b/docs-site/src/content/docs/dotnet/architecture/patterns/saga-process-manager.md
@@ -36,15 +36,15 @@ sequenceDiagram
     participant P2 as Provider B
     participant Blob as BlobStorage
 
-    App->>Saga: PersonalDataRequestedEvent
+    App->>Saga: PersonalDataRequestedEto
     Saga->>P1: Request data
     Saga->>P2: Request data
     Saga->>Saga: Schedule timeout (30 min)
     P1->>Blob: Upload fragment
-    P1->>Saga: PersonalDataPreparedEvent
+    P1->>Saga: PersonalDataPreparedEto
     P2->>Blob: Upload fragment
-    P2->>Saga: PersonalDataPreparedEvent
-    Saga->>App: ExportCompletedEvent (complete)
+    P2->>Saga: PersonalDataPreparedEto
+    Saga->>App: ExportCompletedEto (complete)
 ```
 
 ## Implementation in Granit
@@ -66,8 +66,8 @@ personal data fragments from multiple providers, with configurable timeout.
 
 ```csharp
 // Saga start -- dispatches to all registered providers
-public async Task<ExportCompletedEvent?> StartAsync(
-    PersonalDataRequestedEvent @event,
+public async Task<ExportCompletedEto?> StartAsync(
+    PersonalDataRequestedEto @event,
     IDataProviderRegistry registry,
     IOptions<GranitPrivacyOptions> options,
     IMessageContext context)
@@ -83,7 +83,7 @@ public async Task<ExportCompletedEvent?> StartAsync(
         .ConfigureAwait(false);
 
     return ExpectedCount == 0
-        ? new ExportCompletedEvent(Id, [], IsPartial: false)
+        ? new ExportCompletedEto(Id, [], IsPartial: false)
         : null;
 }
 ```
@@ -154,14 +154,14 @@ Business workflow orchestration with transitions, permissions, and routing to a
 ```csharp
 // --- Trigger a GDPR export ---
 await messageBus.PublishAsync(
-    new PersonalDataRequestedEvent(
+    new PersonalDataRequestedEto(
         RequestId: Guid.NewGuid(),
         UserId: patient.Id),
     cancellationToken).ConfigureAwait(false);
 
 // The GdprExportSaga collects fragments from each provider.
 // When all fragments are received (or timeout):
-// -> ExportCompletedEvent { BlobReferences, IsPartial }
+// -> ExportCompletedEto { BlobReferences, IsPartial }
 
 // --- Trigger an import ---
 Guid jobId = await importOrchestrator

--- a/docs-site/src/content/docs/dotnet/business/workflow.mdx
+++ b/docs-site/src/content/docs/dotnet/business/workflow.mdx
@@ -209,7 +209,7 @@ public static class ApproveInvoiceHandler
 
 When a user triggers a transition that requires a permission they lack, and the
 transition has `RequiresApproval()` enabled, the workflow manager routes the entity to
-a pending review state and publishes a `WorkflowApprovalRequested` domain event:
+a pending review state and publishes a `WorkflowApprovalRequestedEvent` domain event:
 
 ```mermaid
 sequenceDiagram
@@ -223,7 +223,7 @@ sequenceDiagram
     PC-->>WM: false
     Note over WM: RequiresApproval = true
     WM-->>U: ApprovalRequested (→ PendingReview)
-    WM->>EV: WorkflowApprovalRequested
+    WM->>EV: WorkflowApprovalRequestedEvent
     Note over EV: Notifications module sends InApp + Email to approvers
 ```
 
@@ -374,7 +374,7 @@ Query parameters: `page` (default 1), `pageSize` (default 20, max 100).
 
 | Notification type | Severity | Default channels | Trigger |
 |-------------------|----------|------------------|---------|
-| `WorkflowApprovalNotificationType` | Warning | InApp + Email | `WorkflowApprovalRequested` domain event |
+| `WorkflowApprovalNotificationType` | Warning | InApp + Email | `WorkflowApprovalRequestedEvent` domain event |
 | `WorkflowStateChangedNotificationType` | Info | InApp + SignalR | `WorkflowStateChangedEvent` domain event |
 
 Wolverine handlers consume the domain events and dispatch notifications via the
@@ -384,12 +384,12 @@ Wolverine handlers consume the domain events and dispatch notifications via the
 
 | Event | Published when | Payload |
 |-------|----------------|---------|
-| `WorkflowTransitioned<TState>` | Transition completes (generic, app-level) | `EntityType`, `EntityId`, `PreviousState`, `NewState`, `TransitionedBy` |
+| `WorkflowTransitionedEvent<TState>` | Transition completes (generic, app-level) | `EntityType`, `EntityId`, `PreviousState`, `NewState`, `TransitionedBy` |
 | `WorkflowStateChangedEvent` | Transition completes (non-generic, framework-level) | `EntityType`, `EntityId`, `PreviousState`, `NewState`, `TransitionedBy` |
-| `WorkflowApprovalRequested` | Transition routed to approval | `EntityType`, `EntityId`, `RequestedBy`, `TargetState`, `RequiredPermission` |
+| `WorkflowApprovalRequestedEvent` | Transition routed to approval | `EntityType`, `EntityId`, `RequestedBy`, `TargetState`, `RequiredPermission` |
 
 :::tip
-`WorkflowTransitioned<TState>` is generic and type-safe — use it in application
+`WorkflowTransitionedEvent<TState>` is generic and type-safe — use it in application
 handlers. `WorkflowStateChangedEvent` uses string states for framework-level
 consumption (notifications, timeline).
 :::
@@ -407,7 +407,7 @@ consumption (notifications, timeline).
 | Permission | `IWorkflowPermissionChecker` | `Granit.Workflow` |
 | Audit | `WorkflowTransitionRecord`, `IWorkflowTransitionRecorder`, `IWorkflowHistoryQuery` | `Granit.Workflow` / `.EntityFrameworkCore` |
 | Domain | `WorkflowLifecycleStatus`, `PublicationWorkflow` | `Granit.Workflow` |
-| Events | `WorkflowTransitioned<TState>`, `WorkflowStateChangedEvent`, `WorkflowApprovalRequested` | `Granit.Workflow` |
+| Events | `WorkflowTransitionedEvent<TState>`, `WorkflowStateChangedEvent`, `WorkflowApprovalRequestedEvent` | `Granit.Workflow` |
 | EF Core | `IWorkflowDbContext`, `WorkflowTransitionInterceptor` | `Granit.Workflow.EntityFrameworkCore` |
 | Notifications | `IApproverResolver`, `WorkflowApprovalNotificationType`, `WorkflowStateChangedNotificationType` | `Granit.Workflow.Notifications` |
 | Extensions | `AddGranitWorkflow()`, `AddGranitWorkflowEntityFrameworkCore<T>()`, `AddGranitWorkflowEndpoints()`, `AddGranitWorkflowNotifications()`, `MapWorkflowEndpoints()` | -- |

--- a/docs-site/src/content/docs/dotnet/data/blob-storage.mdx
+++ b/docs-site/src/content/docs/dotnet/data/blob-storage.mdx
@@ -567,9 +567,9 @@ Single-tenant deployments (no `ICurrentTenant`) omit the tenant prefix:
 
 | Event | Trigger |
 | ----- | ------- |
-| `BlobValidated(BlobId, ContainerName, VerifiedContentType, SizeBytes)` | Blob passes all validators |
-| `BlobRejected(BlobId, ContainerName, RejectionReason)` | Validation fails |
-| `BlobDeleted(BlobId, ContainerName, DeletionReason)` | GDPR crypto-shredding |
+| `BlobValidatedEvent(BlobId, ContainerName, VerifiedContentType, SizeBytes)` | Blob passes all validators |
+| `BlobRejectedEvent(BlobId, ContainerName, RejectionReason)` | Validation fails |
+| `BlobDeletedEvent(BlobId, ContainerName, DeletionReason)` | GDPR crypto-shredding |
 
 Subscribe via Wolverine handlers to react to blob lifecycle changes (e.g. trigger
 image processing after validation, notify the user on rejection).
@@ -740,7 +740,7 @@ Verifies GCS connectivity by listing one object in the default bucket. Tagged
 | Domain | `BlobDescriptor`, `BlobStatus`, `BlobUploadRequest` | `Granit.BlobStorage` |
 | Presigned URLs | `PresignedUploadTicket`, `PresignedDownloadUrl`, `DownloadUrlOptions` | `Granit.BlobStorage` |
 | Validation | `IBlobValidator`, `BlobValidationResult`, `BlobValidationContext`, `MagicBytesValidator`, `MaxSizeValidator` | `Granit.BlobStorage` |
-| Events | `BlobValidated`, `BlobRejected`, `BlobDeleted` | `Granit.BlobStorage` |
+| Events | `BlobValidatedEvent`, `BlobRejectedEvent`, `BlobDeletedEvent` | `Granit.BlobStorage` |
 | S3 options | `S3BlobOptions`, `BlobTenantIsolation` | `Granit.BlobStorage.S3` |
 | Azure options | `AzureBlobOptions` | `Granit.BlobStorage.AzureBlob` |
 | Google Cloud options | `GoogleCloudStorageOptions` | `Granit.BlobStorage.GoogleCloud` |

--- a/docs-site/src/content/docs/dotnet/data/imaging.mdx
+++ b/docs-site/src/content/docs/dotnet/data/imaging.mdx
@@ -123,15 +123,15 @@ ImageResult sanitized = await pipeline
 
 ## Combining with blob storage
 
-A typical pattern: subscribe to `BlobValidated` events to post-process images
+A typical pattern: subscribe to `BlobValidatedEvent` events to post-process images
 asynchronously after upload validation. The Wolverine handler downloads the validated
 blob, applies the image pipeline, and re-uploads the result:
 
 ```csharp
-public static class BlobValidatedHandler
+public static class BlobValidatedEventHandler
 {
     public static async Task HandleAsync(
-        BlobValidated @event,
+        BlobValidatedEvent @event,
         IBlobStorage blobStorage,
         IImageProcessor imageProcessor,
         CancellationToken cancellationToken)

--- a/docs-site/src/content/docs/dotnet/guides/implement-workflow.mdx
+++ b/docs-site/src/content/docs/dotnet/guides/implement-workflow.mdx
@@ -215,7 +215,7 @@ When a user triggers a transition marked with `RequiresApproval()` but lacks
 the required permission:
 
 1. The entity moves to `PendingReview` instead of the target state
-2. A `WorkflowApprovalRequested` domain event is published
+2. A `WorkflowApprovalRequestedEvent` domain event is published
 3. If `Granit.Workflow.Notifications` is installed, designated approvers receive
    a notification
 4. An approver (a user with the required permission) completes the transition

--- a/docs-site/src/content/docs/dotnet/infrastructure/background-jobs.mdx
+++ b/docs-site/src/content/docs/dotnet/infrastructure/background-jobs.mdx
@@ -226,8 +226,8 @@ public interface IBackgroundJobWriter
 
 | Method | Behavior |
 |--------|----------|
-| `PauseAsync` | Sets `IsEnabled = false`. Current execution completes; rescheduling is skipped. Emits `BackgroundJobPaused` domain event |
-| `ResumeAsync` | Sets `IsEnabled = true` and immediately schedules the next cron occurrence. Emits `BackgroundJobResumed` domain event |
+| `PauseAsync` | Sets `IsEnabled = false`. Current execution completes; rescheduling is skipped. Emits `BackgroundJobPausedEvent` domain event |
+| `ResumeAsync` | Sets `IsEnabled = true` and immediately schedules the next cron occurrence. Emits `BackgroundJobResumedEvent` domain event |
 | `TriggerNowAsync` | Dispatches the job message immediately. Propagates caller identity via `X-Triggered-By` header for audit |
 
 ### Store-level interfaces
@@ -384,8 +384,8 @@ In production, grant the permission via:
 
 | Event | Emitted when |
 |-------|-------------|
-| `BackgroundJobPaused(Guid JobId, string JobName)` | Job is paused via `IBackgroundJobWriter.PauseAsync` |
-| `BackgroundJobResumed(Guid JobId, string JobName)` | Job is resumed via `IBackgroundJobWriter.ResumeAsync` |
+| `BackgroundJobPausedEvent(Guid JobId, string JobName)` | Job is paused via `IBackgroundJobWriter.PauseAsync` |
+| `BackgroundJobResumedEvent(Guid JobId, string JobName)` | Job is resumed via `IBackgroundJobWriter.ResumeAsync` |
 
 Both implement `IDomainEvent` and can be handled by Wolverine or in-process subscribers.
 
@@ -435,7 +435,7 @@ When `Granit.Observability` is loaded, the activity source is auto-discovered vi
 | CQRS | `IBackgroundJobReader`, `IBackgroundJobWriter` | `Granit.BackgroundJobs` |
 | Store | `IBackgroundJobStoreReader`, `IBackgroundJobStoreWriter` | `Granit.BackgroundJobs` |
 | Domain | `BackgroundJobDefinition`, `BackgroundJobStatus`, `RecurringJobRegistration`, `JobStoreMode` | `Granit.BackgroundJobs` |
-| Events | `BackgroundJobPaused`, `BackgroundJobResumed` | `Granit.BackgroundJobs` |
+| Events | `BackgroundJobPausedEvent`, `BackgroundJobResumedEvent` | `Granit.BackgroundJobs` |
 | Abstractions | `IBackgroundJobDispatcher`, `IDeadLetterQueueInspector` | `Granit.BackgroundJobs` |
 | Headers | `BackgroundJobHeaders` (`X-Triggered-By`) | `Granit.BackgroundJobs` |
 | Options | `BackgroundJobsOptions`, `BackgroundJobsEndpointsOptions` | -- |

--- a/docs-site/src/content/docs/dotnet/security/privacy.mdx
+++ b/docs-site/src/content/docs/dotnet/security/privacy.mdx
@@ -70,10 +70,10 @@ providers and waits for each to complete.
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Requested: PersonalDataRequestedEvent
+    [*] --> Requested: PersonalDataRequestedEto
     Requested --> Collecting: Query all providers
-    Collecting --> Prepared: PersonalDataPreparedEvent
-    Prepared --> Completed: ExportCompletedEvent
+    Collecting --> Prepared: PersonalDataPreparedEto
+    Prepared --> Completed: ExportCompletedEto
     Collecting --> TimedOut: ExportTimedOutEvent
     Completed --> [*]
     TimedOut --> [*]
@@ -95,7 +95,7 @@ sequenceDiagram
     participant Notifications
 
     User->>API: DELETE /privacy/my-data
-    API->>Saga: PersonalDataDeletionRequestedEvent
+    API->>Saga: PersonalDataDeletionRequestedEto
     Saga->>Identity: DeleteByIdAsync (hard delete)
     Saga->>BlobStorage: Delete user blobs
     Saga->>Notifications: Delete delivery records
@@ -139,7 +139,7 @@ a policy update.
 | Module | `GranitPrivacyModule` | -- |
 | Registry | `IDataProviderRegistry`, `ILegalDocumentRegistry`, `ILegalAgreementChecker` | `Granit.Privacy` |
 | Builder | `GranitPrivacyBuilder`, `GranitPrivacyOptions` | `Granit.Privacy` |
-| Events | `PersonalDataRequestedEvent`, `PersonalDataDeletionRequestedEvent`, `ExportCompletedEvent`, `ExportTimedOutEvent` | `Granit.Privacy` |
+| Events | `PersonalDataRequestedEto`, `PersonalDataDeletionRequestedEto`, `ExportCompletedEto`, `ExportTimedOutEvent` | `Granit.Privacy` |
 | Extensions | `AddGranitPrivacy()` | `Granit.Privacy` |
 
 ## See also

--- a/src/Granit.BackgroundJobs/Domain/BackgroundJobDefinition.cs
+++ b/src/Granit.BackgroundJobs/Domain/BackgroundJobDefinition.cs
@@ -137,20 +137,20 @@ public sealed class BackgroundJobDefinition : AggregateRoot
     }
 
     /// <summary>
-    /// Pauses the job and emits a <see cref="BackgroundJobPaused"/> domain event.
+    /// Pauses the job and emits a <see cref="BackgroundJobPausedEvent"/> domain event.
     /// </summary>
     internal void Pause()
     {
         IsEnabled = false;
-        AddDomainEvent(new BackgroundJobPaused(Id, JobName));
+        AddDomainEvent(new BackgroundJobPausedEvent(Id, JobName));
     }
 
     /// <summary>
-    /// Resumes the job and emits a <see cref="BackgroundJobResumed"/> domain event.
+    /// Resumes the job and emits a <see cref="BackgroundJobResumedEvent"/> domain event.
     /// </summary>
     internal void Resume()
     {
         IsEnabled = true;
-        AddDomainEvent(new BackgroundJobResumed(Id, JobName));
+        AddDomainEvent(new BackgroundJobResumedEvent(Id, JobName));
     }
 }

--- a/src/Granit.BackgroundJobs/Events/BackgroundJobPausedEvent.cs
+++ b/src/Granit.BackgroundJobs/Events/BackgroundJobPausedEvent.cs
@@ -5,6 +5,6 @@ namespace Granit.BackgroundJobs.Events;
 /// <summary>
 /// Raised when a background job is paused by an administrator.
 /// </summary>
-public sealed record BackgroundJobPaused(
+public sealed record BackgroundJobPausedEvent(
     Guid JobId,
     string JobName) : IDomainEvent;

--- a/src/Granit.BackgroundJobs/Events/BackgroundJobResumedEvent.cs
+++ b/src/Granit.BackgroundJobs/Events/BackgroundJobResumedEvent.cs
@@ -5,6 +5,6 @@ namespace Granit.BackgroundJobs.Events;
 /// <summary>
 /// Raised when a paused background job is resumed by an administrator.
 /// </summary>
-public sealed record BackgroundJobResumed(
+public sealed record BackgroundJobResumedEvent(
     Guid JobId,
     string JobName) : IDomainEvent;

--- a/src/Granit.BlobStorage/Domain/BlobDescriptor.cs
+++ b/src/Granit.BlobStorage/Domain/BlobDescriptor.cs
@@ -139,7 +139,7 @@ public sealed class BlobDescriptor : AggregateRoot, IMultiTenant
         SizeBytes = sizeBytes;
         ValidatedAt = validatedAt;
 
-        AddDomainEvent(new BlobValidated(Id, ContainerName, verifiedContentType, sizeBytes));
+        AddDomainEvent(new BlobValidatedEvent(Id, ContainerName, verifiedContentType, sizeBytes));
     }
 
     /// <summary>
@@ -159,7 +159,7 @@ public sealed class BlobDescriptor : AggregateRoot, IMultiTenant
         Status = BlobStatus.Rejected;
         RejectionReason = reason;
 
-        AddDomainEvent(new BlobRejected(Id, ContainerName, reason));
+        AddDomainEvent(new BlobRejectedEvent(Id, ContainerName, reason));
     }
 
     /// <summary>
@@ -182,6 +182,6 @@ public sealed class BlobDescriptor : AggregateRoot, IMultiTenant
         DeletedAt = deletedAt;
         DeletionReason = reason;
 
-        AddDomainEvent(new BlobDeleted(Id, ContainerName, reason));
+        AddDomainEvent(new BlobDeletedEvent(Id, ContainerName, reason));
     }
 }

--- a/src/Granit.BlobStorage/Events/BlobDeletedEvent.cs
+++ b/src/Granit.BlobStorage/Events/BlobDeletedEvent.cs
@@ -5,7 +5,7 @@ namespace Granit.BlobStorage.Events;
 /// <summary>
 /// Raised when a blob is crypto-shredded (S3 bytes erased, DB record retained for ISO 27001 audit).
 /// </summary>
-public sealed record BlobDeleted(
+public sealed record BlobDeletedEvent(
     Guid BlobId,
     string ContainerName,
     string? DeletionReason) : IDomainEvent;

--- a/src/Granit.BlobStorage/Events/BlobRejectedEvent.cs
+++ b/src/Granit.BlobStorage/Events/BlobRejectedEvent.cs
@@ -5,7 +5,7 @@ namespace Granit.BlobStorage.Events;
 /// <summary>
 /// Raised when a blob fails validation and transitions to <see cref="BlobStatus.Rejected"/>.
 /// </summary>
-public sealed record BlobRejected(
+public sealed record BlobRejectedEvent(
     Guid BlobId,
     string ContainerName,
     string RejectionReason) : IDomainEvent;

--- a/src/Granit.BlobStorage/Events/BlobValidatedEvent.cs
+++ b/src/Granit.BlobStorage/Events/BlobValidatedEvent.cs
@@ -5,7 +5,7 @@ namespace Granit.BlobStorage.Events;
 /// <summary>
 /// Raised when a blob passes all validators and transitions to <see cref="BlobStatus.Valid"/>.
 /// </summary>
-public sealed record BlobValidated(
+public sealed record BlobValidatedEvent(
     Guid BlobId,
     string ContainerName,
     string VerifiedContentType,

--- a/src/Granit.Core/Events/IDomainEvent.cs
+++ b/src/Granit.Core/Events/IDomainEvent.cs
@@ -17,6 +17,6 @@ namespace Granit.Core.Events;
 /// }
 /// </code>
 /// </para>
-/// <para>Naming convention: <c>XxxOccurred</c> (e.g., <c>PatientDischarged</c>).</para>
+/// <para>Naming convention: <c>*Event</c> suffix (e.g., <c>PatientDischargedEvent</c>).</para>
 /// </remarks>
 public interface IDomainEvent { }

--- a/src/Granit.Core/Events/IIntegrationEvent.cs
+++ b/src/Granit.Core/Events/IIntegrationEvent.cs
@@ -12,6 +12,6 @@ namespace Granit.Core.Events;
 /// Use flat, serializable DTOs only. Exposing an entity as an integration event
 /// leaks the internal model and breaks module boundaries.
 /// </para>
-/// <para>Naming convention: <c>XxxEvent</c> (e.g., <c>BedReleasedEvent</c>).</para>
+/// <para>Naming convention: <c>*Eto</c> suffix — Event Transfer Object (e.g., <c>BedReleasedEto</c>).</para>
 /// </remarks>
 public interface IIntegrationEvent { }

--- a/src/Granit.Privacy/DataDeletion/Events/PersonalDataDeletedEto.cs
+++ b/src/Granit.Privacy/DataDeletion/Events/PersonalDataDeletedEto.cs
@@ -6,7 +6,7 @@ namespace Granit.Privacy.DataDeletion.Events;
 /// Published by each data provider after handling a personal data deletion request.
 /// Provides a complete audit trail of what was done (ISO 27001 compliance).
 /// </summary>
-public sealed record PersonalDataDeletedEvent(
+public sealed record PersonalDataDeletedEto(
     Guid RequestId,
     string ProviderName,
     DeletionAction Action,

--- a/src/Granit.Privacy/DataDeletion/Events/PersonalDataDeletionRequestedEto.cs
+++ b/src/Granit.Privacy/DataDeletion/Events/PersonalDataDeletionRequestedEto.cs
@@ -6,7 +6,7 @@ namespace Granit.Privacy.DataDeletion.Events;
 /// Published when a data subject requests deletion of their personal data (RGPD Art. 17).
 /// Each registered data provider handles this event and decides what can be deleted.
 /// </summary>
-public sealed record PersonalDataDeletionRequestedEvent(
+public sealed record PersonalDataDeletionRequestedEto(
     Guid RequestId,
     Guid UserId,
     string RequestedBy,

--- a/src/Granit.Privacy/DataExport/Events/ExportCompletedEto.cs
+++ b/src/Granit.Privacy/DataExport/Events/ExportCompletedEto.cs
@@ -5,7 +5,7 @@ namespace Granit.Privacy.DataExport.Events;
 /// <summary>
 /// Published when the GDPR export Saga completes (all fragments received or timeout).
 /// </summary>
-public sealed record ExportCompletedEvent(
+public sealed record ExportCompletedEto(
     Guid RequestId,
     Guid UserId,
     string ArchiveBlobReferenceId,

--- a/src/Granit.Privacy/DataExport/Events/PersonalDataPreparedEto.cs
+++ b/src/Granit.Privacy/DataExport/Events/PersonalDataPreparedEto.cs
@@ -8,7 +8,7 @@ namespace Granit.Privacy.DataExport.Events;
 /// The <see cref="BlobReferenceId"/> points to the fragment stored in BlobStorage —
 /// raw data is never included in the event payload (ISO 27001 compliance).
 /// </summary>
-public sealed record PersonalDataPreparedEvent(
+public sealed record PersonalDataPreparedEto(
     [property: SagaIdentity] Guid RequestId,
     string ProviderName,
     string BlobReferenceId,

--- a/src/Granit.Privacy/DataExport/Events/PersonalDataRequestedEto.cs
+++ b/src/Granit.Privacy/DataExport/Events/PersonalDataRequestedEto.cs
@@ -6,7 +6,7 @@ namespace Granit.Privacy.DataExport.Events;
 /// Published when a data subject requests export of their personal data (RGPD Art. 15/20).
 /// Each registered data provider handles this event and prepares its fragment.
 /// </summary>
-public sealed record PersonalDataRequestedEvent(
+public sealed record PersonalDataRequestedEto(
     Guid RequestId,
     Guid UserId,
     DateTimeOffset RequestedAt) : IIntegrationEvent;

--- a/src/Granit.Privacy/DataExport/GdprExportSaga.cs
+++ b/src/Granit.Privacy/DataExport/GdprExportSaga.cs
@@ -12,14 +12,14 @@ namespace Granit.Privacy.DataExport;
 /// <para>
 /// Flow:
 /// <list type="number">
-///   <item><see cref="PersonalDataRequestedEvent"/> starts the Saga and schedules a timeout.</item>
+///   <item><see cref="PersonalDataRequestedEto"/> starts the Saga and schedules a timeout.</item>
 ///   <item>Each registered data provider handles the event, uploads its data fragment to
-///   BlobStorage, and publishes a <see cref="PersonalDataPreparedEvent"/> with the
+///   BlobStorage, and publishes a <see cref="PersonalDataPreparedEto"/> with the
 ///   <c>BlobReferenceId</c>.</item>
 ///   <item>The Saga collects fragments. When all expected fragments arrive it publishes
-///   <see cref="ExportCompletedEvent"/> with <c>IsPartial = false</c>.</item>
+///   <see cref="ExportCompletedEto"/> with <c>IsPartial = false</c>.</item>
 ///   <item>If the timeout fires before all fragments arrive, the Saga publishes a partial
-///   <see cref="ExportCompletedEvent"/> with <c>IsPartial = true</c> listing missing providers.</item>
+///   <see cref="ExportCompletedEto"/> with <c>IsPartial = true</c> listing missing providers.</item>
 /// </list>
 /// </para>
 /// <para>
@@ -27,14 +27,14 @@ namespace Granit.Privacy.DataExport;
 /// is never stored in the Saga state or event payloads.
 /// </para>
 /// <para>
-/// The <c>ArchiveBlobReferenceId</c> in <see cref="ExportCompletedEvent"/> uses the convention
+/// The <c>ArchiveBlobReferenceId</c> in <see cref="ExportCompletedEto"/> uses the convention
 /// <c>"gdpr-export/{RequestId}"</c>. The application assembles the final archive under this key
 /// using the individual fragment references.
 /// </para>
 /// </remarks>
 public sealed class GdprExportSaga : Saga
 {
-    /// <summary>Saga correlation ID — equals <see cref="PersonalDataRequestedEvent.RequestId"/>.</summary>
+    /// <summary>Saga correlation ID — equals <see cref="PersonalDataRequestedEto.RequestId"/>.</summary>
     public Guid Id { get; set; }
 
     /// <summary>User whose data is being exported.</summary>
@@ -54,8 +54,8 @@ public sealed class GdprExportSaga : Saga
     /// If no providers are registered, completes immediately.
     /// Otherwise, schedules a timeout to handle unresponsive providers.
     /// </summary>
-    public async Task<ExportCompletedEvent?> StartAsync(
-        PersonalDataRequestedEvent @event,
+    public async Task<ExportCompletedEto?> StartAsync(
+        PersonalDataRequestedEto @event,
         IDataProviderRegistry registry,
         IOptions<GranitPrivacyOptions> options,
         IMessageContext context)
@@ -68,7 +68,7 @@ public sealed class GdprExportSaga : Saga
         if (ExpectedCount == 0)
         {
             MarkCompleted();
-            return new ExportCompletedEvent(Id, UserId, $"gdpr-export/{Id}", IsPartial: false, []);
+            return new ExportCompletedEto(Id, UserId, $"gdpr-export/{Id}", IsPartial: false, []);
         }
 
         await context.ScheduleAsync(
@@ -82,7 +82,7 @@ public sealed class GdprExportSaga : Saga
     /// Handles a fragment prepared by a data provider.
     /// Completes the Saga if all expected fragments have been received.
     /// </summary>
-    public ExportCompletedEvent? Handle(PersonalDataPreparedEvent @event)
+    public ExportCompletedEto? Handle(PersonalDataPreparedEto @event)
     {
         ReceivedFragments.Add(new ReceivedFragment(@event.ProviderName, @event.BlobReferenceId, @event.ContentType));
         PendingProviders.Remove(@event.ProviderName);
@@ -93,17 +93,17 @@ public sealed class GdprExportSaga : Saga
         }
 
         MarkCompleted();
-        return new ExportCompletedEvent(Id, UserId, $"gdpr-export/{Id}", IsPartial: false, []);
+        return new ExportCompletedEto(Id, UserId, $"gdpr-export/{Id}", IsPartial: false, []);
     }
 
     /// <summary>
     /// Handles the timeout event.
-    /// Publishes a partial <see cref="ExportCompletedEvent"/> with whatever fragments arrived.
+    /// Publishes a partial <see cref="ExportCompletedEto"/> with whatever fragments arrived.
     /// </summary>
-    public ExportCompletedEvent Handle(ExportTimedOutEvent @event)
+    public ExportCompletedEto Handle(ExportTimedOutEvent @event)
     {
         MarkCompleted();
-        return new ExportCompletedEvent(
+        return new ExportCompletedEto(
             Id,
             UserId,
             $"gdpr-export/{Id}",

--- a/src/Granit.Timeline/Domain/TimelineEntry.cs
+++ b/src/Granit.Timeline/Domain/TimelineEntry.cs
@@ -61,14 +61,14 @@ public sealed class TimelineEntry : CreationAuditedEntity, ISoftDeletable, IMult
     public void ClearDomainEvents() => _domainEvents.Clear();
 
     /// <summary>
-    /// Raises a <see cref="TimelineEntryPosted"/> domain event.
+    /// Raises a <see cref="TimelineEntryPostedEvent"/> domain event.
     /// Called by the store after the entry is fully initialized.
     /// </summary>
     internal void RaisePostedEvent() =>
-        _domainEvents.Add(new TimelineEntryPosted(Id, EntityType, EntityId, EntryType, AuthorId));
+        _domainEvents.Add(new TimelineEntryPostedEvent(Id, EntityType, EntityId, EntryType, AuthorId));
 
     /// <summary>
-    /// Marks this entry as soft-deleted and raises a <see cref="TimelineEntrySoftDeleted"/> domain event.
+    /// Marks this entry as soft-deleted and raises a <see cref="TimelineEntrySoftDeletedEvent"/> domain event.
     /// </summary>
     /// <exception cref="InvalidOperationException">When the entry is a <see cref="TimelineEntryType.SystemLog"/>.</exception>
     internal void SoftDelete(DateTimeOffset deletedAt, string? deletedBy)
@@ -81,6 +81,6 @@ public sealed class TimelineEntry : CreationAuditedEntity, ISoftDeletable, IMult
         IsDeleted = true;
         DeletedAt = deletedAt;
         DeletedBy = deletedBy;
-        _domainEvents.Add(new TimelineEntrySoftDeleted(Id, EntityType, EntityId));
+        _domainEvents.Add(new TimelineEntrySoftDeletedEvent(Id, EntityType, EntityId));
     }
 }

--- a/src/Granit.Timeline/Events/TimelineEntryPostedEvent.cs
+++ b/src/Granit.Timeline/Events/TimelineEntryPostedEvent.cs
@@ -6,7 +6,7 @@ namespace Granit.Timeline.Events;
 /// <summary>
 /// Raised when a new timeline entry (comment, internal note, or system log) is created.
 /// </summary>
-public sealed record TimelineEntryPosted(
+public sealed record TimelineEntryPostedEvent(
     Guid EntryId,
     string EntityType,
     string EntityId,

--- a/src/Granit.Timeline/Events/TimelineEntrySoftDeletedEvent.cs
+++ b/src/Granit.Timeline/Events/TimelineEntrySoftDeletedEvent.cs
@@ -6,7 +6,7 @@ namespace Granit.Timeline.Events;
 /// Raised when a timeline entry is soft-deleted (RGPD right to erasure).
 /// System log entries cannot be deleted (ISO 27001 audit trail).
 /// </summary>
-public sealed record TimelineEntrySoftDeleted(
+public sealed record TimelineEntrySoftDeletedEvent(
     Guid EntryId,
     string EntityType,
     string EntityId) : IDomainEvent;

--- a/src/Granit.Webhooks/Domain/WebhookSubscription.cs
+++ b/src/Granit.Webhooks/Domain/WebhookSubscription.cs
@@ -111,7 +111,7 @@ public sealed class WebhookSubscription : AuditedAggregateRoot
     }
 
     /// <summary>
-    /// Suspends the subscription and emits a <see cref="WebhookSubscriptionSuspended"/> domain event.
+    /// Suspends the subscription and emits a <see cref="WebhookSubscriptionSuspendedEvent"/> domain event.
     /// </summary>
     internal void Suspend(DateTimeOffset suspendedAt, string suspendedBy, string reason)
     {
@@ -119,16 +119,16 @@ public sealed class WebhookSubscription : AuditedAggregateRoot
         DeactivationReason = reason;
         SuspendedAt = suspendedAt;
         SuspendedBy = suspendedBy;
-        AddDomainEvent(new WebhookSubscriptionSuspended(Id, reason));
+        AddDomainEvent(new WebhookSubscriptionSuspendedEvent(Id, reason));
     }
 
     /// <summary>
-    /// Permanently deactivates the subscription and emits a <see cref="WebhookSubscriptionDeactivated"/> domain event.
+    /// Permanently deactivates the subscription and emits a <see cref="WebhookSubscriptionDeactivatedEvent"/> domain event.
     /// </summary>
     internal void Deactivate(string reason)
     {
         Status = WebhookSubscriptionStatus.Deactivated;
         DeactivationReason = reason;
-        AddDomainEvent(new WebhookSubscriptionDeactivated(Id, reason));
+        AddDomainEvent(new WebhookSubscriptionDeactivatedEvent(Id, reason));
     }
 }

--- a/src/Granit.Webhooks/Events/WebhookSubscriptionDeactivatedEvent.cs
+++ b/src/Granit.Webhooks/Events/WebhookSubscriptionDeactivatedEvent.cs
@@ -3,8 +3,8 @@ using Granit.Core.Events;
 namespace Granit.Webhooks.Events;
 
 /// <summary>
-/// Raised when a webhook subscription is suspended after a non-retriable HTTP error.
+/// Raised when a webhook subscription is permanently deactivated.
 /// </summary>
-public sealed record WebhookSubscriptionSuspended(
+public sealed record WebhookSubscriptionDeactivatedEvent(
     Guid SubscriptionId,
     string Reason) : IDomainEvent;

--- a/src/Granit.Webhooks/Events/WebhookSubscriptionSuspendedEvent.cs
+++ b/src/Granit.Webhooks/Events/WebhookSubscriptionSuspendedEvent.cs
@@ -3,8 +3,8 @@ using Granit.Core.Events;
 namespace Granit.Webhooks.Events;
 
 /// <summary>
-/// Raised when a webhook subscription is permanently deactivated.
+/// Raised when a webhook subscription is suspended after a non-retriable HTTP error.
 /// </summary>
-public sealed record WebhookSubscriptionDeactivated(
+public sealed record WebhookSubscriptionSuspendedEvent(
     Guid SubscriptionId,
     string Reason) : IDomainEvent;

--- a/src/Granit.Workflow.Notifications/GranitWorkflowNotificationsModule.cs
+++ b/src/Granit.Workflow.Notifications/GranitWorkflowNotificationsModule.cs
@@ -8,7 +8,7 @@ namespace Granit.Workflow.Notifications;
 
 /// <summary>
 /// Granit module for the workflow approval notification bridge.
-/// Routes <see cref="Events.WorkflowApprovalRequested"/> events to designated approvers
+/// Routes <see cref="Events.WorkflowApprovalRequestedEvent"/> events to designated approvers
 /// via <c>Granit.Notifications</c>.
 /// </summary>
 /// <remarks>

--- a/src/Granit.Workflow.Notifications/Handlers/WorkflowApprovalRequestedHandler.cs
+++ b/src/Granit.Workflow.Notifications/Handlers/WorkflowApprovalRequestedHandler.cs
@@ -7,14 +7,14 @@ using Microsoft.Extensions.Logging;
 namespace Granit.Workflow.Notifications.Handlers;
 
 /// <summary>
-/// Wolverine handler that processes <see cref="WorkflowApprovalRequested"/> domain events
+/// Wolverine handler that processes <see cref="WorkflowApprovalRequestedEvent"/> domain events
 /// by notifying designated approvers via <see cref="INotificationPublisher"/>.
 /// </summary>
 /// <remarks>
 /// <para>
 /// When a user without the required permission triggers a transition that supports
 /// approval routing (<c>RequiresApproval = true</c>), the workflow engine publishes
-/// a <see cref="WorkflowApprovalRequested"/> event. This handler:
+/// a <see cref="WorkflowApprovalRequestedEvent"/> event. This handler:
 /// </para>
 /// <list type="number">
 ///   <item>Resolves approver user IDs via <see cref="IApproverResolver"/>.</item>
@@ -32,10 +32,10 @@ public sealed partial class WorkflowApprovalRequestedHandler(
     ILogger<WorkflowApprovalRequestedHandler> logger)
 {
     /// <summary>
-    /// Handles the <see cref="WorkflowApprovalRequested"/> event by notifying approvers.
+    /// Handles the <see cref="WorkflowApprovalRequestedEvent"/> event by notifying approvers.
     /// </summary>
     public async Task HandleAsync(
-        WorkflowApprovalRequested message,
+        WorkflowApprovalRequestedEvent message,
         CancellationToken cancellationToken)
     {
         IReadOnlyList<string> approverIds = await approverResolver.ResolveApproversAsync(

--- a/src/Granit.Workflow/Events/WorkflowApprovalRequestedEvent.cs
+++ b/src/Granit.Workflow/Events/WorkflowApprovalRequestedEvent.cs
@@ -7,7 +7,7 @@ namespace Granit.Workflow.Events;
 /// requesting user lacks the required permission. Handled by
 /// <c>Granit.Workflow.Notifications</c> to notify designated approvers.
 /// </summary>
-public sealed record WorkflowApprovalRequested(
+public sealed record WorkflowApprovalRequestedEvent(
     string EntityType,
     string EntityId,
     string RequestedBy,

--- a/src/Granit.Workflow/Events/WorkflowStateChangedEvent.cs
+++ b/src/Granit.Workflow/Events/WorkflowStateChangedEvent.cs
@@ -4,7 +4,7 @@ namespace Granit.Workflow.Events;
 
 /// <summary>
 /// Non-generic domain event published when a workflow state transition completes.
-/// Unlike <see cref="WorkflowTransitioned{TState}"/> (generic, app-published),
+/// Unlike <see cref="WorkflowTransitionedEvent{TState}"/> (generic, app-published),
 /// this event uses string states for framework-level consumption by notification handlers.
 /// </summary>
 /// <param name="EntityType">The entity type (e.g. "Publication", "Invoice").</param>

--- a/src/Granit.Workflow/Events/WorkflowTransitionedEvent.cs
+++ b/src/Granit.Workflow/Events/WorkflowTransitionedEvent.cs
@@ -7,7 +7,7 @@ namespace Granit.Workflow.Events;
 /// Routed to the Wolverine local <c>domain-events</c> queue (in-process, transactional).
 /// </summary>
 /// <typeparam name="TState">Enum type representing the workflow states.</typeparam>
-public sealed record WorkflowTransitioned<TState>(
+public sealed record WorkflowTransitionedEvent<TState>(
     string EntityType,
     string EntityId,
     TState PreviousState,

--- a/src/Granit.Workflow/WorkflowTransition.cs
+++ b/src/Granit.Workflow/WorkflowTransition.cs
@@ -30,7 +30,7 @@ public sealed record WorkflowTransition<TState> where TState : struct, Enum
     /// <summary>
     /// When <c>true</c> and the current user lacks <see cref="RequiredPermission"/>,
     /// the transition is routed to a pending review state instead of being denied.
-    /// A <see cref="Events.WorkflowApprovalRequested"/> domain event is published
+    /// A <see cref="Events.WorkflowApprovalRequestedEvent"/> domain event is published
     /// to notify designated approvers.
     /// </summary>
     public bool RequiresApproval { get; init; }

--- a/tests/Granit.BackgroundJobs.Tests/BackgroundJobDefinitionTests.cs
+++ b/tests/Granit.BackgroundJobs.Tests/BackgroundJobDefinitionTests.cs
@@ -16,7 +16,7 @@ namespace Granit.BackgroundJobs.Tests;
 public sealed class BackgroundJobDefinitionTests
 {
     [Fact]
-    public void Pause_ShouldEmitBackgroundJobPausedEvent()
+    public void Pause_ShouldEmitBackgroundJobPausedEventEvent()
     {
         BackgroundJobDefinition job = BuildJob();
 
@@ -25,13 +25,13 @@ public sealed class BackgroundJobDefinitionTests
         job.IsEnabled.ShouldBeFalse();
 
         IDomainEvent domainEvent = job.DomainEvents.ShouldHaveSingleItem();
-        BackgroundJobPaused paused = domainEvent.ShouldBeOfType<BackgroundJobPaused>();
+        BackgroundJobPausedEvent paused = domainEvent.ShouldBeOfType<BackgroundJobPausedEvent>();
         paused.JobId.ShouldBe(job.Id);
         paused.JobName.ShouldBe("test-job");
     }
 
     [Fact]
-    public void Resume_ShouldEmitBackgroundJobResumedEvent()
+    public void Resume_ShouldEmitBackgroundJobResumedEventEvent()
     {
         BackgroundJobDefinition job = BuildJob(enabled: false);
 
@@ -40,7 +40,7 @@ public sealed class BackgroundJobDefinitionTests
         job.IsEnabled.ShouldBeTrue();
 
         IDomainEvent domainEvent = job.DomainEvents.ShouldHaveSingleItem();
-        BackgroundJobResumed resumed = domainEvent.ShouldBeOfType<BackgroundJobResumed>();
+        BackgroundJobResumedEvent resumed = domainEvent.ShouldBeOfType<BackgroundJobResumedEvent>();
         resumed.JobId.ShouldBe(job.Id);
         resumed.JobName.ShouldBe("test-job");
     }
@@ -65,8 +65,8 @@ public sealed class BackgroundJobDefinitionTests
         job.Resume();
 
         job.DomainEvents.Count.ShouldBe(2);
-        job.DomainEvents.First().ShouldBeOfType<BackgroundJobPaused>();
-        job.DomainEvents.Last().ShouldBeOfType<BackgroundJobResumed>();
+        job.DomainEvents.First().ShouldBeOfType<BackgroundJobPausedEvent>();
+        job.DomainEvents.Last().ShouldBeOfType<BackgroundJobResumedEvent>();
     }
 
     private static BackgroundJobDefinition BuildJob(bool enabled = true)

--- a/tests/Granit.BlobStorage.Tests/BlobDescriptorTests.cs
+++ b/tests/Granit.BlobStorage.Tests/BlobDescriptorTests.cs
@@ -205,7 +205,7 @@ public sealed class BlobDescriptorTests
     }
 
     [Fact]
-    public void MarkAsValid_ShouldEmitBlobValidatedEvent()
+    public void MarkAsValid_ShouldEmitBlobValidatedEventEvent()
     {
         BlobDescriptor descriptor = CreatePending();
         descriptor.MarkAsUploading();
@@ -213,7 +213,7 @@ public sealed class BlobDescriptorTests
         descriptor.MarkAsValid("image/jpeg", 512_000, Now.AddMinutes(2));
 
         descriptor.DomainEvents.ShouldHaveSingleItem();
-        BlobValidated evt = descriptor.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<BlobValidated>();
+        BlobValidatedEvent evt = descriptor.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<BlobValidatedEvent>();
         evt.BlobId.ShouldBe(descriptor.Id);
         evt.ContainerName.ShouldBe("medical-images");
         evt.VerifiedContentType.ShouldBe("image/jpeg");
@@ -221,21 +221,21 @@ public sealed class BlobDescriptorTests
     }
 
     [Fact]
-    public void MarkAsRejected_ShouldEmitBlobRejectedEvent()
+    public void MarkAsRejected_ShouldEmitBlobRejectedEventEvent()
     {
         BlobDescriptor descriptor = CreatePending();
         descriptor.MarkAsUploading();
 
         descriptor.MarkAsRejected("MIME mismatch");
 
-        BlobRejected evt = descriptor.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<BlobRejected>();
+        BlobRejectedEvent evt = descriptor.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<BlobRejectedEvent>();
         evt.BlobId.ShouldBe(descriptor.Id);
         evt.ContainerName.ShouldBe("medical-images");
         evt.RejectionReason.ShouldBe("MIME mismatch");
     }
 
     [Fact]
-    public void MarkAsDeleted_ShouldEmitBlobDeletedEvent()
+    public void MarkAsDeleted_ShouldEmitBlobDeletedEventEvent()
     {
         BlobDescriptor descriptor = CreatePending();
         descriptor.MarkAsUploading();
@@ -244,7 +244,7 @@ public sealed class BlobDescriptorTests
 
         descriptor.MarkAsDeleted(Now.AddDays(1), "RGPD Art. 17");
 
-        BlobDeleted evt = descriptor.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<BlobDeleted>();
+        BlobDeletedEvent evt = descriptor.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<BlobDeletedEvent>();
         evt.BlobId.ShouldBe(descriptor.Id);
         evt.ContainerName.ShouldBe("medical-images");
         evt.DeletionReason.ShouldBe("RGPD Art. 17");
@@ -272,8 +272,8 @@ public sealed class BlobDescriptorTests
         descriptor.MarkAsDeleted(Now.AddDays(1), "cleanup");
 
         descriptor.DomainEvents.Count.ShouldBe(2);
-        descriptor.DomainEvents.ShouldContain(e => e is BlobValidated);
-        descriptor.DomainEvents.ShouldContain(e => e is BlobDeleted);
+        descriptor.DomainEvents.ShouldContain(e => e is BlobValidatedEvent);
+        descriptor.DomainEvents.ShouldContain(e => e is BlobDeletedEvent);
     }
 
     // ── Helper ────────────────────────────────────────────────────────────────

--- a/tests/Granit.Privacy.Tests/DataDeletion/Events/PersonalDataDeletedEtoTests.cs
+++ b/tests/Granit.Privacy.Tests/DataDeletion/Events/PersonalDataDeletedEtoTests.cs
@@ -5,14 +5,14 @@ using Xunit;
 
 namespace Granit.Privacy.Tests.DataDeletion.Events;
 
-public sealed class PersonalDataDeletedEventTests
+public sealed class PersonalDataDeletedEtoTests
 {
     [Fact]
     public void Constructor_SetsAllProperties()
     {
         var requestId = Guid.NewGuid();
 
-        var sut = new PersonalDataDeletedEvent(
+        var sut = new PersonalDataDeletedEto(
             requestId,
             "patients",
             DeletionAction.PhysicalDelete,
@@ -29,7 +29,7 @@ public sealed class PersonalDataDeletedEventTests
     [Fact]
     public void Details_CanBeNull()
     {
-        var sut = new PersonalDataDeletedEvent(
+        var sut = new PersonalDataDeletedEto(
             Guid.NewGuid(),
             "billing",
             DeletionAction.Anonymized,
@@ -47,7 +47,7 @@ public sealed class PersonalDataDeletedEventTests
     [InlineData(DeletionAction.Mixed)]
     public void Constructor_AcceptsAllDeletionActions(DeletionAction action)
     {
-        var sut = new PersonalDataDeletedEvent(
+        var sut = new PersonalDataDeletedEto(
             Guid.NewGuid(),
             "provider",
             action,
@@ -62,8 +62,8 @@ public sealed class PersonalDataDeletedEventTests
     {
         var requestId = Guid.NewGuid();
 
-        var a = new PersonalDataDeletedEvent(requestId, "p", DeletionAction.SoftDelete, 3, "info");
-        var b = new PersonalDataDeletedEvent(requestId, "p", DeletionAction.SoftDelete, 3, "info");
+        var a = new PersonalDataDeletedEto(requestId, "p", DeletionAction.SoftDelete, 3, "info");
+        var b = new PersonalDataDeletedEto(requestId, "p", DeletionAction.SoftDelete, 3, "info");
 
         a.ShouldBe(b);
     }
@@ -71,8 +71,8 @@ public sealed class PersonalDataDeletedEventTests
     [Fact]
     public void Equality_DifferentValues_AreNotEqual()
     {
-        var a = new PersonalDataDeletedEvent(Guid.NewGuid(), "p", DeletionAction.SoftDelete, 3, null);
-        var b = new PersonalDataDeletedEvent(Guid.NewGuid(), "q", DeletionAction.Retained, 1, null);
+        var a = new PersonalDataDeletedEto(Guid.NewGuid(), "p", DeletionAction.SoftDelete, 3, null);
+        var b = new PersonalDataDeletedEto(Guid.NewGuid(), "q", DeletionAction.Retained, 1, null);
 
         a.ShouldNotBe(b);
     }

--- a/tests/Granit.Privacy.Tests/DataDeletion/Events/PersonalDataDeletionRequestedEtoTests.cs
+++ b/tests/Granit.Privacy.Tests/DataDeletion/Events/PersonalDataDeletionRequestedEtoTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Granit.Privacy.Tests.DataDeletion.Events;
 
-public sealed class PersonalDataDeletionRequestedEventTests
+public sealed class PersonalDataDeletionRequestedEtoTests
 {
     [Fact]
     public void Constructor_SetsAllProperties()
@@ -13,7 +13,7 @@ public sealed class PersonalDataDeletionRequestedEventTests
         var userId = Guid.NewGuid();
         DateTimeOffset requestedAt = DateTimeOffset.UtcNow;
 
-        var sut = new PersonalDataDeletionRequestedEvent(
+        var sut = new PersonalDataDeletionRequestedEto(
             requestId,
             userId,
             "dpo@example.com",
@@ -34,8 +34,8 @@ public sealed class PersonalDataDeletionRequestedEventTests
         var userId = Guid.NewGuid();
         DateTimeOffset requestedAt = DateTimeOffset.UtcNow;
 
-        var a = new PersonalDataDeletionRequestedEvent(requestId, userId, "admin", requestedAt, "reason");
-        var b = new PersonalDataDeletionRequestedEvent(requestId, userId, "admin", requestedAt, "reason");
+        var a = new PersonalDataDeletionRequestedEto(requestId, userId, "admin", requestedAt, "reason");
+        var b = new PersonalDataDeletionRequestedEto(requestId, userId, "admin", requestedAt, "reason");
 
         a.ShouldBe(b);
     }
@@ -45,8 +45,8 @@ public sealed class PersonalDataDeletionRequestedEventTests
     {
         DateTimeOffset requestedAt = DateTimeOffset.UtcNow;
 
-        PersonalDataDeletionRequestedEvent a = new(Guid.NewGuid(), Guid.NewGuid(), "a", requestedAt, "r1");
-        PersonalDataDeletionRequestedEvent b = new(Guid.NewGuid(), Guid.NewGuid(), "b", requestedAt, "r2");
+        PersonalDataDeletionRequestedEto a = new(Guid.NewGuid(), Guid.NewGuid(), "a", requestedAt, "r1");
+        PersonalDataDeletionRequestedEto b = new(Guid.NewGuid(), Guid.NewGuid(), "b", requestedAt, "r2");
 
         a.ShouldNotBe(b);
     }

--- a/tests/Granit.Privacy.Tests/GdprExportSagaTests.cs
+++ b/tests/Granit.Privacy.Tests/GdprExportSagaTests.cs
@@ -39,7 +39,7 @@ public sealed class GdprExportSagaTests
         DataProviderRegistry registry = BuildRegistry("patients", "billing");
         var requestId = Guid.NewGuid();
         var userId = Guid.NewGuid();
-        PersonalDataRequestedEvent evt = new(requestId, userId, DateTimeOffset.UtcNow);
+        PersonalDataRequestedEto evt = new(requestId, userId, DateTimeOffset.UtcNow);
 
         await saga.StartAsync(evt, registry, DefaultOptions(), context);
 
@@ -57,7 +57,7 @@ public sealed class GdprExportSagaTests
         IMessageContext context = Substitute.For<IMessageContext>();
         DataProviderRegistry registry = BuildRegistry("patients", "billing");
         var requestId = Guid.NewGuid();
-        PersonalDataRequestedEvent evt = new(requestId, Guid.NewGuid(), DateTimeOffset.UtcNow);
+        PersonalDataRequestedEto evt = new(requestId, Guid.NewGuid(), DateTimeOffset.UtcNow);
 
         await saga.StartAsync(evt, registry, DefaultOptions(), context);
 
@@ -74,13 +74,13 @@ public sealed class GdprExportSagaTests
         GdprExportSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
         DataProviderRegistry registry = BuildRegistry("patients", "billing", "appointments");
-        PersonalDataRequestedEvent startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow);
+        PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow);
         await saga.StartAsync(startEvt, registry, DefaultOptions(), context);
 
-        ExportCompletedEvent? result1 = saga.Handle(
-            new PersonalDataPreparedEvent(startEvt.RequestId, "patients", "blob-1", "application/json"));
-        ExportCompletedEvent? result2 = saga.Handle(
-            new PersonalDataPreparedEvent(startEvt.RequestId, "billing", "blob-2", "application/json"));
+        ExportCompletedEto? result1 = saga.Handle(
+            new PersonalDataPreparedEto(startEvt.RequestId, "patients", "blob-1", "application/json"));
+        ExportCompletedEto? result2 = saga.Handle(
+            new PersonalDataPreparedEto(startEvt.RequestId, "billing", "blob-2", "application/json"));
 
         result1.ShouldBeNull();
         result2.ShouldBeNull();
@@ -94,12 +94,12 @@ public sealed class GdprExportSagaTests
         GdprExportSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
         DataProviderRegistry registry = BuildRegistry("patients", "billing");
-        PersonalDataRequestedEvent startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow);
+        PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow);
         await saga.StartAsync(startEvt, registry, DefaultOptions(), context);
 
-        saga.Handle(new PersonalDataPreparedEvent(startEvt.RequestId, "patients", "blob-patients", "application/json"));
-        ExportCompletedEvent? result = saga.Handle(
-            new PersonalDataPreparedEvent(startEvt.RequestId, "billing", "blob-billing", "application/json"));
+        saga.Handle(new PersonalDataPreparedEto(startEvt.RequestId, "patients", "blob-patients", "application/json"));
+        ExportCompletedEto? result = saga.Handle(
+            new PersonalDataPreparedEto(startEvt.RequestId, "billing", "blob-billing", "application/json"));
 
         result.ShouldNotBeNull();
         result!.RequestId.ShouldBe(startEvt.RequestId);
@@ -119,12 +119,12 @@ public sealed class GdprExportSagaTests
         GdprExportSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
         DataProviderRegistry registry = BuildRegistry("patients", "billing", "appointments");
-        PersonalDataRequestedEvent startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow);
+        PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow);
         await saga.StartAsync(startEvt, registry, DefaultOptions(), context);
 
-        saga.Handle(new PersonalDataPreparedEvent(startEvt.RequestId, "patients", "blob-patients", "application/json"));
-        saga.Handle(new PersonalDataPreparedEvent(startEvt.RequestId, "billing", "blob-billing", "application/json"));
-        ExportCompletedEvent result = saga.Handle(new ExportTimedOutEvent(startEvt.RequestId));
+        saga.Handle(new PersonalDataPreparedEto(startEvt.RequestId, "patients", "blob-patients", "application/json"));
+        saga.Handle(new PersonalDataPreparedEto(startEvt.RequestId, "billing", "blob-billing", "application/json"));
+        ExportCompletedEto result = saga.Handle(new ExportTimedOutEvent(startEvt.RequestId));
 
         result.IsPartial.ShouldBeTrue();
         result.MissingProviders.ShouldContain("appointments");
@@ -141,9 +141,9 @@ public sealed class GdprExportSagaTests
         GdprExportSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
         DataProviderRegistry emptyRegistry = new();
-        PersonalDataRequestedEvent evt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow);
+        PersonalDataRequestedEto evt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow);
 
-        ExportCompletedEvent? result = await saga.StartAsync(evt, emptyRegistry, DefaultOptions(), context);
+        ExportCompletedEto? result = await saga.StartAsync(evt, emptyRegistry, DefaultOptions(), context);
 
         result.ShouldNotBeNull();
         result!.IsPartial.ShouldBeFalse();
@@ -160,17 +160,17 @@ public sealed class GdprExportSagaTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void PersonalDataPreparedEvent_ContainsOnlyBlobReferenceId_NotRawData()
+    public void PersonalDataPreparedEto_ContainsOnlyBlobReferenceId_NotRawData()
     {
         // Structural contract: the event record only carries a BlobReferenceId,
         // never raw personal data — enforced by the type definition (ISO 27001 compliance).
-        PersonalDataPreparedEvent evt = new(
+        PersonalDataPreparedEto evt = new(
             Guid.NewGuid(), "patients", "blob-ref-123", "application/json");
 
         evt.BlobReferenceId.ShouldBe("blob-ref-123");
 
         System.Reflection.PropertyInfo[] properties =
-            typeof(PersonalDataPreparedEvent).GetProperties();
+            typeof(PersonalDataPreparedEto).GetProperties();
         string[] allowedProperties =
             ["RequestId", "ProviderName", "BlobReferenceId", "ContentType", "EqualityContract"];
         properties.Select(p => p.Name).ShouldAllBe(name => allowedProperties.Contains(name));
@@ -188,7 +188,7 @@ public sealed class GdprExportSagaTests
         IOptions<GranitPrivacyOptions> options = Microsoft.Extensions.Options.Options.Create(
             new GranitPrivacyOptions { ExportTimeoutMinutes = 10 });
         DataProviderRegistry registry = BuildRegistry("auth");
-        PersonalDataRequestedEvent evt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow);
+        PersonalDataRequestedEto evt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow);
 
         await saga.StartAsync(evt, registry, options, context);
 
@@ -205,16 +205,16 @@ public sealed class GdprExportSagaTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public async Task ExportCompletedEvent_ArchiveBlobReferenceId_UsesGdprExportConvention()
+    public async Task ExportCompletedEto_ArchiveBlobReferenceId_UsesGdprExportConvention()
     {
         GdprExportSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
         DataProviderRegistry registry = BuildRegistry("auth");
-        PersonalDataRequestedEvent startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow);
+        PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow);
         await saga.StartAsync(startEvt, registry, DefaultOptions(), context);
 
-        ExportCompletedEvent? result = saga.Handle(
-            new PersonalDataPreparedEvent(startEvt.RequestId, "auth", "blob-auth", "application/json"));
+        ExportCompletedEto? result = saga.Handle(
+            new PersonalDataPreparedEto(startEvt.RequestId, "auth", "blob-auth", "application/json"));
 
         result!.ArchiveBlobReferenceId.ShouldBe($"gdpr-export/{startEvt.RequestId}");
     }

--- a/tests/Granit.Timeline.Tests/InMemoryTimelineStoreTests.cs
+++ b/tests/Granit.Timeline.Tests/InMemoryTimelineStoreTests.cs
@@ -157,13 +157,13 @@ public sealed class InMemoryTimelineStoreTests
     // ── Domain Events ────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task PostEntryAsync_ShouldEmitTimelineEntryPostedEvent()
+    public async Task PostEntryAsync_ShouldEmitTimelineEntryPostedEventEvent()
     {
         TimelineEntry entry = await _store.PostEntryAsync(
             "Patient", "p-1", TimelineEntryType.Comment, "Hello",
             cancellationToken: TestContext.Current.CancellationToken);
 
-        TimelineEntryPosted evt = entry.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<TimelineEntryPosted>();
+        TimelineEntryPostedEvent evt = entry.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<TimelineEntryPostedEvent>();
         evt.EntryId.ShouldBe(entry.Id);
         evt.EntityType.ShouldBe("Patient");
         evt.EntityId.ShouldBe("p-1");
@@ -172,7 +172,7 @@ public sealed class InMemoryTimelineStoreTests
     }
 
     [Fact]
-    public async Task DeleteEntryAsync_ShouldEmitTimelineEntrySoftDeletedEvent()
+    public async Task DeleteEntryAsync_ShouldEmitTimelineEntrySoftDeletedEventEvent()
     {
         TimelineEntry entry = await _store.PostEntryAsync(
             "Patient", "p-1", TimelineEntryType.Comment, "To delete",
@@ -181,7 +181,7 @@ public sealed class InMemoryTimelineStoreTests
 
         await _store.DeleteEntryAsync(entry.Id, TestContext.Current.CancellationToken);
 
-        TimelineEntrySoftDeleted evt = entry.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<TimelineEntrySoftDeleted>();
+        TimelineEntrySoftDeletedEvent evt = entry.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<TimelineEntrySoftDeletedEvent>();
         evt.EntryId.ShouldBe(entry.Id);
         evt.EntityType.ShouldBe("Patient");
         evt.EntityId.ShouldBe("p-1");

--- a/tests/Granit.Webhooks.Tests/WebhookSubscriptionTests.cs
+++ b/tests/Granit.Webhooks.Tests/WebhookSubscriptionTests.cs
@@ -16,7 +16,7 @@ namespace Granit.Webhooks.Tests;
 public sealed class WebhookSubscriptionTests
 {
     [Fact]
-    public void Suspend_ShouldEmitWebhookSubscriptionSuspendedEvent()
+    public void Suspend_ShouldEmitWebhookSubscriptionSuspendedEventEvent()
     {
         WebhookSubscription subscription = BuildSubscription();
 
@@ -27,13 +27,13 @@ public sealed class WebhookSubscriptionTests
         subscription.SuspendedBy.ShouldBe("system");
 
         IDomainEvent domainEvent = subscription.DomainEvents.ShouldHaveSingleItem();
-        WebhookSubscriptionSuspended suspended = domainEvent.ShouldBeOfType<WebhookSubscriptionSuspended>();
+        WebhookSubscriptionSuspendedEvent suspended = domainEvent.ShouldBeOfType<WebhookSubscriptionSuspendedEvent>();
         suspended.SubscriptionId.ShouldBe(subscription.Id);
         suspended.Reason.ShouldBe("HTTP 401");
     }
 
     [Fact]
-    public void Deactivate_ShouldEmitWebhookSubscriptionDeactivatedEvent()
+    public void Deactivate_ShouldEmitWebhookSubscriptionDeactivatedEventEvent()
     {
         WebhookSubscription subscription = BuildSubscription();
 
@@ -43,7 +43,7 @@ public sealed class WebhookSubscriptionTests
         subscription.DeactivationReason.ShouldBe("Admin request");
 
         IDomainEvent domainEvent = subscription.DomainEvents.ShouldHaveSingleItem();
-        WebhookSubscriptionDeactivated deactivated = domainEvent.ShouldBeOfType<WebhookSubscriptionDeactivated>();
+        WebhookSubscriptionDeactivatedEvent deactivated = domainEvent.ShouldBeOfType<WebhookSubscriptionDeactivatedEvent>();
         deactivated.SubscriptionId.ShouldBe(subscription.Id);
         deactivated.Reason.ShouldBe("Admin request");
     }
@@ -68,8 +68,8 @@ public sealed class WebhookSubscriptionTests
         subscription.Deactivate("Permanently removed");
 
         subscription.DomainEvents.Count.ShouldBe(2);
-        subscription.DomainEvents.First().ShouldBeOfType<WebhookSubscriptionSuspended>();
-        subscription.DomainEvents.Last().ShouldBeOfType<WebhookSubscriptionDeactivated>();
+        subscription.DomainEvents.First().ShouldBeOfType<WebhookSubscriptionSuspendedEvent>();
+        subscription.DomainEvents.Last().ShouldBeOfType<WebhookSubscriptionDeactivatedEvent>();
     }
 
     private static WebhookSubscription BuildSubscription() =>

--- a/tests/Granit.Workflow.Notifications.Tests/WorkflowApprovalRequestedHandlerTests.cs
+++ b/tests/Granit.Workflow.Notifications.Tests/WorkflowApprovalRequestedHandlerTests.cs
@@ -18,7 +18,7 @@ public sealed class WorkflowApprovalRequestedHandlerTests
     private readonly ICurrentTenant _currentTenant = Substitute.For<ICurrentTenant>();
     private readonly WorkflowApprovalRequestedHandler _handler;
 
-    private static readonly WorkflowApprovalRequested SampleEvent = new(
+    private static readonly WorkflowApprovalRequestedEvent SampleEvent = new(
         EntityType: "Patient",
         EntityId: "42",
         RequestedBy: "user-1",

--- a/tests/Granit.Workflow.Tests/WorkflowApprovalRequestedTests.cs
+++ b/tests/Granit.Workflow.Tests/WorkflowApprovalRequestedTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 namespace Granit.Workflow.Tests;
 
 /// <summary>
-/// Tests for <see cref="WorkflowApprovalRequested"/> domain event record.
+/// Tests for <see cref="WorkflowApprovalRequestedEvent"/> domain event record.
 /// </summary>
 public sealed class WorkflowApprovalRequestedTests
 {
@@ -14,7 +14,7 @@ public sealed class WorkflowApprovalRequestedTests
     public void Constructor_ShouldSetAllProperties()
     {
         // Arrange & Act
-        WorkflowApprovalRequested evt = new(
+        WorkflowApprovalRequestedEvent evt = new(
             EntityType: "Invoice",
             EntityId: "inv-456",
             RequestedBy: "user-7",
@@ -33,7 +33,7 @@ public sealed class WorkflowApprovalRequestedTests
     public void Record_ShouldImplementIDomainEvent()
     {
         // Arrange & Act
-        WorkflowApprovalRequested evt = new(
+        WorkflowApprovalRequestedEvent evt = new(
             "Document", "id-1", "user-1", "Published", "workflow.publish");
 
         // Assert
@@ -44,10 +44,10 @@ public sealed class WorkflowApprovalRequestedTests
     public void Record_ShouldSupportValueEquality()
     {
         // Arrange
-        WorkflowApprovalRequested evt1 = new(
+        WorkflowApprovalRequestedEvent evt1 = new(
             "Document", "id-1", "user-1", "Published", "workflow.publish");
 
-        WorkflowApprovalRequested evt2 = new(
+        WorkflowApprovalRequestedEvent evt2 = new(
             "Document", "id-1", "user-1", "Published", "workflow.publish");
 
         // Assert
@@ -58,10 +58,10 @@ public sealed class WorkflowApprovalRequestedTests
     public void Record_WithDifferentValues_ShouldNotBeEqual()
     {
         // Arrange
-        WorkflowApprovalRequested evt1 = new(
+        WorkflowApprovalRequestedEvent evt1 = new(
             "Document", "id-1", "user-1", "Published", "workflow.publish");
 
-        WorkflowApprovalRequested evt2 = new(
+        WorkflowApprovalRequestedEvent evt2 = new(
             "Document", "id-1", "user-2", "Published", "workflow.publish");
 
         // Assert
@@ -72,11 +72,11 @@ public sealed class WorkflowApprovalRequestedTests
     public void Record_ShouldSupportWith()
     {
         // Arrange
-        WorkflowApprovalRequested original = new(
+        WorkflowApprovalRequestedEvent original = new(
             "Document", "id-1", "user-1", "Published", "workflow.publish");
 
         // Act
-        WorkflowApprovalRequested copy = original with { RequestedBy = "user-99" };
+        WorkflowApprovalRequestedEvent copy = original with { RequestedBy = "user-99" };
 
         // Assert
         copy.RequestedBy.ShouldBe("user-99");

--- a/tests/Granit.Workflow.Tests/WorkflowTransitionedTests.cs
+++ b/tests/Granit.Workflow.Tests/WorkflowTransitionedTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace Granit.Workflow.Tests;
 
 /// <summary>
-/// Tests for <see cref="WorkflowTransitioned{TState}"/> domain event record.
+/// Tests for <see cref="WorkflowTransitionedEvent{TState}"/> domain event record.
 /// </summary>
 public sealed class WorkflowTransitionedTests
 {
@@ -15,7 +15,7 @@ public sealed class WorkflowTransitionedTests
     public void Constructor_ShouldSetAllProperties()
     {
         // Arrange & Act
-        WorkflowTransitioned<WorkflowLifecycleStatus> evt = new(
+        WorkflowTransitionedEvent<WorkflowLifecycleStatus> evt = new(
             EntityType: "Document",
             EntityId: "abc-123",
             PreviousState: WorkflowLifecycleStatus.Draft,
@@ -34,7 +34,7 @@ public sealed class WorkflowTransitionedTests
     public void Record_ShouldImplementIDomainEvent()
     {
         // Arrange & Act
-        WorkflowTransitioned<WorkflowLifecycleStatus> evt = new(
+        WorkflowTransitionedEvent<WorkflowLifecycleStatus> evt = new(
             "Document", "id-1", WorkflowLifecycleStatus.Draft,
             WorkflowLifecycleStatus.PendingReview, "user-1");
 
@@ -46,11 +46,11 @@ public sealed class WorkflowTransitionedTests
     public void Record_ShouldSupportValueEquality()
     {
         // Arrange
-        WorkflowTransitioned<WorkflowLifecycleStatus> evt1 = new(
+        WorkflowTransitionedEvent<WorkflowLifecycleStatus> evt1 = new(
             "Document", "id-1", WorkflowLifecycleStatus.Draft,
             WorkflowLifecycleStatus.Published, "user-1");
 
-        WorkflowTransitioned<WorkflowLifecycleStatus> evt2 = new(
+        WorkflowTransitionedEvent<WorkflowLifecycleStatus> evt2 = new(
             "Document", "id-1", WorkflowLifecycleStatus.Draft,
             WorkflowLifecycleStatus.Published, "user-1");
 
@@ -62,11 +62,11 @@ public sealed class WorkflowTransitionedTests
     public void Record_WithDifferentValues_ShouldNotBeEqual()
     {
         // Arrange
-        WorkflowTransitioned<WorkflowLifecycleStatus> evt1 = new(
+        WorkflowTransitionedEvent<WorkflowLifecycleStatus> evt1 = new(
             "Document", "id-1", WorkflowLifecycleStatus.Draft,
             WorkflowLifecycleStatus.Published, "user-1");
 
-        WorkflowTransitioned<WorkflowLifecycleStatus> evt2 = new(
+        WorkflowTransitionedEvent<WorkflowLifecycleStatus> evt2 = new(
             "Document", "id-2", WorkflowLifecycleStatus.Draft,
             WorkflowLifecycleStatus.Published, "user-1");
 
@@ -78,12 +78,12 @@ public sealed class WorkflowTransitionedTests
     public void Record_ShouldSupportWith()
     {
         // Arrange
-        WorkflowTransitioned<WorkflowLifecycleStatus> original = new(
+        WorkflowTransitionedEvent<WorkflowLifecycleStatus> original = new(
             "Document", "id-1", WorkflowLifecycleStatus.Draft,
             WorkflowLifecycleStatus.Published, "user-1");
 
         // Act
-        WorkflowTransitioned<WorkflowLifecycleStatus> copy = original with { TransitionedBy = "user-2" };
+        WorkflowTransitionedEvent<WorkflowLifecycleStatus> copy = original with { TransitionedBy = "user-2" };
 
         // Assert
         copy.TransitionedBy.ShouldBe("user-2");


### PR DESCRIPTION
## Summary

- Rename 11 domain events to `*Event` suffix (align with `EntityCreatedEvent<T>` pattern)
- Rename 5 integration events from `*Event` to `*Eto` suffix (align with `EntityCreatedEto<T>` pattern)
- Update `IDomainEvent` / `IIntegrationEvent` XML doc naming conventions
- Update event-driven.md, privacy.mdx, saga-process-manager.md documentation

Closes #461

## Convention

| Scope | Interface | Suffix | Example |
| ----- | --------- | ------ | ------- |
| Domain (local, in-process) | `IDomainEvent` | `*Event` | `BlobValidatedEvent` |
| Integration (distributed, outbox) | `IIntegrationEvent` | `*Eto` | `PersonalDataDeletedEto` |

## Test plan

- [ ] `dotnet build` passes
- [ ] `dotnet test` — all affected modules pass
- [ ] No behavioral changes — pure rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)
