### PR TITLE
chore(deps): update WolverineFx 5.20 → 5.21 and restore floating packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,12 +57,12 @@
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.*" />
   </ItemGroup>
   <ItemGroup Label="Wolverine">
-    <PackageVersion Include="WolverineFx" Version="5.20.*" />
-    <PackageVersion Include="WolverineFx.EntityFrameworkCore" Version="5.20.*" />
-    <PackageVersion Include="WolverineFx.Postgresql" Version="5.20.*" />
-    <PackageVersion Include="WolverineFx.SqlServer" Version="5.20.*" />
-    <PackageVersion Include="WolverineFx.FluentValidation" Version="5.20.*" />
-    <PackageVersion Include="WolverineFx.Http.FluentValidation" Version="5.20.*" />
+    <PackageVersion Include="WolverineFx" Version="5.21.*" />
+    <PackageVersion Include="WolverineFx.EntityFrameworkCore" Version="5.21.*" />
+    <PackageVersion Include="WolverineFx.Postgresql" Version="5.21.*" />
+    <PackageVersion Include="WolverineFx.SqlServer" Version="5.21.*" />
+    <PackageVersion Include="WolverineFx.FluentValidation" Version="5.21.*" />
+    <PackageVersion Include="WolverineFx.Http.FluentValidation" Version="5.21.*" />
   </ItemGroup>
   <ItemGroup Label="Blob Storage">
     <PackageVersion Include="AWSSDK.S3" Version="4.*" />

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -4,7 +4,7 @@ Ce fichier répertorie les bibliothèques tierces utilisées par le projet
 **granit-dotnet** ainsi que leurs licences respectives. Il est mis à jour
 à chaque ajout ou modification de dépendance externe.
 
-Dernière mise à jour : 2026-03-19
+Dernière mise à jour : 2026-03-20
 
 ---
 
@@ -67,11 +67,12 @@ Dernière mise à jour : 2026-03-19
 | MailKit | 4.12.0 | Copyright (c) 2013-2026 .NET Foundation and Contributors |
 | Microsoft.AspNetCore.SignalR.StackExchangeRedis | 10.0.3 | (c) Microsoft Corporation |
 | Microsoft.Extensions.Http | 10.0.3 | (c) Microsoft Corporation |
-| WolverineFx | 5.19.1 | JasperFx Contributors |
-| WolverineFx.EntityFrameworkCore | 5.19.1 | JasperFx Contributors |
-| WolverineFx.FluentValidation | 5.19.1 | JasperFx Contributors |
-| WolverineFx.Http.FluentValidation | 5.19.1 | JasperFx Contributors |
-| WolverineFx.Postgresql | 5.19.1 | JasperFx Contributors |
+| WolverineFx | 5.21.0 | JasperFx Contributors |
+| WolverineFx.EntityFrameworkCore | 5.21.0 | JasperFx Contributors |
+| WolverineFx.FluentValidation | 5.21.0 | JasperFx Contributors |
+| WolverineFx.Http.FluentValidation | 5.21.0 | JasperFx Contributors |
+| WolverineFx.Postgresql | 5.21.0 | JasperFx Contributors |
+| WolverineFx.SqlServer | 5.21.0 | JasperFx Contributors |
 
 ### Apache-2.0
 

--- a/src/Granit.BackgroundJobs.Wolverine/packages.lock.json
+++ b/src/Granit.BackgroundJobs.Wolverine/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "WolverineFx": {
         "type": "Direct",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -553,8 +553,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "Cronos": {
@@ -730,12 +730,12 @@
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       }
     }

--- a/src/Granit.DataExchange.Wolverine/packages.lock.json
+++ b/src/Granit.DataExchange.Wolverine/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "WolverineFx": {
         "type": "Direct",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -564,8 +564,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "FluentValidation": {
@@ -735,12 +735,12 @@
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       }
     }

--- a/src/Granit.EventBus.Wolverine/packages.lock.json
+++ b/src/Granit.EventBus.Wolverine/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "WolverineFx": {
         "type": "Direct",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -532,8 +532,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "FluentValidation": {
@@ -703,12 +703,12 @@
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       }
     }

