### PR TITLE
feat(events): add missing high-priority domain and integration events

### DIFF
--- a/src/Granit.Authentication.ApiKeys/Domain/ApiKeyEntry.cs
+++ b/src/Granit.Authentication.ApiKeys/Domain/ApiKeyEntry.cs
@@ -95,6 +95,7 @@ public sealed class ApiKeyEntry : FullAuditedAggregateRoot, IMultiTenant
     internal void RecordUsage(DateTimeOffset usedAt)
     {
         LastUsedAt = usedAt;
+        AddDistributedEvent(new Events.ApiKeyUsedEto(Id, Prefix, usedAt));
     }
 
     /// <summary>

--- a/src/Granit.Authentication.ApiKeys/Events/ApiKeyUsedEto.cs
+++ b/src/Granit.Authentication.ApiKeys/Events/ApiKeyUsedEto.cs
@@ -1,0 +1,15 @@
+using Granit.Core.Events;
+
+namespace Granit.Authentication.ApiKeys.Events;
+
+/// <summary>
+/// Published when an API key is used for an API call.
+/// Provides a security audit trail for ISO 27001 compliance — usage tracking.
+/// </summary>
+/// <param name="ApiKeyId">The unique identifier of the used key.</param>
+/// <param name="Prefix">The key prefix for identification (e.g., <c>gk_live_sk_</c>).</param>
+/// <param name="UsedAt">The timestamp when the key was used.</param>
+public sealed record ApiKeyUsedEto(
+    Guid ApiKeyId,
+    string Prefix,
+    DateTimeOffset UsedAt) : IIntegrationEvent;

--- a/src/Granit.BackgroundJobs/Domain/BackgroundJobDefinition.cs
+++ b/src/Granit.BackgroundJobs/Domain/BackgroundJobDefinition.cs
@@ -1,6 +1,7 @@
 using Granit.BackgroundJobs.Events;
 using Granit.BackgroundJobs.Internal;
 using Granit.Core.Domain;
+using Granit.Core.Events;
 
 namespace Granit.BackgroundJobs.Domain;
 
@@ -126,6 +127,12 @@ public sealed class BackgroundJobDefinition : AggregateRoot
     {
         ConsecutiveFailureCount++;
         LastErrorMessage = errorMessage;
+
+        if (ConsecutiveFailureCount >= 3)
+        {
+            AddDistributedEvent(new BackgroundJobFailureThresholdExceededEto(
+                Id, JobName, ConsecutiveFailureCount, errorMessage));
+        }
     }
 
     /// <summary>

--- a/src/Granit.BackgroundJobs/Events/BackgroundJobFailureThresholdExceededEto.cs
+++ b/src/Granit.BackgroundJobs/Events/BackgroundJobFailureThresholdExceededEto.cs
@@ -1,0 +1,13 @@
+using Granit.Core.Events;
+
+namespace Granit.BackgroundJobs.Events;
+
+/// <summary>
+/// Published when a background job reaches 3 consecutive failures, signaling potential
+/// infrastructure or configuration issues that require operator attention.
+/// </summary>
+public sealed record BackgroundJobFailureThresholdExceededEto(
+    Guid JobId,
+    string JobName,
+    int ConsecutiveFailureCount,
+    string? LastErrorMessage) : IIntegrationEvent;

--- a/src/Granit.Features.EntityFrameworkCore/Internal/TenantFeatureOverride.cs
+++ b/src/Granit.Features.EntityFrameworkCore/Internal/TenantFeatureOverride.cs
@@ -13,7 +13,7 @@ namespace Granit.Features.EntityFrameworkCore.Internal;
 /// satisfying the ISO 27001 3-year audit trail requirement.
 /// <c>TenantId</c> is injected automatically by the same interceptor on insert.
 /// </remarks>
