### PR TITLE
fix: resolve SonarQube code smells — unused params, expression bodies, missing assertion

### DIFF
--- a/src/Granit.Authentication.ApiKeys.Endpoints/Endpoints/ApiKeyCreateEndpoints.cs
+++ b/src/Granit.Authentication.ApiKeys.Endpoints/Endpoints/ApiKeyCreateEndpoints.cs
@@ -1,7 +1,6 @@
 using Granit.Authentication.ApiKeys.Domain;
 using Granit.Authentication.ApiKeys.Endpoints.Dtos;
 using Granit.Guids;
-using Granit.Timing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -30,7 +29,6 @@ internal static class ApiKeyCreateEndpoints
         [FromServices] IApiKeyGenerator generator,
         [FromServices] IApiKeyAdminStore adminStore,
         [FromServices] IGuidGenerator guidGenerator,
-        [FromServices] IClock clock,
         CancellationToken cancellationToken)
     {
         ApiKeyGenerationResult keyResult = generator.Generate(request.Type, request.Environment);

--- a/src/Granit.Authentication.ApiKeys/Domain/ApiKeyEntry.cs
+++ b/src/Granit.Authentication.ApiKeys/Domain/ApiKeyEntry.cs
@@ -85,10 +85,8 @@ public sealed class ApiKeyEntry : FullAuditedAggregateRoot, IMultiTenant
     /// <summary>
     /// Revokes the API key.
     /// </summary>
-    public void Revoke(DateTimeOffset revokedAt)
-    {
+    public void Revoke(DateTimeOffset revokedAt) =>
         RevokedAt = revokedAt;
-    }
 
     /// <summary>
     /// Records that this key was used for an API call.
@@ -116,32 +114,24 @@ public sealed class ApiKeyEntry : FullAuditedAggregateRoot, IMultiTenant
     /// <summary>
     /// Updates the permissions granted to this key.
     /// </summary>
-    public void UpdatePermissions(List<string> permissions)
-    {
+    public void UpdatePermissions(List<string> permissions) =>
         Permissions = permissions;
-    }
 
     /// <summary>
     /// Updates the allowed CIDR ranges for IP whitelisting.
     /// </summary>
-    public void UpdateAllowedCidrs(List<string> cidrs)
-    {
+    public void UpdateAllowedCidrs(List<string> cidrs) =>
         AllowedCidrs = cidrs;
-    }
 
     /// <summary>
     /// Sets the expiration date.
     /// </summary>
-    public void SetExpiration(DateTimeOffset? expiresAt)
-    {
+    public void SetExpiration(DateTimeOffset? expiresAt) =>
         ExpiresAt = expiresAt;
-    }
 
     /// <summary>
     /// Sets the caching behavior.
     /// </summary>
-    public void SetCacheBehavior(CacheBehavior cacheBehavior)
-    {
+    public void SetCacheBehavior(CacheBehavior cacheBehavior) =>
         CacheBehavior = cacheBehavior;
-    }
 }

--- a/src/Granit.BackgroundJobs/Domain/BackgroundJobDefinition.cs
+++ b/src/Granit.BackgroundJobs/Domain/BackgroundJobDefinition.cs
@@ -121,10 +121,8 @@ public sealed class BackgroundJobDefinition : AggregateRoot
     /// <summary>
     /// Schedules the next execution time.
     /// </summary>
-    internal void ScheduleNext(DateTimeOffset? nextExecution)
-    {
+    internal void ScheduleNext(DateTimeOffset? nextExecution) =>
         NextExecutionAt = nextExecution;
-    }
 
     /// <summary>
     /// Records an execution failure.
@@ -144,10 +142,8 @@ public sealed class BackgroundJobDefinition : AggregateRoot
     /// <summary>
     /// Sets the UserId of the operator who manually triggered this job.
     /// </summary>
-    internal void SetTriggeredBy(string? triggeredBy)
-    {
+    internal void SetTriggeredBy(string? triggeredBy) =>
         TriggeredBy = triggeredBy;
-    }
 
     /// <summary>
     /// Pauses the job and emits a <see cref="BackgroundJobPausedEvent"/> domain event.