--- a/src/Granit.Notifications.Wolverine/packages.lock.json
+++ b/src/Granit.Notifications.Wolverine/packages.lock.json
@@ -20,9 +20,9 @@
       },
       "WolverineFx": {
         "type": "Direct",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -568,8 +568,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "FluentValidation": {
@@ -729,12 +729,12 @@
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       }
     }

--- a/src/Granit.Persistence.Migrations.Wolverine/packages.lock.json
+++ b/src/Granit.Persistence.Migrations.Wolverine/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "WolverineFx": {
         "type": "Direct",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -578,8 +578,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "FluentValidation": {
@@ -796,12 +796,12 @@
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       }
     }

--- a/src/Granit.Privacy.AI/packages.lock.json
+++ b/src/Granit.Privacy.AI/packages.lock.json
@@ -496,7 +496,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Core": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )"
         }
       },
       "granit.timing": {
@@ -540,8 +540,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",
@@ -612,9 +612,9 @@
       },
       "WolverineFx": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",

--- a/src/Granit.Privacy/packages.lock.json
+++ b/src/Granit.Privacy/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "WolverineFx": {
         "type": "Direct",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",

--- a/src/Granit.Webhooks.Wolverine/packages.lock.json
+++ b/src/Granit.Webhooks.Wolverine/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "WolverineFx": {
         "type": "Direct",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -660,8 +660,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "FluentValidation": {
@@ -856,12 +856,12 @@
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       }
     }

--- a/src/Granit.Wolverine.Postgresql/packages.lock.json
+++ b/src/Granit.Wolverine.Postgresql/packages.lock.json
@@ -57,25 +57,25 @@
       },
       "WolverineFx.EntityFrameworkCore": {
         "type": "Direct",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "QeQmhzs47WRo8al2Uw7aFrSKKupbJjR7PTXtGkyarhOpKI+Nq97pwheFkESLiEkDJzdYboG7kPGH5eeBu8br7A==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "bbm5v5C9+g2x9tdnYD1dMZ0MnplTCRKCDSfMRjySewHM+2CvvUy1UesPLGD/tVF7XumXloHBW+41VdtpoNEfNQ==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.9.0",
-          "WolverineFx.RDBMS": "5.20.1"
+          "WolverineFx.RDBMS": "5.21.0"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "Direct",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "HMcSyipQW56oIKxn4lNaPKgCDfauCL9dRQb0xfFkW1tuqBv6nk4KsmPzb5UClZZnek/xT1nxR5ycwhS83AagNw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "b6jBqF9KD2uqvFcQMZYk5Ysy5H2EwxVa4K9nK7g6jZUlPYy9XQJ/3QFrTlSB9WEtyrJGv881EU1a2r1hsUv52Q==",
         "dependencies": {
           "Weasel.Postgresql": "8.9.0",
-          "WolverineFx.RDBMS": "5.20.1"
+          "WolverineFx.RDBMS": "5.21.0"
         }
       },
       "DistributedLock.Core": {
@@ -684,11 +684,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.20.1",
-        "contentHash": "RHxsgLTqic3hcWDdS5ItiEugfYRGVQf+QIcvZejloKqxXLXwaT7+4Lnl425GdDi92RguZLTEPjmSBle3KC64sw==",
+        "resolved": "5.21.0",
+        "contentHash": "P5ENI94TzD8fmWsOijI8SVLHzrrYklcmD2VobPZehpMCjFf6O04cdXl55TB2WA7V7SpytuLz0thClnSN+O9g2g==",
         "dependencies": {
           "Weasel.Core": "8.9.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       },
       "ZString": {
@@ -766,8 +766,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "FluentValidation": {
@@ -948,9 +948,9 @@
       },
       "WolverineFx": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -969,12 +969,12 @@
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       }
     }

--- a/src/Granit.Wolverine.SqlServer/packages.lock.json
+++ b/src/Granit.Wolverine.SqlServer/packages.lock.json
@@ -59,25 +59,25 @@
       },
       "WolverineFx.EntityFrameworkCore": {
         "type": "Direct",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "QeQmhzs47WRo8al2Uw7aFrSKKupbJjR7PTXtGkyarhOpKI+Nq97pwheFkESLiEkDJzdYboG7kPGH5eeBu8br7A==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "bbm5v5C9+g2x9tdnYD1dMZ0MnplTCRKCDSfMRjySewHM+2CvvUy1UesPLGD/tVF7XumXloHBW+41VdtpoNEfNQ==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.9.0",
-          "WolverineFx.RDBMS": "5.20.1"
+          "WolverineFx.RDBMS": "5.21.0"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "Direct",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "l7HzYLhIUgdrJHucPitQeu23JNmCkoZB4gmvG7JwyLsXRRl/pDsbifcNycnEtFgSD2Es17uZ69ilnfpVGOWBMw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "hKSDNU7Zg2nMzk/+afbCHDnjUr7gFChrG4lj8n7RcHboX1TKX6vZIedvho9ExJdTiKVnYKoGKmDDML2mttXCDA==",
         "dependencies": {
           "Weasel.SqlServer": "8.9.0",
-          "WolverineFx.RDBMS": "5.20.1"
+          "WolverineFx.RDBMS": "5.21.0"
         }
       },
       "Azure.Core": {
@@ -787,11 +787,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.20.1",
-        "contentHash": "RHxsgLTqic3hcWDdS5ItiEugfYRGVQf+QIcvZejloKqxXLXwaT7+4Lnl425GdDi92RguZLTEPjmSBle3KC64sw==",
+        "resolved": "5.21.0",
+        "contentHash": "P5ENI94TzD8fmWsOijI8SVLHzrrYklcmD2VobPZehpMCjFf6O04cdXl55TB2WA7V7SpytuLz0thClnSN+O9g2g==",
         "dependencies": {
           "Weasel.Core": "8.9.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       },
       "ZString": {
@@ -869,8 +869,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "Azure.Identity": {
@@ -1062,9 +1062,9 @@
       },
       "WolverineFx": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -1083,12 +1083,12 @@
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       }
     }

--- a/src/Granit.Wolverine/packages.lock.json
+++ b/src/Granit.Wolverine/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "WolverineFx": {
         "type": "Direct",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -23,12 +23,12 @@
       },
       "WolverineFx.FluentValidation": {
         "type": "Direct",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       },
       "FastExpressionCompiler": {

--- a/tests/Granit.ArchitectureTests.Abstractions/Rules/BackgroundJobConventionRules.cs
+++ b/tests/Granit.ArchitectureTests.Abstractions/Rules/BackgroundJobConventionRules.cs
@@ -19,7 +19,7 @@ public static class BackgroundJobConventionRules
         Architecture architecture,
         string typePrefix)
     {
-        List<string> violations = architecture.Classes
+        var violations = architecture.Classes
             .Where(c => c.FullName.StartsWith(typePrefix, StringComparison.Ordinal)
                 && !c.IsAbstract.GetValueOrDefault()
                 && ImplementsInterface(c, "Granit.BackgroundJobs.IBackgroundJob"))
@@ -39,7 +39,7 @@ public static class BackgroundJobConventionRules
         Architecture architecture,
         string typePrefix)
     {
-        List<string> violations = architecture.Classes
+        var violations = architecture.Classes
             .Where(c => c.FullName.StartsWith(typePrefix, StringComparison.Ordinal)
                 && !c.IsAbstract.GetValueOrDefault()
                 && HasAttribute(c, "Granit.BackgroundJobs.RecurringJobAttribute"))
@@ -58,7 +58,5 @@ public static class BackgroundJobConventionRules
             && d is ArchUnitNET.Domain.Dependencies.ImplementsInterfaceDependency);
 
     private static bool HasAttribute(Class c, string attributeFullName) =>
-        c.Attributes.Any(a =>
-            a.FullName == attributeFullName
-            || a.Type.FullName == attributeFullName);
+        c.Attributes.Any(a => a.FullName == attributeFullName);
 }

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1150,11 +1150,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.20.1",
-        "contentHash": "RHxsgLTqic3hcWDdS5ItiEugfYRGVQf+QIcvZejloKqxXLXwaT7+4Lnl425GdDi92RguZLTEPjmSBle3KC64sw==",
+        "resolved": "5.21.0",
+        "contentHash": "P5ENI94TzD8fmWsOijI8SVLHzrrYklcmD2VobPZehpMCjFf6O04cdXl55TB2WA7V7SpytuLz0thClnSN+O9g2g==",
         "dependencies": {
           "Weasel.Core": "8.9.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       },
       "xunit.analyzers": {
@@ -1460,7 +1460,7 @@
         "dependencies": {
           "Granit.BackgroundJobs": "[0.1.0-dev, )",
           "Granit.Wolverine": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )"
         }
       },
       "granit.blobstorage": {
@@ -1619,7 +1619,7 @@
         "dependencies": {
           "Granit.DataExchange": "[0.1.0-dev, )",
           "Granit.Wolverine": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )"
         }
       },
       "granit.diagnostics": {
@@ -1681,7 +1681,7 @@
         "dependencies": {
           "Granit.EventBus": "[0.1.0-dev, )",
           "Granit.Wolverine": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )"
         }
       },
       "granit.features": {
@@ -2098,7 +2098,7 @@
         "dependencies": {
           "Granit.Notifications": "[0.1.0-dev, )",
           "Granit.Wolverine": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )"
         }
       },
       "granit.notifications.zulip": {
@@ -2163,7 +2163,7 @@
         "dependencies": {
           "Granit.Persistence.Migrations": "[0.1.0-dev, )",
           "Granit.Wolverine": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )"
         }
       },
       "granit.persistence.postgres": {
@@ -2184,7 +2184,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Core": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )"
         }
       },
       "granit.privacy.ai": {
@@ -2521,7 +2521,7 @@
         "dependencies": {
           "Granit.Webhooks": "[0.1.0-dev, )",
           "Granit.Wolverine": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )"
         }
       },
       "granit.wolverine": {
@@ -2529,8 +2529,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "granit.wolverine.postgresql": {
@@ -2539,8 +2539,8 @@
           "Granit.Persistence": "[0.1.0-dev, )",
           "Granit.Wolverine": "[0.1.0-dev, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.*, )",
-          "WolverineFx.EntityFrameworkCore": "[5.20.*, )",
-          "WolverineFx.Postgresql": "[5.20.*, )"
+          "WolverineFx.EntityFrameworkCore": "[5.21.*, )",
+          "WolverineFx.Postgresql": "[5.21.*, )"
         }
       },
       "granit.wolverine.sqlserver": {
@@ -2549,8 +2549,8 @@
           "Granit.Persistence": "[0.1.0-dev, )",
           "Granit.Wolverine": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.SqlServer": "[10.*, )",
-          "WolverineFx.EntityFrameworkCore": "[5.20.*, )",
-          "WolverineFx.SqlServer": "[5.20.*, )"
+          "WolverineFx.EntityFrameworkCore": "[5.21.*, )",
+          "WolverineFx.SqlServer": "[5.21.*, )"
         }
       },
       "granit.workflow": {
@@ -3227,9 +3227,9 @@
       },
       "WolverineFx": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -3240,45 +3240,45 @@
       },
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "QeQmhzs47WRo8al2Uw7aFrSKKupbJjR7PTXtGkyarhOpKI+Nq97pwheFkESLiEkDJzdYboG7kPGH5eeBu8br7A==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "bbm5v5C9+g2x9tdnYD1dMZ0MnplTCRKCDSfMRjySewHM+2CvvUy1UesPLGD/tVF7XumXloHBW+41VdtpoNEfNQ==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.9.0",
-          "WolverineFx.RDBMS": "5.20.1"
+          "WolverineFx.RDBMS": "5.21.0"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "HMcSyipQW56oIKxn4lNaPKgCDfauCL9dRQb0xfFkW1tuqBv6nk4KsmPzb5UClZZnek/xT1nxR5ycwhS83AagNw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "b6jBqF9KD2uqvFcQMZYk5Ysy5H2EwxVa4K9nK7g6jZUlPYy9XQJ/3QFrTlSB9WEtyrJGv881EU1a2r1hsUv52Q==",
         "dependencies": {
           "Weasel.Postgresql": "8.9.0",
-          "WolverineFx.RDBMS": "5.20.1"
+          "WolverineFx.RDBMS": "5.21.0"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "l7HzYLhIUgdrJHucPitQeu23JNmCkoZB4gmvG7JwyLsXRRl/pDsbifcNycnEtFgSD2Es17uZ69ilnfpVGOWBMw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "hKSDNU7Zg2nMzk/+afbCHDnjUr7gFChrG4lj8n7RcHboX1TKX6vZIedvho9ExJdTiKVnYKoGKmDDML2mttXCDA==",
         "dependencies": {
           "Weasel.SqlServer": "8.9.0",
-          "WolverineFx.RDBMS": "5.20.1"
+          "WolverineFx.RDBMS": "5.21.0"
         }
       }
     }