-internal sealed class TenantFeatureOverride : AuditedEntity, IMultiTenant
+internal sealed class TenantFeatureOverride : AuditedEntity, IMultiTenant, IEmitEntityLifecycleEvents
 {
     /// <summary>Tenant scope. Never null for a tenant override (enforced at the store level).</summary>
     public Guid? TenantId { get; set; }

--- a/src/Granit.Identity/Events/UserCacheEntryErasedEto.cs
+++ b/src/Granit.Identity/Events/UserCacheEntryErasedEto.cs
@@ -1,0 +1,23 @@
+using Granit.Core.Events;
+
+namespace Granit.Identity.Events;
+
+/// <summary>
+/// Published when a user cache entry is permanently deleted (RGPD Art. 17 — right to erasure).
+/// Provides an audit trail for ISO 27001 compliance and enables downstream modules to react
+/// to user data removal (e.g., clearing related caches, triggering cascade erasure).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Entities.UserCacheEntry"/> is an anemic entity (not an aggregate root), so this
+/// event cannot be raised from the entity itself. It should be dispatched by the store or service
+/// that performs the deletion (e.g., <c>IUserCacheStore.DeleteByExternalIdAsync</c> implementation).
+/// </para>
+/// </remarks>
+/// <param name="ExternalUserId">The user identifier in the external identity provider.</param>
+/// <param name="TenantId">The tenant scope of the erased entry, or <c>null</c> for host-level entries.</param>
+/// <param name="ErasedAt">The timestamp when the cache entry was erased.</param>
+public sealed record UserCacheEntryErasedEto(
+    string ExternalUserId,
+    Guid? TenantId,
+    DateTimeOffset ErasedAt) : IIntegrationEvent;

--- a/src/Granit.Localization.EntityFrameworkCore/Entities/LocalizationOverride.cs
+++ b/src/Granit.Localization.EntityFrameworkCore/Entities/LocalizationOverride.cs
@@ -15,7 +15,7 @@ namespace Granit.Localization.EntityFrameworkCore.Entities;
 /// satisfying the ISO 27001 3-year audit trail requirement.
 /// </para>
 /// </remarks>
-public sealed class LocalizationOverride : AuditedEntity, IMultiTenant
+public sealed class LocalizationOverride : AuditedEntity, IMultiTenant, IEmitEntityLifecycleEvents
 {
     /// <summary>Tenant scope. <c>null</c> = host-level override (applies to all tenants).</summary>
     public Guid? TenantId { get; set; }

--- a/src/Granit.Notifications/Domain/UserNotification.cs
+++ b/src/Granit.Notifications/Domain/UserNotification.cs
@@ -1,4 +1,5 @@
 using Granit.Core.Domain;
+using Granit.Notifications.Events;
 
 namespace Granit.Notifications.Domain;
 
@@ -70,5 +71,15 @@ public sealed class UserNotification : AggregateRoot, IMultiTenant
 
         State = UserNotificationState.Read;
         ReadAt = readAt;
+
+        AddDomainEvent(new UserNotificationReadEvent(Id, RecipientUserId, readAt));
     }
+
+    /// <summary>
+    /// Raises a <see cref="UserNotificationCreatedEvent"/> domain event.
+    /// Called by the store/channel after the notification is persisted.
+    /// </summary>
+    internal void RaiseCreatedEvent() =>
+        AddDomainEvent(new UserNotificationCreatedEvent(
+            Id, NotificationTypeName, Severity, RecipientUserId, TenantId));
 }

--- a/src/Granit.Notifications/Events/UserNotificationCreatedEvent.cs
+++ b/src/Granit.Notifications/Events/UserNotificationCreatedEvent.cs
@@ -1,0 +1,13 @@
+using Granit.Core.Events;
+
+namespace Granit.Notifications.Events;
+
+/// <summary>
+/// Raised after a <see cref="Domain.UserNotification"/> is persisted in the user's inbox.
+/// </summary>
+public sealed record UserNotificationCreatedEvent(
+    Guid NotificationId,
+    string NotificationTypeName,
+    NotificationSeverity Severity,
+    string RecipientUserId,
+    Guid? TenantId) : IDomainEvent;

