### PR TITLE
feat(events): add missing domain/integration events + DDD Phase 5 (#460, #465)

### DIFF
--- a/docs-site/src/content/docs/blog/isolated-dbcontext-per-module.md
+++ b/docs-site/src/content/docs/blog/isolated-dbcontext-per-module.md
@@ -129,7 +129,7 @@ services.AddGranitDbContext<GranitLocalizationOverridesDbContext>(
 `UseGranitInterceptors` adds four interceptors in a fixed sequence:
 
 1. **`AuditedEntityInterceptor`** — sets `CreatedAt`, `CreatedBy`, `ModifiedAt`, `ModifiedBy`, `TenantId`, and `Id` (sequential GUID) on new or modified entities. ISO 27001 compliance.
-2. **`VersioningInterceptor`** — assigns `BusinessId` and increments `Version` on `IVersioned` entities.
+2. **`VersioningInterceptor`** — assigns `VersionId` and increments `Version` on `IVersioned` entities.
 3. **`DomainEventDispatcherInterceptor`** — collects domain events from entities after `SaveChanges` and dispatches them through Wolverine.
 4. **`SoftDeleteInterceptor`** — converts physical deletes to soft deletes for `ISoftDeletable` entities by flipping `IsDeleted = true` and changing the entry state from `Deleted` to `Modified`.
 

--- a/docs-site/src/content/docs/dotnet/architecture/patterns/unit-of-work.md
+++ b/docs-site/src/content/docs/dotnet/architecture/patterns/unit-of-work.md
@@ -32,7 +32,7 @@ sequenceDiagram
 
     activate DB
     DB->>AI: SavingChanges -- CreatedAt/By, ModifiedAt/By, TenantId
-    AI->>VI: SavingChanges -- BusinessId, Version
+    AI->>VI: SavingChanges -- VersionId, Version
     VI->>DEI: SavingChanges -- collects IDomainEvent
     DEI->>SDI: SavingChanges -- DELETE to UPDATE (IsDeleted)
     SDI->>PG: BEGIN + INSERT/UPDATE
@@ -55,7 +55,7 @@ Registered in `src/Granit.Persistence/Extensions/DbContextOptionsBuilderExtensio
 | Order | Interceptor | Role |
 | --- | --- | --- |
 | 1 | `AuditedEntityInterceptor` | ISO 27001 -- `CreatedAt/By`, `ModifiedAt/By`, `TenantId`, auto-`Id` |
-| 2 | `VersioningInterceptor` | `BusinessId` and `Version` on `IVersioned` entities |
+| 2 | `VersioningInterceptor` | `VersionId` and `Version` on `IVersioned` entities |
 | 3 | `DomainEventDispatcherInterceptor` | Collects `IDomainEvent` before save, dispatches after commit |
 | 4 | `SoftDeleteInterceptor` | GDPR -- converts `DELETE` to `UPDATE` (`IsDeleted`, `DeletedAt/By`) |
 

--- a/docs-site/src/content/docs/dotnet/business/workflow.mdx
+++ b/docs-site/src/content/docs/dotnet/business/workflow.mdx
@@ -149,7 +149,7 @@ stateDiagram-v2
 |-------|-------------|
 | `Draft` | Being edited. Filtered by `IPublishable` (not visible in standard queries). |
 | `PendingReview` | Awaiting approval from a user with the required permission. |
-| `Published` | Active published version. Exactly one per `BusinessId` (unique filtered index). |
+| `Published` | Active published version. Exactly one per `VersionId` (unique filtered index). |
 | `Archived` | Former version, preserved for ISO 27001 audit trail (3-year retention). |
 
 ```csharp
@@ -274,7 +274,7 @@ public class DocumentRevision : VersionedWorkflowEntity
 }
 ```
 
-`VersionedWorkflowEntity` provides `BusinessId`, `Version`, `LifecycleStatus`, and
+`VersionedWorkflowEntity` provides `VersionId`, `Version`, `LifecycleStatus`, and
 `IsPublished` — the interceptor keeps `IsPublished` in sync with the lifecycle status.
 
 ## ISO 27001 audit trail

--- a/docs-site/src/content/docs/dotnet/concepts/persistence.mdx
+++ b/docs-site/src/content/docs/dotnet/concepts/persistence.mdx
@@ -102,9 +102,9 @@ The filter is restored automatically when the `using` block exits.
 
 Targets entities implementing `IVersionedEntity`. On insert:
 
-- Assigns a `BusinessId` (human-readable sequential identifier scoped to
-  the entity type).
-- Sets `Version` to `max(Version) + 1` for that `BusinessId`.
+- Assigns a `VersionId` (stable GUID shared across all versions of the same
+  logical entity).
+- Sets `Version` to `max(Version) + 1` for that `VersionId`.
 
 This gives you an immutable version history without a separate history table.
 

--- a/docs-site/src/content/docs/dotnet/core/module-system.mdx
+++ b/docs-site/src/content/docs/dotnet/core/module-system.mdx
@@ -350,7 +350,7 @@ background jobs or admin operations with explicit authorization checks.
 
 | Interface | Properties | Purpose |
 |-----------|-----------|---------|
-| `IVersioned` | `BusinessId`, `Version` | Versioned audit history (stable ID across versions) |
+| `IVersioned` | `VersionId`, `Version` | Versioned audit history (stable ID across versions) |
 | `ITranslatable<T>` | `Translations` collection | Multi-language entity content |
 | `ITranslation` | `ParentId`, `Culture` | Translation record (with `Translation<T>` and `AuditedTranslation<T>` base classes) |
 

--- a/docs-site/src/content/docs/dotnet/data/interceptors.mdx
+++ b/docs-site/src/content/docs/dotnet/data/interceptors.mdx
@@ -13,7 +13,7 @@ Five interceptors execute on every `SaveChanges` call, in this order:
 | Order | Interceptor | Behavior |
 |-------|-------------|----------|
 | 1 | `AuditedEntityInterceptor` | Populates `CreatedAt`, `CreatedBy`, `ModifiedAt`, `ModifiedBy`, auto-generates `Id`, injects `TenantId` |
-| 2 | `VersioningInterceptor` | Sets `BusinessId` and `Version` on `IVersioned` entities |
+| 2 | `VersioningInterceptor` | Sets `VersionId` and `Version` on `IVersioned` entities |
 | 3 | `ConcurrencyStampInterceptor` | Regenerates `ConcurrencyStamp` on `IConcurrencyAware` entities |
 | 4 | `DomainEventDispatcherInterceptor` | Collects domain events before save, dispatches after commit |
 | 5 | `SoftDeleteInterceptor` | Converts `DELETE` to `UPDATE` for `ISoftDeletable` entities |
@@ -115,9 +115,9 @@ replaces it with real message bus dispatch.
 
 For `IVersioned` entities on `EntityState.Added`:
 
-- Generates `BusinessId` if empty (first version of a new entity)
+- Generates `VersionId` if empty (first version of a new entity)
 - Determines `Version` from change tracker (starting at 1)
-- Modified entities are untouched — versioning is explicit (create a new entity with same `BusinessId`)
+- Modified entities are untouched — versioning is explicit (create a new entity with same `VersionId`)
 
 ## ConcurrencyStampInterceptor
 

--- a/docs-site/src/content/docs/dotnet/guides/implement-workflow.mdx
+++ b/docs-site/src/content/docs/dotnet/guides/implement-workflow.mdx
@@ -114,7 +114,7 @@ public sealed class Document : VersionedWorkflowEntity
 }
 ```
 
-`VersionedWorkflowEntity` provides `BusinessId`, `Version`,
+`VersionedWorkflowEntity` provides `VersionId`, `Version`,
 `LifecycleStatus`, and `IsPublished` out of the box.
   </TabItem>
 </Tabs>

--- a/docs-site/src/content/docs/dotnet/infrastructure/event-bus.mdx
+++ b/docs-site/src/content/docs/dotnet/infrastructure/event-bus.mdx
@@ -8,6 +8,10 @@ sidebar:
 
 import { Tabs, TabItem, FileTree } from "@astrojs/starlight/components";
 
+:::tip[See also]
+Looking for the complete list of events? Check the [Event Catalog](/dotnet/infrastructure/event-catalog/).
+:::
+
 Think of events in two ways: a **phone call** (local — instant, same room, you hear
 the answer immediately) and **registered mail** (distributed — crosses boundaries,
 guaranteed delivery, but you don't know when). Granit's dual event bus, inspired by

--- a/docs-site/src/content/docs/dotnet/infrastructure/event-catalog.mdx
+++ b/docs-site/src/content/docs/dotnet/infrastructure/event-catalog.mdx
@@ -1,0 +1,164 @@
+---
+title: "Event Catalog — All Domain and Integration Events"
+description: Comprehensive reference of all domain events (*Event) and integration events (*Eto) emitted across Granit modules, organized by module with compliance tags.
+sidebar:
+  label: Event Catalog
+  order: 8
+  badge:
+    text: New
+    variant: tip
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+Every event in Granit follows two naming conventions enforced by architecture tests:
+
+- **Domain events** (`IDomainEvent`) — suffix `*Event`, in-process, after commit
+- **Integration events** (`IIntegrationEvent`) — suffix `*Eto`, durable Wolverine outbox
+
+See the [Event Bus](/dotnet/infrastructure/event-bus/) page for architecture and usage patterns.
+
+## Custom events by module
+
+<Tabs>
+<TabItem label="Security & Audit">
+
+### Authentication.ApiKeys
+
+| Event | Type | Trigger | Compliance |
+|-------|------|---------|------------|
+| `ApiKeyCreatedEvent` | Domain | `ApiKeyEntry.Create()` | ISO 27001 |
+| `ApiKeyRevokedEvent` | Domain | Service layer | ISO 27001 |
+| `ApiKeyRotatedEvent` | Domain | Service layer | ISO 27001 |
+| `ApiKeyScopesUpdatedEvent` | Domain | Service layer | ISO 27001 |
+| `ApiKeyUsedEto` | Integration | `ApiKeyEntry.RecordUsage()` | ISO 27001 |
+| `ApiKeyExpiredEvent` | Domain | `ApiKeyEntry.MarkAsExpired()` | ISO 27001 |
+
+### Identity
+
+| Event | Type | Trigger | Compliance |
+|-------|------|---------|------------|
+| `IdentityUserUpdatedEvent` | Wolverine | Identity provider webhook | — |
+| `IdentityUserDeletedEvent` | Wolverine | Identity provider webhook | GDPR Art. 17 |
+| `UserCacheEntryErasedEvent` | Domain | After hard-delete in handler | GDPR Art. 17 |
+| `UserCacheSyncedEto` | Integration | After cache upsert in handler | — |
+
+### Privacy
+
+| Event | Type | Trigger | Compliance |
+|-------|------|---------|------------|
+| `PersonalDataDeletionRequestedEto` | Integration | GDPR Art. 17 request | GDPR |
+| `PersonalDataDeletedEto` | Integration | After provider deletion | GDPR + ISO 27001 |
+| `PersonalDataRequestedEto` | Integration | GDPR Art. 15/20 export | GDPR |
+| `PersonalDataPreparedEto` | Integration | Provider fragment ready | GDPR |
+| `ExportCompletedEto` | Integration | All fragments assembled | GDPR |
+| `ExportTimedOutEvent` | Domain | Provider deadline exceeded | GDPR |
+| `LegalAgreementAcceptedEto` | Integration | User accepts agreement | GDPR Art. 7 |
+| `LegalAgreementObsoleteEto` | Integration | Document version superseded | GDPR Art. 7 |
+
+### Authorization
+
+| Event | Type | Trigger | Compliance |
+|-------|------|---------|------------|
+| `PermissionGrantChangedEvent` | Domain | Permission grant mutation | ISO 27001 |
+
+</TabItem>
+<TabItem label="Delivery & Observability">
+
+### Notifications
+
+| Event | Type | Trigger | Compliance |
+|-------|------|---------|------------|
+| `UserNotificationCreatedEvent` | Domain | `UserNotification.RaiseCreatedEvent()` | — |
+| `UserNotificationReadEvent` | Domain | `UserNotification.MarkAsRead()` | — |
+
+### Webhooks
+
+| Event | Type | Trigger | Compliance |
+|-------|------|---------|------------|
+| `WebhookSubscriptionCreatedEvent` | Domain | `WebhookSubscription.Create()` | ISO 27001 |
+| `WebhookSubscriptionActivatedEvent` | Domain | `WebhookSubscription.Activate()` | — |
+| `WebhookSubscriptionSuspendedEvent` | Domain | `WebhookSubscription.Suspend()` | ISO 27001 |
+| `WebhookSubscriptionDeactivatedEvent` | Domain | `WebhookSubscription.Deactivate()` | — |
+| `WebhookDeliverySucceededEvent` | Domain | `WebhookSubscription.RecordSuccess()` | — |
+| `WebhookDeliveryFailureThresholdExceededEto` | Integration | `RecordFailure()` (threshold: 5) | SLA |
+
+### BackgroundJobs
+
+| Event | Type | Trigger | Compliance |
+|-------|------|---------|------------|
+| `BackgroundJobPausedEvent` | Domain | `BackgroundJobDefinition.Pause()` | ISO 27001 |
+| `BackgroundJobResumedEvent` | Domain | `BackgroundJobDefinition.Resume()` | — |
+| `BackgroundJobDefinitionChangedEvent` | Domain | `UpdateDefinition()` (cron changed) | ISO 27001 |
+| `BackgroundJobExecutionStartedEto` | Integration | `RecordExecutionStart()` | — |
+| `BackgroundJobFailureThresholdExceededEto` | Integration | `RecordFailure()` (threshold: 3) | SLA |
+
+</TabItem>
+<TabItem label="Data Pipeline">
+
+### BlobStorage
+
+| Event | Type | Trigger | Compliance |
+|-------|------|---------|------------|
+| `BlobUploadStartedEvent` | Domain | `BlobDescriptor.MarkAsUploading()` | — |
+| `BlobValidatedEvent` | Domain | `BlobDescriptor.MarkAsValid()` | — |
+| `BlobRejectedEvent` | Domain | `BlobDescriptor.MarkAsRejected()` | — |
+| `BlobDeletedEvent` | Domain | `BlobDescriptor.MarkAsDeleted()` | GDPR Art. 17 |
+
+### DataExchange
+
+| Event | Type | Trigger | Compliance |
+|-------|------|---------|------------|
+| `ImportJobCompletedEvent` | Wolverine | Import orchestrator | — |
+| `ImportJobCancelledEvent` | Domain | `ImportJob.Cancel()` | ISO 27001 |
+| `ExportJobCompletedEvent` | Wolverine | Export orchestrator | — |
+| `ExportJobFailedEto` | Integration | Export orchestrator catch block | SLA |
+
+### Timeline
+
+| Event | Type | Trigger | Compliance |
+|-------|------|---------|------------|
+| `TimelineEntryPostedEvent` | Domain | `TimelineEntry.RaisePostedEvent()` | — |
+| `TimelineEntrySoftDeletedEvent` | Domain | `TimelineEntry.SoftDelete()` | ISO 27001 |
+
+### Workflow
+
+| Event | Type | Trigger | Compliance |
+|-------|------|---------|------------|
+| `WorkflowTransitionedEvent<TState>` | Domain | State transition | — |
+| `WorkflowStateChangedEvent` | Domain | State change | — |
+| `WorkflowApprovalRequestedEvent` | Domain | Approval requested | — |
+
+</TabItem>
+</Tabs>
+
+## Lifecycle events (automatic)
+
+Entities implementing `IEmitEntityLifecycleEvents` automatically emit six events via `EntityLifecycleEventInterceptor`:
+
+| Domain Event | Integration Event | Trigger |
+|-------------|------------------|---------|
+| `EntityCreatedEvent<T>` | `EntityCreatedEto<T>` | First `SaveChanges` |
+| `EntityUpdatedEvent<T>` | `EntityUpdatedEto<T>` | Property change detected |
+| `EntityDeletedEvent<T>` | `EntityDeletedEto<T>` | Entity removed or soft-deleted |
+
+### Entities with lifecycle events
+
+| Entity | Module | Use case |
+|--------|--------|----------|
+| `SettingRecord` | Settings.EntityFrameworkCore | Config cache invalidation |
+| `TenantFeatureOverride` | Features.EntityFrameworkCore | Feature flag cache refresh |
+| `LocalizationOverride` | Localization.EntityFrameworkCore | Translation cache + CDN invalidation |
+| `ReferenceDataEntity` | ReferenceData | Client-side cache invalidation |
+
+See [Entity Lifecycle Events](/dotnet/data/entity-lifecycle-events/) for setup details.
+
+## Event count summary
+
+| Category | Custom | Lifecycle (auto) | Total |
+|----------|--------|-----------------|-------|
+| Security & Audit | 14 | 0 | 14 |
+| Delivery & Observability | 12 | 0 | 12 |
+| Data Pipeline | 11 | 0 | 11 |
+| Cache Invalidation | 0 | 24 (4 entities x 6) | 24 |
+| **Total** | **37** | **24** | **61** |

--- a/src/Granit.Authentication.ApiKeys/Domain/ApiKeyEntry.cs
+++ b/src/Granit.Authentication.ApiKeys/Domain/ApiKeyEntry.cs
@@ -1,3 +1,4 @@
+using Granit.Authentication.ApiKeys.Events;
 using Granit.Core.Domain;
 using Granit.Core.MultiTenancy;
 
@@ -95,6 +96,21 @@ public sealed class ApiKeyEntry : FullAuditedAggregateRoot, IMultiTenant
     internal void RecordUsage(DateTimeOffset usedAt)
     {
         LastUsedAt = usedAt;
+        AddDistributedEvent(new ApiKeyUsedEto(Id, Prefix, usedAt));
+    }
+
+    /// <summary>
+    /// Marks this key as expired and emits an <see cref="ApiKeyExpiredEvent"/> domain event.
+    /// Called by the authentication handler when an expired key is detected.
+    /// </summary>
+    internal void MarkAsExpired()
+    {
+        if (ExpiresAt is null)
+        {
+            return;
+        }
+
+        AddDomainEvent(new ApiKeyExpiredEvent(Id, Prefix, ExpiresAt.Value));
     }
 
     /// <summary>

--- a/src/Granit.Authentication.ApiKeys/Events/ApiKeyExpiredEvent.cs
+++ b/src/Granit.Authentication.ApiKeys/Events/ApiKeyExpiredEvent.cs
@@ -1,0 +1,15 @@
+using Granit.Core.Events;
+
+namespace Granit.Authentication.ApiKeys.Events;
+
+/// <summary>
+/// Raised when an API key is detected as expired.
+/// Enables security monitoring and automatic expiration enforcement.
+/// </summary>
+/// <param name="ApiKeyId">The unique identifier of the expired key.</param>
+/// <param name="Prefix">Key prefix for identification (e.g., <c>gk_live_sk_</c>).</param>
+/// <param name="ExpiredAt">The expiration timestamp of the key.</param>
+public sealed record ApiKeyExpiredEvent(
+    Guid ApiKeyId,
+    string Prefix,
+    DateTimeOffset ExpiredAt) : IDomainEvent;

--- a/src/Granit.Authentication.ApiKeys/Events/ApiKeyUsedEto.cs
+++ b/src/Granit.Authentication.ApiKeys/Events/ApiKeyUsedEto.cs
@@ -1,0 +1,15 @@
+using Granit.Core.Events;
+
+namespace Granit.Authentication.ApiKeys.Events;
+
+/// <summary>
+/// Published when an API key is used for authentication.
+/// Enables usage tracking and ISO 27001 compliance auditing.
+/// </summary>
+/// <param name="ApiKeyId">The unique identifier of the key.</param>
+/// <param name="Prefix">Key prefix for identification (e.g., <c>gk_live_sk_</c>).</param>
+/// <param name="UsedAt">Timestamp of the API call.</param>
+public sealed record ApiKeyUsedEto(
+    Guid ApiKeyId,
+    string Prefix,
+    DateTimeOffset UsedAt) : IIntegrationEvent;

--- a/src/Granit.BackgroundJobs/Domain/BackgroundJobDefinition.cs
+++ b/src/Granit.BackgroundJobs/Domain/BackgroundJobDefinition.cs
@@ -96,8 +96,14 @@ public sealed class BackgroundJobDefinition : AggregateRoot
     /// </summary>
     internal void UpdateDefinition(string cronExpression, string messageType)
     {
+        string oldCron = CronExpression;
         CronExpression = cronExpression;
         MessageType = messageType;
+
+        if (!string.Equals(oldCron, cronExpression, StringComparison.Ordinal))
+        {
+            AddDomainEvent(new BackgroundJobDefinitionChangedEvent(Id, JobName, oldCron, cronExpression));
+        }
     }
 
     /// <summary>
@@ -109,6 +115,7 @@ public sealed class BackgroundJobDefinition : AggregateRoot
         LastErrorMessage = null;
         ConsecutiveFailureCount = 0;
         TriggeredBy = null;
+        AddDistributedEvent(new BackgroundJobExecutionStartedEto(Id, JobName, startedAt));
     }
 
     /// <summary>
@@ -126,6 +133,12 @@ public sealed class BackgroundJobDefinition : AggregateRoot
     {
         ConsecutiveFailureCount++;
         LastErrorMessage = errorMessage;
+
+        if (ConsecutiveFailureCount >= 3)
+        {
+            AddDistributedEvent(new BackgroundJobFailureThresholdExceededEto(
+                Id, JobName, ConsecutiveFailureCount, LastErrorMessage));
+        }
     }
 
     /// <summary>

--- a/src/Granit.BackgroundJobs/Events/BackgroundJobDefinitionChangedEvent.cs
+++ b/src/Granit.BackgroundJobs/Events/BackgroundJobDefinitionChangedEvent.cs
@@ -1,0 +1,17 @@
+using Granit.Core.Events;
+
+namespace Granit.BackgroundJobs.Events;
+
+/// <summary>
+/// Raised when a background job definition is updated on deployment.
+/// Enables deployment audit for schedule modifications.
+/// </summary>
+/// <param name="JobId">The unique identifier of the job definition.</param>
+/// <param name="JobName">Stable job name for identification.</param>
+/// <param name="OldCronExpression">Previous cron schedule.</param>
+/// <param name="NewCronExpression">Updated cron schedule.</param>
+public sealed record BackgroundJobDefinitionChangedEvent(
+    Guid JobId,
+    string JobName,
+    string OldCronExpression,
+    string NewCronExpression) : IDomainEvent;

--- a/src/Granit.BackgroundJobs/Events/BackgroundJobExecutionStartedEto.cs
+++ b/src/Granit.BackgroundJobs/Events/BackgroundJobExecutionStartedEto.cs
@@ -1,0 +1,15 @@
+using Granit.Core.Events;
+
+namespace Granit.BackgroundJobs.Events;
+
+/// <summary>
+/// Published when a background job execution starts.
+/// Enables real-time monitoring dashboards.
+/// </summary>
+/// <param name="JobId">The unique identifier of the job definition.</param>
+/// <param name="JobName">Stable job name for identification.</param>
+/// <param name="StartedAt">Timestamp of the execution start.</param>
+public sealed record BackgroundJobExecutionStartedEto(
+    Guid JobId,
+    string JobName,
+    DateTimeOffset StartedAt) : IIntegrationEvent;

--- a/src/Granit.BackgroundJobs/Events/BackgroundJobFailureThresholdExceededEto.cs
+++ b/src/Granit.BackgroundJobs/Events/BackgroundJobFailureThresholdExceededEto.cs
@@ -1,0 +1,17 @@
+using Granit.Core.Events;
+
+namespace Granit.BackgroundJobs.Events;
+
+/// <summary>
+/// Published when consecutive job failures reach the threshold (3).
+/// Enables SLA alerting before automatic pause.
+/// </summary>
+/// <param name="JobId">The unique identifier of the job definition.</param>
+/// <param name="JobName">Stable job name for identification.</param>
+/// <param name="ConsecutiveFailureCount">Number of consecutive failures.</param>
+/// <param name="LastErrorMessage">Error message from the last failure.</param>
+public sealed record BackgroundJobFailureThresholdExceededEto(
+    Guid JobId,
+    string JobName,
+    int ConsecutiveFailureCount,
+    string? LastErrorMessage) : IIntegrationEvent;

--- a/src/Granit.BlobStorage/Domain/BlobDescriptor.cs
+++ b/src/Granit.BlobStorage/Domain/BlobDescriptor.cs
@@ -116,6 +116,7 @@ public sealed class BlobDescriptor : AggregateRoot, IMultiTenant
         }
 
         Status = BlobStatus.Uploading;