--- a/tests/Granit.BackgroundJobs.Tests.Integration/packages.lock.json
+++ b/tests/Granit.BackgroundJobs.Tests.Integration/packages.lock.json
@@ -51,9 +51,9 @@
       },
       "WolverineFx": {
         "type": "Direct",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -719,7 +719,7 @@
         "dependencies": {
           "Granit.BackgroundJobs": "[0.1.0-dev, )",
           "Granit.Wolverine": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )"
         }
       },
       "granit.core": {
@@ -778,8 +778,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "Cronos": {
@@ -955,12 +955,12 @@
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       }
     }

--- a/tests/Granit.BackgroundJobs.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.BackgroundJobs.Wolverine.Tests/packages.lock.json
@@ -698,7 +698,7 @@
         "dependencies": {
           "Granit.BackgroundJobs": "[0.1.0-dev, )",
           "Granit.Wolverine": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )"
         }
       },
       "granit.core": {
@@ -757,8 +757,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "Cronos": {
@@ -934,9 +934,9 @@
       },
       "WolverineFx": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -955,12 +955,12 @@
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       }
     }

--- a/tests/Granit.DataExchange.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.DataExchange.Wolverine.Tests/packages.lock.json
@@ -698,7 +698,7 @@
         "dependencies": {
           "Granit.DataExchange": "[0.1.0-dev, )",
           "Granit.Wolverine": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )"
         }
       },
       "granit.eventbus": {
@@ -768,8 +768,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "FluentValidation": {
@@ -939,9 +939,9 @@
       },
       "WolverineFx": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -960,12 +960,12 @@
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       }
     }