--- a/src/Granit.Notifications/Events/UserNotificationReadEvent.cs
+++ b/src/Granit.Notifications/Events/UserNotificationReadEvent.cs
@@ -1,0 +1,11 @@
+using Granit.Core.Events;
+
+namespace Granit.Notifications.Events;
+
+/// <summary>
+/// Raised when a <see cref="Domain.UserNotification"/> is marked as read by the recipient.
+/// </summary>
+public sealed record UserNotificationReadEvent(
+    Guid NotificationId,
+    string RecipientUserId,
+    DateTimeOffset ReadAt) : IDomainEvent;

--- a/src/Granit.Privacy/LegalAgreements/Events/LegalAgreementAcceptedEto.cs
+++ b/src/Granit.Privacy/LegalAgreements/Events/LegalAgreementAcceptedEto.cs
@@ -1,0 +1,16 @@
+using Granit.Core.Events;
+
+namespace Granit.Privacy.LegalAgreements.Events;
+
+/// <summary>
+/// Published when a user accepts a legal agreement (RGPD Art. 7 — proof of consent).
+/// </summary>
+/// <remarks>
+/// <see cref="LegalAgreements.Domain.LegalAgreementBase"/> is anemic (CreationAuditedEntity) —
+/// this event is raised by the store/service after persistence, not by the entity itself.
+/// </remarks>
+public sealed record LegalAgreementAcceptedEto(
+    string UserId,
+    string DocumentId,
+    string Version,
+    DateTimeOffset AcceptedAt) : IIntegrationEvent;

--- a/src/Granit.ReferenceData/Domain/ReferenceDataEntity.cs
+++ b/src/Granit.ReferenceData/Domain/ReferenceDataEntity.cs
@@ -24,7 +24,7 @@ namespace Granit.ReferenceData.Domain;
 /// are filtered out by the EF Core global query filter unless explicitly disabled.
 /// </para>
 /// </remarks>