+        AddDomainEvent(new BlobUploadStartedEvent(Id, ContainerName, OriginalFileName));
     }
 
     /// <summary>

--- a/src/Granit.BlobStorage/Events/BlobUploadStartedEvent.cs
+++ b/src/Granit.BlobStorage/Events/BlobUploadStartedEvent.cs
@@ -1,0 +1,15 @@
+using Granit.Core.Events;
+
+namespace Granit.BlobStorage.Events;
+
+/// <summary>
+/// Raised when a blob upload starts (transitions from Pending to Uploading).
+/// Enables OpenTelemetry tracing for the full upload lifecycle.
+/// </summary>
+/// <param name="BlobId">The unique identifier of the blob descriptor.</param>
+/// <param name="ContainerName">Logical container name.</param>
+/// <param name="OriginalFileName">Original filename provided by the client.</param>
+public sealed record BlobUploadStartedEvent(
+    Guid BlobId,
+    string ContainerName,
+    string OriginalFileName) : IDomainEvent;

--- a/src/Granit.Core/Domain/IVersioned.cs
+++ b/src/Granit.Core/Domain/IVersioned.cs
@@ -2,7 +2,7 @@ namespace Granit.Core.Domain;
 
 /// <summary>
 /// Interface for entities that maintain a versioned history of changes.