--- a/tests/Granit.EventBus.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.EventBus.Wolverine.Tests/packages.lock.json
@@ -696,7 +696,7 @@
         "dependencies": {
           "Granit.EventBus": "[0.1.0-dev, )",
           "Granit.Wolverine": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )"
         }
       },
       "granit.http.exceptionhandling": {
@@ -736,8 +736,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "FluentValidation": {
@@ -907,9 +907,9 @@
       },
       "WolverineFx": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -928,12 +928,12 @@
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       }
     }

--- a/tests/Granit.Notifications.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Wolverine.Tests/packages.lock.json
@@ -725,7 +725,7 @@
           "Granit.Notifications": "[0.1.0-dev, )",
           "Granit.Wolverine": "[0.1.0-dev, )",
           "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
-          "WolverineFx": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )"
         }
       },
       "granit.querying": {
@@ -763,8 +763,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "FluentValidation": {
@@ -934,9 +934,9 @@
       },
       "WolverineFx": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -955,12 +955,12 @@
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       }
     }

--- a/tests/Granit.Persistence.Migrations.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Persistence.Migrations.Wolverine.Tests/packages.lock.json
@@ -761,7 +761,7 @@
         "dependencies": {
           "Granit.Persistence.Migrations": "[0.1.0-dev, )",
           "Granit.Wolverine": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )"
         }
       },
       "granit.security": {
@@ -793,8 +793,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "FluentValidation": {
@@ -1011,9 +1011,9 @@
       },
       "WolverineFx": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -1032,12 +1032,12 @@
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       }
     }