--- a/src/Granit.DataExchange/Export/Domain/ExportJob.cs
+++ b/src/Granit.DataExchange/Export/Domain/ExportJob.cs
@@ -87,10 +87,8 @@ public sealed class ExportJob : AuditedAggregateRoot
     /// <summary>
     /// Transitions to <see cref="ExportJobStatus.Exporting"/>.
     /// </summary>
-    internal void MarkAsExporting()
-    {
+    internal void MarkAsExporting() =>
         Status = ExportJobStatus.Exporting;
-    }
 
     /// <summary>
     /// Marks the export as completed.

--- a/src/Granit.DataExchange/Import/Domain/ImportJob.cs
+++ b/src/Granit.DataExchange/Import/Domain/ImportJob.cs
@@ -98,18 +98,14 @@ public sealed class ImportJob : AuditedAggregateRoot
     /// <summary>
     /// Sets the column mappings after user confirmation.
     /// </summary>
-    internal void SetMappings(string mappingsJson)
-    {
+    internal void SetMappings(string mappingsJson) =>
         MappingsJson = mappingsJson;
-    }
 
     /// <summary>
     /// Transitions to <see cref="ImportJobStatus.Previewed"/> after header extraction.
     /// </summary>
-    internal void MarkAsPreviewed()
-    {
+    internal void MarkAsPreviewed() =>
         Status = ImportJobStatus.Previewed;
-    }
 
     /// <summary>
     /// Confirms mappings and transitions to <see cref="ImportJobStatus.Mapped"/>.
@@ -132,10 +128,8 @@ public sealed class ImportJob : AuditedAggregateRoot
     /// <summary>
     /// Transitions to <see cref="ImportJobStatus.Executing"/>.
     /// </summary>
-    internal void MarkAsExecuting()
-    {
+    internal void MarkAsExecuting() =>
         Status = ImportJobStatus.Executing;
-    }
 
     /// <summary>
     /// Marks the import as completed with a final status and report.