-/// Multiple rows can share the same <see cref="BusinessId"/>, each with a different
+/// Multiple rows can share the same <see cref="VersionId"/>, each with a different
 /// <see cref="Version"/> number.
 /// </summary>
 /// <remarks>
@@ -13,18 +13,18 @@ namespace Granit.Core.Domain;
 /// </para>
 /// <para>
 /// The <see cref="Version"/> is auto-incremented by <c>VersioningInterceptor</c>
-/// on <c>EntityState.Added</c>. If <see cref="BusinessId"/> is <see cref="Guid.Empty"/>
-/// at insert time, a new business identifier is generated automatically.
+/// on <c>EntityState.Added</c>. If <see cref="VersionId"/> is <see cref="Guid.Empty"/>
+/// at insert time, a new identifier is generated automatically.
 /// </para>
 /// </remarks>
 public interface IVersioned
 {
     /// <summary>
-    /// Stable business identifier shared across all versions of this logical entity.
-    /// All rows with the same <see cref="BusinessId"/> represent different versions
+    /// Stable identifier shared across all versions of this logical entity.
+    /// All rows with the same <see cref="VersionId"/> represent different versions
     /// of the same business object.
     /// </summary>
-    Guid BusinessId { get; set; }
+    Guid VersionId { get; set; }
 
     /// <summary>
     /// Monotonically increasing version number (1-based).

--- a/src/Granit.DataExchange/Export/Events/ExportJobFailedEto.cs
+++ b/src/Granit.DataExchange/Export/Events/ExportJobFailedEto.cs
@@ -1,0 +1,15 @@
+using Granit.Core.Events;
+
+namespace Granit.DataExchange.Export.Events;
+
+/// <summary>
+/// Published when an export job fails.
+/// Enables cross-service error alerting and monitoring.
+/// </summary>
+/// <param name="ExportJobId">The unique identifier of the failed job.</param>
+/// <param name="DefinitionName">The export definition name.</param>
+/// <param name="ErrorMessage">Error message from the failure.</param>
+public sealed record ExportJobFailedEto(
+    Guid ExportJobId,
+    string DefinitionName,
+    string ErrorMessage) : IIntegrationEvent;

--- a/src/Granit.DataExchange/Export/Internal/ExportOrchestrator.cs
+++ b/src/Granit.DataExchange/Export/Internal/ExportOrchestrator.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Granit.Core.Events;
 using Granit.DataExchange.Export.Domain;
+using Granit.DataExchange.Export.Events;
 using Granit.DataExchange.Export.Messages;
 using Granit.DataExchange.Import.Pipeline;
 using Granit.Guids;
@@ -29,6 +30,7 @@ internal sealed partial class ExportOrchestrator(
     IClock clock,
     IGuidGenerator guidGenerator,
     ILocalEventBus eventBus,
+    IDistributedEventBus distributedEventBus,
     ILogger<ExportOrchestrator> logger) : IExportOrchestrator
 {
     /// <inheritdoc/>
@@ -106,6 +108,9 @@ internal sealed partial class ExportOrchestrator(
             await eventBus.PublishAsync(new ExportJobCompletedEvent(
                 jobId, job.DefinitionName, ExportJobStatus.Failed,
                 job.CreatedBy, RowCount: null, ex.Message), cancellationToken).ConfigureAwait(false);
+
+            await distributedEventBus.PublishAsync(new ExportJobFailedEto(
+                jobId, job.DefinitionName, ex.Message), cancellationToken).ConfigureAwait(false);
 
             LogExportFailed(jobId, ex);
             throw;

--- a/src/Granit.DataExchange/Import/Domain/ImportJob.cs
+++ b/src/Granit.DataExchange/Import/Domain/ImportJob.cs
@@ -1,4 +1,5 @@
 using Granit.Core.Domain;
+using Granit.DataExchange.Import.Events;
 
 namespace Granit.DataExchange.Import.Domain;
 
@@ -125,6 +126,7 @@ public sealed class ImportJob : AuditedAggregateRoot
     internal void Cancel()
     {
         Status = ImportJobStatus.Cancelled;
+        AddDomainEvent(new ImportJobCancelledEvent(Id, DefinitionName));
     }
 
     /// <summary>

--- a/src/Granit.DataExchange/Import/Events/ImportJobCancelledEvent.cs
+++ b/src/Granit.DataExchange/Import/Events/ImportJobCancelledEvent.cs
@@ -1,0 +1,13 @@
+using Granit.Core.Events;
+
+namespace Granit.DataExchange.Import.Events;
+
+/// <summary>
+/// Raised when an import job is cancelled.
+/// Enables audit trail and cleanup workflows.
+/// </summary>
+/// <param name="ImportJobId">The unique identifier of the cancelled job.</param>
+/// <param name="DefinitionName">The import definition name.</param>
+public sealed record ImportJobCancelledEvent(
+    Guid ImportJobId,
+    string DefinitionName) : IDomainEvent;

--- a/src/Granit.Features.EntityFrameworkCore/Internal/TenantFeatureOverride.cs
+++ b/src/Granit.Features.EntityFrameworkCore/Internal/TenantFeatureOverride.cs
@@ -13,7 +13,7 @@ namespace Granit.Features.EntityFrameworkCore.Internal;
 /// satisfying the ISO 27001 3-year audit trail requirement.
 /// <c>TenantId</c> is injected automatically by the same interceptor on insert.
 /// </remarks>
-internal sealed class TenantFeatureOverride : AuditedEntity, IMultiTenant
+internal sealed class TenantFeatureOverride : AuditedEntity, IMultiTenant, IEmitEntityLifecycleEvents
 {
     /// <summary>Tenant scope. Never null for a tenant override (enforced at the store level).</summary>
     public Guid? TenantId { get; set; }

--- a/src/Granit.Identity.EntityFrameworkCore/Events/UserCacheEntryErasedEvent.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Events/UserCacheEntryErasedEvent.cs
@@ -1,0 +1,13 @@
+using Granit.Core.Events;
+
+namespace Granit.Identity.EntityFrameworkCore.Events;
+
+/// <summary>
+/// Raised when a user cache entry is hard-deleted (RGPD Art. 17 erasure).
+/// Enables audit trail of personal data deletion for ISO 27001 compliance.
+/// </summary>
+/// <param name="ExternalUserId">The identity provider user identifier.</param>
+/// <param name="TenantId">Tenant scope. <c>null</c> for host-level entries.</param>
+public sealed record UserCacheEntryErasedEvent(
+    string ExternalUserId,
+    Guid? TenantId) : IDomainEvent;

--- a/src/Granit.Identity.EntityFrameworkCore/Handlers/IdentityUserEventHandler.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Handlers/IdentityUserEventHandler.cs
@@ -1,3 +1,4 @@
+using Granit.Core.Events;
 using Granit.Identity.EntityFrameworkCore.Entities;
 using Granit.Identity.EntityFrameworkCore.Events;
 using Granit.Identity.EntityFrameworkCore.Internal;
@@ -13,6 +14,8 @@ namespace Granit.Identity.EntityFrameworkCore.Handlers;
 internal sealed partial class IdentityUserEventHandler(
     IIdentityProvider identityProvider,
     IUserCacheStore store,
+    ILocalEventBus localEventBus,
+    IDistributedEventBus distributedEventBus,
     TimeProvider timeProvider,
     ILogger<IdentityUserEventHandler> logger)
 {
@@ -33,6 +36,11 @@ internal sealed partial class IdentityUserEventHandler(
     {
         await store.DeleteByExternalIdAsync(@event.UserId, @event.TenantId, cancellationToken)
             .ConfigureAwait(false);
+
+        await localEventBus.PublishAsync(
+            new UserCacheEntryErasedEvent(@event.UserId, @event.TenantId), cancellationToken)
+            .ConfigureAwait(false);
+
         LogUserCacheDeleted(@event.UserId);
     }
 
@@ -90,6 +98,10 @@ internal sealed partial class IdentityUserEventHandler(
         };
 
         await store.UpsertAsync(entry, cancellationToken).ConfigureAwait(false);
+
+        await distributedEventBus.PublishAsync(
+            new UserCacheSyncedEto(user.Id, entry.TenantId, entry.LastSyncedAt), cancellationToken)
+            .ConfigureAwait(false);
     }
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "User {UserId} not found in identity provider during cache sync")]

--- a/src/Granit.Identity/Events/UserCacheSyncedEto.cs
+++ b/src/Granit.Identity/Events/UserCacheSyncedEto.cs
@@ -1,0 +1,15 @@
+using Granit.Core.Events;
+
+namespace Granit.Identity.Events;
+
+/// <summary>
+/// Published when a user cache entry is synchronized from the external identity provider.
+/// Enables profile change propagation to dependent modules.
+/// </summary>
+/// <param name="ExternalUserId">The identity provider user identifier.</param>
+/// <param name="TenantId">Tenant scope. <c>null</c> for host-level entries.</param>
+/// <param name="SyncedAt">Timestamp of the synchronization.</param>
+public sealed record UserCacheSyncedEto(
+    string ExternalUserId,
+    Guid? TenantId,
+    DateTimeOffset SyncedAt) : IIntegrationEvent;

--- a/src/Granit.Localization.EntityFrameworkCore/Entities/LocalizationOverride.cs
+++ b/src/Granit.Localization.EntityFrameworkCore/Entities/LocalizationOverride.cs
@@ -15,7 +15,7 @@ namespace Granit.Localization.EntityFrameworkCore.Entities;
 /// satisfying the ISO 27001 3-year audit trail requirement.
 /// </para>
 /// </remarks>
-public sealed class LocalizationOverride : AuditedEntity, IMultiTenant
+public sealed class LocalizationOverride : AuditedEntity, IMultiTenant, IEmitEntityLifecycleEvents
 {
     /// <summary>Tenant scope. <c>null</c> = host-level override (applies to all tenants).</summary>
     public Guid? TenantId { get; set; }

--- a/src/Granit.Notifications/Domain/UserNotification.cs
+++ b/src/Granit.Notifications/Domain/UserNotification.cs
@@ -1,4 +1,5 @@
 using Granit.Core.Domain;
+using Granit.Notifications.Events;
 
 namespace Granit.Notifications.Domain;
 
@@ -59,6 +60,13 @@ public sealed class UserNotification : AggregateRoot, IMultiTenant
     }
 
     /// <summary>
+    /// Raises a <see cref="UserNotificationCreatedEvent"/> domain event.
+    /// Called by the store after the notification is fully initialized.
+    /// </summary>
+    internal void RaiseCreatedEvent() =>
+        AddDomainEvent(new UserNotificationCreatedEvent(NotificationId, NotificationTypeName, Severity, RecipientUserId, TenantId));
+
+    /// <summary>
     /// Marks the notification as read.
     /// </summary>
     public void MarkAsRead(DateTimeOffset readAt)
@@ -70,5 +78,6 @@ public sealed class UserNotification : AggregateRoot, IMultiTenant
 
         State = UserNotificationState.Read;
         ReadAt = readAt;
+        AddDomainEvent(new UserNotificationReadEvent(Id, RecipientUserId, readAt));
     }
 }

--- a/src/Granit.Notifications/Events/UserNotificationCreatedEvent.cs
+++ b/src/Granit.Notifications/Events/UserNotificationCreatedEvent.cs
@@ -1,0 +1,20 @@
+using Granit.Core.Events;
+using Granit.Notifications.Domain;
+
+namespace Granit.Notifications.Events;
+
+/// <summary>
+/// Raised when a new user notification is created in the inbox.
+/// Enables in-process delivery pipelines (email/SMS/push).
+/// </summary>
+/// <param name="NotificationId">Global notification identifier.</param>
+/// <param name="NotificationTypeName">Logical type (e.g., <c>"order.created"</c>).</param>
+/// <param name="Severity">Notification severity level.</param>
+/// <param name="RecipientUserId">Target user identifier.</param>
+/// <param name="TenantId">Tenant scope. <c>null</c> for host-level notifications.</param>
+public sealed record UserNotificationCreatedEvent(
+    Guid NotificationId,
+    string NotificationTypeName,
+    NotificationSeverity Severity,
+    string RecipientUserId,
+    Guid? TenantId) : IDomainEvent;

--- a/src/Granit.Notifications/Events/UserNotificationReadEvent.cs
+++ b/src/Granit.Notifications/Events/UserNotificationReadEvent.cs
@@ -1,0 +1,15 @@
+using Granit.Core.Events;
+
+namespace Granit.Notifications.Events;
+
+/// <summary>
+/// Raised when a user notification transitions from Unread to Read.
+/// Enables engagement tracking and read-receipt workflows.
+/// </summary>
+/// <param name="NotificationId">The unique identifier of the notification entry.</param>
+/// <param name="RecipientUserId">Target user identifier.</param>
+/// <param name="ReadAt">Timestamp when the notification was read.</param>
+public sealed record UserNotificationReadEvent(
+    Guid NotificationId,
+    string RecipientUserId,
+    DateTimeOffset ReadAt) : IDomainEvent;

--- a/src/Granit.Persistence/Extensions/DbContextOptionsBuilderExtensions.cs
+++ b/src/Granit.Persistence/Extensions/DbContextOptionsBuilderExtensions.cs
@@ -18,7 +18,7 @@ public static class DbContextOptionsBuilderExtensions
     /// Interceptors are added in the correct order:
     /// <list type="number">
     ///   <item><see cref="AuditedEntityInterceptor"/> — ISO 27001 audit fields (created/modified by/at, tenant, GUID).</item>
-    ///   <item><see cref="VersioningInterceptor"/> — auto-assigns <c>BusinessId</c> and <c>Version</c> on <c>IVersioned</c> entities.</item>
+    ///   <item><see cref="VersioningInterceptor"/> — auto-assigns <c>VersionId</c> and <c>Version</c> on <c>IVersioned</c> entities.</item>
     ///   <item><see cref="ConcurrencyStampInterceptor"/> — regenerates <c>ConcurrencyStamp</c> on <c>IConcurrencyAware</c> entities.</item>
     ///   <item><see cref="DomainEventDispatcherInterceptor"/> — collects and dispatches domain and integration events from aggregate roots.</item>
     ///   <item><see cref="EntityLifecycleEventInterceptor"/> — auto-dispatches lifecycle events for <c>IEmitEntityLifecycleEvents</c> / <c>IHasEntityEto&lt;TEto&gt;</c> entities.</item>

--- a/src/Granit.Persistence/Interceptors/VersioningInterceptor.cs
+++ b/src/Granit.Persistence/Interceptors/VersioningInterceptor.cs
@@ -7,22 +7,22 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 namespace Granit.Persistence.Interceptors;
 
 /// <summary>
-/// EF Core interceptor that auto-assigns <see cref="IVersioned.BusinessId"/> and
+/// EF Core interceptor that auto-assigns <see cref="IVersioned.VersionId"/> and
 /// <see cref="IVersioned.Version"/> on newly added entities.
 /// </summary>
 /// <remarks>
 /// <para>
 /// On <c>EntityState.Added</c>:
 /// <list type="bullet">
-///   <item>If <see cref="IVersioned.BusinessId"/> is <see cref="Guid.Empty"/>,
+///   <item>If <see cref="IVersioned.VersionId"/> is <see cref="Guid.Empty"/>,
 ///         a new identifier is generated (first version of a new business entity).</item>
 ///   <item><see cref="IVersioned.Version"/> is set to the next value for that
-///         <see cref="IVersioned.BusinessId"/> (max existing + 1), starting at 1.</item>
+///         <see cref="IVersioned.VersionId"/> (max existing + 1), starting at 1.</item>
 /// </list>
 /// </para>
 /// <para>
 /// <c>EntityState.Modified</c> entities are left untouched — updates are in-place.
-/// Creating a new version is an explicit operation (add a new entity with the same BusinessId).
+/// Creating a new version is an explicit operation (add a new entity with the same VersionId).
 /// </para>
 /// <para>
 /// Registered as Scoped. Must be ordered after <see cref="AuditedEntityInterceptor"/>
@@ -58,7 +58,7 @@ public sealed class VersioningInterceptor(IGuidGenerator guidGenerator) : SaveCh
             return;
         }
 