--- a/tests/Granit.Privacy.AI.Tests/packages.lock.json
+++ b/tests/Granit.Privacy.AI.Tests/packages.lock.json
@@ -691,7 +691,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Core": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )"
         }
       },
       "granit.privacy.ai": {
@@ -744,8 +744,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",
@@ -838,9 +838,9 @@
       },
       "WolverineFx": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",

--- a/tests/Granit.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.Privacy.Tests/packages.lock.json
@@ -51,9 +51,9 @@
       },
       "WolverineFx": {
         "type": "Direct",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -693,7 +693,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Core": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )"
         }
       },
       "Microsoft.CodeAnalysis.Analyzers": {

--- a/tests/Granit.Webhooks.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Webhooks.Wolverine.Tests/packages.lock.json
@@ -856,7 +856,7 @@
         "dependencies": {
           "Granit.Webhooks": "[0.1.0-dev, )",
           "Granit.Wolverine": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )"
         }
       },
       "granit.wolverine": {
@@ -864,8 +864,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "FluentValidation": {
@@ -1060,9 +1060,9 @@
       },
       "WolverineFx": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -1081,12 +1081,12 @@
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       }
     }

--- a/tests/Granit.Wolverine.Postgresql.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Wolverine.Postgresql.Tests.Integration/packages.lock.json
@@ -838,11 +838,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.20.1",
-        "contentHash": "RHxsgLTqic3hcWDdS5ItiEugfYRGVQf+QIcvZejloKqxXLXwaT7+4Lnl425GdDi92RguZLTEPjmSBle3KC64sw==",
+        "resolved": "5.21.0",
+        "contentHash": "P5ENI94TzD8fmWsOijI8SVLHzrrYklcmD2VobPZehpMCjFf6O04cdXl55TB2WA7V7SpytuLz0thClnSN+O9g2g==",
         "dependencies": {
           "Weasel.Core": "8.9.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       },
       "xunit.analyzers": {
@@ -987,8 +987,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "granit.wolverine.postgresql": {
@@ -1000,8 +1000,8 @@
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.*, )",
-          "WolverineFx.EntityFrameworkCore": "[5.20.*, )",
-          "WolverineFx.Postgresql": "[5.20.*, )"
+          "WolverineFx.EntityFrameworkCore": "[5.21.*, )",
+          "WolverineFx.Postgresql": "[5.21.*, )"
         }
       },
       "FluentValidation": {
@@ -1206,9 +1206,9 @@
       },
       "WolverineFx": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -1227,35 +1227,35 @@
       },
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "QeQmhzs47WRo8al2Uw7aFrSKKupbJjR7PTXtGkyarhOpKI+Nq97pwheFkESLiEkDJzdYboG7kPGH5eeBu8br7A==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "bbm5v5C9+g2x9tdnYD1dMZ0MnplTCRKCDSfMRjySewHM+2CvvUy1UesPLGD/tVF7XumXloHBW+41VdtpoNEfNQ==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.9.0",
-          "WolverineFx.RDBMS": "5.20.1"
+          "WolverineFx.RDBMS": "5.21.0"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "HMcSyipQW56oIKxn4lNaPKgCDfauCL9dRQb0xfFkW1tuqBv6nk4KsmPzb5UClZZnek/xT1nxR5ycwhS83AagNw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "b6jBqF9KD2uqvFcQMZYk5Ysy5H2EwxVa4K9nK7g6jZUlPYy9XQJ/3QFrTlSB9WEtyrJGv881EU1a2r1hsUv52Q==",
         "dependencies": {
           "Weasel.Postgresql": "8.9.0",
-          "WolverineFx.RDBMS": "5.20.1"
+          "WolverineFx.RDBMS": "5.21.0"
         }
       }
     }