--- a/src/Granit.Persistence/Extensions/ModelBuilderExtensions.cs
+++ b/src/Granit.Persistence/Extensions/ModelBuilderExtensions.cs
@@ -132,8 +132,6 @@ public static class ModelBuilderExtensions
     // that extracts/wraps the underlying primitive. No schema change — same column type.
     private static void ApplySingleValueObjectConverters(ModelBuilder modelBuilder)
     {
-        Type svoOpenType = typeof(SingleValueObject<>);
-
         foreach (IMutableEntityType entityType in modelBuilder.Model.GetEntityTypes())
         {
             foreach (IMutableProperty property in entityType.GetProperties())

--- a/src/Granit.Webhooks.Endpoints/Validators/WebhookTargetUrlValidatorExtensions.cs
+++ b/src/Granit.Webhooks.Endpoints/Validators/WebhookTargetUrlValidatorExtensions.cs
@@ -138,15 +138,6 @@ public static class WebhookTargetUrlValidatorExtensions
         }
 
         string host = uri.Host;
-
-        foreach (string tld in BlockedTlds)
-        {
-            if (host.EndsWith(tld, StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-        }
-
-        return true;
+        return !BlockedTlds.Any(tld => host.EndsWith(tld, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/Granit.Webhooks/Domain/WebhookSubscription.cs
+++ b/src/Granit.Webhooks/Domain/WebhookSubscription.cs
@@ -165,16 +165,12 @@ public sealed class WebhookSubscription : AuditedAggregateRoot
     /// <summary>
     /// Updates the target URL for webhook delivery.
     /// </summary>
-    internal void UpdateTargetUrl(HttpsUrl targetUrl)
-    {
+    internal void UpdateTargetUrl(HttpsUrl targetUrl) =>
         TargetUrl = targetUrl;
-    }
 
     /// <summary>
     /// Replaces the signing secret with a new protected value.
     /// </summary>
-    internal void RotateSecret(string newProtectedSecret)
-    {
+    internal void RotateSecret(string newProtectedSecret) =>
         SigningSecret = newProtectedSecret;
-    }
 }

--- a/src/Granit.Workflow/Domain/VersionedWorkflowEntity.cs
+++ b/src/Granit.Workflow/Domain/VersionedWorkflowEntity.cs
@@ -84,10 +84,8 @@ public abstract class VersionedWorkflowEntity : AuditedAggregateRoot, IVersioned
     /// methods (e.g., <c>Publish()</c>, <c>Archive()</c>) that call this method.
     /// </summary>
     /// <param name="status">The new lifecycle status.</param>
-    protected void SetLifecycleStatus(WorkflowLifecycleStatus status)
-    {
+    protected void SetLifecycleStatus(WorkflowLifecycleStatus status) =>
         LifecycleStatus = status;
-    }
 
     /// <inheritdoc/>
     public virtual string GetWorkflowEntityId() => Id.ToString();

--- a/tests/Granit.BlobStorage.Endpoints.Tests/BlobStorageEndpointsOptionsTests.cs
+++ b/tests/Granit.BlobStorage.Endpoints.Tests/BlobStorageEndpointsOptionsTests.cs
@@ -17,8 +17,6 @@ public sealed class BlobStorageEndpointsOptionsTests
     }
 
     [Fact]
-    public void SectionName_should_be_BlobStorageEndpoints()
-    {
+    public void SectionName_should_be_BlobStorageEndpoints() =>
         BlobStorageEndpointsOptions.SectionName.ShouldBe("BlobStorageEndpoints");
-    }
 }

--- a/tests/Granit.BlobStorage.Tests/Jobs/OrphanBlobCleanupJobTests.cs
+++ b/tests/Granit.BlobStorage.Tests/Jobs/OrphanBlobCleanupJobTests.cs
@@ -19,8 +19,6 @@ public sealed class OrphanBlobCleanupJobTests
     }
 
     [Fact]
-    public void Should_implement_IBackgroundJob()
-    {
+    public void Should_implement_IBackgroundJob() =>
         typeof(IBackgroundJob).IsAssignableFrom(typeof(OrphanBlobCleanupJob)).ShouldBeTrue();
-    }
 }

--- a/tests/Granit.Identity.EntraId.Tests/NullPasswordResetNotifierTests.cs
+++ b/tests/Granit.Identity.EntraId.Tests/NullPasswordResetNotifierTests.cs
@@ -1,5 +1,6 @@
 using Granit.Identity.EntraId.Internal;
 using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
 using Xunit;
 
 namespace Granit.Identity.EntraId.Tests;
@@ -11,6 +12,7 @@ public sealed class NullPasswordResetNotifierTests
     {
         NullPasswordResetNotifier notifier = new(NullLogger<NullPasswordResetNotifier>.Instance);
 
-        await notifier.NotifyAsync("user-1", "temp-password", TestContext.Current.CancellationToken);
+        await Should.NotThrowAsync(() =>
+            notifier.NotifyAsync("user-1", "temp-password", TestContext.Current.CancellationToken));
     }
 }


### PR DESCRIPTION
## Summary

- Remove unused `clock` parameter from `ApiKeyCreateEndpoints.CreateAsync`
- Remove unused `svoOpenType` local variable from `ModelBuilderExtensions`
- Convert 14 single-statement methods to expression body syntax (IDE0022)
- Replace `foreach` loop with LINQ `Any()` in `WebhookTargetUrlValidatorExtensions`
- Add explicit `Should.NotThrowAsync` assertion in `NullPasswordResetNotifierTests` (SonarQube blocker)

**Won't fix** (per CLAUDE.md conventions):
- `brain-overload` on aggregate root/DI constructors (ApiKeyEntry, DefaultBlobStorage, ImportJob, UserNotification, TimelineEntry)
- Hardcoded IP `192.168.1.42` in `AuditLogSchemaExampleProvider` — OpenAPI schema example, not real usage

## Test plan

- [x] `dotnet build` — 0 errors
- [x] Affected tests pass: Identity.EntraId (96), BlobStorage.Endpoints (32), BlobStorage (84)
- [x] `dotnet format --verify-no-changes` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