-        // Collect all Added IVersioned entries first to handle multiple adds for the same BusinessId
+        // Collect all Added IVersioned entries first to handle multiple adds for the same VersionId
         List<IVersioned> addedEntities = [];
 
         foreach (EntityEntry entry in context.ChangeTracker.Entries()
@@ -72,15 +72,15 @@ public sealed class VersioningInterceptor(IGuidGenerator guidGenerator) : SaveCh
 
         foreach (IVersioned versioned in addedEntities)
         {
-            // Assign a new BusinessId for brand-new logical entities
-            if (versioned.BusinessId == Guid.Empty)
+            // Assign a new VersionId for brand-new logical entities
+            if (versioned.VersionId == Guid.Empty)
             {
-                versioned.BusinessId = guidGenerator.Create();
+                versioned.VersionId = guidGenerator.Create();
             }
 
-            // Determine the next version for this BusinessId.
+            // Determine the next version for this VersionId.
             // Check both the ChangeTracker (for other pending adds) and existing tracked entities.
-            int maxVersion = GetMaxTrackedVersion(context, versioned.BusinessId, versioned);
+            int maxVersion = GetMaxTrackedVersion(context, versioned.VersionId, versioned);
 
             versioned.Version = maxVersion + 1;
         }
@@ -94,7 +94,7 @@ public sealed class VersioningInterceptor(IGuidGenerator guidGenerator) : SaveCh
         {
             if (entry.Entity is IVersioned tracked
                 && !ReferenceEquals(tracked, current)
-                && tracked.BusinessId == businessId
+                && tracked.VersionId == businessId
                 && tracked.Version > max)
             {
                 max = tracked.Version;

--- a/src/Granit.Privacy/LegalAgreements/Events/LegalAgreementAcceptedEto.cs
+++ b/src/Granit.Privacy/LegalAgreements/Events/LegalAgreementAcceptedEto.cs
@@ -1,0 +1,17 @@
+using Granit.Core.Events;
+
+namespace Granit.Privacy.LegalAgreements.Events;
+
+/// <summary>
+/// Published when a user accepts a legal agreement (RGPD Art. 7 consent proof).
+/// Enables cross-service consent tracking and audit trail.
+/// </summary>
+/// <param name="UserId">The user who consented.</param>
+/// <param name="DocumentId">The legal document identifier (e.g., <c>"privacy-policy"</c>).</param>
+/// <param name="Version">Document version that was accepted.</param>
+/// <param name="AcceptedAt">Timestamp of consent.</param>
+public sealed record LegalAgreementAcceptedEto(
+    Guid UserId,
+    string DocumentId,
+    string Version,
+    DateTimeOffset AcceptedAt) : IIntegrationEvent;

--- a/src/Granit.Privacy/LegalAgreements/Events/LegalAgreementObsoleteEto.cs
+++ b/src/Granit.Privacy/LegalAgreements/Events/LegalAgreementObsoleteEto.cs
@@ -1,0 +1,15 @@
+using Granit.Core.Events;
+
+namespace Granit.Privacy.LegalAgreements.Events;
+
+/// <summary>
+/// Published when a legal document version is superseded by a new version.
+/// Triggers re-consent flows for affected users.
+/// </summary>
+/// <param name="DocumentId">The legal document identifier.</param>
+/// <param name="OldVersion">The superseded version.</param>
+/// <param name="NewVersion">The new active version.</param>
+public sealed record LegalAgreementObsoleteEto(
+    string DocumentId,
+    string OldVersion,
+    string NewVersion) : IIntegrationEvent;

--- a/src/Granit.ReferenceData/Domain/ReferenceDataEntity.cs
+++ b/src/Granit.ReferenceData/Domain/ReferenceDataEntity.cs
@@ -24,7 +24,7 @@ namespace Granit.ReferenceData.Domain;
 /// are filtered out by the EF Core global query filter unless explicitly disabled.
 /// </para>
 /// </remarks>
-public abstract class ReferenceDataEntity : AuditedEntity, IActive
+public abstract class ReferenceDataEntity : AuditedEntity, IActive, IEmitEntityLifecycleEvents
 {
     /// <summary>
     /// Unique business key for the reference data entry (e.g., "BE", "EUR", "fr").

--- a/src/Granit.Settings.EntityFrameworkCore/Entities/SettingRecord.cs
+++ b/src/Granit.Settings.EntityFrameworkCore/Entities/SettingRecord.cs
@@ -16,7 +16,7 @@ namespace Granit.Settings.EntityFrameworkCore.Entities;
 /// satisfying the ISO 27001 3-year audit trail requirement.
 /// </para>
 /// </remarks>
-public sealed class SettingRecord : AuditedEntity
+public sealed class SettingRecord : AuditedEntity, IEmitEntityLifecycleEvents
 {
     /// <summary>Setting name (e.g. <c>"Notifications.Email.Enabled"</c>). Max 256 characters.</summary>
     public string Name { get; set; } = string.Empty;

--- a/src/Granit.Webhooks/Domain/WebhookSubscription.cs
+++ b/src/Granit.Webhooks/Domain/WebhookSubscription.cs
@@ -32,7 +32,9 @@ public sealed class WebhookSubscription : AuditedAggregateRoot
         HttpsUrl targetUrl,
         string eventType,
         string signingSecret,
-        Guid? tenantId = null) => new()
+        Guid? tenantId = null)
+    {
+        var subscription = new WebhookSubscription
         {
             Id = id,
             TargetUrl = targetUrl,
@@ -41,6 +43,10 @@ public sealed class WebhookSubscription : AuditedAggregateRoot
             TenantId = tenantId,
             Status = WebhookSubscriptionStatus.Active,
         };
+
+        subscription.AddDomainEvent(new WebhookSubscriptionCreatedEvent(id, eventType, targetUrl.Value));
+        return subscription;
+    }
 
     /// <summary>
     /// The HTTPS endpoint that receives webhook HTTP POST requests.
@@ -96,19 +102,28 @@ public sealed class WebhookSubscription : AuditedAggregateRoot
 
     /// <summary>
     /// Records a successful delivery. Resets failure counters.
+    /// Emits a <see cref="WebhookDeliverySucceededEvent"/> domain event.
     /// </summary>
     internal void RecordSuccess(DateTimeOffset at)
     {
         LastSuccessAt = at;
         ConsecutiveFailureCount = 0;
+        AddDomainEvent(new WebhookDeliverySucceededEvent(Id, at));
     }
 
     /// <summary>
     /// Records a delivery failure.
+    /// Publishes a <see cref="WebhookDeliveryFailureThresholdExceededEto"/> integration event when <see cref="ConsecutiveFailureCount"/> reaches 5.
     /// </summary>
     internal void RecordFailure()
     {
         ConsecutiveFailureCount++;
+
+        if (ConsecutiveFailureCount >= 5)
+        {
+            AddDistributedEvent(new WebhookDeliveryFailureThresholdExceededEto(
+                Id, TargetUrl.Value, ConsecutiveFailureCount));
+        }
     }
 
     /// <summary>

--- a/src/Granit.Webhooks/Events/WebhookDeliveryFailureThresholdExceededEto.cs
+++ b/src/Granit.Webhooks/Events/WebhookDeliveryFailureThresholdExceededEto.cs
@@ -1,0 +1,15 @@
+using Granit.Core.Events;
+
+namespace Granit.Webhooks.Events;
+
+/// <summary>
+/// Published when consecutive webhook delivery failures reach the threshold (5).
+/// Enables SLA alerting before automatic suspension.
+/// </summary>
+/// <param name="SubscriptionId">The unique identifier of the subscription.</param>
+/// <param name="TargetUrl">The HTTPS endpoint that is failing.</param>
+/// <param name="ConsecutiveFailureCount">Number of consecutive failures.</param>
+public sealed record WebhookDeliveryFailureThresholdExceededEto(
+    Guid SubscriptionId,
+    string TargetUrl,
+    int ConsecutiveFailureCount) : IIntegrationEvent;

--- a/src/Granit.Webhooks/Events/WebhookDeliverySucceededEvent.cs
+++ b/src/Granit.Webhooks/Events/WebhookDeliverySucceededEvent.cs
@@ -1,0 +1,13 @@
+using Granit.Core.Events;
+
+namespace Granit.Webhooks.Events;
+
+/// <summary>
+/// Raised when a webhook delivery succeeds.
+/// Enables SLO tracking and delivery observability.
+/// </summary>
+/// <param name="SubscriptionId">The unique identifier of the subscription.</param>
+/// <param name="DeliveredAt">Timestamp of the successful delivery.</param>
+public sealed record WebhookDeliverySucceededEvent(
+    Guid SubscriptionId,
+    DateTimeOffset DeliveredAt) : IDomainEvent;

--- a/src/Granit.Webhooks/Events/WebhookSubscriptionCreatedEvent.cs
+++ b/src/Granit.Webhooks/Events/WebhookSubscriptionCreatedEvent.cs
@@ -1,0 +1,15 @@
+using Granit.Core.Events;
+
+namespace Granit.Webhooks.Events;
+
+/// <summary>
+/// Raised when a new webhook subscription is registered.
+/// Enables subscriber audit trail.
+/// </summary>
+/// <param name="SubscriptionId">The unique identifier of the subscription.</param>
+/// <param name="EventType">Logical event type the subscription is registered for.</param>
+/// <param name="TargetUrl">The HTTPS endpoint receiving webhook deliveries.</param>
+public sealed record WebhookSubscriptionCreatedEvent(
+    Guid SubscriptionId,
+    string EventType,
+    string TargetUrl) : IDomainEvent;

--- a/src/Granit.Workflow/Domain/IVersionedEntity.cs
+++ b/src/Granit.Workflow/Domain/IVersionedEntity.cs
@@ -10,12 +10,12 @@ namespace Granit.Workflow.Domain;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Extends <see cref="IVersioned"/> for <c>BusinessId</c>/<c>Version</c>
+/// Extends <see cref="IVersioned"/> for <c>VersionId</c>/<c>Version</c>
 /// and <see cref="IPublishable"/> for the global query filter
 /// (<c>WHERE IsPublished = true</c>).
 /// </para>
 /// <para>
-/// At most one version per <see cref="IVersioned.BusinessId"/> may have
+/// At most one version per <see cref="IVersioned.VersionId"/> may have
 /// <see cref="WorkflowLifecycleStatus.Published"/> at any time.
 /// This invariant is enforced by a unique filtered index in PostgreSQL.
 /// </para>

--- a/src/Granit.Workflow/Domain/IWorkflowStateful.cs
+++ b/src/Granit.Workflow/Domain/IWorkflowStateful.cs
@@ -1,15 +1,15 @@
-namespace Granit.Workflow;
+namespace Granit.Workflow.Domain;
 
 /// <summary>
 /// Marker interface for entities whose workflow state transitions should be
-/// automatically recorded in the <see cref="Domain.WorkflowTransitionRecord"/> audit trail
+/// automatically recorded in the <see cref="WorkflowTransitionRecord"/> audit trail
 /// by the <c>WorkflowTransitionInterceptor</c>.
 /// </summary>
 /// <remarks>
 /// <para>
 /// The interceptor compares <c>OriginalValues</c> vs <c>CurrentValues</c> for the
 /// property identified by <see cref="StatusPropertyName"/>. When a difference is
-/// detected on <c>SaveChanges</c>, a new <see cref="Domain.WorkflowTransitionRecord"/>
+/// detected on <c>SaveChanges</c>, a new <see cref="WorkflowTransitionRecord"/>
 /// is added to the same transaction.
 /// </para>
 /// <para>
@@ -27,7 +27,7 @@ public interface IWorkflowStateful
 
     /// <summary>
     /// Logical entity type name for audit trail identification (e.g. <c>"Document"</c>).
-    /// Used in <see cref="Domain.WorkflowTransitionRecord.EntityType"/>.
+    /// Used in <see cref="WorkflowTransitionRecord.EntityType"/>.
     /// </summary>
     static abstract string WorkflowEntityType { get; }
 

--- a/src/Granit.Workflow/Domain/VersionedWorkflowEntity.cs
+++ b/src/Granit.Workflow/Domain/VersionedWorkflowEntity.cs
@@ -8,8 +8,8 @@ namespace Granit.Workflow.Domain;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Inherits from <see cref="AuditedEntity"/> for CreatedAt/By and ModifiedAt/By tracking.
-/// Implements both <see cref="IVersionedEntity"/> and <see cref="IWorkflowStateful"/>
+/// Inherits from <see cref="AuditedAggregateRoot"/> for audit tracking and domain/integration
+/// event support. Implements both <see cref="IVersionedEntity"/> and <see cref="IWorkflowStateful"/>
 /// to integrate with the global query filter system and the
 /// <c>WorkflowTransitionInterceptor</c> audit trail.
 /// </para>
@@ -31,19 +31,43 @@ namespace Granit.Workflow.Domain;
 /// by implementing the static abstract member explicitly.
 /// </para>
 /// </remarks>
-public abstract class VersionedWorkflowEntity : AuditedEntity, IVersionedEntity, IWorkflowStateful
+public abstract class VersionedWorkflowEntity : AuditedAggregateRoot, IVersionedEntity, IWorkflowStateful
 {
-    /// <inheritdoc/>
-    public Guid BusinessId { get; set; }
+    /// <summary>
+    /// Initializes a new instance for EF Core materialization.
+    /// </summary>
+    protected VersionedWorkflowEntity()
+    {
+    }
 
     /// <inheritdoc/>
-    public int Version { get; set; }
+    public Guid VersionId { get; private set; }
 
     /// <inheritdoc/>
-    public WorkflowLifecycleStatus LifecycleStatus { get; set; }
+    public int Version { get; private set; }
 
     /// <inheritdoc/>
-    public bool IsPublished { get; set; }
+    public WorkflowLifecycleStatus LifecycleStatus { get; private set; }
+
+    /// <inheritdoc/>
+    public bool IsPublished { get; private set; }
+
+    // Explicit interface implementations for interceptor write access.
+    // VersioningInterceptor writes VersionId/Version via IVersioned cast.
+    // WorkflowTransitionInterceptor writes IsPublished via IPublishable cast.
+    // EF Core ChangeTracker bypasses C# setters entirely.
+
+    /// <inheritdoc/>
+    Guid IVersioned.VersionId { get => VersionId; set => VersionId = value; }
+
+    /// <inheritdoc/>
+    int IVersioned.Version { get => Version; set => Version = value; }
+
+    /// <inheritdoc/>
+    WorkflowLifecycleStatus IVersionedEntity.LifecycleStatus { get => LifecycleStatus; set => LifecycleStatus = value; }
+
+    /// <inheritdoc/>
+    bool IPublishable.IsPublished { get => IsPublished; set => IsPublished = value; }
 
     /// <inheritdoc/>
     static string IWorkflowStateful.StatusPropertyName => nameof(LifecycleStatus);
@@ -54,6 +78,16 @@ public abstract class VersionedWorkflowEntity : AuditedEntity, IVersionedEntity,
     static string IWorkflowStateful.WorkflowEntityType =>
         throw new NotSupportedException(
             "Derived classes must implement IWorkflowStateful.WorkflowEntityType explicitly.");
+
+    /// <summary>
+    /// Transitions the lifecycle status. Subtypes should expose domain-specific behavior
+    /// methods (e.g., <c>Publish()</c>, <c>Archive()</c>) that call this method.
+    /// </summary>
+    /// <param name="status">The new lifecycle status.</param>
+    protected void SetLifecycleStatus(WorkflowLifecycleStatus status)
+    {
+        LifecycleStatus = status;
+    }
 
     /// <inheritdoc/>
     public virtual string GetWorkflowEntityId() => Id.ToString();

--- a/src/Granit.Workflow/Domain/WorkflowLifecycleStatus.cs
+++ b/src/Granit.Workflow/Domain/WorkflowLifecycleStatus.cs
@@ -12,7 +12,7 @@ public enum WorkflowLifecycleStatus
     PendingReview = 1,
 
     /// <summary>
-    /// Active published version. Exactly one per <see cref="IVersionedEntity.BusinessId"/>
+    /// Active published version. Exactly one per <see cref="IVersionedEntity.VersionId"/>
     /// at any time (enforced by unique filtered index).
     /// Maps to <c>IPublishable.IsPublished = true</c>.
     /// </summary>

--- a/tests/Granit.Authentication.ApiKeys.Tests/EventTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.Tests/EventTests.cs
@@ -1,4 +1,6 @@
+using Granit.Authentication.ApiKeys.Domain;
 using Granit.Authentication.ApiKeys.Events;
+using Granit.Core.Events;
 using Shouldly;
 using Xunit;
 
@@ -107,5 +109,67 @@ public sealed class ApiKeyScopesUpdatedEventTests
         var evt2 = new ApiKeyScopesUpdatedEvent(id, "hash");
 
         evt1.ShouldBe(evt2);
+    }
+}
+
+public sealed class ApiKeyUsedEtoTests
+{
+    [Fact]
+    public void ImplementsIIntegrationEvent() =>
+        new ApiKeyUsedEto(Guid.NewGuid(), "gk_live_sk_", DateTimeOffset.UtcNow)
+            .ShouldBeAssignableTo<IIntegrationEvent>();
+
+    [Fact]
+    public void RecordUsage_RaisesApiKeyUsedEto()
+    {
+        DateTimeOffset usedAt = DateTimeOffset.UtcNow;
+        var entry = ApiKeyEntry.Create(
+            Guid.NewGuid(), "Test Key", ApiKeyType.Secret, "live",
+            "hash", "gk_live_sk_", "abcd");
+
+        entry.RecordUsage(usedAt);
+
+        IIntegrationEvent integrationEvent = entry.IntegrationEvents.ShouldHaveSingleItem();
+        ApiKeyUsedEto eto = integrationEvent.ShouldBeOfType<ApiKeyUsedEto>();
+        eto.ApiKeyId.ShouldBe(entry.Id);
+        eto.Prefix.ShouldBe("gk_live_sk_");
+        eto.UsedAt.ShouldBe(usedAt);
+    }
+}
+
+public sealed class ApiKeyExpiredEventTests
+{
+    [Fact]
+    public void ImplementsIDomainEvent() =>
+        new ApiKeyExpiredEvent(Guid.NewGuid(), "gk_live_sk_", DateTimeOffset.UtcNow)
+            .ShouldBeAssignableTo<IDomainEvent>();
+
+    [Fact]
+    public void MarkAsExpired_RaisesApiKeyExpiredEvent()
+    {
+        DateTimeOffset expiresAt = DateTimeOffset.UtcNow.AddDays(-1);
+        var entry = ApiKeyEntry.Create(
+            Guid.NewGuid(), "Test Key", ApiKeyType.Secret, "live",
+            "hash", "gk_live_sk_", "abcd");
+        entry.SetExpiration(expiresAt);
+
+        entry.MarkAsExpired();
+
+        IDomainEvent domainEvent = entry.DomainEvents.ShouldHaveSingleItem();
+        ApiKeyExpiredEvent evt = domainEvent.ShouldBeOfType<ApiKeyExpiredEvent>();
+        evt.ApiKeyId.ShouldBe(entry.Id);
+        evt.ExpiredAt.ShouldBe(expiresAt);
+    }
+
+    [Fact]
+    public void MarkAsExpired_NoExpiration_DoesNotEmitEvent()
+    {
+        var entry = ApiKeyEntry.Create(
+            Guid.NewGuid(), "Test Key", ApiKeyType.Secret, "live",
+            "hash", "gk_live_sk_", "abcd");
+
+        entry.MarkAsExpired();
+
+        entry.DomainEvents.ShouldBeEmpty();
     }
 }

--- a/tests/Granit.BackgroundJobs.Tests/BackgroundJobDefinitionTests.cs
+++ b/tests/Granit.BackgroundJobs.Tests/BackgroundJobDefinitionTests.cs
@@ -69,6 +69,92 @@ public sealed class BackgroundJobDefinitionTests
         job.DomainEvents.Last().ShouldBeOfType<BackgroundJobResumedEvent>();
     }
 
+    [Fact]
+    public void UpdateDefinition_DifferentCron_ShouldEmitBackgroundJobDefinitionChangedEvent()
+    {
+        BackgroundJobDefinition job = BuildJob();
+        job.ClearDomainEvents();
+
+        job.UpdateDefinition("0 9 * * *", "TestMessage, TestAssembly");
+
+        IDomainEvent domainEvent = job.DomainEvents.ShouldHaveSingleItem();
+        BackgroundJobDefinitionChangedEvent changed = domainEvent.ShouldBeOfType<BackgroundJobDefinitionChangedEvent>();
+        changed.JobId.ShouldBe(job.Id);
+        changed.JobName.ShouldBe("test-job");
+        changed.OldCronExpression.ShouldBe("0 8 * * *");
+        changed.NewCronExpression.ShouldBe("0 9 * * *");
+    }
+
+    [Fact]
+    public void UpdateDefinition_SameCron_ShouldNotEmitEvent()
+    {
+        BackgroundJobDefinition job = BuildJob();
+        job.ClearDomainEvents();
+
+        job.UpdateDefinition("0 8 * * *", "NewMessage, NewAssembly");
+
+        job.DomainEvents.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void RecordExecutionStart_ShouldEmitBackgroundJobExecutionStartedEto()
+    {
+        BackgroundJobDefinition job = BuildJob();
+        DateTimeOffset startedAt = DateTimeOffset.UtcNow;
+
+        job.RecordExecutionStart(startedAt);
+
+        IIntegrationEvent integrationEvent = job.IntegrationEvents.ShouldHaveSingleItem();
+        BackgroundJobExecutionStartedEto eto = integrationEvent.ShouldBeOfType<BackgroundJobExecutionStartedEto>();
+        eto.JobId.ShouldBe(job.Id);
+        eto.JobName.ShouldBe("test-job");
+        eto.StartedAt.ShouldBe(startedAt);
+    }
+
+    [Fact]
+    public void RecordFailure_BelowThreshold_ShouldNotEmitIntegrationEvent()
+    {
+        BackgroundJobDefinition job = BuildJob();
+
+        job.RecordFailure("timeout");
+        job.RecordFailure("timeout");
+
+        job.ConsecutiveFailureCount.ShouldBe(2);
+        job.IntegrationEvents.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void RecordFailure_AtThreshold_ShouldEmitBackgroundJobFailureThresholdExceededEto()
+    {
+        BackgroundJobDefinition job = BuildJob();
+
+        job.RecordFailure("error 1");
+        job.RecordFailure("error 2");
+        job.RecordFailure("error 3");
+
+        job.ConsecutiveFailureCount.ShouldBe(3);
+
+        IIntegrationEvent integrationEvent = job.IntegrationEvents.ShouldHaveSingleItem();
+        BackgroundJobFailureThresholdExceededEto eto = integrationEvent.ShouldBeOfType<BackgroundJobFailureThresholdExceededEto>();
+        eto.JobId.ShouldBe(job.Id);
+        eto.JobName.ShouldBe("test-job");
+        eto.ConsecutiveFailureCount.ShouldBe(3);
+        eto.LastErrorMessage.ShouldBe("error 3");
+    }
+
+    [Fact]
+    public void RecordFailure_AboveThreshold_ShouldEmitOnEachSubsequentFailure()
+    {
+        BackgroundJobDefinition job = BuildJob();
+
+        for (int i = 0; i < 5; i++)
+        {
+            job.RecordFailure($"error {i + 1}");
+        }
+
+        job.IntegrationEvents.Count.ShouldBe(3); // failures 3, 4, 5
+    }
+
     private static BackgroundJobDefinition BuildJob(bool enabled = true)
     {
         var job = BackgroundJobDefinition.Create(

--- a/tests/Granit.BlobStorage.Tests/BlobDescriptorTests.cs
+++ b/tests/Granit.BlobStorage.Tests/BlobDescriptorTests.cs
@@ -195,13 +195,16 @@ public sealed class BlobDescriptorTests
     }
 
     [Fact]
-    public void MarkAsUploading_ShouldNotEmitAnyDomainEvent()
+    public void MarkAsUploading_ShouldEmitBlobUploadStartedEvent()
     {
         BlobDescriptor descriptor = CreatePending();
 
         descriptor.MarkAsUploading();
 
-        descriptor.DomainEvents.ShouldBeEmpty();
+        BlobUploadStartedEvent evt = descriptor.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<BlobUploadStartedEvent>();
+        evt.BlobId.ShouldBe(descriptor.Id);
+        evt.ContainerName.ShouldBe("medical-images");
+        evt.OriginalFileName.ShouldBe("radio.jpg");
     }
 
     [Fact]
@@ -209,10 +212,10 @@ public sealed class BlobDescriptorTests
     {
         BlobDescriptor descriptor = CreatePending();
         descriptor.MarkAsUploading();
+        descriptor.ClearDomainEvents();
 
         descriptor.MarkAsValid("image/jpeg", 512_000, Now.AddMinutes(2));
 
-        descriptor.DomainEvents.ShouldHaveSingleItem();
         BlobValidatedEvent evt = descriptor.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<BlobValidatedEvent>();
         evt.BlobId.ShouldBe(descriptor.Id);
         evt.ContainerName.ShouldBe("medical-images");
@@ -225,6 +228,7 @@ public sealed class BlobDescriptorTests
     {
         BlobDescriptor descriptor = CreatePending();
         descriptor.MarkAsUploading();
+        descriptor.ClearDomainEvents();
 
         descriptor.MarkAsRejected("MIME mismatch");
 
@@ -271,7 +275,8 @@ public sealed class BlobDescriptorTests
         descriptor.MarkAsValid("image/jpeg", 512_000, Now);
         descriptor.MarkAsDeleted(Now.AddDays(1), "cleanup");
 
-        descriptor.DomainEvents.Count.ShouldBe(2);
+        descriptor.DomainEvents.Count.ShouldBe(3);
+        descriptor.DomainEvents.ShouldContain(e => e is BlobUploadStartedEvent);
         descriptor.DomainEvents.ShouldContain(e => e is BlobValidatedEvent);
         descriptor.DomainEvents.ShouldContain(e => e is BlobDeletedEvent);
     }

--- a/tests/Granit.DataExchange.Tests/Export/ExportOrchestratorTests.cs
+++ b/tests/Granit.DataExchange.Tests/Export/ExportOrchestratorTests.cs
@@ -28,6 +28,7 @@ public sealed class ExportOrchestratorTests
     private readonly IImportFileProvider _fileProvider = Substitute.For<IImportFileProvider>();
     private readonly IClock _clock = Substitute.For<IClock>();
     private readonly ILocalEventBus _eventBus = Substitute.For<ILocalEventBus>();
+    private readonly IDistributedEventBus _distributedEventBus = Substitute.For<IDistributedEventBus>();
     private readonly DateTimeOffset _now = new(2026, 3, 3, 10, 0, 0, TimeSpan.Zero);
 
     public ExportOrchestratorTests()
@@ -522,6 +523,7 @@ public sealed class ExportOrchestratorTests
             _clock,
             new SimpleGuidGenerator(),
             _eventBus,
+            _distributedEventBus,
             NullLogger<ExportOrchestrator>.Instance);
 
         // Act
@@ -630,6 +632,7 @@ public sealed class ExportOrchestratorTests
             _clock,
             new SimpleGuidGenerator(),
             _eventBus,
+            _distributedEventBus,
             NullLogger<ExportOrchestrator>.Instance);
     }
 
@@ -656,6 +659,7 @@ public sealed class ExportOrchestratorTests
             _clock,
             new SimpleGuidGenerator(),
             _eventBus,
+            _distributedEventBus,
             NullLogger<ExportOrchestrator>.Instance);
     }
 