--- a/tests/Granit.Wolverine.Postgresql.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.Postgresql.Tests/packages.lock.json
@@ -759,11 +759,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.20.1",
-        "contentHash": "RHxsgLTqic3hcWDdS5ItiEugfYRGVQf+QIcvZejloKqxXLXwaT7+4Lnl425GdDi92RguZLTEPjmSBle3KC64sw==",
+        "resolved": "5.21.0",
+        "contentHash": "P5ENI94TzD8fmWsOijI8SVLHzrrYklcmD2VobPZehpMCjFf6O04cdXl55TB2WA7V7SpytuLz0thClnSN+O9g2g==",
         "dependencies": {
           "Weasel.Core": "8.9.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       },
       "xunit.analyzers": {
@@ -908,8 +908,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "granit.wolverine.postgresql": {
@@ -921,8 +921,8 @@
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.*, )",
-          "WolverineFx.EntityFrameworkCore": "[5.20.*, )",
-          "WolverineFx.Postgresql": "[5.20.*, )"
+          "WolverineFx.EntityFrameworkCore": "[5.21.*, )",
+          "WolverineFx.Postgresql": "[5.21.*, )"
         }
       },
       "FluentValidation": {
@@ -1150,9 +1150,9 @@
       },
       "WolverineFx": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -1171,35 +1171,35 @@
       },
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "QeQmhzs47WRo8al2Uw7aFrSKKupbJjR7PTXtGkyarhOpKI+Nq97pwheFkESLiEkDJzdYboG7kPGH5eeBu8br7A==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "bbm5v5C9+g2x9tdnYD1dMZ0MnplTCRKCDSfMRjySewHM+2CvvUy1UesPLGD/tVF7XumXloHBW+41VdtpoNEfNQ==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.9.0",
-          "WolverineFx.RDBMS": "5.20.1"
+          "WolverineFx.RDBMS": "5.21.0"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "HMcSyipQW56oIKxn4lNaPKgCDfauCL9dRQb0xfFkW1tuqBv6nk4KsmPzb5UClZZnek/xT1nxR5ycwhS83AagNw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "b6jBqF9KD2uqvFcQMZYk5Ysy5H2EwxVa4K9nK7g6jZUlPYy9XQJ/3QFrTlSB9WEtyrJGv881EU1a2r1hsUv52Q==",
         "dependencies": {
           "Weasel.Postgresql": "8.9.0",
-          "WolverineFx.RDBMS": "5.20.1"
+          "WolverineFx.RDBMS": "5.21.0"
         }
       }
     }