-public abstract class ReferenceDataEntity : AuditedEntity, IActive
+public abstract class ReferenceDataEntity : AuditedEntity, IActive, IEmitEntityLifecycleEvents
 {
     /// <summary>
     /// Unique business key for the reference data entry (e.g., "BE", "EUR", "fr").

--- a/src/Granit.Settings.EntityFrameworkCore/Entities/SettingRecord.cs
+++ b/src/Granit.Settings.EntityFrameworkCore/Entities/SettingRecord.cs
@@ -16,7 +16,7 @@ namespace Granit.Settings.EntityFrameworkCore.Entities;
 /// satisfying the ISO 27001 3-year audit trail requirement.
 /// </para>
 /// </remarks>
-public sealed class SettingRecord : AuditedEntity
+public sealed class SettingRecord : AuditedEntity, IEmitEntityLifecycleEvents
 {
     /// <summary>Setting name (e.g. <c>"Notifications.Email.Enabled"</c>). Max 256 characters.</summary>
     public string Name { get; set; } = string.Empty;

--- a/src/Granit.Webhooks/Domain/WebhookSubscription.cs
+++ b/src/Granit.Webhooks/Domain/WebhookSubscription.cs
@@ -108,6 +108,12 @@ public sealed class WebhookSubscription : AuditedAggregateRoot
     internal void RecordFailure()
     {
         ConsecutiveFailureCount++;
+
+        if (ConsecutiveFailureCount >= 5)
+        {
+            AddDistributedEvent(new WebhookDeliveryFailureThresholdExceededEto(
+                Id, TargetUrl, ConsecutiveFailureCount));
+        }
     }
 
     /// <summary>

--- a/src/Granit.Webhooks/Events/WebhookDeliveryFailureThresholdExceededEto.cs
+++ b/src/Granit.Webhooks/Events/WebhookDeliveryFailureThresholdExceededEto.cs
@@ -1,0 +1,12 @@
+using Granit.Core.Events;
+
+namespace Granit.Webhooks.Events;
+
+/// <summary>
+/// Published when a webhook subscription reaches 5 consecutive delivery failures,
+/// indicating the target endpoint may be unreachable or misconfigured.
+/// </summary>
+public sealed record WebhookDeliveryFailureThresholdExceededEto(
+    Guid SubscriptionId,
+    string TargetUrl,
+    int ConsecutiveFailureCount) : IIntegrationEvent;

--- a/tests/Granit.Identity.Tests/UserCacheEntryErasedEtoTests.cs
+++ b/tests/Granit.Identity.Tests/UserCacheEntryErasedEtoTests.cs
@@ -1,0 +1,46 @@
+using Granit.Core.Events;
+using Granit.Identity.Events;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Tests;
+
+public sealed class UserCacheEntryErasedEtoTests
+{
+    [Fact]
+    public void ImplementsIIntegrationEvent() =>
+        new UserCacheEntryErasedEto("ext-user-1", Guid.NewGuid(), DateTimeOffset.UtcNow)
+            .ShouldBeAssignableTo<IIntegrationEvent>();
+
+    [Fact]
+    public void Properties_AreSetFromConstructor()
+    {
+        var tenantId = Guid.NewGuid();
+        DateTimeOffset erasedAt = DateTimeOffset.UtcNow;
+        var evt = new UserCacheEntryErasedEto("ext-user-1", tenantId, erasedAt);
+
+        evt.ExternalUserId.ShouldBe("ext-user-1");
+        evt.TenantId.ShouldBe(tenantId);
+        evt.ErasedAt.ShouldBe(erasedAt);
+    }
+
+    [Fact]
+    public void Properties_AllowNullTenantId()
+    {
+        DateTimeOffset erasedAt = DateTimeOffset.UtcNow;
+        var evt = new UserCacheEntryErasedEto("ext-user-1", null, erasedAt);
+
+        evt.TenantId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void RecordEquality_WorksCorrectly()
+    {
+        var tenantId = Guid.NewGuid();
+        DateTimeOffset erasedAt = DateTimeOffset.UtcNow;
+        var evt1 = new UserCacheEntryErasedEto("ext-user-1", tenantId, erasedAt);
+        var evt2 = new UserCacheEntryErasedEto("ext-user-1", tenantId, erasedAt);
+
+        evt1.ShouldBe(evt2);
+    }
+}


### PR DESCRIPTION
## Summary

Add high-priority missing events across 9 modules, identified in the comprehensive event gap analysis (#465).

### New events raised by aggregate root behavior methods (5)

| Event | Type | Module | Trigger |
| ----- | ---- | ------ | ------- |
| `ApiKeyUsedEto` | Integration | Authentication.ApiKeys | `RecordUsage()` — ISO 27001 usage audit |
| `BackgroundJobFailureThresholdExceededEto` | Integration | BackgroundJobs | `RecordFailure()` when 3+ consecutive failures |
| `WebhookDeliveryFailureThresholdExceededEto` | Integration | Webhooks | `RecordFailure()` when 5+ consecutive failures |
| `UserNotificationCreatedEvent` | Domain | Notifications | `RaiseCreatedEvent()` — delivery pipeline trigger |
| `UserNotificationReadEvent` | Domain | Notifications | `MarkAsRead()` — engagement tracking |

### New event records for store/service integration (2)

| Event | Type | Module | Why |
| ----- | ---- | ------ | --- |
| `UserCacheEntryErasedEto` | Integration | Identity | GDPR Art. 17 erasure completion |
| `LegalAgreementAcceptedEto` | Integration | Privacy | GDPR Art. 7 proof of consent |

### Entity lifecycle events via `IEmitEntityLifecycleEvents` marker (4)

| Entity | Module | Enables |
| ------ | ------ | ------- |
| `SettingRecord` | Settings | Config change broadcast to all instances |
| `TenantFeatureOverride` | Features | License/entitlement tracking |
| `LocalizationOverride` | Localization | Cache/CDN invalidation |
| `ReferenceDataEntity` | ReferenceData | Client-side cache invalidation |

Depends on #464 (event naming convention)

## Test plan

- [ ] `dotnet build` passes
- [ ] `dotnet test tests/Granit.Authentication.ApiKeys.Tests` — all pass
- [ ] `dotnet test tests/Granit.BackgroundJobs.Tests` — all pass
- [ ] `dotnet test tests/Granit.Webhooks.Tests` — all pass
- [ ] `dotnet test tests/Granit.Notifications.Tests` — all pass
- [ ] `dotnet test tests/Granit.Identity.Tests` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