--- a/tests/Granit.Identity.EntityFrameworkCore.Tests/IdentityUserEventHandlerTests.cs
+++ b/tests/Granit.Identity.EntityFrameworkCore.Tests/IdentityUserEventHandlerTests.cs
@@ -1,3 +1,4 @@
+using Granit.Core.Events;
 using Granit.Identity.EntityFrameworkCore.Entities;
 using Granit.Identity.EntityFrameworkCore.Events;
 using Granit.Identity.EntityFrameworkCore.Handlers;
@@ -14,10 +15,12 @@ public sealed class IdentityUserEventHandlerTests
 {
     private readonly IIdentityProvider _provider = Substitute.For<IIdentityProvider>();
     private readonly IUserCacheStore _store = Substitute.For<IUserCacheStore>();
+    private readonly ILocalEventBus _localEventBus = Substitute.For<ILocalEventBus>();
+    private readonly IDistributedEventBus _distributedEventBus = Substitute.For<IDistributedEventBus>();
     private readonly TimeProvider _timeProvider = Substitute.For<TimeProvider>();
 
     private IdentityUserEventHandler CreateHandler() => new(
-        _provider, _store, _timeProvider,
+        _provider, _store, _localEventBus, _distributedEventBus, _timeProvider,
         NullLogger<IdentityUserEventHandler>.Instance);
 
     public IdentityUserEventHandlerTests()

--- a/tests/Granit.Notifications.Tests/Domain/UserNotificationTests.cs
+++ b/tests/Granit.Notifications.Tests/Domain/UserNotificationTests.cs
@@ -1,6 +1,8 @@
 using System.Text.Json;
 using Granit.Core.Domain;
+using Granit.Core.Events;
 using Granit.Notifications.Domain;
+using Granit.Notifications.Events;
 using Shouldly;
 using Xunit;
 
@@ -108,5 +110,71 @@ public sealed class UserNotificationTests
         notification.MarkAsRead(secondRead);
 
         notification.ReadAt.ShouldBe(firstRead);
+    }
+
+    [Fact]
+    public void RaiseCreatedEvent_ShouldEmitUserNotificationCreatedEvent()
+    {
+        var notificationId = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+        var notification = UserNotification.Create(
+            Guid.NewGuid(),
+            notificationId,
+            "order.created",
+            NotificationSeverity.Warning,
+            "user-42",
+            JsonSerializer.SerializeToElement(new { }),
+            DateTimeOffset.UtcNow,
+            tenantId);
+
+        notification.RaiseCreatedEvent();
+
+        IDomainEvent domainEvent = notification.DomainEvents.ShouldHaveSingleItem();
+        UserNotificationCreatedEvent created = domainEvent.ShouldBeOfType<UserNotificationCreatedEvent>();
+        created.NotificationId.ShouldBe(notificationId);
+        created.NotificationTypeName.ShouldBe("order.created");
+        created.Severity.ShouldBe(NotificationSeverity.Warning);
+        created.RecipientUserId.ShouldBe("user-42");
+        created.TenantId.ShouldBe(tenantId);
+    }
+
+    [Fact]
+    public void MarkAsRead_ShouldEmitUserNotificationReadEvent()
+    {
+        var notification = UserNotification.Create(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "test.notification",
+            NotificationSeverity.Info,
+            "user-1",
+            JsonSerializer.SerializeToElement(new { }),
+            DateTimeOffset.UtcNow);
+
+        DateTimeOffset readAt = DateTimeOffset.UtcNow.AddMinutes(5);
+        notification.MarkAsRead(readAt);
+
+        IDomainEvent domainEvent = notification.DomainEvents.ShouldHaveSingleItem();
+        UserNotificationReadEvent read = domainEvent.ShouldBeOfType<UserNotificationReadEvent>();
+        read.NotificationId.ShouldBe(notification.Id);
+        read.RecipientUserId.ShouldBe("user-1");
+        read.ReadAt.ShouldBe(readAt);
+    }
+
+    [Fact]
+    public void MarkAsRead_AlreadyRead_DoesNotEmitSecondEvent()
+    {
+        var notification = UserNotification.Create(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "test.notification",
+            NotificationSeverity.Info,
+            "user-1",
+            JsonSerializer.SerializeToElement(new { }),
+            DateTimeOffset.UtcNow);
+
+        notification.MarkAsRead(DateTimeOffset.UtcNow.AddMinutes(5));
+        notification.MarkAsRead(DateTimeOffset.UtcNow.AddMinutes(10));
+
+        notification.DomainEvents.ShouldHaveSingleItem();
     }
 }