--- a/tests/Granit.Wolverine.SqlServer.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Wolverine.SqlServer.Tests.Integration/packages.lock.json
@@ -941,11 +941,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.20.1",
-        "contentHash": "RHxsgLTqic3hcWDdS5ItiEugfYRGVQf+QIcvZejloKqxXLXwaT7+4Lnl425GdDi92RguZLTEPjmSBle3KC64sw==",
+        "resolved": "5.21.0",
+        "contentHash": "P5ENI94TzD8fmWsOijI8SVLHzrrYklcmD2VobPZehpMCjFf6O04cdXl55TB2WA7V7SpytuLz0thClnSN+O9g2g==",
         "dependencies": {
           "Weasel.Core": "8.9.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       },
       "xunit.analyzers": {
@@ -1090,8 +1090,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "granit.wolverine.sqlserver": {
@@ -1103,8 +1103,8 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
-          "WolverineFx.EntityFrameworkCore": "[5.20.*, )",
-          "WolverineFx.SqlServer": "[5.20.*, )"
+          "WolverineFx.EntityFrameworkCore": "[5.21.*, )",
+          "WolverineFx.SqlServer": "[5.21.*, )"
         }
       },
       "Azure.Identity": {
@@ -1320,9 +1320,9 @@
       },
       "WolverineFx": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -1341,35 +1341,35 @@
       },
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "QeQmhzs47WRo8al2Uw7aFrSKKupbJjR7PTXtGkyarhOpKI+Nq97pwheFkESLiEkDJzdYboG7kPGH5eeBu8br7A==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "bbm5v5C9+g2x9tdnYD1dMZ0MnplTCRKCDSfMRjySewHM+2CvvUy1UesPLGD/tVF7XumXloHBW+41VdtpoNEfNQ==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.9.0",
-          "WolverineFx.RDBMS": "5.20.1"
+          "WolverineFx.RDBMS": "5.21.0"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "l7HzYLhIUgdrJHucPitQeu23JNmCkoZB4gmvG7JwyLsXRRl/pDsbifcNycnEtFgSD2Es17uZ69ilnfpVGOWBMw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "hKSDNU7Zg2nMzk/+afbCHDnjUr7gFChrG4lj8n7RcHboX1TKX6vZIedvho9ExJdTiKVnYKoGKmDDML2mttXCDA==",
         "dependencies": {
           "Weasel.SqlServer": "8.9.0",
-          "WolverineFx.RDBMS": "5.20.1"
+          "WolverineFx.RDBMS": "5.21.0"
         }
       }
     }

--- a/tests/Granit.Wolverine.SqlServer.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.SqlServer.Tests/packages.lock.json
@@ -860,11 +860,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.20.1",
-        "contentHash": "RHxsgLTqic3hcWDdS5ItiEugfYRGVQf+QIcvZejloKqxXLXwaT7+4Lnl425GdDi92RguZLTEPjmSBle3KC64sw==",
+        "resolved": "5.21.0",
+        "contentHash": "P5ENI94TzD8fmWsOijI8SVLHzrrYklcmD2VobPZehpMCjFf6O04cdXl55TB2WA7V7SpytuLz0thClnSN+O9g2g==",
         "dependencies": {
           "Weasel.Core": "8.9.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       },
       "xunit.analyzers": {
@@ -1009,8 +1009,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "granit.wolverine.sqlserver": {
@@ -1022,8 +1022,8 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
-          "WolverineFx.EntityFrameworkCore": "[5.20.*, )",
-          "WolverineFx.SqlServer": "[5.20.*, )"
+          "WolverineFx.EntityFrameworkCore": "[5.21.*, )",
+          "WolverineFx.SqlServer": "[5.21.*, )"
         }
       },
       "Azure.Identity": {
@@ -1264,9 +1264,9 @@
       },
       "WolverineFx": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -1285,35 +1285,35 @@
       },
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "QeQmhzs47WRo8al2Uw7aFrSKKupbJjR7PTXtGkyarhOpKI+Nq97pwheFkESLiEkDJzdYboG7kPGH5eeBu8br7A==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "bbm5v5C9+g2x9tdnYD1dMZ0MnplTCRKCDSfMRjySewHM+2CvvUy1UesPLGD/tVF7XumXloHBW+41VdtpoNEfNQ==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
           "Weasel.EntityFrameworkCore": "8.9.0",
-          "WolverineFx.RDBMS": "5.20.1"
+          "WolverineFx.RDBMS": "5.21.0"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "l7HzYLhIUgdrJHucPitQeu23JNmCkoZB4gmvG7JwyLsXRRl/pDsbifcNycnEtFgSD2Es17uZ69ilnfpVGOWBMw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "hKSDNU7Zg2nMzk/+afbCHDnjUr7gFChrG4lj8n7RcHboX1TKX6vZIedvho9ExJdTiKVnYKoGKmDDML2mttXCDA==",
         "dependencies": {
           "Weasel.SqlServer": "8.9.0",
-          "WolverineFx.RDBMS": "5.20.1"
+          "WolverineFx.RDBMS": "5.21.0"
         }
       }
     }

--- a/tests/Granit.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Wolverine.Tests/packages.lock.json
@@ -477,8 +477,8 @@
         "dependencies": {
           "Granit.Security": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
-          "WolverineFx": "[5.20.*, )",
-          "WolverineFx.FluentValidation": "[5.20.*, )"
+          "WolverineFx": "[5.21.*, )",
+          "WolverineFx.FluentValidation": "[5.21.*, )"
         }
       },
       "FluentValidation": {
@@ -552,9 +552,9 @@
       },
       "WolverineFx": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "8wB+Y5BBzQTulHxpbzi6BCG55vM4yvgz/savFUAzWU+Vs6qFpL8joV/O8Gj0VMVVY0c9Isyx9+wLoGJPsYTrZw==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
         "dependencies": {
           "JasperFx": "1.21.1",
           "JasperFx.Events": "1.24.0",
@@ -565,12 +565,12 @@
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[5.20.*, )",
-        "resolved": "5.20.1",
-        "contentHash": "DhQ/mYbOOYZWNN5W5Q4GWk0hFrWeDnIio7FwwMWsnDOBubSViN1FCwWT7mYY/T+CGzTMDHKh9W+MFkfcxnTQ2g==",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "T0vdmTObXUZ3MjeUZ4WN4SrBtXI7mqLtPk1JDXy0NvzrHpZ3RKmSun/EZs63xeutExXdO6BhqQscd9PdFdKwgw==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.20.1"
+          "WolverineFx": "5.21.0"
         }
       }
     }


### PR DESCRIPTION
## Summary

- **WolverineFx.*** bumped from `5.20.*` to `5.21.*` (all 6 packages)
- **ArchUnitNET 0.13.3 compat fix**: `Attribute.Type` property removed — simplified `HasAttribute` in `BackgroundJobConventionRules` to use `FullName` directly
- **THIRD-PARTY-NOTICES.md**: updated WolverineFx versions (5.19.1 → 5.21.0), added missing `WolverineFx.SqlServer` entry
- Other requested packages (AWSSDK.*, FirebaseAdmin, Microsoft.Extensions.AI.*, PuppeteerSharp, Scriban, StackExchange.Redis, Scalar.AspNetCore) already use floating versions and resolve to latest on restore

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet format --verify-no-changes` — clean
- [x] `dotnet test tests/Granit.ArchitectureTests` — 65/65 passed
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)