--- a/tests/Granit.Persistence.Tests/VersioningInterceptorTests.cs
+++ b/tests/Granit.Persistence.Tests/VersioningInterceptorTests.cs
@@ -17,7 +17,7 @@ public sealed class VersioningInterceptorTests
 
     public VersioningInterceptorTests()
     {
-        // Each call returns a distinct GUID so we can distinguish multiple BusinessId assignments
+        // Each call returns a distinct GUID so we can distinguish multiple VersionId assignments
         _guidGenerator.Create().Returns(_ =>
         {
             int n = ++_guidCallCount;
@@ -26,11 +26,11 @@ public sealed class VersioningInterceptorTests
     }
 
     // ========================================================================
-    // BusinessId assignment
+    // VersionId assignment
     // ========================================================================
 
     [Fact]
-    public async Task SaveChanges_WhenBusinessIdIsEmpty_ShouldAssignNewBusinessId()
+    public async Task SaveChanges_WhenVersionIdIsEmpty_ShouldAssignNewVersionId()
     {
         // Arrange
         using TestDbContext context = CreateContext();
@@ -45,20 +45,20 @@ public sealed class VersioningInterceptorTests
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Assert
-        entity.BusinessId.ShouldNotBe(Guid.Empty);
+        entity.VersionId.ShouldNotBe(Guid.Empty);
     }
 
     [Fact]
-    public async Task SaveChanges_WhenBusinessIdIsSet_ShouldNotOverwrite()
+    public async Task SaveChanges_WhenVersionIdIsSet_ShouldNotOverwrite()
     {
         // Arrange
-        var existingBusinessId = Guid.NewGuid();
+        var existingVersionId = Guid.NewGuid();
         using TestDbContext context = CreateContext();
         TestVersionedEntity entity = new()
         {
             Id = Guid.NewGuid(),
             Name = "Patient v2",
-            BusinessId = existingBusinessId,
+            VersionId = existingVersionId,
         };
         context.Entities.Add(entity);
 
@@ -66,7 +66,7 @@ public sealed class VersioningInterceptorTests
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Assert
-        entity.BusinessId.ShouldBe(existingBusinessId);
+        entity.VersionId.ShouldBe(existingVersionId);
     }
 
     // ========================================================================
@@ -104,17 +104,17 @@ public sealed class VersioningInterceptorTests
         {
             Id = Guid.NewGuid(),
             Name = "v1",
-            BusinessId = businessId,
+            VersionId = businessId,
         };
         context.Entities.Add(v1);
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        // Add second version with same BusinessId
+        // Add second version with same VersionId
         TestVersionedEntity v2 = new()
         {
             Id = Guid.NewGuid(),
             Name = "v2",
-            BusinessId = businessId,
+            VersionId = businessId,
         };
         context.Entities.Add(v2);
 
@@ -127,7 +127,7 @@ public sealed class VersioningInterceptorTests
     }
 
     [Fact]
-    public async Task SaveChanges_MultipleAddsForSameBusinessId_ShouldIncrementSequentially()
+    public async Task SaveChanges_MultipleAddsForSameVersionId_ShouldIncrementSequentially()
     {
         // Arrange — two entities added in the same SaveChanges batch
         var businessId = Guid.NewGuid();
@@ -137,13 +137,13 @@ public sealed class VersioningInterceptorTests
         {
             Id = Guid.NewGuid(),
             Name = "Batch v1",
-            BusinessId = businessId,
+            VersionId = businessId,
         };
         TestVersionedEntity v2 = new()
         {
             Id = Guid.NewGuid(),
             Name = "Batch v2",
-            BusinessId = businessId,
+            VersionId = businessId,
         };
         context.Entities.Add(v1);
         context.Entities.Add(v2);
@@ -170,7 +170,7 @@ public sealed class VersioningInterceptorTests
         {
             Id = Guid.NewGuid(),
             Name = "Original",
-            BusinessId = Guid.NewGuid(),
+            VersionId = Guid.NewGuid(),
             Version = 1,
         };
         context.Entities.Add(entity);
@@ -227,7 +227,7 @@ public sealed class VersioningInterceptorTests
         context.SaveChanges();
 
         // Assert
-        entity.BusinessId.ShouldNotBe(Guid.Empty);
+        entity.VersionId.ShouldNotBe(Guid.Empty);
         entity.Version.ShouldBe(1);
     }
 
@@ -252,7 +252,7 @@ public sealed class VersioningInterceptorTests
     private sealed class TestVersionedEntity : Entity, IVersioned
     {
         public string Name { get; set; } = string.Empty;
-        public Guid BusinessId { get; set; }
+        public Guid VersionId { get; set; }
         public int Version { get; set; }
     }
 

--- a/tests/Granit.Webhooks.Tests/WebhookSubscriptionTests.cs
+++ b/tests/Granit.Webhooks.Tests/WebhookSubscriptionTests.cs
@@ -19,6 +19,7 @@ public sealed class WebhookSubscriptionTests
     public void Suspend_ShouldEmitWebhookSubscriptionSuspendedEventEvent()
     {
         WebhookSubscription subscription = BuildSubscription();
+        subscription.ClearDomainEvents();
 
         subscription.Suspend(DateTimeOffset.UtcNow, "system", "HTTP 401");
 
@@ -36,6 +37,7 @@ public sealed class WebhookSubscriptionTests
     public void Deactivate_ShouldEmitWebhookSubscriptionDeactivatedEventEvent()
     {
         WebhookSubscription subscription = BuildSubscription();
+        subscription.ClearDomainEvents();
 
         subscription.Deactivate("Admin request");
 
@@ -63,6 +65,7 @@ public sealed class WebhookSubscriptionTests
     public void MultipleTransitions_ShouldAccumulateEvents()
     {
         WebhookSubscription subscription = BuildSubscription();
+        subscription.ClearDomainEvents();
 
         subscription.Suspend(DateTimeOffset.UtcNow, "system", "HTTP 401");
         subscription.Deactivate("Permanently removed");
@@ -70,6 +73,79 @@ public sealed class WebhookSubscriptionTests
         subscription.DomainEvents.Count.ShouldBe(2);
         subscription.DomainEvents.First().ShouldBeOfType<WebhookSubscriptionSuspendedEvent>();
         subscription.DomainEvents.Last().ShouldBeOfType<WebhookSubscriptionDeactivatedEvent>();
+    }
+
+    [Fact]
+    public void Create_ShouldEmitWebhookSubscriptionCreatedEvent()
+    {
+        WebhookSubscription subscription = BuildSubscription();
+
+        IDomainEvent domainEvent = subscription.DomainEvents.ShouldHaveSingleItem();
+        WebhookSubscriptionCreatedEvent created = domainEvent.ShouldBeOfType<WebhookSubscriptionCreatedEvent>();
+        created.SubscriptionId.ShouldBe(subscription.Id);
+        created.EventType.ShouldBe("test.event");
+        created.TargetUrl.ShouldBe("https://example.com/webhook");
+    }
+
+    [Fact]
+    public void RecordSuccess_ShouldEmitWebhookDeliverySucceededEvent()
+    {
+        WebhookSubscription subscription = BuildSubscription();
+        subscription.ClearDomainEvents();
+
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        subscription.RecordSuccess(now);
+
+        IDomainEvent domainEvent = subscription.DomainEvents.ShouldHaveSingleItem();
+        WebhookDeliverySucceededEvent succeeded = domainEvent.ShouldBeOfType<WebhookDeliverySucceededEvent>();
+        succeeded.SubscriptionId.ShouldBe(subscription.Id);
+        succeeded.DeliveredAt.ShouldBe(now);
+    }
+
+    [Fact]
+    public void RecordFailure_BelowThreshold_ShouldNotEmitIntegrationEvent()
+    {
+        WebhookSubscription subscription = BuildSubscription();
+
+        for (int i = 0; i < 4; i++)
+        {
+            subscription.RecordFailure();
+        }
+
+        subscription.ConsecutiveFailureCount.ShouldBe(4);
+        subscription.IntegrationEvents.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void RecordFailure_AtThreshold_ShouldEmitWebhookDeliveryFailureThresholdExceededEto()
+    {
+        WebhookSubscription subscription = BuildSubscription();
+
+        for (int i = 0; i < 5; i++)
+        {
+            subscription.RecordFailure();
+        }
+
+        subscription.ConsecutiveFailureCount.ShouldBe(5);
+
+        IIntegrationEvent integrationEvent = subscription.IntegrationEvents.ShouldHaveSingleItem();
+        WebhookDeliveryFailureThresholdExceededEto eto = integrationEvent.ShouldBeOfType<WebhookDeliveryFailureThresholdExceededEto>();
+        eto.SubscriptionId.ShouldBe(subscription.Id);
+        eto.TargetUrl.ShouldBe("https://example.com/webhook");
+        eto.ConsecutiveFailureCount.ShouldBe(5);
+    }
+
+    [Fact]
+    public void RecordFailure_AboveThreshold_ShouldEmitOnEachSubsequentFailure()
+    {
+        WebhookSubscription subscription = BuildSubscription();
+
+        for (int i = 0; i < 7; i++)
+        {
+            subscription.RecordFailure();
+        }
+
+        subscription.IntegrationEvents.Count.ShouldBe(3); // failures 5, 6, 7
     }
 
     private static WebhookSubscription BuildSubscription() =>

--- a/tests/Granit.Workflow.EntityFrameworkCore.Tests/WorkflowTransitionInterceptorTests.cs
+++ b/tests/Granit.Workflow.EntityFrameworkCore.Tests/WorkflowTransitionInterceptorTests.cs
@@ -187,7 +187,7 @@ public sealed class WorkflowTransitionInterceptorTests
         TestVersionedEntity entity = new()
         {
             Id = Guid.NewGuid(),
-            BusinessId = Guid.NewGuid(),
+            VersionId = Guid.NewGuid(),
             Version = 1,
             LifecycleStatus = WorkflowLifecycleStatus.Published,
             IsPublished = false, // Intentionally wrong — interceptor should fix
@@ -209,7 +209,7 @@ public sealed class WorkflowTransitionInterceptorTests
         TestVersionedEntity entity = new()
         {
             Id = Guid.NewGuid(),
-            BusinessId = Guid.NewGuid(),
+            VersionId = Guid.NewGuid(),
             Version = 1,
             LifecycleStatus = WorkflowLifecycleStatus.Draft,
             IsPublished = true, // Intentionally wrong
@@ -254,7 +254,7 @@ public sealed class WorkflowTransitionInterceptorTests
 
     private sealed class TestVersionedEntity : Entity, IVersionedEntity, IWorkflowStateful
     {
-        public Guid BusinessId { get; set; }
+        public Guid VersionId { get; set; }
         public int Version { get; set; }
         public WorkflowLifecycleStatus LifecycleStatus { get; set; }
         public bool IsPublished { get; set; }

--- a/tests/Granit.Workflow.Tests/VersionedWorkflowEntityTests.cs
+++ b/tests/Granit.Workflow.Tests/VersionedWorkflowEntityTests.cs
@@ -23,7 +23,7 @@ public sealed class VersionedWorkflowEntityTests
         TestVersionedWorkflowEntity entity = new();
 
         // Assert
-        entity.BusinessId.ShouldBe(Guid.Empty);
+        entity.VersionId.ShouldBe(Guid.Empty);
         entity.Version.ShouldBe(0);
         entity.LifecycleStatus.ShouldBe(WorkflowLifecycleStatus.Draft);
         entity.IsPublished.ShouldBeFalse();
@@ -42,7 +42,7 @@ public sealed class VersionedWorkflowEntityTests
 
         // Act — write through interface casts (same as VersioningInterceptor / WorkflowTransitionInterceptor)
         IVersioned versioned = entity;
-        versioned.BusinessId = businessId;
+        versioned.VersionId = businessId;
         versioned.Version = 3;
 
         IVersionedEntity versionedEntity = entity;
@@ -52,7 +52,7 @@ public sealed class VersionedWorkflowEntityTests
         publishable.IsPublished = true;
 
         // Assert — read through concrete type
-        entity.BusinessId.ShouldBe(businessId);
+        entity.VersionId.ShouldBe(businessId);
         entity.Version.ShouldBe(3);
         entity.LifecycleStatus.ShouldBe(WorkflowLifecycleStatus.Published);
         entity.IsPublished.ShouldBeTrue();
@@ -143,7 +143,7 @@ public sealed class VersionedWorkflowEntityTests
         TestVersionedWorkflowEntity entity = new();
 
         IVersioned versioned = entity;
-        versioned.BusinessId = businessId;
+        versioned.VersionId = businessId;
         versioned.Version = 5;
 
         IVersionedEntity versionedEntity = entity;
@@ -153,7 +153,7 @@ public sealed class VersionedWorkflowEntityTests
         publishable.IsPublished = false;
 
         // Assert — cast to interface
-        versionedEntity.BusinessId.ShouldBe(businessId);
+        versionedEntity.VersionId.ShouldBe(businessId);
         versionedEntity.Version.ShouldBe(5);
         versionedEntity.LifecycleStatus.ShouldBe(WorkflowLifecycleStatus.Archived);
         versionedEntity.IsPublished.ShouldBeFalse();

--- a/tests/Granit.Workflow.Tests/VersionedWorkflowEntityTests.cs
+++ b/tests/Granit.Workflow.Tests/VersionedWorkflowEntityTests.cs
@@ -1,4 +1,6 @@
 using System.Reflection;
+using Granit.Core.Domain;
+using Granit.Core.Events;
 using Granit.Workflow.Domain;
 using Shouldly;
 using Xunit;
@@ -28,23 +30,28 @@ public sealed class VersionedWorkflowEntityTests
     }
 
     // ========================================================================
-    // Property setters
+    // Property setters via interface casts (same path as interceptors)
     // ========================================================================
 
     [Fact]
-    public void Properties_ShouldBeSettable()
+    public void Properties_ShouldBeSettableViaInterfaceCast()
     {
         // Arrange
         var businessId = Guid.NewGuid();
-        TestVersionedWorkflowEntity entity = new()
-        {
-            BusinessId = businessId,
-            Version = 3,
-            LifecycleStatus = WorkflowLifecycleStatus.Published,
-            IsPublished = true,
-        };
+        TestVersionedWorkflowEntity entity = new();
 
-        // Assert
+        // Act — write through interface casts (same as VersioningInterceptor / WorkflowTransitionInterceptor)
+        IVersioned versioned = entity;
+        versioned.BusinessId = businessId;
+        versioned.Version = 3;
+
+        IVersionedEntity versionedEntity = entity;
+        versionedEntity.LifecycleStatus = WorkflowLifecycleStatus.Published;
+
+        IPublishable publishable = entity;
+        publishable.IsPublished = true;
+
+        // Assert — read through concrete type
         entity.BusinessId.ShouldBe(businessId);
         entity.Version.ShouldBe(3);
         entity.LifecycleStatus.ShouldBe(WorkflowLifecycleStatus.Published);
@@ -100,11 +107,11 @@ public sealed class VersionedWorkflowEntityTests
     }
 
     // ========================================================================
-    // AuditedEntity inheritance
+    // AuditedAggregateRoot inheritance
     // ========================================================================
 
     [Fact]
-    public void Entity_ShouldInheritAuditedEntityProperties()
+    public void Entity_ShouldInheritAuditedAggregateRootProperties()
     {
         // Arrange
         DateTimeOffset now = DateTimeOffset.UtcNow;
@@ -131,18 +138,22 @@ public sealed class VersionedWorkflowEntityTests
     [Fact]
     public void Entity_ShouldImplementIVersionedEntity()
     {
-        // Arrange & Act
-        TestVersionedWorkflowEntity entity = new()
-        {
-            BusinessId = Guid.NewGuid(),
-            Version = 5,
-            LifecycleStatus = WorkflowLifecycleStatus.Archived,
-            IsPublished = false,
-        };
+        // Arrange & Act — set via interface casts
+        var businessId = Guid.NewGuid();
+        TestVersionedWorkflowEntity entity = new();
+
+        IVersioned versioned = entity;
+        versioned.BusinessId = businessId;
+        versioned.Version = 5;
+
+        IVersionedEntity versionedEntity = entity;
+        versionedEntity.LifecycleStatus = WorkflowLifecycleStatus.Archived;
+
+        IPublishable publishable = entity;
+        publishable.IsPublished = false;
 
         // Assert — cast to interface
-        IVersionedEntity versionedEntity = entity;
-        versionedEntity.BusinessId.ShouldBe(entity.BusinessId);
+        versionedEntity.BusinessId.ShouldBe(businessId);
         versionedEntity.Version.ShouldBe(5);
         versionedEntity.LifecycleStatus.ShouldBe(WorkflowLifecycleStatus.Archived);
         versionedEntity.IsPublished.ShouldBeFalse();
@@ -163,6 +174,58 @@ public sealed class VersionedWorkflowEntityTests
     }
 
     // ========================================================================
+    // Domain & integration event support (from AuditedAggregateRoot)
+    // ========================================================================
+
+    [Fact]
+    public void Entity_ShouldSupportDomainEvents()
+    {
+        // Arrange
+        TestVersionedWorkflowEntity entity = new();
+
+        // Act
+        entity.RaiseDomainEvent(new TestDomainEvent("test-payload"));
+
+        // Assert
+        entity.DomainEvents.ShouldHaveSingleItem();
+        entity.DomainEvents.First().ShouldBeOfType<TestDomainEvent>()
+            .Payload.ShouldBe("test-payload");
+    }
+
+    [Fact]
+    public void Entity_ShouldSupportIntegrationEvents()
+    {
+        // Arrange
+        TestVersionedWorkflowEntity entity = new();
+
+        // Act
+        entity.RaiseIntegrationEvent(new TestIntegrationEto("test-data"));
+
+        // Assert
+        entity.IntegrationEvents.ShouldHaveSingleItem();
+        entity.IntegrationEvents.First().ShouldBeOfType<TestIntegrationEto>()
+            .Data.ShouldBe("test-data");
+    }
+
+    // ========================================================================
+    // SetLifecycleStatus behavior method
+    // ========================================================================
+
+    [Fact]
+    public void SetLifecycleStatus_ShouldUpdateStatus()
+    {
+        // Arrange
+        TestVersionedWorkflowEntity entity = new();
+        entity.LifecycleStatus.ShouldBe(WorkflowLifecycleStatus.Draft);
+
+        // Act
+        entity.TransitionTo(WorkflowLifecycleStatus.PendingReview);
+
+        // Assert
+        entity.LifecycleStatus.ShouldBe(WorkflowLifecycleStatus.PendingReview);
+    }
+
+    // ========================================================================
     // Helpers
     // ========================================================================
 
@@ -173,12 +236,25 @@ public sealed class VersionedWorkflowEntityTests
             .GetValue(null)!;
 
     // ========================================================================
-    // Test entity — re-implements IWorkflowStateful to provide WorkflowEntityType
+    // Test types
     // ========================================================================
 
     private sealed class TestVersionedWorkflowEntity : VersionedWorkflowEntity, IWorkflowStateful
     {
         public static string StatusPropertyName => nameof(LifecycleStatus);
         public static string WorkflowEntityType => "TestDocument";
+
+        /// <summary>Exposes <see cref="AddDomainEvent"/> for testing.</summary>
+        public void RaiseDomainEvent(IDomainEvent domainEvent) => AddDomainEvent(domainEvent);
+
+        /// <summary>Exposes <see cref="AddDistributedEvent"/> for testing.</summary>
+        public void RaiseIntegrationEvent(IIntegrationEvent integrationEvent) => AddDistributedEvent(integrationEvent);
+
+        /// <summary>Exposes <see cref="SetLifecycleStatus"/> for testing.</summary>
+        public void TransitionTo(WorkflowLifecycleStatus status) => SetLifecycleStatus(status);
     }
+
+    private sealed record TestDomainEvent(string Payload) : IDomainEvent;
+
+    private sealed record TestIntegrationEto(string Data) : IIntegrationEvent;
 }


### PR DESCRIPTION
## Summary

- **Missing events (#465)**: Add domain events (`*Event`) and integration events (`*Eto`) across all modules — ApiKeys, BackgroundJobs, BlobStorage, DataExchange, Identity, Notifications, Privacy, Webhooks
- **Event catalog**: New docs page listing all framework events with dispatch type and module
- **DDD Phase 5 (#460)**: Migrate `VersionedWorkflowEntity` from `AuditedEntity` to `AuditedAggregateRoot` — gives subtypes `AddDomainEvent()`/`AddDistributedEvent()` support
- **Rename `BusinessId` → `VersionId`** on `IVersioned` for clarity (stable ID shared across versions)
- **Move `IWorkflowStateful`** to `Granit.Workflow.Domain` namespace (was misplaced at root)

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test tests/Granit.Workflow.Tests` — 59 passed
- [x] `dotnet test tests/Granit.Workflow.EntityFrameworkCore.Tests` — 27 passed
- [x] `dotnet test tests/Granit.Persistence.Tests` — 181 passed
- [x] `dotnet test tests/Granit.ArchitectureTests` — 63 passed
- [x] `dotnet format --verify-no-changes` — clean
- [x] guava-backend adapted and tests passing (separate MR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)