### PR TITLE
test: add FusionCache integration tests for backplane and fail-safe (#534)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1,0 +1,26696 @@
+{
+  "generatedAt": "2026-03-20T21:01:16.520707+00:00",
+  "repo": "granit-dotnet",
+  "projectGraph": [
+    {
+      "name": "Granit.AI",
+      "deps": [
+        "Granit.Core",
+        "Granit.Guids"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AI.AzureOpenAI",
+      "deps": [
+        "Granit.AI"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AI.Endpoints",
+      "deps": [
+        "Granit.AI",
+        "Granit.Authorization",
+        "Granit.Querying.Endpoints",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AI.EntityFrameworkCore",
+      "deps": [
+        "Granit.AI",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AI.Extraction",
+      "deps": [
+        "Granit.AI"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AI.Ollama",
+      "deps": [
+        "Granit.AI",
+        "Granit.Http.Resilience"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AI.OpenAI",
+      "deps": [
+        "Granit.AI"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AI.VectorData",
+      "deps": [
+        "Granit.AI"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AuditLog",
+      "deps": [
+        "Granit.Core",
+        "Granit.Querying"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AuditLog.ConfigurationChanges",
+      "deps": [
+        "Granit.AuditLog",
+        "Granit.Features",
+        "Granit.Guids",
+        "Granit.Settings"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AuditLog.Endpoints",
+      "deps": [
+        "Granit.AuditLog",
+        "Granit.Http.ApiDocumentation",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AuditLog.EntityFrameworkCore",
+      "deps": [
+        "Granit.AuditLog",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authentication.ApiKeys",
+      "deps": [
+        "Granit.Security",
+        "Granit.Timing",
+        "Granit.Guids",
+        "Granit.Http.ExceptionHandling",
+        "Granit.Querying"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authentication.ApiKeys.Endpoints",
+      "deps": [
+        "Granit.Http.ApiDocumentation",
+        "Granit.Authentication.ApiKeys",
+        "Granit.Authorization",
+        "Granit.Querying",
+        "Granit.Timing",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authentication.ApiKeys.EntityFrameworkCore",
+      "deps": [
+        "Granit.Authentication.ApiKeys",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authentication.Cognito",
+      "deps": [
+        "Granit.Authentication.JwtBearer"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authentication.EntraId",
+      "deps": [
+        "Granit.Authentication.JwtBearer"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authentication.GoogleCloud",
+      "deps": [
+        "Granit.Authentication.JwtBearer"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authentication.JwtBearer",
+      "deps": [
+        "Granit.Security"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authentication.Keycloak",
+      "deps": [
+        "Granit.Authentication.JwtBearer"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authorization",
+      "deps": [
+        "Granit.Caching",
+        "Granit.Security"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authorization.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Authorization"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authorization.Endpoints",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.Http.ApiDocumentation",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authorization.EntityFrameworkCore",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BackgroundJobs",
+      "deps": [
+        "Granit.Core",
+        "Granit.Guids",
+        "Granit.Security",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BackgroundJobs.Endpoints",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.BackgroundJobs",
+        "Granit.Querying",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BackgroundJobs.EntityFrameworkCore",
+      "deps": [
+        "Granit.BackgroundJobs",
+        "Granit.Guids",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BackgroundJobs.Wolverine",
+      "deps": [
+        "Granit.BackgroundJobs",
+        "Granit.Wolverine"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BlobStorage",
+      "deps": [
+        "Granit.BackgroundJobs",
+        "Granit.Core",
+        "Granit.Guids"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BlobStorage.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.BlobStorage"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BlobStorage.AzureBlob",
+      "deps": [
+        "Granit.BlobStorage"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BlobStorage.DbStore",
+      "deps": [
+        "Granit.BlobStorage",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BlobStorage.Endpoints",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.BlobStorage",
+        "Granit.Querying.Endpoints",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BlobStorage.EntityFrameworkCore",
+      "deps": [
+        "Granit.BlobStorage",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BlobStorage.FileSystem",
+      "deps": [
+        "Granit.BlobStorage"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BlobStorage.GoogleCloud",
+      "deps": [
+        "Granit.BlobStorage"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BlobStorage.Proxy",
+      "deps": [
+        "Granit.BlobStorage"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BlobStorage.S3",
+      "deps": [
+        "Granit.BlobStorage"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Caching",
+      "deps": [
+        "Granit.Core",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Caching.StackExchangeRedis",
+      "deps": [
+        "Granit.Caching"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Core",
+      "deps": [],
+      "framework": ""
+    },
+    {
+      "name": "Granit.DataExchange",
+      "deps": [
+        "Granit.EventBus",
+        "Granit.Guids",
+        "Granit.Querying",
+        "Granit.Timing",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.DataExchange.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.DataExchange"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.DataExchange.Csv",
+      "deps": [
+        "Granit.DataExchange"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.DataExchange.Endpoints",
+      "deps": [
+        "Granit.Http.ApiDocumentation",
+        "Granit.Authorization",
+        "Granit.DataExchange",
+        "Granit.Guids",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.DataExchange.EntityFrameworkCore",
+      "deps": [
+        "Granit.DataExchange",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.DataExchange.Excel",
+      "deps": [
+        "Granit.DataExchange"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.DataExchange.Wolverine",
+      "deps": [
+        "Granit.DataExchange",
+        "Granit.Wolverine"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Diagnostics",
+      "deps": [
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Diagnostics.Endpoints",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.Diagnostics",
+        "Granit.Http.ApiDocumentation",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.DocumentGeneration",
+      "deps": [
+        "Granit.Templating"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.DocumentGeneration.Excel",
+      "deps": [
+        "Granit.Templating"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.DocumentGeneration.Pdf",
+      "deps": [
+        "Granit.DocumentGeneration"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Encryption",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Encryption.EntityFrameworkCore",
+      "deps": [
+        "Granit.Core",
+        "Granit.Encryption",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Encryption.ReEncryption",
+      "deps": [
+        "Granit.Encryption.EntityFrameworkCore"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.EventBus",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.EventBus.Wolverine",
+      "deps": [
+        "Granit.EventBus",
+        "Granit.Wolverine"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Features",
+      "deps": [
+        "Granit.Caching",
+        "Granit.Localization"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Features.Endpoints",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.Features",
+        "Granit.Http.ApiDocumentation",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Features.EntityFrameworkCore",
+      "deps": [
+        "Granit.EventBus",
+        "Granit.Features",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Guids",
+      "deps": [
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.ApiDocumentation",
+      "deps": [
+        "Granit.Http.ApiVersioning",
+        "Granit.Security"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.ApiVersioning",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.Bulkhead",
+      "deps": [
+        "Granit.Core",
+        "Granit.Http.ExceptionHandling",
+        "Granit.Features",
+        "Granit.Security"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.Cookies",
+      "deps": [
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.Cookies.Endpoints",
+      "deps": [
+        "Granit.Core",
+        "Granit.Http.ApiDocumentation",
+        "Granit.Http.Cookies"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.Cookies.Klaro",
+      "deps": [
+        "Granit.Http.Cookies"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.Cors",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.ExceptionHandling",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.Idempotency",
+      "deps": [
+        "Granit.Caching",
+        "Granit.Security"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.OutputCaching",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.OutputCaching.StackExchangeRedis",
+      "deps": [
+        "Granit.Caching.StackExchangeRedis",
+        "Granit.Http.OutputCaching"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.Resilience",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.ResponseCompression",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Identity",
+      "deps": [
+        "Granit.Core",
+        "Granit.Querying"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Identity.Cognito",
+      "deps": [
+        "Granit.Identity"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Identity.Endpoints",
+      "deps": [
+        "Granit.Http.ApiDocumentation",
+        "Granit.Authorization",
+        "Granit.Identity",
+        "Granit.Querying",
+        "Granit.Querying.Endpoints",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Identity.EntityFrameworkCore",
+      "deps": [
+        "Granit.Identity",
+        "Granit.Persistence",
+        "Granit.Security"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Identity.EntraId",
+      "deps": [
+        "Granit.Http.Resilience",
+        "Granit.Identity",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Identity.GoogleCloud",
+      "deps": [
+        "Granit.Identity"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Identity.Keycloak",
+      "deps": [
+        "Granit.Http.Resilience",
+        "Granit.Identity",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Imaging",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Imaging.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Imaging"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Imaging.MagickNet",
+      "deps": [
+        "Granit.Imaging"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Localization",
+      "deps": [
+        "Granit.Caching",
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Localization.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Localization"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Localization.Endpoints",
+      "deps": [
+        "Granit.Http.ApiDocumentation",
+        "Granit.Authorization",
+        "Granit.Localization",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Localization.EntityFrameworkCore",
+      "deps": [
+        "Granit.Persistence",
+        "Granit.Localization"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.MultiTenancy",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications",
+      "deps": [
+        "Granit.Guids",
+        "Granit.Querying",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Brevo",
+      "deps": [
+        "Granit.Http.Resilience",
+        "Granit.Notifications.Email",
+        "Granit.Notifications.Sms",
+        "Granit.Notifications.WhatsApp"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Email",
+      "deps": [
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Email.AwsSes",
+      "deps": [
+        "Granit.Notifications.Email"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Email.AzureCommunicationServices",
+      "deps": [
+        "Granit.Notifications.Email"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Email.Scaleway",
+      "deps": [
+        "Granit.Http.Resilience",
+        "Granit.Notifications.Email"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Email.SendGrid",
+      "deps": [
+        "Granit.Http.Resilience",
+        "Granit.Notifications.Email"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Email.Smtp",
+      "deps": [
+        "Granit.Notifications.Email"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Endpoints",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.Http.ApiDocumentation",
+        "Granit.Guids",
+        "Granit.Notifications",
+        "Granit.Notifications.MobilePush",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.EntityFrameworkCore",
+      "deps": [
+        "Granit.Notifications",
+        "Granit.Notifications.MobilePush",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.MobilePush",
+      "deps": [
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.MobilePush.AwsSns",
+      "deps": [
+        "Granit.Notifications.MobilePush"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.MobilePush.AzureNotificationHubs",
+      "deps": [
+        "Granit.Notifications.MobilePush"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.MobilePush.GoogleFcm",
+      "deps": [
+        "Granit.Http.Resilience",
+        "Granit.Notifications.MobilePush"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.SignalR",
+      "deps": [
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Sms",
+      "deps": [
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Sms.AwsSns",
+      "deps": [
+        "Granit.Notifications.Sms"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Sms.AzureCommunicationServices",
+      "deps": [
+        "Granit.Notifications.Sms"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Sse",
+      "deps": [
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Twilio",
+      "deps": [
+        "Granit.Http.Resilience",
+        "Granit.Notifications.Sms",
+        "Granit.Notifications.WhatsApp"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.WebPush",
+      "deps": [
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.WhatsApp",
+      "deps": [
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Wolverine",
+      "deps": [
+        "Granit.Notifications",
+        "Granit.Wolverine"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Zulip",
+      "deps": [
+        "Granit.Http.Resilience",
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Observability",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Observability.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Observability"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Persistence",
+      "deps": [
+        "Granit.Guids",
+        "Granit.Security",
+        "Granit.Timing",
+        "Granit.Http.ExceptionHandling"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Persistence.Hosting",
+      "deps": [
+        "Granit.Persistence",
+        "Granit.Persistence.Migrations"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Persistence.Migrations",
+      "deps": [
+        "Granit.Persistence",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Persistence.Migrations.Wolverine",
+      "deps": [
+        "Granit.Persistence.Migrations",
+        "Granit.Wolverine"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Persistence.Postgres",
+      "deps": [
+        "Granit.Persistence.Hosting"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Persistence.SqlServer",
+      "deps": [
+        "Granit.Persistence.Hosting"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Privacy",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Privacy.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Privacy"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Querying",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Querying.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Querying",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Querying.Endpoints",
+      "deps": [
+        "Granit.Http.ApiDocumentation",
+        "Granit.Authorization",
+        "Granit.Guids",
+        "Granit.Querying",
+        "Granit.Timing",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Querying.EntityFrameworkCore",
+      "deps": [
+        "Granit.Querying",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.RateLimiting",
+      "deps": [
+        "Granit.Core",
+        "Granit.Http.ExceptionHandling",
+        "Granit.Features",
+        "Granit.Security"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.ReferenceData",
+      "deps": [
+        "Granit.Core",
+        "Granit.Querying"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.ReferenceData.Endpoints",
+      "deps": [
+        "Granit.Http.ApiDocumentation",
+        "Granit.Guids",
+        "Granit.ReferenceData",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.ReferenceData.EntityFrameworkCore",
+      "deps": [
+        "Granit.Caching",
+        "Granit.Persistence",
+        "Granit.ReferenceData"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Security",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Settings",
+      "deps": [
+        "Granit.Caching",
+        "Granit.Encryption",
+        "Granit.EventBus",
+        "Granit.Security"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Settings.Endpoints",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.Http.ApiDocumentation",
+        "Granit.Settings",
+        "Granit.Timing",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Settings.EntityFrameworkCore",
+      "deps": [
+        "Granit.Persistence",
+        "Granit.Settings"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Templating",
+      "deps": [
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Templating.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Templating"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Templating.Endpoints",
+      "deps": [
+        "Granit.Http.ApiDocumentation",
+        "Granit.Authorization",
+        "Granit.Security",
+        "Granit.Templating",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Templating.EntityFrameworkCore",
+      "deps": [
+        "Granit.Guids",
+        "Granit.Persistence",
+        "Granit.Templating",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Templating.Scriban",
+      "deps": [
+        "Granit.Templating"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Templating.Workflow",
+      "deps": [
+        "Granit.Templating",
+        "Granit.Workflow"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Testing",
+      "deps": [
+        "Granit.Core",
+        "Granit.Guids",
+        "Granit.Security",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Testing.EntityFrameworkCore",
+      "deps": [
+        "Granit.Persistence",
+        "Granit.Testing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Timeline",
+      "deps": [
+        "Granit.Core",
+        "Granit.Guids",
+        "Granit.Querying",
+        "Granit.Security",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Timeline.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Timeline"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Timeline.Endpoints",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.Http.ApiDocumentation",
+        "Granit.Timeline",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Timeline.EntityFrameworkCore",
+      "deps": [
+        "Granit.Timeline",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Timeline.Notifications",
+      "deps": [
+        "Granit.Timeline",
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Timing",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Validation",
+      "deps": [
+        "Granit.Http.ExceptionHandling",
+        "Granit.Localization"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Validation.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Validation.Endpoints",
+      "deps": [
+        "Granit.Http.ApiDocumentation",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Validation.Europe",
+      "deps": [
+        "Granit.Localization",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Validation.NorthAmerica",
+      "deps": [
+        "Granit.Localization",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Validation.UnitedKingdom",
+      "deps": [
+        "Granit.Localization",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Vault",
+      "deps": [
+        "Granit.Encryption"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Vault.Aws",
+      "deps": [
+        "Granit.Vault"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Vault.Azure",
+      "deps": [
+        "Granit.Vault"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Vault.GoogleCloud",
+      "deps": [
+        "Granit.Vault"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Vault.HashiCorp",
+      "deps": [
+        "Granit.Vault"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Webhooks",
+      "deps": [
+        "Granit.Core",
+        "Granit.Guids",
+        "Granit.Http.Resilience",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Webhooks.Endpoints",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.Querying.Endpoints",
+        "Granit.Validation",
+        "Granit.Webhooks"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Webhooks.EntityFrameworkCore",
+      "deps": [
+        "Granit.Webhooks",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Webhooks.Wolverine",
+      "deps": [
+        "Granit.Webhooks",
+        "Granit.Wolverine"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Wolverine",
+      "deps": [
+        "Granit.Security",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Wolverine.Postgresql",
+      "deps": [
+        "Granit.Wolverine",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Wolverine.SqlServer",
+      "deps": [
+        "Granit.Wolverine",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Workflow",
+      "deps": [
+        "Granit.Querying",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Workflow.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Workflow"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Workflow.Endpoints",
+      "deps": [
+        "Granit.Http.ApiDocumentation",
+        "Granit.Authorization",
+        "Granit.Workflow",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Workflow.EntityFrameworkCore",
+      "deps": [
+        "Granit.Workflow",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Workflow.Notifications",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.Identity",
+        "Granit.Workflow",
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    }
+  ],
+  "symbols": [
+    {
+      "name": "AILocalizationResource",
+      "fqn": "Granit.AI.AILocalizationResource",
+      "kind": "class",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/AILocalizationResource.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "AIUsageRecord",
+      "fqn": "Granit.AI.AIUsageRecord",
+      "kind": "record",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/AIUsageRecord.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "AIAzureOpenAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.AI.AzureOpenAI.Extensions.AIAzureOpenAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AI.AzureOpenAI",
+      "file": "src/Granit.AI.AzureOpenAI/Extensions/AIAzureOpenAIHostApplicationBuilderExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "AddGranitAIAzureOpenAI",
+          "kind": "method",
+          "signature": "AddGranitAIAzureOpenAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIAzureOpenAIModule",
+      "fqn": "Granit.AI.AzureOpenAI.GranitAIAzureOpenAIModule",
+      "kind": "class",
+      "project": "Granit.AI.AzureOpenAI",
+      "file": "src/Granit.AI.AzureOpenAI/GranitAIAzureOpenAIModule.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "AzureOpenAIProviderOptions",
+      "fqn": "Granit.AI.AzureOpenAI.Options.AzureOpenAIProviderOptions",
+      "kind": "class",
+      "project": "Granit.AI.AzureOpenAI",
+      "file": "src/Granit.AI.AzureOpenAI/Options/AzureOpenAIProviderOptions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Endpoint",
+          "kind": "property",
+          "signature": "string Endpoint",
+          "returnType": "string"
+        },
+        {
+          "name": "ApiKey",
+          "kind": "property",
+          "signature": "string? ApiKey",
+          "returnType": "string?"
+        },
+        {
+          "name": "DefaultEmbeddingDeployment",
+          "kind": "property",
+          "signature": "string DefaultEmbeddingDeployment",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "AIMetrics",
+      "fqn": "Granit.AI.Diagnostics.AIMetrics",
+      "kind": "class",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Diagnostics/AIMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordTokensUsed",
+          "kind": "method",
+          "signature": "RecordTokensUsed(string? tenantId, string model, string provider, long inputTokens, long outputTokens)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AIChatMessageRequest",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIChatMessageRequest",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIChatRequest.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "AIChatRequest",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIChatRequest",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIChatRequest.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "AIChatResponse",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIChatResponse",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIChatResponse.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "AIChatUsageResponse",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIChatUsageResponse",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIChatResponse.cs",
+      "line": 24,
+      "members": []
+    },
+    {
+      "name": "AIEmbeddingDataResponse",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIEmbeddingDataResponse",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIEmbeddingResponse.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "AIEmbeddingRequest",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIEmbeddingRequest",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIEmbeddingRequest.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "AIEmbeddingResponse",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIEmbeddingResponse",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIEmbeddingResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "AIWorkspaceCreateRequest",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIWorkspaceCreateRequest",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIWorkspaceCreateRequest.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "AIWorkspaceListResponse",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIWorkspaceListResponse",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIWorkspaceListResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "AIWorkspaceResponse",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIWorkspaceResponse",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIWorkspaceResponse.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "AIWorkspaceUpdateRequest",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIWorkspaceUpdateRequest",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIWorkspaceUpdateRequest.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "AIEndpointRouteBuilderExtensions",
+      "fqn": "Granit.AI.Endpoints.Extensions.AIEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Extensions/AIEndpointRouteBuilderExtensions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "MapAIEndpoints",
+          "kind": "method",
+          "signature": "MapAIEndpoints(this IEndpointRouteBuilder endpoints, Action<AIEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIEndpointsModule",
+      "fqn": "Granit.AI.Endpoints.GranitAIEndpointsModule",
+      "kind": "class",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/GranitAIEndpointsModule.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "AIEndpointsOptions",
+      "fqn": "Granit.AI.Endpoints.Options.AIEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Options/AIEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "AdminRole",
+          "kind": "property",
+          "signature": "string AdminRole",
+          "returnType": "string"
+        },
+        {
+          "name": "UserRole",
+          "kind": "property",
+          "signature": "string UserRole",
+          "returnType": "string"
+        },
+        {
+          "name": "WorkspacesTagName",
+          "kind": "property",
+          "signature": "string WorkspacesTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "UsageTagName",
+          "kind": "property",
+          "signature": "string UsageTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "InferenceTagName",
+          "kind": "property",
+          "signature": "string InferenceTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "MaxChatMessages",
+          "kind": "property",
+          "signature": "int MaxChatMessages",
+          "returnType": "int"
+        },
+        {
+          "name": "MaxEmbeddingInputs",
+          "kind": "property",
+          "signature": "int MaxEmbeddingInputs",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "AIPermissions",
+      "fqn": "Granit.AI.Endpoints.Permissions.AIPermissions",
+      "kind": "class",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Permissions/AIPermissions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "Chat",
+      "fqn": "Granit.AI.Endpoints.Permissions.Chat",
+      "kind": "class",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Permissions/AIPermissions.cs",
+      "line": 23,
+      "members": []
+    },
+    {
+      "name": "Embeddings",
+      "fqn": "Granit.AI.Endpoints.Permissions.Embeddings",
+      "kind": "class",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Permissions/AIPermissions.cs",
+      "line": 28,
+      "members": []
+    },
+    {
+      "name": "Usage",
+      "fqn": "Granit.AI.Endpoints.Permissions.Usage",
+      "kind": "class",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Permissions/AIPermissions.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "Workspaces",
+      "fqn": "Granit.AI.Endpoints.Permissions.Workspaces",
+      "kind": "class",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Permissions/AIPermissions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "AIUsageRecordQueryDefinition",
+      "fqn": "Granit.AI.Endpoints.Queries.AIUsageRecordQueryDefinition",
+      "kind": "class",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Queries/AIUsageRecordQueryDefinition.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "AIEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.AI.EntityFrameworkCore.Extensions.AIEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AI.EntityFrameworkCore",
+      "file": "src/Granit.AI.EntityFrameworkCore/Extensions/AIEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitAIEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitAIEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "AIModelBuilderExtensions",
+      "fqn": "Granit.AI.EntityFrameworkCore.Extensions.AIModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AI.EntityFrameworkCore",
+      "file": "src/Granit.AI.EntityFrameworkCore/Extensions/AIModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureAIModule",
+          "kind": "method",
+          "signature": "ConfigureAIModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIDbProperties",
+      "fqn": "Granit.AI.EntityFrameworkCore.GranitAIDbProperties",
+      "kind": "class",
+      "project": "Granit.AI.EntityFrameworkCore",
+      "file": "src/Granit.AI.EntityFrameworkCore/GranitAIDbProperties.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIEntityFrameworkCoreModule",
+      "fqn": "Granit.AI.EntityFrameworkCore.GranitAIEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.AI.EntityFrameworkCore",
+      "file": "src/Granit.AI.EntityFrameworkCore/GranitAIEntityFrameworkCoreModule.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "AIProviderNotRegisteredException",
+      "fqn": "Granit.AI.Exceptions.AIProviderNotRegisteredException",
+      "kind": "class",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Exceptions/AIProviderNotRegisteredException.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "AIWorkspaceNotFoundException",
+      "fqn": "Granit.AI.Exceptions.AIWorkspaceNotFoundException",
+      "kind": "class",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Exceptions/AIWorkspaceNotFoundException.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "AIServiceCollectionExtensions",
+      "fqn": "Granit.AI.Extensions.AIServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Extensions/AIServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitAI",
+          "kind": "method",
+          "signature": "AddGranitAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "AIExtractionServiceCollectionExtensions",
+      "fqn": "Granit.AI.Extraction.Extensions.AIExtractionServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.AI.Extraction",
+      "file": "src/Granit.AI.Extraction/Extensions/AIExtractionServiceCollectionExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitAIExtraction",
+          "kind": "method",
+          "signature": "AddGranitAIExtraction(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "ExtractionResult",
+      "fqn": "Granit.AI.Extraction.ExtractionResult",
+      "kind": "class",
+      "project": "Granit.AI.Extraction",
+      "file": "src/Granit.AI.Extraction/ExtractionResult.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Status",
+          "kind": "property",
+          "signature": "required ExtractionStatus Status",
+          "returnType": "required ExtractionStatus"
+        }
+      ]
+    },
+    {
+      "name": "ExtractionStatus",
+      "fqn": "Granit.AI.Extraction.ExtractionStatus",
+      "kind": "enum",
+      "project": "Granit.AI.Extraction",
+      "file": "src/Granit.AI.Extraction/ExtractionStatus.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "GranitAIExtractionModule",
+      "fqn": "Granit.AI.Extraction.GranitAIExtractionModule",
+      "kind": "class",
+      "project": "Granit.AI.Extraction",
+      "file": "src/Granit.AI.Extraction/GranitAIExtractionModule.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "IDocumentExtractor",
+      "fqn": "Granit.AI.Extraction.IDocumentExtractor",
+      "kind": "interface",
+      "project": "Granit.AI.Extraction",
+      "file": "src/Granit.AI.Extraction/IDocumentExtractor.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "ExtractAsync",
+          "kind": "method",
+          "signature": "ExtractAsync(string content, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ExtractionResult<TResult>>"
+        }
+      ]
+    },
+    {
+      "name": "ExtractionOptions",
+      "fqn": "Granit.AI.Extraction.Options.ExtractionOptions",
+      "kind": "class",
+      "project": "Granit.AI.Extraction",
+      "file": "src/Granit.AI.Extraction/Options/ExtractionOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string WorkspaceName",
+          "returnType": "string"
+        },
+        {
+          "name": "ReviewThreshold",
+          "kind": "property",
+          "signature": "double ReviewThreshold",
+          "returnType": "double"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIModule",
+      "fqn": "Granit.AI.GranitAIModule",
+      "kind": "class",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/GranitAIModule.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "IAIChatClientFactory",
+      "fqn": "Granit.AI.IAIChatClientFactory",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/IAIChatClientFactory.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(string? workspaceName = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IChatClient>"
+        }
+      ]
+    },
+    {
+      "name": "IAIEmbeddingGeneratorFactory",
+      "fqn": "Granit.AI.IAIEmbeddingGeneratorFactory",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/IAIEmbeddingGeneratorFactory.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(string? workspaceName = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IEmbeddingGenerator<string, Embedding<float>>>"
+        }
+      ]
+    },
+    {
+      "name": "IAIProviderFactory",
+      "fqn": "Granit.AI.IAIProviderFactory",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/IAIProviderFactory.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "CreateChatClient",
+          "kind": "method",
+          "signature": "CreateChatClient(AIWorkspace workspace)",
+          "returnType": "string ProviderName { get; } IChatClient"
+        },
+        {
+          "name": "CreateEmbeddingGenerator",
+          "kind": "method",
+          "signature": "CreateEmbeddingGenerator(AIWorkspace workspace)",
+          "returnType": "IEmbeddingGenerator<string, Embedding<float>>?"
+        }
+      ]
+    },
+    {
+      "name": "IAIUsageQueryableProvider",
+      "fqn": "Granit.AI.IAIUsageQueryableProvider",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/IAIUsageQueryableProvider.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "GetUsageRecords",
+          "kind": "method",
+          "signature": "GetUsageRecords()",
+          "returnType": "IQueryable<AIUsageRecord>"
+        }
+      ]
+    },
+    {
+      "name": "IAIUsageTracker",
+      "fqn": "Granit.AI.IAIUsageTracker",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/IAIUsageTracker.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "RecordAsync",
+          "kind": "method",
+          "signature": "RecordAsync(AIUsageRecord record, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "AIOllamaHostApplicationBuilderExtensions",
+      "fqn": "Granit.AI.Ollama.Extensions.AIOllamaHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AI.Ollama",
+      "file": "src/Granit.AI.Ollama/Extensions/AIOllamaHostApplicationBuilderExtensions.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "AddGranitAIOllama",
+          "kind": "method",
+          "signature": "AddGranitAIOllama(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIOllamaModule",
+      "fqn": "Granit.AI.Ollama.GranitAIOllamaModule",
+      "kind": "class",
+      "project": "Granit.AI.Ollama",
+      "file": "src/Granit.AI.Ollama/GranitAIOllamaModule.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "OllamaOptions",
+      "fqn": "Granit.AI.Ollama.Options.OllamaOptions",
+      "kind": "class",
+      "project": "Granit.AI.Ollama",
+      "file": "src/Granit.AI.Ollama/Options/OllamaOptions.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "Endpoint",
+          "kind": "property",
+          "signature": "string Endpoint",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultModel",
+          "kind": "property",
+          "signature": "string DefaultModel",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "AIOpenAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.AI.OpenAI.Extensions.AIOpenAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AI.OpenAI",
+      "file": "src/Granit.AI.OpenAI/Extensions/AIOpenAIHostApplicationBuilderExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitAIOpenAI",
+          "kind": "method",
+          "signature": "AddGranitAIOpenAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIOpenAIModule",
+      "fqn": "Granit.AI.OpenAI.GranitAIOpenAIModule",
+      "kind": "class",
+      "project": "Granit.AI.OpenAI",
+      "file": "src/Granit.AI.OpenAI/GranitAIOpenAIModule.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "OpenAIProviderOptions",
+      "fqn": "Granit.AI.OpenAI.Options.OpenAIProviderOptions",
+      "kind": "class",
+      "project": "Granit.AI.OpenAI",
+      "file": "src/Granit.AI.OpenAI/Options/OpenAIProviderOptions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "ApiKey",
+          "kind": "property",
+          "signature": "string ApiKey",
+          "returnType": "string"
+        },
+        {
+          "name": "Endpoint",
+          "kind": "property",
+          "signature": "string? Endpoint",
+          "returnType": "string?"
+        },
+        {
+          "name": "DefaultEmbeddingModel",
+          "kind": "property",
+          "signature": "string DefaultEmbeddingModel",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIOptions",
+      "fqn": "Granit.AI.Options.GranitAIOptions",
+      "kind": "class",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Options/GranitAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "DefaultWorkspace",
+          "kind": "property",
+          "signature": "string DefaultWorkspace",
+          "returnType": "string"
+        },
+        {
+          "name": "EnableUsageTracking",
+          "kind": "property",
+          "signature": "bool EnableUsageTracking",
+          "returnType": "bool"
+        },
+        {
+          "name": "EnableAuditTrail",
+          "kind": "property",
+          "signature": "bool EnableAuditTrail",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "VectorDataHostApplicationBuilderExtensions",
+      "fqn": "Granit.AI.VectorData.Extensions.VectorDataHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AI.VectorData",
+      "file": "src/Granit.AI.VectorData/Extensions/VectorDataHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitAIVectorData",
+          "kind": "method",
+          "signature": "AddGranitAIVectorData(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIVectorDataModule",
+      "fqn": "Granit.AI.VectorData.GranitAIVectorDataModule",
+      "kind": "class",
+      "project": "Granit.AI.VectorData",
+      "file": "src/Granit.AI.VectorData/GranitAIVectorDataModule.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "ISemanticSearchService",
+      "fqn": "Granit.AI.VectorData.ISemanticSearchService",
+      "kind": "interface",
+      "project": "Granit.AI.VectorData",
+      "file": "src/Granit.AI.VectorData/ISemanticSearchService.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "IndexAsync",
+          "kind": "method",
+          "signature": "IndexAsync(string collectionName, string key, string text, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SearchAsync",
+          "kind": "method",
+          "signature": "SearchAsync(string collectionName, string query, int limit = 10, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<SemanticSearchResult>>"
+        }
+      ]
+    },
+    {
+      "name": "IVectorCollection",
+      "fqn": "Granit.AI.VectorData.IVectorCollection",
+      "kind": "interface",
+      "project": "Granit.AI.VectorData",
+      "file": "src/Granit.AI.VectorData/IVectorCollection.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "UpsertAsync",
+          "kind": "method",
+          "signature": "UpsertAsync(TRecord record, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(string key, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SearchAsync",
+          "kind": "method",
+          "signature": "SearchAsync(ReadOnlyMemory<float> vector, int limit = 10, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<VectorSearchResult<TRecord>>>"
+        }
+      ]
+    },
+    {
+      "name": "IVectorCollectionFactory",
+      "fqn": "Granit.AI.VectorData.IVectorCollectionFactory",
+      "kind": "interface",
+      "project": "Granit.AI.VectorData",
+      "file": "src/Granit.AI.VectorData/IVectorCollectionFactory.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "VectorDataOptions",
+      "fqn": "Granit.AI.VectorData.Options.VectorDataOptions",
+      "kind": "class",
+      "project": "Granit.AI.VectorData",
+      "file": "src/Granit.AI.VectorData/Options/VectorDataOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "EmbeddingWorkspace",
+          "kind": "property",
+          "signature": "string EmbeddingWorkspace",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSearchLimit",
+          "kind": "property",
+          "signature": "int DefaultSearchLimit",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "SemanticSearchResult",
+      "fqn": "Granit.AI.VectorData.SemanticSearchResult",
+      "kind": "record",
+      "project": "Granit.AI.VectorData",
+      "file": "src/Granit.AI.VectorData/SemanticSearchResult.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "VectorSearchResult",
+      "fqn": "Granit.AI.VectorData.VectorSearchResult",
+      "kind": "record",
+      "project": "Granit.AI.VectorData",
+      "file": "src/Granit.AI.VectorData/VectorSearchResult.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "AIWorkspace",
+      "fqn": "Granit.AI.Workspaces.AIWorkspace",
+      "kind": "record",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Workspaces/AIWorkspace.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "required string Name",
+          "returnType": "required string"
+        },
+        {
+          "name": "TenantId",
+          "kind": "property",
+          "signature": "Guid? TenantId",
+          "returnType": "Guid?"
+        }
+      ]
+    },
+    {
+      "name": "AIWorkspaceKind",
+      "fqn": "Granit.AI.Workspaces.AIWorkspaceKind",
+      "kind": "enum",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Workspaces/AIWorkspaceKind.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "IAIWorkspaceDefinitionContext",
+      "fqn": "Granit.AI.Workspaces.IAIWorkspaceDefinitionContext",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Workspaces/IAIWorkspaceDefinitionContext.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Add",
+          "kind": "method",
+          "signature": "Add(AIWorkspace workspace)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IAIWorkspaceDefinitionProvider",
+      "fqn": "Granit.AI.Workspaces.IAIWorkspaceDefinitionProvider",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Workspaces/IAIWorkspaceDefinitionProvider.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Define",
+          "kind": "method",
+          "signature": "Define(IAIWorkspaceDefinitionContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IAIWorkspaceManager",
+      "fqn": "Granit.AI.Workspaces.IAIWorkspaceManager",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Workspaces/IAIWorkspaceManager.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(AIWorkspace workspace, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UpdateAsync",
+          "kind": "method",
+          "signature": "UpdateAsync(AIWorkspace workspace, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(string workspaceName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IAIWorkspaceProvider",
+      "fqn": "Granit.AI.Workspaces.IAIWorkspaceProvider",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Workspaces/IAIWorkspaceProvider.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(string workspaceName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<AIWorkspace?>"
+        },
+        {
+          "name": "GetAllAsync",
+          "kind": "method",
+          "signature": "GetAllAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<AIWorkspace>>"
+        }
+      ]
+    },
+    {
+      "name": "IAIWorkspaceStoreReader",
+      "fqn": "Granit.AI.Workspaces.IAIWorkspaceStoreReader",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Workspaces/IAIWorkspaceStoreReader.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "FindAsync",
+          "kind": "method",
+          "signature": "FindAsync(string workspaceName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<AIWorkspace?>"
+        },
+        {
+          "name": "GetAllAsync",
+          "kind": "method",
+          "signature": "GetAllAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<AIWorkspace>>"
+        }
+      ]
+    },
+    {
+      "name": "IAIWorkspaceStoreWriter",
+      "fqn": "Granit.AI.Workspaces.IAIWorkspaceStoreWriter",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Workspaces/IAIWorkspaceStoreWriter.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "SaveAsync",
+          "kind": "method",
+          "signature": "SaveAsync(AIWorkspace workspace, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UpdateAsync",
+          "kind": "method",
+          "signature": "UpdateAsync(AIWorkspace workspace, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(string workspaceName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "AlterColumnWithoutContractAnalyzer",
+      "fqn": "Granit.Analyzers.AlterColumnWithoutContractAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/AlterColumnWithoutContractAnalyzer.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "CrossModuleReferenceCodeFixProvider",
+      "fqn": "Granit.Analyzers.CodeFixes.CrossModuleReferenceCodeFixProvider",
+      "kind": "class",
+      "project": "Granit.Analyzers.CodeFixes",
+      "file": "src/Granit.Analyzers.CodeFixes/CrossModuleReferenceCodeFixProvider.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "FixableDiagnosticIds",
+          "kind": "property",
+          "signature": "ImmutableArray<string> FixableDiagnosticIds",
+          "returnType": "ImmutableArray<string>"
+        },
+        {
+          "name": "GetFixAllProvider",
+          "kind": "method",
+          "signature": "GetFixAllProvider()",
+          "returnType": "FixAllProvider"
+        },
+        {
+          "name": "RegisterCodeFixesAsync",
+          "kind": "method",
+          "signature": "RegisterCodeFixesAsync(CodeFixContext context)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "DateTimeNowCodeFixProvider",
+      "fqn": "Granit.Analyzers.CodeFixes.DateTimeNowCodeFixProvider",
+      "kind": "class",
+      "project": "Granit.Analyzers.CodeFixes",
+      "file": "src/Granit.Analyzers.CodeFixes/DateTimeNowCodeFixProvider.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "DependencyInjectionCodeFixProviderBase",
+      "fqn": "Granit.Analyzers.CodeFixes.DependencyInjectionCodeFixProviderBase",
+      "kind": "class",
+      "project": "Granit.Analyzers.CodeFixes",
+      "file": "src/Granit.Analyzers.CodeFixes/DependencyInjectionCodeFixProviderBase.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "FixableDiagnosticIds",
+          "kind": "property",
+          "signature": "sealed ImmutableArray<string> FixableDiagnosticIds",
+          "returnType": "sealed ImmutableArray<string>"
+        },
+        {
+          "name": "GetFixAllProvider",
+          "kind": "method",
+          "signature": "GetFixAllProvider()",
+          "returnType": "sealed FixAllProvider"
+        },
+        {
+          "name": "RegisterCodeFixesAsync",
+          "kind": "method",
+          "signature": "RegisterCodeFixesAsync(CodeFixContext context)",
+          "returnType": "sealed Task"
+        }
+      ]
+    },
+    {
+      "name": "DirectCookieAccessCodeFixProvider",
+      "fqn": "Granit.Analyzers.CodeFixes.DirectCookieAccessCodeFixProvider",
+      "kind": "class",
+      "project": "Granit.Analyzers.CodeFixes",
+      "file": "src/Granit.Analyzers.CodeFixes/DirectCookieAccessCodeFixProvider.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "GuidNewGuidCodeFixProvider",
+      "fqn": "Granit.Analyzers.CodeFixes.GuidNewGuidCodeFixProvider",
+      "kind": "class",
+      "project": "Granit.Analyzers.CodeFixes",
+      "file": "src/Granit.Analyzers.CodeFixes/GuidNewGuidCodeFixProvider.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "MinimalApiServiceParameterCodeFixProvider",
+      "fqn": "Granit.Analyzers.CodeFixes.MinimalApiServiceParameterCodeFixProvider",
+      "kind": "class",
+      "project": "Granit.Analyzers.CodeFixes",
+      "file": "src/Granit.Analyzers.CodeFixes/MinimalApiServiceParameterCodeFixProvider.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "FixableDiagnosticIds",
+          "kind": "property",
+          "signature": "ImmutableArray<string> FixableDiagnosticIds",
+          "returnType": "ImmutableArray<string>"
+        },
+        {
+          "name": "GetFixAllProvider",
+          "kind": "method",
+          "signature": "GetFixAllProvider()",
+          "returnType": "FixAllProvider"
+        },
+        {
+          "name": "RegisterCodeFixesAsync",
+          "kind": "method",
+          "signature": "RegisterCodeFixesAsync(CodeFixContext context)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "SynchronousSaveChangesCodeFixProvider",
+      "fqn": "Granit.Analyzers.CodeFixes.SynchronousSaveChangesCodeFixProvider",
+      "kind": "class",
+      "project": "Granit.Analyzers.CodeFixes",
+      "file": "src/Granit.Analyzers.CodeFixes/SynchronousSaveChangesCodeFixProvider.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "FixableDiagnosticIds",
+          "kind": "property",
+          "signature": "ImmutableArray<string> FixableDiagnosticIds",
+          "returnType": "ImmutableArray<string>"
+        },
+        {
+          "name": "GetFixAllProvider",
+          "kind": "method",
+          "signature": "GetFixAllProvider()",
+          "returnType": "FixAllProvider"
+        },
+        {
+          "name": "RegisterCodeFixesAsync",
+          "kind": "method",
+          "signature": "RegisterCodeFixesAsync(CodeFixContext context)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "TypedResultsBadRequestCodeFixProvider",
+      "fqn": "Granit.Analyzers.CodeFixes.TypedResultsBadRequestCodeFixProvider",
+      "kind": "class",
+      "project": "Granit.Analyzers.CodeFixes",
+      "file": "src/Granit.Analyzers.CodeFixes/TypedResultsBadRequestCodeFixProvider.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "FixableDiagnosticIds",
+          "kind": "property",
+          "signature": "ImmutableArray<string> FixableDiagnosticIds",
+          "returnType": "ImmutableArray<string>"
+        },
+        {
+          "name": "GetFixAllProvider",
+          "kind": "method",
+          "signature": "GetFixAllProvider()",
+          "returnType": "FixAllProvider"
+        },
+        {
+          "name": "RegisterCodeFixesAsync",
+          "kind": "method",
+          "signature": "RegisterCodeFixesAsync(CodeFixContext context)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "UntypedResultsCodeFixProvider",
+      "fqn": "Granit.Analyzers.CodeFixes.UntypedResultsCodeFixProvider",
+      "kind": "class",
+      "project": "Granit.Analyzers.CodeFixes",
+      "file": "src/Granit.Analyzers.CodeFixes/UntypedResultsCodeFixProvider.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "FixableDiagnosticIds",
+          "kind": "property",
+          "signature": "ImmutableArray<string> FixableDiagnosticIds",
+          "returnType": "ImmutableArray<string>"
+        },
+        {
+          "name": "GetFixAllProvider",
+          "kind": "method",
+          "signature": "GetFixAllProvider()",
+          "returnType": "FixAllProvider"
+        },
+        {
+          "name": "RegisterCodeFixesAsync",
+          "kind": "method",
+          "signature": "RegisterCodeFixesAsync(CodeFixContext context)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "CrossModuleReferenceAnalyzer",
+      "fqn": "Granit.Analyzers.CrossModuleReferenceAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/CrossModuleReferenceAnalyzer.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "DateTimeNowAnalyzer",
+      "fqn": "Granit.Analyzers.DateTimeNowAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/DateTimeNowAnalyzer.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "DirectCookieAccessAnalyzer",
+      "fqn": "Granit.Analyzers.DirectCookieAccessAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/DirectCookieAccessAnalyzer.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "DropColumnWithoutContractAnalyzer",
+      "fqn": "Granit.Analyzers.DropColumnWithoutContractAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/DropColumnWithoutContractAnalyzer.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "EfCoreMigrationAnalyzerBase",
+      "fqn": "Granit.Analyzers.EfCoreMigrationAnalyzerBase",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/MigrationAnalyzerBase.cs",
+      "line": 77,
+      "members": []
+    },
+    {
+      "name": "GranitMigrationAnalyzerBase",
+      "fqn": "Granit.Analyzers.GranitMigrationAnalyzerBase",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/MigrationAnalyzerBase.cs",
+      "line": 31,
+      "members": []
+    },
+    {
+      "name": "GuidNewGuidAnalyzer",
+      "fqn": "Granit.Analyzers.GuidNewGuidAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/GuidNewGuidAnalyzer.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "HardcodedSecretAnalyzer",
+      "fqn": "Granit.Analyzers.HardcodedSecretAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/HardcodedSecretAnalyzer.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "MigrationAnalyzerBase",
+      "fqn": "Granit.Analyzers.MigrationAnalyzerBase",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/MigrationAnalyzerBase.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "MinimalApiServiceParameterAnalyzer",
+      "fqn": "Granit.Analyzers.MinimalApiServiceParameterAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/MinimalApiServiceParameterAnalyzer.cs",
+      "line": 31,
+      "members": []
+    },
+    {
+      "name": "NullableColumnInExpandAnalyzer",
+      "fqn": "Granit.Analyzers.NullableColumnInExpandAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/NullableColumnInExpandAnalyzer.cs",
+      "line": 24,
+      "members": []
+    },
+    {
+      "name": "RenameColumnForbiddenAnalyzer",
+      "fqn": "Granit.Analyzers.RenameColumnForbiddenAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/RenameColumnForbiddenAnalyzer.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "SingleRuleAnalyzerBase",
+      "fqn": "Granit.Analyzers.SingleRuleAnalyzerBase",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/SingleRuleAnalyzerBase.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "Initialize",
+          "kind": "method",
+          "signature": "Initialize(AnalysisContext context)",
+          "returnType": "sealed void"
+        }
+      ]
+    },
+    {
+      "name": "SynchronousSaveChangesAnalyzer",
+      "fqn": "Granit.Analyzers.SynchronousSaveChangesAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/SynchronousSaveChangesAnalyzer.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "TypedResultsBadRequestAnalyzer",
+      "fqn": "Granit.Analyzers.TypedResultsBadRequestAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/TypedResultsBadRequestAnalyzer.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "UntypedResultsAnalyzer",
+      "fqn": "Granit.Analyzers.UntypedResultsAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/UntypedResultsAnalyzer.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "AuditLogQuery",
+      "fqn": "Granit.AuditLog.Abstractions.AuditLogQuery",
+      "kind": "record",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Abstractions/AuditLogQuery.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "IAuditLogEntryPublisher",
+      "fqn": "Granit.AuditLog.Abstractions.IAuditLogEntryPublisher",
+      "kind": "interface",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Abstractions/IAuditLogEntryPublisher.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "PublishAsync",
+          "kind": "method",
+          "signature": "PublishAsync(AuditLogBatch batch, CancellationToken cancellationToken = default)",
+          "returnType": "ValueTask"
+        }
+      ]
+    },
+    {
+      "name": "IAuditLogReader",
+      "fqn": "Granit.AuditLog.Abstractions.IAuditLogReader",
+      "kind": "interface",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Abstractions/IAuditLogReader.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "GetByIdAsync",
+          "kind": "method",
+          "signature": "GetByIdAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<AuditLogEntry?>"
+        },
+        {
+          "name": "GetPagedAsync",
+          "kind": "method",
+          "signature": "GetPagedAsync(AuditLogQuery query, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<AuditLogEntry>>"
+        },
+        {
+          "name": "GetByEntityAsync",
+          "kind": "method",
+          "signature": "GetByEntityAsync(string entityType, string entityId, int page = 1, int pageSize = QueryingDefaults.DefaultPageSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<AuditLogEntry>>"
+        }
+      ]
+    },
+    {
+      "name": "IAuditLogWriter",
+      "fqn": "Granit.AuditLog.Abstractions.IAuditLogWriter",
+      "kind": "interface",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Abstractions/IAuditLogWriter.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "WriteAsync",
+          "kind": "method",
+          "signature": "WriteAsync(AuditLogEntry entry, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "AuditIgnoreAttribute",
+      "fqn": "Granit.AuditLog.Attributes.AuditIgnoreAttribute",
+      "kind": "class",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Attributes/AuditIgnoreAttribute.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "AuditSensitiveAttribute",
+      "fqn": "Granit.AuditLog.Attributes.AuditSensitiveAttribute",
+      "kind": "class",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Attributes/AuditSensitiveAttribute.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "GranitAuditLogConfigurationChangesModule",
+      "fqn": "Granit.AuditLog.ConfigurationChanges.GranitAuditLogConfigurationChangesModule",
+      "kind": "class",
+      "project": "Granit.AuditLog.ConfigurationChanges",
+      "file": "src/Granit.AuditLog.ConfigurationChanges/GranitAuditLogConfigurationChangesModule.cs",
+      "line": 31,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "FeatureOverrideChangedAuditHandler",
+      "fqn": "Granit.AuditLog.ConfigurationChanges.Handlers.FeatureOverrideChangedAuditHandler",
+      "kind": "class",
+      "project": "Granit.AuditLog.ConfigurationChanges",
+      "file": "src/Granit.AuditLog.ConfigurationChanges/Handlers/FeatureOverrideChangedAuditHandler.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(FeatureOverrideChangedEvent localEvent, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "SettingChangedAuditHandler",
+      "fqn": "Granit.AuditLog.ConfigurationChanges.Handlers.SettingChangedAuditHandler",
+      "kind": "class",
+      "project": "Granit.AuditLog.ConfigurationChanges",
+      "file": "src/Granit.AuditLog.ConfigurationChanges/Handlers/SettingChangedAuditHandler.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(SettingChangedEvent localEvent, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "AuditChangeType",
+      "fqn": "Granit.AuditLog.Domain.AuditChangeType",
+      "kind": "enum",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Domain/AuditChangeType.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "AuditEntityChange",
+      "fqn": "Granit.AuditLog.Domain.AuditEntityChange",
+      "kind": "class",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Domain/AuditEntityChange.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "AuditLogEntryId",
+          "kind": "property",
+          "signature": "Guid AuditLogEntryId",
+          "returnType": "Guid"
+        },
+        {
+          "name": "EntityId",
+          "kind": "property",
+          "signature": "string EntityId",
+          "returnType": "string"
+        },
+        {
+          "name": "ChangeType",
+          "kind": "property",
+          "signature": "AuditChangeType ChangeType",
+          "returnType": "AuditChangeType"
+        }
+      ]
+    },
+    {
+      "name": "AuditLogCategory",
+      "fqn": "Granit.AuditLog.Domain.AuditLogCategory",
+      "kind": "enum",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Domain/AuditLogCategory.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "AuditLogEntry",
+      "fqn": "Granit.AuditLog.Domain.AuditLogEntry",
+      "kind": "class",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Domain/AuditLogEntry.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Timestamp",
+          "kind": "property",
+          "signature": "DateTimeOffset Timestamp",
+          "returnType": "DateTimeOffset"
+        },
+        {
+          "name": "UserName",
+          "kind": "property",
+          "signature": "string? UserName",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "AuditPersistenceMode",
+      "fqn": "Granit.AuditLog.Domain.AuditPersistenceMode",
+      "kind": "enum",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Domain/AuditPersistenceMode.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "AuditPropertyChange",
+      "fqn": "Granit.AuditLog.Domain.AuditPropertyChange",
+      "kind": "class",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Domain/AuditPropertyChange.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "AuditEntityChangeId",
+          "kind": "property",
+          "signature": "Guid AuditEntityChangeId",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "AuditEntityChangeResponse",
+      "fqn": "Granit.AuditLog.Endpoints.Dtos.AuditEntityChangeResponse",
+      "kind": "record",
+      "project": "Granit.AuditLog.Endpoints",
+      "file": "src/Granit.AuditLog.Endpoints/Dtos/AuditEntityChangeResponse.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "AuditLogEntryDetailResponse",
+      "fqn": "Granit.AuditLog.Endpoints.Dtos.AuditLogEntryDetailResponse",
+      "kind": "record",
+      "project": "Granit.AuditLog.Endpoints",
+      "file": "src/Granit.AuditLog.Endpoints/Dtos/AuditLogEntryDetailResponse.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "AuditLogEntryResponse",
+      "fqn": "Granit.AuditLog.Endpoints.Dtos.AuditLogEntryResponse",
+      "kind": "record",
+      "project": "Granit.AuditLog.Endpoints",
+      "file": "src/Granit.AuditLog.Endpoints/Dtos/AuditLogEntryResponse.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "AuditLogQueryParameters",
+      "fqn": "Granit.AuditLog.Endpoints.Dtos.AuditLogQueryParameters",
+      "kind": "class",
+      "project": "Granit.AuditLog.Endpoints",
+      "file": "src/Granit.AuditLog.Endpoints/Dtos/AuditLogQueryParameters.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "AuditPropertyChangeResponse",
+      "fqn": "Granit.AuditLog.Endpoints.Dtos.AuditPropertyChangeResponse",
+      "kind": "record",
+      "project": "Granit.AuditLog.Endpoints",
+      "file": "src/Granit.AuditLog.Endpoints/Dtos/AuditPropertyChangeResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "AuditLogEndpointRouteBuilderExtensions",
+      "fqn": "Granit.AuditLog.Endpoints.Extensions.AuditLogEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AuditLog.Endpoints",
+      "file": "src/Granit.AuditLog.Endpoints/Extensions/AuditLogEndpointRouteBuilderExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "MapAuditLogEndpoints",
+          "kind": "method",
+          "signature": "MapAuditLogEndpoints(this IEndpointRouteBuilder endpoints, Action<AuditLogEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuditLogEndpointsModule",
+      "fqn": "Granit.AuditLog.Endpoints.GranitAuditLogEndpointsModule",
+      "kind": "class",
+      "project": "Granit.AuditLog.Endpoints",
+      "file": "src/Granit.AuditLog.Endpoints/GranitAuditLogEndpointsModule.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "AuditLogEndpointsOptions",
+      "fqn": "Granit.AuditLog.Endpoints.Options.AuditLogEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.AuditLog.Endpoints",
+      "file": "src/Granit.AuditLog.Endpoints/Options/AuditLogEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "AuthorizationPolicy",
+          "kind": "property",
+          "signature": "string AuthorizationPolicy",
+          "returnType": "string"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "AuditLogMetrics",
+      "fqn": "Granit.AuditLog.EntityFrameworkCore.Diagnostics.AuditLogMetrics",
+      "kind": "class",
+      "project": "Granit.AuditLog.EntityFrameworkCore",
+      "file": "src/Granit.AuditLog.EntityFrameworkCore/Diagnostics/AuditLogMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordPurged",
+          "kind": "method",
+          "signature": "RecordPurged(long count, string category)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordCaptureError",
+          "kind": "method",
+          "signature": "RecordCaptureError(string? tenantId)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AuditLogEntityFrameworkCoreServiceCollectionExtensions",
+      "fqn": "Granit.AuditLog.EntityFrameworkCore.Extensions.AuditLogEntityFrameworkCoreServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.AuditLog.EntityFrameworkCore",
+      "file": "src/Granit.AuditLog.EntityFrameworkCore/Extensions/AuditLogEntityFrameworkCoreServiceCollectionExtensions.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "AddGranitAuditLogEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitAuditLogEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "AuditLogModelBuilderExtensions",
+      "fqn": "Granit.AuditLog.EntityFrameworkCore.Extensions.AuditLogModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AuditLog.EntityFrameworkCore",
+      "file": "src/Granit.AuditLog.EntityFrameworkCore/Extensions/AuditLogModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureAuditLogModule",
+          "kind": "method",
+          "signature": "ConfigureAuditLogModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "DbContextOptionsBuilderAuditLogExtensions",
+      "fqn": "Granit.AuditLog.EntityFrameworkCore.Extensions.DbContextOptionsBuilderAuditLogExtensions",
+      "kind": "class",
+      "project": "Granit.AuditLog.EntityFrameworkCore",
+      "file": "src/Granit.AuditLog.EntityFrameworkCore/Extensions/DbContextOptionsBuilderAuditLogExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "UseGranitAuditLogInterceptor",
+          "kind": "method",
+          "signature": "UseGranitAuditLogInterceptor(this DbContextOptionsBuilder options, IServiceProvider serviceProvider)",
+          "returnType": "DbContextOptionsBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuditLogDbProperties",
+      "fqn": "Granit.AuditLog.EntityFrameworkCore.GranitAuditLogDbProperties",
+      "kind": "class",
+      "project": "Granit.AuditLog.EntityFrameworkCore",
+      "file": "src/Granit.AuditLog.EntityFrameworkCore/GranitAuditLogDbProperties.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuditLogEntityFrameworkCoreModule",
+      "fqn": "Granit.AuditLog.EntityFrameworkCore.GranitAuditLogEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.AuditLog.EntityFrameworkCore",
+      "file": "src/Granit.AuditLog.EntityFrameworkCore/GranitAuditLogEntityFrameworkCoreModule.cs",
+      "line": 23,
+      "members": []
+    },
+    {
+      "name": "AuditLogChangeTrackingInterceptor",
+      "fqn": "Granit.AuditLog.EntityFrameworkCore.Interceptors.AuditLogChangeTrackingInterceptor",
+      "kind": "class",
+      "project": "Granit.AuditLog.EntityFrameworkCore",
+      "file": "src/Granit.AuditLog.EntityFrameworkCore/Interceptors/AuditLogChangeTrackingInterceptor.cs",
+      "line": 32,
+      "members": [
+        {
+          "name": "SavingChanges",
+          "kind": "method",
+          "signature": "SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)",
+          "returnType": "InterceptionResult<int>"
+        }
+      ]
+    },
+    {
+      "name": "AuditLogServiceCollectionExtensions",
+      "fqn": "Granit.AuditLog.Extensions.AuditLogServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Extensions/AuditLogServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitAuditLog",
+          "kind": "method",
+          "signature": "AddGranitAuditLog(this IServiceCollection services, Action<AuditLogOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuditLogModule",
+      "fqn": "Granit.AuditLog.GranitAuditLogModule",
+      "kind": "class",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/GranitAuditLogModule.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AuditEntityChangeSnapshot",
+      "fqn": "Granit.AuditLog.Messages.AuditEntityChangeSnapshot",
+      "kind": "record",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Messages/AuditEntityChangeSnapshot.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "AuditLogBatch",
+      "fqn": "Granit.AuditLog.Messages.AuditLogBatch",
+      "kind": "record",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Messages/AuditLogBatch.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "AuditPropertyChangeSnapshot",
+      "fqn": "Granit.AuditLog.Messages.AuditPropertyChangeSnapshot",
+      "kind": "record",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Messages/AuditPropertyChangeSnapshot.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "AuditLogOptions",
+      "fqn": "Granit.AuditLog.Options.AuditLogOptions",
+      "kind": "class",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Options/AuditLogOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "PersistenceMode",
+          "kind": "property",
+          "signature": "AuditPersistenceMode PersistenceMode",
+          "returnType": "AuditPersistenceMode"
+        },
+        {
+          "name": "EnablePropertyTracking",
+          "kind": "property",
+          "signature": "bool EnablePropertyTracking",
+          "returnType": "bool"
+        },
+        {
+          "name": "PersistenceBatchSize",
+          "kind": "property",
+          "signature": "int PersistenceBatchSize",
+          "returnType": "int"
+        },
+        {
+          "name": "FromDays",
+          "kind": "method",
+          "signature": "FromDays(2555)",
+          "returnType": "TimeSpan ConfigurationChangeRetention { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromDays",
+          "kind": "method",
+          "signature": "FromDays(365)",
+          "returnType": "TimeSpan DataMutationRetention { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromDays",
+          "kind": "method",
+          "signature": "FromDays(90)",
+          "returnType": "TimeSpan DataAccessRetention { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromDays",
+          "kind": "method",
+          "signature": "FromDays(2555)",
+          "returnType": "TimeSpan AccessDeniedRetention { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(30)",
+          "returnType": "TimeSpan CacheEntryTtl { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(2)",
+          "returnType": "TimeSpan CacheEntityQueryTtl { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromHours",
+          "kind": "method",
+          "signature": "FromHours(24)",
+          "returnType": "TimeSpan CleanupInterval { get; set; } = TimeSpan."
+        },
+        {
+          "name": "CleanupBatchSize",
+          "kind": "property",
+          "signature": "int CleanupBatchSize",
+          "returnType": "int"
+        },
+        {
+          "name": "GetRetention",
+          "kind": "method",
+          "signature": "GetRetention(AuditLogCategory category)",
+          "returnType": "TimeSpan"
+        }
+      ]
+    },
+    {
+      "name": "ApiKeyAuthenticationDefaults",
+      "fqn": "Granit.Authentication.ApiKeys.ApiKeyAuthenticationDefaults",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/ApiKeyAuthenticationDefaults.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ApiKeyClaimTypes",
+      "fqn": "Granit.Authentication.ApiKeys.ApiKeyClaimTypes",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/ApiKeyClaimTypes.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ApiKeyGenerationResult",
+      "fqn": "Granit.Authentication.ApiKeys.ApiKeyGenerationResult",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/IApiKeyGenerator.cs",
+      "line": 26,
+      "members": []
+    },
+    {
+      "name": "ApiKeyType",
+      "fqn": "Granit.Authentication.ApiKeys.ApiKeyType",
+      "kind": "enum",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/ApiKeyType.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "CacheBehavior",
+      "fqn": "Granit.Authentication.ApiKeys.CacheBehavior",
+      "kind": "enum",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/CacheBehavior.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "CidrValidator",
+      "fqn": "Granit.Authentication.ApiKeys.CidrValidator",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/CidrValidator.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "IsAllowed",
+          "kind": "method",
+          "signature": "IsAllowed(IPAddress? ipAddress, IReadOnlyList<string> allowedCidrs)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "ApiKeyEntry",
+      "fqn": "Granit.Authentication.ApiKeys.Domain.ApiKeyEntry",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/Domain/ApiKeyEntry.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, string name, ApiKeyType type, string environment, string hashedKey, string prefix, string lastFourChars, Guid? tenantId = null)",
+          "returnType": "ApiKeyEntry"
+        },
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Type",
+          "kind": "property",
+          "signature": "ApiKeyType Type",
+          "returnType": "ApiKeyType"
+        },
+        {
+          "name": "HashedKey",
+          "kind": "property",
+          "signature": "string HashedKey",
+          "returnType": "string"
+        },
+        {
+          "name": "Prefix",
+          "kind": "property",
+          "signature": "string Prefix",
+          "returnType": "string"
+        },
+        {
+          "name": "LastFourChars",
+          "kind": "property",
+          "signature": "string LastFourChars",
+          "returnType": "string"
+        },
+        {
+          "name": "Permissions",
+          "kind": "property",
+          "signature": "List<string> Permissions",
+          "returnType": "List<string>"
+        },
+        {
+          "name": "AllowedCidrs",
+          "kind": "property",
+          "signature": "List<string> AllowedCidrs",
+          "returnType": "List<string>"
+        },
+        {
+          "name": "UpdateAllowedCidrs",
+          "kind": "method",
+          "signature": "UpdateAllowedCidrs(List<string> cidrs)",
+          "returnType": "void"
+        },
+        {
+          "name": "SetExpiration",
+          "kind": "method",
+          "signature": "SetExpiration(DateTimeOffset? expiresAt)",
+          "returnType": "void"
+        },
+        {
+          "name": "SetCacheBehavior",
+          "kind": "method",
+          "signature": "SetCacheBehavior(CacheBehavior cacheBehavior)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ApiKeyCreateRequest",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Dtos.ApiKeyCreateRequest",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Dtos/ApiKeyCreateRequest.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "ApiKeyCreateResponse",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Dtos.ApiKeyCreateResponse",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Dtos/ApiKeyCreateResponse.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "ApiKeyResponse",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Dtos.ApiKeyResponse",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Dtos/ApiKeyResponse.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "ApiKeyRotateResponse",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Dtos.ApiKeyRotateResponse",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Dtos/ApiKeyRotateResponse.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "ApiKeyUpdateScopesRequest",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Dtos.ApiKeyUpdateScopesRequest",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Dtos/ApiKeyUpdateScopesRequest.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ApiKeysEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Extensions.ApiKeysEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Extensions/ApiKeysEndpointRouteBuilderExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "MapApiKeysEndpoints",
+          "kind": "method",
+          "signature": "MapApiKeysEndpoints(this IEndpointRouteBuilder endpoints, Action<ApiKeysEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "ApiKeysEndpointsServiceCollectionExtensions",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Extensions.ApiKeysEndpointsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Extensions/ApiKeysEndpointsServiceCollectionExtensions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "AddGranitApiKeysEndpoints",
+          "kind": "method",
+          "signature": "AddGranitApiKeysEndpoints(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthenticationApiKeysEndpointsModule",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.GranitAuthenticationApiKeysEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/GranitAuthenticationApiKeysEndpointsModule.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "ApiKeysEndpointsOptions",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Options.ApiKeysEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Options/ApiKeysEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        },
+        {
+          "name": "AllowedEnvironments",
+          "kind": "property",
+          "signature": "IReadOnlyList<string> AllowedEnvironments",
+          "returnType": "IReadOnlyList<string>"
+        }
+      ]
+    },
+    {
+      "name": "ApiKeyPermissions",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Permissions.ApiKeyPermissions",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Permissions/ApiKeyPermissions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "Keys",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Permissions.Keys",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Permissions/ApiKeyPermissions.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "ApiKeysEntityFrameworkCoreServiceCollectionExtensions",
+      "fqn": "Granit.Authentication.ApiKeys.EntityFrameworkCore.Extensions.ApiKeysEntityFrameworkCoreServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.EntityFrameworkCore",
+      "file": "src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Extensions/ApiKeysEntityFrameworkCoreServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitApiKeysEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitApiKeysEntityFrameworkCore(this IServiceCollection services, Action<DbContextOptionsBuilder> configureDbContext)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "ApiKeysModelBuilderExtensions",
+      "fqn": "Granit.Authentication.ApiKeys.EntityFrameworkCore.Extensions.ApiKeysModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.EntityFrameworkCore",
+      "file": "src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Extensions/ApiKeysModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureApiKeysModule",
+          "kind": "method",
+          "signature": "ConfigureApiKeysModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitApiKeysDbProperties",
+      "fqn": "Granit.Authentication.ApiKeys.EntityFrameworkCore.GranitApiKeysDbProperties",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.EntityFrameworkCore",
+      "file": "src/Granit.Authentication.ApiKeys.EntityFrameworkCore/GranitApiKeysDbProperties.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthenticationApiKeysEntityFrameworkCoreModule",
+      "fqn": "Granit.Authentication.ApiKeys.EntityFrameworkCore.GranitAuthenticationApiKeysEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.EntityFrameworkCore",
+      "file": "src/Granit.Authentication.ApiKeys.EntityFrameworkCore/GranitAuthenticationApiKeysEntityFrameworkCoreModule.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "ApiKeyCreatedEvent",
+      "fqn": "Granit.Authentication.ApiKeys.Events.ApiKeyCreatedEvent",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/Events/ApiKeyCreatedEvent.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ApiKeyExpiredEvent",
+      "fqn": "Granit.Authentication.ApiKeys.Events.ApiKeyExpiredEvent",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/Events/ApiKeyExpiredEvent.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "ApiKeyRevokedEvent",
+      "fqn": "Granit.Authentication.ApiKeys.Events.ApiKeyRevokedEvent",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/Events/ApiKeyRevokedEvent.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ApiKeyRotatedEvent",
+      "fqn": "Granit.Authentication.ApiKeys.Events.ApiKeyRotatedEvent",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/Events/ApiKeyRotatedEvent.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ApiKeyScopesUpdatedEvent",
+      "fqn": "Granit.Authentication.ApiKeys.Events.ApiKeyScopesUpdatedEvent",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/Events/ApiKeyScopesUpdatedEvent.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ApiKeyUsedEto",
+      "fqn": "Granit.Authentication.ApiKeys.Events.ApiKeyUsedEto",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/Events/ApiKeyUsedEto.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "ApiKeyServiceCollectionExtensions",
+      "fqn": "Granit.Authentication.ApiKeys.Extensions.ApiKeyServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/Extensions/ApiKeyServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitApiKeyAuthentication",
+          "kind": "method",
+          "signature": "AddGranitApiKeyAuthentication(this IServiceCollection services, Action<ApiKeyOptions>? configureOptions = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthenticationApiKeysModule",
+      "fqn": "Granit.Authentication.ApiKeys.GranitAuthenticationApiKeysModule",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/GranitAuthenticationApiKeysModule.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IApiKeyAdminStore",
+      "fqn": "Granit.Authentication.ApiKeys.IApiKeyAdminStore",
+      "kind": "interface",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/IApiKeyAdminStore.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "FindByIdAsync",
+          "kind": "method",
+          "signature": "FindByIdAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ApiKeyEntry?>"
+        },
+        {
+          "name": "ListAsync",
+          "kind": "method",
+          "signature": "ListAsync(string? search = null, ApiKeyType? type = null, string? environment = null, bool includeRevoked = false, int page = 1, int pageSize = 20, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<ApiKeyEntry>>"
+        },
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(ApiKeyEntry entry, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RevokeAsync",
+          "kind": "method",
+          "signature": "RevokeAsync(Guid id, DateTimeOffset revokedAt, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        },
+        {
+          "name": "UpdateScopesAsync",
+          "kind": "method",
+          "signature": "UpdateScopesAsync(Guid id, List<string> permissions, List<string> allowedCidrs, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "IApiKeyCacheService",
+      "fqn": "Granit.Authentication.ApiKeys.IApiKeyCacheService",
+      "kind": "interface",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/IApiKeyCacheService.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "GetOrLoadAsync",
+          "kind": "method",
+          "signature": "GetOrLoadAsync(string hashedKey, Func<CancellationToken, Task<ApiKeyEntry?>> factory, TimeSpan duration, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ApiKeyEntry?>"
+        },
+        {
+          "name": "RemoveAsync",
+          "kind": "method",
+          "signature": "RemoveAsync(string hashedKey, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IApiKeyGenerator",
+      "fqn": "Granit.Authentication.ApiKeys.IApiKeyGenerator",
+      "kind": "interface",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/IApiKeyGenerator.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Generate",
+          "kind": "method",
+          "signature": "Generate(ApiKeyType type, string environment)",
+          "returnType": "ApiKeyGenerationResult"
+        }
+      ]
+    },
+    {
+      "name": "IApiKeyStore",
+      "fqn": "Granit.Authentication.ApiKeys.IApiKeyStore",
+      "kind": "interface",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/IApiKeyStore.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "FindByHashAsync",
+          "kind": "method",
+          "signature": "FindByHashAsync(string hashedKey, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ApiKeyEntry?>"
+        },
+        {
+          "name": "UpdateLastUsedAsync",
+          "kind": "method",
+          "signature": "UpdateLastUsedAsync(Guid id, DateTimeOffset usedAt, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ApiKeyOptions",
+      "fqn": "Granit.Authentication.ApiKeys.Options.ApiKeyOptions",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/Options/ApiKeyOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(5)",
+          "returnType": "TimeSpan CacheDuration { get; set; } = TimeSpan."
+        },
+        {
+          "name": "TrackLastUsed",
+          "kind": "property",
+          "signature": "bool TrackLastUsed",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "CognitoClaimsTransformation",
+      "fqn": "Granit.Authentication.Cognito.Authentication.CognitoClaimsTransformation",
+      "kind": "class",
+      "project": "Granit.Authentication.Cognito",
+      "file": "src/Granit.Authentication.Cognito/Authentication/CognitoClaimsTransformation.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "TransformAsync",
+          "kind": "method",
+          "signature": "TransformAsync(ClaimsPrincipal principal)",
+          "returnType": "Task<ClaimsPrincipal>"
+        }
+      ]
+    },
+    {
+      "name": "CognitoServiceCollectionExtensions",
+      "fqn": "Granit.Authentication.Cognito.Extensions.CognitoServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.Cognito",
+      "file": "src/Granit.Authentication.Cognito/Extensions/CognitoServiceCollectionExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitCognito",
+          "kind": "method",
+          "signature": "AddGranitCognito(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthenticationCognitoModule",
+      "fqn": "Granit.Authentication.Cognito.GranitAuthenticationCognitoModule",
+      "kind": "class",
+      "project": "Granit.Authentication.Cognito",
+      "file": "src/Granit.Authentication.Cognito/GranitAuthenticationCognitoModule.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "CognitoOptions",
+      "fqn": "Granit.Authentication.Cognito.Options.CognitoOptions",
+      "kind": "class",
+      "project": "Granit.Authentication.Cognito",
+      "file": "src/Granit.Authentication.Cognito/Options/CognitoOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Authority",
+          "kind": "property",
+          "signature": "string Authority",
+          "returnType": "string"
+        },
+        {
+          "name": "ClientId",
+          "kind": "property",
+          "signature": "string ClientId",
+          "returnType": "string"
+        },
+        {
+          "name": "RequireHttpsMetadata",
+          "kind": "property",
+          "signature": "bool RequireHttpsMetadata",
+          "returnType": "bool"
+        },
+        {
+          "name": "Audience",
+          "kind": "property",
+          "signature": "string? Audience",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "EntraIdClaimsTransformation",
+      "fqn": "Granit.Authentication.EntraId.Authentication.EntraIdClaimsTransformation",
+      "kind": "class",
+      "project": "Granit.Authentication.EntraId",
+      "file": "src/Granit.Authentication.EntraId/Authentication/EntraIdClaimsTransformation.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "TransformAsync",
+          "kind": "method",
+          "signature": "TransformAsync(ClaimsPrincipal principal)",
+          "returnType": "Task<ClaimsPrincipal>"
+        }
+      ]
+    },
+    {
+      "name": "EntraIdServiceCollectionExtensions",
+      "fqn": "Granit.Authentication.EntraId.Extensions.EntraIdServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.EntraId",
+      "file": "src/Granit.Authentication.EntraId/Extensions/EntraIdServiceCollectionExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitEntraId",
+          "kind": "method",
+          "signature": "AddGranitEntraId(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthenticationEntraIdModule",
+      "fqn": "Granit.Authentication.EntraId.GranitAuthenticationEntraIdModule",
+      "kind": "class",
+      "project": "Granit.Authentication.EntraId",
+      "file": "src/Granit.Authentication.EntraId/GranitAuthenticationEntraIdModule.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "EntraIdOptions",
+      "fqn": "Granit.Authentication.EntraId.Options.EntraIdOptions",
+      "kind": "class",
+      "project": "Granit.Authentication.EntraId",
+      "file": "src/Granit.Authentication.EntraId/Options/EntraIdOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Instance",
+          "kind": "property",
+          "signature": "string Instance",
+          "returnType": "string"
+        },
+        {
+          "name": "TenantId",
+          "kind": "property",
+          "signature": "string TenantId",
+          "returnType": "string"
+        },
+        {
+          "name": "ClientId",
+          "kind": "property",
+          "signature": "string ClientId",
+          "returnType": "string"
+        },
+        {
+          "name": "RequireHttpsMetadata",
+          "kind": "property",
+          "signature": "bool RequireHttpsMetadata",
+          "returnType": "bool"
+        },
+        {
+          "name": "AdminRole",
+          "kind": "property",
+          "signature": "string AdminRole",
+          "returnType": "string"
+        },
+        {
+          "name": "TrimEnd",
+          "kind": "method",
+          "signature": "TrimEnd('/')",
+          "returnType": "string Authority => $\"{Instance."
+        }
+      ]
+    },
+    {
+      "name": "GoogleCloudClaimsTransformation",
+      "fqn": "Granit.Authentication.GoogleCloud.Authentication.GoogleCloudClaimsTransformation",
+      "kind": "class",
+      "project": "Granit.Authentication.GoogleCloud",
+      "file": "src/Granit.Authentication.GoogleCloud/Authentication/GoogleCloudClaimsTransformation.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "TransformAsync",
+          "kind": "method",
+          "signature": "TransformAsync(ClaimsPrincipal principal)",
+          "returnType": "Task<ClaimsPrincipal>"
+        }
+      ]
+    },
+    {
+      "name": "GoogleCloudAuthenticationServiceCollectionExtensions",
+      "fqn": "Granit.Authentication.GoogleCloud.Extensions.GoogleCloudAuthenticationServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.GoogleCloud",
+      "file": "src/Granit.Authentication.GoogleCloud/Extensions/GoogleCloudAuthenticationServiceCollectionExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitGoogleCloudAuthentication",
+          "kind": "method",
+          "signature": "AddGranitGoogleCloudAuthentication(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthenticationGoogleCloudModule",
+      "fqn": "Granit.Authentication.GoogleCloud.GranitAuthenticationGoogleCloudModule",
+      "kind": "class",
+      "project": "Granit.Authentication.GoogleCloud",
+      "file": "src/Granit.Authentication.GoogleCloud/GranitAuthenticationGoogleCloudModule.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GoogleCloudAuthenticationOptions",
+      "fqn": "Granit.Authentication.GoogleCloud.Options.GoogleCloudAuthenticationOptions",
+      "kind": "class",
+      "project": "Granit.Authentication.GoogleCloud",
+      "file": "src/Granit.Authentication.GoogleCloud/Options/GoogleCloudAuthenticationOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ProjectId",
+          "kind": "property",
+          "signature": "string ProjectId",
+          "returnType": "string"
+        },
+        {
+          "name": "RequireHttpsMetadata",
+          "kind": "property",
+          "signature": "bool RequireHttpsMetadata",
+          "returnType": "bool"
+        },
+        {
+          "name": "AdminRole",
+          "kind": "property",
+          "signature": "string AdminRole",
+          "returnType": "string"
+        },
+        {
+          "name": "RolesClaimKey",
+          "kind": "property",
+          "signature": "string RolesClaimKey",
+          "returnType": "string"
+        },
+        {
+          "name": "Authority",
+          "kind": "property",
+          "signature": "string Authority",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "CurrentUserService",
+      "fqn": "Granit.Authentication.JwtBearer.Authentication.CurrentUserService",
+      "kind": "class",
+      "project": "Granit.Authentication.JwtBearer",
+      "file": "src/Granit.Authentication.JwtBearer/Authentication/CurrentUserService.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "FindFirstValue",
+          "kind": "method",
+          "signature": "FindFirstValue(ClaimTypes.NameIdentifier)",
+          "returnType": "string? UserId => User?."
+        },
+        {
+          "name": "UserName",
+          "kind": "property",
+          "signature": "string? UserName",
+          "returnType": "string?"
+        },
+        {
+          "name": "FindFirstValue",
+          "kind": "method",
+          "signature": "FindFirstValue(ClaimTypes.Email)",
+          "returnType": "string? Email => User?."
+        },
+        {
+          "name": "FindFirstValue",
+          "kind": "method",
+          "signature": "FindFirstValue(ClaimTypes.GivenName)",
+          "returnType": "string? FirstName => User?."
+        },
+        {
+          "name": "FindFirstValue",
+          "kind": "method",
+          "signature": "FindFirstValue(ClaimTypes.Surname)",
+          "returnType": "string? LastName => User?."
+        },
+        {
+          "name": "IsAuthenticated",
+          "kind": "property",
+          "signature": "bool IsAuthenticated",
+          "returnType": "bool"
+        },
+        {
+          "name": "GetRoles",
+          "kind": "method",
+          "signature": "GetRoles()",
+          "returnType": "IReadOnlyList<string>"
+        }
+      ]
+    },
+    {
+      "name": "BackChannelLogoutResult",
+      "fqn": "Granit.Authentication.JwtBearer.BackChannelLogout.BackChannelLogoutResult",
+      "kind": "record",
+      "project": "Granit.Authentication.JwtBearer",
+      "file": "src/Granit.Authentication.JwtBearer/BackChannelLogout/BackChannelLogoutResult.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "IRevokedSessionStore",
+      "fqn": "Granit.Authentication.JwtBearer.BackChannelLogout.IRevokedSessionStore",
+      "kind": "interface",
+      "project": "Granit.Authentication.JwtBearer",
+      "file": "src/Granit.Authentication.JwtBearer/BackChannelLogout/IRevokedSessionStore.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RevokeSessionAsync",
+          "kind": "method",
+          "signature": "RevokeSessionAsync(string sessionId, TimeSpan ttl, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "IsSessionRevokedAsync",
+          "kind": "method",
+          "signature": "IsSessionRevokedAsync(string sessionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "JwtBearerEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Authentication.JwtBearer.Extensions.JwtBearerEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.JwtBearer",
+      "file": "src/Granit.Authentication.JwtBearer/Extensions/JwtBearerEndpointRouteBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "MapBackChannelLogout",
+          "kind": "method",
+          "signature": "MapBackChannelLogout(this IEndpointRouteBuilder endpoints)",
+          "returnType": "IEndpointRouteBuilder"
+        }
+      ]
+    },
+    {
+      "name": "JwtBearerServiceCollectionExtensions",
+      "fqn": "Granit.Authentication.JwtBearer.Extensions.JwtBearerServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.JwtBearer",
+      "file": "src/Granit.Authentication.JwtBearer/Extensions/JwtBearerServiceCollectionExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "AddGranitJwtBearer",
+          "kind": "method",
+          "signature": "AddGranitJwtBearer(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitJwtBearerModule",
+      "fqn": "Granit.Authentication.JwtBearer.GranitJwtBearerModule",
+      "kind": "class",
+      "project": "Granit.Authentication.JwtBearer",
+      "file": "src/Granit.Authentication.JwtBearer/GranitJwtBearerModule.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "BackChannelLogoutOptions",
+      "fqn": "Granit.Authentication.JwtBearer.Options.BackChannelLogoutOptions",
+      "kind": "class",
+      "project": "Granit.Authentication.JwtBearer",
+      "file": "src/Granit.Authentication.JwtBearer/Options/BackChannelLogoutOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Enabled",
+          "kind": "property",
+          "signature": "bool Enabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "FromHours",
+          "kind": "method",
+          "signature": "FromHours(1)",
+          "returnType": "TimeSpan SessionRevocationTtl { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "JwtBearerAuthOptions",
+      "fqn": "Granit.Authentication.JwtBearer.Options.JwtBearerAuthOptions",
+      "kind": "class",
+      "project": "Granit.Authentication.JwtBearer",
+      "file": "src/Granit.Authentication.JwtBearer/Options/JwtBearerAuthOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Authority",
+          "kind": "property",
+          "signature": "string Authority",
+          "returnType": "string"
+        },
+        {
+          "name": "Audience",
+          "kind": "property",
+          "signature": "string Audience",
+          "returnType": "string"
+        },
+        {
+          "name": "RequireHttpsMetadata",
+          "kind": "property",
+          "signature": "bool RequireHttpsMetadata",
+          "returnType": "bool"
+        },
+        {
+          "name": "NameClaimType",
+          "kind": "property",
+          "signature": "string NameClaimType",
+          "returnType": "string"
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "BackChannelLogoutOptions BackChannelLogout { get; set; } ="
+        }
+      ]
+    },
+    {
+      "name": "KeycloakClaimsTransformation",
+      "fqn": "Granit.Authentication.Keycloak.Authentication.KeycloakClaimsTransformation",
+      "kind": "class",
+      "project": "Granit.Authentication.Keycloak",
+      "file": "src/Granit.Authentication.Keycloak/Authentication/KeycloakClaimsTransformation.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "TransformAsync",
+          "kind": "method",
+          "signature": "TransformAsync(ClaimsPrincipal principal)",
+          "returnType": "Task<ClaimsPrincipal>"
+        }
+      ]
+    },
+    {
+      "name": "KeycloakServiceCollectionExtensions",
+      "fqn": "Granit.Authentication.Keycloak.Extensions.KeycloakServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.Keycloak",
+      "file": "src/Granit.Authentication.Keycloak/Extensions/KeycloakServiceCollectionExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitKeycloak",
+          "kind": "method",
+          "signature": "AddGranitKeycloak(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthenticationKeycloakModule",
+      "fqn": "Granit.Authentication.Keycloak.GranitAuthenticationKeycloakModule",
+      "kind": "class",
+      "project": "Granit.Authentication.Keycloak",
+      "file": "src/Granit.Authentication.Keycloak/GranitAuthenticationKeycloakModule.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "KeycloakOptions",
+      "fqn": "Granit.Authentication.Keycloak.Options.KeycloakOptions",
+      "kind": "class",
+      "project": "Granit.Authentication.Keycloak",
+      "file": "src/Granit.Authentication.Keycloak/Options/KeycloakOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Authority",
+          "kind": "property",
+          "signature": "string Authority",
+          "returnType": "string"
+        },
+        {
+          "name": "ClientId",
+          "kind": "property",
+          "signature": "string ClientId",
+          "returnType": "string"
+        },
+        {
+          "name": "ClientSecret",
+          "kind": "property",
+          "signature": "string ClientSecret",
+          "returnType": "string"
+        },
+        {
+          "name": "RequireHttpsMetadata",
+          "kind": "property",
+          "signature": "bool RequireHttpsMetadata",
+          "returnType": "bool"
+        },
+        {
+          "name": "Audience",
+          "kind": "property",
+          "signature": "string? Audience",
+          "returnType": "string?"
+        },
+        {
+          "name": "RoleClaimsSource",
+          "kind": "property",
+          "signature": "string RoleClaimsSource",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "AccessRiskScore",
+      "fqn": "Granit.Authorization.AI.AccessRiskScore",
+      "kind": "record",
+      "project": "Granit.Authorization.AI",
+      "file": "src/Granit.Authorization.AI/AccessRiskScore.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "AuthorizationAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Authorization.AI.Extensions.AuthorizationAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Authorization.AI",
+      "file": "src/Granit.Authorization.AI/Extensions/AuthorizationAIHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitAuthorizationAI",
+          "kind": "method",
+          "signature": "AddGranitAuthorizationAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthorizationAIModule",
+      "fqn": "Granit.Authorization.AI.GranitAuthorizationAIModule",
+      "kind": "class",
+      "project": "Granit.Authorization.AI",
+      "file": "src/Granit.Authorization.AI/GranitAuthorizationAIModule.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "IAIAccessAnomalyDetector",
+      "fqn": "Granit.Authorization.AI.IAIAccessAnomalyDetector",
+      "kind": "interface",
+      "project": "Granit.Authorization.AI",
+      "file": "src/Granit.Authorization.AI/IAIAccessAnomalyDetector.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "EvaluateAccessAsync",
+          "kind": "method",
+          "signature": "EvaluateAccessAsync(string userId, string permission, string? context = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<AccessRiskScore>"
+        }
+      ]
+    },
+    {
+      "name": "AuthorizationAIOptions",
+      "fqn": "Granit.Authorization.AI.Options.AuthorizationAIOptions",
+      "kind": "class",
+      "project": "Granit.Authorization.AI",
+      "file": "src/Granit.Authorization.AI/Options/AuthorizationAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string WorkspaceName",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "IPermissionChecker",
+      "fqn": "Granit.Authorization.Abstractions.IPermissionChecker",
+      "kind": "interface",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Abstractions/IPermissionChecker.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "IsGrantedAsync",
+          "kind": "method",
+          "signature": "IsGrantedAsync(string permissionName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "IPermissionDefinitionContext",
+      "fqn": "Granit.Authorization.Abstractions.IPermissionDefinitionContext",
+      "kind": "interface",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Abstractions/IPermissionDefinitionContext.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "AddGroup",
+          "kind": "method",
+          "signature": "AddGroup(string name, LocalizableString? displayName = null)",
+          "returnType": "PermissionGroup"
+        }
+      ]
+    },
+    {
+      "name": "IPermissionDefinitionManager",
+      "fqn": "Granit.Authorization.Abstractions.IPermissionDefinitionManager",
+      "kind": "interface",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Abstractions/IPermissionDefinitionManager.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Exists",
+          "kind": "method",
+          "signature": "Exists(string name)",
+          "returnType": "bool"
+        },
+        {
+          "name": "Find",
+          "kind": "method",
+          "signature": "Find(string name)",
+          "returnType": "PermissionDefinition?"
+        },
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IReadOnlyList<PermissionDefinition>"
+        },
+        {
+          "name": "GetGroups",
+          "kind": "method",
+          "signature": "GetGroups()",
+          "returnType": "IReadOnlyList<PermissionGroup>"
+        }
+      ]
+    },
+    {
+      "name": "IPermissionDefinitionProvider",
+      "fqn": "Granit.Authorization.Abstractions.IPermissionDefinitionProvider",
+      "kind": "interface",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Abstractions/IPermissionDefinitionProvider.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "DefinePermissions",
+          "kind": "method",
+          "signature": "DefinePermissions(IPermissionDefinitionContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IPermissionGrantStore",
+      "fqn": "Granit.Authorization.Abstractions.IPermissionGrantStore",
+      "kind": "interface",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Abstractions/IPermissionGrantStore.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "IsGrantedAsync",
+          "kind": "method",
+          "signature": "IsGrantedAsync(string roleName, string permissionName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "IPermissionManagerReader",
+      "fqn": "Granit.Authorization.Abstractions.IPermissionManagerReader",
+      "kind": "interface",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Abstractions/IPermissionManagerReader.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "IsGrantedAsync",
+          "kind": "method",
+          "signature": "IsGrantedAsync(string permissionName, string roleName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        },
+        {
+          "name": "GetGrantedPermissionsAsync",
+          "kind": "method",
+          "signature": "GetGrantedPermissionsAsync(string roleName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<string>>"
+        },
+        {
+          "name": "GetGrantedRolesAsync",
+          "kind": "method",
+          "signature": "GetGrantedRolesAsync(string permissionName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<string>>"
+        }
+      ]
+    },
+    {
+      "name": "IPermissionManagerWriter",
+      "fqn": "Granit.Authorization.Abstractions.IPermissionManagerWriter",
+      "kind": "interface",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Abstractions/IPermissionManagerWriter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "SetAsync",
+          "kind": "method",
+          "signature": "SetAsync(string permissionName, string roleName, Guid? tenantId, bool isGranted, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "PermissionDefinition",
+      "fqn": "Granit.Authorization.Abstractions.PermissionDefinition",
+      "kind": "record",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Abstractions/PermissionDefinition.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "PermissionGroup",
+      "fqn": "Granit.Authorization.Abstractions.PermissionGroup",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Abstractions/PermissionGroup.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "DisplayName",
+          "kind": "property",
+          "signature": "LocalizableString? DisplayName",
+          "returnType": "LocalizableString?"
+        },
+        {
+          "name": "AsReadOnly",
+          "kind": "method",
+          "signature": "AsReadOnly()",
+          "returnType": "IReadOnlyList<PermissionDefinition> Permissions => _permissions."
+        },
+        {
+          "name": "AddPermission",
+          "kind": "method",
+          "signature": "AddPermission(string name, LocalizableString? displayName = null)",
+          "returnType": "PermissionDefinition"
+        }
+      ]
+    },
+    {
+      "name": "PermissionAttribute",
+      "fqn": "Granit.Authorization.Attributes.PermissionAttribute",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Attributes/PermissionAttribute.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "PermissionRequirement",
+      "fqn": "Granit.Authorization.Authorization.PermissionRequirement",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Authorization/PermissionRequirement.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "PermissionName",
+          "kind": "property",
+          "signature": "string PermissionName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "PermissionCacheInvalidationHandler",
+      "fqn": "Granit.Authorization.Cache.PermissionCacheInvalidationHandler",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Cache/PermissionCacheInvalidationHandler.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(PermissionGrantChangedEvent @event, IFusionCache cache, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "PermissionGrantCacheItem",
+      "fqn": "Granit.Authorization.Cache.PermissionGrantCacheItem",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Cache/PermissionGrantCacheItem.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "MyPermissionsResponse",
+      "fqn": "Granit.Authorization.Endpoints.Dtos.MyPermissionsResponse",
+      "kind": "record",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/Dtos/MyPermissionsResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "PermissionDefinitionResponse",
+      "fqn": "Granit.Authorization.Endpoints.Dtos.PermissionDefinitionResponse",
+      "kind": "record",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/Dtos/PermissionDefinitionResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "PermissionGrantResponse",
+      "fqn": "Granit.Authorization.Endpoints.Dtos.PermissionGrantResponse",
+      "kind": "record",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/Dtos/PermissionGrantResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "PermissionGroupResponse",
+      "fqn": "Granit.Authorization.Endpoints.Dtos.PermissionGroupResponse",
+      "kind": "record",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/Dtos/PermissionGroupResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "AuthorizationEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Authorization.Endpoints.Extensions.AuthorizationEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/Extensions/AuthorizationEndpointRouteBuilderExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "MapAuthorizationEndpoints",
+          "kind": "method",
+          "signature": "MapAuthorizationEndpoints(this IEndpointRouteBuilder endpoints, Action<AuthorizationEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthorizationEndpointsModule",
+      "fqn": "Granit.Authorization.Endpoints.GranitAuthorizationEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/GranitAuthorizationEndpointsModule.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "AuthorizationEndpointsOptions",
+      "fqn": "Granit.Authorization.Endpoints.Options.AuthorizationEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/Options/AuthorizationEndpointsOptions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "AuthorizationEndpointsPermissions",
+      "fqn": "Granit.Authorization.Endpoints.Permissions.AuthorizationEndpointsPermissions",
+      "kind": "class",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/Permissions/AuthorizationEndpointsPermissions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "Definitions",
+      "fqn": "Granit.Authorization.Endpoints.Permissions.Definitions",
+      "kind": "class",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/Permissions/AuthorizationEndpointsPermissions.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "Grants",
+      "fqn": "Granit.Authorization.Endpoints.Permissions.Grants",
+      "kind": "class",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/Permissions/AuthorizationEndpointsPermissions.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "IPermissionGrantDbContext",
+      "fqn": "Granit.Authorization.EntityFrameworkCore.DbContext.IPermissionGrantDbContext",
+      "kind": "interface",
+      "project": "Granit.Authorization.EntityFrameworkCore",
+      "file": "src/Granit.Authorization.EntityFrameworkCore/DbContext/IPermissionGrantDbContext.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "PermissionGrantModelBuilderExtensions",
+      "fqn": "Granit.Authorization.EntityFrameworkCore.DbContext.PermissionGrantModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Authorization.EntityFrameworkCore",
+      "file": "src/Granit.Authorization.EntityFrameworkCore/DbContext/PermissionGrantModelBuilderExtensions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "ConfigureAuthorizationModule",
+          "kind": "method",
+          "signature": "ConfigureAuthorizationModule(this ModelBuilder builder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "PermissionGrant",
+      "fqn": "Granit.Authorization.EntityFrameworkCore.Entities.PermissionGrant",
+      "kind": "class",
+      "project": "Granit.Authorization.EntityFrameworkCore",
+      "file": "src/Granit.Authorization.EntityFrameworkCore/Entities/PermissionGrant.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "RoleName",
+          "kind": "property",
+          "signature": "string RoleName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "AuthorizationEfCoreServiceCollectionExtensions",
+      "fqn": "Granit.Authorization.EntityFrameworkCore.Extensions.AuthorizationEfCoreServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Authorization.EntityFrameworkCore",
+      "file": "src/Granit.Authorization.EntityFrameworkCore/Extensions/AuthorizationEfCoreServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "GranitAuthorizationDbProperties",
+      "fqn": "Granit.Authorization.EntityFrameworkCore.GranitAuthorizationDbProperties",
+      "kind": "class",
+      "project": "Granit.Authorization.EntityFrameworkCore",
+      "file": "src/Granit.Authorization.EntityFrameworkCore/GranitAuthorizationDbProperties.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthorizationEntityFrameworkCoreModule",
+      "fqn": "Granit.Authorization.EntityFrameworkCore.GranitAuthorizationEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Authorization.EntityFrameworkCore",
+      "file": "src/Granit.Authorization.EntityFrameworkCore/GranitAuthorizationEntityFrameworkCoreModule.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "PermissionGrantChangedEvent",
+      "fqn": "Granit.Authorization.Events.PermissionGrantChangedEvent",
+      "kind": "record",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Events/PermissionGrantChangedEvent.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "AuthorizationServiceCollectionExtensions",
+      "fqn": "Granit.Authorization.Extensions.AuthorizationServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Extensions/AuthorizationServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitAuthorization",
+          "kind": "method",
+          "signature": "AddGranitAuthorization(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthorizationModule",
+      "fqn": "Granit.Authorization.GranitAuthorizationModule",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/GranitAuthorizationModule.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthorizationOptions",
+      "fqn": "Granit.Authorization.Options.GranitAuthorizationOptions",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Options/GranitAuthorizationOptions.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "AdminRoles",
+          "kind": "property",
+          "signature": "IList<string> AdminRoles",
+          "returnType": "IList<string>"
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(5)",
+          "returnType": "TimeSpan CacheDuration { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "IBackgroundJobDispatcher",
+      "fqn": "Granit.BackgroundJobs.Abstractions.IBackgroundJobDispatcher",
+      "kind": "interface",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Abstractions/IBackgroundJobDispatcher.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "PublishAsync",
+          "kind": "method",
+          "signature": "PublishAsync(object message, IDictionary<string, string>? headers = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "ScheduleAsync",
+          "kind": "method",
+          "signature": "ScheduleAsync(object message, DateTimeOffset scheduledTime, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IDeadLetterQueueInspector",
+      "fqn": "Granit.BackgroundJobs.Abstractions.IDeadLetterQueueInspector",
+      "kind": "interface",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Abstractions/IDeadLetterQueueInspector.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "GetCountsAsync",
+          "kind": "method",
+          "signature": "GetCountsAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyDictionary<string, long>>"
+        }
+      ]
+    },
+    {
+      "name": "BackgroundJobHeaders",
+      "fqn": "Granit.BackgroundJobs.BackgroundJobHeaders",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/BackgroundJobHeaders.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobStatus",
+      "fqn": "Granit.BackgroundJobs.BackgroundJobStatus",
+      "kind": "record",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/BackgroundJobStatus.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobsMetrics",
+      "fqn": "Granit.BackgroundJobs.Diagnostics.BackgroundJobsMetrics",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Diagnostics/BackgroundJobsMetrics.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobDefinition",
+      "fqn": "Granit.BackgroundJobs.Domain.BackgroundJobDefinition",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Domain/BackgroundJobDefinition.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, string jobName, string cronExpression, string messageType)",
+          "returnType": "BackgroundJobDefinition"
+        },
+        {
+          "name": "JobName",
+          "kind": "property",
+          "signature": "string JobName",
+          "returnType": "string"
+        },
+        {
+          "name": "MessageType",
+          "kind": "property",
+          "signature": "string MessageType",
+          "returnType": "string"
+        },
+        {
+          "name": "CronExpression",
+          "kind": "property",
+          "signature": "string CronExpression",
+          "returnType": "string"
+        },
+        {
+          "name": "IsEnabled",
+          "kind": "property",
+          "signature": "bool IsEnabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "UpdateDefinition",
+          "kind": "method",
+          "signature": "UpdateDefinition(string cronExpression, string messageType)",
+          "returnType": "DateTimeOffset? LastExecutedAt { get; private set; } public DateTimeOffset? NextExecutionAt { get; private set; } public int ConsecutiveFailureCount { get; private set; } public string? LastErrorMessage { get; private set; } public string? TriggeredBy { get; private set; } internal void"
+        }
+      ]
+    },
+    {
+      "name": "JobStoreMode",
+      "fqn": "Granit.BackgroundJobs.Domain.JobStoreMode",
+      "kind": "enum",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Domain/JobStoreMode.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "RecurringJobRegistration",
+      "fqn": "Granit.BackgroundJobs.Domain.RecurringJobRegistration",
+      "kind": "record",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Domain/RecurringJobRegistration.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "CronSchedule",
+      "fqn": "Granit.BackgroundJobs.Domain.ValueObjects.CronSchedule",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Domain/ValueObjects/CronSchedule.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(string value)",
+          "returnType": "required string Value { get; init; } public CronSchedule"
+        },
+        {
+          "name": "CronSchedule",
+          "kind": "method",
+          "signature": "CronSchedule(string value)",
+          "returnType": "implicit operator"
+        }
+      ]
+    },
+    {
+      "name": "BackgroundJobsEndpointRouteBuilderExtensions",
+      "fqn": "Granit.BackgroundJobs.Endpoints.Extensions.BackgroundJobsEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.Endpoints",
+      "file": "src/Granit.BackgroundJobs.Endpoints/Extensions/BackgroundJobsEndpointRouteBuilderExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "MapBackgroundJobsEndpoints",
+          "kind": "method",
+          "signature": "MapBackgroundJobsEndpoints(this IEndpointRouteBuilder endpoints, Action<BackgroundJobsEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBackgroundJobsEndpointsModule",
+      "fqn": "Granit.BackgroundJobs.Endpoints.GranitBackgroundJobsEndpointsModule",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.Endpoints",
+      "file": "src/Granit.BackgroundJobs.Endpoints/GranitBackgroundJobsEndpointsModule.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobsAuthorizationPolicy",
+      "fqn": "Granit.BackgroundJobs.Endpoints.Internal.BackgroundJobsAuthorizationPolicy",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.Endpoints",
+      "file": "src/Granit.BackgroundJobs.Endpoints/Internal/BackgroundJobsAuthorizationPolicy.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobsEndpointsOptions",
+      "fqn": "Granit.BackgroundJobs.Endpoints.Options.BackgroundJobsEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.Endpoints",
+      "file": "src/Granit.BackgroundJobs.Endpoints/Options/BackgroundJobsEndpointsOptions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "BackgroundJobsPermissions",
+      "fqn": "Granit.BackgroundJobs.Endpoints.Permissions.BackgroundJobsPermissions",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.Endpoints",
+      "file": "src/Granit.BackgroundJobs.Endpoints/Permissions/BackgroundJobsPermissions.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "Jobs",
+      "fqn": "Granit.BackgroundJobs.Endpoints.Permissions.Jobs",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.Endpoints",
+      "file": "src/Granit.BackgroundJobs.Endpoints/Permissions/BackgroundJobsPermissions.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobsEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.BackgroundJobs.EntityFrameworkCore.Extensions.BackgroundJobsEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.EntityFrameworkCore",
+      "file": "src/Granit.BackgroundJobs.EntityFrameworkCore/Extensions/BackgroundJobsEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitBackgroundJobsEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitBackgroundJobsEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "BackgroundJobsModelBuilderExtensions",
+      "fqn": "Granit.BackgroundJobs.EntityFrameworkCore.Extensions.BackgroundJobsModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.EntityFrameworkCore",
+      "file": "src/Granit.BackgroundJobs.EntityFrameworkCore/Extensions/BackgroundJobsModelBuilderExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "ConfigureBackgroundJobsModule",
+          "kind": "method",
+          "signature": "ConfigureBackgroundJobsModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBackgroundJobsDbProperties",
+      "fqn": "Granit.BackgroundJobs.EntityFrameworkCore.GranitBackgroundJobsDbProperties",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.EntityFrameworkCore",
+      "file": "src/Granit.BackgroundJobs.EntityFrameworkCore/GranitBackgroundJobsDbProperties.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitBackgroundJobsEntityFrameworkCoreModule",
+      "fqn": "Granit.BackgroundJobs.EntityFrameworkCore.GranitBackgroundJobsEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.EntityFrameworkCore",
+      "file": "src/Granit.BackgroundJobs.EntityFrameworkCore/GranitBackgroundJobsEntityFrameworkCoreModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobDefinitionChangedEvent",
+      "fqn": "Granit.BackgroundJobs.Events.BackgroundJobDefinitionChangedEvent",
+      "kind": "record",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Events/BackgroundJobDefinitionChangedEvent.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobExecutionStartedEto",
+      "fqn": "Granit.BackgroundJobs.Events.BackgroundJobExecutionStartedEto",
+      "kind": "record",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Events/BackgroundJobExecutionStartedEto.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobFailureThresholdExceededEto",
+      "fqn": "Granit.BackgroundJobs.Events.BackgroundJobFailureThresholdExceededEto",
+      "kind": "record",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Events/BackgroundJobFailureThresholdExceededEto.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobPausedEvent",
+      "fqn": "Granit.BackgroundJobs.Events.BackgroundJobPausedEvent",
+      "kind": "record",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Events/BackgroundJobPausedEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobResumedEvent",
+      "fqn": "Granit.BackgroundJobs.Events.BackgroundJobResumedEvent",
+      "kind": "record",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Events/BackgroundJobResumedEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobsHostApplicationBuilderExtensions",
+      "fqn": "Granit.BackgroundJobs.Extensions.BackgroundJobsHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Extensions/BackgroundJobsHostApplicationBuilderExtensions.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "AddGranitBackgroundJobs",
+          "kind": "method",
+          "signature": "AddGranitBackgroundJobs(this IHostApplicationBuilder builder, IEnumerable<Assembly>? additionalAssemblies = null)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBackgroundJobsModule",
+      "fqn": "Granit.BackgroundJobs.GranitBackgroundJobsModule",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/GranitBackgroundJobsModule.cs",
+      "line": 30,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IBackgroundJob",
+      "fqn": "Granit.BackgroundJobs.IBackgroundJob",
+      "kind": "interface",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/IBackgroundJob.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "IBackgroundJobReader",
+      "fqn": "Granit.BackgroundJobs.IBackgroundJobReader",
+      "kind": "interface",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/IBackgroundJobReader.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetAllAsync",
+          "kind": "method",
+          "signature": "GetAllAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<BackgroundJobStatus>>"
+        },
+        {
+          "name": "FindAsync",
+          "kind": "method",
+          "signature": "FindAsync(string jobName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<BackgroundJobStatus?>"
+        }
+      ]
+    },
+    {
+      "name": "IBackgroundJobStoreReader",
+      "fqn": "Granit.BackgroundJobs.IBackgroundJobStoreReader",
+      "kind": "interface",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/IBackgroundJobStoreReader.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "FindAsync",
+          "kind": "method",
+          "signature": "FindAsync(string jobName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<BackgroundJobDefinition?>"
+        },
+        {
+          "name": "GetEnabledJobsAsync",
+          "kind": "method",
+          "signature": "GetEnabledJobsAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<BackgroundJobDefinition>>"
+        },
+        {
+          "name": "GetAllJobsAsync",
+          "kind": "method",
+          "signature": "GetAllJobsAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<BackgroundJobDefinition>>"
+        }
+      ]
+    },
+    {
+      "name": "IBackgroundJobStoreWriter",
+      "fqn": "Granit.BackgroundJobs.IBackgroundJobStoreWriter",
+      "kind": "interface",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/IBackgroundJobStoreWriter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "SeedJobsAsync",
+          "kind": "method",
+          "signature": "SeedJobsAsync(IEnumerable<RecurringJobRegistration> registrations, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RecordExecutionStartAsync",
+          "kind": "method",
+          "signature": "RecordExecutionStartAsync(string jobName, DateTimeOffset startedAt, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RecordNextExecutionAsync",
+          "kind": "method",
+          "signature": "RecordNextExecutionAsync(string jobName, DateTimeOffset nextExecution, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RecordExecutionFailureAsync",
+          "kind": "method",
+          "signature": "RecordExecutionFailureAsync(string jobName, string errorMessage, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SetEnabledAsync",
+          "kind": "method",
+          "signature": "SetEnabledAsync(string jobName, bool enabled, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SetTriggeredByAsync",
+          "kind": "method",
+          "signature": "SetTriggeredByAsync(string jobName, string? triggeredBy, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IBackgroundJobWriter",
+      "fqn": "Granit.BackgroundJobs.IBackgroundJobWriter",
+      "kind": "interface",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/IBackgroundJobWriter.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "PauseAsync",
+          "kind": "method",
+          "signature": "PauseAsync(string jobName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "ResumeAsync",
+          "kind": "method",
+          "signature": "ResumeAsync(string jobName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "TriggerNowAsync",
+          "kind": "method",
+          "signature": "TriggerNowAsync(string jobName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "BackgroundJobsOptions",
+      "fqn": "Granit.BackgroundJobs.Options.BackgroundJobsOptions",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Options/BackgroundJobsOptions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "Mode",
+          "kind": "property",
+          "signature": "JobStoreMode Mode",
+          "returnType": "JobStoreMode"
+        },
+        {
+          "name": "ConnectionString",
+          "kind": "property",
+          "signature": "string ConnectionString",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "RecurringJobAttribute",
+      "fqn": "Granit.BackgroundJobs.RecurringJobAttribute",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/RecurringJobAttribute.cs",
+      "line": 34,
+      "members": []
+    },
+    {
+      "name": "GranitBackgroundJobsWolverineModule",
+      "fqn": "Granit.BackgroundJobs.Wolverine.GranitBackgroundJobsWolverineModule",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.Wolverine",
+      "file": "src/Granit.BackgroundJobs.Wolverine/GranitBackgroundJobsWolverineModule.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "RecurringJobSchedulingMiddleware",
+      "fqn": "Granit.BackgroundJobs.Wolverine.RecurringJobSchedulingMiddleware",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.Wolverine",
+      "file": "src/Granit.BackgroundJobs.Wolverine/RecurringJobSchedulingMiddleware.cs",
+      "line": 33,
+      "members": [
+        {
+          "name": "BeforeAsync",
+          "kind": "method",
+          "signature": "BeforeAsync(Envelope envelope, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "BlobClassification",
+      "fqn": "Granit.BlobStorage.AI.BlobClassification",
+      "kind": "record",
+      "project": "Granit.BlobStorage.AI",
+      "file": "src/Granit.BlobStorage.AI/BlobClassification.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "BlobStorageAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.BlobStorage.AI.Extensions.BlobStorageAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.AI",
+      "file": "src/Granit.BlobStorage.AI/Extensions/BlobStorageAIHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitBlobStorageAI",
+          "kind": "method",
+          "signature": "AddGranitBlobStorageAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageAIModule",
+      "fqn": "Granit.BlobStorage.AI.GranitBlobStorageAIModule",
+      "kind": "class",
+      "project": "Granit.BlobStorage.AI",
+      "file": "src/Granit.BlobStorage.AI/GranitBlobStorageAIModule.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "IAIBlobClassifier",
+      "fqn": "Granit.BlobStorage.AI.IAIBlobClassifier",
+      "kind": "interface",
+      "project": "Granit.BlobStorage.AI",
+      "file": "src/Granit.BlobStorage.AI/IAIBlobClassifier.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ClassifyAsync",
+          "kind": "method",
+          "signature": "ClassifyAsync(string fileName, string contentType, CancellationToken cancellationToken = default)",
+          "returnType": "Task<BlobClassification>"
+        }
+      ]
+    },
+    {
+      "name": "BlobStorageAIOptions",
+      "fqn": "Granit.BlobStorage.AI.Options.BlobStorageAIOptions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.AI",
+      "file": "src/Granit.BlobStorage.AI/Options/BlobStorageAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string? WorkspaceName",
+          "returnType": "string?"
+        },
+        {
+          "name": "EnablePiiDetection",
+          "kind": "property",
+          "signature": "bool EnablePiiDetection",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "BlobTenantIsolation",
+      "fqn": "Granit.BlobStorage.AzureBlob.BlobTenantIsolation",
+      "kind": "enum",
+      "project": "Granit.BlobStorage.AzureBlob",
+      "file": "src/Granit.BlobStorage.AzureBlob/BlobTenantIsolation.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "BlobStorageAzureBlobHostApplicationBuilderExtensions",
+      "fqn": "Granit.BlobStorage.AzureBlob.Extensions.BlobStorageAzureBlobHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.AzureBlob",
+      "file": "src/Granit.BlobStorage.AzureBlob/Extensions/BlobStorageAzureBlobHostApplicationBuilderExtensions.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "AddGranitBlobStorageAzureBlob",
+          "kind": "method",
+          "signature": "AddGranitBlobStorageAzureBlob(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageAzureBlobModule",
+      "fqn": "Granit.BlobStorage.AzureBlob.GranitBlobStorageAzureBlobModule",
+      "kind": "class",
+      "project": "Granit.BlobStorage.AzureBlob",
+      "file": "src/Granit.BlobStorage.AzureBlob/GranitBlobStorageAzureBlobModule.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "AzureBlobOptions",
+      "fqn": "Granit.BlobStorage.AzureBlob.Options.AzureBlobOptions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.AzureBlob",
+      "file": "src/Granit.BlobStorage.AzureBlob/Options/AzureBlobOptions.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "ConnectionString",
+          "kind": "property",
+          "signature": "string ConnectionString",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultContainer",
+          "kind": "property",
+          "signature": "string DefaultContainer",
+          "returnType": "string"
+        },
+        {
+          "name": "UseManagedIdentity",
+          "kind": "property",
+          "signature": "bool UseManagedIdentity",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "BlobConfirmationResult",
+      "fqn": "Granit.BlobStorage.BlobConfirmationResult",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/BlobConfirmationResult.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "BlobStorageLocalizationResource",
+      "fqn": "Granit.BlobStorage.BlobStorageLocalizationResource",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/BlobStorageLocalizationResource.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "BlobUploadRequest",
+      "fqn": "Granit.BlobStorage.BlobUploadRequest",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/BlobUploadRequest.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "BlobValidationContext",
+      "fqn": "Granit.BlobStorage.BlobValidationContext",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/BlobValidationContext.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "BlobValidationResult",
+      "fqn": "Granit.BlobStorage.BlobValidationResult",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/BlobValidationResult.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Success",
+          "kind": "method",
+          "signature": "Success(string? verifiedContentType = null)",
+          "returnType": "bool IsValid { get; private init; } public string? FailureReason { get; private init; } public string? VerifiedContentType { get; private init; } public BlobValidationResult"
+        },
+        {
+          "name": "Failure",
+          "kind": "method",
+          "signature": "Failure(string reason)",
+          "returnType": "BlobValidationResult"
+        }
+      ]
+    },
+    {
+      "name": "DbStoreBlobContent",
+      "fqn": "Granit.BlobStorage.DbStore.Entities.DbStoreBlobContent",
+      "kind": "class",
+      "project": "Granit.BlobStorage.DbStore",
+      "file": "src/Granit.BlobStorage.DbStore/Entities/DbStoreBlobContent.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "Id",
+          "kind": "property",
+          "signature": "Guid Id",
+          "returnType": "Guid"
+        },
+        {
+          "name": "Content",
+          "kind": "property",
+          "signature": "byte[] Content",
+          "returnType": "byte[]"
+        }
+      ]
+    },
+    {
+      "name": "BlobStorageDbStoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.BlobStorage.DbStore.Extensions.BlobStorageDbStoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.DbStore",
+      "file": "src/Granit.BlobStorage.DbStore/Extensions/BlobStorageDbStoreHostApplicationBuilderExtensions.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "AddGranitBlobStorageDbStore",
+          "kind": "method",
+          "signature": "AddGranitBlobStorageDbStore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageDbStoreModule",
+      "fqn": "Granit.BlobStorage.DbStore.GranitBlobStorageDbStoreModule",
+      "kind": "class",
+      "project": "Granit.BlobStorage.DbStore",
+      "file": "src/Granit.BlobStorage.DbStore/GranitBlobStorageDbStoreModule.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "DbStoreBlobOptions",
+      "fqn": "Granit.BlobStorage.DbStore.Options.DbStoreBlobOptions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.DbStore",
+      "file": "src/Granit.BlobStorage.DbStore/Options/DbStoreBlobOptions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "MaxBlobSizeBytes",
+          "kind": "property",
+          "signature": "long MaxBlobSizeBytes",
+          "returnType": "long"
+        }
+      ]
+    },
+    {
+      "name": "BlobStorageMetrics",
+      "fqn": "Granit.BlobStorage.Diagnostics.BlobStorageMetrics",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Diagnostics/BlobStorageMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordValidationCompleted",
+          "kind": "method",
+          "signature": "RecordValidationCompleted(string? tenantId, string status, string container)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordValidationFailed",
+          "kind": "method",
+          "signature": "RecordValidationFailed(string? tenantId, string reason, string container)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordDeleted",
+          "kind": "method",
+          "signature": "RecordDeleted(string? tenantId, string container)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordOrphanCleaned",
+          "kind": "method",
+          "signature": "RecordOrphanCleaned(string? tenantId)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordConfirmDuration",
+          "kind": "method",
+          "signature": "RecordConfirmDuration(string? tenantId, string status, string container, TimeSpan duration)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "BlobDescriptor",
+      "fqn": "Granit.BlobStorage.Domain.BlobDescriptor",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Domain/BlobDescriptor.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, Guid? tenantId, string containerName, string objectKey, BlobUploadRequest request, DateTimeOffset createdAt)",
+          "returnType": "BlobDescriptor"
+        },
+        {
+          "name": "ObjectKey",
+          "kind": "property",
+          "signature": "string ObjectKey",
+          "returnType": "string"
+        },
+        {
+          "name": "OriginalFileName",
+          "kind": "property",
+          "signature": "string OriginalFileName",
+          "returnType": "string"
+        },
+        {
+          "name": "DeclaredContentType",
+          "kind": "property",
+          "signature": "string DeclaredContentType",
+          "returnType": "string"
+        },
+        {
+          "name": "MarkAsUploading",
+          "kind": "method",
+          "signature": "MarkAsUploading()",
+          "returnType": "long MaxAllowedBytes { get; private set; } public string? VerifiedContentType { get; private set; } public long? SizeBytes { get; private set; } public BlobStatus Status { get; private set; } public DateTimeOffset CreatedAt { get; private set; } public DateTimeOffset? ValidatedAt { get; private set; } public DateTimeOffset? DeletedAt { get; private set; } public string? RejectionReason { get; private set; } public string? DeletionReason { get; private set; } public void"
+        }
+      ]
+    },
+    {
+      "name": "BlobStatus",
+      "fqn": "Granit.BlobStorage.Domain.BlobStatus",
+      "kind": "enum",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Domain/BlobStatus.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "BlobCleanupOrphansResponse",
+      "fqn": "Granit.BlobStorage.Endpoints.Dtos.BlobCleanupOrphansResponse",
+      "kind": "record",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Dtos/BlobCleanupOrphansResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "BlobConfirmUploadRequest",
+      "fqn": "Granit.BlobStorage.Endpoints.Dtos.BlobConfirmUploadRequest",
+      "kind": "record",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Dtos/BlobConfirmUploadRequest.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "BlobConfirmUploadResponse",
+      "fqn": "Granit.BlobStorage.Endpoints.Dtos.BlobConfirmUploadResponse",
+      "kind": "record",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Dtos/BlobConfirmUploadResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "BlobDeleteRequest",
+      "fqn": "Granit.BlobStorage.Endpoints.Dtos.BlobDeleteRequest",
+      "kind": "record",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Dtos/BlobDeleteRequest.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "BlobDescriptorResponse",
+      "fqn": "Granit.BlobStorage.Endpoints.Dtos.BlobDescriptorResponse",
+      "kind": "record",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Dtos/BlobDescriptorResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "BlobDownloadUrlRequest",
+      "fqn": "Granit.BlobStorage.Endpoints.Dtos.BlobDownloadUrlRequest",
+      "kind": "record",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Dtos/BlobDownloadUrlRequest.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "BlobDownloadUrlResponse",
+      "fqn": "Granit.BlobStorage.Endpoints.Dtos.BlobDownloadUrlResponse",
+      "kind": "record",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Dtos/BlobDownloadUrlResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "BlobUploadInitiateRequest",
+      "fqn": "Granit.BlobStorage.Endpoints.Dtos.BlobUploadInitiateRequest",
+      "kind": "record",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Dtos/BlobUploadInitiateRequest.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "BlobUploadInitiateResponse",
+      "fqn": "Granit.BlobStorage.Endpoints.Dtos.BlobUploadInitiateResponse",
+      "kind": "record",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Dtos/BlobUploadInitiateResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "BlobStorageEndpointRouteBuilderExtensions",
+      "fqn": "Granit.BlobStorage.Endpoints.Extensions.BlobStorageEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Extensions/BlobStorageEndpointRouteBuilderExtensions.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "MapBlobStorageEndpoints",
+          "kind": "method",
+          "signature": "MapBlobStorageEndpoints(this IEndpointRouteBuilder endpoints, Action<BlobStorageEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageEndpointsModule",
+      "fqn": "Granit.BlobStorage.Endpoints.GranitBlobStorageEndpointsModule",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/GranitBlobStorageEndpointsModule.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "BlobStorageEndpointsOptions",
+      "fqn": "Granit.BlobStorage.Endpoints.Options.BlobStorageEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Options/BlobStorageEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "BlobStoragePermissions",
+      "fqn": "Granit.BlobStorage.Endpoints.Permissions.BlobStoragePermissions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Permissions/BlobStoragePermissions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "Blobs",
+      "fqn": "Granit.BlobStorage.Endpoints.Permissions.Blobs",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Permissions/BlobStoragePermissions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "BlobStorageEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.BlobStorage.EntityFrameworkCore.Extensions.BlobStorageEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.EntityFrameworkCore",
+      "file": "src/Granit.BlobStorage.EntityFrameworkCore/Extensions/BlobStorageEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitBlobStorageEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitBlobStorageEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "BlobStorageModelBuilderExtensions",
+      "fqn": "Granit.BlobStorage.EntityFrameworkCore.Extensions.BlobStorageModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.EntityFrameworkCore",
+      "file": "src/Granit.BlobStorage.EntityFrameworkCore/Extensions/BlobStorageModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureBlobStorageModule",
+          "kind": "method",
+          "signature": "ConfigureBlobStorageModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageDbProperties",
+      "fqn": "Granit.BlobStorage.EntityFrameworkCore.GranitBlobStorageDbProperties",
+      "kind": "class",
+      "project": "Granit.BlobStorage.EntityFrameworkCore",
+      "file": "src/Granit.BlobStorage.EntityFrameworkCore/GranitBlobStorageDbProperties.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageEntityFrameworkCoreModule",
+      "fqn": "Granit.BlobStorage.EntityFrameworkCore.GranitBlobStorageEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.BlobStorage.EntityFrameworkCore",
+      "file": "src/Granit.BlobStorage.EntityFrameworkCore/GranitBlobStorageEntityFrameworkCoreModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "BlobDeletedEvent",
+      "fqn": "Granit.BlobStorage.Events.BlobDeletedEvent",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Events/BlobDeletedEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "BlobRejectedEvent",
+      "fqn": "Granit.BlobStorage.Events.BlobRejectedEvent",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Events/BlobRejectedEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "BlobUploadStartedEvent",
+      "fqn": "Granit.BlobStorage.Events.BlobUploadStartedEvent",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Events/BlobUploadStartedEvent.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "BlobValidatedEvent",
+      "fqn": "Granit.BlobStorage.Events.BlobValidatedEvent",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Events/BlobValidatedEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "BlobNotFoundException",
+      "fqn": "Granit.BlobStorage.Exceptions.BlobNotFoundException",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Exceptions/BlobNotFoundException.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "BlobId",
+          "kind": "property",
+          "signature": "Guid BlobId",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "BlobNotValidException",
+      "fqn": "Granit.BlobStorage.Exceptions.BlobNotValidException",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Exceptions/BlobNotValidException.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "BlobId",
+          "kind": "property",
+          "signature": "Guid BlobId",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "BlobStorageFileSystemHostApplicationBuilderExtensions",
+      "fqn": "Granit.BlobStorage.FileSystem.Extensions.BlobStorageFileSystemHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.FileSystem",
+      "file": "src/Granit.BlobStorage.FileSystem/Extensions/BlobStorageFileSystemHostApplicationBuilderExtensions.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "AddGranitBlobStorageFileSystem",
+          "kind": "method",
+          "signature": "AddGranitBlobStorageFileSystem(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageFileSystemModule",
+      "fqn": "Granit.BlobStorage.FileSystem.GranitBlobStorageFileSystemModule",
+      "kind": "class",
+      "project": "Granit.BlobStorage.FileSystem",
+      "file": "src/Granit.BlobStorage.FileSystem/GranitBlobStorageFileSystemModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "FileSystemBlobOptions",
+      "fqn": "Granit.BlobStorage.FileSystem.Options.FileSystemBlobOptions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.FileSystem",
+      "file": "src/Granit.BlobStorage.FileSystem/Options/FileSystemBlobOptions.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "BasePath",
+          "kind": "property",
+          "signature": "string BasePath",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "BlobTenantIsolation",
+      "fqn": "Granit.BlobStorage.GoogleCloud.BlobTenantIsolation",
+      "kind": "enum",
+      "project": "Granit.BlobStorage.GoogleCloud",
+      "file": "src/Granit.BlobStorage.GoogleCloud/BlobTenantIsolation.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "BlobStorageGoogleCloudHostApplicationBuilderExtensions",
+      "fqn": "Granit.BlobStorage.GoogleCloud.Extensions.BlobStorageGoogleCloudHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.GoogleCloud",
+      "file": "src/Granit.BlobStorage.GoogleCloud/Extensions/BlobStorageGoogleCloudHostApplicationBuilderExtensions.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "AddGranitBlobStorageGoogleCloud",
+          "kind": "method",
+          "signature": "AddGranitBlobStorageGoogleCloud(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageGoogleCloudModule",
+      "fqn": "Granit.BlobStorage.GoogleCloud.GranitBlobStorageGoogleCloudModule",
+      "kind": "class",
+      "project": "Granit.BlobStorage.GoogleCloud",
+      "file": "src/Granit.BlobStorage.GoogleCloud/GranitBlobStorageGoogleCloudModule.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "GoogleCloudStorageOptions",
+      "fqn": "Granit.BlobStorage.GoogleCloud.Options.GoogleCloudStorageOptions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.GoogleCloud",
+      "file": "src/Granit.BlobStorage.GoogleCloud/Options/GoogleCloudStorageOptions.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "ProjectId",
+          "kind": "property",
+          "signature": "string ProjectId",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultBucket",
+          "kind": "property",
+          "signature": "string DefaultBucket",
+          "returnType": "string"
+        },
+        {
+          "name": "CredentialFilePath",
+          "kind": "property",
+          "signature": "string? CredentialFilePath",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageModule",
+      "fqn": "Granit.BlobStorage.GranitBlobStorageModule",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/GranitBlobStorageModule.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IBlobDescriptorReader",
+      "fqn": "Granit.BlobStorage.IBlobDescriptorReader",
+      "kind": "interface",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/IBlobDescriptorReader.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "FindAsync",
+          "kind": "method",
+          "signature": "FindAsync(Guid blobId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<BlobDescriptor?>"
+        },
+        {
+          "name": "FindOrphanedAsync",
+          "kind": "method",
+          "signature": "FindOrphanedAsync(DateTimeOffset cutoff, int batchSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<BlobDescriptor>>"
+        },
+        {
+          "name": "FindByContainerBeforeAsync",
+          "kind": "method",
+          "signature": "FindByContainerBeforeAsync(string containerName, DateTimeOffset cutoff, int batchSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<BlobDescriptor>>"
+        }
+      ]
+    },
+    {
+      "name": "IBlobDescriptorStore",
+      "fqn": "Granit.BlobStorage.IBlobDescriptorStore",
+      "kind": "interface",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/IBlobDescriptorStore.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "IBlobDescriptorWriter",
+      "fqn": "Granit.BlobStorage.IBlobDescriptorWriter",
+      "kind": "interface",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/IBlobDescriptorWriter.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "SaveAsync",
+          "kind": "method",
+          "signature": "SaveAsync(BlobDescriptor descriptor, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UpdateAsync",
+          "kind": "method",
+          "signature": "UpdateAsync(BlobDescriptor descriptor, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IBlobKeyStrategy",
+      "fqn": "Granit.BlobStorage.IBlobKeyStrategy",
+      "kind": "interface",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/IBlobKeyStrategy.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "BuildObjectKey",
+          "kind": "method",
+          "signature": "BuildObjectKey(string containerName, Guid blobId)",
+          "returnType": "string"
+        },
+        {
+          "name": "ResolveBucketName",
+          "kind": "method",
+          "signature": "ResolveBucketName(string containerName)",
+          "returnType": "string"
+        },
+        {
+          "name": "TryExtractTenantId",
+          "kind": "method",
+          "signature": "TryExtractTenantId(string objectKey, out string? tenantId)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "IBlobQueryableProvider",
+      "fqn": "Granit.BlobStorage.IBlobQueryableProvider",
+      "kind": "interface",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/IBlobQueryableProvider.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "GetDescriptors",
+          "kind": "method",
+          "signature": "GetDescriptors()",
+          "returnType": "IQueryable<BlobDescriptor>"
+        }
+      ]
+    },
+    {
+      "name": "IBlobStorage",
+      "fqn": "Granit.BlobStorage.IBlobStorage",
+      "kind": "interface",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/IBlobStorage.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "InitiateUploadAsync",
+          "kind": "method",
+          "signature": "InitiateUploadAsync(string containerName, BlobUploadRequest request, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PresignedUploadTicket>"
+        },
+        {
+          "name": "CreateDownloadUrlAsync",
+          "kind": "method",
+          "signature": "CreateDownloadUrlAsync(string containerName, Guid blobId, DownloadUrlOptions? options = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PresignedDownloadUrl>"
+        },
+        {
+          "name": "GetDescriptorAsync",
+          "kind": "method",
+          "signature": "GetDescriptorAsync(string containerName, Guid blobId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<BlobDescriptor?>"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(string containerName, Guid blobId, string? deletionReason = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "ConfirmUploadAsync",
+          "kind": "method",
+          "signature": "ConfirmUploadAsync(string containerName, Guid blobId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<BlobConfirmationResult>"
+        },
+        {
+          "name": "CleanupOrphansAsync",
+          "kind": "method",
+          "signature": "CleanupOrphansAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        }
+      ]
+    },
+    {
+      "name": "IBlobValidator",
+      "fqn": "Granit.BlobStorage.IBlobValidator",
+      "kind": "interface",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/IBlobValidator.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "ValidateAsync",
+          "kind": "method",
+          "signature": "ValidateAsync(BlobValidationContext context, CancellationToken cancellationToken = default)",
+          "returnType": "int Order { get; } Task<BlobValidationResult>"
+        }
+      ]
+    },
+    {
+      "name": "OrphanBlobCleanupJob",
+      "fqn": "Granit.BlobStorage.Jobs.OrphanBlobCleanupJob",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Jobs/OrphanBlobCleanupJob.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "BlobStorageOptions",
+      "fqn": "Granit.BlobStorage.Options.BlobStorageOptions",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Options/BlobStorageOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(15)",
+          "returnType": "TimeSpan UploadUrlExpiry { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(5)",
+          "returnType": "TimeSpan DownloadUrlExpiry { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "DownloadUrlOptions",
+      "fqn": "Granit.BlobStorage.Options.DownloadUrlOptions",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Options/DownloadUrlOptions.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "PresignedDownloadUrl",
+      "fqn": "Granit.BlobStorage.PresignedDownloadUrl",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/PresignedDownloadUrl.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "PresignedUploadTicket",
+      "fqn": "Granit.BlobStorage.PresignedUploadTicket",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/PresignedUploadTicket.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "BlobStorageProxyLocalizationResource",
+      "fqn": "Granit.BlobStorage.Proxy.BlobStorageProxyLocalizationResource",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Proxy",
+      "file": "src/Granit.BlobStorage.Proxy/BlobStorageProxyLocalizationResource.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "BlobStorageProxyEndpointRouteBuilderExtensions",
+      "fqn": "Granit.BlobStorage.Proxy.Extensions.BlobStorageProxyEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Proxy",
+      "file": "src/Granit.BlobStorage.Proxy/Extensions/BlobStorageProxyEndpointRouteBuilderExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "MapGranitBlobProxyEndpoints",
+          "kind": "method",
+          "signature": "MapGranitBlobProxyEndpoints(this IEndpointRouteBuilder endpoints)",
+          "returnType": "IEndpointRouteBuilder"
+        }
+      ]
+    },
+    {
+      "name": "BlobStorageProxyHostApplicationBuilderExtensions",
+      "fqn": "Granit.BlobStorage.Proxy.Extensions.BlobStorageProxyHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Proxy",
+      "file": "src/Granit.BlobStorage.Proxy/Extensions/BlobStorageProxyHostApplicationBuilderExtensions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "AddGranitBlobStorageProxy",
+          "kind": "method",
+          "signature": "AddGranitBlobStorageProxy(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageProxyModule",
+      "fqn": "Granit.BlobStorage.Proxy.GranitBlobStorageProxyModule",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Proxy",
+      "file": "src/Granit.BlobStorage.Proxy/GranitBlobStorageProxyModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "ProxyBlobOptions",
+      "fqn": "Granit.BlobStorage.Proxy.Options.ProxyBlobOptions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Proxy",
+      "file": "src/Granit.BlobStorage.Proxy/Options/ProxyBlobOptions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "BaseUrl",
+          "kind": "property",
+          "signature": "string BaseUrl",
+          "returnType": "string"
+        },
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "MaxUploadBytes",
+          "kind": "property",
+          "signature": "long MaxUploadBytes",
+          "returnType": "long"
+        }
+      ]
+    },
+    {
+      "name": "BlobTenantIsolation",
+      "fqn": "Granit.BlobStorage.S3.BlobTenantIsolation",
+      "kind": "enum",
+      "project": "Granit.BlobStorage.S3",
+      "file": "src/Granit.BlobStorage.S3/BlobTenantIsolation.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "BlobStorageS3HostApplicationBuilderExtensions",
+      "fqn": "Granit.BlobStorage.S3.Extensions.BlobStorageS3HostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.S3",
+      "file": "src/Granit.BlobStorage.S3/Extensions/BlobStorageS3HostApplicationBuilderExtensions.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "AddGranitBlobStorageS3",
+          "kind": "method",
+          "signature": "AddGranitBlobStorageS3(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageS3Module",
+      "fqn": "Granit.BlobStorage.S3.GranitBlobStorageS3Module",
+      "kind": "class",
+      "project": "Granit.BlobStorage.S3",
+      "file": "src/Granit.BlobStorage.S3/GranitBlobStorageS3Module.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "S3BlobOptions",
+      "fqn": "Granit.BlobStorage.S3.Options.S3BlobOptions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.S3",
+      "file": "src/Granit.BlobStorage.S3/Options/S3BlobOptions.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "ServiceUrl",
+          "kind": "property",
+          "signature": "string ServiceUrl",
+          "returnType": "string"
+        },
+        {
+          "name": "AccessKey",
+          "kind": "property",
+          "signature": "string AccessKey",
+          "returnType": "string"
+        },
+        {
+          "name": "SecretKey",
+          "kind": "property",
+          "signature": "string SecretKey",
+          "returnType": "string"
+        },
+        {
+          "name": "Region",
+          "kind": "property",
+          "signature": "string Region",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultBucket",
+          "kind": "property",
+          "signature": "string DefaultBucket",
+          "returnType": "string"
+        },
+        {
+          "name": "ForcePathStyle",
+          "kind": "property",
+          "signature": "bool ForcePathStyle",
+          "returnType": "bool"
+        },
+        {
+          "name": "TenantIsolation",
+          "kind": "property",
+          "signature": "BlobTenantIsolation TenantIsolation",
+          "returnType": "BlobTenantIsolation"
+        }
+      ]
+    },
+    {
+      "name": "TenantPrefixBlobKeyStrategy",
+      "fqn": "Granit.BlobStorage.TenantPrefixBlobKeyStrategy",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/TenantPrefixBlobKeyStrategy.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "BuildObjectKey",
+          "kind": "method",
+          "signature": "BuildObjectKey(string containerName, Guid blobId)",
+          "returnType": "string"
+        },
+        {
+          "name": "TryExtractTenantId",
+          "kind": "method",
+          "signature": "TryExtractTenantId(string objectKey, out string? tenantId)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "MagicBytesValidator",
+      "fqn": "Granit.BlobStorage.Validators.MagicBytesValidator",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Validators/MagicBytesValidator.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "Order",
+          "kind": "property",
+          "signature": "int Order",
+          "returnType": "int"
+        },
+        {
+          "name": "ValidateAsync",
+          "kind": "method",
+          "signature": "ValidateAsync(BlobValidationContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task<BlobValidationResult>"
+        }
+      ]
+    },
+    {
+      "name": "MaxSizeValidator",
+      "fqn": "Granit.BlobStorage.Validators.MaxSizeValidator",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Validators/MaxSizeValidator.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "Order",
+          "kind": "property",
+          "signature": "int Order",
+          "returnType": "int"
+        },
+        {
+          "name": "ValidateAsync",
+          "kind": "method",
+          "signature": "ValidateAsync(BlobValidationContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task<BlobValidationResult>"
+        }
+      ]
+    },
+    {
+      "name": "AesCacheValueEncryptor",
+      "fqn": "Granit.Caching.AesCacheValueEncryptor",
+      "kind": "class",
+      "project": "Granit.Caching",
+      "file": "src/Granit.Caching/AesCacheValueEncryptor.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "CacheEncryptedAttribute",
+      "fqn": "Granit.Caching.CacheEncryptedAttribute",
+      "kind": "class",
+      "project": "Granit.Caching",
+      "file": "src/Granit.Caching/CacheEncryptedAttribute.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "Encrypt",
+          "kind": "property",
+          "signature": "bool Encrypt",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "CachingServiceCollectionExtensions",
+      "fqn": "Granit.Caching.Extensions.CachingServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Caching",
+      "file": "src/Granit.Caching/Extensions/CachingServiceCollectionExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitCaching",
+          "kind": "method",
+          "signature": "AddGranitCaching(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitCachingModule",
+      "fqn": "Granit.Caching.GranitCachingModule",
+      "kind": "class",
+      "project": "Granit.Caching",
+      "file": "src/Granit.Caching/GranitCachingModule.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ICacheValueEncryptor",
+      "fqn": "Granit.Caching.ICacheValueEncryptor",
+      "kind": "interface",
+      "project": "Granit.Caching",
+      "file": "src/Granit.Caching/ICacheValueEncryptor.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "Encrypt",
+          "kind": "method",
+          "signature": "Encrypt(byte[] plaintext)",
+          "returnType": "byte[]"
+        },
+        {
+          "name": "Decrypt",
+          "kind": "method",
+          "signature": "Decrypt(byte[] ciphertext)",
+          "returnType": "byte[]"
+        }
+      ]
+    },
+    {
+      "name": "NullCacheValueEncryptor",
+      "fqn": "Granit.Caching.NullCacheValueEncryptor",
+      "kind": "class",
+      "project": "Granit.Caching",
+      "file": "src/Granit.Caching/NullCacheValueEncryptor.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "Encrypt",
+          "kind": "method",
+          "signature": "Encrypt(byte[] plaintext)",
+          "returnType": "byte[]"
+        },
+        {
+          "name": "Decrypt",
+          "kind": "method",
+          "signature": "Decrypt(byte[] ciphertext)",
+          "returnType": "byte[]"
+        }
+      ]
+    },
+    {
+      "name": "CacheEncryptionOptions",
+      "fqn": "Granit.Caching.Options.CacheEncryptionOptions",
+      "kind": "class",
+      "project": "Granit.Caching",
+      "file": "src/Granit.Caching/Options/CacheEncryptionOptions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "CachingOptions",
+      "fqn": "Granit.Caching.Options.CachingOptions",
+      "kind": "class",
+      "project": "Granit.Caching",
+      "file": "src/Granit.Caching/Options/CachingOptions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "KeyPrefix",
+          "kind": "property",
+          "signature": "string KeyPrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "FromHours",
+          "kind": "method",
+          "signature": "FromHours(1)",
+          "returnType": "TimeSpan? DefaultAbsoluteExpirationRelativeToNow { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(20)",
+          "returnType": "TimeSpan? DefaultSlidingExpiration { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "FusionCachingOptions",
+      "fqn": "Granit.Caching.Options.FusionCachingOptions",
+      "kind": "class",
+      "project": "Granit.Caching",
+      "file": "src/Granit.Caching/Options/FusionCachingOptions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "FailSafeIsEnabled",
+          "kind": "property",
+          "signature": "bool FailSafeIsEnabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "FromHours",
+          "kind": "method",
+          "signature": "FromHours(2)",
+          "returnType": "TimeSpan FailSafeMaxDuration { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(30)",
+          "returnType": "TimeSpan FailSafeThrottleDuration { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(2)",
+          "returnType": "TimeSpan FactorySoftTimeout { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(10)",
+          "returnType": "TimeSpan FactoryHardTimeout { get; set; } = TimeSpan."
+        },
+        {
+          "name": "EagerRefreshThreshold",
+          "kind": "property",
+          "signature": "float EagerRefreshThreshold",
+          "returnType": "float"
+        },
+        {
+          "name": "BackplaneChannelPrefix",
+          "kind": "property",
+          "signature": "string BackplaneChannelPrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "RedisCachingServiceCollectionExtensions",
+      "fqn": "Granit.Caching.StackExchangeRedis.Extensions.RedisCachingServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Caching.StackExchangeRedis",
+      "file": "src/Granit.Caching.StackExchangeRedis/Extensions/RedisCachingServiceCollectionExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "AddGranitCachingRedis",
+          "kind": "method",
+          "signature": "AddGranitCachingRedis(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitCachingRedisModule",
+      "fqn": "Granit.Caching.StackExchangeRedis.GranitCachingRedisModule",
+      "kind": "class",
+      "project": "Granit.Caching.StackExchangeRedis",
+      "file": "src/Granit.Caching.StackExchangeRedis/GranitCachingRedisModule.cs",
+      "line": 30,
+      "members": [
+        {
+          "name": "IsEnabled",
+          "kind": "method",
+          "signature": "IsEnabled(ServiceConfigurationContext context)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "RedisCachingOptions",
+      "fqn": "Granit.Caching.StackExchangeRedis.Options.RedisCachingOptions",
+      "kind": "class",
+      "project": "Granit.Caching.StackExchangeRedis",
+      "file": "src/Granit.Caching.StackExchangeRedis/Options/RedisCachingOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "IsEnabled",
+          "kind": "property",
+          "signature": "bool IsEnabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "Configuration",
+          "kind": "property",
+          "signature": "string Configuration",
+          "returnType": "string"
+        },
+        {
+          "name": "InstanceName",
+          "kind": "property",
+          "signature": "string InstanceName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "DataFilter",
+      "fqn": "Granit.Core.DataFiltering.DataFilter",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/DataFiltering/DataFilter.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "class",
+          "kind": "property",
+          "signature": "IDisposable Disable<TFilter>() where TFilter : class",
+          "returnType": "IDisposable Disable<TFilter>() where TFilter :"
+        },
+        {
+          "name": "class",
+          "kind": "property",
+          "signature": "IDisposable Enable<TFilter>() where TFilter : class",
+          "returnType": "IDisposable Enable<TFilter>() where TFilter :"
+        },
+        {
+          "name": "class",
+          "kind": "property",
+          "signature": "bool IsEnabled<TFilter>() where TFilter : class",
+          "returnType": "bool IsEnabled<TFilter>() where TFilter :"
+        }
+      ]
+    },
+    {
+      "name": "IDataFilter",
+      "fqn": "Granit.Core.DataFiltering.IDataFilter",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/DataFiltering/IDataFilter.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "GranitActivitySourceRegistry",
+      "fqn": "Granit.Core.Diagnostics.GranitActivitySourceRegistry",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Diagnostics/GranitActivitySourceRegistry.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "Register",
+          "kind": "method",
+          "signature": "Register(string sourceName)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AggregateRoot",
+      "fqn": "Granit.Core.Domain.AggregateRoot",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/AggregateRoot.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "AsReadOnly",
+          "kind": "method",
+          "signature": "AsReadOnly()",
+          "returnType": "IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents."
+        },
+        {
+          "name": "AsReadOnly",
+          "kind": "method",
+          "signature": "AsReadOnly()",
+          "returnType": "IReadOnlyCollection<IIntegrationEvent> IntegrationEvents => _integrationEvents."
+        },
+        {
+          "name": "ClearIntegrationEvents",
+          "kind": "method",
+          "signature": "ClearIntegrationEvents()",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AuditableEntity",
+      "fqn": "Granit.Core.Domain.AuditableEntity",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/AuditableEntity.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Id",
+          "kind": "property",
+          "signature": "Guid Id",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "AuditedAggregateRoot",
+      "fqn": "Granit.Core.Domain.AuditedAggregateRoot",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/AuditedAggregateRoot.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "AuditedEntity",
+      "fqn": "Granit.Core.Domain.AuditedEntity",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/AuditedEntity.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "AuditedTranslation",
+      "fqn": "Granit.Core.Domain.AuditedTranslation",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/AuditedTranslation.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "ParentId",
+          "kind": "property",
+          "signature": "Guid ParentId",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "CreationAuditedAggregateRoot",
+      "fqn": "Granit.Core.Domain.CreationAuditedAggregateRoot",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/CreationAuditedAggregateRoot.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AsReadOnly",
+          "kind": "method",
+          "signature": "AsReadOnly()",
+          "returnType": "IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents."
+        },
+        {
+          "name": "AsReadOnly",
+          "kind": "method",
+          "signature": "AsReadOnly()",
+          "returnType": "IReadOnlyCollection<IIntegrationEvent> IntegrationEvents => _integrationEvents."
+        },
+        {
+          "name": "ClearIntegrationEvents",
+          "kind": "method",
+          "signature": "ClearIntegrationEvents()",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "CreationAuditedEntity",
+      "fqn": "Granit.Core.Domain.CreationAuditedEntity",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/CreationAuditedEntity.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "CreatedAt",
+          "kind": "property",
+          "signature": "DateTimeOffset CreatedAt",
+          "returnType": "DateTimeOffset"
+        }
+      ]
+    },
+    {
+      "name": "Entity",
+      "fqn": "Granit.Core.Domain.Entity",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/Entity.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "FullAuditedAggregateRoot",
+      "fqn": "Granit.Core.Domain.FullAuditedAggregateRoot",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/FullAuditedAggregateRoot.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "FullAuditedEntity",
+      "fqn": "Granit.Core.Domain.FullAuditedEntity",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/FullAuditedEntity.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "IActive",
+      "fqn": "Granit.Core.Domain.IActive",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/IActive.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "IConcurrencyAware",
+      "fqn": "Granit.Core.Domain.IConcurrencyAware",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/IConcurrencyAware.cs",
+      "line": 26,
+      "members": []
+    },
+    {
+      "name": "IConcurrencyStampRequest",
+      "fqn": "Granit.Core.Domain.IConcurrencyStampRequest",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/IConcurrencyStampRequest.cs",
+      "line": 26,
+      "members": []
+    },
+    {
+      "name": "IEmitEntityLifecycleEvents",
+      "fqn": "Granit.Core.Domain.IEmitEntityLifecycleEvents",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/IEmitEntityLifecycleEvents.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "IEntityEtoProvider",
+      "fqn": "Granit.Core.Domain.IEntityEtoProvider",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/IEntityEtoProvider.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "IHasEntityEto",
+      "fqn": "Granit.Core.Domain.IHasEntityEto",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/IHasEntityEto.cs",
+      "line": 33,
+      "members": [
+        {
+          "name": "ToEto",
+          "kind": "method",
+          "signature": "ToEto()",
+          "returnType": "TEto"
+        }
+      ]
+    },
+    {
+      "name": "IMultiTenant",
+      "fqn": "Granit.Core.Domain.IMultiTenant",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/IMultiTenant.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "IProcessingRestrictable",
+      "fqn": "Granit.Core.Domain.IProcessingRestrictable",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/IProcessingRestrictable.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "IPublishable",
+      "fqn": "Granit.Core.Domain.IPublishable",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/IPublishable.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "ISoftDeletable",
+      "fqn": "Granit.Core.Domain.ISoftDeletable",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/ISoftDeletable.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ITranslatable",
+      "fqn": "Granit.Core.Domain.ITranslatable",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/ITranslatable.cs",
+      "line": 34,
+      "members": []
+    },
+    {
+      "name": "ITranslation",
+      "fqn": "Granit.Core.Domain.ITranslation",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/ITranslation.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "IVersioned",
+      "fqn": "Granit.Core.Domain.IVersioned",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/IVersioned.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "SingleValueObject",
+      "fqn": "Granit.Core.Domain.SingleValueObject",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/SingleValueObject.cs",
+      "line": 26,
+      "members": [
+        {
+          "name": "GetEqualityComponents",
+          "kind": "method",
+          "signature": "GetEqualityComponents()",
+          "returnType": "T Value { get; init; } protected sealed IEnumerable<object?>"
+        }
+      ]
+    },
+    {
+      "name": "TranslatableExtensions",
+      "fqn": "Granit.Core.Domain.TranslatableExtensions",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/TranslatableExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "Translation",
+      "fqn": "Granit.Core.Domain.Translation",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/Translation.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "ParentId",
+          "kind": "property",
+          "signature": "Guid ParentId",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "ValueObject",
+      "fqn": "Granit.Core.Domain.ValueObject",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/ValueObject.cs",
+      "line": 32,
+      "members": [
+        {
+          "name": "Equals",
+          "kind": "method",
+          "signature": "Equals(ValueObject? other)",
+          "returnType": "bool"
+        },
+        {
+          "name": "GetHashCode",
+          "kind": "method",
+          "signature": "GetHashCode()",
+          "returnType": "sealed int"
+        },
+        {
+          "name": "operator",
+          "kind": "property",
+          "signature": "bool operator",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "ContentType",
+      "fqn": "Granit.Core.Domain.ValueObjects.ContentType",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/ValueObjects/ContentType.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(string value)",
+          "returnType": "required string Value { get; init; } public ContentType"
+        },
+        {
+          "name": "ContentType",
+          "kind": "method",
+          "signature": "ContentType(string value)",
+          "returnType": "implicit operator"
+        }
+      ]
+    },
+    {
+      "name": "EntityTypeName",
+      "fqn": "Granit.Core.Domain.ValueObjects.EntityTypeName",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/ValueObjects/EntityTypeName.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(string value)",
+          "returnType": "required string Value { get; init; } public EntityTypeName"
+        },
+        {
+          "name": "EntityTypeName",
+          "kind": "method",
+          "signature": "EntityTypeName(string value)",
+          "returnType": "implicit operator"
+        }
+      ]
+    },
+    {
+      "name": "FileName",
+      "fqn": "Granit.Core.Domain.ValueObjects.FileName",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/ValueObjects/FileName.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(string value)",
+          "returnType": "required string Value { get; init; } public FileName"
+        },
+        {
+          "name": "FileName",
+          "kind": "method",
+          "signature": "FileName(string value)",
+          "returnType": "implicit operator"
+        }
+      ]
+    },
+    {
+      "name": "HttpsUrl",
+      "fqn": "Granit.Core.Domain.ValueObjects.HttpsUrl",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/ValueObjects/HttpsUrl.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(string value)",
+          "returnType": "required string Value { get; init; } public HttpsUrl"
+        },
+        {
+          "name": "HttpsUrl",
+          "kind": "method",
+          "signature": "HttpsUrl(string value)",
+          "returnType": "implicit operator"
+        }
+      ]
+    },
+    {
+      "name": "BatchItemResult",
+      "fqn": "Granit.Core.Endpoints.BatchItemResult",
+      "kind": "record",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Endpoints/BatchResult.cs",
+      "line": 28,
+      "members": []
+    },
+    {
+      "name": "BatchResult",
+      "fqn": "Granit.Core.Endpoints.BatchResult",
+      "kind": "record",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Endpoints/BatchResult.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "BatchResultHelper",
+      "fqn": "Granit.Core.Endpoints.BatchResultHelper",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Endpoints/BatchResultHelper.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "statusCode",
+          "kind": "property",
+          "signature": "BatchItemResult<T> Failure<T>(string detail, int statusCode",
+          "returnType": "BatchItemResult<T> Failure<T>(string detail, int"
+        }
+      ]
+    },
+    {
+      "name": "ModuleConfigEndpointExtensions",
+      "fqn": "Granit.Core.Endpoints.ModuleConfigEndpointExtensions",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Endpoints/ModuleConfigEndpointExtensions.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "EntityCreatedEto",
+      "fqn": "Granit.Core.Events.EntityCreatedEto",
+      "kind": "record",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/EntityCreatedEto.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "EntityCreatedEvent",
+      "fqn": "Granit.Core.Events.EntityCreatedEvent",
+      "kind": "record",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/EntityCreatedEvent.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "EntityDeletedEto",
+      "fqn": "Granit.Core.Events.EntityDeletedEto",
+      "kind": "record",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/EntityDeletedEto.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "EntityDeletedEvent",
+      "fqn": "Granit.Core.Events.EntityDeletedEvent",
+      "kind": "record",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/EntityDeletedEvent.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "EntityUpdatedEto",
+      "fqn": "Granit.Core.Events.EntityUpdatedEto",
+      "kind": "record",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/EntityUpdatedEto.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "EntityUpdatedEvent",
+      "fqn": "Granit.Core.Events.EntityUpdatedEvent",
+      "kind": "record",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/EntityUpdatedEvent.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "IDistributedEventBus",
+      "fqn": "Granit.Core.Events.IDistributedEventBus",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/IDistributedEventBus.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "IDistributedEventHandler",
+      "fqn": "Granit.Core.Events.IDistributedEventHandler",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/IDistributedEventHandler.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(TEvent integrationEvent, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IDomainEvent",
+      "fqn": "Granit.Core.Events.IDomainEvent",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/IDomainEvent.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "IDomainEventDispatcher",
+      "fqn": "Granit.Core.Events.IDomainEventDispatcher",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/IDomainEventDispatcher.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "DispatchAsync",
+          "kind": "method",
+          "signature": "DispatchAsync(IReadOnlyList<IDomainEvent> domainEvents, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IDomainEventSource",
+      "fqn": "Granit.Core.Events.IDomainEventSource",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/IDomainEventSource.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ClearDomainEvents",
+          "kind": "method",
+          "signature": "ClearDomainEvents()",
+          "returnType": "IReadOnlyCollection<IDomainEvent> DomainEvents { get; } void"
+        }
+      ]
+    },
+    {
+      "name": "IIntegrationEvent",
+      "fqn": "Granit.Core.Events.IIntegrationEvent",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/IIntegrationEvent.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "IIntegrationEventDispatcher",
+      "fqn": "Granit.Core.Events.IIntegrationEventDispatcher",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/IIntegrationEventDispatcher.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "DispatchAsync",
+          "kind": "method",
+          "signature": "DispatchAsync(IReadOnlyList<IIntegrationEvent> integrationEvents, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IIntegrationEventSource",
+      "fqn": "Granit.Core.Events.IIntegrationEventSource",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/IIntegrationEventSource.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "ClearIntegrationEvents",
+          "kind": "method",
+          "signature": "ClearIntegrationEvents()",
+          "returnType": "IReadOnlyCollection<IIntegrationEvent> IntegrationEvents { get; } void"
+        }
+      ]
+    },
+    {
+      "name": "ILocalEventBus",
+      "fqn": "Granit.Core.Events.ILocalEventBus",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/ILocalEventBus.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "ILocalEventHandler",
+      "fqn": "Granit.Core.Events.ILocalEventHandler",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/ILocalEventHandler.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(TEvent localEvent, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "NullDomainEventDispatcher",
+      "fqn": "Granit.Core.Events.NullDomainEventDispatcher",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/NullDomainEventDispatcher.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "DispatchAsync",
+          "kind": "method",
+          "signature": "DispatchAsync(IReadOnlyList<IDomainEvent> domainEvents, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "BusinessException",
+      "fqn": "Granit.Core.Exceptions.BusinessException",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Exceptions/BusinessException.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "BusinessException",
+          "kind": "method",
+          "signature": "BusinessException(string errorCode, string? message = null, Exception? innerException = null)",
+          "returnType": "string ErrorCode { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "BusinessRuleViolationException",
+      "fqn": "Granit.Core.Exceptions.BusinessRuleViolationException",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Exceptions/BusinessRuleViolationException.cs",
+      "line": 23,
+      "members": []
+    },
+    {
+      "name": "ConflictException",
+      "fqn": "Granit.Core.Exceptions.ConflictException",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Exceptions/ConflictException.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "ConflictException",
+          "kind": "method",
+          "signature": "ConflictException(string errorCode, string? message = null, Exception? innerException = null)",
+          "returnType": "string ErrorCode { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "EntityNotFoundException",
+      "fqn": "Granit.Core.Exceptions.EntityNotFoundException",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Exceptions/EntityNotFoundException.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "EntityNotFoundException",
+          "kind": "method",
+          "signature": "EntityNotFoundException(Type entityType, object id)",
+          "returnType": "Type EntityType { get; } public object EntityId { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "ForbiddenException",
+      "fqn": "Granit.Core.Exceptions.ForbiddenException",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Exceptions/ForbiddenException.cs",
+      "line": 26,
+      "members": []
+    },
+    {
+      "name": "IHasErrorCode",
+      "fqn": "Granit.Core.Exceptions.IHasErrorCode",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Exceptions/IHasErrorCode.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "IHasValidationErrors",
+      "fqn": "Granit.Core.Exceptions.IHasValidationErrors",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Exceptions/IHasValidationErrors.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "IUserFriendlyException",
+      "fqn": "Granit.Core.Exceptions.IUserFriendlyException",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Exceptions/IUserFriendlyException.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "NotFoundException",
+      "fqn": "Granit.Core.Exceptions.NotFoundException",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Exceptions/NotFoundException.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "ValidationException",
+      "fqn": "Granit.Core.Exceptions.ValidationException",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Exceptions/ValidationException.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "ValidationException",
+          "kind": "method",
+          "signature": "ValidationException(IReadOnlyDictionary<string, string[]> validationErrors)",
+          "returnType": "IReadOnlyDictionary<string, string[]> ValidationErrors { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "GranitApplicationExtensions",
+      "fqn": "Granit.Core.Extensions.GranitApplicationExtensions",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Extensions/GranitApplicationExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "UseGranit",
+          "kind": "method",
+          "signature": "UseGranit(this IApplicationBuilder app)",
+          "returnType": "IApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitHostBuilderExtensions",
+      "fqn": "Granit.Core.Extensions.GranitHostBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Extensions/GranitHostBuilderExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranit",
+          "kind": "method",
+          "signature": "AddGranit(this IHostApplicationBuilder builder, Action<GranitBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        },
+        {
+          "name": "AddGranitAsync",
+          "kind": "method",
+          "signature": "AddGranitAsync(this IHostApplicationBuilder builder, Action<GranitBuilder> configure)",
+          "returnType": "Task<IHostApplicationBuilder>"
+        }
+      ]
+    },
+    {
+      "name": "SingleValueObjectJsonConverterFactory",
+      "fqn": "Granit.Core.Json.SingleValueObjectJsonConverterFactory",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Json/SingleValueObjectJsonConverterFactory.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "CanConvert",
+          "kind": "method",
+          "signature": "CanConvert(Type typeToConvert)",
+          "returnType": "bool"
+        },
+        {
+          "name": "CreateConverter",
+          "kind": "method",
+          "signature": "CreateConverter(Type typeToConvert, JsonSerializerOptions options)",
+          "returnType": "JsonConverter"
+        }
+      ]
+    },
+    {
+      "name": "InheritResourceAttribute",
+      "fqn": "Granit.Core.Localization.InheritResourceAttribute",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Localization/InheritResourceAttribute.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "BaseResourceTypes",
+          "kind": "property",
+          "signature": "Type[] BaseResourceTypes",
+          "returnType": "Type[]"
+        }
+      ]
+    },
+    {
+      "name": "LocalizableString",
+      "fqn": "Granit.Core.Localization.LocalizableString",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Localization/LocalizableString.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Localize",
+          "kind": "method",
+          "signature": "Localize(IStringLocalizerFactory? localizerFactory)",
+          "returnType": "string"
+        },
+        {
+          "name": "Fixed",
+          "kind": "method",
+          "signature": "Fixed(string value)",
+          "returnType": "LocalizableString"
+        }
+      ]
+    },
+    {
+      "name": "LocalizationResourceNameAttribute",
+      "fqn": "Granit.Core.Localization.LocalizationResourceNameAttribute",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Localization/LocalizationResourceNameAttribute.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultCulture",
+          "kind": "property",
+          "signature": "string DefaultCulture",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "ApplicationInitializationContext",
+      "fqn": "Granit.Core.Modularity.ApplicationInitializationContext",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Modularity/ApplicationInitializationContext.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ServiceProvider",
+          "kind": "property",
+          "signature": "IServiceProvider ServiceProvider",
+          "returnType": "IServiceProvider"
+        }
+      ]
+    },
+    {
+      "name": "DependsOnAttribute",
+      "fqn": "Granit.Core.Modularity.DependsOnAttribute",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Modularity/DependsOnAttribute.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "DependedTypes",
+          "kind": "property",
+          "signature": "Type[] DependedTypes",
+          "returnType": "Type[]"
+        }
+      ]
+    },
+    {
+      "name": "GranitApplication",
+      "fqn": "Granit.Core.Modularity.GranitApplication",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Modularity/GranitApplication.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetModuleInstances",
+          "kind": "method",
+          "signature": "GetModuleInstances()",
+          "returnType": "IReadOnlyList<GranitModule>"
+        }
+      ]
+    },
+    {
+      "name": "GranitBuilder",
+      "fqn": "Granit.Core.Modularity.GranitBuilder",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Modularity/GranitBuilder.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "GranitModule",
+      "fqn": "Granit.Core.Modularity.GranitModule",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Modularity/GranitModule.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "IsEnabled",
+          "kind": "method",
+          "signature": "IsEnabled(ServiceConfigurationContext context)",
+          "returnType": "bool"
+        },
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IModuleConfigProvider",
+      "fqn": "Granit.Core.Modularity.IModuleConfigProvider",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Modularity/IModuleConfigProvider.cs",
+      "line": 31,
+      "members": [
+        {
+          "name": "GetConfig",
+          "kind": "method",
+          "signature": "GetConfig()",
+          "returnType": "TResponse"
+        }
+      ]
+    },
+    {
+      "name": "ServiceConfigurationContext",
+      "fqn": "Granit.Core.Modularity.ServiceConfigurationContext",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Modularity/ServiceConfigurationContext.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "Services",
+          "kind": "property",
+          "signature": "IServiceCollection Services",
+          "returnType": "IServiceCollection"
+        },
+        {
+          "name": "Configuration",
+          "kind": "property",
+          "signature": "IConfiguration Configuration",
+          "returnType": "IConfiguration"
+        },
+        {
+          "name": "Builder",
+          "kind": "property",
+          "signature": "IHostApplicationBuilder Builder",
+          "returnType": "IHostApplicationBuilder"
+        },
+        {
+          "name": "ModuleAssemblies",
+          "kind": "property",
+          "signature": "IReadOnlyList<Assembly> ModuleAssemblies",
+          "returnType": "IReadOnlyList<Assembly>"
+        },
+        {
+          "name": "Items",
+          "kind": "property",
+          "signature": "IDictionary<string, object?> Items",
+          "returnType": "IDictionary<string, object?>"
+        }
+      ]
+    },
+    {
+      "name": "AllowAnonymousTenantAttribute",
+      "fqn": "Granit.Core.MultiTenancy.AllowAnonymousTenantAttribute",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/MultiTenancy/AllowAnonymousTenantAttribute.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ICurrentTenant",
+      "fqn": "Granit.Core.MultiTenancy.ICurrentTenant",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/MultiTenancy/ICurrentTenant.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "Change",
+          "kind": "method",
+          "signature": "Change(Guid? id, string? name = null)",
+          "returnType": "bool IsAvailable { get; } Guid? Id { get; } string? Name { get; } IDisposable"
+        }
+      ]
+    },
+    {
+      "name": "DataExchangeAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.DataExchange.AI.Extensions.DataExchangeAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.DataExchange.AI",
+      "file": "src/Granit.DataExchange.AI/Extensions/DataExchangeAIHostApplicationBuilderExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitDataExchangeAI",
+          "kind": "method",
+          "signature": "AddGranitDataExchangeAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitDataExchangeAIModule",
+      "fqn": "Granit.DataExchange.AI.GranitDataExchangeAIModule",
+      "kind": "class",
+      "project": "Granit.DataExchange.AI",
+      "file": "src/Granit.DataExchange.AI/GranitDataExchangeAIModule.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "DataExchangeAIOptions",
+      "fqn": "Granit.DataExchange.AI.Options.DataExchangeAIOptions",
+      "kind": "class",
+      "project": "Granit.DataExchange.AI",
+      "file": "src/Granit.DataExchange.AI/Options/DataExchangeAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string WorkspaceName",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        },
+        {
+          "name": "MinConfidenceScore",
+          "kind": "property",
+          "signature": "double MinConfidenceScore",
+          "returnType": "double"
+        },
+        {
+          "name": "IncludePreviewRows",
+          "kind": "property",
+          "signature": "bool IncludePreviewRows",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.DataExchange.Csv.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.DataExchange.Csv",
+      "file": "src/Granit.DataExchange.Csv/Extensions/ServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitDataExchangeCsv",
+          "kind": "method",
+          "signature": "AddGranitDataExchangeCsv(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitDataExchangeCsvModule",
+      "fqn": "Granit.DataExchange.Csv.GranitDataExchangeCsvModule",
+      "kind": "class",
+      "project": "Granit.DataExchange.Csv",
+      "file": "src/Granit.DataExchange.Csv/GranitDataExchangeCsvModule.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "DataExchangeMetrics",
+      "fqn": "Granit.DataExchange.Diagnostics.DataExchangeMetrics",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Diagnostics/DataExchangeMetrics.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "CreateExportJobRequest",
+      "fqn": "Granit.DataExchange.Endpoints.Dtos.Export.CreateExportJobRequest",
+      "kind": "record",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Dtos/Export/CreateExportJobRequest.cs",
+      "line": 24,
+      "members": []
+    },
+    {
+      "name": "ExportDefinitionResponse",
+      "fqn": "Granit.DataExchange.Endpoints.Dtos.Export.ExportDefinitionResponse",
+      "kind": "record",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Dtos/Export/ExportDefinitionResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ExportFieldResponse",
+      "fqn": "Granit.DataExchange.Endpoints.Dtos.Export.ExportFieldResponse",
+      "kind": "record",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Dtos/Export/ExportFieldResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ExportJobResponse",
+      "fqn": "Granit.DataExchange.Endpoints.Dtos.Export.ExportJobResponse",
+      "kind": "record",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Dtos/Export/ExportJobResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ExportPresetResponse",
+      "fqn": "Granit.DataExchange.Endpoints.Dtos.Export.ExportPresetResponse",
+      "kind": "record",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Dtos/Export/ExportPresetResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "SaveExportPresetRequest",
+      "fqn": "Granit.DataExchange.Endpoints.Dtos.Export.SaveExportPresetRequest",
+      "kind": "record",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Dtos/Export/SaveExportPresetRequest.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "ConfirmMappingsRequest",
+      "fqn": "Granit.DataExchange.Endpoints.Dtos.Import.ConfirmMappingsRequest",
+      "kind": "record",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Dtos/Import/ConfirmMappingsRequest.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ImportJobResponse",
+      "fqn": "Granit.DataExchange.Endpoints.Dtos.Import.ImportJobResponse",
+      "kind": "record",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Dtos/Import/ImportJobResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ImportPreviewResponse",
+      "fqn": "Granit.DataExchange.Endpoints.Dtos.Import.ImportPreviewResponse",
+      "kind": "record",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Dtos/Import/ImportPreviewResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ImportReportResponse",
+      "fqn": "Granit.DataExchange.Endpoints.Dtos.Import.ImportReportResponse",
+      "kind": "record",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Dtos/Import/ImportReportResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "DataExchangeEndpointRouteBuilderExtensions",
+      "fqn": "Granit.DataExchange.Endpoints.Extensions.DataExchangeEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Extensions/DataExchangeEndpointRouteBuilderExtensions.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "MapDataExchangeEndpoints",
+          "kind": "method",
+          "signature": "MapDataExchangeEndpoints(this IEndpointRouteBuilder endpoints, Action<DataExchangeEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitDataExchangeEndpointsModule",
+      "fqn": "Granit.DataExchange.Endpoints.GranitDataExchangeEndpointsModule",
+      "kind": "class",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/GranitDataExchangeEndpointsModule.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "ImportAuthorizationPolicy",
+      "fqn": "Granit.DataExchange.Endpoints.Internal.Import.ImportAuthorizationPolicy",
+      "kind": "class",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Internal/Import/ImportAuthorizationPolicy.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "DataExchangeEndpointsOptions",
+      "fqn": "Granit.DataExchange.Endpoints.Options.DataExchangeEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Options/DataExchangeEndpointsOptions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "DataExchangePermissions",
+      "fqn": "Granit.DataExchange.Endpoints.Permissions.DataExchangePermissions",
+      "kind": "class",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Permissions/DataExchangePermissions.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "Exports",
+      "fqn": "Granit.DataExchange.Endpoints.Permissions.Exports",
+      "kind": "class",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Permissions/DataExchangePermissions.cs",
+      "line": 30,
+      "members": []
+    },
+    {
+      "name": "Imports",
+      "fqn": "Granit.DataExchange.Endpoints.Permissions.Imports",
+      "kind": "class",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Permissions/DataExchangePermissions.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "DataExchangeEfCoreHostBuilderExtensions",
+      "fqn": "Granit.DataExchange.EntityFrameworkCore.Extensions.DataExchangeEfCoreHostBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.DataExchange.EntityFrameworkCore",
+      "file": "src/Granit.DataExchange.EntityFrameworkCore/Extensions/DataExchangeEfCoreHostBuilderExtensions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "AddGranitDataExchangeEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitDataExchangeEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "DataExchangeEfCoreServiceCollectionExtensions",
+      "fqn": "Granit.DataExchange.EntityFrameworkCore.Extensions.DataExchangeEfCoreServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.DataExchange.EntityFrameworkCore",
+      "file": "src/Granit.DataExchange.EntityFrameworkCore/Extensions/DataExchangeEfCoreServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "DataExchangeModelBuilderExtensions",
+      "fqn": "Granit.DataExchange.EntityFrameworkCore.Extensions.DataExchangeModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.DataExchange.EntityFrameworkCore",
+      "file": "src/Granit.DataExchange.EntityFrameworkCore/Extensions/DataExchangeModelBuilderExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureDataExchangeModule",
+          "kind": "method",
+          "signature": "ConfigureDataExchangeModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitDataExchangeDbProperties",
+      "fqn": "Granit.DataExchange.EntityFrameworkCore.GranitDataExchangeDbProperties",
+      "kind": "class",
+      "project": "Granit.DataExchange.EntityFrameworkCore",
+      "file": "src/Granit.DataExchange.EntityFrameworkCore/GranitDataExchangeDbProperties.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitDataExchangeEntityFrameworkCoreModule",
+      "fqn": "Granit.DataExchange.EntityFrameworkCore.GranitDataExchangeEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.DataExchange.EntityFrameworkCore",
+      "file": "src/Granit.DataExchange.EntityFrameworkCore/GranitDataExchangeEntityFrameworkCoreModule.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "OnApplicationInitializationAsync",
+          "kind": "method",
+          "signature": "OnApplicationInitializationAsync(ApplicationInitializationContext context)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.DataExchange.Excel.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.DataExchange.Excel",
+      "file": "src/Granit.DataExchange.Excel/Extensions/ServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitDataExchangeExcel",
+          "kind": "method",
+          "signature": "AddGranitDataExchangeExcel(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitDataExchangeExcelModule",
+      "fqn": "Granit.DataExchange.Excel.GranitDataExchangeExcelModule",
+      "kind": "class",
+      "project": "Granit.DataExchange.Excel",
+      "file": "src/Granit.DataExchange.Excel/GranitDataExchangeExcelModule.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ExportJob",
+      "fqn": "Granit.DataExchange.Export.Domain.ExportJob",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/Domain/ExportJob.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, string definitionName, string format, string requestJson, Guid? tenantId = null)",
+          "returnType": "ExportJob"
+        },
+        {
+          "name": "DefinitionName",
+          "kind": "property",
+          "signature": "string DefinitionName",
+          "returnType": "string"
+        },
+        {
+          "name": "Format",
+          "kind": "property",
+          "signature": "string Format",
+          "returnType": "string"
+        },
+        {
+          "name": "RequestJson",
+          "kind": "property",
+          "signature": "string RequestJson",
+          "returnType": "string"
+        },
+        {
+          "name": "Status",
+          "kind": "property",
+          "signature": "ExportJobStatus Status",
+          "returnType": "ExportJobStatus"
+        },
+        {
+          "name": "MarkAsExporting",
+          "kind": "method",
+          "signature": "MarkAsExporting()",
+          "returnType": "string? BlobReference { get; private set; } public string? FileName { get; private set; } public int? RowCount { get; private set; } public string? ErrorMessage { get; private set; } public DateTimeOffset? CompletedAt { get; private set; } public Guid? TenantId { get; private set; } internal void"
+        }
+      ]
+    },
+    {
+      "name": "ExportJobFailedEto",
+      "fqn": "Granit.DataExchange.Export.Events.ExportJobFailedEto",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/Events/ExportJobFailedEto.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "ExportDefinition",
+      "fqn": "Granit.DataExchange.Export.ExportDefinition",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/ExportDefinition.cs",
+      "line": 42,
+      "members": [
+        {
+          "name": "typeof",
+          "kind": "method",
+          "signature": "typeof(TEntity)",
+          "returnType": "string Name { get; } public Type EntityType =>"
+        },
+        {
+          "name": "QueryDefinitionName",
+          "kind": "property",
+          "signature": "string? QueryDefinitionName",
+          "returnType": "string?"
+        },
+        {
+          "name": "SupportedFormats",
+          "kind": "property",
+          "signature": "IReadOnlyList<string> SupportedFormats",
+          "returnType": "IReadOnlyList<string>"
+        },
+        {
+          "name": "GetIncludeId",
+          "kind": "method",
+          "signature": "GetIncludeId()",
+          "returnType": "bool"
+        },
+        {
+          "name": "GetIncludeBusinessKey",
+          "kind": "method",
+          "signature": "GetIncludeBusinessKey()",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "ExportDefinitionBuilder",
+      "fqn": "Granit.DataExchange.Export.ExportDefinitionBuilder",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/ExportDefinitionBuilder.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "ExportDownload",
+      "fqn": "Granit.DataExchange.Export.ExportDownload",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/IExportOrchestrator.cs",
+      "line": 62,
+      "members": []
+    },
+    {
+      "name": "ExportFieldBuilder",
+      "fqn": "Granit.DataExchange.Export.ExportFieldBuilder",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/ExportFieldBuilder.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ExportFieldDescriptor",
+      "fqn": "Granit.DataExchange.Export.ExportFieldDescriptor",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/ExportFieldDescriptor.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "ExportJobResult",
+      "fqn": "Granit.DataExchange.Export.ExportJobResult",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/ExportJobResult.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "ExportJobStatus",
+      "fqn": "Granit.DataExchange.Export.ExportJobStatus",
+      "kind": "enum",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/ExportJobStatus.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ExportOptions",
+      "fqn": "Granit.DataExchange.Export.ExportOptions",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/ExportOptions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "BackgroundThreshold",
+          "kind": "property",
+          "signature": "int BackgroundThreshold",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "ExportPreset",
+      "fqn": "Granit.DataExchange.Export.ExportPreset",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/ExportPreset.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "ExportRequest",
+      "fqn": "Granit.DataExchange.Export.ExportRequest",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/ExportRequest.cs",
+      "line": 33,
+      "members": []
+    },
+    {
+      "name": "IExportCommandDispatcher",
+      "fqn": "Granit.DataExchange.Export.IExportCommandDispatcher",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/IExportCommandDispatcher.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "DispatchAsync",
+          "kind": "method",
+          "signature": "DispatchAsync(ExecuteExportCommand command, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IExportDataSource",
+      "fqn": "Granit.DataExchange.Export.IExportDataSource",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/IExportDataSource.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "GetQueryable",
+          "kind": "method",
+          "signature": "GetQueryable()",
+          "returnType": "IQueryable<TEntity>"
+        }
+      ]
+    },
+    {
+      "name": "IExportDefinitionDescriptor",
+      "fqn": "Granit.DataExchange.Export.IExportDefinitionDescriptor",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/IExportDefinitionDescriptor.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "GetFields",
+          "kind": "method",
+          "signature": "GetFields()",
+          "returnType": "string Name { get; } Type EntityType { get; } string? QueryDefinitionName { get; } IReadOnlyList<string> SupportedFormats { get; } IReadOnlyList<ExportFieldDescriptor>"
+        }
+      ]
+    },
+    {
+      "name": "IExportJobReader",
+      "fqn": "Granit.DataExchange.Export.IExportJobReader",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/IExportJobReader.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ExportJob?>"
+        },
+        {
+          "name": "ListAsync",
+          "kind": "method",
+          "signature": "ListAsync(ExportJobStatus? status = null, int page = 1, int pageSize = 20, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<ExportJob>>"
+        }
+      ]
+    },
+    {
+      "name": "IExportJobWriter",
+      "fqn": "Granit.DataExchange.Export.IExportJobWriter",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/IExportJobWriter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(ExportJob job, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UpdateAsync",
+          "kind": "method",
+          "signature": "UpdateAsync(ExportJob job, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IExportOrchestrator",
+      "fqn": "Granit.DataExchange.Export.IExportOrchestrator",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/IExportOrchestrator.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "ExportAsync",
+          "kind": "method",
+          "signature": "ExportAsync(ExportRequest request, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ExportJobResult>"
+        },
+        {
+          "name": "ExecuteAsync",
+          "kind": "method",
+          "signature": "ExecuteAsync(Guid jobId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "GetJobAsync",
+          "kind": "method",
+          "signature": "GetJobAsync(Guid jobId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ExportJob?>"
+        },
+        {
+          "name": "GetDownloadAsync",
+          "kind": "method",
+          "signature": "GetDownloadAsync(Guid jobId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ExportDownload?>"
+        }
+      ]
+    },
+    {
+      "name": "IExportPresetReader",
+      "fqn": "Granit.DataExchange.Export.IExportPresetReader",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/IExportPresetReader.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(string definitionName, string presetName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ExportPreset?>"
+        },
+        {
+          "name": "ListAsync",
+          "kind": "method",
+          "signature": "ListAsync(string definitionName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<ExportPreset>>"
+        }
+      ]
+    },
+    {
+      "name": "IExportPresetWriter",
+      "fqn": "Granit.DataExchange.Export.IExportPresetWriter",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/IExportPresetWriter.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SaveAsync",
+          "kind": "method",
+          "signature": "SaveAsync(ExportPreset preset, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(string definitionName, string presetName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IExportWriter",
+      "fqn": "Granit.DataExchange.Export.IExportWriter",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/IExportWriter.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "CanWrite",
+          "kind": "method",
+          "signature": "CanWrite(string format)",
+          "returnType": "bool"
+        },
+        {
+          "name": "WriteAsync",
+          "kind": "method",
+          "signature": "WriteAsync(Stream output, IReadOnlyList<ExportFieldDescriptor> fields, IAsyncEnumerable<IReadOnlyDictionary<string, object?>> rows, CancellationToken cancellationToken = default)",
+          "returnType": "string MimeType { get; } string FileExtension { get; } Task"
+        }
+      ]
+    },
+    {
+      "name": "ExecuteExportCommand",
+      "fqn": "Granit.DataExchange.Export.Messages.ExecuteExportCommand",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/Messages/ExecuteExportCommand.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ExportJobCompletedEvent",
+      "fqn": "Granit.DataExchange.Export.Messages.ExportJobCompletedEvent",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/Messages/ExportJobCompletedEvent.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.DataExchange.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Extensions/ServiceCollectionExtensions.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "AddGranitDataImport",
+          "kind": "method",
+          "signature": "AddGranitDataImport(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitDataExchangeModule",
+      "fqn": "Granit.DataExchange.GranitDataExchangeModule",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/GranitDataExchangeModule.cs",
+      "line": 35,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ImportJob",
+      "fqn": "Granit.DataExchange.Import.Domain.ImportJob",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Domain/ImportJob.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, string definitionName, string entityTypeName, string originalFileName, string mimeType, long fileSizeBytes, string blobReference, Guid? tenantId = null)",
+          "returnType": "ImportJob"
+        },
+        {
+          "name": "DefinitionName",
+          "kind": "property",
+          "signature": "string DefinitionName",
+          "returnType": "string"
+        },
+        {
+          "name": "EntityTypeName",
+          "kind": "property",
+          "signature": "string EntityTypeName",
+          "returnType": "string"
+        },
+        {
+          "name": "OriginalFileName",
+          "kind": "property",
+          "signature": "string OriginalFileName",
+          "returnType": "string"
+        },
+        {
+          "name": "MimeType",
+          "kind": "property",
+          "signature": "string MimeType",
+          "returnType": "string"
+        },
+        {
+          "name": "FileSizeBytes",
+          "kind": "property",
+          "signature": "long FileSizeBytes",
+          "returnType": "long"
+        },
+        {
+          "name": "Status",
+          "kind": "property",
+          "signature": "ImportJobStatus Status",
+          "returnType": "ImportJobStatus"
+        },
+        {
+          "name": "SetMappings",
+          "kind": "method",
+          "signature": "SetMappings(string mappingsJson)",
+          "returnType": "string? MappingsJson { get; private set; } public string? ReportJson { get; private set; } public DateTimeOffset? CompletedAt { get; private set; } public Guid? TenantId { get; private set; } internal void"
+        }
+      ]
+    },
+    {
+      "name": "ImportJobStatus",
+      "fqn": "Granit.DataExchange.Import.Domain.ImportJobStatus",
+      "kind": "enum",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Domain/ImportJobStatus.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ImportJobCancelledEvent",
+      "fqn": "Granit.DataExchange.Import.Events.ImportJobCancelledEvent",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Events/ImportJobCancelledEvent.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "IImportExecutor",
+      "fqn": "Granit.DataExchange.Import.Execution.IImportExecutor",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Execution/IImportExecutor.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "ExecuteAsync",
+          "kind": "method",
+          "signature": "ExecuteAsync(IAsyncEnumerable<ValidatedRow<TEntity>> entities, ImportExecutionOptions options, IProgress<ImportProgress>? progress = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImportReport>"
+        }
+      ]
+    },
+    {
+      "name": "ImportErrorBehavior",
+      "fqn": "Granit.DataExchange.Import.Execution.ImportErrorBehavior",
+      "kind": "enum",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Execution/ImportErrorBehavior.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ImportExecutionOptions",
+      "fqn": "Granit.DataExchange.Import.Execution.ImportExecutionOptions",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Execution/ImportExecutionOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "BatchSize",
+          "kind": "property",
+          "signature": "int BatchSize",
+          "returnType": "int"
+        },
+        {
+          "name": "DryRun",
+          "kind": "property",
+          "signature": "bool DryRun",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "ValidatedRow",
+      "fqn": "Granit.DataExchange.Import.Execution.ValidatedRow",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Execution/ValidatedRow.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "GroupedRows",
+      "fqn": "Granit.DataExchange.Import.Grouping.GroupedRows",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Grouping/GroupedRows.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "IRowGrouper",
+      "fqn": "Granit.DataExchange.Import.Grouping.IRowGrouper",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Grouping/IRowGrouper.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "GroupAsync",
+          "kind": "method",
+          "signature": "GroupAsync(IAsyncEnumerable<RawImportRow> rows, CancellationToken cancellationToken = default)",
+          "returnType": "IAsyncEnumerable<GroupedRows>"
+        }
+      ]
+    },
+    {
+      "name": "IRecordIdentityResolver",
+      "fqn": "Granit.DataExchange.Import.Identity.IRecordIdentityResolver",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Identity/IRecordIdentityResolver.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "ResolveAsync",
+          "kind": "method",
+          "signature": "ResolveAsync(TEntity entity, CancellationToken cancellationToken = default)",
+          "returnType": "Task<RecordIdentity<TEntity>>"
+        }
+      ]
+    },
+    {
+      "name": "RecordIdentity",
+      "fqn": "Granit.DataExchange.Import.Identity.RecordIdentity",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Identity/RecordIdentity.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "RecordOperation",
+      "fqn": "Granit.DataExchange.Import.Identity.RecordOperation",
+      "kind": "enum",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Identity/RecordOperation.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ImportOptions",
+      "fqn": "Granit.DataExchange.Import.ImportOptions",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/ImportOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "DefaultMaxFileSizeMb",
+          "kind": "property",
+          "signature": "int DefaultMaxFileSizeMb",
+          "returnType": "int"
+        },
+        {
+          "name": "DefaultBatchSize",
+          "kind": "property",
+          "signature": "int DefaultBatchSize",
+          "returnType": "int"
+        },
+        {
+          "name": "FuzzyMatchThreshold",
+          "kind": "property",
+          "signature": "double FuzzyMatchThreshold",
+          "returnType": "double"
+        }
+      ]
+    },
+    {
+      "name": "CellConversionError",
+      "fqn": "Granit.DataExchange.Import.Mapping.CellConversionError",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/CellConversionError.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "ChildCollectionBuilder",
+      "fqn": "Granit.DataExchange.Import.Mapping.ChildCollectionBuilder",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/ChildCollectionBuilder.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "IDataMapper",
+      "fqn": "Granit.DataExchange.Import.Mapping.IDataMapper",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/IDataMapper.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "MapAsync",
+          "kind": "method",
+          "signature": "MapAsync(RawImportRow row, IReadOnlyList<ImportColumnMapping> mappings, ImportOptions options, CancellationToken cancellationToken = default)",
+          "returnType": "Task<MappingResult<TEntity>>"
+        }
+      ]
+    },
+    {
+      "name": "IImportDefinitionDescriptor",
+      "fqn": "Granit.DataExchange.Import.Mapping.IImportDefinitionDescriptor",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/IImportDefinitionDescriptor.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "GetFieldMetadata",
+          "kind": "method",
+          "signature": "GetFieldMetadata()",
+          "returnType": "string Name { get; } Type EntityType { get; } int MaxFileSizeMb { get; } IReadOnlyList<string> AllowedMimeTypes { get; } IReadOnlyList<ImportFieldMetadata>"
+        }
+      ]
+    },
+    {
+      "name": "IMappingReader",
+      "fqn": "Granit.DataExchange.Import.Mapping.IMappingReader",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/IMappingReader.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "LoadAsync",
+          "kind": "method",
+          "signature": "LoadAsync(string definitionName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<ImportColumnMapping>>"
+        }
+      ]
+    },
+    {
+      "name": "IMappingSuggestionService",
+      "fqn": "Granit.DataExchange.Import.Mapping.IMappingSuggestionService",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/IMappingSuggestionService.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "IMappingWriter",
+      "fqn": "Granit.DataExchange.Import.Mapping.IMappingWriter",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/IMappingWriter.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SaveAsync",
+          "kind": "method",
+          "signature": "SaveAsync(string definitionName, IReadOnlyList<ImportColumnMapping> mappings, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ISemanticMappingService",
+      "fqn": "Granit.DataExchange.Import.Mapping.ISemanticMappingService",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/ISemanticMappingService.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "SuggestSemanticMappingsAsync",
+          "kind": "method",
+          "signature": "SuggestSemanticMappingsAsync(IReadOnlyList<string> headers, IReadOnlyList<ImportFieldMetadata> targetFields, CancellationToken cancellationToken = default)",
+          "returnType": "bool IsAvailable { get; } Task<IReadOnlyList<SemanticMappingSuggestion>>"
+        },
+        {
+          "name": "SuggestSemanticMappingsAsync",
+          "kind": "method",
+          "signature": "SuggestSemanticMappingsAsync(IReadOnlyList<string> headers, IReadOnlyList<ImportFieldMetadata> targetFields, IReadOnlyList<string[]>? previewRows, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<SemanticMappingSuggestion>>"
+        },
+        {
+          "name": "SuggestSemanticMappingsAsync",
+          "kind": "method",
+          "signature": "SuggestSemanticMappingsAsync(headers, targetFields, cancellationToken)",
+          "returnType": "=>"
+        }
+      ]
+    },
+    {
+      "name": "ImportColumnMapping",
+      "fqn": "Granit.DataExchange.Import.Mapping.ImportColumnMapping",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/ImportColumnMapping.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "ImportDefinition",
+      "fqn": "Granit.DataExchange.Import.Mapping.ImportDefinition",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/ImportDefinition.cs",
+      "line": 31,
+      "members": [
+        {
+          "name": "typeof",
+          "kind": "method",
+          "signature": "typeof(TEntity)",
+          "returnType": "string Name { get; } public Type EntityType =>"
+        },
+        {
+          "name": "MaxFileSizeMb",
+          "kind": "property",
+          "signature": "int MaxFileSizeMb",
+          "returnType": "int"
+        },
+        {
+          "name": "AllowedMimeTypes",
+          "kind": "property",
+          "signature": "IReadOnlyList<string> AllowedMimeTypes",
+          "returnType": "IReadOnlyList<string>"
+        },
+        {
+          "name": "GetFieldMetadata",
+          "kind": "method",
+          "signature": "GetFieldMetadata()",
+          "returnType": "IReadOnlyList<ImportFieldMetadata>"
+        },
+        {
+          "name": "GetBusinessKeyProperties",
+          "kind": "method",
+          "signature": "GetBusinessKeyProperties()",
+          "returnType": "IReadOnlyList<string>"
+        },
+        {
+          "name": "GetExcludedOnUpdateProperties",
+          "kind": "method",
+          "signature": "GetExcludedOnUpdateProperties()",
+          "returnType": "IReadOnlyList<string>"
+        },
+        {
+          "name": "GetGroupByColumn",
+          "kind": "method",
+          "signature": "GetGroupByColumn()",
+          "returnType": "string?"
+        },
+        {
+          "name": "GetHasExternalId",
+          "kind": "method",
+          "signature": "GetHasExternalId()",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "ImportDefinitionBuilder",
+      "fqn": "Granit.DataExchange.Import.Mapping.ImportDefinitionBuilder",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/ImportDefinitionBuilder.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ImportFieldMetadata",
+      "fqn": "Granit.DataExchange.Import.Mapping.ImportFieldMetadata",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/ImportFieldMetadata.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "MappingConfidence",
+      "fqn": "Granit.DataExchange.Import.Mapping.MappingConfidence",
+      "kind": "enum",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/MappingConfidence.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "MappingResult",
+      "fqn": "Granit.DataExchange.Import.Mapping.MappingResult",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/MappingResult.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Entity",
+          "kind": "property",
+          "signature": "TEntity? Entity",
+          "returnType": "TEntity?"
+        },
+        {
+          "name": "Succeeded",
+          "kind": "property",
+          "signature": "bool Succeeded",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "PropertyMapping",
+      "fqn": "Granit.DataExchange.Import.Mapping.PropertyMapping",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/PropertyMapping.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "PropertyPath",
+          "kind": "property",
+          "signature": "required string PropertyPath",
+          "returnType": "required string"
+        },
+        {
+          "name": "ToFieldMetadata",
+          "kind": "method",
+          "signature": "ToFieldMetadata()",
+          "returnType": "bool IsRequired { get; init; } public string? Format { get; init; } public bool IsChildCollection { get; init; } internal ImportFieldMetadata"
+        }
+      ]
+    },
+    {
+      "name": "PropertyMappingBuilder",
+      "fqn": "Granit.DataExchange.Import.Mapping.PropertyMappingBuilder",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/PropertyMappingBuilder.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "SemanticMappingSuggestion",
+      "fqn": "Granit.DataExchange.Import.Mapping.SemanticMappingSuggestion",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/SemanticMappingSuggestion.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ExecuteImportCommand",
+      "fqn": "Granit.DataExchange.Import.Messages.ExecuteImportCommand",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Messages/ExecuteImportCommand.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ImportJobCompletedEvent",
+      "fqn": "Granit.DataExchange.Import.Messages.ImportJobCompletedEvent",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Messages/ImportJobCompletedEvent.cs",
+      "line": 24,
+      "members": []
+    },
+    {
+      "name": "FileParsingOptions",
+      "fqn": "Granit.DataExchange.Import.Parsing.FileParsingOptions",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Parsing/FileParsingOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Encoding",
+          "kind": "property",
+          "signature": "string? Encoding",
+          "returnType": "string?"
+        },
+        {
+          "name": "QuoteChar",
+          "kind": "property",
+          "signature": "string QuoteChar",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "IFileParser",
+      "fqn": "Granit.DataExchange.Import.Parsing.IFileParser",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Parsing/IFileParser.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "CanParse",
+          "kind": "method",
+          "signature": "CanParse(string mimeType)",
+          "returnType": "bool"
+        },
+        {
+          "name": "ExtractHeadersAsync",
+          "kind": "method",
+          "signature": "ExtractHeadersAsync(Stream stream, FileParsingOptions options, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<string>>"
+        },
+        {
+          "name": "ReadPreviewAsync",
+          "kind": "method",
+          "signature": "ReadPreviewAsync(Stream stream, FileParsingOptions options, int maxRows = 10, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<string[]>>"
+        },
+        {
+          "name": "ParseAsync",
+          "kind": "method",
+          "signature": "ParseAsync(Stream stream, FileParsingOptions options, CancellationToken cancellationToken = default)",
+          "returnType": "IAsyncEnumerable<RawImportRow>"
+        }
+      ]
+    },
+    {
+      "name": "RawImportRow",
+      "fqn": "Granit.DataExchange.Import.Parsing.RawImportRow",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Parsing/RawImportRow.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "IImportCommandDispatcher",
+      "fqn": "Granit.DataExchange.Import.Pipeline.IImportCommandDispatcher",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Pipeline/IImportCommandDispatcher.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "DispatchAsync",
+          "kind": "method",
+          "signature": "DispatchAsync(ExecuteImportCommand command, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IImportFileProvider",
+      "fqn": "Granit.DataExchange.Import.Pipeline.IImportFileProvider",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Pipeline/IImportFileProvider.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "OpenAsync",
+          "kind": "method",
+          "signature": "OpenAsync(string blobReference, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Stream>"
+        },
+        {
+          "name": "SaveAsync",
+          "kind": "method",
+          "signature": "SaveAsync(string fileName, Stream content, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(string blobReference, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IImportJobReader",
+      "fqn": "Granit.DataExchange.Import.Pipeline.IImportJobReader",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Pipeline/IImportJobReader.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImportJob?>"
+        },
+        {
+          "name": "ListAsync",
+          "kind": "method",
+          "signature": "ListAsync(ImportJobStatus? status = null, int page = 1, int pageSize = 20, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<ImportJob>>"
+        }
+      ]
+    },
+    {
+      "name": "IImportJobWriter",
+      "fqn": "Granit.DataExchange.Import.Pipeline.IImportJobWriter",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Pipeline/IImportJobWriter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(ImportJob job, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UpdateAsync",
+          "kind": "method",
+          "signature": "UpdateAsync(ImportJob job, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IImportOrchestrator",
+      "fqn": "Granit.DataExchange.Import.Pipeline.IImportOrchestrator",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Pipeline/IImportOrchestrator.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "ExecuteAsync",
+          "kind": "method",
+          "signature": "ExecuteAsync(Guid importJobId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImportReport>"
+        },
+        {
+          "name": "DryRunAsync",
+          "kind": "method",
+          "signature": "DryRunAsync(Guid importJobId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImportReport>"
+        }
+      ]
+    },
+    {
+      "name": "ICorrectionFileGenerator",
+      "fqn": "Granit.DataExchange.Import.Reporting.ICorrectionFileGenerator",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Reporting/ICorrectionFileGenerator.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "GenerateAsync",
+          "kind": "method",
+          "signature": "GenerateAsync(Stream originalFileStream, string mimeType, ImportReport report, FileParsingOptions parsingOptions, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Stream>"
+        }
+      ]
+    },
+    {
+      "name": "ImportProgress",
+      "fqn": "Granit.DataExchange.Import.Reporting.ImportProgress",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Reporting/ImportProgress.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ImportReport",
+      "fqn": "Granit.DataExchange.Import.Reporting.ImportReport",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Reporting/ImportReport.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "ImportRowError",
+      "fqn": "Granit.DataExchange.Import.Reporting.ImportRowError",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Reporting/ImportRowError.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ImportRowErrorKind",
+      "fqn": "Granit.DataExchange.Import.Reporting.ImportRowErrorKind",
+      "kind": "enum",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Reporting/ImportRowErrorKind.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IRowValidator",
+      "fqn": "Granit.DataExchange.Import.Validation.IRowValidator",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Validation/IRowValidator.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "ValidateAsync",
+          "kind": "method",
+          "signature": "ValidateAsync(TEntity entity, int rowNumber, CancellationToken cancellationToken = default)",
+          "returnType": "Task<RowValidationResult>"
+        }
+      ]
+    },
+    {
+      "name": "RowFieldError",
+      "fqn": "Granit.DataExchange.Import.Validation.RowFieldError",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Validation/RowFieldError.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "RowValidationResult",
+      "fqn": "Granit.DataExchange.Import.Validation.RowValidationResult",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Validation/RowValidationResult.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "IsValid",
+          "kind": "property",
+          "signature": "bool IsValid",
+          "returnType": "bool"
+        },
+        {
+          "name": "Errors",
+          "kind": "property",
+          "signature": "IReadOnlyList<RowFieldError> Errors",
+          "returnType": "IReadOnlyList<RowFieldError>"
+        }
+      ]
+    },
+    {
+      "name": "GranitDataExchangeWolverineModule",
+      "fqn": "Granit.DataExchange.Wolverine.GranitDataExchangeWolverineModule",
+      "kind": "class",
+      "project": "Granit.DataExchange.Wolverine",
+      "file": "src/Granit.DataExchange.Wolverine/GranitDataExchangeWolverineModule.cs",
+      "line": 29,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IHealthCheckAggregator",
+      "fqn": "Granit.Diagnostics.Abstractions.IHealthCheckAggregator",
+      "kind": "interface",
+      "project": "Granit.Diagnostics",
+      "file": "src/Granit.Diagnostics/Abstractions/IHealthCheckAggregator.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "CheckAllAsync",
+          "kind": "method",
+          "signature": "CheckAllAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<MonitoringHealthResponse>"
+        }
+      ]
+    },
+    {
+      "name": "CachedHealthCheck",
+      "fqn": "Granit.Diagnostics.Caching.CachedHealthCheck",
+      "kind": "class",
+      "project": "Granit.Diagnostics",
+      "file": "src/Granit.Diagnostics/Caching/CachedHealthCheck.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "CheckHealthAsync",
+          "kind": "method",
+          "signature": "CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task<HealthCheckResult>"
+        }
+      ]
+    },
+    {
+      "name": "MonitoringHealthResponse",
+      "fqn": "Granit.Diagnostics.Dtos.MonitoringHealthResponse",
+      "kind": "record",
+      "project": "Granit.Diagnostics",
+      "file": "src/Granit.Diagnostics/Dtos/MonitoringHealthResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ServiceHealthResponse",
+      "fqn": "Granit.Diagnostics.Dtos.ServiceHealthResponse",
+      "kind": "record",
+      "project": "Granit.Diagnostics",
+      "file": "src/Granit.Diagnostics/Dtos/MonitoringHealthResponse.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "DiagnosticsEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Diagnostics.Endpoints.Extensions.DiagnosticsEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Diagnostics.Endpoints",
+      "file": "src/Granit.Diagnostics.Endpoints/Extensions/DiagnosticsEndpointRouteBuilderExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "MapGranitDiagnosticsMonitoring",
+          "kind": "method",
+          "signature": "MapGranitDiagnosticsMonitoring(this IEndpointRouteBuilder endpoints, Action<DiagnosticsEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitDiagnosticsEndpointsModule",
+      "fqn": "Granit.Diagnostics.Endpoints.GranitDiagnosticsEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Diagnostics.Endpoints",
+      "file": "src/Granit.Diagnostics.Endpoints/GranitDiagnosticsEndpointsModule.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "DiagnosticsEndpointsOptions",
+      "fqn": "Granit.Diagnostics.Endpoints.Options.DiagnosticsEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Diagnostics.Endpoints",
+      "file": "src/Granit.Diagnostics.Endpoints/Options/DiagnosticsEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "DiagnosticsPermissions",
+      "fqn": "Granit.Diagnostics.Endpoints.Permissions.DiagnosticsPermissions",
+      "kind": "class",
+      "project": "Granit.Diagnostics.Endpoints",
+      "file": "src/Granit.Diagnostics.Endpoints/Permissions/DiagnosticsPermissions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "Monitoring",
+      "fqn": "Granit.Diagnostics.Endpoints.Permissions.Monitoring",
+      "kind": "class",
+      "project": "Granit.Diagnostics.Endpoints",
+      "file": "src/Granit.Diagnostics.Endpoints/Permissions/DiagnosticsPermissions.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "DiagnosticsEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Diagnostics.Extensions.DiagnosticsEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Diagnostics",
+      "file": "src/Granit.Diagnostics/Extensions/DiagnosticsEndpointRouteBuilderExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "MapGranitHealthChecks",
+          "kind": "method",
+          "signature": "MapGranitHealthChecks(this IEndpointRouteBuilder endpoints, Action<DiagnosticsOptions>? configure = null)",
+          "returnType": "IEndpointRouteBuilder"
+        }
+      ]
+    },
+    {
+      "name": "DiagnosticsServiceCollectionExtensions",
+      "fqn": "Granit.Diagnostics.Extensions.DiagnosticsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Diagnostics",
+      "file": "src/Granit.Diagnostics/Extensions/DiagnosticsServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitDiagnostics",
+          "kind": "method",
+          "signature": "AddGranitDiagnostics(this IServiceCollection services, Action<DiagnosticsOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitDiagnosticsModule",
+      "fqn": "Granit.Diagnostics.GranitDiagnosticsModule",
+      "kind": "class",
+      "project": "Granit.Diagnostics",
+      "file": "src/Granit.Diagnostics/GranitDiagnosticsModule.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "DiagnosticsOptions",
+      "fqn": "Granit.Diagnostics.Options.DiagnosticsOptions",
+      "kind": "class",
+      "project": "Granit.Diagnostics",
+      "file": "src/Granit.Diagnostics/Options/DiagnosticsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "LivenessPath",
+          "kind": "property",
+          "signature": "string LivenessPath",
+          "returnType": "string"
+        },
+        {
+          "name": "ReadinessPath",
+          "kind": "property",
+          "signature": "string ReadinessPath",
+          "returnType": "string"
+        },
+        {
+          "name": "StartupPath",
+          "kind": "property",
+          "signature": "string StartupPath",
+          "returnType": "string"
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(10)",
+          "returnType": "TimeSpan DefaultCacheDuration { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(30)",
+          "returnType": "TimeSpan MonitoringCacheDuration { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "GranitHealthCheckWriter",
+      "fqn": "Granit.Diagnostics.ResponseWriters.GranitHealthCheckWriter",
+      "kind": "class",
+      "project": "Granit.Diagnostics",
+      "file": "src/Granit.Diagnostics/ResponseWriters/GranitHealthCheckWriter.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "WriteAsync",
+          "kind": "method",
+          "signature": "WriteAsync(HttpContext context, HealthReport report)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.DocumentGeneration.Excel.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.DocumentGeneration.Excel",
+      "file": "src/Granit.DocumentGeneration.Excel/Extensions/ServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitDocumentGenerationExcel",
+          "kind": "method",
+          "signature": "AddGranitDocumentGenerationExcel(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitDocumentGenerationExcelModule",
+      "fqn": "Granit.DocumentGeneration.Excel.GranitDocumentGenerationExcelModule",
+      "kind": "class",
+      "project": "Granit.DocumentGeneration.Excel",
+      "file": "src/Granit.DocumentGeneration.Excel/GranitDocumentGenerationExcelModule.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "DocumentRendererNotFoundException",
+      "fqn": "Granit.DocumentGeneration.Exceptions.DocumentRendererNotFoundException",
+      "kind": "class",
+      "project": "Granit.DocumentGeneration",
+      "file": "src/Granit.DocumentGeneration/Exceptions/DocumentRendererNotFoundException.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "DocumentRendererNotFoundException",
+          "kind": "method",
+          "signature": "DocumentRendererNotFoundException(DocumentFormat format)",
+          "returnType": "DocumentFormat Format { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.DocumentGeneration.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.DocumentGeneration",
+      "file": "src/Granit.DocumentGeneration/Extensions/ServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitDocumentGeneration",
+          "kind": "method",
+          "signature": "AddGranitDocumentGeneration(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitDocumentGenerationModule",
+      "fqn": "Granit.DocumentGeneration.GranitDocumentGenerationModule",
+      "kind": "class",
+      "project": "Granit.DocumentGeneration",
+      "file": "src/Granit.DocumentGeneration/GranitDocumentGenerationModule.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.DocumentGeneration.Pdf.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.DocumentGeneration.Pdf",
+      "file": "src/Granit.DocumentGeneration.Pdf/Extensions/ServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitDocumentGenerationPdf",
+          "kind": "method",
+          "signature": "AddGranitDocumentGenerationPdf(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitDocumentGenerationPdfModule",
+      "fqn": "Granit.DocumentGeneration.Pdf.GranitDocumentGenerationPdfModule",
+      "kind": "class",
+      "project": "Granit.DocumentGeneration.Pdf",
+      "file": "src/Granit.DocumentGeneration.Pdf/GranitDocumentGenerationPdfModule.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "PdfRenderOptions",
+      "fqn": "Granit.DocumentGeneration.Pdf.Options.PdfRenderOptions",
+      "kind": "class",
+      "project": "Granit.DocumentGeneration.Pdf",
+      "file": "src/Granit.DocumentGeneration.Pdf/Options/PdfRenderOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "PaperFormat",
+          "kind": "property",
+          "signature": "string PaperFormat",
+          "returnType": "string"
+        },
+        {
+          "name": "Landscape",
+          "kind": "property",
+          "signature": "bool Landscape",
+          "returnType": "bool"
+        },
+        {
+          "name": "MarginBottom",
+          "kind": "property",
+          "signature": "string MarginBottom",
+          "returnType": "string"
+        },
+        {
+          "name": "MarginLeft",
+          "kind": "property",
+          "signature": "string MarginLeft",
+          "returnType": "string"
+        },
+        {
+          "name": "MarginRight",
+          "kind": "property",
+          "signature": "string MarginRight",
+          "returnType": "string"
+        },
+        {
+          "name": "HeaderTemplate",
+          "kind": "property",
+          "signature": "string? HeaderTemplate",
+          "returnType": "string?"
+        },
+        {
+          "name": "ChromiumExecutablePath",
+          "kind": "property",
+          "signature": "string? ChromiumExecutablePath",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "IPdfAConverter",
+      "fqn": "Granit.DocumentGeneration.Pdf.PdfA.IPdfAConverter",
+      "kind": "interface",
+      "project": "Granit.DocumentGeneration.Pdf",
+      "file": "src/Granit.DocumentGeneration.Pdf/PdfA/IPdfAConverter.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "ConvertToPdfAAsync",
+          "kind": "method",
+          "signature": "ConvertToPdfAAsync(DocumentResult pdfResult, PdfAConversionOptions options, CancellationToken cancellationToken = default)",
+          "returnType": "Task<DocumentResult>"
+        }
+      ]
+    },
+    {
+      "name": "PdfAConformanceLevel",
+      "fqn": "Granit.DocumentGeneration.Pdf.PdfA.PdfAConformanceLevel",
+      "kind": "enum",
+      "project": "Granit.DocumentGeneration.Pdf",
+      "file": "src/Granit.DocumentGeneration.Pdf/PdfA/PdfAConversionOptions.cs",
+      "line": 40,
+      "members": []
+    },
+    {
+      "name": "PdfAConversionOptions",
+      "fqn": "Granit.DocumentGeneration.Pdf.PdfA.PdfAConversionOptions",
+      "kind": "class",
+      "project": "Granit.DocumentGeneration.Pdf",
+      "file": "src/Granit.DocumentGeneration.Pdf/PdfA/PdfAConversionOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ConformanceLevel",
+          "kind": "property",
+          "signature": "PdfAConformanceLevel ConformanceLevel",
+          "returnType": "PdfAConformanceLevel"
+        }
+      ]
+    },
+    {
+      "name": "DocumentResult",
+      "fqn": "Granit.DocumentGeneration.Pipeline.DocumentResult",
+      "kind": "record",
+      "project": "Granit.DocumentGeneration",
+      "file": "src/Granit.DocumentGeneration/Pipeline/DocumentResult.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "DocumentTemplateType",
+      "fqn": "Granit.DocumentGeneration.Pipeline.DocumentTemplateType",
+      "kind": "class",
+      "project": "Granit.DocumentGeneration",
+      "file": "src/Granit.DocumentGeneration/Pipeline/DocumentTemplateType.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "DefaultFormat",
+          "kind": "property",
+          "signature": "DocumentFormat DefaultFormat",
+          "returnType": "DocumentFormat"
+        }
+      ]
+    },
+    {
+      "name": "IDocumentGenerator",
+      "fqn": "Granit.DocumentGeneration.Pipeline.IDocumentGenerator",
+      "kind": "interface",
+      "project": "Granit.DocumentGeneration",
+      "file": "src/Granit.DocumentGeneration/Pipeline/IDocumentGenerator.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "IDocumentRenderer",
+      "fqn": "Granit.DocumentGeneration.Pipeline.IDocumentRenderer",
+      "kind": "interface",
+      "project": "Granit.DocumentGeneration",
+      "file": "src/Granit.DocumentGeneration/Pipeline/IDocumentRenderer.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "CanRender",
+          "kind": "method",
+          "signature": "CanRender(DocumentFormat targetFormat)",
+          "returnType": "bool"
+        },
+        {
+          "name": "RenderAsync",
+          "kind": "method",
+          "signature": "RenderAsync(string html, DocumentFormat targetFormat, CancellationToken cancellationToken = default)",
+          "returnType": "Task<DocumentResult>"
+        }
+      ]
+    },
+    {
+      "name": "EncryptedAttribute",
+      "fqn": "Granit.Encryption.EntityFrameworkCore.EncryptedAttribute",
+      "kind": "class",
+      "project": "Granit.Encryption.EntityFrameworkCore",
+      "file": "src/Granit.Encryption.EntityFrameworkCore/EncryptedAttribute.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "EncryptedStringConverter",
+      "fqn": "Granit.Encryption.EntityFrameworkCore.EncryptedStringConverter",
+      "kind": "class",
+      "project": "Granit.Encryption.EntityFrameworkCore",
+      "file": "src/Granit.Encryption.EntityFrameworkCore/EncryptedStringConverter.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "ModelBuilderEncryptionExtensions",
+      "fqn": "Granit.Encryption.EntityFrameworkCore.Extensions.ModelBuilderEncryptionExtensions",
+      "kind": "class",
+      "project": "Granit.Encryption.EntityFrameworkCore",
+      "file": "src/Granit.Encryption.EntityFrameworkCore/Extensions/ModelBuilderEncryptionExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "ApplyEncryptionConventions",
+          "kind": "method",
+          "signature": "ApplyEncryptionConventions(this ModelBuilder modelBuilder, IStringEncryptionService encryptionService)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitEncryptionEntityFrameworkCoreModule",
+      "fqn": "Granit.Encryption.EntityFrameworkCore.GranitEncryptionEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Encryption.EntityFrameworkCore",
+      "file": "src/Granit.Encryption.EntityFrameworkCore/GranitEncryptionEntityFrameworkCoreModule.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "EncryptionServiceCollectionExtensions",
+      "fqn": "Granit.Encryption.Extensions.EncryptionServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Encryption",
+      "file": "src/Granit.Encryption/Extensions/EncryptionServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitEncryption",
+          "kind": "method",
+          "signature": "AddGranitEncryption(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitEncryptionModule",
+      "fqn": "Granit.Encryption.GranitEncryptionModule",
+      "kind": "class",
+      "project": "Granit.Encryption",
+      "file": "src/Granit.Encryption/GranitEncryptionModule.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IStringEncryptionProvider",
+      "fqn": "Granit.Encryption.IStringEncryptionProvider",
+      "kind": "interface",
+      "project": "Granit.Encryption",
+      "file": "src/Granit.Encryption/IStringEncryptionProvider.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Encrypt",
+          "kind": "method",
+          "signature": "Encrypt(string plainText)",
+          "returnType": "string ProviderName { get; } string"
+        },
+        {
+          "name": "Decrypt",
+          "kind": "method",
+          "signature": "Decrypt(string cipherText)",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "IStringEncryptionService",
+      "fqn": "Granit.Encryption.IStringEncryptionService",
+      "kind": "interface",
+      "project": "Granit.Encryption",
+      "file": "src/Granit.Encryption/IStringEncryptionService.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Encrypt",
+          "kind": "method",
+          "signature": "Encrypt(string plainText)",
+          "returnType": "string"
+        },
+        {
+          "name": "Decrypt",
+          "kind": "method",
+          "signature": "Decrypt(string cipherText)",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "StringEncryptionOptions",
+      "fqn": "Granit.Encryption.Options.StringEncryptionOptions",
+      "kind": "class",
+      "project": "Granit.Encryption",
+      "file": "src/Granit.Encryption/Options/StringEncryptionOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "PassPhrase",
+          "kind": "property",
+          "signature": "string PassPhrase",
+          "returnType": "string"
+        },
+        {
+          "name": "KeySize",
+          "kind": "property",
+          "signature": "int KeySize",
+          "returnType": "int"
+        },
+        {
+          "name": "ProviderName",
+          "kind": "property",
+          "signature": "string ProviderName",
+          "returnType": "string"
+        },
+        {
+          "name": "VaultKeyName",
+          "kind": "property",
+          "signature": "string VaultKeyName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "AesStringEncryptionProvider",
+      "fqn": "Granit.Encryption.Providers.AesStringEncryptionProvider",
+      "kind": "class",
+      "project": "Granit.Encryption",
+      "file": "src/Granit.Encryption/Providers/AesStringEncryptionProvider.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "ProviderName",
+          "kind": "property",
+          "signature": "string ProviderName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "DefaultReEncryptionJob",
+      "fqn": "Granit.Encryption.ReEncryption.DefaultReEncryptionJob",
+      "kind": "class",
+      "project": "Granit.Encryption.ReEncryption",
+      "file": "src/Granit.Encryption.ReEncryption/DefaultReEncryptionJob.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "ReEncryptionServiceCollectionExtensions",
+      "fqn": "Granit.Encryption.ReEncryption.Extensions.ReEncryptionServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Encryption.ReEncryption",
+      "file": "src/Granit.Encryption.ReEncryption/Extensions/ReEncryptionServiceCollectionExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "GranitEncryptionReEncryptionModule",
+      "fqn": "Granit.Encryption.ReEncryption.GranitEncryptionReEncryptionModule",
+      "kind": "class",
+      "project": "Granit.Encryption.ReEncryption",
+      "file": "src/Granit.Encryption.ReEncryption/GranitEncryptionReEncryptionModule.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "IReEncryptionJob",
+      "fqn": "Granit.Encryption.ReEncryption.IReEncryptionJob",
+      "kind": "interface",
+      "project": "Granit.Encryption.ReEncryption",
+      "file": "src/Granit.Encryption.ReEncryption/IReEncryptionJob.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "DefaultStringEncryptionService",
+      "fqn": "Granit.Encryption.Services.DefaultStringEncryptionService",
+      "kind": "class",
+      "project": "Granit.Encryption",
+      "file": "src/Granit.Encryption/Services/DefaultStringEncryptionService.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "Decrypt",
+          "kind": "method",
+          "signature": "Decrypt(string cipherText)",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "EventBusMetrics",
+      "fqn": "Granit.EventBus.Diagnostics.EventBusMetrics",
+      "kind": "class",
+      "project": "Granit.EventBus",
+      "file": "src/Granit.EventBus/Diagnostics/EventBusMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordHandlerExecuted",
+          "kind": "method",
+          "signature": "RecordHandlerExecuted(string? tenantId, string eventType, string status)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "EventBusServiceCollectionExtensions",
+      "fqn": "Granit.EventBus.Extensions.EventBusServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.EventBus",
+      "file": "src/Granit.EventBus/Extensions/EventBusServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitEventBus",
+          "kind": "method",
+          "signature": "AddGranitEventBus(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitEventBusModule",
+      "fqn": "Granit.EventBus.GranitEventBusModule",
+      "kind": "class",
+      "project": "Granit.EventBus",
+      "file": "src/Granit.EventBus/GranitEventBusModule.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GranitEventBusWolverineModule",
+      "fqn": "Granit.EventBus.Wolverine.GranitEventBusWolverineModule",
+      "kind": "class",
+      "project": "Granit.EventBus.Wolverine",
+      "file": "src/Granit.EventBus.Wolverine/GranitEventBusWolverineModule.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "FeatureEndpointConventionBuilderExtensions",
+      "fqn": "Granit.Features.AspNetCore.FeatureEndpointConventionBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/AspNetCore/FeatureEndpointConventionBuilderExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "RequiresFeature",
+          "kind": "method",
+          "signature": "RequiresFeature(this IEndpointConventionBuilder builder, string featureName)",
+          "returnType": "IEndpointConventionBuilder"
+        }
+      ]
+    },
+    {
+      "name": "FeatureCacheInvalidationHandler",
+      "fqn": "Granit.Features.Cache.FeatureCacheInvalidationHandler",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Cache/FeatureCacheInvalidationHandler.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(FeatureValueChangedEvent @event, IFusionCache cache, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "FeatureDefinition",
+      "fqn": "Granit.Features.Definitions.FeatureDefinition",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Definitions/FeatureDefinition.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "FeatureDefinition",
+          "kind": "method",
+          "signature": "FeatureDefinition(string name, string defaultValue, FeatureValueType valueType)",
+          "returnType": "string Name { get; } public string DefaultValue { get; } public FeatureValueType ValueType { get; } public NumericConstraint? NumericConstraint { get; init; } public SelectionValues? SelectionValues { get; init; } public string? DisplayName { get; init; } public string? Description { get; init; } public"
+        }
+      ]
+    },
+    {
+      "name": "FeatureGroupDefinition",
+      "fqn": "Granit.Features.Definitions.FeatureGroupDefinition",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Definitions/FeatureGroupDefinition.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Features",
+          "kind": "property",
+          "signature": "IReadOnlyList<FeatureDefinition> Features",
+          "returnType": "IReadOnlyList<FeatureDefinition>"
+        }
+      ]
+    },
+    {
+      "name": "IFeatureDefinitionContext",
+      "fqn": "Granit.Features.Definitions.IFeatureDefinitionContext",
+      "kind": "interface",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Definitions/IFeatureDefinitionContext.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "AddGroup",
+          "kind": "method",
+          "signature": "AddGroup(string name, string? displayName = null)",
+          "returnType": "FeatureGroupDefinition"
+        }
+      ]
+    },
+    {
+      "name": "IFeatureDefinitionProvider",
+      "fqn": "Granit.Features.Definitions.IFeatureDefinitionProvider",
+      "kind": "interface",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Definitions/FeatureDefinitionProvider.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "Define",
+          "kind": "method",
+          "signature": "Define(IFeatureDefinitionContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IFeatureDefinitionStore",
+      "fqn": "Granit.Features.Definitions.IFeatureDefinitionStore",
+      "kind": "interface",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Definitions/IFeatureDefinitionStore.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetRequired",
+          "kind": "method",
+          "signature": "GetRequired(string featureName)",
+          "returnType": "FeatureDefinition"
+        },
+        {
+          "name": "GetOrNull",
+          "kind": "method",
+          "signature": "GetOrNull(string featureName)",
+          "returnType": "FeatureDefinition?"
+        },
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IReadOnlyList<FeatureDefinition>"
+        }
+      ]
+    },
+    {
+      "name": "FeatureDefinitionResponse",
+      "fqn": "Granit.Features.Endpoints.Dtos.FeatureDefinitionResponse",
+      "kind": "record",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/Dtos/FeatureDefinitionResponse.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "FeatureGroupResponse",
+      "fqn": "Granit.Features.Endpoints.Dtos.FeatureGroupResponse",
+      "kind": "record",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/Dtos/FeatureGroupResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "FeatureNumericConstraintResponse",
+      "fqn": "Granit.Features.Endpoints.Dtos.FeatureNumericConstraintResponse",
+      "kind": "record",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/Dtos/FeatureDefinitionResponse.cs",
+      "line": 27,
+      "members": []
+    },
+    {
+      "name": "FeatureValueResponse",
+      "fqn": "Granit.Features.Endpoints.Dtos.FeatureValueResponse",
+      "kind": "record",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/Dtos/FeatureValueResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "SetFeatureOverrideRequest",
+      "fqn": "Granit.Features.Endpoints.Dtos.SetFeatureOverrideRequest",
+      "kind": "record",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/Dtos/SetFeatureOverrideRequest.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "FeaturesEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Features.Endpoints.Extensions.FeaturesEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/Extensions/FeaturesEndpointRouteBuilderExtensions.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "MapGranitFeatures",
+          "kind": "method",
+          "signature": "MapGranitFeatures(this IEndpointRouteBuilder endpoints, Action<FeaturesEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitFeaturesEndpointsModule",
+      "fqn": "Granit.Features.Endpoints.GranitFeaturesEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/GranitFeaturesEndpointsModule.cs",
+      "line": 26,
+      "members": []
+    },
+    {
+      "name": "FeaturesEndpointsOptions",
+      "fqn": "Granit.Features.Endpoints.Options.FeaturesEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/Options/FeaturesEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "FeaturesPermissions",
+      "fqn": "Granit.Features.Endpoints.Permissions.FeaturesPermissions",
+      "kind": "class",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/Permissions/FeaturesPermissions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "Flags",
+      "fqn": "Granit.Features.Endpoints.Permissions.Flags",
+      "kind": "class",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/Permissions/FeaturesPermissions.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "FeaturesEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.Features.EntityFrameworkCore.Extensions.FeaturesEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Features.EntityFrameworkCore",
+      "file": "src/Granit.Features.EntityFrameworkCore/Extensions/FeaturesEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitFeaturesEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitFeaturesEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "FeaturesModelBuilderExtensions",
+      "fqn": "Granit.Features.EntityFrameworkCore.Extensions.FeaturesModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Features.EntityFrameworkCore",
+      "file": "src/Granit.Features.EntityFrameworkCore/Extensions/FeaturesModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureFeaturesModule",
+          "kind": "method",
+          "signature": "ConfigureFeaturesModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitFeaturesDbProperties",
+      "fqn": "Granit.Features.EntityFrameworkCore.GranitFeaturesDbProperties",
+      "kind": "class",
+      "project": "Granit.Features.EntityFrameworkCore",
+      "file": "src/Granit.Features.EntityFrameworkCore/GranitFeaturesDbProperties.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitFeaturesEntityFrameworkCoreModule",
+      "fqn": "Granit.Features.EntityFrameworkCore.GranitFeaturesEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Features.EntityFrameworkCore",
+      "file": "src/Granit.Features.EntityFrameworkCore/GranitFeaturesEntityFrameworkCoreModule.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "FeatureOverrideChangedEvent",
+      "fqn": "Granit.Features.Events.FeatureOverrideChangedEvent",
+      "kind": "record",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Events/FeatureOverrideChangedEvent.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "FeatureValueChangedEvent",
+      "fqn": "Granit.Features.Events.FeatureValueChangedEvent",
+      "kind": "record",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Events/FeatureValueChangedEvent.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "FeatureLimitExceededException",
+      "fqn": "Granit.Features.Exceptions.FeatureLimitExceededException",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Exceptions/FeatureLimitExceededException.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "FeatureName",
+          "kind": "property",
+          "signature": "string FeatureName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "FeatureNotEnabledException",
+      "fqn": "Granit.Features.Exceptions.FeatureNotEnabledException",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Exceptions/FeatureNotEnabledException.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "FeatureName",
+          "kind": "property",
+          "signature": "string FeatureName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "FeatureNotFoundException",
+      "fqn": "Granit.Features.Exceptions.FeatureNotFoundException",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Exceptions/FeatureNotFoundException.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "FeatureNotFoundException",
+          "kind": "method",
+          "signature": "FeatureNotFoundException(string featureName)",
+          "returnType": "string FeatureName { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "FeatureValueValidationException",
+      "fqn": "Granit.Features.Exceptions.FeatureValueValidationException",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Exceptions/FeatureValueValidationException.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "FeatureValueValidationException",
+          "kind": "method",
+          "signature": "FeatureValueValidationException(string featureName, string invalidValue, string reason)",
+          "returnType": "string FeatureName { get; } public string InvalidValue { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.Features.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Extensions/ServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitFeatures",
+          "kind": "method",
+          "signature": "AddGranitFeatures(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "FeaturesLocalizationResource",
+      "fqn": "Granit.Features.FeaturesLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/FeaturesLocalizationResource.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "GranitFeaturesModule",
+      "fqn": "Granit.Features.GranitFeaturesModule",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/GranitFeaturesModule.cs",
+      "line": 33,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IFeatureChecker",
+      "fqn": "Granit.Features.IFeatureChecker",
+      "kind": "interface",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/IFeatureChecker.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "IsEnabledAsync",
+          "kind": "method",
+          "signature": "IsEnabledAsync(string featureName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        },
+        {
+          "name": "GetNumericAsync",
+          "kind": "method",
+          "signature": "GetNumericAsync(string featureName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<long>"
+        },
+        {
+          "name": "GetValueAsync",
+          "kind": "method",
+          "signature": "GetValueAsync(string featureName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
+        },
+        {
+          "name": "RequireEnabledAsync",
+          "kind": "method",
+          "signature": "RequireEnabledAsync(string featureName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IFeatureLimitGuard",
+      "fqn": "Granit.Features.IFeatureLimitGuard",
+      "kind": "interface",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/IFeatureLimitGuard.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "CheckAsync",
+          "kind": "method",
+          "signature": "CheckAsync(string featureName, long currentCount, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "GetLimitAsync",
+          "kind": "method",
+          "signature": "GetLimitAsync(string featureName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<long>"
+        }
+      ]
+    },
+    {
+      "name": "IFeatureStoreReader",
+      "fqn": "Granit.Features.IFeatureStoreReader",
+      "kind": "interface",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/IFeatureStoreReader.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(string featureName, string? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string?>"
+        }
+      ]
+    },
+    {
+      "name": "IFeatureStoreWriter",
+      "fqn": "Granit.Features.IFeatureStoreWriter",
+      "kind": "interface",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/IFeatureStoreWriter.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SetAsync",
+          "kind": "method",
+          "signature": "SetAsync(string featureName, string? tenantId, string value, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(string featureName, string? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IPlanFeatureStore",
+      "fqn": "Granit.Features.Plans.IPlanFeatureStore",
+      "kind": "interface",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Plans/IPlanFeatureStore.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(string planId, string featureName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string?>"
+        }
+      ]
+    },
+    {
+      "name": "IPlanIdProvider",
+      "fqn": "Granit.Features.Plans.IPlanIdProvider",
+      "kind": "interface",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Plans/IPlanIdProvider.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "GetCurrentPlanIdAsync",
+          "kind": "method",
+          "signature": "GetCurrentPlanIdAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<string?>"
+        }
+      ]
+    },
+    {
+      "name": "RequiresFeatureAttribute",
+      "fqn": "Granit.Features.RequiresFeatureAttribute",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/RequiresFeatureAttribute.cs",
+      "line": 41,
+      "members": [
+        {
+          "name": "FeatureName",
+          "kind": "property",
+          "signature": "string FeatureName",
+          "returnType": "string"
+        },
+        {
+          "name": "IsReusable",
+          "kind": "property",
+          "signature": "bool IsReusable",
+          "returnType": "bool"
+        },
+        {
+          "name": "CreateInstance",
+          "kind": "method",
+          "signature": "CreateInstance(IServiceProvider serviceProvider)",
+          "returnType": "IFilterMetadata"
+        }
+      ]
+    },
+    {
+      "name": "IFeatureValueProvider",
+      "fqn": "Granit.Features.ValueProviders.IFeatureValueProvider",
+      "kind": "interface",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/ValueProviders/IFeatureValueProvider.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(FeatureDefinition definition, CancellationToken cancellationToken = default)",
+          "returnType": "string Name { get; } int Order { get; } Task<string?>"
+        }
+      ]
+    },
+    {
+      "name": "FeatureValueType",
+      "fqn": "Granit.Features.ValueTypes.FeatureValueType",
+      "kind": "enum",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/ValueTypes/FeatureValueType.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "NumericConstraint",
+      "fqn": "Granit.Features.ValueTypes.NumericConstraint",
+      "kind": "record",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/ValueTypes/NumericConstraint.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Validate",
+          "kind": "method",
+          "signature": "Validate(string featureName, string rawValue)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "SelectionValues",
+      "fqn": "Granit.Features.ValueTypes.SelectionValues",
+      "kind": "record",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/ValueTypes/SelectionValues.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Validate",
+          "kind": "method",
+          "signature": "Validate(string featureName, string rawValue)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "RequiresFeatureMiddleware",
+      "fqn": "Granit.Features.Wolverine.RequiresFeatureMiddleware",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Wolverine/RequiresFeatureMiddleware.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "BeforeAsync",
+          "kind": "method",
+          "signature": "BeforeAsync(object message, IFeatureChecker featureChecker, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "GuidsServiceCollectionExtensions",
+      "fqn": "Granit.Guids.Extensions.GuidsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Guids",
+      "file": "src/Granit.Guids/Extensions/GuidsServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitGuids",
+          "kind": "method",
+          "signature": "AddGranitGuids(this IServiceCollection services, Action<GuidGeneratorOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitGuidsModule",
+      "fqn": "Granit.Guids.GranitGuidsModule",
+      "kind": "class",
+      "project": "Granit.Guids",
+      "file": "src/Granit.Guids/GranitGuidsModule.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GuidStrategy",
+      "fqn": "Granit.Guids.GuidStrategy",
+      "kind": "enum",
+      "project": "Granit.Guids",
+      "file": "src/Granit.Guids/GuidStrategy.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IGuidGenerator",
+      "fqn": "Granit.Guids.IGuidGenerator",
+      "kind": "interface",
+      "project": "Granit.Guids",
+      "file": "src/Granit.Guids/IGuidGenerator.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create()",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "GuidGeneratorOptions",
+      "fqn": "Granit.Guids.Options.GuidGeneratorOptions",
+      "kind": "class",
+      "project": "Granit.Guids",
+      "file": "src/Granit.Guids/Options/GuidGeneratorOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Strategy",
+          "kind": "property",
+          "signature": "GuidStrategy Strategy",
+          "returnType": "GuidStrategy"
+        },
+        {
+          "name": "GetDefaultSequentialGuidType",
+          "kind": "method",
+          "signature": "GetDefaultSequentialGuidType()",
+          "returnType": "SequentialGuidType? DefaultSequentialGuidType { get; set; } public SequentialGuidType"
+        }
+      ]
+    },
+    {
+      "name": "SequentialGuidGenerator",
+      "fqn": "Granit.Guids.SequentialGuidGenerator",
+      "kind": "class",
+      "project": "Granit.Guids",
+      "file": "src/Granit.Guids/SequentialGuidGenerator.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create()",
+          "returnType": "Guid"
+        },
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(SequentialGuidType guidType)",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "SequentialGuidType",
+      "fqn": "Granit.Guids.SequentialGuidType",
+      "kind": "enum",
+      "project": "Granit.Guids",
+      "file": "src/Granit.Guids/SequentialGuidType.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "SimpleGuidGenerator",
+      "fqn": "Granit.Guids.SimpleGuidGenerator",
+      "kind": "class",
+      "project": "Granit.Guids",
+      "file": "src/Granit.Guids/SimpleGuidGenerator.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "SimpleGuidGenerator Instance { get; } ="
+        },
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create()",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "UuidV7GuidGenerator",
+      "fqn": "Granit.Guids.UuidV7GuidGenerator",
+      "kind": "class",
+      "project": "Granit.Guids",
+      "file": "src/Granit.Guids/UuidV7GuidGenerator.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create()",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "InternalApiAttribute",
+      "fqn": "Granit.Http.ApiDocumentation.Attributes.InternalApiAttribute",
+      "kind": "class",
+      "project": "Granit.Http.ApiDocumentation",
+      "file": "src/Granit.Http.ApiDocumentation/Attributes/InternalApiAttribute.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ApiDocumentationApplicationBuilderExtensions",
+      "fqn": "Granit.Http.ApiDocumentation.Extensions.ApiDocumentationApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.ApiDocumentation",
+      "file": "src/Granit.Http.ApiDocumentation/Extensions/ApiDocumentationApplicationBuilderExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "UseGranitApiDocumentation",
+          "kind": "method",
+          "signature": "UseGranitApiDocumentation(this WebApplication app)",
+          "returnType": "WebApplication"
+        }
+      ]
+    },
+    {
+      "name": "ApiDocumentationServiceCollectionExtensions",
+      "fqn": "Granit.Http.ApiDocumentation.Extensions.ApiDocumentationServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.ApiDocumentation",
+      "file": "src/Granit.Http.ApiDocumentation/Extensions/ApiDocumentationServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitApiDocumentation",
+          "kind": "method",
+          "signature": "AddGranitApiDocumentation(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpApiDocumentationModule",
+      "fqn": "Granit.Http.ApiDocumentation.GranitHttpApiDocumentationModule",
+      "kind": "class",
+      "project": "Granit.Http.ApiDocumentation",
+      "file": "src/Granit.Http.ApiDocumentation/GranitHttpApiDocumentationModule.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ISchemaExampleProvider",
+      "fqn": "Granit.Http.ApiDocumentation.ISchemaExampleProvider",
+      "kind": "interface",
+      "project": "Granit.Http.ApiDocumentation",
+      "file": "src/Granit.Http.ApiDocumentation/ISchemaExampleProvider.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetExamples",
+          "kind": "method",
+          "signature": "GetExamples()",
+          "returnType": "IReadOnlyDictionary<Type, JsonNode>"
+        }
+      ]
+    },
+    {
+      "name": "ApiDocumentationOptions",
+      "fqn": "Granit.Http.ApiDocumentation.Options.ApiDocumentationOptions",
+      "kind": "class",
+      "project": "Granit.Http.ApiDocumentation",
+      "file": "src/Granit.Http.ApiDocumentation/Options/ApiDocumentationOptions.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "MajorVersions",
+          "kind": "property",
+          "signature": "IList<int> MajorVersions",
+          "returnType": "IList<int>"
+        },
+        {
+          "name": "Title",
+          "kind": "property",
+          "signature": "string Title",
+          "returnType": "string"
+        },
+        {
+          "name": "Description",
+          "kind": "property",
+          "signature": "string? Description",
+          "returnType": "string?"
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "string? AuthorizationPolicy { get; set; } public OAuth2Options OAuth2 { get; set; } ="
+        }
+      ]
+    },
+    {
+      "name": "OAuth2Options",
+      "fqn": "Granit.Http.ApiDocumentation.Options.OAuth2Options",
+      "kind": "class",
+      "project": "Granit.Http.ApiDocumentation",
+      "file": "src/Granit.Http.ApiDocumentation/Options/OAuth2Options.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "AuthorizationUrl",
+          "kind": "property",
+          "signature": "string? AuthorizationUrl",
+          "returnType": "string?"
+        },
+        {
+          "name": "Scopes",
+          "kind": "property",
+          "signature": "IList<string> Scopes",
+          "returnType": "IList<string>"
+        }
+      ]
+    },
+    {
+      "name": "DeprecatedAttribute",
+      "fqn": "Granit.Http.ApiVersioning.Deprecation.DeprecatedAttribute",
+      "kind": "class",
+      "project": "Granit.Http.ApiVersioning",
+      "file": "src/Granit.Http.ApiVersioning/Deprecation/DeprecatedAttribute.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "DeprecationEndpointExtensions",
+      "fqn": "Granit.Http.ApiVersioning.Deprecation.DeprecationEndpointExtensions",
+      "kind": "class",
+      "project": "Granit.Http.ApiVersioning",
+      "file": "src/Granit.Http.ApiVersioning/Deprecation/DeprecationEndpointExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Deprecated",
+          "kind": "method",
+          "signature": "Deprecated(this RouteHandlerBuilder builder, string? sunsetDate = null, string? link = null)",
+          "returnType": "RouteHandlerBuilder"
+        }
+      ]
+    },
+    {
+      "name": "ApiVersioningServiceCollectionExtensions",
+      "fqn": "Granit.Http.ApiVersioning.Extensions.ApiVersioningServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.ApiVersioning",
+      "file": "src/Granit.Http.ApiVersioning/Extensions/ApiVersioningServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitApiVersioning",
+          "kind": "method",
+          "signature": "AddGranitApiVersioning(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpApiVersioningModule",
+      "fqn": "Granit.Http.ApiVersioning.GranitHttpApiVersioningModule",
+      "kind": "class",
+      "project": "Granit.Http.ApiVersioning",
+      "file": "src/Granit.Http.ApiVersioning/GranitHttpApiVersioningModule.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GranitApiVersioningOptions",
+      "fqn": "Granit.Http.ApiVersioning.Options.GranitApiVersioningOptions",
+      "kind": "class",
+      "project": "Granit.Http.ApiVersioning",
+      "file": "src/Granit.Http.ApiVersioning/Options/GranitApiVersioningOptions.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "DefaultMajorVersion",
+          "kind": "property",
+          "signature": "int DefaultMajorVersion",
+          "returnType": "int"
+        },
+        {
+          "name": "ReportApiVersions",
+          "kind": "property",
+          "signature": "bool ReportApiVersions",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "BulkheadLease",
+      "fqn": "Granit.Http.Bulkhead.Abstractions.BulkheadLease",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/Abstractions/BulkheadLease.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(null, null)",
+          "returnType": "BulkheadLease NoOp ="
+        }
+      ]
+    },
+    {
+      "name": "IBulkheadQuotaProvider",
+      "fqn": "Granit.Http.Bulkhead.Abstractions.IBulkheadQuotaProvider",
+      "kind": "interface",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/Abstractions/IBulkheadQuotaProvider.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "GetPermitLimitAsync",
+          "kind": "method",
+          "signature": "GetPermitLimitAsync(string policyName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int?>"
+        }
+      ]
+    },
+    {
+      "name": "BulkheadEndpointExtensions",
+      "fqn": "Granit.Http.Bulkhead.AspNetCore.BulkheadEndpointExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/AspNetCore/BulkheadEndpointExtensions.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "BulkheadAttribute",
+      "fqn": "Granit.Http.Bulkhead.Attributes.BulkheadAttribute",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/Attributes/BulkheadAttribute.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "PolicyName",
+          "kind": "property",
+          "signature": "string PolicyName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "ConcurrencyLimiterRegistry",
+      "fqn": "Granit.Http.Bulkhead.ConcurrencyLimiterRegistry",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/ConcurrencyLimiterRegistry.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "AcquireAsync",
+          "kind": "method",
+          "signature": "AcquireAsync(string key, int permitLimit, int queueLimit, CancellationToken cancellationToken)",
+          "returnType": "ValueTask<RateLimitLease>"
+        },
+        {
+          "name": "Dispose",
+          "kind": "method",
+          "signature": "Dispose()",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "BulkheadMetrics",
+      "fqn": "Granit.Http.Bulkhead.Diagnostics.BulkheadMetrics",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/Diagnostics/BulkheadMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordReleased",
+          "kind": "method",
+          "signature": "RecordReleased(string policyName, string? tenantId)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordRejected",
+          "kind": "method",
+          "signature": "RecordRejected(string policyName, string? tenantId)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "BulkheadRejectedException",
+      "fqn": "Granit.Http.Bulkhead.Exceptions.BulkheadRejectedException",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/Exceptions/BulkheadRejectedException.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "BulkheadServiceCollectionExtensions",
+      "fqn": "Granit.Http.Bulkhead.Extensions.BulkheadServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/Extensions/BulkheadServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitBulkhead",
+          "kind": "method",
+          "signature": "AddGranitBulkhead(this IServiceCollection services, Action<GranitBulkheadOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpBulkheadModule",
+      "fqn": "Granit.Http.Bulkhead.GranitHttpBulkheadModule",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/GranitHttpBulkheadModule.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "BulkheadPolicyOptions",
+      "fqn": "Granit.Http.Bulkhead.Options.BulkheadPolicyOptions",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/Options/BulkheadPolicyOptions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "PermitLimit",
+          "kind": "property",
+          "signature": "int PermitLimit",
+          "returnType": "int"
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(30)",
+          "returnType": "int QueueLimit { get; set; } public TimeSpan QueueTimeout { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "GranitBulkheadOptions",
+      "fqn": "Granit.Http.Bulkhead.Options.GranitBulkheadOptions",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/Options/GranitBulkheadOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Enabled",
+          "kind": "property",
+          "signature": "bool Enabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "BypassRoles",
+          "kind": "property",
+          "signature": "string[] BypassRoles",
+          "returnType": "string[]"
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(StringComparer.OrdinalIgnoreCase)",
+          "returnType": "bool UseFeatureBasedQuotas { get; set; } public Dictionary<string, BulkheadPolicyOptions> Policies { get; set; } ="
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(30)",
+          "returnType": "TimeSpan IdleTimeout { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(5)",
+          "returnType": "TimeSpan CleanupInterval { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "TenantPartitionedBulkhead",
+      "fqn": "Granit.Http.Bulkhead.TenantPartitionedBulkhead",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/TenantPartitionedBulkhead.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "AcquireAsync",
+          "kind": "method",
+          "signature": "AcquireAsync(string policyName, CancellationToken cancellationToken)",
+          "returnType": "Task<BulkheadLease>"
+        }
+      ]
+    },
+    {
+      "name": "BulkheadMiddleware",
+      "fqn": "Granit.Http.Bulkhead.Wolverine.BulkheadMiddleware",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/Wolverine/BulkheadMiddleware.cs",
+      "line": 29,
+      "members": [
+        {
+          "name": "BeforeAsync",
+          "kind": "method",
+          "signature": "BeforeAsync(object message, TenantPartitionedBulkhead bulkhead, CancellationToken cancellationToken)",
+          "returnType": "Task<BulkheadLease>"
+        }
+      ]
+    },
+    {
+      "name": "CookieCategory",
+      "fqn": "Granit.Http.Cookies.CookieCategory",
+      "kind": "enum",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/CookieCategory.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "CookieDefinition",
+      "fqn": "Granit.Http.Cookies.CookieDefinition",
+      "kind": "record",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/CookieDefinition.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "CookiesLocalizationResource",
+      "fqn": "Granit.Http.Cookies.CookiesLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/CookiesLocalizationResource.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "CookieConsentConfigResponse",
+      "fqn": "Granit.Http.Cookies.Endpoints.Dtos.CookieConsentConfigResponse",
+      "kind": "record",
+      "project": "Granit.Http.Cookies.Endpoints",
+      "file": "src/Granit.Http.Cookies.Endpoints/Dtos/CookieConsentConfigResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "CookieDefinitionResponse",
+      "fqn": "Granit.Http.Cookies.Endpoints.Dtos.CookieDefinitionResponse",
+      "kind": "record",
+      "project": "Granit.Http.Cookies.Endpoints",
+      "file": "src/Granit.Http.Cookies.Endpoints/Dtos/CookieConsentConfigResponse.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "ThirdPartyServiceResponse",
+      "fqn": "Granit.Http.Cookies.Endpoints.Dtos.ThirdPartyServiceResponse",
+      "kind": "record",
+      "project": "Granit.Http.Cookies.Endpoints",
+      "file": "src/Granit.Http.Cookies.Endpoints/Dtos/CookieConsentConfigResponse.cs",
+      "line": 32,
+      "members": []
+    },
+    {
+      "name": "CookieConsentEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Http.Cookies.Endpoints.Extensions.CookieConsentEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Cookies.Endpoints",
+      "file": "src/Granit.Http.Cookies.Endpoints/Extensions/CookieConsentEndpointRouteBuilderExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "MapGranitCookieConsent",
+          "kind": "method",
+          "signature": "MapGranitCookieConsent(this IEndpointRouteBuilder endpoints, Action<CookieConsentEndpointsOptions>? configure = null)",
+          "returnType": "IEndpointRouteBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpCookiesEndpointsModule",
+      "fqn": "Granit.Http.Cookies.Endpoints.GranitHttpCookiesEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Http.Cookies.Endpoints",
+      "file": "src/Granit.Http.Cookies.Endpoints/GranitHttpCookiesEndpointsModule.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "CookieConsentEndpointsOptions",
+      "fqn": "Granit.Http.Cookies.Endpoints.Options.CookieConsentEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Http.Cookies.Endpoints",
+      "file": "src/Granit.Http.Cookies.Endpoints/Options/CookieConsentEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "UnregisteredCookieException",
+      "fqn": "Granit.Http.Cookies.Exceptions.UnregisteredCookieException",
+      "kind": "class",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/Exceptions/UnregisteredCookieException.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "UnregisteredCookieException",
+          "kind": "method",
+          "signature": "UnregisteredCookieException(string cookieName)",
+          "returnType": "string CookieName { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "CookiesServiceCollectionExtensions",
+      "fqn": "Granit.Http.Cookies.Extensions.CookiesServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/Extensions/CookiesServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitCookies",
+          "kind": "method",
+          "signature": "AddGranitCookies(this IServiceCollection services, Action<GranitCookiesBuilder> configure)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitCookiesBuilder",
+      "fqn": "Granit.Http.Cookies.GranitCookiesBuilder",
+      "kind": "class",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/GranitCookiesBuilder.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "RegisterCookie",
+          "kind": "method",
+          "signature": "RegisterCookie(CookieDefinition definition)",
+          "returnType": "GranitCookiesBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpCookiesModule",
+      "fqn": "Granit.Http.Cookies.GranitHttpCookiesModule",
+      "kind": "class",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/GranitHttpCookiesModule.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "IConsentResolver",
+      "fqn": "Granit.Http.Cookies.IConsentResolver",
+      "kind": "interface",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/IConsentResolver.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "ResolveAsync",
+          "kind": "method",
+          "signature": "ResolveAsync(HttpContext httpContext, CookieCategory category)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "ICookieRegistry",
+      "fqn": "Granit.Http.Cookies.ICookieRegistry",
+      "kind": "interface",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/ICookieRegistry.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Register",
+          "kind": "method",
+          "signature": "Register(CookieDefinition definition)",
+          "returnType": "void"
+        },
+        {
+          "name": "GetDefinition",
+          "kind": "method",
+          "signature": "GetDefinition(string cookieName)",
+          "returnType": "CookieDefinition?"
+        },
+        {
+          "name": "GetByCategory",
+          "kind": "method",
+          "signature": "GetByCategory(CookieCategory category)",
+          "returnType": "IReadOnlyList<CookieDefinition>"
+        },
+        {
+          "name": "IsRegistered",
+          "kind": "method",
+          "signature": "IsRegistered(string cookieName)",
+          "returnType": "bool"
+        },
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IReadOnlyList<CookieDefinition>"
+        }
+      ]
+    },
+    {
+      "name": "IGranitCookieManager",
+      "fqn": "Granit.Http.Cookies.IGranitCookieManager",
+      "kind": "interface",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/IGranitCookieManager.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "SetCookieAsync",
+          "kind": "method",
+          "signature": "SetCookieAsync(HttpContext httpContext, string cookieName, string value)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RevokeCategoryAsync",
+          "kind": "method",
+          "signature": "RevokeCategoryAsync(HttpContext httpContext, CookieCategory category)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteCookie",
+          "kind": "method",
+          "signature": "DeleteCookie(HttpContext httpContext, string cookieName)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IThirdPartyServiceRegistry",
+      "fqn": "Granit.Http.Cookies.IThirdPartyServiceRegistry",
+      "kind": "interface",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/IThirdPartyServiceRegistry.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IReadOnlyList<ThirdPartyServiceDefinition>"
+        },
+        {
+          "name": "GetByCategory",
+          "kind": "method",
+          "signature": "GetByCategory(CookieCategory category)",
+          "returnType": "IReadOnlyList<ThirdPartyServiceDefinition>"
+        }
+      ]
+    },
+    {
+      "name": "GranitCookiesBuilderExtensions",
+      "fqn": "Granit.Http.Cookies.Klaro.Extensions.GranitCookiesBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Cookies.Klaro",
+      "file": "src/Granit.Http.Cookies.Klaro/Extensions/GranitCookiesBuilderExtensions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "UseKlaro",
+          "kind": "method",
+          "signature": "UseKlaro(this GranitCookiesBuilder builder)",
+          "returnType": "GranitCookiesBuilder"
+        }
+      ]
+    },
+    {
+      "name": "KlaroServiceCollectionExtensions",
+      "fqn": "Granit.Http.Cookies.Klaro.Extensions.KlaroServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Cookies.Klaro",
+      "file": "src/Granit.Http.Cookies.Klaro/Extensions/KlaroServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitCookiesKlaro",
+          "kind": "method",
+          "signature": "AddGranitCookiesKlaro(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpCookiesKlaroModule",
+      "fqn": "Granit.Http.Cookies.Klaro.GranitHttpCookiesKlaroModule",
+      "kind": "class",
+      "project": "Granit.Http.Cookies.Klaro",
+      "file": "src/Granit.Http.Cookies.Klaro/GranitHttpCookiesKlaroModule.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "KlaroOptions",
+      "fqn": "Granit.Http.Cookies.Klaro.Options.KlaroOptions",
+      "kind": "class",
+      "project": "Granit.Http.Cookies.Klaro",
+      "file": "src/Granit.Http.Cookies.Klaro/Options/KlaroOptions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "CookieName",
+          "kind": "property",
+          "signature": "string CookieName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitCookiesOptions",
+      "fqn": "Granit.Http.Cookies.Options.GranitCookiesOptions",
+      "kind": "class",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/Options/GranitCookiesOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ThrowOnUnregistered",
+          "kind": "property",
+          "signature": "bool ThrowOnUnregistered",
+          "returnType": "bool"
+        },
+        {
+          "name": "DefaultRetentionDays",
+          "kind": "property",
+          "signature": "int DefaultRetentionDays",
+          "returnType": "int"
+        },
+        {
+          "name": "ThirdPartyServices",
+          "kind": "property",
+          "signature": "List<ThirdPartyServiceOptions> ThirdPartyServices",
+          "returnType": "List<ThirdPartyServiceOptions>"
+        }
+      ]
+    },
+    {
+      "name": "ThirdPartyServiceOptions",
+      "fqn": "Granit.Http.Cookies.Options.ThirdPartyServiceOptions",
+      "kind": "class",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/Options/GranitCookiesOptions.cs",
+      "line": 43,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "required string Name",
+          "returnType": "required string"
+        }
+      ]
+    },
+    {
+      "name": "ThirdPartyServiceDefinition",
+      "fqn": "Granit.Http.Cookies.ThirdPartyServiceDefinition",
+      "kind": "record",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/ThirdPartyServiceDefinition.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "CorsHostApplicationBuilderExtensions",
+      "fqn": "Granit.Http.Cors.Extensions.CorsHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Cors",
+      "file": "src/Granit.Http.Cors/Extensions/CorsHostApplicationBuilderExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitCors",
+          "kind": "method",
+          "signature": "AddGranitCors(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpCorsModule",
+      "fqn": "Granit.Http.Cors.GranitHttpCorsModule",
+      "kind": "class",
+      "project": "Granit.Http.Cors",
+      "file": "src/Granit.Http.Cors/GranitHttpCorsModule.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GranitCorsOptions",
+      "fqn": "Granit.Http.Cors.Options.GranitCorsOptions",
+      "kind": "class",
+      "project": "Granit.Http.Cors",
+      "file": "src/Granit.Http.Cors/Options/GranitCorsOptions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AllowedOrigins",
+          "kind": "property",
+          "signature": "string[] AllowedOrigins",
+          "returnType": "string[]"
+        }
+      ]
+    },
+    {
+      "name": "ExceptionHandlingApplicationBuilderExtensions",
+      "fqn": "Granit.Http.ExceptionHandling.Extensions.ExceptionHandlingApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.ExceptionHandling",
+      "file": "src/Granit.Http.ExceptionHandling/Extensions/ExceptionHandlingApplicationBuilderExtensions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "UseGranitExceptionHandling",
+          "kind": "method",
+          "signature": "UseGranitExceptionHandling(this IApplicationBuilder app)",
+          "returnType": "IApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "ExceptionHandlingServiceCollectionExtensions",
+      "fqn": "Granit.Http.ExceptionHandling.Extensions.ExceptionHandlingServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.ExceptionHandling",
+      "file": "src/Granit.Http.ExceptionHandling/Extensions/ExceptionHandlingServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitExceptionHandling",
+          "kind": "method",
+          "signature": "AddGranitExceptionHandling(this IServiceCollection services, Action<ExceptionHandlingOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitExceptionHandlingModule",
+      "fqn": "Granit.Http.ExceptionHandling.GranitExceptionHandlingModule",
+      "kind": "class",
+      "project": "Granit.Http.ExceptionHandling",
+      "file": "src/Granit.Http.ExceptionHandling/GranitExceptionHandlingModule.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IExceptionStatusCodeMapper",
+      "fqn": "Granit.Http.ExceptionHandling.IExceptionStatusCodeMapper",
+      "kind": "interface",
+      "project": "Granit.Http.ExceptionHandling",
+      "file": "src/Granit.Http.ExceptionHandling/IExceptionStatusCodeMapper.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "TryGetStatusCode",
+          "kind": "method",
+          "signature": "TryGetStatusCode(Exception exception)",
+          "returnType": "int?"
+        }
+      ]
+    },
+    {
+      "name": "ExceptionHandlingOptions",
+      "fqn": "Granit.Http.ExceptionHandling.Options.ExceptionHandlingOptions",
+      "kind": "class",
+      "project": "Granit.Http.ExceptionHandling",
+      "file": "src/Granit.Http.ExceptionHandling/Options/ExceptionHandlingOptions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IIdempotencyMetadata",
+      "fqn": "Granit.Http.Idempotency.Abstractions.IIdempotencyMetadata",
+      "kind": "interface",
+      "project": "Granit.Http.Idempotency",
+      "file": "src/Granit.Http.Idempotency/Abstractions/IIdempotencyMetadata.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "IIdempotencyStore",
+      "fqn": "Granit.Http.Idempotency.Abstractions.IIdempotencyStore",
+      "kind": "interface",
+      "project": "Granit.Http.Idempotency",
+      "file": "src/Granit.Http.Idempotency/Abstractions/IIdempotencyStore.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "TryAcquireAsync",
+          "kind": "method",
+          "signature": "TryAcquireAsync(string key, IdempotencyEntry entry, TimeSpan ttl, CancellationToken cancellationToken)",
+          "returnType": "Task<bool>"
+        },
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(string key, CancellationToken cancellationToken)",
+          "returnType": "Task<IdempotencyEntry?>"
+        },
+        {
+          "name": "SetCompletedAsync",
+          "kind": "method",
+          "signature": "SetCompletedAsync(string key, IdempotencyEntry entry, TimeSpan ttl, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(string key, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IdempotentAttribute",
+      "fqn": "Granit.Http.Idempotency.Attributes.IdempotentAttribute",
+      "kind": "class",
+      "project": "Granit.Http.Idempotency",
+      "file": "src/Granit.Http.Idempotency/Attributes/IdempotentAttribute.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Required",
+          "kind": "property",
+          "signature": "bool Required",
+          "returnType": "bool"
+        },
+        {
+          "name": "CompletedTtlSeconds",
+          "kind": "property",
+          "signature": "int CompletedTtlSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "IdempotencyApplicationBuilderExtensions",
+      "fqn": "Granit.Http.Idempotency.Extensions.IdempotencyApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Idempotency",
+      "file": "src/Granit.Http.Idempotency/Extensions/IdempotencyApplicationBuilderExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "UseGranitIdempotency",
+          "kind": "method",
+          "signature": "UseGranitIdempotency(this IApplicationBuilder app)",
+          "returnType": "IApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "IdempotencyServiceCollectionExtensions",
+      "fqn": "Granit.Http.Idempotency.Extensions.IdempotencyServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Idempotency",
+      "file": "src/Granit.Http.Idempotency/Extensions/IdempotencyServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitIdempotency",
+          "kind": "method",
+          "signature": "AddGranitIdempotency(this IServiceCollection services, IConfigurationSection configurationSection)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitIdempotencyModule",
+      "fqn": "Granit.Http.Idempotency.GranitIdempotencyModule",
+      "kind": "class",
+      "project": "Granit.Http.Idempotency",
+      "file": "src/Granit.Http.Idempotency/GranitIdempotencyModule.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IdempotencyEntry",
+      "fqn": "Granit.Http.Idempotency.Models.IdempotencyEntry",
+      "kind": "record",
+      "project": "Granit.Http.Idempotency",
+      "file": "src/Granit.Http.Idempotency/Models/IdempotencyEntry.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IdempotencyOptions",
+      "fqn": "Granit.Http.Idempotency.Models.IdempotencyOptions",
+      "kind": "class",
+      "project": "Granit.Http.Idempotency",
+      "file": "src/Granit.Http.Idempotency/Models/IdempotencyOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "HeaderName",
+          "kind": "property",
+          "signature": "string HeaderName",
+          "returnType": "string"
+        },
+        {
+          "name": "KeyPrefix",
+          "kind": "property",
+          "signature": "string KeyPrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "FromHours",
+          "kind": "method",
+          "signature": "FromHours(24)",
+          "returnType": "TimeSpan CompletedTtl { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(30)",
+          "returnType": "TimeSpan InProgressTtl { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(25)",
+          "returnType": "TimeSpan ExecutionTimeout { get; set; } = TimeSpan."
+        },
+        {
+          "name": "MaxBodySizeBytes",
+          "kind": "property",
+          "signature": "int MaxBodySizeBytes",
+          "returnType": "int"
+        },
+        {
+          "name": "is",
+          "kind": "method",
+          "signature": "is(>= 200 and < 300)",
+          "returnType": "Func<int, bool> ShouldCacheStatusCode { get; set; } = sc => sc"
+        }
+      ]
+    },
+    {
+      "name": "IdempotencyState",
+      "fqn": "Granit.Http.Idempotency.Models.IdempotencyState",
+      "kind": "enum",
+      "project": "Granit.Http.Idempotency",
+      "file": "src/Granit.Http.Idempotency/Models/IdempotencyState.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IOutputCacheEvictionService",
+      "fqn": "Granit.Http.OutputCaching.Eviction.IOutputCacheEvictionService",
+      "kind": "interface",
+      "project": "Granit.Http.OutputCaching",
+      "file": "src/Granit.Http.OutputCaching/Eviction/IOutputCacheEvictionService.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "EvictModuleCacheAsync",
+          "kind": "method",
+          "signature": "EvictModuleCacheAsync(string moduleName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "EvictTenantCacheAsync",
+          "kind": "method",
+          "signature": "EvictTenantCacheAsync(Guid tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "EvictByTagAsync",
+          "kind": "method",
+          "signature": "EvictByTagAsync(string tag, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "OutputCachingApplicationBuilderExtensions",
+      "fqn": "Granit.Http.OutputCaching.Extensions.OutputCachingApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.OutputCaching",
+      "file": "src/Granit.Http.OutputCaching/Extensions/OutputCachingApplicationBuilderExtensions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "UseGranitOutputCaching",
+          "kind": "method",
+          "signature": "UseGranitOutputCaching(this IApplicationBuilder app)",
+          "returnType": "IApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "OutputCachingServiceCollectionExtensions",
+      "fqn": "Granit.Http.OutputCaching.Extensions.OutputCachingServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.OutputCaching",
+      "file": "src/Granit.Http.OutputCaching/Extensions/OutputCachingServiceCollectionExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitOutputCaching",
+          "kind": "method",
+          "signature": "AddGranitOutputCaching(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpOutputCachingModule",
+      "fqn": "Granit.Http.OutputCaching.GranitHttpOutputCachingModule",
+      "kind": "class",
+      "project": "Granit.Http.OutputCaching",
+      "file": "src/Granit.Http.OutputCaching/GranitHttpOutputCachingModule.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "OutputCachingOptions",
+      "fqn": "Granit.Http.OutputCaching.Options.OutputCachingOptions",
+      "kind": "class",
+      "project": "Granit.Http.OutputCaching",
+      "file": "src/Granit.Http.OutputCaching/Options/OutputCachingOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(60)",
+          "returnType": "TimeSpan DefaultExpiration { get; set; } = TimeSpan."
+        },
+        {
+          "name": "VaryByQueryKeys",
+          "kind": "property",
+          "signature": "string[] VaryByQueryKeys",
+          "returnType": "string[]"
+        },
+        {
+          "name": "ExcludeAuthenticatedResponses",
+          "kind": "property",
+          "signature": "bool ExcludeAuthenticatedResponses",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "GranitOutputCachePolicyNames",
+      "fqn": "Granit.Http.OutputCaching.Policies.GranitOutputCachePolicyNames",
+      "kind": "class",
+      "project": "Granit.Http.OutputCaching",
+      "file": "src/Granit.Http.OutputCaching/Policies/GranitOutputCachePolicyNames.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "RedisOutputCachingServiceCollectionExtensions",
+      "fqn": "Granit.Http.OutputCaching.StackExchangeRedis.Extensions.RedisOutputCachingServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.OutputCaching.StackExchangeRedis",
+      "file": "src/Granit.Http.OutputCaching.StackExchangeRedis/Extensions/RedisOutputCachingServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitRedisOutputCache",
+          "kind": "method",
+          "signature": "AddGranitRedisOutputCache(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpOutputCachingStackExchangeRedisModule",
+      "fqn": "Granit.Http.OutputCaching.StackExchangeRedis.GranitHttpOutputCachingStackExchangeRedisModule",
+      "kind": "class",
+      "project": "Granit.Http.OutputCaching.StackExchangeRedis",
+      "file": "src/Granit.Http.OutputCaching.StackExchangeRedis/GranitHttpOutputCachingStackExchangeRedisModule.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "IsEnabled",
+          "kind": "method",
+          "signature": "IsEnabled(ServiceConfigurationContext context)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "RedisOutputCachingOptions",
+      "fqn": "Granit.Http.OutputCaching.StackExchangeRedis.Options.RedisOutputCachingOptions",
+      "kind": "class",
+      "project": "Granit.Http.OutputCaching.StackExchangeRedis",
+      "file": "src/Granit.Http.OutputCaching.StackExchangeRedis/Options/RedisOutputCachingOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "IsEnabled",
+          "kind": "property",
+          "signature": "bool IsEnabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "Configuration",
+          "kind": "property",
+          "signature": "string Configuration",
+          "returnType": "string"
+        },
+        {
+          "name": "InstanceName",
+          "kind": "property",
+          "signature": "string InstanceName",
+          "returnType": "string"
+        },
+        {
+          "name": "RequireTls",
+          "kind": "property",
+          "signature": "bool RequireTls",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "HttpResilienceServiceCollectionExtensions",
+      "fqn": "Granit.Http.Resilience.Extensions.HttpResilienceServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Resilience",
+      "file": "src/Granit.Http.Resilience/Extensions/HttpResilienceServiceCollectionExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitHttpClient",
+          "kind": "method",
+          "signature": "AddGranitHttpClient(this IServiceCollection services, string name, Action<IServiceProvider, HttpClient>? configure = null)",
+          "returnType": "IHttpClientBuilder"
+        },
+        {
+          "name": "AddAuthTokenPropagation",
+          "kind": "method",
+          "signature": "AddAuthTokenPropagation(this IHttpClientBuilder builder)",
+          "returnType": "IHttpClientBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpResilienceModule",
+      "fqn": "Granit.Http.Resilience.GranitHttpResilienceModule",
+      "kind": "class",
+      "project": "Granit.Http.Resilience",
+      "file": "src/Granit.Http.Resilience/GranitHttpResilienceModule.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "HttpResilienceOptions",
+      "fqn": "Granit.Http.Resilience.Options.HttpResilienceOptions",
+      "kind": "class",
+      "project": "Granit.Http.Resilience",
+      "file": "src/Granit.Http.Resilience/Options/HttpResilienceOptions.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "ResponseCompressionApplicationBuilderExtensions",
+      "fqn": "Granit.Http.ResponseCompression.Extensions.ResponseCompressionApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.ResponseCompression",
+      "file": "src/Granit.Http.ResponseCompression/Extensions/ResponseCompressionApplicationBuilderExtensions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "UseGranitResponseCompression",
+          "kind": "method",
+          "signature": "UseGranitResponseCompression(this IApplicationBuilder app)",
+          "returnType": "IApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "ResponseCompressionHostApplicationBuilderExtensions",
+      "fqn": "Granit.Http.ResponseCompression.Extensions.ResponseCompressionHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.ResponseCompression",
+      "file": "src/Granit.Http.ResponseCompression/Extensions/ResponseCompressionHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitResponseCompression",
+          "kind": "method",
+          "signature": "AddGranitResponseCompression(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpResponseCompressionModule",
+      "fqn": "Granit.Http.ResponseCompression.GranitHttpResponseCompressionModule",
+      "kind": "class",
+      "project": "Granit.Http.ResponseCompression",
+      "file": "src/Granit.Http.ResponseCompression/GranitHttpResponseCompressionModule.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GranitResponseCompressionOptions",
+      "fqn": "Granit.Http.ResponseCompression.Options.GranitResponseCompressionOptions",
+      "kind": "class",
+      "project": "Granit.Http.ResponseCompression",
+      "file": "src/Granit.Http.ResponseCompression/Options/GranitResponseCompressionOptions.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "EnableForHttps",
+          "kind": "property",
+          "signature": "bool EnableForHttps",
+          "returnType": "bool"
+        },
+        {
+          "name": "EnableBrotli",
+          "kind": "property",
+          "signature": "bool EnableBrotli",
+          "returnType": "bool"
+        },
+        {
+          "name": "EnableGzip",
+          "kind": "property",
+          "signature": "bool EnableGzip",
+          "returnType": "bool"
+        },
+        {
+          "name": "BrotliLevel",
+          "kind": "property",
+          "signature": "CompressionLevel BrotliLevel",
+          "returnType": "CompressionLevel"
+        },
+        {
+          "name": "GzipLevel",
+          "kind": "property",
+          "signature": "CompressionLevel GzipLevel",
+          "returnType": "CompressionLevel"
+        }
+      ]
+    },
+    {
+      "name": "IdentityCognitoServiceCollectionExtensions",
+      "fqn": "Granit.Identity.Cognito.Extensions.IdentityCognitoServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.Cognito",
+      "file": "src/Granit.Identity.Cognito/Extensions/IdentityCognitoServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitIdentityCognito",
+          "kind": "method",
+          "signature": "AddGranitIdentityCognito(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitIdentityCognitoModule",
+      "fqn": "Granit.Identity.Cognito.GranitIdentityCognitoModule",
+      "kind": "class",
+      "project": "Granit.Identity.Cognito",
+      "file": "src/Granit.Identity.Cognito/GranitIdentityCognitoModule.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "CognitoAdminOptions",
+      "fqn": "Granit.Identity.Cognito.Options.CognitoAdminOptions",
+      "kind": "class",
+      "project": "Granit.Identity.Cognito",
+      "file": "src/Granit.Identity.Cognito/Options/CognitoAdminOptions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "Region",
+          "kind": "property",
+          "signature": "string Region",
+          "returnType": "string"
+        },
+        {
+          "name": "UserPoolId",
+          "kind": "property",
+          "signature": "string UserPoolId",
+          "returnType": "string"
+        },
+        {
+          "name": "AppClientId",
+          "kind": "property",
+          "signature": "string? AppClientId",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "IdentityMetrics",
+      "fqn": "Granit.Identity.Diagnostics.IdentityMetrics",
+      "kind": "class",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Diagnostics/IdentityMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordOperationError",
+          "kind": "method",
+          "signature": "RecordOperationError(string? tenantId, string operation, string provider)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordOperationDuration",
+          "kind": "method",
+          "signature": "RecordOperationDuration(string? tenantId, string operation, string provider, TimeSpan duration)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IdentityPasswordChangedAtResponse",
+      "fqn": "Granit.Identity.Endpoints.Dtos.IdentityPasswordChangedAtResponse",
+      "kind": "record",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Dtos/IdentityPasswordChangedAtResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IdentityProviderCapabilitiesResponse",
+      "fqn": "Granit.Identity.Endpoints.Dtos.IdentityProviderCapabilitiesResponse",
+      "kind": "record",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Dtos/IdentityProviderCapabilitiesResponse.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "IdentitySetTemporaryPasswordRequest",
+      "fqn": "Granit.Identity.Endpoints.Dtos.IdentitySetTemporaryPasswordRequest",
+      "kind": "record",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Dtos/IdentitySetTemporaryPasswordRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IdentityUserCacheBatchRequest",
+      "fqn": "Granit.Identity.Endpoints.Dtos.IdentityUserCacheBatchRequest",
+      "kind": "record",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Dtos/IdentityUserCacheBatchRequest.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "IdentityUserCacheStatsResponse",
+      "fqn": "Granit.Identity.Endpoints.Dtos.IdentityUserCacheStatsResponse",
+      "kind": "record",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Dtos/IdentityUserCacheStatsResponse.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "IdentityUserCacheSyncRequest",
+      "fqn": "Granit.Identity.Endpoints.Dtos.IdentityUserCacheSyncRequest",
+      "kind": "record",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Dtos/IdentityUserCacheSyncRequest.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "IdentityUserCreateRequest",
+      "fqn": "Granit.Identity.Endpoints.Dtos.IdentityUserCreateRequest",
+      "kind": "record",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Dtos/IdentityUserCreateRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IdentityUserSetEnabledRequest",
+      "fqn": "Granit.Identity.Endpoints.Dtos.IdentityUserSetEnabledRequest",
+      "kind": "record",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Dtos/IdentityUserSetEnabledRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IdentityUserUpdateRequest",
+      "fqn": "Granit.Identity.Endpoints.Dtos.IdentityUserUpdateRequest",
+      "kind": "record",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Dtos/IdentityUserUpdateRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IdentityWebhookPayload",
+      "fqn": "Granit.Identity.Endpoints.Dtos.IdentityWebhookPayload",
+      "kind": "record",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Dtos/IdentityWebhookPayload.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "IdentityEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Identity.Endpoints.Extensions.IdentityEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Extensions/IdentityEndpointRouteBuilderExtensions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "MapIdentityUserCacheEndpoints",
+          "kind": "method",
+          "signature": "MapIdentityUserCacheEndpoints(this IEndpointRouteBuilder endpoints, Action<IdentityEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "IdentityEndpointsServiceCollectionExtensions",
+      "fqn": "Granit.Identity.Endpoints.Extensions.IdentityEndpointsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Extensions/IdentityEndpointsServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitIdentityEndpoints",
+          "kind": "method",
+          "signature": "AddGranitIdentityEndpoints(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "IdentityProviderEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Identity.Endpoints.Extensions.IdentityProviderEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Extensions/IdentityProviderEndpointRouteBuilderExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "MapIdentityProviderEndpoints",
+          "kind": "method",
+          "signature": "MapIdentityProviderEndpoints(this IEndpointRouteBuilder endpoints, Action<IdentityProviderEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitIdentityEndpointsModule",
+      "fqn": "Granit.Identity.Endpoints.GranitIdentityEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/GranitIdentityEndpointsModule.cs",
+      "line": 29,
+      "members": []
+    },
+    {
+      "name": "IdentityEndpointsOptions",
+      "fqn": "Granit.Identity.Endpoints.Options.IdentityEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Options/IdentityEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "IdentityProviderEndpointsOptions",
+      "fqn": "Granit.Identity.Endpoints.Options.IdentityProviderEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Options/IdentityProviderEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "IdentityWebhookOptions",
+      "fqn": "Granit.Identity.Endpoints.Options.IdentityWebhookOptions",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Options/IdentityWebhookOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Secret",
+          "kind": "property",
+          "signature": "string Secret",
+          "returnType": "string"
+        },
+        {
+          "name": "SignatureHeaderName",
+          "kind": "property",
+          "signature": "string SignatureHeaderName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "Groups",
+      "fqn": "Granit.Identity.Endpoints.Permissions.Groups",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityProviderPermissions.cs",
+      "line": 36,
+      "members": []
+    },
+    {
+      "name": "IdentityProviderPermissions",
+      "fqn": "Granit.Identity.Endpoints.Permissions.IdentityProviderPermissions",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityProviderPermissions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "IdentityUserCachePermissions",
+      "fqn": "Granit.Identity.Endpoints.Permissions.IdentityUserCachePermissions",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityUserCachePermissions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "Passwords",
+      "fqn": "Granit.Identity.Endpoints.Permissions.Passwords",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityProviderPermissions.cs",
+      "line": 56,
+      "members": []
+    },
+    {
+      "name": "Roles",
+      "fqn": "Granit.Identity.Endpoints.Permissions.Roles",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityProviderPermissions.cs",
+      "line": 26,
+      "members": []
+    },
+    {
+      "name": "Sessions",
+      "fqn": "Granit.Identity.Endpoints.Permissions.Sessions",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityProviderPermissions.cs",
+      "line": 46,
+      "members": []
+    },
+    {
+      "name": "UserCache",
+      "fqn": "Granit.Identity.Endpoints.Permissions.UserCache",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityUserCachePermissions.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "Users",
+      "fqn": "Granit.Identity.Endpoints.Permissions.Users",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityProviderPermissions.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "IUserCacheDbContext",
+      "fqn": "Granit.Identity.EntityFrameworkCore.DbContext.IUserCacheDbContext",
+      "kind": "interface",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/DbContext/IUserCacheDbContext.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "UserCacheModelBuilderExtensions",
+      "fqn": "Granit.Identity.EntityFrameworkCore.DbContext.UserCacheModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/DbContext/UserCacheModelBuilderExtensions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "ConfigureIdentityModule",
+          "kind": "method",
+          "signature": "ConfigureIdentityModule(this ModelBuilder builder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "UserCacheEntry",
+      "fqn": "Granit.Identity.EntityFrameworkCore.Entities.UserCacheEntry",
+      "kind": "class",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/Entities/UserCacheEntry.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "ExternalUserId",
+          "kind": "property",
+          "signature": "string ExternalUserId",
+          "returnType": "string"
+        },
+        {
+          "name": "Username",
+          "kind": "property",
+          "signature": "string? Username",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "IdentityUserDeletedEvent",
+      "fqn": "Granit.Identity.EntityFrameworkCore.Events.IdentityUserDeletedEvent",
+      "kind": "record",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/Events/IdentityUserDeletedEvent.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "IdentityUserUpdatedEvent",
+      "fqn": "Granit.Identity.EntityFrameworkCore.Events.IdentityUserUpdatedEvent",
+      "kind": "record",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/Events/IdentityUserUpdatedEvent.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "UserCacheEntryErasedEvent",
+      "fqn": "Granit.Identity.EntityFrameworkCore.Events.UserCacheEntryErasedEvent",
+      "kind": "record",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/Events/UserCacheEntryErasedEvent.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "IdentityEfCoreApplicationBuilderExtensions",
+      "fqn": "Granit.Identity.EntityFrameworkCore.Extensions.IdentityEfCoreApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityEfCoreApplicationBuilderExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "UseGranitIdentityUserCacheSync",
+          "kind": "method",
+          "signature": "UseGranitIdentityUserCacheSync(this IApplicationBuilder app)",
+          "returnType": "IApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "IdentityEfCoreServiceCollectionExtensions",
+      "fqn": "Granit.Identity.EntityFrameworkCore.Extensions.IdentityEfCoreServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityEfCoreServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "GranitIdentityDbProperties",
+      "fqn": "Granit.Identity.EntityFrameworkCore.GranitIdentityDbProperties",
+      "kind": "class",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/GranitIdentityDbProperties.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitIdentityEntityFrameworkCoreModule",
+      "fqn": "Granit.Identity.EntityFrameworkCore.GranitIdentityEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/GranitIdentityEntityFrameworkCoreModule.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "UserCacheOptions",
+      "fqn": "Granit.Identity.EntityFrameworkCore.Options.UserCacheOptions",
+      "kind": "class",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/Options/UserCacheOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "FromHours",
+          "kind": "method",
+          "signature": "FromHours(24)",
+          "returnType": "TimeSpan StalenessThreshold { get; set; } = TimeSpan."
+        },
+        {
+          "name": "EnableLoginTimeSync",
+          "kind": "property",
+          "signature": "bool EnableLoginTimeSync",
+          "returnType": "bool"
+        },
+        {
+          "name": "IncrementalSyncBatchSize",
+          "kind": "property",
+          "signature": "int IncrementalSyncBatchSize",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "IdentityEntraIdServiceCollectionExtensions",
+      "fqn": "Granit.Identity.EntraId.Extensions.IdentityEntraIdServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.EntraId",
+      "file": "src/Granit.Identity.EntraId/Extensions/IdentityEntraIdServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitIdentityEntraId",
+          "kind": "method",
+          "signature": "AddGranitIdentityEntraId(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitIdentityEntraIdModule",
+      "fqn": "Granit.Identity.EntraId.GranitIdentityEntraIdModule",
+      "kind": "class",
+      "project": "Granit.Identity.EntraId",
+      "file": "src/Granit.Identity.EntraId/GranitIdentityEntraIdModule.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IPasswordResetNotifier",
+      "fqn": "Granit.Identity.EntraId.IPasswordResetNotifier",
+      "kind": "interface",
+      "project": "Granit.Identity.EntraId",
+      "file": "src/Granit.Identity.EntraId/IPasswordResetNotifier.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "NotifyAsync",
+          "kind": "method",
+          "signature": "NotifyAsync(string userId, string temporaryPassword, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "EntraIdAdminOptions",
+      "fqn": "Granit.Identity.EntraId.Options.EntraIdAdminOptions",
+      "kind": "class",
+      "project": "Granit.Identity.EntraId",
+      "file": "src/Granit.Identity.EntraId/Options/EntraIdAdminOptions.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "TenantId",
+          "kind": "property",
+          "signature": "string TenantId",
+          "returnType": "string"
+        },
+        {
+          "name": "ClientId",
+          "kind": "property",
+          "signature": "string ClientId",
+          "returnType": "string"
+        },
+        {
+          "name": "ClientSecret",
+          "kind": "property",
+          "signature": "string ClientSecret",
+          "returnType": "string"
+        },
+        {
+          "name": "ServicePrincipalObjectId",
+          "kind": "property",
+          "signature": "string ServicePrincipalObjectId",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultDomain",
+          "kind": "property",
+          "signature": "string? DefaultDomain",
+          "returnType": "string?"
+        },
+        {
+          "name": "GraphBaseUrl",
+          "kind": "property",
+          "signature": "string GraphBaseUrl",
+          "returnType": "string"
+        },
+        {
+          "name": "GetTokenEndpoint",
+          "kind": "method",
+          "signature": "GetTokenEndpoint()",
+          "returnType": "string? RopcClientId { get; set; } internal string"
+        }
+      ]
+    },
+    {
+      "name": "IdentityGroupMembershipChangedEvent",
+      "fqn": "Granit.Identity.Events.IdentityGroupMembershipChangedEvent",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Events/IdentityEvents.cs",
+      "line": 47,
+      "members": []
+    },
+    {
+      "name": "IdentityPasswordResetEvent",
+      "fqn": "Granit.Identity.Events.IdentityPasswordResetEvent",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Events/IdentityEvents.cs",
+      "line": 53,
+      "members": []
+    },
+    {
+      "name": "IdentityRoleAssignedEvent",
+      "fqn": "Granit.Identity.Events.IdentityRoleAssignedEvent",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Events/IdentityEvents.cs",
+      "line": 32,
+      "members": []
+    },
+    {
+      "name": "IdentityRoleRemovedEvent",
+      "fqn": "Granit.Identity.Events.IdentityRoleRemovedEvent",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Events/IdentityEvents.cs",
+      "line": 39,
+      "members": []
+    },
+    {
+      "name": "IdentitySessionsRevokedEvent",
+      "fqn": "Granit.Identity.Events.IdentitySessionsRevokedEvent",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Events/IdentityEvents.cs",
+      "line": 59,
+      "members": []
+    },
+    {
+      "name": "IdentityUserCreatedEvent",
+      "fqn": "Granit.Identity.Events.IdentityUserCreatedEvent",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Events/IdentityEvents.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "IdentityUserEnabledChangedEvent",
+      "fqn": "Granit.Identity.Events.IdentityUserEnabledChangedEvent",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Events/IdentityEvents.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "IdentityUserProfileUpdatedEvent",
+      "fqn": "Granit.Identity.Events.IdentityUserProfileUpdatedEvent",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Events/IdentityEvents.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "UserCacheSyncedEto",
+      "fqn": "Granit.Identity.Events.UserCacheSyncedEto",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Events/UserCacheSyncedEto.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "IdentityServiceCollectionExtensions",
+      "fqn": "Granit.Identity.Extensions.IdentityServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Extensions/IdentityServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitIdentity",
+          "kind": "method",
+          "signature": "AddGranitIdentity(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "IdentityGoogleCloudServiceCollectionExtensions",
+      "fqn": "Granit.Identity.GoogleCloud.Extensions.IdentityGoogleCloudServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.GoogleCloud",
+      "file": "src/Granit.Identity.GoogleCloud/Extensions/IdentityGoogleCloudServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitIdentityGoogleCloud",
+          "kind": "method",
+          "signature": "AddGranitIdentityGoogleCloud(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitIdentityGoogleCloudModule",
+      "fqn": "Granit.Identity.GoogleCloud.GranitIdentityGoogleCloudModule",
+      "kind": "class",
+      "project": "Granit.Identity.GoogleCloud",
+      "file": "src/Granit.Identity.GoogleCloud/GranitIdentityGoogleCloudModule.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GoogleCloudIdentityOptions",
+      "fqn": "Granit.Identity.GoogleCloud.Options.GoogleCloudIdentityOptions",
+      "kind": "class",
+      "project": "Granit.Identity.GoogleCloud",
+      "file": "src/Granit.Identity.GoogleCloud/Options/GoogleCloudIdentityOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ProjectId",
+          "kind": "property",
+          "signature": "string ProjectId",
+          "returnType": "string"
+        },
+        {
+          "name": "CredentialFilePath",
+          "kind": "property",
+          "signature": "string? CredentialFilePath",
+          "returnType": "string?"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "GranitIdentityModule",
+      "fqn": "Granit.Identity.GranitIdentityModule",
+      "kind": "class",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/GranitIdentityModule.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IIdentityCredentialVerifier",
+      "fqn": "Granit.Identity.IIdentityCredentialVerifier",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IIdentityCredentialVerifier.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "VerifyUserCredentialsAsync",
+          "kind": "method",
+          "signature": "VerifyUserCredentialsAsync(string username, string password, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "IIdentityEventPublisher",
+      "fqn": "Granit.Identity.IIdentityEventPublisher",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IIdentityEventPublisher.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "IIdentityGroupManager",
+      "fqn": "Granit.Identity.IIdentityGroupManager",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IIdentityGroupManager.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetGroupsAsync",
+          "kind": "method",
+          "signature": "GetGroupsAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<IdentityGroup>>"
+        },
+        {
+          "name": "GetUserGroupsAsync",
+          "kind": "method",
+          "signature": "GetUserGroupsAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<IdentityGroup>>"
+        },
+        {
+          "name": "AddUserToGroupAsync",
+          "kind": "method",
+          "signature": "AddUserToGroupAsync(string userId, string groupId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RemoveUserFromGroupAsync",
+          "kind": "method",
+          "signature": "RemoveUserFromGroupAsync(string userId, string groupId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IIdentityPasswordManager",
+      "fqn": "Granit.Identity.IIdentityPasswordManager",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IIdentityPasswordManager.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetPasswordChangedAtAsync",
+          "kind": "method",
+          "signature": "GetPasswordChangedAtAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<DateTimeOffset?>"
+        },
+        {
+          "name": "SendPasswordResetEmailAsync",
+          "kind": "method",
+          "signature": "SendPasswordResetEmailAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SetTemporaryPasswordAsync",
+          "kind": "method",
+          "signature": "SetTemporaryPasswordAsync(string userId, string temporaryPassword, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IIdentityProvider",
+      "fqn": "Granit.Identity.IIdentityProvider",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IIdentityProvider.cs",
+      "line": 27,
+      "members": []
+    },
+    {
+      "name": "IIdentityProviderCapabilities",
+      "fqn": "Granit.Identity.IIdentityProviderCapabilities",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IIdentityProviderCapabilities.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "IIdentityRoleManager",
+      "fqn": "Granit.Identity.IIdentityRoleManager",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IIdentityRoleManager.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetRolesAsync",
+          "kind": "method",
+          "signature": "GetRolesAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<IdentityRole>>"
+        },
+        {
+          "name": "GetRoleMembersAsync",
+          "kind": "method",
+          "signature": "GetRoleMembersAsync(string roleName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<IdentityUser>>"
+        },
+        {
+          "name": "GetUserRolesAsync",
+          "kind": "method",
+          "signature": "GetUserRolesAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<IdentityRole>>"
+        },
+        {
+          "name": "AssignRoleAsync",
+          "kind": "method",
+          "signature": "AssignRoleAsync(string userId, string roleName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RemoveRoleAsync",
+          "kind": "method",
+          "signature": "RemoveRoleAsync(string userId, string roleName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IIdentitySessionManager",
+      "fqn": "Granit.Identity.IIdentitySessionManager",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IIdentitySessionManager.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetUserSessionsAsync",
+          "kind": "method",
+          "signature": "GetUserSessionsAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<IdentitySession>>"
+        },
+        {
+          "name": "GetUserDeviceActivityAsync",
+          "kind": "method",
+          "signature": "GetUserDeviceActivityAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<IdentityDeviceActivity>>"
+        },
+        {
+          "name": "TerminateSessionAsync",
+          "kind": "method",
+          "signature": "TerminateSessionAsync(string userId, string sessionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "TerminateAllSessionsAsync",
+          "kind": "method",
+          "signature": "TerminateAllSessionsAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IIdentityUserReader",
+      "fqn": "Granit.Identity.IIdentityUserReader",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IIdentityUserReader.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetUsersAsync",
+          "kind": "method",
+          "signature": "GetUsersAsync(string? search = null, int? first = null, int? max = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<IdentityUser>>"
+        },
+        {
+          "name": "GetUserAsync",
+          "kind": "method",
+          "signature": "GetUserAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IdentityUser?>"
+        }
+      ]
+    },
+    {
+      "name": "IIdentityUserWriter",
+      "fqn": "Granit.Identity.IIdentityUserWriter",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IIdentityUserWriter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "SetUserEnabledAsync",
+          "kind": "method",
+          "signature": "SetUserEnabledAsync(string userId, bool enabled, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UpdateUserAsync",
+          "kind": "method",
+          "signature": "UpdateUserAsync(string userId, IdentityUserUpdate update, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "CreateUserAsync",
+          "kind": "method",
+          "signature": "CreateUserAsync(IdentityUserCreate user, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IdentityUser>"
+        }
+      ]
+    },
+    {
+      "name": "IUserCacheStats",
+      "fqn": "Granit.Identity.IUserCacheStats",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IUserCacheStats.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetCountAsync",
+          "kind": "method",
+          "signature": "GetCountAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        },
+        {
+          "name": "GetStaleCountAsync",
+          "kind": "method",
+          "signature": "GetStaleCountAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        }
+      ]
+    },
+    {
+      "name": "IUserLookupService",
+      "fqn": "Granit.Identity.IUserLookupService",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IUserLookupService.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "FindByIdAsync",
+          "kind": "method",
+          "signature": "FindByIdAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IdentityUser?>"
+        },
+        {
+          "name": "FindByIdsAsync",
+          "kind": "method",
+          "signature": "FindByIdsAsync(IReadOnlyCollection<string> userIds, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<IdentityUser>>"
+        },
+        {
+          "name": "SearchAsync",
+          "kind": "method",
+          "signature": "SearchAsync(string searchTerm, int page = 1, int pageSize = QueryingDefaults.DefaultPageSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<IdentityUser>>"
+        },
+        {
+          "name": "RefreshByIdAsync",
+          "kind": "method",
+          "signature": "RefreshByIdAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IdentityUser?>"
+        },
+        {
+          "name": "RefreshAllAsync",
+          "kind": "method",
+          "signature": "RefreshAllAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        },
+        {
+          "name": "RefreshStaleAsync",
+          "kind": "method",
+          "signature": "RefreshStaleAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        },
+        {
+          "name": "DeleteByIdAsync",
+          "kind": "method",
+          "signature": "DeleteByIdAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "PseudonymizeByIdAsync",
+          "kind": "method",
+          "signature": "PseudonymizeByIdAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IdentityKeycloakServiceCollectionExtensions",
+      "fqn": "Granit.Identity.Keycloak.Extensions.IdentityKeycloakServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.Keycloak",
+      "file": "src/Granit.Identity.Keycloak/Extensions/IdentityKeycloakServiceCollectionExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "AddGranitIdentityKeycloak",
+          "kind": "method",
+          "signature": "AddGranitIdentityKeycloak(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitIdentityKeycloakModule",
+      "fqn": "Granit.Identity.Keycloak.GranitIdentityKeycloakModule",
+      "kind": "class",
+      "project": "Granit.Identity.Keycloak",
+      "file": "src/Granit.Identity.Keycloak/GranitIdentityKeycloakModule.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "KeycloakAdminOptions",
+      "fqn": "Granit.Identity.Keycloak.Options.KeycloakAdminOptions",
+      "kind": "class",
+      "project": "Granit.Identity.Keycloak",
+      "file": "src/Granit.Identity.Keycloak/Options/KeycloakAdminOptions.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "BaseUrl",
+          "kind": "property",
+          "signature": "string BaseUrl",
+          "returnType": "string"
+        },
+        {
+          "name": "Realm",
+          "kind": "property",
+          "signature": "string Realm",
+          "returnType": "string"
+        },
+        {
+          "name": "ClientId",
+          "kind": "property",
+          "signature": "string ClientId",
+          "returnType": "string"
+        },
+        {
+          "name": "ClientSecret",
+          "kind": "property",
+          "signature": "string ClientSecret",
+          "returnType": "string"
+        },
+        {
+          "name": "UseTokenExchangeForDeviceActivity",
+          "kind": "property",
+          "signature": "bool UseTokenExchangeForDeviceActivity",
+          "returnType": "bool"
+        },
+        {
+          "name": "GetTokenEndpoint",
+          "kind": "method",
+          "signature": "GetTokenEndpoint()",
+          "returnType": "string? DirectAccessClientId { get; set; } internal string"
+        }
+      ]
+    },
+    {
+      "name": "IdentityDeviceActivity",
+      "fqn": "Granit.Identity.Models.IdentityDeviceActivity",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Models/IdentityDeviceActivity.cs",
+      "line": 27,
+      "members": []
+    },
+    {
+      "name": "IdentityGroup",
+      "fqn": "Granit.Identity.Models.IdentityGroup",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Models/IdentityGroup.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "IdentityRole",
+      "fqn": "Granit.Identity.Models.IdentityRole",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Models/IdentityRole.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "IdentitySession",
+      "fqn": "Granit.Identity.Models.IdentitySession",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Models/IdentitySession.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "IdentityUser",
+      "fqn": "Granit.Identity.Models.IdentityUser",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Models/IdentityUser.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "IdentityUserCreate",
+      "fqn": "Granit.Identity.Models.IdentityUserCreate",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Models/IdentityUserCreate.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "IdentityUserUpdate",
+      "fqn": "Granit.Identity.Models.IdentityUserUpdate",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Models/IdentityUserUpdate.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "ImagingAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Imaging.AI.Extensions.ImagingAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Imaging.AI",
+      "file": "src/Granit.Imaging.AI/Extensions/ImagingAIHostApplicationBuilderExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "AddGranitImagingAI",
+          "kind": "method",
+          "signature": "AddGranitImagingAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitImagingAIModule",
+      "fqn": "Granit.Imaging.AI.GranitImagingAIModule",
+      "kind": "class",
+      "project": "Granit.Imaging.AI",
+      "file": "src/Granit.Imaging.AI/GranitImagingAIModule.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IAIImageAnalyzer",
+      "fqn": "Granit.Imaging.AI.IAIImageAnalyzer",
+      "kind": "interface",
+      "project": "Granit.Imaging.AI",
+      "file": "src/Granit.Imaging.AI/IAIImageAnalyzer.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AnalyzeAsync",
+          "kind": "method",
+          "signature": "AnalyzeAsync(ReadOnlyMemory<byte> imageData, string contentType, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImageAnalysis>"
+        }
+      ]
+    },
+    {
+      "name": "ImageAnalysis",
+      "fqn": "Granit.Imaging.AI.ImageAnalysis",
+      "kind": "record",
+      "project": "Granit.Imaging.AI",
+      "file": "src/Granit.Imaging.AI/ImageAnalysis.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ImagingAIOptions",
+      "fqn": "Granit.Imaging.AI.Options.ImagingAIOptions",
+      "kind": "class",
+      "project": "Granit.Imaging.AI",
+      "file": "src/Granit.Imaging.AI/Options/ImagingAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string? WorkspaceName",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "UnsupportedImageFormatException",
+      "fqn": "Granit.Imaging.Exceptions.UnsupportedImageFormatException",
+      "kind": "class",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/Exceptions/UnsupportedImageFormatException.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "UnsupportedImageFormatException",
+          "kind": "method",
+          "signature": "UnsupportedImageFormatException(string detectedFormat)",
+          "returnType": "string DetectedFormat { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "ImagePipelineExtensions",
+      "fqn": "Granit.Imaging.Extensions.ImagePipelineExtensions",
+      "kind": "class",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/Extensions/ImagePipelineExtensions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SaveAsJpegAsync",
+          "kind": "method",
+          "signature": "SaveAsJpegAsync(this IImagePipeline pipeline, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImageResult>"
+        },
+        {
+          "name": "SaveAsPngAsync",
+          "kind": "method",
+          "signature": "SaveAsPngAsync(this IImagePipeline pipeline, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImageResult>"
+        },
+        {
+          "name": "SaveAsWebPAsync",
+          "kind": "method",
+          "signature": "SaveAsWebPAsync(this IImagePipeline pipeline, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImageResult>"
+        },
+        {
+          "name": "SaveAsAvifAsync",
+          "kind": "method",
+          "signature": "SaveAsAvifAsync(this IImagePipeline pipeline, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImageResult>"
+        }
+      ]
+    },
+    {
+      "name": "ImagingServiceCollectionExtensions",
+      "fqn": "Granit.Imaging.Extensions.ImagingServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/Extensions/ImagingServiceCollectionExtensions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "AddGranitImaging",
+          "kind": "method",
+          "signature": "AddGranitImaging(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitImagingModule",
+      "fqn": "Granit.Imaging.GranitImagingModule",
+      "kind": "class",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/GranitImagingModule.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "IImagePipeline",
+      "fqn": "Granit.Imaging.IImagePipeline",
+      "kind": "interface",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/IImagePipeline.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "Resize",
+          "kind": "method",
+          "signature": "Resize(int width, int height, ResizeMode mode = ResizeMode.Max)",
+          "returnType": "ImageSize SourceSize { get; } ImageFormat SourceFormat { get; } IImagePipeline"
+        },
+        {
+          "name": "Crop",
+          "kind": "method",
+          "signature": "Crop(CropRectangle rectangle)",
+          "returnType": "IImagePipeline"
+        },
+        {
+          "name": "Compress",
+          "kind": "method",
+          "signature": "Compress(int quality)",
+          "returnType": "IImagePipeline"
+        },
+        {
+          "name": "ConvertTo",
+          "kind": "method",
+          "signature": "ConvertTo(ImageFormat format)",
+          "returnType": "IImagePipeline"
+        },
+        {
+          "name": "Watermark",
+          "kind": "method",
+          "signature": "Watermark(ReadOnlyMemory<byte> watermark, WatermarkPosition position = WatermarkPosition.BottomRight, float opacity = 0.5f)",
+          "returnType": "IImagePipeline"
+        },
+        {
+          "name": "Watermark",
+          "kind": "method",
+          "signature": "Watermark(Stream watermark, WatermarkPosition position = WatermarkPosition.BottomRight, float opacity = 0.5f)",
+          "returnType": "IImagePipeline"
+        },
+        {
+          "name": "StripMetadata",
+          "kind": "method",
+          "signature": "StripMetadata()",
+          "returnType": "IImagePipeline"
+        },
+        {
+          "name": "ToResultAsync",
+          "kind": "method",
+          "signature": "ToResultAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImageResult>"
+        },
+        {
+          "name": "SaveToStreamAsync",
+          "kind": "method",
+          "signature": "SaveToStreamAsync(Stream destination, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IImageProcessor",
+      "fqn": "Granit.Imaging.IImageProcessor",
+      "kind": "interface",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/IImageProcessor.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "Load",
+          "kind": "method",
+          "signature": "Load(Stream source)",
+          "returnType": "IImagePipeline"
+        },
+        {
+          "name": "Load",
+          "kind": "method",
+          "signature": "Load(ReadOnlyMemory<byte> source)",
+          "returnType": "IImagePipeline"
+        }
+      ]
+    },
+    {
+      "name": "ImageFormat",
+      "fqn": "Granit.Imaging.ImageFormat",
+      "kind": "enum",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/ImageFormat.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ImageResult",
+      "fqn": "Granit.Imaging.ImageResult",
+      "kind": "record",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/ImageResult.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "ImagingMagickNetServiceCollectionExtensions",
+      "fqn": "Granit.Imaging.MagickNet.Extensions.ImagingMagickNetServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Imaging.MagickNet",
+      "file": "src/Granit.Imaging.MagickNet/Extensions/ImagingMagickNetServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitImagingMagickNet",
+          "kind": "method",
+          "signature": "AddGranitImagingMagickNet(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitImagingMagickNetModule",
+      "fqn": "Granit.Imaging.MagickNet.GranitImagingMagickNetModule",
+      "kind": "class",
+      "project": "Granit.Imaging.MagickNet",
+      "file": "src/Granit.Imaging.MagickNet/GranitImagingMagickNetModule.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ResizeMode",
+      "fqn": "Granit.Imaging.ResizeMode",
+      "kind": "enum",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/ResizeMode.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WatermarkPosition",
+      "fqn": "Granit.Imaging.WatermarkPosition",
+      "kind": "enum",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/WatermarkPosition.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "struct",
+      "fqn": "Granit.Imaging.struct",
+      "kind": "record",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/CropRectangle.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "LocalizationAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Localization.AI.Extensions.LocalizationAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Localization.AI",
+      "file": "src/Granit.Localization.AI/Extensions/LocalizationAIHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitLocalizationAI",
+          "kind": "method",
+          "signature": "AddGranitLocalizationAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitLocalizationAIModule",
+      "fqn": "Granit.Localization.AI.GranitLocalizationAIModule",
+      "kind": "class",
+      "project": "Granit.Localization.AI",
+      "file": "src/Granit.Localization.AI/GranitLocalizationAIModule.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "ITranslationSuggestionService",
+      "fqn": "Granit.Localization.AI.ITranslationSuggestionService",
+      "kind": "interface",
+      "project": "Granit.Localization.AI",
+      "file": "src/Granit.Localization.AI/ITranslationSuggestionService.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SuggestTranslationsAsync",
+          "kind": "method",
+          "signature": "SuggestTranslationsAsync(string key, string sourceValue, string sourceCulture, IReadOnlyList<string> targetCultures, TranslationContext context = TranslationContext.UiLabel, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<TranslationSuggestion>>"
+        }
+      ]
+    },
+    {
+      "name": "LocalizationAIOptions",
+      "fqn": "Granit.Localization.AI.Options.LocalizationAIOptions",
+      "kind": "class",
+      "project": "Granit.Localization.AI",
+      "file": "src/Granit.Localization.AI/Options/LocalizationAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string WorkspaceName",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "TranslationContext",
+      "fqn": "Granit.Localization.AI.TranslationContext",
+      "kind": "enum",
+      "project": "Granit.Localization.AI",
+      "file": "src/Granit.Localization.AI/TranslationContext.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "TranslationSuggestion",
+      "fqn": "Granit.Localization.AI.TranslationSuggestion",
+      "kind": "record",
+      "project": "Granit.Localization.AI",
+      "file": "src/Granit.Localization.AI/TranslationSuggestion.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ApplicationLocalizationResponse",
+      "fqn": "Granit.Localization.Endpoints.Dtos.ApplicationLocalizationResponse",
+      "kind": "record",
+      "project": "Granit.Localization.Endpoints",
+      "file": "src/Granit.Localization.Endpoints/Dtos/ApplicationLocalizationResponse.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "LanguageInfoResponse",
+      "fqn": "Granit.Localization.Endpoints.Dtos.LanguageInfoResponse",
+      "kind": "record",
+      "project": "Granit.Localization.Endpoints",
+      "file": "src/Granit.Localization.Endpoints/Dtos/LanguageInfoResponse.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "SetLocalizationOverrideRequest",
+      "fqn": "Granit.Localization.Endpoints.Dtos.SetLocalizationOverrideRequest",
+      "kind": "record",
+      "project": "Granit.Localization.Endpoints",
+      "file": "src/Granit.Localization.Endpoints/Dtos/SetLocalizationOverrideRequest.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "LocalizationApplicationBuilderExtensions",
+      "fqn": "Granit.Localization.Endpoints.Extensions.LocalizationApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Localization.Endpoints",
+      "file": "src/Granit.Localization.Endpoints/Extensions/LocalizationApplicationBuilderExtensions.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "UseGranitRequestLocalization",
+          "kind": "method",
+          "signature": "UseGranitRequestLocalization(this IApplicationBuilder app, Action<RequestLocalizationOptions>? configure = null)",
+          "returnType": "IApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "LocalizationEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Localization.Endpoints.Extensions.LocalizationEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Localization.Endpoints",
+      "file": "src/Granit.Localization.Endpoints/Extensions/LocalizationEndpointRouteBuilderExtensions.cs",
+      "line": 31,
+      "members": [
+        {
+          "name": "MapGranitLocalization",
+          "kind": "method",
+          "signature": "MapGranitLocalization(this IEndpointRouteBuilder endpoints, Action<LocalizationEndpointsOptions>? configure = null)",
+          "returnType": "IEndpointRouteBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitLocalizationEndpointsModule",
+      "fqn": "Granit.Localization.Endpoints.GranitLocalizationEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Localization.Endpoints",
+      "file": "src/Granit.Localization.Endpoints/GranitLocalizationEndpointsModule.cs",
+      "line": 27,
+      "members": []
+    },
+    {
+      "name": "LocalizationEndpointsOptions",
+      "fqn": "Granit.Localization.Endpoints.Options.LocalizationEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Localization.Endpoints",
+      "file": "src/Granit.Localization.Endpoints/Options/LocalizationEndpointsOptions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "LocalizationOverridesPermissions",
+      "fqn": "Granit.Localization.Endpoints.Permissions.LocalizationOverridesPermissions",
+      "kind": "class",
+      "project": "Granit.Localization.Endpoints",
+      "file": "src/Granit.Localization.Endpoints/Permissions/LocalizationOverridesPermissions.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "LocalizationOverride",
+      "fqn": "Granit.Localization.EntityFrameworkCore.Entities.LocalizationOverride",
+      "kind": "class",
+      "project": "Granit.Localization.EntityFrameworkCore",
+      "file": "src/Granit.Localization.EntityFrameworkCore/Entities/LocalizationOverride.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "TenantId",
+          "kind": "property",
+          "signature": "Guid? TenantId",
+          "returnType": "Guid?"
+        },
+        {
+          "name": "CultureName",
+          "kind": "property",
+          "signature": "string CultureName",
+          "returnType": "string"
+        },
+        {
+          "name": "Key",
+          "kind": "property",
+          "signature": "string Key",
+          "returnType": "string"
+        },
+        {
+          "name": "Value",
+          "kind": "property",
+          "signature": "string Value",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "LocalizationEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.Localization.EntityFrameworkCore.Extensions.LocalizationEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Localization.EntityFrameworkCore",
+      "file": "src/Granit.Localization.EntityFrameworkCore/Extensions/LocalizationEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitLocalizationEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitLocalizationEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "LocalizationModelBuilderExtensions",
+      "fqn": "Granit.Localization.EntityFrameworkCore.Extensions.LocalizationModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Localization.EntityFrameworkCore",
+      "file": "src/Granit.Localization.EntityFrameworkCore/Extensions/LocalizationModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureLocalizationModule",
+          "kind": "method",
+          "signature": "ConfigureLocalizationModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitLocalizationDbProperties",
+      "fqn": "Granit.Localization.EntityFrameworkCore.GranitLocalizationDbProperties",
+      "kind": "class",
+      "project": "Granit.Localization.EntityFrameworkCore",
+      "file": "src/Granit.Localization.EntityFrameworkCore/GranitLocalizationDbProperties.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitLocalizationEntityFrameworkCoreModule",
+      "fqn": "Granit.Localization.EntityFrameworkCore.GranitLocalizationEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Localization.EntityFrameworkCore",
+      "file": "src/Granit.Localization.EntityFrameworkCore/GranitLocalizationEntityFrameworkCoreModule.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "LocalizationServiceCollectionExtensions",
+      "fqn": "Granit.Localization.Extensions.LocalizationServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Localization",
+      "file": "src/Granit.Localization/Extensions/LocalizationServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitLocalization",
+          "kind": "method",
+          "signature": "AddGranitLocalization(this IServiceCollection services, Action<GranitLocalizationOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitLocalizationModule",
+      "fqn": "Granit.Localization.GranitLocalizationModule",
+      "kind": "class",
+      "project": "Granit.Localization",
+      "file": "src/Granit.Localization/GranitLocalizationModule.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GranitLocalizationResource",
+      "fqn": "Granit.Localization.GranitLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Localization",
+      "file": "src/Granit.Localization/GranitLocalizationResource.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "ILocalizationOverrideStoreReader",
+      "fqn": "Granit.Localization.ILocalizationOverrideStoreReader",
+      "kind": "interface",
+      "project": "Granit.Localization",
+      "file": "src/Granit.Localization/ILocalizationOverrideStoreReader.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetOverridesAsync",
+          "kind": "method",
+          "signature": "GetOverridesAsync(string resourceName, string culture, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyDictionary<string, string>>"
+        }
+      ]
+    },
+    {
+      "name": "ILocalizationOverrideStoreWriter",
+      "fqn": "Granit.Localization.ILocalizationOverrideStoreWriter",
+      "kind": "interface",
+      "project": "Granit.Localization",
+      "file": "src/Granit.Localization/ILocalizationOverrideStoreWriter.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SetOverrideAsync",
+          "kind": "method",
+          "signature": "SetOverrideAsync(string resourceName, string culture, string key, string value, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RemoveOverrideAsync",
+          "kind": "method",
+          "signature": "RemoveOverrideAsync(string resourceName, string culture, string key, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "LanguageInfo",
+      "fqn": "Granit.Localization.LanguageInfo",
+      "kind": "class",
+      "project": "Granit.Localization",
+      "file": "src/Granit.Localization/LanguageInfo.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "CultureName",
+          "kind": "property",
+          "signature": "string CultureName",
+          "returnType": "string"
+        },
+        {
+          "name": "DisplayName",
+          "kind": "property",
+          "signature": "string DisplayName",
+          "returnType": "string"
+        },
+        {
+          "name": "FlagIcon",
+          "kind": "property",
+          "signature": "string? FlagIcon",
+          "returnType": "string?"
+        },
+        {
+          "name": "IsDefault",
+          "kind": "property",
+          "signature": "bool IsDefault",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "LocalizationResourceInfo",
+      "fqn": "Granit.Localization.LocalizationResourceInfo",
+      "kind": "class",
+      "project": "Granit.Localization",
+      "file": "src/Granit.Localization/LocalizationResourceInfo.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "ResourceType",
+          "kind": "property",
+          "signature": "Type ResourceType",
+          "returnType": "Type"
+        },
+        {
+          "name": "DefaultCulture",
+          "kind": "property",
+          "signature": "string DefaultCulture",
+          "returnType": "string"
+        },
+        {
+          "name": "BaseTypes",
+          "kind": "property",
+          "signature": "List<Type> BaseTypes",
+          "returnType": "List<Type>"
+        },
+        {
+          "name": "AddJson",
+          "kind": "method",
+          "signature": "AddJson(Assembly assembly, string embeddedResourcePrefix)",
+          "returnType": "LocalizationResourceInfo"
+        }
+      ]
+    },
+    {
+      "name": "LocalizationResourceStore",
+      "fqn": "Granit.Localization.LocalizationResourceStore",
+      "kind": "class",
+      "project": "Granit.Localization",
+      "file": "src/Granit.Localization/LocalizationResourceStore.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "Add",
+          "kind": "method",
+          "signature": "Add(Type resourceType, string defaultCulture = \"fr\")",
+          "returnType": "LocalizationResourceInfo"
+        },
+        {
+          "name": "TryGetValue",
+          "kind": "method",
+          "signature": "TryGetValue(Type resourceType, [NotNullWhen(true)",
+          "returnType": "bool"
+        },
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IEnumerable<LocalizationResourceInfo>"
+        }
+      ]
+    },
+    {
+      "name": "GranitLocalizationOptions",
+      "fqn": "Granit.Localization.Options.GranitLocalizationOptions",
+      "kind": "class",
+      "project": "Granit.Localization",
+      "file": "src/Granit.Localization/Options/GranitLocalizationOptions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "LocalizationResourceStore Resources { get; } ="
+        },
+        {
+          "name": "DefaultResourceType",
+          "kind": "property",
+          "signature": "Type? DefaultResourceType",
+          "returnType": "Type?"
+        },
+        {
+          "name": "FormattingCultures",
+          "kind": "property",
+          "signature": "List<CultureInfo> FormattingCultures",
+          "returnType": "List<CultureInfo>"
+        }
+      ]
+    },
+    {
+      "name": "LocalizationOverridesCacheOptions",
+      "fqn": "Granit.Localization.Options.LocalizationOverridesCacheOptions",
+      "kind": "class",
+      "project": "Granit.Localization",
+      "file": "src/Granit.Localization/Options/LocalizationOverridesCacheOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(5)",
+          "returnType": "TimeSpan CacheTtl { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "LocalizationKeysGenerator",
+      "fqn": "Granit.Localization.SourceGenerator.LocalizationKeysGenerator",
+      "kind": "class",
+      "project": "Granit.Localization.SourceGenerator",
+      "file": "src/Granit.Localization.SourceGenerator/LocalizationKeysGenerator.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "Initialize",
+          "kind": "method",
+          "signature": "Initialize(IncrementalGeneratorInitializationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "CurrentTenant",
+      "fqn": "Granit.MultiTenancy.CurrentTenant",
+      "kind": "class",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/CurrentTenant.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "IsAvailable",
+          "kind": "property",
+          "signature": "bool IsAvailable",
+          "returnType": "bool"
+        },
+        {
+          "name": "Id",
+          "kind": "property",
+          "signature": "Guid? Id",
+          "returnType": "Guid?"
+        },
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string? Name",
+          "returnType": "string?"
+        },
+        {
+          "name": "Change",
+          "kind": "method",
+          "signature": "Change(Guid? id, string? name = null)",
+          "returnType": "IDisposable"
+        }
+      ]
+    },
+    {
+      "name": "MultiTenancyApplicationBuilderExtensions",
+      "fqn": "Granit.MultiTenancy.Extensions.MultiTenancyApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/Extensions/MultiTenancyApplicationBuilderExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "UseGranitMultiTenancy",
+          "kind": "method",
+          "signature": "UseGranitMultiTenancy(this IApplicationBuilder app)",
+          "returnType": "IApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "MultiTenancyServiceCollectionExtensions",
+      "fqn": "Granit.MultiTenancy.Extensions.MultiTenancyServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/Extensions/MultiTenancyServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitMultiTenancy",
+          "kind": "method",
+          "signature": "AddGranitMultiTenancy(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitMultiTenancyModule",
+      "fqn": "Granit.MultiTenancy.GranitMultiTenancyModule",
+      "kind": "class",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/GranitMultiTenancyModule.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ITenantInfo",
+      "fqn": "Granit.MultiTenancy.ITenantInfo",
+      "kind": "interface",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/ITenantInfo.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "TenantResolutionMiddleware",
+      "fqn": "Granit.MultiTenancy.Middleware.TenantResolutionMiddleware",
+      "kind": "class",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/Middleware/TenantResolutionMiddleware.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "InvokeAsync",
+          "kind": "method",
+          "signature": "InvokeAsync(HttpContext context, RequestDelegate next)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "MultiTenancyOptions",
+      "fqn": "Granit.MultiTenancy.Options.MultiTenancyOptions",
+      "kind": "class",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/Options/MultiTenancyOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "IsEnabled",
+          "kind": "property",
+          "signature": "bool IsEnabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "TenantIdClaimType",
+          "kind": "property",
+          "signature": "string TenantIdClaimType",
+          "returnType": "string"
+        },
+        {
+          "name": "TenantIdHeaderName",
+          "kind": "property",
+          "signature": "string TenantIdHeaderName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "TenantResolverPipeline",
+      "fqn": "Granit.MultiTenancy.Pipeline.TenantResolverPipeline",
+      "kind": "class",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/Pipeline/TenantResolverPipeline.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ResolveAsync",
+          "kind": "method",
+          "signature": "ResolveAsync(HttpContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TenantInfo?>"
+        }
+      ]
+    },
+    {
+      "name": "HeaderTenantResolver",
+      "fqn": "Granit.MultiTenancy.Resolvers.HeaderTenantResolver",
+      "kind": "class",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/Resolvers/HeaderTenantResolver.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "Order",
+          "kind": "property",
+          "signature": "int Order",
+          "returnType": "int"
+        },
+        {
+          "name": "ResolveAsync",
+          "kind": "method",
+          "signature": "ResolveAsync(HttpContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TenantInfo?>"
+        }
+      ]
+    },
+    {
+      "name": "ITenantResolver",
+      "fqn": "Granit.MultiTenancy.Resolvers.ITenantResolver",
+      "kind": "interface",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/Resolvers/ITenantResolver.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "ResolveAsync",
+          "kind": "method",
+          "signature": "ResolveAsync(HttpContext context, CancellationToken cancellationToken = default)",
+          "returnType": "int Order { get; } Task<TenantInfo?>"
+        }
+      ]
+    },
+    {
+      "name": "JwtClaimTenantResolver",
+      "fqn": "Granit.MultiTenancy.Resolvers.JwtClaimTenantResolver",
+      "kind": "class",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/Resolvers/JwtClaimTenantResolver.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "Order",
+          "kind": "property",
+          "signature": "int Order",
+          "returnType": "int"
+        },
+        {
+          "name": "ResolveAsync",
+          "kind": "method",
+          "signature": "ResolveAsync(HttpContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TenantInfo?>"
+        }
+      ]
+    },
+    {
+      "name": "TenantInfo",
+      "fqn": "Granit.MultiTenancy.TenantInfo",
+      "kind": "record",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/TenantInfo.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "NotificationsAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Notifications.AI.Extensions.NotificationsAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.AI",
+      "file": "src/Granit.Notifications.AI/Extensions/NotificationsAIHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitNotificationsAI",
+          "kind": "method",
+          "signature": "AddGranitNotificationsAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsAIModule",
+      "fqn": "Granit.Notifications.AI.GranitNotificationsAIModule",
+      "kind": "class",
+      "project": "Granit.Notifications.AI",
+      "file": "src/Granit.Notifications.AI/GranitNotificationsAIModule.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "IAIChannelSelector",
+      "fqn": "Granit.Notifications.AI.IAIChannelSelector",
+      "kind": "interface",
+      "project": "Granit.Notifications.AI",
+      "file": "src/Granit.Notifications.AI/IAIChannelSelector.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "SelectChannelsAsync",
+          "kind": "method",
+          "signature": "SelectChannelsAsync(NotificationDeliveryContext context, IReadOnlyList<string> availableChannels, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<string>>"
+        }
+      ]
+    },
+    {
+      "name": "IAINotificationContentGenerator",
+      "fqn": "Granit.Notifications.AI.IAINotificationContentGenerator",
+      "kind": "interface",
+      "project": "Granit.Notifications.AI",
+      "file": "src/Granit.Notifications.AI/IAINotificationContentGenerator.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GenerateAsync",
+          "kind": "method",
+          "signature": "GenerateAsync(NotificationDeliveryContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task<NotificationContent?>"
+        }
+      ]
+    },
+    {
+      "name": "NotificationContent",
+      "fqn": "Granit.Notifications.AI.NotificationContent",
+      "kind": "record",
+      "project": "Granit.Notifications.AI",
+      "file": "src/Granit.Notifications.AI/NotificationContent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "NotificationsAIOptions",
+      "fqn": "Granit.Notifications.AI.Options.NotificationsAIOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.AI",
+      "file": "src/Granit.Notifications.AI/Options/NotificationsAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string? WorkspaceName",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "INotificationChannel",
+      "fqn": "Granit.Notifications.Abstractions.INotificationChannel",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/INotificationChannel.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SendAsync",
+          "kind": "method",
+          "signature": "SendAsync(NotificationDeliveryContext context, CancellationToken cancellationToken = default)",
+          "returnType": "string Name { get; } Task"
+        }
+      ]
+    },
+    {
+      "name": "INotificationDefinitionContext",
+      "fqn": "Granit.Notifications.Abstractions.INotificationDefinitionContext",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/INotificationDefinitionContext.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Add",
+          "kind": "method",
+          "signature": "Add(NotificationDefinition definition)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "INotificationDefinitionProvider",
+      "fqn": "Granit.Notifications.Abstractions.INotificationDefinitionProvider",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/INotificationDefinitionProvider.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Define",
+          "kind": "method",
+          "signature": "Define(INotificationDefinitionContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "INotificationDefinitionStore",
+      "fqn": "Granit.Notifications.Abstractions.INotificationDefinitionStore",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/INotificationDefinitionStore.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IReadOnlyList<NotificationDefinition>"
+        },
+        {
+          "name": "Get",
+          "kind": "method",
+          "signature": "Get(string notificationTypeName)",
+          "returnType": "NotificationDefinition?"
+        }
+      ]
+    },
+    {
+      "name": "INotificationDeliveryWriter",
+      "fqn": "Granit.Notifications.Abstractions.INotificationDeliveryWriter",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/INotificationDeliveryWriter.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "RecordAsync",
+          "kind": "method",
+          "signature": "RecordAsync(NotificationDeliveryAttempt attempt, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteBeforeAsync",
+          "kind": "method",
+          "signature": "DeleteBeforeAsync(DateTimeOffset cutoff, int batchSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        }
+      ]
+    },
+    {
+      "name": "INotificationPreferenceReader",
+      "fqn": "Granit.Notifications.Abstractions.INotificationPreferenceReader",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/INotificationPreferenceReader.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetListAsync",
+          "kind": "method",
+          "signature": "GetListAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<NotificationPreference>>"
+        },
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(string userId, string notificationTypeName, string channelName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<NotificationPreference?>"
+        },
+        {
+          "name": "IsChannelEnabledAsync",
+          "kind": "method",
+          "signature": "IsChannelEnabledAsync(string userId, string notificationTypeName, string channelName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "INotificationPreferenceWriter",
+      "fqn": "Granit.Notifications.Abstractions.INotificationPreferenceWriter",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/INotificationPreferenceWriter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "SetAsync",
+          "kind": "method",
+          "signature": "SetAsync(NotificationPreference preference, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "INotificationPublisher",
+      "fqn": "Granit.Notifications.Abstractions.INotificationPublisher",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/INotificationPublisher.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "INotificationSubscriptionReader",
+      "fqn": "Granit.Notifications.Abstractions.INotificationSubscriptionReader",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/INotificationSubscriptionReader.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetSubscriberIdsAsync",
+          "kind": "method",
+          "signature": "GetSubscriberIdsAsync(string notificationTypeName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<string>>"
+        },
+        {
+          "name": "GetUserSubscriptionsAsync",
+          "kind": "method",
+          "signature": "GetUserSubscriptionsAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<NotificationSubscription>>"
+        },
+        {
+          "name": "GetEntityFollowerIdsAsync",
+          "kind": "method",
+          "signature": "GetEntityFollowerIdsAsync(string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<string>>"
+        },
+        {
+          "name": "GetEntityFollowersAsync",
+          "kind": "method",
+          "signature": "GetEntityFollowersAsync(string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<NotificationSubscription>>"
+        },
+        {
+          "name": "IsFollowingEntityAsync",
+          "kind": "method",
+          "signature": "IsFollowingEntityAsync(string userId, string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "INotificationSubscriptionWriter",
+      "fqn": "Granit.Notifications.Abstractions.INotificationSubscriptionWriter",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/INotificationSubscriptionWriter.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SubscribeAsync",
+          "kind": "method",
+          "signature": "SubscribeAsync(string userId, string notificationTypeName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UnsubscribeAsync",
+          "kind": "method",
+          "signature": "UnsubscribeAsync(string userId, string notificationTypeName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "FollowEntityAsync",
+          "kind": "method",
+          "signature": "FollowEntityAsync(string userId, string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UnfollowEntityAsync",
+          "kind": "method",
+          "signature": "UnfollowEntityAsync(string userId, string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IRecipientResolver",
+      "fqn": "Granit.Notifications.Abstractions.IRecipientResolver",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/IRecipientResolver.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "ResolveAsync",
+          "kind": "method",
+          "signature": "ResolveAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<RecipientInfo?>"
+        }
+      ]
+    },
+    {
+      "name": "IUserNotificationReader",
+      "fqn": "Granit.Notifications.Abstractions.IUserNotificationReader",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/IUserNotificationReader.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<UserNotification?>"
+        },
+        {
+          "name": "GetListAsync",
+          "kind": "method",
+          "signature": "GetListAsync(string recipientUserId, Guid? tenantId, int page = 1, int pageSize = QueryingDefaults.DefaultPageSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<UserNotification>>"
+        },
+        {
+          "name": "GetUnreadCountAsync",
+          "kind": "method",
+          "signature": "GetUnreadCountAsync(string recipientUserId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        },
+        {
+          "name": "GetByEntityAsync",
+          "kind": "method",
+          "signature": "GetByEntityAsync(string entityType, string entityId, Guid? tenantId, int page = 1, int pageSize = QueryingDefaults.DefaultPageSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<UserNotification>>"
+        }
+      ]
+    },
+    {
+      "name": "IUserNotificationWriter",
+      "fqn": "Granit.Notifications.Abstractions.IUserNotificationWriter",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/IUserNotificationWriter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "InsertAsync",
+          "kind": "method",
+          "signature": "InsertAsync(UserNotification notification, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "MarkAsReadAsync",
+          "kind": "method",
+          "signature": "MarkAsReadAsync(Guid id, DateTimeOffset readAt, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "MarkAllAsReadAsync",
+          "kind": "method",
+          "signature": "MarkAllAsReadAsync(string recipientUserId, Guid? tenantId, DateTimeOffset readAt, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "BrevoNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Brevo.Extensions.BrevoNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Brevo",
+      "file": "src/Granit.Notifications.Brevo/Extensions/BrevoNotificationsServiceCollectionExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitNotificationsBrevo",
+          "kind": "method",
+          "signature": "AddGranitNotificationsBrevo(this IServiceCollection services, Action<BrevoOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsBrevoModule",
+      "fqn": "Granit.Notifications.Brevo.GranitNotificationsBrevoModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Brevo",
+      "file": "src/Granit.Notifications.Brevo/GranitNotificationsBrevoModule.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "BrevoOptions",
+      "fqn": "Granit.Notifications.Brevo.Options.BrevoOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Brevo",
+      "file": "src/Granit.Notifications.Brevo/Options/BrevoOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ApiKey",
+          "kind": "property",
+          "signature": "string ApiKey",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSenderEmail",
+          "kind": "property",
+          "signature": "string DefaultSenderEmail",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSenderName",
+          "kind": "property",
+          "signature": "string DefaultSenderName",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSmsSenderId",
+          "kind": "property",
+          "signature": "string DefaultSmsSenderId",
+          "returnType": "string"
+        },
+        {
+          "name": "BaseUrl",
+          "kind": "property",
+          "signature": "string BaseUrl",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "NotificationsMetrics",
+      "fqn": "Granit.Notifications.Diagnostics.NotificationsMetrics",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Diagnostics/NotificationsMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordDeliverySucceeded",
+          "kind": "method",
+          "signature": "RecordDeliverySucceeded(string? tenantId, string channel, string notificationType)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordDeliveryFailed",
+          "kind": "method",
+          "signature": "RecordDeliveryFailed(string? tenantId, string channel, string notificationType)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordDeliveryDuration",
+          "kind": "method",
+          "signature": "RecordDeliveryDuration(string? tenantId, string channel, string status, TimeSpan duration)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "NotificationDeliveryAttempt",
+      "fqn": "Granit.Notifications.Domain.NotificationDeliveryAttempt",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Domain/NotificationDeliveryAttempt.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "DeliveryId",
+          "kind": "property",
+          "signature": "Guid DeliveryId",
+          "returnType": "Guid"
+        },
+        {
+          "name": "ChannelName",
+          "kind": "property",
+          "signature": "string ChannelName",
+          "returnType": "string"
+        },
+        {
+          "name": "RecipientUserId",
+          "kind": "property",
+          "signature": "string RecipientUserId",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "NotificationPreference",
+      "fqn": "Granit.Notifications.Domain.NotificationPreference",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Domain/NotificationPreference.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "UserId",
+          "kind": "property",
+          "signature": "string UserId",
+          "returnType": "string"
+        },
+        {
+          "name": "NotificationTypeName",
+          "kind": "property",
+          "signature": "string NotificationTypeName",
+          "returnType": "string"
+        },
+        {
+          "name": "ChannelName",
+          "kind": "property",
+          "signature": "string ChannelName",
+          "returnType": "string"
+        },
+        {
+          "name": "IsEnabled",
+          "kind": "property",
+          "signature": "bool IsEnabled",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "NotificationSubscription",
+      "fqn": "Granit.Notifications.Domain.NotificationSubscription",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Domain/NotificationSubscription.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "UserId",
+          "kind": "property",
+          "signature": "string UserId",
+          "returnType": "string"
+        },
+        {
+          "name": "NotificationTypeName",
+          "kind": "property",
+          "signature": "string NotificationTypeName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "UserNotification",
+      "fqn": "Granit.Notifications.Domain.UserNotification",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Domain/UserNotification.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, Guid notificationId, string notificationTypeName, NotificationSeverity severity, string recipientUserId, System.Text.Json.JsonElement data, DateTimeOffset createdAt, Guid? tenantId = null, string? relatedEntityType = null, string? relatedEntityId = null)",
+          "returnType": "UserNotification"
+        },
+        {
+          "name": "NotificationId",
+          "kind": "property",
+          "signature": "Guid NotificationId",
+          "returnType": "Guid"
+        },
+        {
+          "name": "Severity",
+          "kind": "property",
+          "signature": "NotificationSeverity Severity",
+          "returnType": "NotificationSeverity"
+        },
+        {
+          "name": "Data",
+          "kind": "property",
+          "signature": "System.Text.Json.JsonElement Data",
+          "returnType": "System.Text.Json.JsonElement"
+        },
+        {
+          "name": "MarkAsRead",
+          "kind": "method",
+          "signature": "MarkAsRead(DateTimeOffset readAt)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "UserNotificationState",
+      "fqn": "Granit.Notifications.Domain.UserNotificationState",
+      "kind": "enum",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Domain/UserNotificationState.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "SesEmailServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Email.AwsSes.Extensions.SesEmailServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.AwsSes",
+      "file": "src/Granit.Notifications.Email.AwsSes/Extensions/SesEmailServiceCollectionExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitNotificationsEmailAwsSes",
+          "kind": "method",
+          "signature": "AddGranitNotificationsEmailAwsSes(this IServiceCollection services, Action<AwsSesOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsEmailAwsSesModule",
+      "fqn": "Granit.Notifications.Email.AwsSes.GranitNotificationsEmailAwsSesModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.AwsSes",
+      "file": "src/Granit.Notifications.Email.AwsSes/GranitNotificationsEmailAwsSesModule.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AwsSesOptions",
+      "fqn": "Granit.Notifications.Email.AwsSes.Options.AwsSesOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.AwsSes",
+      "file": "src/Granit.Notifications.Email.AwsSes/Options/AwsSesOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Region",
+          "kind": "property",
+          "signature": "string Region",
+          "returnType": "string"
+        },
+        {
+          "name": "FromAddress",
+          "kind": "property",
+          "signature": "string? FromAddress",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "AcsEmailServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Email.AzureCommunicationServices.Extensions.AcsEmailServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.AzureCommunicationServices",
+      "file": "src/Granit.Notifications.Email.AzureCommunicationServices/Extensions/AcsEmailServiceCollectionExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitNotificationsEmailAcs",
+          "kind": "method",
+          "signature": "AddGranitNotificationsEmailAcs(this IServiceCollection services, Action<AcsEmailOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsEmailAcsModule",
+      "fqn": "Granit.Notifications.Email.AzureCommunicationServices.GranitNotificationsEmailAcsModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.AzureCommunicationServices",
+      "file": "src/Granit.Notifications.Email.AzureCommunicationServices/GranitNotificationsEmailAcsModule.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AcsEmailOptions",
+      "fqn": "Granit.Notifications.Email.AzureCommunicationServices.Options.AcsEmailOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.AzureCommunicationServices",
+      "file": "src/Granit.Notifications.Email.AzureCommunicationServices/Options/AcsEmailOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ConnectionString",
+          "kind": "property",
+          "signature": "string? ConnectionString",
+          "returnType": "string?"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "EmailMessage",
+      "fqn": "Granit.Notifications.Email.EmailMessage",
+      "kind": "record",
+      "project": "Granit.Notifications.Email",
+      "file": "src/Granit.Notifications.Email/EmailMessage.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "EmailNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Email.Extensions.EmailNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email",
+      "file": "src/Granit.Notifications.Email/Extensions/EmailNotificationsServiceCollectionExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "AddGranitNotificationsEmail",
+          "kind": "method",
+          "signature": "AddGranitNotificationsEmail(this IServiceCollection services, Action<EmailChannelOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsEmailModule",
+      "fqn": "Granit.Notifications.Email.GranitNotificationsEmailModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Email",
+      "file": "src/Granit.Notifications.Email/GranitNotificationsEmailModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "IEmailSender",
+      "fqn": "Granit.Notifications.Email.IEmailSender",
+      "kind": "interface",
+      "project": "Granit.Notifications.Email",
+      "file": "src/Granit.Notifications.Email/IEmailSender.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "SendAsync",
+          "kind": "method",
+          "signature": "SendAsync(EmailMessage message, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "EmailChannelOptions",
+      "fqn": "Granit.Notifications.Email.Options.EmailChannelOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email",
+      "file": "src/Granit.Notifications.Email/Options/EmailChannelOptions.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "Provider",
+          "kind": "property",
+          "signature": "string Provider",
+          "returnType": "string"
+        },
+        {
+          "name": "SenderAddress",
+          "kind": "property",
+          "signature": "string SenderAddress",
+          "returnType": "string"
+        },
+        {
+          "name": "SenderName",
+          "kind": "property",
+          "signature": "string SenderName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "ScalewayEmailServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Email.Scaleway.Extensions.ScalewayEmailServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.Scaleway",
+      "file": "src/Granit.Notifications.Email.Scaleway/Extensions/ScalewayEmailServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitNotificationsEmailScaleway",
+          "kind": "method",
+          "signature": "AddGranitNotificationsEmailScaleway(this IServiceCollection services, Action<ScalewayEmailOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsEmailScalewayModule",
+      "fqn": "Granit.Notifications.Email.Scaleway.GranitNotificationsEmailScalewayModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.Scaleway",
+      "file": "src/Granit.Notifications.Email.Scaleway/GranitNotificationsEmailScalewayModule.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ScalewayEmailOptions",
+      "fqn": "Granit.Notifications.Email.Scaleway.Options.ScalewayEmailOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.Scaleway",
+      "file": "src/Granit.Notifications.Email.Scaleway/Options/ScalewayEmailOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SecretKey",
+          "kind": "property",
+          "signature": "string SecretKey",
+          "returnType": "string"
+        },
+        {
+          "name": "ProjectId",
+          "kind": "property",
+          "signature": "string ProjectId",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSenderEmail",
+          "kind": "property",
+          "signature": "string DefaultSenderEmail",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSenderName",
+          "kind": "property",
+          "signature": "string DefaultSenderName",
+          "returnType": "string"
+        },
+        {
+          "name": "Region",
+          "kind": "property",
+          "signature": "string Region",
+          "returnType": "string"
+        },
+        {
+          "name": "BaseUrl",
+          "kind": "property",
+          "signature": "string BaseUrl",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "SendGridEmailServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Email.SendGrid.Extensions.SendGridEmailServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.SendGrid",
+      "file": "src/Granit.Notifications.Email.SendGrid/Extensions/SendGridEmailServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitNotificationsEmailSendGrid",
+          "kind": "method",
+          "signature": "AddGranitNotificationsEmailSendGrid(this IServiceCollection services, Action<SendGridEmailOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsEmailSendGridModule",
+      "fqn": "Granit.Notifications.Email.SendGrid.GranitNotificationsEmailSendGridModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.SendGrid",
+      "file": "src/Granit.Notifications.Email.SendGrid/GranitNotificationsEmailSendGridModule.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "SendGridEmailOptions",
+      "fqn": "Granit.Notifications.Email.SendGrid.Options.SendGridEmailOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.SendGrid",
+      "file": "src/Granit.Notifications.Email.SendGrid/Options/SendGridEmailOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ApiKey",
+          "kind": "property",
+          "signature": "string ApiKey",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSenderEmail",
+          "kind": "property",
+          "signature": "string DefaultSenderEmail",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSenderName",
+          "kind": "property",
+          "signature": "string DefaultSenderName",
+          "returnType": "string"
+        },
+        {
+          "name": "BaseUrl",
+          "kind": "property",
+          "signature": "string BaseUrl",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "SmtpEmailServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Email.Smtp.Extensions.SmtpEmailServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.Smtp",
+      "file": "src/Granit.Notifications.Email.Smtp/Extensions/SmtpEmailServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitNotificationsEmailSmtp",
+          "kind": "method",
+          "signature": "AddGranitNotificationsEmailSmtp(this IServiceCollection services, Action<SmtpOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsEmailSmtpModule",
+      "fqn": "Granit.Notifications.Email.Smtp.GranitNotificationsEmailSmtpModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.Smtp",
+      "file": "src/Granit.Notifications.Email.Smtp/GranitNotificationsEmailSmtpModule.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "SmtpOptions",
+      "fqn": "Granit.Notifications.Email.Smtp.Options.SmtpOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.Smtp",
+      "file": "src/Granit.Notifications.Email.Smtp/Options/SmtpOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Host",
+          "kind": "property",
+          "signature": "string Host",
+          "returnType": "string"
+        },
+        {
+          "name": "Port",
+          "kind": "property",
+          "signature": "int Port",
+          "returnType": "int"
+        },
+        {
+          "name": "UseSsl",
+          "kind": "property",
+          "signature": "bool UseSsl",
+          "returnType": "bool"
+        },
+        {
+          "name": "Username",
+          "kind": "property",
+          "signature": "string? Username",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "NotificationPreferenceResponse",
+      "fqn": "Granit.Notifications.Endpoints.Dtos.NotificationPreferenceResponse",
+      "kind": "record",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Dtos/NotificationPreferenceResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "NotificationPreferenceUpdateRequest",
+      "fqn": "Granit.Notifications.Endpoints.Dtos.NotificationPreferenceUpdateRequest",
+      "kind": "record",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Dtos/NotificationPreferenceUpdateRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "NotificationSubscriptionResponse",
+      "fqn": "Granit.Notifications.Endpoints.Dtos.NotificationSubscriptionResponse",
+      "kind": "record",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Dtos/NotificationSubscriptionResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "UnreadCountResponse",
+      "fqn": "Granit.Notifications.Endpoints.Dtos.UnreadCountResponse",
+      "kind": "record",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Dtos/UnreadCountResponse.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "UserNotificationResponse",
+      "fqn": "Granit.Notifications.Endpoints.Dtos.UserNotificationResponse",
+      "kind": "record",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Dtos/UserNotificationResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "MobilePushTokenEndpoints",
+      "fqn": "Granit.Notifications.Endpoints.Endpoints.MobilePushTokenEndpoints",
+      "kind": "class",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Endpoints/MobilePushTokenEndpoints.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "MapMobilePushTokenEndpoints",
+          "kind": "method",
+          "signature": "MapMobilePushTokenEndpoints(this IEndpointRouteBuilder endpoints, string prefix = \"api/notifications/mobile-push/tokens\")",
+          "returnType": "IEndpointRouteBuilder"
+        }
+      ]
+    },
+    {
+      "name": "MobilePushTokenRegisterRequest",
+      "fqn": "Granit.Notifications.Endpoints.Endpoints.MobilePushTokenRegisterRequest",
+      "kind": "record",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Endpoints/MobilePushTokenEndpoints.cs",
+      "line": 119,
+      "members": []
+    },
+    {
+      "name": "MobilePushTokenResponse",
+      "fqn": "Granit.Notifications.Endpoints.Endpoints.MobilePushTokenResponse",
+      "kind": "record",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Endpoints/MobilePushTokenEndpoints.cs",
+      "line": 129,
+      "members": []
+    },
+    {
+      "name": "NotificationEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Notifications.Endpoints.Extensions.NotificationEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Extensions/NotificationEndpointRouteBuilderExtensions.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "MapGranitNotificationEndpoints",
+          "kind": "method",
+          "signature": "MapGranitNotificationEndpoints(this IEndpointRouteBuilder endpoints, Action<NotificationEndpointsOptions>? configure = null)",
+          "returnType": "IEndpointRouteBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsEndpointsModule",
+      "fqn": "Granit.Notifications.Endpoints.GranitNotificationsEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/GranitNotificationsEndpointsModule.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "NotificationEndpointsOptions",
+      "fqn": "Granit.Notifications.Endpoints.Options.NotificationEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Options/NotificationEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "NotificationPermissions",
+      "fqn": "Granit.Notifications.Endpoints.Permissions.NotificationPermissions",
+      "kind": "class",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Permissions/NotificationPermissions.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "Notifications",
+      "fqn": "Granit.Notifications.Endpoints.Permissions.Notifications",
+      "kind": "class",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Permissions/NotificationPermissions.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "MobilePushTokenEntity",
+      "fqn": "Granit.Notifications.EntityFrameworkCore.Entities.MobilePushTokenEntity",
+      "kind": "class",
+      "project": "Granit.Notifications.EntityFrameworkCore",
+      "file": "src/Granit.Notifications.EntityFrameworkCore/Entities/MobilePushTokenEntity.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "UserId",
+          "kind": "property",
+          "signature": "string UserId",
+          "returnType": "string"
+        },
+        {
+          "name": "DeviceToken",
+          "kind": "property",
+          "signature": "string DeviceToken",
+          "returnType": "string"
+        },
+        {
+          "name": "ToTokenInfo",
+          "kind": "method",
+          "signature": "ToTokenInfo()",
+          "returnType": "MobilePlatform Platform { get; set; } public Guid? TenantId { get; set; } internal MobilePushTokenInfo"
+        }
+      ]
+    },
+    {
+      "name": "NotificationsEfCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.Notifications.EntityFrameworkCore.Extensions.NotificationsEfCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.EntityFrameworkCore",
+      "file": "src/Granit.Notifications.EntityFrameworkCore/Extensions/NotificationsEfCoreHostApplicationBuilderExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitNotificationsEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitNotificationsEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "NotificationsModelBuilderExtensions",
+      "fqn": "Granit.Notifications.EntityFrameworkCore.Extensions.NotificationsModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.EntityFrameworkCore",
+      "file": "src/Granit.Notifications.EntityFrameworkCore/Extensions/NotificationsModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureNotificationsModule",
+          "kind": "method",
+          "signature": "ConfigureNotificationsModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsDbProperties",
+      "fqn": "Granit.Notifications.EntityFrameworkCore.GranitNotificationsDbProperties",
+      "kind": "class",
+      "project": "Granit.Notifications.EntityFrameworkCore",
+      "file": "src/Granit.Notifications.EntityFrameworkCore/GranitNotificationsDbProperties.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsEntityFrameworkCoreModule",
+      "fqn": "Granit.Notifications.EntityFrameworkCore.GranitNotificationsEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Notifications.EntityFrameworkCore",
+      "file": "src/Granit.Notifications.EntityFrameworkCore/GranitNotificationsEntityFrameworkCoreModule.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "EntityReference",
+      "fqn": "Granit.Notifications.EntityReference",
+      "kind": "record",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/EntityReference.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "EntityStateChangedData",
+      "fqn": "Granit.Notifications.EntityStateChangedData",
+      "kind": "record",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/EntityStateChangedData.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "UserNotificationCreatedEvent",
+      "fqn": "Granit.Notifications.Events.UserNotificationCreatedEvent",
+      "kind": "record",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Events/UserNotificationCreatedEvent.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "UserNotificationReadEvent",
+      "fqn": "Granit.Notifications.Events.UserNotificationReadEvent",
+      "kind": "record",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Events/UserNotificationReadEvent.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "NotificationDeliveryException",
+      "fqn": "Granit.Notifications.Exceptions.NotificationDeliveryException",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Exceptions/NotificationDeliveryException.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "NotificationsHostApplicationBuilderExtensions",
+      "fqn": "Granit.Notifications.Extensions.NotificationsHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Extensions/NotificationsHostApplicationBuilderExtensions.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "AddGranitNotifications",
+          "kind": "method",
+          "signature": "AddGranitNotifications(this IHostApplicationBuilder builder, Action<NotificationsOptions>? configure = null)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsModule",
+      "fqn": "Granit.Notifications.GranitNotificationsModule",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/GranitNotificationsModule.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "NotificationDeliveryHandler",
+      "fqn": "Granit.Notifications.Handlers.NotificationDeliveryHandler",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Handlers/NotificationDeliveryHandler.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(DeliverNotificationCommand command, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "NotificationFanoutHandler",
+      "fqn": "Granit.Notifications.Handlers.NotificationFanoutHandler",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Handlers/NotificationFanoutHandler.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(NotificationTrigger trigger, CancellationToken cancellationToken)",
+          "returnType": "Task<IEnumerable<DeliverNotificationCommand>>"
+        }
+      ]
+    },
+    {
+      "name": "ITrackedEntity",
+      "fqn": "Granit.Notifications.ITrackedEntity",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/ITrackedEntity.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "GetEntityId",
+          "kind": "method",
+          "signature": "GetEntityId()",
+          "returnType": "string EntityTypeName { get; } string"
+        }
+      ]
+    },
+    {
+      "name": "DeliverNotificationCommand",
+      "fqn": "Granit.Notifications.Messages.DeliverNotificationCommand",
+      "kind": "record",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Messages/DeliverNotificationCommand.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "NotificationTrigger",
+      "fqn": "Granit.Notifications.Messages.NotificationTrigger",
+      "kind": "record",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Messages/NotificationTrigger.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "NewGuid",
+          "kind": "method",
+          "signature": "NewGuid()",
+          "returnType": "Guid NotificationId { get; init; } = Guid."
+        },
+        {
+          "name": "NotificationTypeName",
+          "kind": "property",
+          "signature": "required string NotificationTypeName",
+          "returnType": "required string"
+        }
+      ]
+    },
+    {
+      "name": "AwsSnsMobilePushServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.MobilePush.AwsSns.Extensions.AwsSnsMobilePushServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush.AwsSns",
+      "file": "src/Granit.Notifications.MobilePush.AwsSns/Extensions/AwsSnsMobilePushServiceCollectionExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitNotificationsMobilePushAwsSns",
+          "kind": "method",
+          "signature": "AddGranitNotificationsMobilePushAwsSns(this IServiceCollection services, Action<AwsSnsMobilePushOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsMobilePushAwsSnsModule",
+      "fqn": "Granit.Notifications.MobilePush.AwsSns.GranitNotificationsMobilePushAwsSnsModule",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush.AwsSns",
+      "file": "src/Granit.Notifications.MobilePush.AwsSns/GranitNotificationsMobilePushAwsSnsModule.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AwsSnsMobilePushOptions",
+      "fqn": "Granit.Notifications.MobilePush.AwsSns.Options.AwsSnsMobilePushOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush.AwsSns",
+      "file": "src/Granit.Notifications.MobilePush.AwsSns/Options/AwsSnsMobilePushOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Region",
+          "kind": "property",
+          "signature": "string Region",
+          "returnType": "string"
+        },
+        {
+          "name": "PlatformApplicationArn",
+          "kind": "property",
+          "signature": "string PlatformApplicationArn",
+          "returnType": "string"
+        },
+        {
+          "name": "AccessKeyId",
+          "kind": "property",
+          "signature": "string? AccessKeyId",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "AzureNotificationHubsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.MobilePush.AzureNotificationHubs.Extensions.AzureNotificationHubsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush.AzureNotificationHubs",
+      "file": "src/Granit.Notifications.MobilePush.AzureNotificationHubs/Extensions/AzureNotificationHubsServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitNotificationsMobilePushAzureNotificationHubs",
+          "kind": "method",
+          "signature": "AddGranitNotificationsMobilePushAzureNotificationHubs(this IServiceCollection services, Action<AzureNotificationHubsOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsMobilePushAnhModule",
+      "fqn": "Granit.Notifications.MobilePush.AzureNotificationHubs.GranitNotificationsMobilePushAnhModule",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush.AzureNotificationHubs",
+      "file": "src/Granit.Notifications.MobilePush.AzureNotificationHubs/GranitNotificationsMobilePushAnhModule.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AzureNotificationHubsOptions",
+      "fqn": "Granit.Notifications.MobilePush.AzureNotificationHubs.Options.AzureNotificationHubsOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush.AzureNotificationHubs",
+      "file": "src/Granit.Notifications.MobilePush.AzureNotificationHubs/Options/AzureNotificationHubsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ConnectionString",
+          "kind": "property",
+          "signature": "string ConnectionString",
+          "returnType": "string"
+        },
+        {
+          "name": "HubName",
+          "kind": "property",
+          "signature": "string HubName",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "MobilePushNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.MobilePush.Extensions.MobilePushNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/Extensions/MobilePushNotificationsServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitNotificationsMobilePush",
+          "kind": "method",
+          "signature": "AddGranitNotificationsMobilePush(this IServiceCollection services, Action<MobilePushChannelOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GoogleFcmMobilePushServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.MobilePush.GoogleFcm.Extensions.GoogleFcmMobilePushServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush.GoogleFcm",
+      "file": "src/Granit.Notifications.MobilePush.GoogleFcm/Extensions/GoogleFcmMobilePushServiceCollectionExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "AddGranitNotificationsMobilePushGoogleFcm",
+          "kind": "method",
+          "signature": "AddGranitNotificationsMobilePushGoogleFcm(this IServiceCollection services, Action<GoogleFcmOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsMobilePushGoogleFcmModule",
+      "fqn": "Granit.Notifications.MobilePush.GoogleFcm.GranitNotificationsMobilePushGoogleFcmModule",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush.GoogleFcm",
+      "file": "src/Granit.Notifications.MobilePush.GoogleFcm/GranitNotificationsMobilePushGoogleFcmModule.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "GoogleFcmOptions",
+      "fqn": "Granit.Notifications.MobilePush.GoogleFcm.Options.GoogleFcmOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush.GoogleFcm",
+      "file": "src/Granit.Notifications.MobilePush.GoogleFcm/Options/GoogleFcmOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ProjectId",
+          "kind": "property",
+          "signature": "string ProjectId",
+          "returnType": "string"
+        },
+        {
+          "name": "ServiceAccountJson",
+          "kind": "property",
+          "signature": "string ServiceAccountJson",
+          "returnType": "string"
+        },
+        {
+          "name": "BaseAddress",
+          "kind": "property",
+          "signature": "string BaseAddress",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsMobilePushModule",
+      "fqn": "Granit.Notifications.MobilePush.GranitNotificationsMobilePushModule",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/GranitNotificationsMobilePushModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "IMobilePushEventPublisher",
+      "fqn": "Granit.Notifications.MobilePush.IMobilePushEventPublisher",
+      "kind": "interface",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/IMobilePushEventPublisher.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "PublishTokenInvalidatedAsync",
+          "kind": "method",
+          "signature": "PublishTokenInvalidatedAsync(MobilePushTokenInvalidated tokenInvalidated, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IMobilePushSender",
+      "fqn": "Granit.Notifications.MobilePush.IMobilePushSender",
+      "kind": "interface",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/IMobilePushSender.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "SendAsync",
+          "kind": "method",
+          "signature": "SendAsync(MobilePushMessage message, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IMobilePushTokenReader",
+      "fqn": "Granit.Notifications.MobilePush.IMobilePushTokenReader",
+      "kind": "interface",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/IMobilePushTokenReader.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "GetTokensAsync",
+          "kind": "method",
+          "signature": "GetTokensAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<MobilePushTokenInfo>>"
+        }
+      ]
+    },
+    {
+      "name": "IMobilePushTokenWriter",
+      "fqn": "Granit.Notifications.MobilePush.IMobilePushTokenWriter",
+      "kind": "interface",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/IMobilePushTokenWriter.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "RegisterAsync",
+          "kind": "method",
+          "signature": "RegisterAsync(MobilePushTokenInfo tokenInfo, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RemoveAsync",
+          "kind": "method",
+          "signature": "RemoveAsync(string deviceToken, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "MobilePlatform",
+      "fqn": "Granit.Notifications.MobilePush.MobilePlatform",
+      "kind": "enum",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/MobilePlatform.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "MobilePushMessage",
+      "fqn": "Granit.Notifications.MobilePush.MobilePushMessage",
+      "kind": "record",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/MobilePushMessage.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "MobilePushTokenInfo",
+      "fqn": "Granit.Notifications.MobilePush.MobilePushTokenInfo",
+      "kind": "record",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/MobilePushTokenInfo.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "MobilePushTokenInvalidated",
+      "fqn": "Granit.Notifications.MobilePush.MobilePushTokenInvalidated",
+      "kind": "record",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/MobilePushTokenInvalidated.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "MobilePushChannelOptions",
+      "fqn": "Granit.Notifications.MobilePush.Options.MobilePushChannelOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/Options/MobilePushChannelOptions.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "Provider",
+          "kind": "property",
+          "signature": "string Provider",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "NotificationChannels",
+      "fqn": "Granit.Notifications.NotificationChannels",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/NotificationChannels.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "NotificationDefinition",
+      "fqn": "Granit.Notifications.NotificationDefinition",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/NotificationDefinition.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultChannels",
+          "kind": "property",
+          "signature": "IReadOnlyList<string> DefaultChannels",
+          "returnType": "IReadOnlyList<string>"
+        },
+        {
+          "name": "DisplayName",
+          "kind": "property",
+          "signature": "string? DisplayName",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "NotificationDeliveryContext",
+      "fqn": "Granit.Notifications.NotificationDeliveryContext",
+      "kind": "record",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/NotificationDeliveryContext.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "NotificationSeverity",
+      "fqn": "Granit.Notifications.NotificationSeverity",
+      "kind": "enum",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/NotificationSeverity.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "NotificationType",
+      "fqn": "Granit.Notifications.NotificationType",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/NotificationType.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "typeof",
+          "kind": "method",
+          "signature": "typeof(TData)",
+          "returnType": "Type DataType =>"
+        },
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "NotificationsOptions",
+      "fqn": "Granit.Notifications.Options.NotificationsOptions",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Options/NotificationsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "MaxParallelDeliveries",
+          "kind": "property",
+          "signature": "int MaxParallelDeliveries",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "RecipientInfo",
+      "fqn": "Granit.Notifications.RecipientInfo",
+      "kind": "record",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/RecipientInfo.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "SignalRNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.SignalR.Extensions.SignalRNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.SignalR",
+      "file": "src/Granit.Notifications.SignalR/Extensions/SignalRNotificationsServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitNotificationsSignalR",
+          "kind": "method",
+          "signature": "AddGranitNotificationsSignalR(this IServiceCollection services, Action<SignalRChannelOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsSignalRModule",
+      "fqn": "Granit.Notifications.SignalR.GranitNotificationsSignalRModule",
+      "kind": "class",
+      "project": "Granit.Notifications.SignalR",
+      "file": "src/Granit.Notifications.SignalR/GranitNotificationsSignalRModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "NotificationHub",
+      "fqn": "Granit.Notifications.SignalR.NotificationHub",
+      "kind": "class",
+      "project": "Granit.Notifications.SignalR",
+      "file": "src/Granit.Notifications.SignalR/NotificationHub.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "OnConnectedAsync",
+          "kind": "method",
+          "signature": "OnConnectedAsync()",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "SignalRChannelOptions",
+      "fqn": "Granit.Notifications.SignalR.Options.SignalRChannelOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.SignalR",
+      "file": "src/Granit.Notifications.SignalR/Options/SignalRChannelOptions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "SignalRNotificationMessage",
+      "fqn": "Granit.Notifications.SignalR.SignalRNotificationMessage",
+      "kind": "record",
+      "project": "Granit.Notifications.SignalR",
+      "file": "src/Granit.Notifications.SignalR/SignalRNotificationMessage.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "NotificationId",
+          "kind": "property",
+          "signature": "Guid NotificationId",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "SnsSmsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Sms.AwsSns.Extensions.SnsSmsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Sms.AwsSns",
+      "file": "src/Granit.Notifications.Sms.AwsSns/Extensions/SnsSmsServiceCollectionExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitNotificationsSmsAwsSns",
+          "kind": "method",
+          "signature": "AddGranitNotificationsSmsAwsSns(this IServiceCollection services, Action<AwsSnsSmsOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsSmsAwsSnsModule",
+      "fqn": "Granit.Notifications.Sms.AwsSns.GranitNotificationsSmsAwsSnsModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Sms.AwsSns",
+      "file": "src/Granit.Notifications.Sms.AwsSns/GranitNotificationsSmsAwsSnsModule.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AwsSnsSmsOptions",
+      "fqn": "Granit.Notifications.Sms.AwsSns.Options.AwsSnsSmsOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Sms.AwsSns",
+      "file": "src/Granit.Notifications.Sms.AwsSns/Options/AwsSnsSmsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Region",
+          "kind": "property",
+          "signature": "string Region",
+          "returnType": "string"
+        },
+        {
+          "name": "SenderId",
+          "kind": "property",
+          "signature": "string? SenderId",
+          "returnType": "string?"
+        },
+        {
+          "name": "OriginationNumber",
+          "kind": "property",
+          "signature": "string? OriginationNumber",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "AcsSmsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Sms.AzureCommunicationServices.Extensions.AcsSmsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Sms.AzureCommunicationServices",
+      "file": "src/Granit.Notifications.Sms.AzureCommunicationServices/Extensions/AcsSmsServiceCollectionExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitNotificationsSmsAcs",
+          "kind": "method",
+          "signature": "AddGranitNotificationsSmsAcs(this IServiceCollection services, Action<AcsSmsOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsSmsAcsModule",
+      "fqn": "Granit.Notifications.Sms.AzureCommunicationServices.GranitNotificationsSmsAcsModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Sms.AzureCommunicationServices",
+      "file": "src/Granit.Notifications.Sms.AzureCommunicationServices/GranitNotificationsSmsAcsModule.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AcsSmsOptions",
+      "fqn": "Granit.Notifications.Sms.AzureCommunicationServices.Options.AcsSmsOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Sms.AzureCommunicationServices",
+      "file": "src/Granit.Notifications.Sms.AzureCommunicationServices/Options/AcsSmsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ConnectionString",
+          "kind": "property",
+          "signature": "string? ConnectionString",
+          "returnType": "string?"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "SmsNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Sms.Extensions.SmsNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Sms",
+      "file": "src/Granit.Notifications.Sms/Extensions/SmsNotificationsServiceCollectionExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "AddGranitNotificationsSms",
+          "kind": "method",
+          "signature": "AddGranitNotificationsSms(this IServiceCollection services, Action<SmsChannelOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsSmsModule",
+      "fqn": "Granit.Notifications.Sms.GranitNotificationsSmsModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Sms",
+      "file": "src/Granit.Notifications.Sms/GranitNotificationsSmsModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "ISmsSender",
+      "fqn": "Granit.Notifications.Sms.ISmsSender",
+      "kind": "interface",
+      "project": "Granit.Notifications.Sms",
+      "file": "src/Granit.Notifications.Sms/ISmsSender.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "SendAsync",
+          "kind": "method",
+          "signature": "SendAsync(SmsMessage message, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "SmsChannelOptions",
+      "fqn": "Granit.Notifications.Sms.Options.SmsChannelOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Sms",
+      "file": "src/Granit.Notifications.Sms/Options/SmsChannelOptions.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "Provider",
+          "kind": "property",
+          "signature": "string Provider",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "SmsMessage",
+      "fqn": "Granit.Notifications.Sms.SmsMessage",
+      "kind": "record",
+      "project": "Granit.Notifications.Sms",
+      "file": "src/Granit.Notifications.Sms/SmsMessage.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "SseNotificationEndpoints",
+      "fqn": "Granit.Notifications.Sse.Endpoints.SseNotificationEndpoints",
+      "kind": "class",
+      "project": "Granit.Notifications.Sse",
+      "file": "src/Granit.Notifications.Sse/Endpoints/SseNotificationEndpoints.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "MapGranitSseNotificationEndpoints",
+          "kind": "method",
+          "signature": "MapGranitSseNotificationEndpoints(this IEndpointRouteBuilder endpoints)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "SseNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Sse.Extensions.SseNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Sse",
+      "file": "src/Granit.Notifications.Sse/Extensions/SseNotificationsServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitNotificationsSse",
+          "kind": "method",
+          "signature": "AddGranitNotificationsSse(this IServiceCollection services, Action<SseChannelOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsSseModule",
+      "fqn": "Granit.Notifications.Sse.GranitNotificationsSseModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Sse",
+      "file": "src/Granit.Notifications.Sse/GranitNotificationsSseModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "ISseConnectionManager",
+      "fqn": "Granit.Notifications.Sse.ISseConnectionManager",
+      "kind": "interface",
+      "project": "Granit.Notifications.Sse",
+      "file": "src/Granit.Notifications.Sse/ISseConnectionManager.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Connect",
+          "kind": "method",
+          "signature": "Connect(string userId)",
+          "returnType": "SseConnection"
+        },
+        {
+          "name": "Disconnect",
+          "kind": "method",
+          "signature": "Disconnect(SseConnection connection)",
+          "returnType": "void"
+        },
+        {
+          "name": "SendToUserAsync",
+          "kind": "method",
+          "signature": "SendToUserAsync(string userId, SseNotificationMessage message, CancellationToken cancellationToken = default)",
+          "returnType": "ValueTask"
+        },
+        {
+          "name": "GetConnectionCount",
+          "kind": "method",
+          "signature": "GetConnectionCount(string userId)",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "SseChannelOptions",
+      "fqn": "Granit.Notifications.Sse.Options.SseChannelOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Sse",
+      "file": "src/Granit.Notifications.Sse/Options/SseChannelOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "HeartbeatIntervalSeconds",
+          "kind": "property",
+          "signature": "int HeartbeatIntervalSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "SseConnection",
+      "fqn": "Granit.Notifications.Sse.SseConnection",
+      "kind": "record",
+      "project": "Granit.Notifications.Sse",
+      "file": "src/Granit.Notifications.Sse/SseConnection.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "Reader",
+          "kind": "property",
+          "signature": "ChannelReader<SseNotificationMessage> Reader",
+          "returnType": "ChannelReader<SseNotificationMessage>"
+        }
+      ]
+    },
+    {
+      "name": "SseNotificationMessage",
+      "fqn": "Granit.Notifications.Sse.SseNotificationMessage",
+      "kind": "record",
+      "project": "Granit.Notifications.Sse",
+      "file": "src/Granit.Notifications.Sse/SseNotificationMessage.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "NotificationId",
+          "kind": "property",
+          "signature": "Guid NotificationId",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "TrackedPropertyConfig",
+      "fqn": "Granit.Notifications.TrackedPropertyConfig",
+      "kind": "record",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/TrackedPropertyConfig.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "NotificationTypeName",
+          "kind": "property",
+          "signature": "required string NotificationTypeName",
+          "returnType": "required string"
+        }
+      ]
+    },
+    {
+      "name": "TwilioNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Twilio.Extensions.TwilioNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Twilio",
+      "file": "src/Granit.Notifications.Twilio/Extensions/TwilioNotificationsServiceCollectionExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitNotificationsTwilio",
+          "kind": "method",
+          "signature": "AddGranitNotificationsTwilio(this IServiceCollection services, Action<TwilioOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsTwilioModule",
+      "fqn": "Granit.Notifications.Twilio.GranitNotificationsTwilioModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Twilio",
+      "file": "src/Granit.Notifications.Twilio/GranitNotificationsTwilioModule.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "TwilioOptions",
+      "fqn": "Granit.Notifications.Twilio.Options.TwilioOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Twilio",
+      "file": "src/Granit.Notifications.Twilio/Options/TwilioOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "AccountSid",
+          "kind": "property",
+          "signature": "string AccountSid",
+          "returnType": "string"
+        },
+        {
+          "name": "AuthToken",
+          "kind": "property",
+          "signature": "string AuthToken",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSmsFromNumber",
+          "kind": "property",
+          "signature": "string DefaultSmsFromNumber",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultWhatsAppFromNumber",
+          "kind": "property",
+          "signature": "string? DefaultWhatsAppFromNumber",
+          "returnType": "string?"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "PushNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.WebPush.Extensions.PushNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.WebPush",
+      "file": "src/Granit.Notifications.WebPush/Extensions/PushNotificationsServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitNotificationsPush",
+          "kind": "method",
+          "signature": "AddGranitNotificationsPush(this IServiceCollection services, Action<PushChannelOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsWebPushModule",
+      "fqn": "Granit.Notifications.WebPush.GranitNotificationsWebPushModule",
+      "kind": "class",
+      "project": "Granit.Notifications.WebPush",
+      "file": "src/Granit.Notifications.WebPush/GranitNotificationsWebPushModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "IPushSubscriptionReader",
+      "fqn": "Granit.Notifications.WebPush.IPushSubscriptionReader",
+      "kind": "interface",
+      "project": "Granit.Notifications.WebPush",
+      "file": "src/Granit.Notifications.WebPush/IPushSubscriptionReader.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "GetSubscriptionsAsync",
+          "kind": "method",
+          "signature": "GetSubscriptionsAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<PushSubscriptionInfo>>"
+        }
+      ]
+    },
+    {
+      "name": "IPushSubscriptionWriter",
+      "fqn": "Granit.Notifications.WebPush.IPushSubscriptionWriter",
+      "kind": "interface",
+      "project": "Granit.Notifications.WebPush",
+      "file": "src/Granit.Notifications.WebPush/IPushSubscriptionWriter.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "SaveSubscriptionAsync",
+          "kind": "method",
+          "signature": "SaveSubscriptionAsync(string userId, PushSubscriptionInfo subscription, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RemoveSubscriptionAsync",
+          "kind": "method",
+          "signature": "RemoveSubscriptionAsync(string endpoint, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "PushChannelOptions",
+      "fqn": "Granit.Notifications.WebPush.Options.PushChannelOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.WebPush",
+      "file": "src/Granit.Notifications.WebPush/Options/PushChannelOptions.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "VapidSubject",
+          "kind": "property",
+          "signature": "string VapidSubject",
+          "returnType": "string"
+        },
+        {
+          "name": "VapidPublicKey",
+          "kind": "property",
+          "signature": "string VapidPublicKey",
+          "returnType": "string"
+        },
+        {
+          "name": "VapidPrivateKey",
+          "kind": "property",
+          "signature": "string VapidPrivateKey",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "PushNotificationPayload",
+      "fqn": "Granit.Notifications.WebPush.PushNotificationPayload",
+      "kind": "record",
+      "project": "Granit.Notifications.WebPush",
+      "file": "src/Granit.Notifications.WebPush/PushNotificationPayload.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "PushSubscriptionInfo",
+      "fqn": "Granit.Notifications.WebPush.PushSubscriptionInfo",
+      "kind": "record",
+      "project": "Granit.Notifications.WebPush",
+      "file": "src/Granit.Notifications.WebPush/PushSubscriptionInfo.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "WhatsAppNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.WhatsApp.Extensions.WhatsAppNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.WhatsApp",
+      "file": "src/Granit.Notifications.WhatsApp/Extensions/WhatsAppNotificationsServiceCollectionExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "AddGranitNotificationsWhatsApp",
+          "kind": "method",
+          "signature": "AddGranitNotificationsWhatsApp(this IServiceCollection services, Action<WhatsAppChannelOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsWhatsAppModule",
+      "fqn": "Granit.Notifications.WhatsApp.GranitNotificationsWhatsAppModule",
+      "kind": "class",
+      "project": "Granit.Notifications.WhatsApp",
+      "file": "src/Granit.Notifications.WhatsApp/GranitNotificationsWhatsAppModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "IWhatsAppSender",
+      "fqn": "Granit.Notifications.WhatsApp.IWhatsAppSender",
+      "kind": "interface",
+      "project": "Granit.Notifications.WhatsApp",
+      "file": "src/Granit.Notifications.WhatsApp/IWhatsAppSender.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "SendAsync",
+          "kind": "method",
+          "signature": "SendAsync(WhatsAppMessage message, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "WhatsAppChannelOptions",
+      "fqn": "Granit.Notifications.WhatsApp.Options.WhatsAppChannelOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.WhatsApp",
+      "file": "src/Granit.Notifications.WhatsApp/Options/WhatsAppChannelOptions.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "Provider",
+          "kind": "property",
+          "signature": "string Provider",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "WhatsAppMessage",
+      "fqn": "Granit.Notifications.WhatsApp.WhatsAppMessage",
+      "kind": "record",
+      "project": "Granit.Notifications.WhatsApp",
+      "file": "src/Granit.Notifications.WhatsApp/WhatsAppMessage.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "To",
+          "kind": "property",
+          "signature": "required string To",
+          "returnType": "required string"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsWolverineModule",
+      "fqn": "Granit.Notifications.Wolverine.GranitNotificationsWolverineModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Wolverine",
+      "file": "src/Granit.Notifications.Wolverine/GranitNotificationsWolverineModule.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ZulipNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Zulip.Extensions.ZulipNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Zulip",
+      "file": "src/Granit.Notifications.Zulip/Extensions/ZulipNotificationsServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitNotificationsZulip",
+          "kind": "method",
+          "signature": "AddGranitNotificationsZulip(this IServiceCollection services, Action<ZulipChannelOptions>? configureChannel = null, Action<ZulipBotOptions>? configureBot = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsZulipModule",
+      "fqn": "Granit.Notifications.Zulip.GranitNotificationsZulipModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Zulip",
+      "file": "src/Granit.Notifications.Zulip/GranitNotificationsZulipModule.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "IZulipSender",
+      "fqn": "Granit.Notifications.Zulip.IZulipSender",
+      "kind": "interface",
+      "project": "Granit.Notifications.Zulip",
+      "file": "src/Granit.Notifications.Zulip/IZulipSender.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "SendAsync",
+          "kind": "method",
+          "signature": "SendAsync(ZulipMessage message, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ZulipBotOptions",
+      "fqn": "Granit.Notifications.Zulip.Options.ZulipBotOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Zulip",
+      "file": "src/Granit.Notifications.Zulip/Options/ZulipBotOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "BaseUrl",
+          "kind": "property",
+          "signature": "string BaseUrl",
+          "returnType": "string"
+        },
+        {
+          "name": "BotEmail",
+          "kind": "property",
+          "signature": "string BotEmail",
+          "returnType": "string"
+        },
+        {
+          "name": "ApiKey",
+          "kind": "property",
+          "signature": "string ApiKey",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "ZulipChannelOptions",
+      "fqn": "Granit.Notifications.Zulip.Options.ZulipChannelOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Zulip",
+      "file": "src/Granit.Notifications.Zulip/Options/ZulipChannelOptions.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "DefaultStream",
+          "kind": "property",
+          "signature": "string DefaultStream",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultTopic",
+          "kind": "property",
+          "signature": "string DefaultTopic",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "ZulipMessage",
+      "fqn": "Granit.Notifications.Zulip.ZulipMessage",
+      "kind": "record",
+      "project": "Granit.Notifications.Zulip",
+      "file": "src/Granit.Notifications.Zulip/ZulipMessage.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "ObservabilityAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Observability.AI.Extensions.ObservabilityAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Observability.AI",
+      "file": "src/Granit.Observability.AI/Extensions/ObservabilityAIHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitObservabilityAI",
+          "kind": "method",
+          "signature": "AddGranitObservabilityAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitObservabilityAIModule",
+      "fqn": "Granit.Observability.AI.GranitObservabilityAIModule",
+      "kind": "class",
+      "project": "Granit.Observability.AI",
+      "file": "src/Granit.Observability.AI/GranitObservabilityAIModule.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IAILogAnalyzer",
+      "fqn": "Granit.Observability.AI.IAILogAnalyzer",
+      "kind": "interface",
+      "project": "Granit.Observability.AI",
+      "file": "src/Granit.Observability.AI/IAILogAnalyzer.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AnalyzeAsync",
+          "kind": "method",
+          "signature": "AnalyzeAsync(IReadOnlyList<LogEntry> entries, CancellationToken cancellationToken = default)",
+          "returnType": "Task<LogAnalysisReport>"
+        }
+      ]
+    },
+    {
+      "name": "LogAnalysisReport",
+      "fqn": "Granit.Observability.AI.LogAnalysisReport",
+      "kind": "record",
+      "project": "Granit.Observability.AI",
+      "file": "src/Granit.Observability.AI/LogAnalysisReport.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "LogEntry",
+      "fqn": "Granit.Observability.AI.LogEntry",
+      "kind": "record",
+      "project": "Granit.Observability.AI",
+      "file": "src/Granit.Observability.AI/LogEntry.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "LogInsight",
+      "fqn": "Granit.Observability.AI.LogInsight",
+      "kind": "record",
+      "project": "Granit.Observability.AI",
+      "file": "src/Granit.Observability.AI/LogInsight.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ObservabilityAIOptions",
+      "fqn": "Granit.Observability.AI.Options.ObservabilityAIOptions",
+      "kind": "class",
+      "project": "Granit.Observability.AI",
+      "file": "src/Granit.Observability.AI/Options/ObservabilityAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string? WorkspaceName",
+          "returnType": "string?"
+        },
+        {
+          "name": "MaxLogEntries",
+          "kind": "property",
+          "signature": "int MaxLogEntries",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "ObservabilityServiceCollectionExtensions",
+      "fqn": "Granit.Observability.Extensions.ObservabilityServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Observability",
+      "file": "src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "AddGranitObservability",
+          "kind": "method",
+          "signature": "AddGranitObservability(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitObservabilityModule",
+      "fqn": "Granit.Observability.GranitObservabilityModule",
+      "kind": "class",
+      "project": "Granit.Observability",
+      "file": "src/Granit.Observability/GranitObservabilityModule.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ObservabilityOptions",
+      "fqn": "Granit.Observability.Options.ObservabilityOptions",
+      "kind": "class",
+      "project": "Granit.Observability",
+      "file": "src/Granit.Observability/Options/ObservabilityOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ServiceName",
+          "kind": "property",
+          "signature": "string ServiceName",
+          "returnType": "string"
+        },
+        {
+          "name": "ServiceVersion",
+          "kind": "property",
+          "signature": "string ServiceVersion",
+          "returnType": "string"
+        },
+        {
+          "name": "OtlpEndpoint",
+          "kind": "property",
+          "signature": "string OtlpEndpoint",
+          "returnType": "string"
+        },
+        {
+          "name": "ServiceNamespace",
+          "kind": "property",
+          "signature": "string ServiceNamespace",
+          "returnType": "string"
+        },
+        {
+          "name": "Environment",
+          "kind": "property",
+          "signature": "string Environment",
+          "returnType": "string"
+        },
+        {
+          "name": "EnableTracing",
+          "kind": "property",
+          "signature": "bool EnableTracing",
+          "returnType": "bool"
+        },
+        {
+          "name": "EnableMetrics",
+          "kind": "property",
+          "signature": "bool EnableMetrics",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "DataSeedContext",
+      "fqn": "Granit.Persistence.DataSeeding.DataSeedContext",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/DataSeeding/DataSeedContext.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "IDataSeedContributor",
+      "fqn": "Granit.Persistence.DataSeeding.IDataSeedContributor",
+      "kind": "interface",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/DataSeeding/IDataSeedContributor.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "SeedAsync",
+          "kind": "method",
+          "signature": "SeedAsync(DataSeedContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IDataSeeder",
+      "fqn": "Granit.Persistence.DataSeeding.IDataSeeder",
+      "kind": "interface",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/DataSeeding/IDataSeeder.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "SeedAsync",
+          "kind": "method",
+          "signature": "SeedAsync(DataSeedContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "DbContextOptionsBuilderExtensions",
+      "fqn": "Granit.Persistence.Extensions.DbContextOptionsBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Extensions/DbContextOptionsBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "UseGranitInterceptors",
+          "kind": "method",
+          "signature": "UseGranitInterceptors(this DbContextOptionsBuilder options, IServiceProvider serviceProvider)",
+          "returnType": "DbContextOptionsBuilder"
+        }
+      ]
+    },
+    {
+      "name": "DbContextPurgeExtensions",
+      "fqn": "Granit.Persistence.Extensions.DbContextPurgeExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Extensions/DbContextPurgeExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "PurgeSoftDeletedBeforeAsync",
+          "kind": "method",
+          "signature": "PurgeSoftDeletedBeforeAsync(this DbContext context, DateTimeOffset cutoff, int batchSize = 1000, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        }
+      ]
+    },
+    {
+      "name": "ModelBuilderExtensions",
+      "fqn": "Granit.Persistence.Extensions.ModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Extensions/ModelBuilderExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "ApplyGranitConventions",
+          "kind": "method",
+          "signature": "ApplyGranitConventions(this ModelBuilder modelBuilder, ICurrentTenant? currentTenant = null, IDataFilter? dataFilter = null)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "PersistenceDbContextServiceCollectionExtensions",
+      "fqn": "Granit.Persistence.Extensions.PersistenceDbContextServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Extensions/PersistenceDbContextServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "PersistenceServiceCollectionExtensions",
+      "fqn": "Granit.Persistence.Extensions.PersistenceServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Extensions/PersistenceServiceCollectionExtensions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "AddGranitPersistence",
+          "kind": "method",
+          "signature": "AddGranitPersistence(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "PersistenceTenantExtensions",
+      "fqn": "Granit.Persistence.Extensions.PersistenceTenantExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Extensions/PersistenceTenantExtensions.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "TranslatableQueryExtensions",
+      "fqn": "Granit.Persistence.Extensions.TranslatableQueryExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Extensions/TranslatableQueryExtensions.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "GranitFilterNames",
+      "fqn": "Granit.Persistence.GranitFilterNames",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/GranitFilterNames.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "GranitPersistenceModule",
+      "fqn": "Granit.Persistence.GranitPersistenceModule",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/GranitPersistenceModule.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "PersistenceHostingHostApplicationBuilderExtensions",
+      "fqn": "Granit.Persistence.Hosting.Extensions.PersistenceHostingHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.Hosting",
+      "file": "src/Granit.Persistence.Hosting/Extensions/PersistenceHostingHostApplicationBuilderExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitMigrateSupport",
+          "kind": "method",
+          "signature": "AddGranitMigrateSupport(this IHostApplicationBuilder builder, Action<GranitMigrateOptions>? configure = null)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "PersistenceHostingWebApplicationExtensions",
+      "fqn": "Granit.Persistence.Hosting.Extensions.PersistenceHostingWebApplicationExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.Hosting",
+      "file": "src/Granit.Persistence.Hosting/Extensions/PersistenceHostingWebApplicationExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "HasGranitMigrateFlag",
+          "kind": "method",
+          "signature": "HasGranitMigrateFlag(this WebApplication app)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "GranitPersistenceHostingModule",
+      "fqn": "Granit.Persistence.Hosting.GranitPersistenceHostingModule",
+      "kind": "class",
+      "project": "Granit.Persistence.Hosting",
+      "file": "src/Granit.Persistence.Hosting/GranitPersistenceHostingModule.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IGranitMigrationLock",
+      "fqn": "Granit.Persistence.Hosting.IGranitMigrationLock",
+      "kind": "interface",
+      "project": "Granit.Persistence.Hosting",
+      "file": "src/Granit.Persistence.Hosting/IGranitMigrationLock.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "TryAcquireAsync",
+          "kind": "method",
+          "signature": "TryAcquireAsync(string resource, CancellationToken cancellationToken)",
+          "returnType": "Task<IAsyncDisposable?>"
+        }
+      ]
+    },
+    {
+      "name": "IGranitMigrationRunner",
+      "fqn": "Granit.Persistence.Hosting.IGranitMigrationRunner",
+      "kind": "interface",
+      "project": "Granit.Persistence.Hosting",
+      "file": "src/Granit.Persistence.Hosting/IGranitMigrationRunner.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "RunAsync",
+          "kind": "method",
+          "signature": "RunAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        }
+      ]
+    },
+    {
+      "name": "IMigratableModule",
+      "fqn": "Granit.Persistence.Hosting.IMigratableModule",
+      "kind": "interface",
+      "project": "Granit.Persistence.Hosting",
+      "file": "src/Granit.Persistence.Hosting/IMigratableModule.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "typeof",
+          "kind": "method",
+          "signature": "typeof(TContext)",
+          "returnType": "Type IMigratableModule.DbContextType =>"
+        }
+      ]
+    },
+    {
+      "name": "GranitMigrateOptions",
+      "fqn": "Granit.Persistence.Hosting.Options.GranitMigrateOptions",
+      "kind": "class",
+      "project": "Granit.Persistence.Hosting",
+      "file": "src/Granit.Persistence.Hosting/Options/GranitMigrateOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "CliFlag",
+          "kind": "property",
+          "signature": "string CliFlag",
+          "returnType": "string"
+        },
+        {
+          "name": "SeedAfterMigration",
+          "kind": "property",
+          "signature": "bool SeedAfterMigration",
+          "returnType": "bool"
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(5)",
+          "returnType": "TimeSpan Timeout { get; set; } = TimeSpan."
+        },
+        {
+          "name": "SeedOnStartup",
+          "kind": "property",
+          "signature": "bool SeedOnStartup",
+          "returnType": "bool"
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(5)",
+          "returnType": "TimeSpan RetryDelay { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "ISoftDeletePurgeTarget",
+      "fqn": "Granit.Persistence.ISoftDeletePurgeTarget",
+      "kind": "interface",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/ISoftDeletePurgeTarget.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "PurgeAsync",
+          "kind": "method",
+          "signature": "PurgeAsync(DateTimeOffset cutoff, int batchSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        }
+      ]
+    },
+    {
+      "name": "AuditedEntityInterceptor",
+      "fqn": "Granit.Persistence.Interceptors.AuditedEntityInterceptor",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Interceptors/AuditedEntityInterceptor.cs",
+      "line": 26,
+      "members": [
+        {
+          "name": "SavingChanges",
+          "kind": "method",
+          "signature": "SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)",
+          "returnType": "InterceptionResult<int>"
+        }
+      ]
+    },
+    {
+      "name": "ConcurrencyStampInterceptor",
+      "fqn": "Granit.Persistence.Interceptors.ConcurrencyStampInterceptor",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Interceptors/ConcurrencyStampInterceptor.cs",
+      "line": 33,
+      "members": [
+        {
+          "name": "SavingChanges",
+          "kind": "method",
+          "signature": "SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)",
+          "returnType": "InterceptionResult<int>"
+        }
+      ]
+    },
+    {
+      "name": "DomainEventDispatcherInterceptor",
+      "fqn": "Granit.Persistence.Interceptors.DomainEventDispatcherInterceptor",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Interceptors/DomainEventDispatcherInterceptor.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "SavingChanges",
+          "kind": "method",
+          "signature": "SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)",
+          "returnType": "InterceptionResult<int>"
+        }
+      ]
+    },
+    {
+      "name": "EntityLifecycleEventInterceptor",
+      "fqn": "Granit.Persistence.Interceptors.EntityLifecycleEventInterceptor",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Interceptors/EntityLifecycleEventInterceptor.cs",
+      "line": 40,
+      "members": [
+        {
+          "name": "SavingChanges",
+          "kind": "method",
+          "signature": "SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)",
+          "returnType": "InterceptionResult<int>"
+        }
+      ]
+    },
+    {
+      "name": "SoftDeleteInterceptor",
+      "fqn": "Granit.Persistence.Interceptors.SoftDeleteInterceptor",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Interceptors/SoftDeleteInterceptor.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "SavingChanges",
+          "kind": "method",
+          "signature": "SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)",
+          "returnType": "InterceptionResult<int>"
+        }
+      ]
+    },
+    {
+      "name": "VersioningInterceptor",
+      "fqn": "Granit.Persistence.Interceptors.VersioningInterceptor",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Interceptors/VersioningInterceptor.cs",
+      "line": 32,
+      "members": [
+        {
+          "name": "SavingChanges",
+          "kind": "method",
+          "signature": "SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)",
+          "returnType": "InterceptionResult<int>"
+        }
+      ]
+    },
+    {
+      "name": "MigrationCycleRegistryExtensions",
+      "fqn": "Granit.Persistence.Migrations.Extensions.MigrationCycleRegistryExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/Extensions/MigrationCycleRegistryExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "PersistenceMigrationsHostApplicationBuilderExtensions",
+      "fqn": "Granit.Persistence.Migrations.Extensions.PersistenceMigrationsHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/Extensions/PersistenceMigrationsHostApplicationBuilderExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitPersistenceMigrations",
+          "kind": "method",
+          "signature": "AddGranitPersistenceMigrations(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configureProgressDb)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitPersistenceMigrationsModule",
+      "fqn": "Granit.Persistence.Migrations.GranitPersistenceMigrationsModule",
+      "kind": "class",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/GranitPersistenceMigrationsModule.cs",
+      "line": 35,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IMigrationBatchDispatcher",
+      "fqn": "Granit.Persistence.Migrations.IMigrationBatchDispatcher",
+      "kind": "interface",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/IMigrationBatchDispatcher.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "DispatchAsync",
+          "kind": "method",
+          "signature": "DispatchAsync(RunMigrationBatchCommand command, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DispatchAsync",
+          "kind": "method",
+          "signature": "DispatchAsync(IEnumerable<RunMigrationBatchCommand> commands, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IMigrationCycleRegistry",
+      "fqn": "Granit.Persistence.Migrations.IMigrationCycleRegistry",
+      "kind": "interface",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/IMigrationCycleRegistry.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Register",
+          "kind": "method",
+          "signature": "Register(string cycleId, Type dbContextType, BatchMigrationDelegate migration)",
+          "returnType": "void"
+        },
+        {
+          "name": "Find",
+          "kind": "method",
+          "signature": "Find(string cycleId)",
+          "returnType": "MigrationCycleRegistration?"
+        }
+      ]
+    },
+    {
+      "name": "IMigrationProgressDbEnsurer",
+      "fqn": "Granit.Persistence.Migrations.IMigrationProgressDbEnsurer",
+      "kind": "interface",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/IMigrationProgressDbEnsurer.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "EnsureCreatedAsync",
+          "kind": "method",
+          "signature": "EnsureCreatedAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ITenantDbIsolator",
+      "fqn": "Granit.Persistence.Migrations.ITenantDbIsolator",
+      "kind": "interface",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/ITenantDbIsolator.cs",
+      "line": 39,
+      "members": [
+        {
+          "name": "IsolateAsync",
+          "kind": "method",
+          "signature": "IsolateAsync(DbContext context, Guid tenantId, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ITenantEnumerator",
+      "fqn": "Granit.Persistence.Migrations.ITenantEnumerator",
+      "kind": "interface",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/ITenantEnumerator.cs",
+      "line": 45,
+      "members": [
+        {
+          "name": "GetActiveTenantIdsAsync",
+          "kind": "method",
+          "signature": "GetActiveTenantIdsAsync(CancellationToken cancellationToken)",
+          "returnType": "IAsyncEnumerable<Guid>"
+        }
+      ]
+    },
+    {
+      "name": "RunMigrationBatchCommand",
+      "fqn": "Granit.Persistence.Migrations.Messages.RunMigrationBatchCommand",
+      "kind": "record",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/Messages/RunMigrationBatchCommand.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "MigrationBatchContext",
+      "fqn": "Granit.Persistence.Migrations.MigrationBatchContext",
+      "kind": "record",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/MigrationBatchContext.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "MigrationBatchResult",
+      "fqn": "Granit.Persistence.Migrations.MigrationBatchResult",
+      "kind": "record",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/MigrationBatchResult.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "MigrationCycleAttribute",
+      "fqn": "Granit.Persistence.Migrations.MigrationCycleAttribute",
+      "kind": "class",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/MigrationCycleAttribute.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "Phase",
+          "kind": "property",
+          "signature": "MigrationPhase Phase",
+          "returnType": "MigrationPhase"
+        },
+        {
+          "name": "CycleId",
+          "kind": "property",
+          "signature": "string CycleId",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "MigrationCycleRegistration",
+      "fqn": "Granit.Persistence.Migrations.MigrationCycleRegistration",
+      "kind": "record",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/MigrationCycleRegistration.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "MigrationPhase",
+      "fqn": "Granit.Persistence.Migrations.MigrationPhase",
+      "kind": "enum",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/MigrationPhase.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "MigrationStatus",
+      "fqn": "Granit.Persistence.Migrations.MigrationStatus",
+      "kind": "enum",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/MigrationStatus.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "MigrationStartupOptions",
+      "fqn": "Granit.Persistence.Migrations.Options.MigrationStartupOptions",
+      "kind": "class",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/Options/MigrationStartupOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "DefaultBatchSize",
+          "kind": "property",
+          "signature": "int DefaultBatchSize",
+          "returnType": "int"
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(5)",
+          "returnType": "TimeSpan BatchExecutionTimeout { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "GranitPersistenceMigrationsWolverineModule",
+      "fqn": "Granit.Persistence.Migrations.Wolverine.GranitPersistenceMigrationsWolverineModule",
+      "kind": "class",
+      "project": "Granit.Persistence.Migrations.Wolverine",
+      "file": "src/Granit.Persistence.Migrations.Wolverine/GranitPersistenceMigrationsWolverineModule.cs",
+      "line": 28,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ITenantConnectionStringProvider",
+      "fqn": "Granit.Persistence.MultiTenancy.ITenantConnectionStringProvider",
+      "kind": "interface",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/MultiTenancy/ITenantConnectionStringProvider.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "GetConnectionStringAsync",
+          "kind": "method",
+          "signature": "GetConnectionStringAsync(Guid tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
+        }
+      ]
+    },
+    {
+      "name": "ITenantIsolationStrategyProvider",
+      "fqn": "Granit.Persistence.MultiTenancy.ITenantIsolationStrategyProvider",
+      "kind": "interface",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/MultiTenancy/ITenantIsolationStrategyProvider.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "GetStrategyAsync",
+          "kind": "method",
+          "signature": "GetStrategyAsync(Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "ValueTask<TenantIsolationStrategy>"
+        }
+      ]
+    },
+    {
+      "name": "ITenantSchemaActivator",
+      "fqn": "Granit.Persistence.MultiTenancy.ITenantSchemaActivator",
+      "kind": "interface",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/MultiTenancy/ITenantSchemaActivator.cs",
+      "line": 40,
+      "members": [
+        {
+          "name": "ActivateSchema",
+          "kind": "method",
+          "signature": "ActivateSchema(DbConnection connection, string schemaName)",
+          "returnType": "void"
+        },
+        {
+          "name": "ActivateSchemaAsync",
+          "kind": "method",
+          "signature": "ActivateSchemaAsync(DbConnection connection, string schemaName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ITenantSchemaProvider",
+      "fqn": "Granit.Persistence.MultiTenancy.ITenantSchemaProvider",
+      "kind": "interface",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/MultiTenancy/ITenantSchemaProvider.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "GetSchemaNameAsync",
+          "kind": "method",
+          "signature": "GetSchemaNameAsync(Guid tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "ValueTask<string>"
+        }
+      ]
+    },
+    {
+      "name": "TenantIsolationOptions",
+      "fqn": "Granit.Persistence.MultiTenancy.TenantIsolationOptions",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/MultiTenancy/TenantIsolationOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Strategy",
+          "kind": "property",
+          "signature": "TenantIsolationStrategy Strategy",
+          "returnType": "TenantIsolationStrategy"
+        }
+      ]
+    },
+    {
+      "name": "TenantIsolationStrategy",
+      "fqn": "Granit.Persistence.MultiTenancy.TenantIsolationStrategy",
+      "kind": "enum",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/MultiTenancy/TenantIsolationStrategy.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "TenantSchemaNamingConvention",
+      "fqn": "Granit.Persistence.MultiTenancy.TenantSchemaNamingConvention",
+      "kind": "enum",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/MultiTenancy/TenantSchemaOptions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "TenantSchemaOptions",
+      "fqn": "Granit.Persistence.MultiTenancy.TenantSchemaOptions",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/MultiTenancy/TenantSchemaOptions.cs",
+      "line": 31,
+      "members": [
+        {
+          "name": "NamingConvention",
+          "kind": "property",
+          "signature": "TenantSchemaNamingConvention NamingConvention",
+          "returnType": "TenantSchemaNamingConvention"
+        },
+        {
+          "name": "Prefix",
+          "kind": "property",
+          "signature": "string Prefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "NpgsqlDbContextOptionsExtensions",
+      "fqn": "Granit.Persistence.Postgres.Extensions.NpgsqlDbContextOptionsExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.Postgres",
+      "file": "src/Granit.Persistence.Postgres/Extensions/NpgsqlDbContextOptionsExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "UseGranitNpgsql",
+          "kind": "method",
+          "signature": "UseGranitNpgsql(this DbContextOptionsBuilder optionsBuilder, string connectionString, Action<NpgsqlDbContextOptionsBuilder>? npgsqlOptionsAction = null)",
+          "returnType": "DbContextOptionsBuilder"
+        }
+      ]
+    },
+    {
+      "name": "NpgsqlHealthChecksBuilderExtensions",
+      "fqn": "Granit.Persistence.Postgres.Extensions.NpgsqlHealthChecksBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.Postgres",
+      "file": "src/Granit.Persistence.Postgres/Extensions/NpgsqlHealthChecksBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitPostgresHealthCheck",
+          "kind": "method",
+          "signature": "AddGranitPostgresHealthCheck(this IHealthChecksBuilder builder, string connectionString, string name = \"postgres\", HealthStatus failureStatus = HealthStatus.Unhealthy, IEnumerable<string>? tags = null)",
+          "returnType": "IHealthChecksBuilder"
+        }
+      ]
+    },
+    {
+      "name": "PersistencePostgresHostApplicationBuilderExtensions",
+      "fqn": "Granit.Persistence.Postgres.Extensions.PersistencePostgresHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.Postgres",
+      "file": "src/Granit.Persistence.Postgres/Extensions/PersistencePostgresHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitPostgres",
+          "kind": "method",
+          "signature": "AddGranitPostgres(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitPersistencePostgresModule",
+      "fqn": "Granit.Persistence.Postgres.GranitPersistencePostgresModule",
+      "kind": "class",
+      "project": "Granit.Persistence.Postgres",
+      "file": "src/Granit.Persistence.Postgres/GranitPersistencePostgresModule.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "PersistenceSqlServerHostApplicationBuilderExtensions",
+      "fqn": "Granit.Persistence.SqlServer.Extensions.PersistenceSqlServerHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.SqlServer",
+      "file": "src/Granit.Persistence.SqlServer/Extensions/PersistenceSqlServerHostApplicationBuilderExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitSqlServer",
+          "kind": "method",
+          "signature": "AddGranitSqlServer(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "SqlServerDbContextOptionsExtensions",
+      "fqn": "Granit.Persistence.SqlServer.Extensions.SqlServerDbContextOptionsExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.SqlServer",
+      "file": "src/Granit.Persistence.SqlServer/Extensions/SqlServerDbContextOptionsExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "UseGranitSqlServer",
+          "kind": "method",
+          "signature": "UseGranitSqlServer(this DbContextOptionsBuilder optionsBuilder, string connectionString, Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)",
+          "returnType": "DbContextOptionsBuilder"
+        }
+      ]
+    },
+    {
+      "name": "SqlServerHealthChecksBuilderExtensions",
+      "fqn": "Granit.Persistence.SqlServer.Extensions.SqlServerHealthChecksBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.SqlServer",
+      "file": "src/Granit.Persistence.SqlServer/Extensions/SqlServerHealthChecksBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitSqlServerHealthCheck",
+          "kind": "method",
+          "signature": "AddGranitSqlServerHealthCheck(this IHealthChecksBuilder builder, string connectionString, string name = \"sqlserver\", HealthStatus failureStatus = HealthStatus.Unhealthy, IEnumerable<string>? tags = null)",
+          "returnType": "IHealthChecksBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitPersistenceSqlServerModule",
+      "fqn": "Granit.Persistence.SqlServer.GranitPersistenceSqlServerModule",
+      "kind": "class",
+      "project": "Granit.Persistence.SqlServer",
+      "file": "src/Granit.Persistence.SqlServer/GranitPersistenceSqlServerModule.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "DetectedPii",
+      "fqn": "Granit.Privacy.AI.DetectedPii",
+      "kind": "record",
+      "project": "Granit.Privacy.AI",
+      "file": "src/Granit.Privacy.AI/PiiDetectionResult.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "PrivacyAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Privacy.AI.Extensions.PrivacyAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Privacy.AI",
+      "file": "src/Granit.Privacy.AI/Extensions/PrivacyAIHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitPrivacyAI",
+          "kind": "method",
+          "signature": "AddGranitPrivacyAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitPrivacyAIModule",
+      "fqn": "Granit.Privacy.AI.GranitPrivacyAIModule",
+      "kind": "class",
+      "project": "Granit.Privacy.AI",
+      "file": "src/Granit.Privacy.AI/GranitPrivacyAIModule.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "IAIPiiDetector",
+      "fqn": "Granit.Privacy.AI.IAIPiiDetector",
+      "kind": "interface",
+      "project": "Granit.Privacy.AI",
+      "file": "src/Granit.Privacy.AI/IAIPiiDetector.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "ScanAsync",
+          "kind": "method",
+          "signature": "ScanAsync(string text, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PiiDetectionResult>"
+        }
+      ]
+    },
+    {
+      "name": "PrivacyAIOptions",
+      "fqn": "Granit.Privacy.AI.Options.PrivacyAIOptions",
+      "kind": "class",
+      "project": "Granit.Privacy.AI",
+      "file": "src/Granit.Privacy.AI/Options/PrivacyAIOptions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string WorkspaceName",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "PiiDetectionResult",
+      "fqn": "Granit.Privacy.AI.PiiDetectionResult",
+      "kind": "record",
+      "project": "Granit.Privacy.AI",
+      "file": "src/Granit.Privacy.AI/PiiDetectionResult.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "PiiType",
+      "fqn": "Granit.Privacy.AI.PiiType",
+      "kind": "enum",
+      "project": "Granit.Privacy.AI",
+      "file": "src/Granit.Privacy.AI/PiiDetectionResult.cs",
+      "line": 30,
+      "members": []
+    },
+    {
+      "name": "DeletionAction",
+      "fqn": "Granit.Privacy.DataDeletion.DeletionAction",
+      "kind": "enum",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataDeletion/DeletionAction.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "PersonalDataDeletedEto",
+      "fqn": "Granit.Privacy.DataDeletion.Events.PersonalDataDeletedEto",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataDeletion/Events/PersonalDataDeletedEto.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "PersonalDataDeletionRequestedEto",
+      "fqn": "Granit.Privacy.DataDeletion.Events.PersonalDataDeletionRequestedEto",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataDeletion/Events/PersonalDataDeletionRequestedEto.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ExportCompletedEto",
+      "fqn": "Granit.Privacy.DataExport.Events.ExportCompletedEto",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/Events/ExportCompletedEto.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ExportTimedOutEvent",
+      "fqn": "Granit.Privacy.DataExport.Events.ExportTimedOutEvent",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/Events/ExportTimedOutEvent.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "PersonalDataPreparedEto",
+      "fqn": "Granit.Privacy.DataExport.Events.PersonalDataPreparedEto",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/Events/PersonalDataPreparedEto.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "PersonalDataRequestedEto",
+      "fqn": "Granit.Privacy.DataExport.Events.PersonalDataRequestedEto",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/Events/PersonalDataRequestedEto.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "GdprExportSaga",
+      "fqn": "Granit.Privacy.DataExport.GdprExportSaga",
+      "kind": "class",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/GdprExportSaga.cs",
+      "line": 36,
+      "members": [
+        {
+          "name": "Id",
+          "kind": "property",
+          "signature": "Guid Id",
+          "returnType": "Guid"
+        },
+        {
+          "name": "PendingProviders",
+          "kind": "property",
+          "signature": "List<string> PendingProviders",
+          "returnType": "List<string>"
+        },
+        {
+          "name": "StartAsync",
+          "kind": "method",
+          "signature": "StartAsync(PersonalDataRequestedEto @event, IDataProviderRegistry registry, IOptions<GranitPrivacyOptions> options, IMessageContext context, PrivacyMetrics metrics)",
+          "returnType": "Task<ExportCompletedEto?>"
+        }
+      ]
+    },
+    {
+      "name": "GdprExportSagaState",
+      "fqn": "Granit.Privacy.DataExport.GdprExportSagaState",
+      "kind": "class",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/GdprExportSagaState.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "RequestId",
+          "kind": "property",
+          "signature": "Guid RequestId",
+          "returnType": "Guid"
+        },
+        {
+          "name": "AllProviders",
+          "kind": "property",
+          "signature": "List<string> AllProviders",
+          "returnType": "List<string>"
+        }
+      ]
+    },
+    {
+      "name": "IDataProviderRegistry",
+      "fqn": "Granit.Privacy.DataExport.IDataProviderRegistry",
+      "kind": "interface",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/IDataProviderRegistry.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "Register",
+          "kind": "method",
+          "signature": "Register(string providerName)",
+          "returnType": "void"
+        },
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IReadOnlyList<string>"
+        }
+      ]
+    },
+    {
+      "name": "ReceivedFragment",
+      "fqn": "Granit.Privacy.DataExport.ReceivedFragment",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/GdprExportSagaState.cs",
+      "line": 31,
+      "members": []
+    },
+    {
+      "name": "PrivacyMetrics",
+      "fqn": "Granit.Privacy.Diagnostics.PrivacyMetrics",
+      "kind": "class",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/Diagnostics/PrivacyMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordFragmentReceived",
+          "kind": "method",
+          "signature": "RecordFragmentReceived(string? tenantId, string provider)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordDeletionRequested",
+          "kind": "method",
+          "signature": "RecordDeletionRequested(string? tenantId)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordExportCompleted",
+          "kind": "method",
+          "signature": "RecordExportCompleted(string? tenantId, string status, TimeSpan duration)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "PrivacyServiceCollectionExtensions",
+      "fqn": "Granit.Privacy.Extensions.PrivacyServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/Extensions/PrivacyServiceCollectionExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "AddGranitPrivacy",
+          "kind": "method",
+          "signature": "AddGranitPrivacy(this IServiceCollection services, Action<GranitPrivacyBuilder> configure)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitPrivacyBuilder",
+      "fqn": "Granit.Privacy.GranitPrivacyBuilder",
+      "kind": "class",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/GranitPrivacyBuilder.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "RegisterDataProvider",
+          "kind": "method",
+          "signature": "RegisterDataProvider(string providerName)",
+          "returnType": "GranitPrivacyBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitPrivacyModule",
+      "fqn": "Granit.Privacy.GranitPrivacyModule",
+      "kind": "class",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/GranitPrivacyModule.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "LegalAgreementBase",
+      "fqn": "Granit.Privacy.LegalAgreements.Domain.LegalAgreementBase",
+      "kind": "class",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/LegalAgreements/Domain/LegalAgreementBase.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "UserId",
+          "kind": "property",
+          "signature": "Guid UserId",
+          "returnType": "Guid"
+        },
+        {
+          "name": "Version",
+          "kind": "property",
+          "signature": "string Version",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "LegalAgreementAcceptedEto",
+      "fqn": "Granit.Privacy.LegalAgreements.Events.LegalAgreementAcceptedEto",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/LegalAgreements/Events/LegalAgreementAcceptedEto.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "LegalAgreementObsoleteEto",
+      "fqn": "Granit.Privacy.LegalAgreements.Events.LegalAgreementObsoleteEto",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/LegalAgreements/Events/LegalAgreementObsoleteEto.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "ILegalAgreementChecker",
+      "fqn": "Granit.Privacy.LegalAgreements.ILegalAgreementChecker",
+      "kind": "interface",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/LegalAgreements/ILegalAgreementChecker.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "HasAcceptedLatestAsync",
+          "kind": "method",
+          "signature": "HasAcceptedLatestAsync(Guid userId, string documentId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        },
+        {
+          "name": "GetUserAgreementsAsync",
+          "kind": "method",
+          "signature": "GetUserAgreementsAsync(Guid userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<LegalAgreementBase>>"
+        }
+      ]
+    },
+    {
+      "name": "ILegalAgreementStoreReader",
+      "fqn": "Granit.Privacy.LegalAgreements.ILegalAgreementStoreReader",
+      "kind": "interface",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/LegalAgreements/ILegalAgreementStoreReader.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "FindLatestAsync",
+          "kind": "method",
+          "signature": "FindLatestAsync(Guid userId, string documentId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<LegalAgreementBase?>"
+        },
+        {
+          "name": "FindAllByUserAsync",
+          "kind": "method",
+          "signature": "FindAllByUserAsync(Guid userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<LegalAgreementBase>>"
+        }
+      ]
+    },
+    {
+      "name": "ILegalAgreementStoreWriter",
+      "fqn": "Granit.Privacy.LegalAgreements.ILegalAgreementStoreWriter",
+      "kind": "interface",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/LegalAgreements/ILegalAgreementStoreWriter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "RecordAsync",
+          "kind": "method",
+          "signature": "RecordAsync(LegalAgreementBase agreement, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ILegalDocumentRegistry",
+      "fqn": "Granit.Privacy.LegalAgreements.ILegalDocumentRegistry",
+      "kind": "interface",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/LegalAgreements/ILegalDocumentRegistry.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetDefinition",
+          "kind": "method",
+          "signature": "GetDefinition(string documentId)",
+          "returnType": "LegalDocumentDefinition?"
+        },
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IReadOnlyList<LegalDocumentDefinition>"
+        }
+      ]
+    },
+    {
+      "name": "LegalDocumentDefinition",
+      "fqn": "Granit.Privacy.LegalAgreements.LegalDocumentDefinition",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/LegalAgreements/LegalDocumentDefinition.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "GranitPrivacyOptions",
+      "fqn": "Granit.Privacy.Options.GranitPrivacyOptions",
+      "kind": "class",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/Options/GranitPrivacyOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ExportTimeoutMinutes",
+          "kind": "property",
+          "signature": "int ExportTimeoutMinutes",
+          "returnType": "int"
+        },
+        {
+          "name": "ExportMaxSizeMb",
+          "kind": "property",
+          "signature": "int ExportMaxSizeMb",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "QueryingAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Querying.AI.Extensions.QueryingAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Querying.AI",
+      "file": "src/Granit.Querying.AI/Extensions/QueryingAIHostApplicationBuilderExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitQueryingAI",
+          "kind": "method",
+          "signature": "AddGranitQueryingAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitQueryingAIModule",
+      "fqn": "Granit.Querying.AI.GranitQueryingAIModule",
+      "kind": "class",
+      "project": "Granit.Querying.AI",
+      "file": "src/Granit.Querying.AI/GranitQueryingAIModule.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "INaturalLanguageQueryTranslator",
+      "fqn": "Granit.Querying.AI.INaturalLanguageQueryTranslator",
+      "kind": "interface",
+      "project": "Granit.Querying.AI",
+      "file": "src/Granit.Querying.AI/INaturalLanguageQueryTranslator.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "TranslateAsync",
+          "kind": "method",
+          "signature": "TranslateAsync(string naturalLanguage, QueryMetadata metadata, CancellationToken cancellationToken = default)",
+          "returnType": "Task<QueryRequest?>"
+        }
+      ]
+    },
+    {
+      "name": "QueryingAIOptions",
+      "fqn": "Granit.Querying.AI.Options.QueryingAIOptions",
+      "kind": "class",
+      "project": "Granit.Querying.AI",
+      "file": "src/Granit.Querying.AI/Options/QueryingAIOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string WorkspaceName",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "ColumnBuilder",
+      "fqn": "Granit.Querying.ColumnBuilder",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/ColumnBuilder.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "ColumnDescriptor",
+      "fqn": "Granit.Querying.ColumnDescriptor",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/ColumnDescriptor.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "PropertyName",
+          "kind": "property",
+          "signature": "required string PropertyName",
+          "returnType": "required string"
+        }
+      ]
+    },
+    {
+      "name": "DatePeriod",
+      "fqn": "Granit.Querying.DatePeriod",
+      "kind": "enum",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/DatePeriod.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "QueryRequestBinder",
+      "fqn": "Granit.Querying.Endpoints.Binding.QueryRequestBinder",
+      "kind": "class",
+      "project": "Granit.Querying.Endpoints",
+      "file": "src/Granit.Querying.Endpoints/Binding/QueryRequestBinder.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "BindAsync",
+          "kind": "method",
+          "signature": "BindAsync(HttpContext context, ParameterInfo parameter)",
+          "returnType": "ValueTask<QueryRequest?>"
+        }
+      ]
+    },
+    {
+      "name": "BindableQueryRequest",
+      "fqn": "Granit.Querying.Endpoints.Dtos.BindableQueryRequest",
+      "kind": "class",
+      "project": "Granit.Querying.Endpoints",
+      "file": "src/Granit.Querying.Endpoints/Dtos/BindableQueryRequest.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "BindableQueryRequest",
+          "kind": "method",
+          "signature": "BindableQueryRequest(QueryRequest value)",
+          "returnType": "QueryRequest Value { get; } private"
+        },
+        {
+          "name": "BindAsync",
+          "kind": "method",
+          "signature": "BindAsync(HttpContext context, ParameterInfo parameter)",
+          "returnType": "ValueTask<BindableQueryRequest?>"
+        }
+      ]
+    },
+    {
+      "name": "SavedViewResponse",
+      "fqn": "Granit.Querying.Endpoints.Dtos.SavedViewResponse",
+      "kind": "record",
+      "project": "Granit.Querying.Endpoints",
+      "file": "src/Granit.Querying.Endpoints/Dtos/SavedViewResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "QueryEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Querying.Endpoints.Extensions.QueryEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Querying.Endpoints",
+      "file": "src/Granit.Querying.Endpoints/Extensions/QueryEndpointRouteBuilderExtensions.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "GranitQueryingEndpointsModule",
+      "fqn": "Granit.Querying.Endpoints.GranitQueryingEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Querying.Endpoints",
+      "file": "src/Granit.Querying.Endpoints/GranitQueryingEndpointsModule.cs",
+      "line": 28,
+      "members": []
+    },
+    {
+      "name": "QueryEndpointOptions",
+      "fqn": "Granit.Querying.Endpoints.Options.QueryEndpointOptions",
+      "kind": "class",
+      "project": "Granit.Querying.Endpoints",
+      "file": "src/Granit.Querying.Endpoints/Options/QueryEndpointOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string? TagName",
+          "returnType": "string?"
+        },
+        {
+          "name": "IncludeSavedViewEndpoints",
+          "kind": "property",
+          "signature": "bool IncludeSavedViewEndpoints",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "QueryingEfCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.Querying.EntityFrameworkCore.Extensions.QueryingEfCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Querying.EntityFrameworkCore",
+      "file": "src/Granit.Querying.EntityFrameworkCore/Extensions/QueryingEfCoreHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitQueryingEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitQueryingEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "QueryingModelBuilderExtensions",
+      "fqn": "Granit.Querying.EntityFrameworkCore.Extensions.QueryingModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Querying.EntityFrameworkCore",
+      "file": "src/Granit.Querying.EntityFrameworkCore/Extensions/QueryingModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureQueryingModule",
+          "kind": "method",
+          "signature": "ConfigureQueryingModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitQueryingDbProperties",
+      "fqn": "Granit.Querying.EntityFrameworkCore.GranitQueryingDbProperties",
+      "kind": "class",
+      "project": "Granit.Querying.EntityFrameworkCore",
+      "file": "src/Granit.Querying.EntityFrameworkCore/GranitQueryingDbProperties.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitQueryingEntityFrameworkCoreModule",
+      "fqn": "Granit.Querying.EntityFrameworkCore.GranitQueryingEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Querying.EntityFrameworkCore",
+      "file": "src/Granit.Querying.EntityFrameworkCore/GranitQueryingEntityFrameworkCoreModule.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.Querying.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Extensions/ServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitQuerying",
+          "kind": "method",
+          "signature": "AddGranitQuerying(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "AggregateDescriptor",
+      "fqn": "Granit.Querying.Filtering.AggregateDescriptor",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/AggregateDescriptor.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "AggregateFunction",
+      "fqn": "Granit.Querying.Filtering.AggregateFunction",
+      "kind": "enum",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/AggregateFunction.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "DateFilterDescriptor",
+      "fqn": "Granit.Querying.Filtering.DateFilterDescriptor",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/DateFilterDescriptor.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "FilterCriteria",
+      "fqn": "Granit.Querying.Filtering.FilterCriteria",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/FilterCriteria.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "FilterGroupBuilder",
+      "fqn": "Granit.Querying.Filtering.FilterGroupBuilder",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/FilterGroupBuilder.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Preset",
+          "kind": "method",
+          "signature": "Preset(string name, Expression<Func<TEntity, bool>> predicate, bool isDefault = false)",
+          "returnType": "FilterGroupBuilder<TEntity>"
+        }
+      ]
+    },
+    {
+      "name": "FilterGroupDescriptor",
+      "fqn": "Granit.Querying.Filtering.FilterGroupDescriptor",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/FilterGroupDescriptor.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "FilterOperator",
+      "fqn": "Granit.Querying.Filtering.FilterOperator",
+      "kind": "enum",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/FilterOperator.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "FilterOperatorInference",
+      "fqn": "Granit.Querying.Filtering.FilterOperatorInference",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/FilterOperatorInference.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetOperators",
+          "kind": "method",
+          "signature": "GetOperators(Type clrType)",
+          "returnType": "IReadOnlyList<FilterOperator>"
+        }
+      ]
+    },
+    {
+      "name": "GroupByDescriptor",
+      "fqn": "Granit.Querying.Filtering.GroupByDescriptor",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/GroupByDescriptor.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IQueryFilter",
+      "fqn": "Granit.Querying.Filtering.IQueryFilter",
+      "kind": "interface",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/IQueryFilter.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Apply",
+          "kind": "method",
+          "signature": "Apply(string value)",
+          "returnType": "string Name { get; } Expression<Func<TEntity, bool>>"
+        }
+      ]
+    },
+    {
+      "name": "PresetDescriptor",
+      "fqn": "Granit.Querying.Filtering.PresetDescriptor",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/PresetDescriptor.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "QuickFilterDescriptor",
+      "fqn": "Granit.Querying.Filtering.QuickFilterDescriptor",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/QuickFilterDescriptor.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "GranitQueryingModule",
+      "fqn": "Granit.Querying.GranitQueryingModule",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/GranitQueryingModule.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GroupEntry",
+      "fqn": "Granit.Querying.GroupEntry",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/GroupedResult.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "GroupedResult",
+      "fqn": "Granit.Querying.GroupedResult",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/GroupedResult.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "IQueryDefinitionDescriptor",
+      "fqn": "Granit.Querying.IQueryDefinitionDescriptor",
+      "kind": "interface",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/IQueryDefinitionDescriptor.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "IQueryEngine",
+      "fqn": "Granit.Querying.IQueryEngine",
+      "kind": "interface",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/IQueryEngine.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ExecuteAsync",
+          "kind": "method",
+          "signature": "ExecuteAsync(IQueryable<TEntity> source, QueryRequest request, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<TEntity>>"
+        },
+        {
+          "name": "ExecuteGroupedAsync",
+          "kind": "method",
+          "signature": "ExecuteGroupedAsync(IQueryable<TEntity> source, QueryRequest request, CancellationToken cancellationToken = default)",
+          "returnType": "Task<GroupedResult<TEntity>>"
+        },
+        {
+          "name": "ExecuteStreamAsync",
+          "kind": "method",
+          "signature": "ExecuteStreamAsync(IQueryable<TEntity> source, QueryRequest request, CancellationToken cancellationToken = default)",
+          "returnType": "IAsyncEnumerable<TEntity>"
+        },
+        {
+          "name": "GetMetadata",
+          "kind": "method",
+          "signature": "GetMetadata(IReadOnlyList<SavedViewSummary>? savedViews = null)",
+          "returnType": "QueryMetadata"
+        }
+      ]
+    },
+    {
+      "name": "ColumnDefinition",
+      "fqn": "Granit.Querying.Meta.ColumnDefinition",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Meta/ColumnDefinition.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "DateFilterMeta",
+      "fqn": "Granit.Querying.Meta.DateFilterMeta",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Meta/DateFilterMeta.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "FilterGroupMeta",
+      "fqn": "Granit.Querying.Meta.FilterGroupMeta",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Meta/FilterGroupMeta.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "FilterableField",
+      "fqn": "Granit.Querying.Meta.FilterableField",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Meta/FilterableField.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "GroupByField",
+      "fqn": "Granit.Querying.Meta.GroupByField",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Meta/GroupByField.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "PaginationMeta",
+      "fqn": "Granit.Querying.Meta.PaginationMeta",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Meta/PaginationMeta.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "PresetMeta",
+      "fqn": "Granit.Querying.Meta.PresetMeta",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Meta/FilterGroupMeta.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "QueryMetadata",
+      "fqn": "Granit.Querying.Meta.QueryMetadata",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Meta/QueryMetadata.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "QuickFilterMeta",
+      "fqn": "Granit.Querying.Meta.QuickFilterMeta",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Meta/QuickFilterMeta.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "SortableField",
+      "fqn": "Granit.Querying.Meta.SortableField",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Meta/SortableField.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "QueryingOptions",
+      "fqn": "Granit.Querying.Options.QueryingOptions",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Options/QueryingOptions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "DefaultPageSize",
+          "kind": "property",
+          "signature": "int DefaultPageSize",
+          "returnType": "int"
+        },
+        {
+          "name": "MaxPageSize",
+          "kind": "property",
+          "signature": "int MaxPageSize",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "PagedResult",
+      "fqn": "Granit.Querying.PagedResult",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/PagedResult.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "QueryDefinition",
+      "fqn": "Granit.Querying.QueryDefinition",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/QueryDefinition.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "typeof",
+          "kind": "method",
+          "signature": "typeof(TEntity)",
+          "returnType": "string Name { get; } public Type EntityType =>"
+        },
+        {
+          "name": "GetFilterGroups",
+          "kind": "method",
+          "signature": "GetFilterGroups()",
+          "returnType": "IReadOnlyList<Filtering.FilterGroupDescriptor>"
+        },
+        {
+          "name": "GetDateFilters",
+          "kind": "method",
+          "signature": "GetDateFilters()",
+          "returnType": "IReadOnlyList<Filtering.DateFilterDescriptor>"
+        },
+        {
+          "name": "GetGroupByFields",
+          "kind": "method",
+          "signature": "GetGroupByFields()",
+          "returnType": "IReadOnlyList<Filtering.GroupByDescriptor>"
+        },
+        {
+          "name": "GetAggregates",
+          "kind": "method",
+          "signature": "GetAggregates()",
+          "returnType": "IReadOnlyList<Filtering.AggregateDescriptor>"
+        },
+        {
+          "name": "GetQuickFilters",
+          "kind": "method",
+          "signature": "GetQuickFilters()",
+          "returnType": "IReadOnlyList<Filtering.QuickFilterDescriptor>"
+        },
+        {
+          "name": "GetGlobalSearchProperties",
+          "kind": "method",
+          "signature": "GetGlobalSearchProperties()",
+          "returnType": "IReadOnlyList<string>"
+        },
+        {
+          "name": "GetDefaultPageSize",
+          "kind": "method",
+          "signature": "GetDefaultPageSize()",
+          "returnType": "int"
+        },
+        {
+          "name": "GetMaxPageSize",
+          "kind": "method",
+          "signature": "GetMaxPageSize()",
+          "returnType": "int"
+        },
+        {
+          "name": "GetCursorProperty",
+          "kind": "method",
+          "signature": "GetCursorProperty()",
+          "returnType": "string?"
+        },
+        {
+          "name": "GetDefaultSort",
+          "kind": "method",
+          "signature": "GetDefaultSort()",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "QueryDefinitionBuilder",
+      "fqn": "Granit.Querying.QueryDefinitionBuilder",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/QueryDefinitionBuilder.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "QueryRequest",
+      "fqn": "Granit.Querying.QueryRequest",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/QueryRequest.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "QueryingDefaults",
+      "fqn": "Granit.Querying.QueryingDefaults",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/QueryingDefaults.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "CreateSavedViewRequest",
+      "fqn": "Granit.Querying.SavedViews.CreateSavedViewRequest",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/SavedViews/CreateSavedViewRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "SavedView",
+      "fqn": "Granit.Querying.SavedViews.Domain.SavedView",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/SavedViews/Domain/SavedView.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ISavedViewStoreReader",
+      "fqn": "Granit.Querying.SavedViews.ISavedViewStoreReader",
+      "kind": "interface",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/SavedViews/ISavedViewStoreReader.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetListAsync",
+          "kind": "method",
+          "signature": "GetListAsync(string entityType, string userId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<SavedView>>"
+        },
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<SavedView?>"
+        }
+      ]
+    },
+    {
+      "name": "ISavedViewStoreWriter",
+      "fqn": "Granit.Querying.SavedViews.ISavedViewStoreWriter",
+      "kind": "interface",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/SavedViews/ISavedViewStoreWriter.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(SavedView view, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UpdateAsync",
+          "kind": "method",
+          "signature": "UpdateAsync(SavedView view, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SetDefaultAsync",
+          "kind": "method",
+          "signature": "SetDefaultAsync(Guid id, string userId, string entityType, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "SavedViewSummary",
+      "fqn": "Granit.Querying.SavedViews.SavedViewSummary",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/SavedViews/SavedViewSummary.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "UpdateSavedViewRequest",
+      "fqn": "Granit.Querying.SavedViews.UpdateSavedViewRequest",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/SavedViews/UpdateSavedViewRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IRateLimitCounterStore",
+      "fqn": "Granit.RateLimiting.Abstractions.IRateLimitCounterStore",
+      "kind": "interface",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Abstractions/IRateLimitCounterStore.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "CheckAndIncrementAsync",
+          "kind": "method",
+          "signature": "CheckAndIncrementAsync(string key, int permitLimit, TimeSpan window, RateLimitAlgorithm algorithm, RateLimitPolicyOptions policyOptions, CancellationToken cancellationToken)",
+          "returnType": "Task<RateLimitResult>"
+        }
+      ]
+    },
+    {
+      "name": "IRateLimitQuotaProvider",
+      "fqn": "Granit.RateLimiting.Abstractions.IRateLimitQuotaProvider",
+      "kind": "interface",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Abstractions/IRateLimitQuotaProvider.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "GetPermitLimitAsync",
+          "kind": "method",
+          "signature": "GetPermitLimitAsync(string policyName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int?>"
+        }
+      ]
+    },
+    {
+      "name": "RateLimitResult",
+      "fqn": "Granit.RateLimiting.Abstractions.RateLimitResult",
+      "kind": "record",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Abstractions/RateLimitResult.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "RateLimitEndpointExtensions",
+      "fqn": "Granit.RateLimiting.AspNetCore.RateLimitEndpointExtensions",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/AspNetCore/RateLimitEndpointExtensions.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "RateLimitedAttribute",
+      "fqn": "Granit.RateLimiting.Attributes.RateLimitedAttribute",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Attributes/RateLimitedAttribute.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "PolicyName",
+          "kind": "property",
+          "signature": "string PolicyName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "RateLimitingMetrics",
+      "fqn": "Granit.RateLimiting.Diagnostics.RateLimitingMetrics",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Diagnostics/RateLimitingMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordRejected",
+          "kind": "method",
+          "signature": "RecordRejected(string policyName, string? tenantId)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "RateLimitExceededException",
+      "fqn": "Granit.RateLimiting.Exceptions.RateLimitExceededException",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Exceptions/RateLimitExceededException.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "RateLimitingApplicationBuilderExtensions",
+      "fqn": "Granit.RateLimiting.Extensions.RateLimitingApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Extensions/RateLimitingApplicationBuilderExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "UseGranitRateLimiting",
+          "kind": "method",
+          "signature": "UseGranitRateLimiting(this IApplicationBuilder app)",
+          "returnType": "IApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "RateLimitingServiceCollectionExtensions",
+      "fqn": "Granit.RateLimiting.Extensions.RateLimitingServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Extensions/RateLimitingServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitRateLimiting",
+          "kind": "method",
+          "signature": "AddGranitRateLimiting(this IServiceCollection services, Action<GranitRateLimitingOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitRateLimitingModule",
+      "fqn": "Granit.RateLimiting.GranitRateLimitingModule",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/GranitRateLimitingModule.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "CounterStoreFailureBehavior",
+      "fqn": "Granit.RateLimiting.Options.CounterStoreFailureBehavior",
+      "kind": "enum",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Options/CounterStoreFailureBehavior.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "GranitRateLimitingOptions",
+      "fqn": "Granit.RateLimiting.Options.GranitRateLimitingOptions",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Options/GranitRateLimitingOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Enabled",
+          "kind": "property",
+          "signature": "bool Enabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "KeyPrefix",
+          "kind": "property",
+          "signature": "string KeyPrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "FallbackOnCounterStoreFailure",
+          "kind": "property",
+          "signature": "CounterStoreFailureBehavior FallbackOnCounterStoreFailure",
+          "returnType": "CounterStoreFailureBehavior"
+        },
+        {
+          "name": "BypassRoles",
+          "kind": "property",
+          "signature": "string[] BypassRoles",
+          "returnType": "string[]"
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(StringComparer.OrdinalIgnoreCase)",
+          "returnType": "Dictionary<string, RateLimitPolicyOptions> Policies { get; set; } ="
+        }
+      ]
+    },
+    {
+      "name": "RateLimitAlgorithm",
+      "fqn": "Granit.RateLimiting.Options.RateLimitAlgorithm",
+      "kind": "enum",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Options/RateLimitAlgorithm.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "RateLimitPolicyOptions",
+      "fqn": "Granit.RateLimiting.Options.RateLimitPolicyOptions",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Options/RateLimitPolicyOptions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "Algorithm",
+          "kind": "property",
+          "signature": "RateLimitAlgorithm Algorithm",
+          "returnType": "RateLimitAlgorithm"
+        },
+        {
+          "name": "PermitLimit",
+          "kind": "property",
+          "signature": "int PermitLimit",
+          "returnType": "int"
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(1)",
+          "returnType": "TimeSpan Window { get; set; } = TimeSpan."
+        },
+        {
+          "name": "SegmentsPerWindow",
+          "kind": "property",
+          "signature": "int SegmentsPerWindow",
+          "returnType": "int"
+        },
+        {
+          "name": "TokenLimit",
+          "kind": "property",
+          "signature": "int TokenLimit",
+          "returnType": "int"
+        },
+        {
+          "name": "TokensPerPeriod",
+          "kind": "property",
+          "signature": "int TokensPerPeriod",
+          "returnType": "int"
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(10)",
+          "returnType": "TimeSpan ReplenishmentPeriod { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "TenantPartitionedRateLimiter",
+      "fqn": "Granit.RateLimiting.TenantPartitionedRateLimiter",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/TenantPartitionedRateLimiter.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "CheckAsync",
+          "kind": "method",
+          "signature": "CheckAsync(string policyName, CancellationToken cancellationToken)",
+          "returnType": "Task<RateLimitResult?>"
+        }
+      ]
+    },
+    {
+      "name": "RateLimitMiddleware",
+      "fqn": "Granit.RateLimiting.Wolverine.RateLimitMiddleware",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Wolverine/RateLimitMiddleware.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "BeforeAsync",
+          "kind": "method",
+          "signature": "BeforeAsync(object message, TenantPartitionedRateLimiter limiter, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ReferenceDataEntity",
+      "fqn": "Granit.ReferenceData.Domain.ReferenceDataEntity",
+      "kind": "class",
+      "project": "Granit.ReferenceData",
+      "file": "src/Granit.ReferenceData/Domain/ReferenceDataEntity.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "Code",
+          "kind": "property",
+          "signature": "string Code",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelEn",
+          "kind": "property",
+          "signature": "string LabelEn",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelFr",
+          "kind": "property",
+          "signature": "string LabelFr",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelNl",
+          "kind": "property",
+          "signature": "string LabelNl",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelDe",
+          "kind": "property",
+          "signature": "string LabelDe",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelEs",
+          "kind": "property",
+          "signature": "string LabelEs",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelIt",
+          "kind": "property",
+          "signature": "string LabelIt",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelPt",
+          "kind": "property",
+          "signature": "string LabelPt",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelZh",
+          "kind": "property",
+          "signature": "string LabelZh",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelJa",
+          "kind": "property",
+          "signature": "string LabelJa",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelPl",
+          "kind": "property",
+          "signature": "string LabelPl",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelTr",
+          "kind": "property",
+          "signature": "string LabelTr",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelKo",
+          "kind": "property",
+          "signature": "string LabelKo",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelSv",
+          "kind": "property",
+          "signature": "string LabelSv",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelCs",
+          "kind": "property",
+          "signature": "string LabelCs",
+          "returnType": "string"
+        },
+        {
+          "name": "Label",
+          "kind": "property",
+          "signature": "string Label",
+          "returnType": "string"
+        },
+        {
+          "name": "IsActive",
+          "kind": "property",
+          "signature": "bool IsActive",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "ReferenceDataCreateRequest",
+      "fqn": "Granit.ReferenceData.Endpoints.Dtos.ReferenceDataCreateRequest",
+      "kind": "record",
+      "project": "Granit.ReferenceData.Endpoints",
+      "file": "src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataCreateRequest.cs",
+      "line": 24,
+      "members": []
+    },
+    {
+      "name": "ReferenceDataUpdateRequest",
+      "fqn": "Granit.ReferenceData.Endpoints.Dtos.ReferenceDataUpdateRequest",
+      "kind": "record",
+      "project": "Granit.ReferenceData.Endpoints",
+      "file": "src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataUpdateRequest.cs",
+      "line": 24,
+      "members": []
+    },
+    {
+      "name": "ReferenceDataEndpointRouteBuilderExtensions",
+      "fqn": "Granit.ReferenceData.Endpoints.Extensions.ReferenceDataEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.ReferenceData.Endpoints",
+      "file": "src/Granit.ReferenceData.Endpoints/Extensions/ReferenceDataEndpointRouteBuilderExtensions.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "GranitReferenceDataEndpointsModule",
+      "fqn": "Granit.ReferenceData.Endpoints.GranitReferenceDataEndpointsModule",
+      "kind": "class",
+      "project": "Granit.ReferenceData.Endpoints",
+      "file": "src/Granit.ReferenceData.Endpoints/GranitReferenceDataEndpointsModule.cs",
+      "line": 23,
+      "members": []
+    },
+    {
+      "name": "ReferenceDataEndpointsOptions",
+      "fqn": "Granit.ReferenceData.Endpoints.Options.ReferenceDataEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.ReferenceData.Endpoints",
+      "file": "src/Granit.ReferenceData.Endpoints/Options/ReferenceDataEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        },
+        {
+          "name": "AdminPolicyName",
+          "kind": "property",
+          "signature": "string? AdminPolicyName",
+          "returnType": "string?"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "ModelBuilderExtensions",
+      "fqn": "Granit.ReferenceData.EntityFrameworkCore.Extensions.ModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.ReferenceData.EntityFrameworkCore",
+      "file": "src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ReferenceDataEfCoreServiceCollectionExtensions",
+      "fqn": "Granit.ReferenceData.EntityFrameworkCore.Extensions.ReferenceDataEfCoreServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.ReferenceData.EntityFrameworkCore",
+      "file": "src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ReferenceDataEfCoreServiceCollectionExtensions.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "GranitReferenceDataEntityFrameworkCoreModule",
+      "fqn": "Granit.ReferenceData.EntityFrameworkCore.GranitReferenceDataEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.ReferenceData.EntityFrameworkCore",
+      "file": "src/Granit.ReferenceData.EntityFrameworkCore/GranitReferenceDataEntityFrameworkCoreModule.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "ReferenceDataEntityTypeConfiguration",
+      "fqn": "Granit.ReferenceData.EntityFrameworkCore.Internal.ReferenceDataEntityTypeConfiguration",
+      "kind": "class",
+      "project": "Granit.ReferenceData.EntityFrameworkCore",
+      "file": "src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataEntityTypeConfiguration.cs",
+      "line": 33,
+      "members": []
+    },
+    {
+      "name": "ReferenceDataServiceCollectionExtensions",
+      "fqn": "Granit.ReferenceData.Extensions.ReferenceDataServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.ReferenceData",
+      "file": "src/Granit.ReferenceData/Extensions/ReferenceDataServiceCollectionExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "AddGranitReferenceData",
+          "kind": "method",
+          "signature": "AddGranitReferenceData(this IServiceCollection services, Action<ReferenceDataOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitReferenceDataModule",
+      "fqn": "Granit.ReferenceData.GranitReferenceDataModule",
+      "kind": "class",
+      "project": "Granit.ReferenceData",
+      "file": "src/Granit.ReferenceData/GranitReferenceDataModule.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IReferenceDataSeeder",
+      "fqn": "Granit.ReferenceData.IReferenceDataSeeder",
+      "kind": "interface",
+      "project": "Granit.ReferenceData",
+      "file": "src/Granit.ReferenceData/IReferenceDataSeeder.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "SeedAsync",
+          "kind": "method",
+          "signature": "SeedAsync(IReferenceDataStoreReader<TEntity> storeReader, IReferenceDataStoreWriter<TEntity> storeWriter, CancellationToken cancellationToken = default)",
+          "returnType": "int Order { get; } Task"
+        }
+      ]
+    },
+    {
+      "name": "IReferenceDataStoreReader",
+      "fqn": "Granit.ReferenceData.IReferenceDataStoreReader",
+      "kind": "interface",
+      "project": "Granit.ReferenceData",
+      "file": "src/Granit.ReferenceData/IReferenceDataStoreReader.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetAllAsync",
+          "kind": "method",
+          "signature": "GetAllAsync(ReferenceDataQuery? query = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<TEntity>>"
+        },
+        {
+          "name": "GetByCodeAsync",
+          "kind": "method",
+          "signature": "GetByCodeAsync(string code, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TEntity?>"
+        }
+      ]
+    },
+    {
+      "name": "IReferenceDataStoreWriter",
+      "fqn": "Granit.ReferenceData.IReferenceDataStoreWriter",
+      "kind": "interface",
+      "project": "Granit.ReferenceData",
+      "file": "src/Granit.ReferenceData/IReferenceDataStoreWriter.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(TEntity entity, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UpdateAsync",
+          "kind": "method",
+          "signature": "UpdateAsync(TEntity entity, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SetActiveAsync",
+          "kind": "method",
+          "signature": "SetActiveAsync(string code, bool isActive, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ReferenceDataOptions",
+      "fqn": "Granit.ReferenceData.Options.ReferenceDataOptions",
+      "kind": "class",
+      "project": "Granit.ReferenceData",
+      "file": "src/Granit.ReferenceData/Options/ReferenceDataOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "FromHours",
+          "kind": "method",
+          "signature": "FromHours(1)",
+          "returnType": "TimeSpan CacheTimeToLive { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "ReferenceDataQuery",
+      "fqn": "Granit.ReferenceData.ReferenceDataQuery",
+      "kind": "record",
+      "project": "Granit.ReferenceData",
+      "file": "src/Granit.ReferenceData/ReferenceDataQuery.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "ActorKind",
+      "fqn": "Granit.Security.ActorKind",
+      "kind": "enum",
+      "project": "Granit.Security",
+      "file": "src/Granit.Security/ActorKind.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "GranitSecurityModule",
+      "fqn": "Granit.Security.GranitSecurityModule",
+      "kind": "class",
+      "project": "Granit.Security",
+      "file": "src/Granit.Security/GranitSecurityModule.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ICurrentUserService",
+      "fqn": "Granit.Security.ICurrentUserService",
+      "kind": "interface",
+      "project": "Granit.Security",
+      "file": "src/Granit.Security/ICurrentUserService.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "GetRoles",
+          "kind": "method",
+          "signature": "GetRoles()",
+          "returnType": "string? UserId { get; } string? UserName { get; } string? Email { get; } string? FirstName { get; } string? LastName { get; } bool IsAuthenticated { get; } IReadOnlyList<string>"
+        },
+        {
+          "name": "IsInRole",
+          "kind": "method",
+          "signature": "IsInRole(string role)",
+          "returnType": "bool"
+        },
+        {
+          "name": "ActorKind",
+          "kind": "property",
+          "signature": "ActorKind ActorKind",
+          "returnType": "ActorKind"
+        },
+        {
+          "name": "IsMachine",
+          "kind": "property",
+          "signature": "bool IsMachine",
+          "returnType": "bool"
+        },
+        {
+          "name": "ApiKeyId",
+          "kind": "property",
+          "signature": "Guid? ApiKeyId",
+          "returnType": "Guid?"
+        }
+      ]
+    },
+    {
+      "name": "SystemCurrentUserService",
+      "fqn": "Granit.Security.SystemCurrentUserService",
+      "kind": "class",
+      "project": "Granit.Security",
+      "file": "src/Granit.Security/SystemCurrentUserService.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "UserId",
+          "kind": "property",
+          "signature": "string? UserId",
+          "returnType": "string?"
+        },
+        {
+          "name": "UserName",
+          "kind": "property",
+          "signature": "string? UserName",
+          "returnType": "string?"
+        },
+        {
+          "name": "Email",
+          "kind": "property",
+          "signature": "string? Email",
+          "returnType": "string?"
+        },
+        {
+          "name": "FirstName",
+          "kind": "property",
+          "signature": "string? FirstName",
+          "returnType": "string?"
+        },
+        {
+          "name": "LastName",
+          "kind": "property",
+          "signature": "string? LastName",
+          "returnType": "string?"
+        },
+        {
+          "name": "IsAuthenticated",
+          "kind": "property",
+          "signature": "bool IsAuthenticated",
+          "returnType": "bool"
+        },
+        {
+          "name": "GetRoles",
+          "kind": "method",
+          "signature": "GetRoles()",
+          "returnType": "IReadOnlyList<string>"
+        },
+        {
+          "name": "IsInRole",
+          "kind": "method",
+          "signature": "IsInRole(string role)",
+          "returnType": "bool"
+        },
+        {
+          "name": "ActorKind",
+          "kind": "property",
+          "signature": "ActorKind ActorKind",
+          "returnType": "ActorKind"
+        },
+        {
+          "name": "IsMachine",
+          "kind": "property",
+          "signature": "bool IsMachine",
+          "returnType": "bool"
+        },
+        {
+          "name": "ApiKeyId",
+          "kind": "property",
+          "signature": "Guid? ApiKeyId",
+          "returnType": "Guid?"
+        }
+      ]
+    },
+    {
+      "name": "ISettingDefinitionContext",
+      "fqn": "Granit.Settings.Definitions.ISettingDefinitionContext",
+      "kind": "interface",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Definitions/ISettingDefinitionContext.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Add",
+          "kind": "method",
+          "signature": "Add(SettingDefinition definition)",
+          "returnType": "void"
+        },
+        {
+          "name": "GetOrNull",
+          "kind": "method",
+          "signature": "GetOrNull(string name)",
+          "returnType": "SettingDefinition?"
+        }
+      ]
+    },
+    {
+      "name": "ISettingDefinitionProvider",
+      "fqn": "Granit.Settings.Definitions.ISettingDefinitionProvider",
+      "kind": "interface",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Definitions/ISettingDefinitionProvider.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Define",
+          "kind": "method",
+          "signature": "Define(ISettingDefinitionContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "SettingDefinition",
+      "fqn": "Granit.Settings.Definitions.SettingDefinition",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Definitions/SettingDefinition.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Providers",
+          "kind": "property",
+          "signature": "IList<string> Providers",
+          "returnType": "IList<string>"
+        },
+        {
+          "name": "SettingDefinition",
+          "kind": "method",
+          "signature": "SettingDefinition(string name)",
+          "returnType": "string? DisplayName { get; init; } public string? Description { get; init; } public"
+        }
+      ]
+    },
+    {
+      "name": "SettingDefinitionManager",
+      "fqn": "Granit.Settings.Definitions.SettingDefinitionManager",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Definitions/SettingDefinitionManager.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetOrNull",
+          "kind": "method",
+          "signature": "GetOrNull(string name)",
+          "returnType": "SettingDefinition?"
+        },
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IReadOnlyCollection<SettingDefinition>"
+        }
+      ]
+    },
+    {
+      "name": "SettingValueResponse",
+      "fqn": "Granit.Settings.Endpoints.Dtos.SettingValueResponse",
+      "kind": "record",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/Dtos/SettingValueResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "UpdateSettingValueRequest",
+      "fqn": "Granit.Settings.Endpoints.Dtos.UpdateSettingValueRequest",
+      "kind": "record",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/Dtos/UpdateSettingValueRequest.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "AdminSettingsEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Settings.Endpoints.Extensions.AdminSettingsEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/Extensions/AdminSettingsEndpointRouteBuilderExtensions.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "MapGranitGlobalSettings",
+          "kind": "method",
+          "signature": "MapGranitGlobalSettings(this IEndpointRouteBuilder endpoints, Action<SettingsEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "UserSettingsEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Settings.Endpoints.Extensions.UserSettingsEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/Extensions/UserSettingsEndpointRouteBuilderExtensions.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "MapGranitUserSettings",
+          "kind": "method",
+          "signature": "MapGranitUserSettings(this IEndpointRouteBuilder endpoints, Action<SettingsEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitSettingsEndpointsModule",
+      "fqn": "Granit.Settings.Endpoints.GranitSettingsEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/GranitSettingsEndpointsModule.cs",
+      "line": 32,
+      "members": []
+    },
+    {
+      "name": "WellKnownSettingNames",
+      "fqn": "Granit.Settings.Endpoints.Internal.WellKnownSettingNames",
+      "kind": "class",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/Internal/WellKnownSettingNames.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "SettingsCultureMiddleware",
+      "fqn": "Granit.Settings.Endpoints.Middleware.SettingsCultureMiddleware",
+      "kind": "class",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/Middleware/SettingsCultureMiddleware.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "InvokeAsync",
+          "kind": "method",
+          "signature": "InvokeAsync(HttpContext context)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "SettingsEndpointsOptions",
+      "fqn": "Granit.Settings.Endpoints.Options.SettingsEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/Options/SettingsEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "UserRoutePrefix",
+          "kind": "property",
+          "signature": "string UserRoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "GlobalRoutePrefix",
+          "kind": "property",
+          "signature": "string GlobalRoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TenantRoutePrefix",
+          "kind": "property",
+          "signature": "string TenantRoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "SettingsPermissions",
+      "fqn": "Granit.Settings.Endpoints.Permissions.SettingsPermissions",
+      "kind": "class",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/Permissions/SettingsPermissions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "SettingRecord",
+      "fqn": "Granit.Settings.EntityFrameworkCore.Entities.SettingRecord",
+      "kind": "class",
+      "project": "Granit.Settings.EntityFrameworkCore",
+      "file": "src/Granit.Settings.EntityFrameworkCore/Entities/SettingRecord.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ProviderName",
+          "kind": "property",
+          "signature": "string ProviderName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "ModelBuilderExtensions",
+      "fqn": "Granit.Settings.EntityFrameworkCore.Extensions.ModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Settings.EntityFrameworkCore",
+      "file": "src/Granit.Settings.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "ConfigureSettingsModule",
+          "kind": "method",
+          "signature": "ConfigureSettingsModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "SettingsEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.Settings.EntityFrameworkCore.Extensions.SettingsEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Settings.EntityFrameworkCore",
+      "file": "src/Granit.Settings.EntityFrameworkCore/Extensions/SettingsEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "GranitSettingsDbProperties",
+      "fqn": "Granit.Settings.EntityFrameworkCore.GranitSettingsDbProperties",
+      "kind": "class",
+      "project": "Granit.Settings.EntityFrameworkCore",
+      "file": "src/Granit.Settings.EntityFrameworkCore/GranitSettingsDbProperties.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitSettingsEntityFrameworkCoreModule",
+      "fqn": "Granit.Settings.EntityFrameworkCore.GranitSettingsEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Settings.EntityFrameworkCore",
+      "file": "src/Granit.Settings.EntityFrameworkCore/GranitSettingsEntityFrameworkCoreModule.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "ISettingsDbContext",
+      "fqn": "Granit.Settings.EntityFrameworkCore.ISettingsDbContext",
+      "kind": "interface",
+      "project": "Granit.Settings.EntityFrameworkCore",
+      "file": "src/Granit.Settings.EntityFrameworkCore/ISettingsDbContext.cs",
+      "line": 30,
+      "members": []
+    },
+    {
+      "name": "SettingChangedEvent",
+      "fqn": "Granit.Settings.Events.SettingChangedEvent",
+      "kind": "record",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Events/SettingChangedEvent.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "SettingsServiceCollectionExtensions",
+      "fqn": "Granit.Settings.Extensions.SettingsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Extensions/SettingsServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitSettings",
+          "kind": "method",
+          "signature": "AddGranitSettings(this IServiceCollection services, IConfigurationSection? configuration = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitSettingsModule",
+      "fqn": "Granit.Settings.GranitSettingsModule",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/GranitSettingsModule.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "SettingsOptions",
+      "fqn": "Granit.Settings.Options.SettingsOptions",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Options/SettingsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(30)",
+          "returnType": "TimeSpan CacheExpiration { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "ConfigurationSettingValueProvider",
+      "fqn": "Granit.Settings.Providers.ConfigurationSettingValueProvider",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Providers/ConfigurationSettingValueProvider.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Order",
+          "kind": "property",
+          "signature": "int Order",
+          "returnType": "int"
+        },
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(SettingDefinition definition, CancellationToken cancellationToken = default)",
+          "returnType": "Task<SettingValue?>"
+        },
+        {
+          "name": "ClearAsync",
+          "kind": "method",
+          "signature": "ClearAsync(SettingDefinition definition, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "DefaultValueSettingValueProvider",
+      "fqn": "Granit.Settings.Providers.DefaultValueSettingValueProvider",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Providers/DefaultValueSettingValueProvider.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Order",
+          "kind": "property",
+          "signature": "int Order",
+          "returnType": "int"
+        },
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(SettingDefinition definition, CancellationToken cancellationToken = default)",
+          "returnType": "Task<SettingValue?>"
+        },
+        {
+          "name": "ClearAsync",
+          "kind": "method",
+          "signature": "ClearAsync(SettingDefinition definition, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "GlobalSettingValueProvider",
+      "fqn": "Granit.Settings.Providers.GlobalSettingValueProvider",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Providers/GlobalSettingValueProvider.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Order",
+          "kind": "property",
+          "signature": "int Order",
+          "returnType": "int"
+        },
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(SettingDefinition definition, CancellationToken cancellationToken = default)",
+          "returnType": "Task<SettingValue?>"
+        }
+      ]
+    },
+    {
+      "name": "ISettingValueProvider",
+      "fqn": "Granit.Settings.Providers.ISettingValueProvider",
+      "kind": "interface",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Providers/ISettingValueProvider.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(SettingDefinition definition, CancellationToken cancellationToken = default)",
+          "returnType": "string Name { get; } int Order { get; } Task<SettingValue?>"
+        },
+        {
+          "name": "SetAsync",
+          "kind": "method",
+          "signature": "SetAsync(SettingDefinition definition, string? value, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "ClearAsync",
+          "kind": "method",
+          "signature": "ClearAsync(SettingDefinition definition, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "SettingValueProviderManager",
+      "fqn": "Granit.Settings.Providers.SettingValueProviderManager",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Providers/SettingValueProviderManager.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "OrderBy",
+          "kind": "method",
+          "signature": "OrderBy(p => p.Order)",
+          "returnType": "IReadOnlyList<ISettingValueProvider> Providers { get; } = [.. providers."
+        },
+        {
+          "name": "GetOrNull",
+          "kind": "method",
+          "signature": "GetOrNull(string name)",
+          "returnType": "ISettingValueProvider?"
+        }
+      ]
+    },
+    {
+      "name": "TenantSettingValueProvider",
+      "fqn": "Granit.Settings.Providers.TenantSettingValueProvider",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Providers/TenantSettingValueProvider.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Order",
+          "kind": "property",
+          "signature": "int Order",
+          "returnType": "int"
+        },
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(SettingDefinition definition, CancellationToken cancellationToken = default)",
+          "returnType": "Task<SettingValue?>"
+        }
+      ]
+    },
+    {
+      "name": "UserSettingValueProvider",
+      "fqn": "Granit.Settings.Providers.UserSettingValueProvider",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Providers/UserSettingValueProvider.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Order",
+          "kind": "property",
+          "signature": "int Order",
+          "returnType": "int"
+        },
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(SettingDefinition definition, CancellationToken cancellationToken = default)",
+          "returnType": "Task<SettingValue?>"
+        }
+      ]
+    },
+    {
+      "name": "ISettingManager",
+      "fqn": "Granit.Settings.Services.ISettingManager",
+      "kind": "interface",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Services/ISettingManager.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SetGlobalAsync",
+          "kind": "method",
+          "signature": "SetGlobalAsync(string name, string? value, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SetForTenantAsync",
+          "kind": "method",
+          "signature": "SetForTenantAsync(Guid tenantId, string name, string? value, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SetForUserAsync",
+          "kind": "method",
+          "signature": "SetForUserAsync(string userId, string name, string? value, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(string name, string providerName, string? providerKey = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ISettingProvider",
+      "fqn": "Granit.Settings.Services.ISettingProvider",
+      "kind": "interface",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Services/ISettingProvider.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(string name, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string?>"
+        },
+        {
+          "name": "GetAllAsync",
+          "kind": "method",
+          "signature": "GetAllAsync(string[] names, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<SettingValue>>"
+        }
+      ]
+    },
+    {
+      "name": "SettingManager",
+      "fqn": "Granit.Settings.Services.SettingManager",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Services/SettingManager.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "SetGlobalAsync",
+          "kind": "method",
+          "signature": "SetGlobalAsync(string name, string? value, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "SettingProvider",
+      "fqn": "Granit.Settings.Services.SettingProvider",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Services/SettingProvider.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(string name, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string?>"
+        }
+      ]
+    },
+    {
+      "name": "InMemorySettingStore",
+      "fqn": "Granit.Settings.Stores.InMemorySettingStore",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Stores/InMemorySettingStore.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(string name, string providerName, string? providerKey, CancellationToken cancellationToken = default)",
+          "returnType": "Task<SettingValue?>"
+        }
+      ]
+    },
+    {
+      "name": "ISettingStoreReader",
+      "fqn": "Granit.Settings.Values.ISettingStoreReader",
+      "kind": "interface",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Values/ISettingStoreReader.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(string name, string providerName, string? providerKey, CancellationToken cancellationToken = default)",
+          "returnType": "Task<SettingValue?>"
+        },
+        {
+          "name": "GetListAsync",
+          "kind": "method",
+          "signature": "GetListAsync(string providerName, string? providerKey, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<SettingValue>>"
+        }
+      ]
+    },
+    {
+      "name": "ISettingStoreWriter",
+      "fqn": "Granit.Settings.Values.ISettingStoreWriter",
+      "kind": "interface",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Values/ISettingStoreWriter.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "SetAsync",
+          "kind": "method",
+          "signature": "SetAsync(string name, string providerName, string? providerKey, string? value, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(string name, string providerName, string? providerKey, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "SettingValue",
+      "fqn": "Granit.Settings.Values.SettingValue",
+      "kind": "record",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Values/SettingValue.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "AITemplateDataEnricher",
+      "fqn": "Granit.Templating.AI.AITemplateDataEnricher",
+      "kind": "class",
+      "project": "Granit.Templating.AI",
+      "file": "src/Granit.Templating.AI/AITemplateDataEnricher.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "BuildPrompt",
+          "kind": "method",
+          "signature": "BuildPrompt(TData data)",
+          "returnType": "int Order { get; } protected string"
+        },
+        {
+          "name": "EnrichAsync",
+          "kind": "method",
+          "signature": "EnrichAsync(TData data, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TData>"
+        }
+      ]
+    },
+    {
+      "name": "TemplatingAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Templating.AI.Extensions.TemplatingAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Templating.AI",
+      "file": "src/Granit.Templating.AI/Extensions/TemplatingAIHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitTemplatingAI",
+          "kind": "method",
+          "signature": "AddGranitTemplatingAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitTemplatingAIModule",
+      "fqn": "Granit.Templating.AI.GranitTemplatingAIModule",
+      "kind": "class",
+      "project": "Granit.Templating.AI",
+      "file": "src/Granit.Templating.AI/GranitTemplatingAIModule.cs",
+      "line": 24,
+      "members": []
+    },
+    {
+      "name": "IAITemplateAssistant",
+      "fqn": "Granit.Templating.AI.IAITemplateAssistant",
+      "kind": "interface",
+      "project": "Granit.Templating.AI",
+      "file": "src/Granit.Templating.AI/IAITemplateAssistant.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GenerateDraftAsync",
+          "kind": "method",
+          "signature": "GenerateDraftAsync(string description, Type dataType, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string?>"
+        }
+      ]
+    },
+    {
+      "name": "TemplatingAIOptions",
+      "fqn": "Granit.Templating.AI.Options.TemplatingAIOptions",
+      "kind": "class",
+      "project": "Granit.Templating.AI",
+      "file": "src/Granit.Templating.AI/Options/TemplatingAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string WorkspaceName",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "SaveTemplateCategoryRequest",
+      "fqn": "Granit.Templating.Endpoints.Dtos.SaveTemplateCategoryRequest",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/SaveTemplateCategoryRequest.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "SaveTemplateRequest",
+      "fqn": "Granit.Templating.Endpoints.Dtos.SaveTemplateRequest",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/SaveTemplateRequest.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "TemplateCategoryResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplateCategoryResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplateCategoryResponse.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "TemplateDetailResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplateDetailResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplateDetailResponse.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "TemplateHistoryResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplateHistoryResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplateHistoryResponse.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "TemplateLifecycleResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplateLifecycleResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplateLifecycleResponse.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "TemplateListItemResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplateListItemResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplateListItemResponse.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "TemplateListResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplateListResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplateListResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "TemplatePreviewRequest",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplatePreviewRequest",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplatePreviewRequest.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "TemplatePreviewResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplatePreviewResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplatePreviewResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "TemplateRevisionResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplateRevisionResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplateRevisionResponse.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "TemplateRevisionSummaryResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplateRevisionSummaryResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplateRevisionSummaryResponse.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "TemplateVariableItemResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplateVariableItemResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplateVariableItemResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "TemplateVariablesResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplateVariablesResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplateVariablesResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "TemplatingEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Templating.Endpoints.Extensions.TemplatingEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Extensions/TemplatingEndpointRouteBuilderExtensions.cs",
+      "line": 35,
+      "members": [
+        {
+          "name": "MapGranitTemplatingAdmin",
+          "kind": "method",
+          "signature": "MapGranitTemplatingAdmin(this IEndpointRouteBuilder endpoints, Action<TemplatingEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitTemplatingEndpointsModule",
+      "fqn": "Granit.Templating.Endpoints.GranitTemplatingEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/GranitTemplatingEndpointsModule.cs",
+      "line": 28,
+      "members": []
+    },
+    {
+      "name": "TemplatingEndpointsOptions",
+      "fqn": "Granit.Templating.Endpoints.Options.TemplatingEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Options/TemplatingEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "Templates",
+      "fqn": "Granit.Templating.Endpoints.Permissions.Templates",
+      "kind": "class",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Permissions/TemplatingPermissions.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "TemplatingPermissions",
+      "fqn": "Granit.Templating.Endpoints.Permissions.TemplatingPermissions",
+      "kind": "class",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Permissions/TemplatingPermissions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ITemplateDataEnricher",
+      "fqn": "Granit.Templating.Enrichment.ITemplateDataEnricher",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Enrichment/ITemplateDataEnricher.cs",
+      "line": 35,
+      "members": [
+        {
+          "name": "EnrichAsync",
+          "kind": "method",
+          "signature": "EnrichAsync(TData data, CancellationToken cancellationToken = default)",
+          "returnType": "int Order { get; } Task<TData>"
+        }
+      ]
+    },
+    {
+      "name": "TemplatingEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.Templating.EntityFrameworkCore.Extensions.TemplatingEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Templating.EntityFrameworkCore",
+      "file": "src/Granit.Templating.EntityFrameworkCore/Extensions/TemplatingEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitTemplatingEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitTemplatingEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "TemplatingModelBuilderExtensions",
+      "fqn": "Granit.Templating.EntityFrameworkCore.Extensions.TemplatingModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Templating.EntityFrameworkCore",
+      "file": "src/Granit.Templating.EntityFrameworkCore/Extensions/TemplatingModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureTemplatingModule",
+          "kind": "method",
+          "signature": "ConfigureTemplatingModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitTemplatingDbProperties",
+      "fqn": "Granit.Templating.EntityFrameworkCore.GranitTemplatingDbProperties",
+      "kind": "class",
+      "project": "Granit.Templating.EntityFrameworkCore",
+      "file": "src/Granit.Templating.EntityFrameworkCore/GranitTemplatingDbProperties.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitTemplatingEntityFrameworkCoreModule",
+      "fqn": "Granit.Templating.EntityFrameworkCore.GranitTemplatingEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Templating.EntityFrameworkCore",
+      "file": "src/Granit.Templating.EntityFrameworkCore/GranitTemplatingEntityFrameworkCoreModule.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "TemplateNotFoundException",
+      "fqn": "Granit.Templating.Exceptions.TemplateNotFoundException",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Exceptions/TemplateNotFoundException.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "TemplateNotFoundException",
+          "kind": "method",
+          "signature": "TemplateNotFoundException(string templateName, string? culture = null)",
+          "returnType": "string TemplateName { get; } public string? Culture { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "TemplateTransitionDeniedException",
+      "fqn": "Granit.Templating.Exceptions.TemplateTransitionDeniedException",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Exceptions/TemplateTransitionDeniedException.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "TemplateTransitionDeniedException",
+          "kind": "method",
+          "signature": "TemplateTransitionDeniedException(TemplateLifecycleStatus from, TemplateLifecycleStatus to)",
+          "returnType": "TemplateLifecycleStatus From { get; } public TemplateLifecycleStatus To { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.Templating.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Extensions/ServiceCollectionExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "AddGranitTemplating",
+          "kind": "method",
+          "signature": "AddGranitTemplating(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "ITemplateGlobalContext",
+      "fqn": "Granit.Templating.GlobalContext.ITemplateGlobalContext",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/GlobalContext/ITemplateGlobalContext.cs",
+      "line": 36,
+      "members": [
+        {
+          "name": "Resolve",
+          "kind": "method",
+          "signature": "Resolve()",
+          "returnType": "string ContextName { get; } object"
+        }
+      ]
+    },
+    {
+      "name": "GranitTemplatingModule",
+      "fqn": "Granit.Templating.GranitTemplatingModule",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/GranitTemplatingModule.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "DocumentFormat",
+      "fqn": "Granit.Templating.Keys.DocumentFormat",
+      "kind": "enum",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Keys/DocumentFormat.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "TemplateKey",
+      "fqn": "Granit.Templating.Keys.TemplateKey",
+      "kind": "record",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Keys/TemplateKey.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "TemplateType",
+      "fqn": "Granit.Templating.Keys.TemplateType",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Keys/TemplateType.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "typeof",
+          "kind": "method",
+          "signature": "typeof(TData)",
+          "returnType": "string Name { get; } public Type DataType =>"
+        },
+        {
+          "name": "GetType",
+          "kind": "method",
+          "signature": "GetType()",
+          "returnType": "Assembly ResourceAssembly =>"
+        }
+      ]
+    },
+    {
+      "name": "TextTemplateType",
+      "fqn": "Granit.Templating.Keys.TextTemplateType",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Keys/TextTemplateType.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "BinaryRenderedContent",
+      "fqn": "Granit.Templating.Pipeline.BinaryRenderedContent",
+      "kind": "record",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Pipeline/RenderedContent.cs",
+      "line": 45,
+      "members": []
+    },
+    {
+      "name": "ITemplateEngine",
+      "fqn": "Granit.Templating.Pipeline.ITemplateEngine",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Pipeline/ITemplateEngine.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "CanRender",
+          "kind": "method",
+          "signature": "CanRender(TemplateDescriptor descriptor)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "ITemplateResolver",
+      "fqn": "Granit.Templating.Pipeline.ITemplateResolver",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Pipeline/ITemplateResolver.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "TryResolveAsync",
+          "kind": "method",
+          "signature": "TryResolveAsync(TemplateKey key, CancellationToken cancellationToken = default)",
+          "returnType": "int Priority { get; } Task<TemplateDescriptor?>"
+        }
+      ]
+    },
+    {
+      "name": "ITextTemplateRenderer",
+      "fqn": "Granit.Templating.Pipeline.ITextTemplateRenderer",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Pipeline/ITextTemplateRenderer.cs",
+      "line": 30,
+      "members": []
+    },
+    {
+      "name": "RenderedContent",
+      "fqn": "Granit.Templating.Pipeline.RenderedContent",
+      "kind": "record",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Pipeline/RenderedContent.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "RenderedTextResult",
+      "fqn": "Granit.Templating.Pipeline.RenderedTextResult",
+      "kind": "record",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Pipeline/RenderedTextResult.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "TemplateDescriptor",
+      "fqn": "Granit.Templating.Pipeline.TemplateDescriptor",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Pipeline/TemplateDescriptor.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "TextRenderedContent",
+      "fqn": "Granit.Templating.Pipeline.TextRenderedContent",
+      "kind": "record",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Pipeline/RenderedContent.cs",
+      "line": 37,
+      "members": []
+    },
+    {
+      "name": "TemplateParseException",
+      "fqn": "Granit.Templating.Scriban.Exceptions.TemplateParseException",
+      "kind": "class",
+      "project": "Granit.Templating.Scriban",
+      "file": "src/Granit.Templating.Scriban/Exceptions/TemplateParseException.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "TemplateParseException",
+          "kind": "method",
+          "signature": "TemplateParseException(IReadOnlyList<LogMessage> errors)",
+          "returnType": "IReadOnlyList<LogMessage> Errors { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.Templating.Scriban.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Templating.Scriban",
+      "file": "src/Granit.Templating.Scriban/Extensions/ServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitTemplatingWithScriban",
+          "kind": "method",
+          "signature": "AddGranitTemplatingWithScriban(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitTemplatingScribanModule",
+      "fqn": "Granit.Templating.Scriban.GranitTemplatingScribanModule",
+      "kind": "class",
+      "project": "Granit.Templating.Scriban",
+      "file": "src/Granit.Templating.Scriban/GranitTemplatingScribanModule.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IDocumentTemplateStoreReader",
+      "fqn": "Granit.Templating.Store.IDocumentTemplateStoreReader",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/IDocumentTemplateStoreReader.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "TryGetPublishedAsync",
+          "kind": "method",
+          "signature": "TryGetPublishedAsync(TemplateKey key, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TemplateDescriptor?>"
+        },
+        {
+          "name": "TryGetDraftAsync",
+          "kind": "method",
+          "signature": "TryGetDraftAsync(TemplateKey key, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TemplateRevision?>"
+        },
+        {
+          "name": "ListTemplatesAsync",
+          "kind": "method",
+          "signature": "ListTemplatesAsync(TemplateListFilter filter, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedTemplateResult>"
+        },
+        {
+          "name": "GetHistoryAsync",
+          "kind": "method",
+          "signature": "GetHistoryAsync(TemplateKey key, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<TemplateRevision>>"
+        }
+      ]
+    },
+    {
+      "name": "IDocumentTemplateStoreWriter",
+      "fqn": "Granit.Templating.Store.IDocumentTemplateStoreWriter",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/IDocumentTemplateStoreWriter.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "SaveDraftAsync",
+          "kind": "method",
+          "signature": "SaveDraftAsync(TemplateKey key, string content, string mimeType, string updatedBy, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "PublishAsync",
+          "kind": "method",
+          "signature": "PublishAsync(TemplateKey key, string publishedBy, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UnpublishAsync",
+          "kind": "method",
+          "signature": "UnpublishAsync(TemplateKey key, string unpublishedBy, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteDraftAsync",
+          "kind": "method",
+          "signature": "DeleteDraftAsync(TemplateKey key, string deletedBy, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ITemplateCategoryStoreReader",
+      "fqn": "Granit.Templating.Store.ITemplateCategoryStoreReader",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/ITemplateCategoryStoreReader.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ListCategoriesAsync",
+          "kind": "method",
+          "signature": "ListCategoriesAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<TemplateCategory>>"
+        },
+        {
+          "name": "GetCategoryAsync",
+          "kind": "method",
+          "signature": "GetCategoryAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TemplateCategory?>"
+        }
+      ]
+    },
+    {
+      "name": "ITemplateCategoryStoreWriter",
+      "fqn": "Granit.Templating.Store.ITemplateCategoryStoreWriter",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/ITemplateCategoryStoreWriter.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "CreateCategoryAsync",
+          "kind": "method",
+          "signature": "CreateCategoryAsync(string name, string? description, string? icon, int sortOrder, string createdBy, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TemplateCategory>"
+        },
+        {
+          "name": "UpdateCategoryAsync",
+          "kind": "method",
+          "signature": "UpdateCategoryAsync(Guid id, string name, string? description, string? icon, int sortOrder, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TemplateCategory>"
+        },
+        {
+          "name": "DeleteCategoryAsync",
+          "kind": "method",
+          "signature": "DeleteCategoryAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ITemplateTransitionHook",
+      "fqn": "Granit.Templating.Store.ITemplateTransitionHook",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/ITemplateTransitionHook.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "CanTransitionAsync",
+          "kind": "method",
+          "signature": "CanTransitionAsync(TemplateLifecycleStatus from, TemplateLifecycleStatus target, CancellationToken cancellationToken = default)",
+          "returnType": "bool IsWorkflowEnabled { get; } Task<bool>"
+        },
+        {
+          "name": "OnTransitionedAsync",
+          "kind": "method",
+          "signature": "OnTransitionedAsync(Guid revisionId, TemplateLifecycleStatus from, TemplateLifecycleStatus target, string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "PagedTemplateResult",
+      "fqn": "Granit.Templating.Store.PagedTemplateResult",
+      "kind": "record",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/PagedTemplateResult.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "TemplateCategory",
+      "fqn": "Granit.Templating.Store.TemplateCategory",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/TemplateCategory.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "TemplateLifecycleStatus",
+      "fqn": "Granit.Templating.Store.TemplateLifecycleStatus",
+      "kind": "enum",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/TemplateLifecycleStatus.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "TemplateListFilter",
+      "fqn": "Granit.Templating.Store.TemplateListFilter",
+      "kind": "record",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/TemplateListFilter.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "TemplateRevision",
+      "fqn": "Granit.Templating.Store.TemplateRevision",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/TemplateRevision.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "TemplateSummary",
+      "fqn": "Granit.Templating.Store.TemplateSummary",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/TemplateSummary.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "TemplateCategoryLocalizationResource",
+      "fqn": "Granit.Templating.TemplateCategoryLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/TemplateCategoryLocalizationResource.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "TemplateLocalizationResource",
+      "fqn": "Granit.Templating.TemplateLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/TemplateLocalizationResource.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.Templating.Workflow.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Templating.Workflow",
+      "file": "src/Granit.Templating.Workflow/Extensions/ServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitTemplatingWorkflow",
+          "kind": "method",
+          "signature": "AddGranitTemplatingWorkflow(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitTemplatingWorkflowModule",
+      "fqn": "Granit.Templating.Workflow.GranitTemplatingWorkflowModule",
+      "kind": "class",
+      "project": "Granit.Templating.Workflow",
+      "file": "src/Granit.Templating.Workflow/GranitTemplatingWorkflowModule.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "TestDbContextServiceCollectionExtensions",
+      "fqn": "Granit.Testing.EntityFrameworkCore.Extensions.TestDbContextServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Testing.EntityFrameworkCore",
+      "file": "src/Granit.Testing.EntityFrameworkCore/Extensions/TestDbContextServiceCollectionExtensions.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "GranitTestingEntityFrameworkCoreModule",
+      "fqn": "Granit.Testing.EntityFrameworkCore.GranitTestingEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Testing.EntityFrameworkCore",
+      "file": "src/Granit.Testing.EntityFrameworkCore/GranitTestingEntityFrameworkCoreModule.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "InMemoryDbContextFactory",
+      "fqn": "Granit.Testing.EntityFrameworkCore.InMemoryDbContextFactory",
+      "kind": "class",
+      "project": "Granit.Testing.EntityFrameworkCore",
+      "file": "src/Granit.Testing.EntityFrameworkCore/InMemoryDbContextFactory.cs",
+      "line": 29,
+      "members": []
+    },
+    {
+      "name": "SqliteDbContextFactory",
+      "fqn": "Granit.Testing.EntityFrameworkCore.SqliteDbContextFactory",
+      "kind": "class",
+      "project": "Granit.Testing.EntityFrameworkCore",
+      "file": "src/Granit.Testing.EntityFrameworkCore/SqliteDbContextFactory.cs",
+      "line": 29,
+      "members": []
+    },
+    {
+      "name": "FakeClock",
+      "fqn": "Granit.Testing.Fakes.FakeClock",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/Fakes/FakeClock.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "Normalize",
+          "kind": "method",
+          "signature": "Normalize(DateTimeOffset dateTime)",
+          "returnType": "DateTimeOffset"
+        },
+        {
+          "name": "ConvertToUserTime",
+          "kind": "method",
+          "signature": "ConvertToUserTime(DateTimeOffset utcDateTime)",
+          "returnType": "DateTimeOffset"
+        },
+        {
+          "name": "ConvertToUtc",
+          "kind": "method",
+          "signature": "ConvertToUtc(DateTimeOffset dateTime)",
+          "returnType": "DateTimeOffset"
+        },
+        {
+          "name": "Advance",
+          "kind": "method",
+          "signature": "Advance(TimeSpan duration)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "FakeCurrentTenant",
+      "fqn": "Granit.Testing.Fakes.FakeCurrentTenant",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/Fakes/FakeCurrentTenant.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "FakeCurrentUser",
+      "fqn": "Granit.Testing.Fakes.FakeCurrentUser",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/Fakes/FakeCurrentUser.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "IsInRole",
+          "kind": "method",
+          "signature": "IsInRole(string role)",
+          "returnType": "bool"
+        },
+        {
+          "name": "AddRole",
+          "kind": "method",
+          "signature": "AddRole(string role)",
+          "returnType": "void"
+        },
+        {
+          "name": "ClearRoles",
+          "kind": "method",
+          "signature": "ClearRoles()",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "FakeGuidGenerator",
+      "fqn": "Granit.Testing.Fakes.FakeGuidGenerator",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/Fakes/FakeGuidGenerator.cs",
+      "line": 28,
+      "members": []
+    },
+    {
+      "name": "GranitEntityFakerExtensions",
+      "fqn": "Granit.Testing.Generators.GranitEntityFakerExtensions",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/Generators/GranitEntityFakerExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "GranitFaker",
+      "fqn": "Granit.Testing.Generators.GranitFaker",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/Generators/GranitFaker.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "CurrentUser",
+          "kind": "method",
+          "signature": "CurrentUser()",
+          "returnType": "Faker<FakeCurrentUser>"
+        },
+        {
+          "name": "Tenant",
+          "kind": "method",
+          "signature": "Tenant()",
+          "returnType": "Faker<FakeCurrentTenant>"
+        }
+      ]
+    },
+    {
+      "name": "GranitTestFixture",
+      "fqn": "Granit.Testing.GranitTestFixture",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/GranitTestFixture.cs",
+      "line": 35,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "FakeCurrentTenant Tenant { get; } ="
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "FakeCurrentUser User { get; } ="
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "FakeClock Clock { get; } ="
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "FakeGuidGenerator GuidGenerator { get; } ="
+        },
+        {
+          "name": "ServiceProvider",
+          "kind": "property",
+          "signature": "IServiceProvider ServiceProvider",
+          "returnType": "IServiceProvider"
+        },
+        {
+          "name": "BuildAsync",
+          "kind": "method",
+          "signature": "BuildAsync(Action<IServiceCollection>? configureServices = null)",
+          "returnType": "Task"
+        },
+        {
+          "name": "Dispose",
+          "kind": "method",
+          "signature": "Dispose()",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GranitTestingModule",
+      "fqn": "Granit.Testing.GranitTestingModule",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/GranitTestingModule.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "GranitWebApplicationFactory",
+      "fqn": "Granit.Testing.GranitWebApplicationFactory",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/GranitWebApplicationFactory.cs",
+      "line": 33,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "FakeCurrentTenant Tenant { get; } ="
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "FakeCurrentUser User { get; } ="
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "FakeClock Clock { get; } ="
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "FakeGuidGenerator GuidGenerator { get; } ="
+        }
+      ]
+    },
+    {
+      "name": "AnomalyReport",
+      "fqn": "Granit.Timeline.AI.AnomalyReport",
+      "kind": "record",
+      "project": "Granit.Timeline.AI",
+      "file": "src/Granit.Timeline.AI/AnomalyReport.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "TimelineAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Timeline.AI.Extensions.TimelineAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Timeline.AI",
+      "file": "src/Granit.Timeline.AI/Extensions/TimelineAIHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitTimelineAI",
+          "kind": "method",
+          "signature": "AddGranitTimelineAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitTimelineAIModule",
+      "fqn": "Granit.Timeline.AI.GranitTimelineAIModule",
+      "kind": "class",
+      "project": "Granit.Timeline.AI",
+      "file": "src/Granit.Timeline.AI/GranitTimelineAIModule.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "ITimelineAnomalyDetector",
+      "fqn": "Granit.Timeline.AI.ITimelineAnomalyDetector",
+      "kind": "interface",
+      "project": "Granit.Timeline.AI",
+      "file": "src/Granit.Timeline.AI/ITimelineAnomalyDetector.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "DetectAnomaliesAsync",
+          "kind": "method",
+          "signature": "DetectAnomaliesAsync(string entityType, Guid entityId, CancellationToken ct = default)",
+          "returnType": "Task<AnomalyReport>"
+        }
+      ]
+    },
+    {
+      "name": "ITimelineSummarizer",
+      "fqn": "Granit.Timeline.AI.ITimelineSummarizer",
+      "kind": "interface",
+      "project": "Granit.Timeline.AI",
+      "file": "src/Granit.Timeline.AI/ITimelineSummarizer.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SummarizeAsync",
+          "kind": "method",
+          "signature": "SummarizeAsync(string entityType, Guid entityId, DateTimeOffset? since = null, CancellationToken ct = default)",
+          "returnType": "Task<TimelineSummary>"
+        }
+      ]
+    },
+    {
+      "name": "TimelineAIOptions",
+      "fqn": "Granit.Timeline.AI.Options.TimelineAIOptions",
+      "kind": "class",
+      "project": "Granit.Timeline.AI",
+      "file": "src/Granit.Timeline.AI/Options/TimelineAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string? WorkspaceName",
+          "returnType": "string?"
+        },
+        {
+          "name": "MaxEntriesToAnalyze",
+          "kind": "property",
+          "signature": "int MaxEntriesToAnalyze",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "TimelineAnomaly",
+      "fqn": "Granit.Timeline.AI.TimelineAnomaly",
+      "kind": "record",
+      "project": "Granit.Timeline.AI",
+      "file": "src/Granit.Timeline.AI/TimelineAnomaly.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "TimelineSummary",
+      "fqn": "Granit.Timeline.AI.TimelineSummary",
+      "kind": "record",
+      "project": "Granit.Timeline.AI",
+      "file": "src/Granit.Timeline.AI/TimelineSummary.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ITimelineFollowerService",
+      "fqn": "Granit.Timeline.Abstractions.ITimelineFollowerService",
+      "kind": "interface",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Abstractions/ITimelineFollowerService.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "FollowAsync",
+          "kind": "method",
+          "signature": "FollowAsync(string userId, string entityType, string entityId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UnfollowAsync",
+          "kind": "method",
+          "signature": "UnfollowAsync(string userId, string entityType, string entityId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "GetFollowerIdsAsync",
+          "kind": "method",
+          "signature": "GetFollowerIdsAsync(string entityType, string entityId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<string>>"
+        },
+        {
+          "name": "IsFollowingAsync",
+          "kind": "method",
+          "signature": "IsFollowingAsync(string userId, string entityType, string entityId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "ITimelineNotifier",
+      "fqn": "Granit.Timeline.Abstractions.ITimelineNotifier",
+      "kind": "interface",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Abstractions/ITimelineNotifier.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "NotifyEntryPostedAsync",
+          "kind": "method",
+          "signature": "NotifyEntryPostedAsync(TimelineEntry entry, IReadOnlyList<string> followerUserIds, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "NotifyMentionedUsersAsync",
+          "kind": "method",
+          "signature": "NotifyMentionedUsersAsync(TimelineEntry entry, IReadOnlyList<string> mentionedUserIds, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ITimelineReader",
+      "fqn": "Granit.Timeline.Abstractions.ITimelineReader",
+      "kind": "interface",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Abstractions/ITimelineReader.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "GetStreamAsync",
+          "kind": "method",
+          "signature": "GetStreamAsync(string entityType, string entityId, int page = 1, int pageSize = QueryingDefaults.DefaultPageSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<TimelineStreamEntry>>"
+        }
+      ]
+    },
+    {
+      "name": "ITimelineWriter",
+      "fqn": "Granit.Timeline.Abstractions.ITimelineWriter",
+      "kind": "interface",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Abstractions/ITimelineWriter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "PostEntryAsync",
+          "kind": "method",
+          "signature": "PostEntryAsync(string entityType, string entityId, TimelineEntryType entryType, string body, Guid? parentEntryId = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TimelineEntry>"
+        },
+        {
+          "name": "DeleteEntryAsync",
+          "kind": "method",
+          "signature": "DeleteEntryAsync(Guid entryId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "AddAttachmentAsync",
+          "kind": "method",
+          "signature": "AddAttachmentAsync(Guid entryId, Guid blobId, string fileName, string contentType, long sizeBytes, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TimelineAttachment>"
+        }
+      ]
+    },
+    {
+      "name": "TimelineAttachment",
+      "fqn": "Granit.Timeline.Domain.TimelineAttachment",
+      "kind": "class",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Domain/TimelineAttachment.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "EntryId",
+          "kind": "property",
+          "signature": "Guid EntryId",
+          "returnType": "Guid"
+        },
+        {
+          "name": "ContentType",
+          "kind": "property",
+          "signature": "string ContentType",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "TimelineEntry",
+      "fqn": "Granit.Timeline.Domain.TimelineEntry",
+      "kind": "class",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Domain/TimelineEntry.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, string entityType, string entityId, TimelineEntryType entryType, string body, string authorId, string authorName, DateTimeOffset createdAt, string createdBy, Guid? tenantId = null, Guid? parentEntryId = null)",
+          "returnType": "TimelineEntry"
+        },
+        {
+          "name": "EntityType",
+          "kind": "property",
+          "signature": "string EntityType",
+          "returnType": "string"
+        },
+        {
+          "name": "EntityId",
+          "kind": "property",
+          "signature": "string EntityId",
+          "returnType": "string"
+        },
+        {
+          "name": "EntryType",
+          "kind": "property",
+          "signature": "TimelineEntryType EntryType",
+          "returnType": "TimelineEntryType"
+        },
+        {
+          "name": "AuthorId",
+          "kind": "property",
+          "signature": "string AuthorId",
+          "returnType": "string"
+        },
+        {
+          "name": "AuthorName",
+          "kind": "property",
+          "signature": "string AuthorName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "TimelineEntryType",
+      "fqn": "Granit.Timeline.Domain.TimelineEntryType",
+      "kind": "enum",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Domain/TimelineEntryType.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "TimelineEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Timeline.Endpoints.Extensions.TimelineEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Timeline.Endpoints",
+      "file": "src/Granit.Timeline.Endpoints/Extensions/TimelineEndpointRouteBuilderExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "MapTimelineEndpoints",
+          "kind": "method",
+          "signature": "MapTimelineEndpoints(this IEndpointRouteBuilder endpoints, Action<TimelineEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitTimelineEndpointsModule",
+      "fqn": "Granit.Timeline.Endpoints.GranitTimelineEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Timeline.Endpoints",
+      "file": "src/Granit.Timeline.Endpoints/GranitTimelineEndpointsModule.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "TimelineAuthorizationPolicy",
+      "fqn": "Granit.Timeline.Endpoints.Internal.TimelineAuthorizationPolicy",
+      "kind": "class",
+      "project": "Granit.Timeline.Endpoints",
+      "file": "src/Granit.Timeline.Endpoints/Internal/TimelineAuthorizationPolicy.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "TimelineEndpointsOptions",
+      "fqn": "Granit.Timeline.Endpoints.Options.TimelineEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Timeline.Endpoints",
+      "file": "src/Granit.Timeline.Endpoints/Options/TimelineEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "Entries",
+      "fqn": "Granit.Timeline.Endpoints.Permissions.Entries",
+      "kind": "class",
+      "project": "Granit.Timeline.Endpoints",
+      "file": "src/Granit.Timeline.Endpoints/Permissions/TimelinePermissions.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "TimelinePermissions",
+      "fqn": "Granit.Timeline.Endpoints.Permissions.TimelinePermissions",
+      "kind": "class",
+      "project": "Granit.Timeline.Endpoints",
+      "file": "src/Granit.Timeline.Endpoints/Permissions/TimelinePermissions.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "TimelineEfCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.Timeline.EntityFrameworkCore.Extensions.TimelineEfCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Timeline.EntityFrameworkCore",
+      "file": "src/Granit.Timeline.EntityFrameworkCore/Extensions/TimelineEfCoreHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitTimelineEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitTimelineEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "TimelineModelBuilderExtensions",
+      "fqn": "Granit.Timeline.EntityFrameworkCore.Extensions.TimelineModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Timeline.EntityFrameworkCore",
+      "file": "src/Granit.Timeline.EntityFrameworkCore/Extensions/TimelineModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureTimelineModule",
+          "kind": "method",
+          "signature": "ConfigureTimelineModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitTimelineDbProperties",
+      "fqn": "Granit.Timeline.EntityFrameworkCore.GranitTimelineDbProperties",
+      "kind": "class",
+      "project": "Granit.Timeline.EntityFrameworkCore",
+      "file": "src/Granit.Timeline.EntityFrameworkCore/GranitTimelineDbProperties.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitTimelineEntityFrameworkCoreModule",
+      "fqn": "Granit.Timeline.EntityFrameworkCore.GranitTimelineEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Timeline.EntityFrameworkCore",
+      "file": "src/Granit.Timeline.EntityFrameworkCore/GranitTimelineEntityFrameworkCoreModule.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "TimelineEntryPostedEvent",
+      "fqn": "Granit.Timeline.Events.TimelineEntryPostedEvent",
+      "kind": "record",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Events/TimelineEntryPostedEvent.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "TimelineEntrySoftDeletedEvent",
+      "fqn": "Granit.Timeline.Events.TimelineEntrySoftDeletedEvent",
+      "kind": "record",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Events/TimelineEntrySoftDeletedEvent.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "TimelineServiceCollectionExtensions",
+      "fqn": "Granit.Timeline.Extensions.TimelineServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Extensions/TimelineServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitTimeline",
+          "kind": "method",
+          "signature": "AddGranitTimeline(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitTimelineModule",
+      "fqn": "Granit.Timeline.GranitTimelineModule",
+      "kind": "class",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/GranitTimelineModule.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ITimelined",
+      "fqn": "Granit.Timeline.ITimelined",
+      "kind": "interface",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/ITimelined.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "MentionParser",
+      "fqn": "Granit.Timeline.Internal.MentionParser",
+      "kind": "class",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Internal/MentionParser.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "ExtractMentionedUserIds",
+          "kind": "method",
+          "signature": "ExtractMentionedUserIds(string body)",
+          "returnType": "IReadOnlyList<string>"
+        }
+      ]
+    },
+    {
+      "name": "TimelineNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Timeline.Notifications.Extensions.TimelineNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Timeline.Notifications",
+      "file": "src/Granit.Timeline.Notifications/Extensions/TimelineNotificationsServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitTimelineNotifications",
+          "kind": "method",
+          "signature": "AddGranitTimelineNotifications(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitTimelineNotificationsModule",
+      "fqn": "Granit.Timeline.Notifications.GranitTimelineNotificationsModule",
+      "kind": "class",
+      "project": "Granit.Timeline.Notifications",
+      "file": "src/Granit.Timeline.Notifications/GranitTimelineNotificationsModule.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "TimelineCommentNotificationData",
+      "fqn": "Granit.Timeline.Notifications.TimelineCommentNotificationData",
+      "kind": "record",
+      "project": "Granit.Timeline.Notifications",
+      "file": "src/Granit.Timeline.Notifications/TimelineCommentNotificationType.cs",
+      "line": 31,
+      "members": []
+    },
+    {
+      "name": "TimelineCommentNotificationType",
+      "fqn": "Granit.Timeline.Notifications.TimelineCommentNotificationType",
+      "kind": "class",
+      "project": "Granit.Timeline.Notifications",
+      "file": "src/Granit.Timeline.Notifications/TimelineCommentNotificationType.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "TimelineCommentNotificationType Instance ="
+        },
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "TimelineMentionNotificationData",
+      "fqn": "Granit.Timeline.Notifications.TimelineMentionNotificationData",
+      "kind": "record",
+      "project": "Granit.Timeline.Notifications",
+      "file": "src/Granit.Timeline.Notifications/TimelineMentionNotificationType.cs",
+      "line": 31,
+      "members": []
+    },
+    {
+      "name": "TimelineMentionNotificationType",
+      "fqn": "Granit.Timeline.Notifications.TimelineMentionNotificationType",
+      "kind": "class",
+      "project": "Granit.Timeline.Notifications",
+      "file": "src/Granit.Timeline.Notifications/TimelineMentionNotificationType.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "TimelineMentionNotificationType Instance ="
+        },
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "PostTimelineEntryRequest",
+      "fqn": "Granit.Timeline.PostTimelineEntryRequest",
+      "kind": "record",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/PostTimelineEntryRequest.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "TimelineAttachmentInfo",
+      "fqn": "Granit.Timeline.TimelineAttachmentInfo",
+      "kind": "record",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/TimelineAttachmentInfo.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "TimelineStreamEntry",
+      "fqn": "Granit.Timeline.TimelineStreamEntry",
+      "kind": "record",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/TimelineStreamEntry.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Id",
+          "kind": "property",
+          "signature": "required Guid Id",
+          "returnType": "required Guid"
+        },
+        {
+          "name": "Attachments",
+          "kind": "property",
+          "signature": "IReadOnlyList<TimelineAttachmentInfo> Attachments",
+          "returnType": "IReadOnlyList<TimelineAttachmentInfo>"
+        }
+      ]
+    },
+    {
+      "name": "TimelineStreamEntryType",
+      "fqn": "Granit.Timeline.TimelineStreamEntryType",
+      "kind": "enum",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/TimelineStreamEntryType.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "TimelinedAttribute",
+      "fqn": "Granit.Timeline.TimelinedAttribute",
+      "kind": "class",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/TimelinedAttribute.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "EntityTypeName",
+          "kind": "property",
+          "signature": "string EntityTypeName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "Clock",
+      "fqn": "Granit.Timing.Clock",
+      "kind": "class",
+      "project": "Granit.Timing",
+      "file": "src/Granit.Timing/Clock.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetUtcNow",
+          "kind": "method",
+          "signature": "GetUtcNow()",
+          "returnType": "DateTimeOffset Now => _timeProvider."
+        },
+        {
+          "name": "SupportsMultipleTimezone",
+          "kind": "property",
+          "signature": "bool SupportsMultipleTimezone",
+          "returnType": "bool"
+        },
+        {
+          "name": "Normalize",
+          "kind": "method",
+          "signature": "Normalize(DateTimeOffset dateTime)",
+          "returnType": "DateTimeOffset"
+        },
+        {
+          "name": "ConvertToUserTime",
+          "kind": "method",
+          "signature": "ConvertToUserTime(DateTimeOffset utcDateTime)",
+          "returnType": "DateTimeOffset"
+        }
+      ]
+    },
+    {
+      "name": "CurrentTimezoneProvider",
+      "fqn": "Granit.Timing.CurrentTimezoneProvider",
+      "kind": "class",
+      "project": "Granit.Timing",
+      "file": "src/Granit.Timing/CurrentTimezoneProvider.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "DisableDateTimeNormalizationAttribute",
+      "fqn": "Granit.Timing.DisableDateTimeNormalizationAttribute",
+      "kind": "class",
+      "project": "Granit.Timing",
+      "file": "src/Granit.Timing/DisableDateTimeNormalizationAttribute.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "TimingServiceCollectionExtensions",
+      "fqn": "Granit.Timing.Extensions.TimingServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Timing",
+      "file": "src/Granit.Timing/Extensions/TimingServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitTiming",
+          "kind": "method",
+          "signature": "AddGranitTiming(this IServiceCollection services, Action<ClockOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitTimingModule",
+      "fqn": "Granit.Timing.GranitTimingModule",
+      "kind": "class",
+      "project": "Granit.Timing",
+      "file": "src/Granit.Timing/GranitTimingModule.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IClock",
+      "fqn": "Granit.Timing.IClock",
+      "kind": "interface",
+      "project": "Granit.Timing",
+      "file": "src/Granit.Timing/IClock.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Normalize",
+          "kind": "method",
+          "signature": "Normalize(DateTimeOffset dateTime)",
+          "returnType": "DateTimeOffset Now { get; } bool SupportsMultipleTimezone { get; } DateTimeOffset"
+        },
+        {
+          "name": "ConvertToUserTime",
+          "kind": "method",
+          "signature": "ConvertToUserTime(DateTimeOffset utcDateTime)",
+          "returnType": "DateTimeOffset"
+        },
+        {
+          "name": "ConvertToUtc",
+          "kind": "method",
+          "signature": "ConvertToUtc(DateTimeOffset dateTime)",
+          "returnType": "DateTimeOffset"
+        }
+      ]
+    },
+    {
+      "name": "ICurrentTimezoneProvider",
+      "fqn": "Granit.Timing.ICurrentTimezoneProvider",
+      "kind": "interface",
+      "project": "Granit.Timing",
+      "file": "src/Granit.Timing/ICurrentTimezoneProvider.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ClockOptions",
+      "fqn": "Granit.Timing.Options.ClockOptions",
+      "kind": "class",
+      "project": "Granit.Timing",
+      "file": "src/Granit.Timing/Options/ClockOptions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ValidationAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Validation.AI.Extensions.ValidationAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.AI",
+      "file": "src/Granit.Validation.AI/Extensions/ValidationAIHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitValidationAI",
+          "kind": "method",
+          "signature": "AddGranitValidationAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitValidationAIModule",
+      "fqn": "Granit.Validation.AI.GranitValidationAIModule",
+      "kind": "class",
+      "project": "Granit.Validation.AI",
+      "file": "src/Granit.Validation.AI/GranitValidationAIModule.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "IAIContentModerator",
+      "fqn": "Granit.Validation.AI.IAIContentModerator",
+      "kind": "interface",
+      "project": "Granit.Validation.AI",
+      "file": "src/Granit.Validation.AI/IAIContentModerator.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "ModerateAsync",
+          "kind": "method",
+          "signature": "ModerateAsync(string text, string? context = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ModerationResult>"
+        }
+      ]
+    },
+    {
+      "name": "ModerationCategory",
+      "fqn": "Granit.Validation.AI.ModerationCategory",
+      "kind": "enum",
+      "project": "Granit.Validation.AI",
+      "file": "src/Granit.Validation.AI/ModerationResult.cs",
+      "line": 30,
+      "members": []
+    },
+    {
+      "name": "ModerationFlag",
+      "fqn": "Granit.Validation.AI.ModerationFlag",
+      "kind": "record",
+      "project": "Granit.Validation.AI",
+      "file": "src/Granit.Validation.AI/ModerationResult.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "ModerationResult",
+      "fqn": "Granit.Validation.AI.ModerationResult",
+      "kind": "record",
+      "project": "Granit.Validation.AI",
+      "file": "src/Granit.Validation.AI/ModerationResult.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ValidationAIOptions",
+      "fqn": "Granit.Validation.AI.Options.ValidationAIOptions",
+      "kind": "class",
+      "project": "Granit.Validation.AI",
+      "file": "src/Granit.Validation.AI/Options/ValidationAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string WorkspaceName",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        },
+        {
+          "name": "SeverityThreshold",
+          "kind": "property",
+          "signature": "double SeverityThreshold",
+          "returnType": "double"
+        }
+      ]
+    },
+    {
+      "name": "GranitEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Validation.AspNetCore.GranitEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/AspNetCore/GranitEndpointRouteBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "MapGranitGroup",
+          "kind": "method",
+          "signature": "MapGranitGroup(this IEndpointRouteBuilder endpoints, string prefix)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "SkipAutoValidationAttribute",
+      "fqn": "Granit.Validation.AspNetCore.SkipAutoValidationAttribute",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/AspNetCore/SkipAutoValidationAttribute.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "ValidationFieldStatus",
+      "fqn": "Granit.Validation.Endpoints.Dtos.ValidationFieldStatus",
+      "kind": "enum",
+      "project": "Granit.Validation.Endpoints",
+      "file": "src/Granit.Validation.Endpoints/Dtos/ValidationFieldStatus.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ValidationFieldValidateBatchRequest",
+      "fqn": "Granit.Validation.Endpoints.Dtos.ValidationFieldValidateBatchRequest",
+      "kind": "record",
+      "project": "Granit.Validation.Endpoints",
+      "file": "src/Granit.Validation.Endpoints/Dtos/ValidationFieldValidateBatchRequest.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "ValidationFieldValidateBatchResponse",
+      "fqn": "Granit.Validation.Endpoints.Dtos.ValidationFieldValidateBatchResponse",
+      "kind": "record",
+      "project": "Granit.Validation.Endpoints",
+      "file": "src/Granit.Validation.Endpoints/Dtos/ValidationFieldValidateBatchResponse.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ValidationFieldValidateRequest",
+      "fqn": "Granit.Validation.Endpoints.Dtos.ValidationFieldValidateRequest",
+      "kind": "record",
+      "project": "Granit.Validation.Endpoints",
+      "file": "src/Granit.Validation.Endpoints/Dtos/ValidationFieldValidateRequest.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "ValidationFieldValidateResponse",
+      "fqn": "Granit.Validation.Endpoints.Dtos.ValidationFieldValidateResponse",
+      "kind": "record",
+      "project": "Granit.Validation.Endpoints",
+      "file": "src/Granit.Validation.Endpoints/Dtos/ValidationFieldValidateResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ValidationEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Validation.Endpoints.Extensions.ValidationEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Endpoints",
+      "file": "src/Granit.Validation.Endpoints/Extensions/ValidationEndpointRouteBuilderExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "MapGranitValidation",
+          "kind": "method",
+          "signature": "MapGranitValidation(this IEndpointRouteBuilder endpoints, Action<ValidationEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitValidationEndpointsModule",
+      "fqn": "Granit.Validation.Endpoints.GranitValidationEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Validation.Endpoints",
+      "file": "src/Granit.Validation.Endpoints/GranitValidationEndpointsModule.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "ValidationEndpointsOptions",
+      "fqn": "Granit.Validation.Endpoints.Options.ValidationEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Validation.Endpoints",
+      "file": "src/Granit.Validation.Endpoints/Options/ValidationEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "AddressValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.AddressValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/AddressValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "CompanyIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.CompanyIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/CompanyIdentifierValidatorExtensions.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "DutchIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.DutchIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/DutchIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "EuropeanIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.EuropeanIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/EuropeanIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "EuropeanPaymentValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.EuropeanPaymentValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/EuropeanPaymentValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "GermanIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.GermanIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/GermanIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ItalianIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.ItalianIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/ItalianIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "LuxembourgishIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.LuxembourgishIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/LuxembourgishIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "PersonalIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.PersonalIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/PersonalIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ProfessionalRegistryValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.ProfessionalRegistryValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/ProfessionalRegistryValidatorExtensions.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "SpanishIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.SpanishIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/SpanishIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "TaxIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.TaxIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/TaxIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "GranitValidationEuropeModule",
+      "fqn": "Granit.Validation.Europe.GranitValidationEuropeModule",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/GranitValidationEuropeModule.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ValidationEuropeLocalizationResource",
+      "fqn": "Granit.Validation.Europe.ValidationEuropeLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/ValidationEuropeLocalizationResource.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "ContactValidatorExtensions",
+      "fqn": "Granit.Validation.Extensions.ContactValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/ContactValidatorExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "FinancialValidatorExtensions",
+      "fqn": "Granit.Validation.Extensions.FinancialValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/FinancialValidatorExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "FormatValidatorExtensions",
+      "fqn": "Granit.Validation.Extensions.FormatValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/FormatValidatorExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "GeoValidatorExtensions",
+      "fqn": "Granit.Validation.Extensions.GeoValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/GeoValidatorExtensions.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "LocaleValidatorExtensions",
+      "fqn": "Granit.Validation.Extensions.LocaleValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/LocaleValidatorExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "NetworkValidatorExtensions",
+      "fqn": "Granit.Validation.Extensions.NetworkValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/NetworkValidatorExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "PaymentValidatorExtensions",
+      "fqn": "Granit.Validation.Extensions.PaymentValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/PaymentValidatorExtensions.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "RuleBuilderExtensions",
+      "fqn": "Granit.Validation.Extensions.RuleBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/RuleBuilderExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "StandardValidatorExtensions",
+      "fqn": "Granit.Validation.Extensions.StandardValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/StandardValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ValidationServiceCollectionExtensions",
+      "fqn": "Granit.Validation.Extensions.ValidationServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/ValidationServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitValidation",
+          "kind": "method",
+          "signature": "AddGranitValidation(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitValidationModule",
+      "fqn": "Granit.Validation.GranitValidationModule",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/GranitValidationModule.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GranitValidator",
+      "fqn": "Granit.Validation.GranitValidator",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/GranitValidator.cs",
+      "line": 23,
+      "members": []
+    },
+    {
+      "name": "AmericanAddressValidatorExtensions",
+      "fqn": "Granit.Validation.NorthAmerica.Extensions.AmericanAddressValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.NorthAmerica",
+      "file": "src/Granit.Validation.NorthAmerica/Extensions/AmericanAddressValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "AmericanIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.NorthAmerica.Extensions.AmericanIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.NorthAmerica",
+      "file": "src/Granit.Validation.NorthAmerica/Extensions/AmericanIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "CanadianAddressValidatorExtensions",
+      "fqn": "Granit.Validation.NorthAmerica.Extensions.CanadianAddressValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.NorthAmerica",
+      "file": "src/Granit.Validation.NorthAmerica/Extensions/CanadianAddressValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "CanadianIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.NorthAmerica.Extensions.CanadianIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.NorthAmerica",
+      "file": "src/Granit.Validation.NorthAmerica/Extensions/CanadianIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "GranitValidationNorthAmericaModule",
+      "fqn": "Granit.Validation.NorthAmerica.GranitValidationNorthAmericaModule",
+      "kind": "class",
+      "project": "Granit.Validation.NorthAmerica",
+      "file": "src/Granit.Validation.NorthAmerica/GranitValidationNorthAmericaModule.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ValidationNorthAmericaLocalizationResource",
+      "fqn": "Granit.Validation.NorthAmerica.ValidationNorthAmericaLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Validation.NorthAmerica",
+      "file": "src/Granit.Validation.NorthAmerica/ValidationNorthAmericaLocalizationResource.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "IPatternHintProvider",
+      "fqn": "Granit.Validation.OpenApi.IPatternHintProvider",
+      "kind": "interface",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/OpenApi/IPatternHintProvider.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "PatternHintValidator",
+      "fqn": "Granit.Validation.OpenApi.PatternHintValidator",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/OpenApi/PatternHintValidator.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "ArgumentNullException",
+          "kind": "method",
+          "signature": "ArgumentNullException(nameof(hintKey)",
+          "returnType": "string HintKey { get; } = hintKey ?? throw"
+        },
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "IsValid",
+          "kind": "method",
+          "signature": "IsValid(ValidationContext<T> context, TProperty value)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "DelegatingServerValidator",
+      "fqn": "Granit.Validation.ServerValidation.DelegatingServerValidator",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/ServerValidation/DelegatingServerValidator.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ArgumentNullException",
+          "kind": "method",
+          "signature": "ArgumentNullException(nameof(errorCode)",
+          "returnType": "string ErrorCode { get; } = errorCode ?? throw"
+        },
+        {
+          "name": "Validate",
+          "kind": "method",
+          "signature": "Validate(string? value)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "IServerValidator",
+      "fqn": "Granit.Validation.ServerValidation.IServerValidator",
+      "kind": "interface",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/ServerValidation/IServerValidator.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "Validate",
+          "kind": "method",
+          "signature": "Validate(string? value)",
+          "returnType": "string ErrorCode { get; } bool"
+        }
+      ]
+    },
+    {
+      "name": "IServerValidatorContributor",
+      "fqn": "Granit.Validation.ServerValidation.IServerValidatorContributor",
+      "kind": "interface",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/ServerValidation/IServerValidatorContributor.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "GetValidators",
+          "kind": "method",
+          "signature": "GetValidators()",
+          "returnType": "IEnumerable<IServerValidator>"
+        }
+      ]
+    },
+    {
+      "name": "ServerValidatorRegistry",
+      "fqn": "Granit.Validation.ServerValidation.ServerValidatorRegistry",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/ServerValidation/ServerValidatorRegistry.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetAllErrorCodes",
+          "kind": "method",
+          "signature": "GetAllErrorCodes()",
+          "returnType": "IReadOnlyCollection<string>"
+        }
+      ]
+    },
+    {
+      "name": "BritishAddressValidatorExtensions",
+      "fqn": "Granit.Validation.UnitedKingdom.Extensions.BritishAddressValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.UnitedKingdom",
+      "file": "src/Granit.Validation.UnitedKingdom/Extensions/BritishAddressValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "BritishIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.UnitedKingdom.Extensions.BritishIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.UnitedKingdom",
+      "file": "src/Granit.Validation.UnitedKingdom/Extensions/BritishIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "BritishPaymentValidatorExtensions",
+      "fqn": "Granit.Validation.UnitedKingdom.Extensions.BritishPaymentValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.UnitedKingdom",
+      "file": "src/Granit.Validation.UnitedKingdom/Extensions/BritishPaymentValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "BritishTaxValidatorExtensions",
+      "fqn": "Granit.Validation.UnitedKingdom.Extensions.BritishTaxValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.UnitedKingdom",
+      "file": "src/Granit.Validation.UnitedKingdom/Extensions/BritishTaxValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "GranitValidationUnitedKingdomModule",
+      "fqn": "Granit.Validation.UnitedKingdom.GranitValidationUnitedKingdomModule",
+      "kind": "class",
+      "project": "Granit.Validation.UnitedKingdom",
+      "file": "src/Granit.Validation.UnitedKingdom/GranitValidationUnitedKingdomModule.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ValidationUnitedKingdomLocalizationResource",
+      "fqn": "Granit.Validation.UnitedKingdom.ValidationUnitedKingdomLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Validation.UnitedKingdom",
+      "file": "src/Granit.Validation.UnitedKingdom/ValidationUnitedKingdomLocalizationResource.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "ValidationLocalizationResource",
+      "fqn": "Granit.Validation.ValidationLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/ValidationLocalizationResource.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "AwsVaultServiceCollectionExtensions",
+      "fqn": "Granit.Vault.Aws.Extensions.AwsVaultServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Vault.Aws",
+      "file": "src/Granit.Vault.Aws/Extensions/AwsVaultServiceCollectionExtensions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "AddGranitVaultAws",
+          "kind": "method",
+          "signature": "AddGranitVaultAws(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitVaultAwsModule",
+      "fqn": "Granit.Vault.Aws.GranitVaultAwsModule",
+      "kind": "class",
+      "project": "Granit.Vault.Aws",
+      "file": "src/Granit.Vault.Aws/GranitVaultAwsModule.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "IsEnabled",
+          "kind": "method",
+          "signature": "IsEnabled(ServiceConfigurationContext context)",
+          "returnType": "bool"
+        },
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AwsVaultOptions",
+      "fqn": "Granit.Vault.Aws.Options.AwsVaultOptions",
+      "kind": "class",
+      "project": "Granit.Vault.Aws",
+      "file": "src/Granit.Vault.Aws/Options/AwsVaultOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Region",
+          "kind": "property",
+          "signature": "string Region",
+          "returnType": "string"
+        },
+        {
+          "name": "KmsKeyId",
+          "kind": "property",
+          "signature": "string KmsKeyId",
+          "returnType": "string"
+        },
+        {
+          "name": "DatabaseSecretArn",
+          "kind": "property",
+          "signature": "string? DatabaseSecretArn",
+          "returnType": "string?"
+        },
+        {
+          "name": "AccessKeyId",
+          "kind": "property",
+          "signature": "string? AccessKeyId",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "AzureKeyVaultServiceCollectionExtensions",
+      "fqn": "Granit.Vault.Azure.Extensions.AzureKeyVaultServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Vault.Azure",
+      "file": "src/Granit.Vault.Azure/Extensions/AzureKeyVaultServiceCollectionExtensions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "AddGranitVaultAzure",
+          "kind": "method",
+          "signature": "AddGranitVaultAzure(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitVaultAzureModule",
+      "fqn": "Granit.Vault.Azure.GranitVaultAzureModule",
+      "kind": "class",
+      "project": "Granit.Vault.Azure",
+      "file": "src/Granit.Vault.Azure/GranitVaultAzureModule.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "IsEnabled",
+          "kind": "method",
+          "signature": "IsEnabled(ServiceConfigurationContext context)",
+          "returnType": "bool"
+        },
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AzureKeyVaultOptions",
+      "fqn": "Granit.Vault.Azure.Options.AzureKeyVaultOptions",
+      "kind": "class",
+      "project": "Granit.Vault.Azure",
+      "file": "src/Granit.Vault.Azure/Options/AzureKeyVaultOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "VaultUri",
+          "kind": "property",
+          "signature": "string VaultUri",
+          "returnType": "string"
+        },
+        {
+          "name": "EncryptionKeyName",
+          "kind": "property",
+          "signature": "string EncryptionKeyName",
+          "returnType": "string"
+        },
+        {
+          "name": "EncryptionAlgorithm",
+          "kind": "property",
+          "signature": "string EncryptionAlgorithm",
+          "returnType": "string"
+        },
+        {
+          "name": "DatabaseSecretName",
+          "kind": "property",
+          "signature": "string? DatabaseSecretName",
+          "returnType": "string?"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "VaultMetrics",
+      "fqn": "Granit.Vault.Diagnostics.VaultMetrics",
+      "kind": "class",
+      "project": "Granit.Vault",
+      "file": "src/Granit.Vault/Diagnostics/VaultMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordOperationError",
+          "kind": "method",
+          "signature": "RecordOperationError(string? tenantId, string operation, string provider)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordOperationDuration",
+          "kind": "method",
+          "signature": "RecordOperationDuration(string? tenantId, string operation, string provider, TimeSpan duration)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordRotationDetected",
+          "kind": "method",
+          "signature": "RecordRotationDetected(string provider)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "RetiredKeyVersionException",
+      "fqn": "Granit.Vault.Exceptions.RetiredKeyVersionException",
+      "kind": "class",
+      "project": "Granit.Vault",
+      "file": "src/Granit.Vault/Exceptions/RetiredKeyVersionException.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "RetiredKeyVersionException",
+          "kind": "method",
+          "signature": "RetiredKeyVersionException(string keyVersion)",
+          "returnType": "string KeyVersion { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "GoogleCloudVaultServiceCollectionExtensions",
+      "fqn": "Granit.Vault.GoogleCloud.Extensions.GoogleCloudVaultServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Vault.GoogleCloud",
+      "file": "src/Granit.Vault.GoogleCloud/Extensions/GoogleCloudVaultServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitVaultGoogleCloud",
+          "kind": "method",
+          "signature": "AddGranitVaultGoogleCloud(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitVaultGoogleCloudModule",
+      "fqn": "Granit.Vault.GoogleCloud.GranitVaultGoogleCloudModule",
+      "kind": "class",
+      "project": "Granit.Vault.GoogleCloud",
+      "file": "src/Granit.Vault.GoogleCloud/GranitVaultGoogleCloudModule.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "IsEnabled",
+          "kind": "method",
+          "signature": "IsEnabled(ServiceConfigurationContext context)",
+          "returnType": "bool"
+        },
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GoogleCloudVaultOptions",
+      "fqn": "Granit.Vault.GoogleCloud.Options.GoogleCloudVaultOptions",
+      "kind": "class",
+      "project": "Granit.Vault.GoogleCloud",
+      "file": "src/Granit.Vault.GoogleCloud/Options/GoogleCloudVaultOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ProjectId",
+          "kind": "property",
+          "signature": "string ProjectId",
+          "returnType": "string"
+        },
+        {
+          "name": "Location",
+          "kind": "property",
+          "signature": "string Location",
+          "returnType": "string"
+        },
+        {
+          "name": "KeyRing",
+          "kind": "property",
+          "signature": "string KeyRing",
+          "returnType": "string"
+        },
+        {
+          "name": "CryptoKey",
+          "kind": "property",
+          "signature": "string CryptoKey",
+          "returnType": "string"
+        },
+        {
+          "name": "DatabaseSecretName",
+          "kind": "property",
+          "signature": "string? DatabaseSecretName",
+          "returnType": "string?"
+        },
+        {
+          "name": "CredentialFilePath",
+          "kind": "property",
+          "signature": "string? CredentialFilePath",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "GranitVaultModule",
+      "fqn": "Granit.Vault.GranitVaultModule",
+      "kind": "class",
+      "project": "Granit.Vault",
+      "file": "src/Granit.Vault/GranitVaultModule.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "HashiCorpVaultConfigurationException",
+      "fqn": "Granit.Vault.HashiCorp.Exceptions.HashiCorpVaultConfigurationException",
+      "kind": "class",
+      "project": "Granit.Vault.HashiCorp",
+      "file": "src/Granit.Vault.HashiCorp/Exceptions/HashiCorpVaultConfigurationException.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "HashiCorpVaultConfigurationException",
+          "kind": "method",
+          "signature": "HashiCorpVaultConfigurationException(string errorCode, string message)",
+          "returnType": "string ErrorCode { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "HashiCorpVaultServiceCollectionExtensions",
+      "fqn": "Granit.Vault.HashiCorp.Extensions.HashiCorpVaultServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Vault.HashiCorp",
+      "file": "src/Granit.Vault.HashiCorp/Extensions/HashiCorpVaultServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitVaultHashiCorp",
+          "kind": "method",
+          "signature": "AddGranitVaultHashiCorp(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitVaultHashiCorpModule",
+      "fqn": "Granit.Vault.HashiCorp.GranitVaultHashiCorpModule",
+      "kind": "class",
+      "project": "Granit.Vault.HashiCorp",
+      "file": "src/Granit.Vault.HashiCorp/GranitVaultHashiCorpModule.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "IsEnabled",
+          "kind": "method",
+          "signature": "IsEnabled(ServiceConfigurationContext context)",
+          "returnType": "bool"
+        },
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "HashiCorpVaultOptions",
+      "fqn": "Granit.Vault.HashiCorp.Options.HashiCorpVaultOptions",
+      "kind": "class",
+      "project": "Granit.Vault.HashiCorp",
+      "file": "src/Granit.Vault.HashiCorp/Options/HashiCorpVaultOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Address",
+          "kind": "property",
+          "signature": "string Address",
+          "returnType": "string"
+        },
+        {
+          "name": "AuthMethod",
+          "kind": "property",
+          "signature": "string AuthMethod",
+          "returnType": "string"
+        },
+        {
+          "name": "Token",
+          "kind": "property",
+          "signature": "string? Token",
+          "returnType": "string?"
+        },
+        {
+          "name": "KubernetesTokenPath",
+          "kind": "property",
+          "signature": "string KubernetesTokenPath",
+          "returnType": "string"
+        },
+        {
+          "name": "DatabaseMountPoint",
+          "kind": "property",
+          "signature": "string DatabaseMountPoint",
+          "returnType": "string"
+        },
+        {
+          "name": "DatabaseRoleName",
+          "kind": "property",
+          "signature": "string DatabaseRoleName",
+          "returnType": "string"
+        },
+        {
+          "name": "TransitMountPoint",
+          "kind": "property",
+          "signature": "string TransitMountPoint",
+          "returnType": "string"
+        },
+        {
+          "name": "LeaseRenewalThreshold",
+          "kind": "property",
+          "signature": "double LeaseRenewalThreshold",
+          "returnType": "double"
+        }
+      ]
+    },
+    {
+      "name": "HashiCorpVaultStringEncryptionProvider",
+      "fqn": "Granit.Vault.HashiCorp.Providers.HashiCorpVaultStringEncryptionProvider",
+      "kind": "class",
+      "project": "Granit.Vault.HashiCorp",
+      "file": "src/Granit.Vault.HashiCorp/Providers/HashiCorpVaultStringEncryptionProvider.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "ProviderName",
+          "kind": "property",
+          "signature": "string ProviderName",
+          "returnType": "string"
+        },
+        {
+          "name": "Encrypt",
+          "kind": "method",
+          "signature": "Encrypt(string plainText)",
+          "returnType": "string"
+        },
+        {
+          "name": "Decrypt",
+          "kind": "method",
+          "signature": "Decrypt(string cipherText)",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "HashiCorpTransitEncryptionService",
+      "fqn": "Granit.Vault.HashiCorp.Services.HashiCorpTransitEncryptionService",
+      "kind": "class",
+      "project": "Granit.Vault.HashiCorp",
+      "file": "src/Granit.Vault.HashiCorp/Services/HashiCorpTransitEncryptionService.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "EncryptAsync",
+          "kind": "method",
+          "signature": "EncryptAsync(string keyName, string plaintext, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
+        }
+      ]
+    },
+    {
+      "name": "VaultClientFactory",
+      "fqn": "Granit.Vault.HashiCorp.Services.VaultClientFactory",
+      "kind": "class",
+      "project": "Granit.Vault.HashiCorp",
+      "file": "src/Granit.Vault.HashiCorp/Services/VaultClientFactory.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create()",
+          "returnType": "IVaultClient"
+        }
+      ]
+    },
+    {
+      "name": "VaultCredentialLeaseManager",
+      "fqn": "Granit.Vault.HashiCorp.Services.VaultCredentialLeaseManager",
+      "kind": "class",
+      "project": "Granit.Vault.HashiCorp",
+      "file": "src/Granit.Vault.HashiCorp/Services/VaultCredentialLeaseManager.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "Username",
+          "kind": "property",
+          "signature": "string Username",
+          "returnType": "string"
+        },
+        {
+          "name": "Password",
+          "kind": "property",
+          "signature": "string Password",
+          "returnType": "string"
+        },
+        {
+          "name": "IsNullOrEmpty",
+          "kind": "method",
+          "signature": "IsNullOrEmpty(_username)",
+          "returnType": "bool IsReady => !string."
+        }
+      ]
+    },
+    {
+      "name": "IDatabaseCredentialProvider",
+      "fqn": "Granit.Vault.IDatabaseCredentialProvider",
+      "kind": "interface",
+      "project": "Granit.Vault",
+      "file": "src/Granit.Vault/IDatabaseCredentialProvider.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ITransitEncryptionService",
+      "fqn": "Granit.Vault.ITransitEncryptionService",
+      "kind": "interface",
+      "project": "Granit.Vault",
+      "file": "src/Granit.Vault/ITransitEncryptionService.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "EncryptAsync",
+          "kind": "method",
+          "signature": "EncryptAsync(string keyName, string plaintext, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
+        },
+        {
+          "name": "DecryptAsync",
+          "kind": "method",
+          "signature": "DecryptAsync(string keyName, string ciphertext, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
+        },
+        {
+          "name": "RewrapAsync",
+          "kind": "method",
+          "signature": "RewrapAsync(string keyName, string ciphertext, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
+        },
+        {
+          "name": "GetKeyVersion",
+          "kind": "method",
+          "signature": "GetKeyVersion(string ciphertext)",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "ReEncryptionOptions",
+      "fqn": "Granit.Vault.Options.ReEncryptionOptions",
+      "kind": "class",
+      "project": "Granit.Vault",
+      "file": "src/Granit.Vault/Options/ReEncryptionOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RetiredKeyVersions",
+          "kind": "property",
+          "signature": "ISet<string> RetiredKeyVersions",
+          "returnType": "ISet<string>"
+        },
+        {
+          "name": "BatchSize",
+          "kind": "property",
+          "signature": "int BatchSize",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "VaultLocalizationResource",
+      "fqn": "Granit.Vault.VaultLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Vault",
+      "file": "src/Granit.Vault/VaultLocalizationResource.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "IWebhookCommandDispatcher",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookCommandDispatcher",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookCommandDispatcher.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "DispatchAsync",
+          "kind": "method",
+          "signature": "DispatchAsync(SendWebhookCommand command, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IWebhookDeliveryReader",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookDeliveryReader",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookDeliveryReader.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "FindByDeliveryIdAsync",
+          "kind": "method",
+          "signature": "FindByDeliveryIdAsync(Guid deliveryId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<WebhookDeliveryAttempt?>"
+        },
+        {
+          "name": "CountBeforeAsync",
+          "kind": "method",
+          "signature": "CountBeforeAsync(DateTimeOffset cutoff, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        }
+      ]
+    },
+    {
+      "name": "IWebhookDeliveryWriter",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookDeliveryWriter",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookDeliveryWriter.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "RecordSuccessAsync",
+          "kind": "method",
+          "signature": "RecordSuccessAsync(SendWebhookCommand command, int httpStatusCode, long durationMs, string payloadHash, string? payload, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RecordFailureAsync",
+          "kind": "method",
+          "signature": "RecordFailureAsync(SendWebhookCommand command, int? httpStatusCode, long durationMs, string errorMessage, string? payload, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SuspendSubscriptionAsync",
+          "kind": "method",
+          "signature": "SuspendSubscriptionAsync(Guid subscriptionId, string reason, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteBeforeAsync",
+          "kind": "method",
+          "signature": "DeleteBeforeAsync(DateTimeOffset cutoff, int batchSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        }
+      ]
+    },
+    {
+      "name": "IWebhookPublisher",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookPublisher",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookPublisher.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "IWebhookQueryableProvider",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookQueryableProvider",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookQueryableProvider.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "GetSubscriptions",
+          "kind": "method",
+          "signature": "GetSubscriptions()",
+          "returnType": "IQueryable<WebhookSubscription>"
+        },
+        {
+          "name": "GetDeliveryAttempts",
+          "kind": "method",
+          "signature": "GetDeliveryAttempts()",
+          "returnType": "IQueryable<WebhookDeliveryAttempt>"
+        }
+      ]
+    },
+    {
+      "name": "IWebhookSecretProtector",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookSecretProtector",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookSecretProtector.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "ProtectAsync",
+          "kind": "method",
+          "signature": "ProtectAsync(string plainSecret, CancellationToken cancellationToken = default)",
+          "returnType": "ValueTask<string>"
+        },
+        {
+          "name": "UnprotectAsync",
+          "kind": "method",
+          "signature": "UnprotectAsync(string protectedSecret, CancellationToken cancellationToken = default)",
+          "returnType": "ValueTask<string>"
+        }
+      ]
+    },
+    {
+      "name": "IWebhookStatsReader",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookStatsReader",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookStatsReader.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetStatsAsync",
+          "kind": "method",
+          "signature": "GetStatsAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<WebhookStats>"
+        }
+      ]
+    },
+    {
+      "name": "IWebhookSubscriptionReader",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookSubscriptionReader",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookSubscriptionReader.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetActiveSubscriptionsAsync",
+          "kind": "method",
+          "signature": "GetActiveSubscriptionsAsync(string eventType, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<WebhookSubscription>>"
+        },
+        {
+          "name": "FindByIdAsync",
+          "kind": "method",
+          "signature": "FindByIdAsync(Guid subscriptionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<WebhookSubscription?>"
+        },
+        {
+          "name": "GetAllAsync",
+          "kind": "method",
+          "signature": "GetAllAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<WebhookSubscription>>"
+        }
+      ]
+    },
+    {
+      "name": "IWebhookSubscriptionWriter",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookSubscriptionWriter",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookSubscriptionWriter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(HttpsUrl targetUrl, string eventType, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<WebhookSubscriptionCreatedResult>"
+        },
+        {
+          "name": "UpdateTargetUrlAsync",
+          "kind": "method",
+          "signature": "UpdateTargetUrlAsync(Guid subscriptionId, HttpsUrl targetUrl, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "ActivateAsync",
+          "kind": "method",
+          "signature": "ActivateAsync(Guid subscriptionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SuspendAsync",
+          "kind": "method",
+          "signature": "SuspendAsync(Guid subscriptionId, string suspendedBy, string reason, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeactivateAsync",
+          "kind": "method",
+          "signature": "DeactivateAsync(Guid subscriptionId, string reason, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(Guid subscriptionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RotateSecretAsync",
+          "kind": "method",
+          "signature": "RotateSecretAsync(Guid subscriptionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
+        }
+      ]
+    },
+    {
+      "name": "IWebhookTestPingService",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookTestPingService",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookTestPingService.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SendTestPingAsync",
+          "kind": "method",
+          "signature": "SendTestPingAsync(Guid subscriptionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<WebhookTestPingResult>"
+        }
+      ]
+    },
+    {
+      "name": "WebhookStats",
+      "fqn": "Granit.Webhooks.Abstractions.WebhookStats",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/WebhookStats.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionCreatedResult",
+      "fqn": "Granit.Webhooks.Abstractions.WebhookSubscriptionCreatedResult",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/WebhookSubscriptionCreatedResult.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "WebhookTestPingResult",
+      "fqn": "Granit.Webhooks.Abstractions.WebhookTestPingResult",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/WebhookTestPingResult.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "WebhooksMetrics",
+      "fqn": "Granit.Webhooks.Diagnostics.WebhooksMetrics",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Diagnostics/WebhooksMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordDeliverySucceeded",
+          "kind": "method",
+          "signature": "RecordDeliverySucceeded(string? tenantId, string eventType)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordDeliveryFailed",
+          "kind": "method",
+          "signature": "RecordDeliveryFailed(string? tenantId, string eventType, int? httpStatus)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordSubscriptionSuspended",
+          "kind": "method",
+          "signature": "RecordSubscriptionSuspended(string? tenantId, int httpStatus)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordDeliveryDuration",
+          "kind": "method",
+          "signature": "RecordDeliveryDuration(string? tenantId, string eventType, string status, TimeSpan duration)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "EventTypeName",
+      "fqn": "Granit.Webhooks.Domain.ValueObjects.EventTypeName",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Domain/ValueObjects/EventTypeName.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(string value)",
+          "returnType": "required string Value { get; init; } public EventTypeName"
+        },
+        {
+          "name": "EventTypeName",
+          "kind": "method",
+          "signature": "EventTypeName(string value)",
+          "returnType": "implicit operator"
+        }
+      ]
+    },
+    {
+      "name": "WebhookDeliveryAttempt",
+      "fqn": "Granit.Webhooks.Domain.WebhookDeliveryAttempt",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Domain/WebhookDeliveryAttempt.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "DeliveryId",
+          "kind": "property",
+          "signature": "Guid DeliveryId",
+          "returnType": "Guid"
+        },
+        {
+          "name": "TargetUrl",
+          "kind": "property",
+          "signature": "string TargetUrl",
+          "returnType": "string"
+        },
+        {
+          "name": "HttpStatusCode",
+          "kind": "property",
+          "signature": "int? HttpStatusCode",
+          "returnType": "int?"
+        }
+      ]
+    },
+    {
+      "name": "WebhookSubscription",
+      "fqn": "Granit.Webhooks.Domain.WebhookSubscription",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Domain/WebhookSubscription.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, HttpsUrl targetUrl, string eventType, string signingSecret, Guid? tenantId = null)",
+          "returnType": "WebhookSubscription"
+        },
+        {
+          "name": "EventType",
+          "kind": "property",
+          "signature": "string EventType",
+          "returnType": "string"
+        },
+        {
+          "name": "SigningSecret",
+          "kind": "property",
+          "signature": "string SigningSecret",
+          "returnType": "string"
+        },
+        {
+          "name": "TenantId",
+          "kind": "property",
+          "signature": "Guid? TenantId",
+          "returnType": "Guid?"
+        },
+        {
+          "name": "RecordSuccess",
+          "kind": "method",
+          "signature": "RecordSuccess(DateTimeOffset at)",
+          "returnType": "string? DeactivationReason { get; private set; } public int ConsecutiveFailureCount { get; private set; } public DateTimeOffset? LastSuccessAt { get; private set; } public DateTimeOffset? SuspendedAt { get; private set; } public string? SuspendedBy { get; private set; } internal void"
+        }
+      ]
+    },
+    {
+      "name": "WebhookSubscriptionStatus",
+      "fqn": "Granit.Webhooks.Domain.WebhookSubscriptionStatus",
+      "kind": "enum",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Domain/WebhookSubscriptionStatus.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhookModuleConfigResponse",
+      "fqn": "Granit.Webhooks.Dtos.WebhookModuleConfigResponse",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Dtos/WebhookModuleConfigResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionCreateRequest",
+      "fqn": "Granit.Webhooks.Endpoints.Dtos.WebhookSubscriptionCreateRequest",
+      "kind": "record",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionCreateRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionCreatedResponse",
+      "fqn": "Granit.Webhooks.Endpoints.Dtos.WebhookSubscriptionCreatedResponse",
+      "kind": "record",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionCreatedResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionDeactivateRequest",
+      "fqn": "Granit.Webhooks.Endpoints.Dtos.WebhookSubscriptionDeactivateRequest",
+      "kind": "record",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionDeactivateRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionResponse",
+      "fqn": "Granit.Webhooks.Endpoints.Dtos.WebhookSubscriptionResponse",
+      "kind": "record",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionRotateSecretResponse",
+      "fqn": "Granit.Webhooks.Endpoints.Dtos.WebhookSubscriptionRotateSecretResponse",
+      "kind": "record",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionRotateSecretResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionStatsResponse",
+      "fqn": "Granit.Webhooks.Endpoints.Dtos.WebhookSubscriptionStatsResponse",
+      "kind": "record",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionStatsResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionTestPingResponse",
+      "fqn": "Granit.Webhooks.Endpoints.Dtos.WebhookSubscriptionTestPingResponse",
+      "kind": "record",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionTestPingResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionUpdateRequest",
+      "fqn": "Granit.Webhooks.Endpoints.Dtos.WebhookSubscriptionUpdateRequest",
+      "kind": "record",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionUpdateRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhooksEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Webhooks.Endpoints.Extensions.WebhooksEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Extensions/WebhooksEndpointRouteBuilderExtensions.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "MapWebhooksEndpoints",
+          "kind": "method",
+          "signature": "MapWebhooksEndpoints(this IEndpointRouteBuilder endpoints, Action<WebhooksEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitWebhooksEndpointsModule",
+      "fqn": "Granit.Webhooks.Endpoints.GranitWebhooksEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/GranitWebhooksEndpointsModule.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "WebhooksEndpointsOptions",
+      "fqn": "Granit.Webhooks.Endpoints.Options.WebhooksEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Options/WebhooksEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "Subscriptions",
+      "fqn": "Granit.Webhooks.Endpoints.Permissions.Subscriptions",
+      "kind": "class",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Permissions/WebhooksPermissions.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "WebhooksPermissions",
+      "fqn": "Granit.Webhooks.Endpoints.Permissions.WebhooksPermissions",
+      "kind": "class",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Permissions/WebhooksPermissions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhookTargetUrlValidatorExtensions",
+      "fqn": "Granit.Webhooks.Endpoints.Validators.WebhookTargetUrlValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Validators/WebhookTargetUrlValidatorExtensions.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "WebhookConfigEndpoint",
+      "fqn": "Granit.Webhooks.Endpoints.WebhookConfigEndpoint",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Endpoints/WebhookConfigEndpoint.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "MapGranitWebhooksConfig",
+          "kind": "method",
+          "signature": "MapGranitWebhooksConfig(this IEndpointRouteBuilder endpoints, string routePrefix = \"webhooks\")",
+          "returnType": "IEndpointRouteBuilder"
+        }
+      ]
+    },
+    {
+      "name": "WebhookRedeliveryEndpoint",
+      "fqn": "Granit.Webhooks.Endpoints.WebhookRedeliveryEndpoint",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Endpoints/WebhookRedeliveryEndpoint.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "MapGranitWebhooksRedelivery",
+          "kind": "method",
+          "signature": "MapGranitWebhooksRedelivery(this IEndpointRouteBuilder endpoints, string routePrefix = \"webhooks\")",
+          "returnType": "IEndpointRouteBuilder"
+        }
+      ]
+    },
+    {
+      "name": "WebhooksEfCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.Webhooks.EntityFrameworkCore.Extensions.WebhooksEfCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Webhooks.EntityFrameworkCore",
+      "file": "src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksEfCoreHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitWebhooksEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitWebhooksEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "WebhooksModelBuilderExtensions",
+      "fqn": "Granit.Webhooks.EntityFrameworkCore.Extensions.WebhooksModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Webhooks.EntityFrameworkCore",
+      "file": "src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureWebhooksModule",
+          "kind": "method",
+          "signature": "ConfigureWebhooksModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitWebhooksDbProperties",
+      "fqn": "Granit.Webhooks.EntityFrameworkCore.GranitWebhooksDbProperties",
+      "kind": "class",
+      "project": "Granit.Webhooks.EntityFrameworkCore",
+      "file": "src/Granit.Webhooks.EntityFrameworkCore/GranitWebhooksDbProperties.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitWebhooksEntityFrameworkCoreModule",
+      "fqn": "Granit.Webhooks.EntityFrameworkCore.GranitWebhooksEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Webhooks.EntityFrameworkCore",
+      "file": "src/Granit.Webhooks.EntityFrameworkCore/GranitWebhooksEntityFrameworkCoreModule.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "WebhookDeliveryFailureThresholdExceededEto",
+      "fqn": "Granit.Webhooks.Events.WebhookDeliveryFailureThresholdExceededEto",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Events/WebhookDeliveryFailureThresholdExceededEto.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "WebhookDeliverySucceededEvent",
+      "fqn": "Granit.Webhooks.Events.WebhookDeliverySucceededEvent",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Events/WebhookDeliverySucceededEvent.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionActivatedEvent",
+      "fqn": "Granit.Webhooks.Events.WebhookSubscriptionActivatedEvent",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Events/WebhookSubscriptionActivatedEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionCreatedEvent",
+      "fqn": "Granit.Webhooks.Events.WebhookSubscriptionCreatedEvent",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Events/WebhookSubscriptionCreatedEvent.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionDeactivatedEvent",
+      "fqn": "Granit.Webhooks.Events.WebhookSubscriptionDeactivatedEvent",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Events/WebhookSubscriptionDeactivatedEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionSuspendedEvent",
+      "fqn": "Granit.Webhooks.Events.WebhookSubscriptionSuspendedEvent",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Events/WebhookSubscriptionSuspendedEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "WebhookDeliveryException",
+      "fqn": "Granit.Webhooks.Exceptions.WebhookDeliveryException",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Exceptions/WebhookDeliveryException.cs",
+      "line": 24,
+      "members": []
+    },
+    {
+      "name": "WebhooksHostApplicationBuilderExtensions",
+      "fqn": "Granit.Webhooks.Extensions.WebhooksHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Extensions/WebhooksHostApplicationBuilderExtensions.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "AddGranitWebhooks",
+          "kind": "method",
+          "signature": "AddGranitWebhooks(this IHostApplicationBuilder builder, Action<WebhooksOptions>? configure = null)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitWebhooksModule",
+      "fqn": "Granit.Webhooks.GranitWebhooksModule",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/GranitWebhooksModule.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "RetryWebhookErrorKind",
+      "fqn": "Granit.Webhooks.Handlers.RetryWebhookErrorKind",
+      "kind": "enum",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Handlers/RetryWebhookHandler.cs",
+      "line": 135,
+      "members": []
+    },
+    {
+      "name": "RetryWebhookHandler",
+      "fqn": "Granit.Webhooks.Handlers.RetryWebhookHandler",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Handlers/RetryWebhookHandler.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(Guid deliveryId, CancellationToken cancellationToken)",
+          "returnType": "Task<RetryWebhookResult>"
+        }
+      ]
+    },
+    {
+      "name": "RetryWebhookResult",
+      "fqn": "Granit.Webhooks.Handlers.RetryWebhookResult",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Handlers/RetryWebhookHandler.cs",
+      "line": 104,
+      "members": []
+    },
+    {
+      "name": "SendWebhookHandler",
+      "fqn": "Granit.Webhooks.Handlers.SendWebhookHandler",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Handlers/SendWebhookHandler.cs",
+      "line": 43,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(SendWebhookCommand command, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "WebhookFanoutHandler",
+      "fqn": "Granit.Webhooks.Handlers.WebhookFanoutHandler",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Handlers/WebhookFanoutHandler.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(WebhookTrigger trigger, CancellationToken cancellationToken)",
+          "returnType": "Task<IEnumerable<SendWebhookCommand>>"
+        }
+      ]
+    },
+    {
+      "name": "SendWebhookCommand",
+      "fqn": "Granit.Webhooks.Messages.SendWebhookCommand",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Messages/SendWebhookCommand.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "WebhookEnvelope",
+      "fqn": "Granit.Webhooks.Messages.WebhookEnvelope",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Messages/WebhookEnvelope.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "WebhookTrigger",
+      "fqn": "Granit.Webhooks.Messages.WebhookTrigger",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Messages/WebhookTrigger.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "NewGuid",
+          "kind": "method",
+          "signature": "NewGuid()",
+          "returnType": "Guid EventId { get; init; } = Guid."
+        }
+      ]
+    },
+    {
+      "name": "WebhooksOptions",
+      "fqn": "Granit.Webhooks.Options.WebhooksOptions",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Options/WebhooksOptions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "HttpTimeoutSeconds",
+          "kind": "property",
+          "signature": "int HttpTimeoutSeconds",
+          "returnType": "int"
+        },
+        {
+          "name": "MaxParallelDeliveries",
+          "kind": "property",
+          "signature": "int MaxParallelDeliveries",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "GranitWebhooksWolverineModule",
+      "fqn": "Granit.Webhooks.Wolverine.GranitWebhooksWolverineModule",
+      "kind": "class",
+      "project": "Granit.Webhooks.Wolverine",
+      "file": "src/Granit.Webhooks.Wolverine/GranitWebhooksWolverineModule.cs",
+      "line": 28,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "TenantContextBehavior",
+      "fqn": "Granit.Wolverine.Behaviors.TenantContextBehavior",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/Behaviors/TenantContextBehavior.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "Before",
+          "kind": "method",
+          "signature": "Before(Envelope envelope)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "TraceContextBehavior",
+      "fqn": "Granit.Wolverine.Behaviors.TraceContextBehavior",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/Behaviors/TraceContextBehavior.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "Before",
+          "kind": "method",
+          "signature": "Before(Envelope envelope)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "UserContextBehavior",
+      "fqn": "Granit.Wolverine.Behaviors.UserContextBehavior",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/Behaviors/UserContextBehavior.cs",
+      "line": 28,
+      "members": [
+        {
+          "name": "Before",
+          "kind": "method",
+          "signature": "Before(Envelope envelope)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ClaimCheckExtensions",
+      "fqn": "Granit.Wolverine.ClaimCheck.ClaimCheckExtensions",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/ClaimCheck/ClaimCheckExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ClaimCheckReference",
+      "fqn": "Granit.Wolverine.ClaimCheck.ClaimCheckReference",
+      "kind": "record",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/ClaimCheck/ClaimCheckReference.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "ClaimCheckServiceCollectionExtensions",
+      "fqn": "Granit.Wolverine.ClaimCheck.ClaimCheckServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/ClaimCheck/ClaimCheckServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddInMemoryClaimCheckStore",
+          "kind": "method",
+          "signature": "AddInMemoryClaimCheckStore(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "IClaimCheckStore",
+      "fqn": "Granit.Wolverine.ClaimCheck.IClaimCheckStore",
+      "kind": "interface",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/ClaimCheck/IClaimCheckStore.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "StoreAsync",
+          "kind": "method",
+          "signature": "StoreAsync(ReadOnlyMemory<byte> data, string? contentType = null, TimeSpan? expiry = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Guid>"
+        },
+        {
+          "name": "RetrieveAsync",
+          "kind": "method",
+          "signature": "RetrieveAsync(Guid referenceId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<byte[]?>"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(Guid referenceId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "WolverineHostApplicationBuilderExtensions",
+      "fqn": "Granit.Wolverine.Extensions.WolverineHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "AddGranitWolverine",
+          "kind": "method",
+          "signature": "AddGranitWolverine(this IHostApplicationBuilder builder, Action<WolverineOptions>? configure = null)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "WolverineValidationServiceCollectionExtensions",
+      "fqn": "Granit.Wolverine.Extensions.WolverineValidationServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/Extensions/WolverineValidationServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitValidatorsFromWolverineHandlerModules",
+          "kind": "method",
+          "signature": "AddGranitValidatorsFromWolverineHandlerModules(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitWolverineModule",
+      "fqn": "Granit.Wolverine.GranitWolverineModule",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/GranitWolverineModule.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IWolverineUserContextSetter",
+      "fqn": "Granit.Wolverine.Internal.IWolverineUserContextSetter",
+      "kind": "interface",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/Internal/IWolverineUserContextSetter.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Change",
+          "kind": "method",
+          "signature": "Change(string? userId, string? firstName = null, string? lastName = null, ActorKind actorKind = ActorKind.User, Guid? apiKeyId = null)",
+          "returnType": "IDisposable"
+        }
+      ]
+    },
+    {
+      "name": "OutgoingContextMiddleware",
+      "fqn": "Granit.Wolverine.Middleware.OutgoingContextMiddleware",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/Middleware/OutgoingContextMiddleware.cs",
+      "line": 29,
+      "members": [
+        {
+          "name": "Before",
+          "kind": "method",
+          "signature": "Before(Envelope envelope)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "WolverineMessagingOptions",
+      "fqn": "Granit.Wolverine.Options.WolverineMessagingOptions",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/Options/WolverineMessagingOptions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(5)",
+          "returnType": "TimeSpan[] RetryDelays { get; set; } = TimeSpan."
+        },
+        {
+          "name": "MaxRetryAttempts",
+          "kind": "property",
+          "signature": "int MaxRetryAttempts",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "WolverinePostgresqlHostApplicationBuilderExtensions",
+      "fqn": "Granit.Wolverine.Postgresql.Extensions.WolverinePostgresqlHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Wolverine.Postgresql",
+      "file": "src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "AddGranitWolverineWithPostgresql",
+          "kind": "method",
+          "signature": "AddGranitWolverineWithPostgresql(this IHostApplicationBuilder builder, Action<WolverineOptions>? configure = null)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitWolverinePostgresqlModule",
+      "fqn": "Granit.Wolverine.Postgresql.GranitWolverinePostgresqlModule",
+      "kind": "class",
+      "project": "Granit.Wolverine.Postgresql",
+      "file": "src/Granit.Wolverine.Postgresql/GranitWolverinePostgresqlModule.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "WolverinePostgresqlOptions",
+      "fqn": "Granit.Wolverine.Postgresql.Options.WolverinePostgresqlOptions",
+      "kind": "class",
+      "project": "Granit.Wolverine.Postgresql",
+      "file": "src/Granit.Wolverine.Postgresql/Options/WolverinePostgresqlOptions.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "TransportConnectionStringName",
+          "kind": "property",
+          "signature": "string? TransportConnectionStringName",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "WolverineSqlServerHostApplicationBuilderExtensions",
+      "fqn": "Granit.Wolverine.SqlServer.Extensions.WolverineSqlServerHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Wolverine.SqlServer",
+      "file": "src/Granit.Wolverine.SqlServer/Extensions/WolverineSqlServerHostApplicationBuilderExtensions.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "AddGranitWolverineWithSqlServer",
+          "kind": "method",
+          "signature": "AddGranitWolverineWithSqlServer(this IHostApplicationBuilder builder, Action<WolverineOptions>? configure = null)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitWolverineSqlServerModule",
+      "fqn": "Granit.Wolverine.SqlServer.GranitWolverineSqlServerModule",
+      "kind": "class",
+      "project": "Granit.Wolverine.SqlServer",
+      "file": "src/Granit.Wolverine.SqlServer/GranitWolverineSqlServerModule.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "WolverineSqlServerOptions",
+      "fqn": "Granit.Wolverine.SqlServer.Options.WolverineSqlServerOptions",
+      "kind": "class",
+      "project": "Granit.Wolverine.SqlServer",
+      "file": "src/Granit.Wolverine.SqlServer/Options/WolverineSqlServerOptions.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "TransportConnectionString",
+          "kind": "property",
+          "signature": "string TransportConnectionString",
+          "returnType": "string"
+        },
+        {
+          "name": "TransactionMode",
+          "kind": "property",
+          "signature": "TransactionMiddlewareMode TransactionMode",
+          "returnType": "TransactionMiddlewareMode"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Workflow.AI.Extensions.WorkflowAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Workflow.AI",
+      "file": "src/Granit.Workflow.AI/Extensions/WorkflowAIHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitWorkflowAI",
+          "kind": "method",
+          "signature": "AddGranitWorkflowAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitWorkflowAIModule",
+      "fqn": "Granit.Workflow.AI.GranitWorkflowAIModule",
+      "kind": "class",
+      "project": "Granit.Workflow.AI",
+      "file": "src/Granit.Workflow.AI/GranitWorkflowAIModule.cs",
+      "line": 27,
+      "members": []
+    },
+    {
+      "name": "IAIApprovalEvaluator",
+      "fqn": "Granit.Workflow.AI.IAIApprovalEvaluator",
+      "kind": "interface",
+      "project": "Granit.Workflow.AI",
+      "file": "src/Granit.Workflow.AI/IAIApprovalEvaluator.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "EvaluateRiskAsync",
+          "kind": "method",
+          "signature": "EvaluateRiskAsync(string entityType, string transition, string entityContext, CancellationToken cancellationToken = default)",
+          "returnType": "Task<RiskAssessment>"
+        }
+      ]
+    },
+    {
+      "name": "IAITransitionAdvisor",
+      "fqn": "Granit.Workflow.AI.IAITransitionAdvisor",
+      "kind": "interface",
+      "project": "Granit.Workflow.AI",
+      "file": "src/Granit.Workflow.AI/IAITransitionAdvisor.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "RecommendAsync",
+          "kind": "method",
+          "signature": "RecommendAsync(string entityType, string currentState, string entityContext, IReadOnlyList<string> allowedTransitions, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TransitionRecommendation?>"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowAIOptions",
+      "fqn": "Granit.Workflow.AI.Options.WorkflowAIOptions",
+      "kind": "class",
+      "project": "Granit.Workflow.AI",
+      "file": "src/Granit.Workflow.AI/Options/WorkflowAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string WorkspaceName",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        },
+        {
+          "name": "AutoApprovalThreshold",
+          "kind": "property",
+          "signature": "double AutoApprovalThreshold",
+          "returnType": "double"
+        }
+      ]
+    },
+    {
+      "name": "RiskAssessment",
+      "fqn": "Granit.Workflow.AI.RiskAssessment",
+      "kind": "record",
+      "project": "Granit.Workflow.AI",
+      "file": "src/Granit.Workflow.AI/RiskAssessment.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "TransitionRecommendation",
+      "fqn": "Granit.Workflow.AI.TransitionRecommendation",
+      "kind": "record",
+      "project": "Granit.Workflow.AI",
+      "file": "src/Granit.Workflow.AI/TransitionRecommendation.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "PublicationWorkflow",
+      "fqn": "Granit.Workflow.Definitions.PublicationWorkflow",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Definitions/PublicationWorkflow.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "Default",
+          "kind": "property",
+          "signature": "WorkflowDefinition<WorkflowLifecycleStatus> Default",
+          "returnType": "WorkflowDefinition<WorkflowLifecycleStatus>"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowMetrics",
+      "fqn": "Granit.Workflow.Diagnostics.WorkflowMetrics",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Diagnostics/WorkflowMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordTransitionDuration",
+          "kind": "method",
+          "signature": "RecordTransitionDuration(string? tenantId, string outcome, TimeSpan duration)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IVersionedEntity",
+      "fqn": "Granit.Workflow.Domain.IVersionedEntity",
+      "kind": "interface",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Domain/IVersionedEntity.cs",
+      "line": 23,
+      "members": []
+    },
+    {
+      "name": "IWorkflowStateful",
+      "fqn": "Granit.Workflow.Domain.IWorkflowStateful",
+      "kind": "interface",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Domain/IWorkflowStateful.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "GetWorkflowEntityId",
+          "kind": "method",
+          "signature": "GetWorkflowEntityId()",
+          "returnType": "string StatusPropertyName { get; } string WorkflowEntityType { get; } string"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowStateName",
+      "fqn": "Granit.Workflow.Domain.ValueObjects.WorkflowStateName",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Domain/ValueObjects/WorkflowStateName.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(string value)",
+          "returnType": "required string Value { get; init; } public WorkflowStateName"
+        },
+        {
+          "name": "WorkflowStateName",
+          "kind": "method",
+          "signature": "WorkflowStateName(string value)",
+          "returnType": "implicit operator"
+        }
+      ]
+    },
+    {
+      "name": "VersionedWorkflowEntity",
+      "fqn": "Granit.Workflow.Domain.VersionedWorkflowEntity",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Domain/VersionedWorkflowEntity.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "GetWorkflowEntityId",
+          "kind": "method",
+          "signature": "GetWorkflowEntityId()",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowLifecycleStatus",
+      "fqn": "Granit.Workflow.Domain.WorkflowLifecycleStatus",
+      "kind": "enum",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Domain/WorkflowLifecycleStatus.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WorkflowTransitionRecord",
+      "fqn": "Granit.Workflow.Domain.WorkflowTransitionRecord",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Domain/WorkflowTransitionRecord.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "EntityType",
+          "kind": "property",
+          "signature": "string EntityType",
+          "returnType": "string"
+        },
+        {
+          "name": "EntityId",
+          "kind": "property",
+          "signature": "string EntityId",
+          "returnType": "string"
+        },
+        {
+          "name": "PreviousState",
+          "kind": "property",
+          "signature": "string PreviousState",
+          "returnType": "string"
+        },
+        {
+          "name": "NewState",
+          "kind": "property",
+          "signature": "string NewState",
+          "returnType": "string"
+        },
+        {
+          "name": "TransitionedAt",
+          "kind": "property",
+          "signature": "DateTimeOffset TransitionedAt",
+          "returnType": "DateTimeOffset"
+        }
+      ]
+    },
+    {
+      "name": "TransitionHistoryResponse",
+      "fqn": "Granit.Workflow.Dtos.TransitionHistoryResponse",
+      "kind": "record",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Dtos/TransitionHistoryResponse.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "WorkflowStatusResponse",
+      "fqn": "Granit.Workflow.Endpoints.Dtos.WorkflowStatusResponse",
+      "kind": "record",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Dtos/WorkflowStatusResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "WorkflowTransitionRequest",
+      "fqn": "Granit.Workflow.Endpoints.Dtos.WorkflowTransitionRequest",
+      "kind": "record",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Dtos/WorkflowTransitionRequest.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "WorkflowTransitionResponse",
+      "fqn": "Granit.Workflow.Endpoints.Dtos.WorkflowTransitionResponse",
+      "kind": "record",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Dtos/WorkflowTransitionResponse.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "WorkflowTransitionResultResponse",
+      "fqn": "Granit.Workflow.Endpoints.Dtos.WorkflowTransitionResultResponse",
+      "kind": "record",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Dtos/WorkflowTransitionResultResponse.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "WorkflowEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Workflow.Endpoints.Extensions.WorkflowEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Extensions/WorkflowEndpointRouteBuilderExtensions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "MapWorkflowEndpoints",
+          "kind": "method",
+          "signature": "MapWorkflowEndpoints(this IEndpointRouteBuilder endpoints, Action<WorkflowEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowEndpointsServiceCollectionExtensions",
+      "fqn": "Granit.Workflow.Endpoints.Extensions.WorkflowEndpointsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Extensions/WorkflowEndpointsServiceCollectionExtensions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "AddGranitWorkflowEndpoints",
+          "kind": "method",
+          "signature": "AddGranitWorkflowEndpoints(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitWorkflowEndpointsModule",
+      "fqn": "Granit.Workflow.Endpoints.GranitWorkflowEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/GranitWorkflowEndpointsModule.cs",
+      "line": 32,
+      "members": []
+    },
+    {
+      "name": "WorkflowAuthorizationPolicy",
+      "fqn": "Granit.Workflow.Endpoints.Internal.WorkflowAuthorizationPolicy",
+      "kind": "class",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Internal/WorkflowAuthorizationPolicy.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "WorkflowEndpointsOptions",
+      "fqn": "Granit.Workflow.Endpoints.Options.WorkflowEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Options/WorkflowEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "History",
+      "fqn": "Granit.Workflow.Endpoints.Permissions.History",
+      "kind": "class",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Permissions/WorkflowPermissions.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "Transitions",
+      "fqn": "Granit.Workflow.Endpoints.Permissions.Transitions",
+      "kind": "class",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Permissions/WorkflowPermissions.cs",
+      "line": 23,
+      "members": []
+    },
+    {
+      "name": "WorkflowPermissions",
+      "fqn": "Granit.Workflow.Endpoints.Permissions.WorkflowPermissions",
+      "kind": "class",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Permissions/WorkflowPermissions.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "WorkflowEfCoreServiceCollectionExtensions",
+      "fqn": "Granit.Workflow.EntityFrameworkCore.Extensions.WorkflowEfCoreServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Workflow.EntityFrameworkCore",
+      "file": "src/Granit.Workflow.EntityFrameworkCore/Extensions/WorkflowEfCoreServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "WorkflowModelBuilderExtensions",
+      "fqn": "Granit.Workflow.EntityFrameworkCore.Extensions.WorkflowModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Workflow.EntityFrameworkCore",
+      "file": "src/Granit.Workflow.EntityFrameworkCore/Extensions/WorkflowModelBuilderExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "ConfigureWorkflowModule",
+          "kind": "method",
+          "signature": "ConfigureWorkflowModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitWorkflowDbProperties",
+      "fqn": "Granit.Workflow.EntityFrameworkCore.GranitWorkflowDbProperties",
+      "kind": "class",
+      "project": "Granit.Workflow.EntityFrameworkCore",
+      "file": "src/Granit.Workflow.EntityFrameworkCore/GranitWorkflowDbProperties.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitWorkflowEntityFrameworkCoreModule",
+      "fqn": "Granit.Workflow.EntityFrameworkCore.GranitWorkflowEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Workflow.EntityFrameworkCore",
+      "file": "src/Granit.Workflow.EntityFrameworkCore/GranitWorkflowEntityFrameworkCoreModule.cs",
+      "line": 29,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IWorkflowDbContext",
+      "fqn": "Granit.Workflow.EntityFrameworkCore.IWorkflowDbContext",
+      "kind": "interface",
+      "project": "Granit.Workflow.EntityFrameworkCore",
+      "file": "src/Granit.Workflow.EntityFrameworkCore/IWorkflowDbContext.cs",
+      "line": 29,
+      "members": []
+    },
+    {
+      "name": "WorkflowTransitionInterceptor",
+      "fqn": "Granit.Workflow.EntityFrameworkCore.Interceptors.WorkflowTransitionInterceptor",
+      "kind": "class",
+      "project": "Granit.Workflow.EntityFrameworkCore",
+      "file": "src/Granit.Workflow.EntityFrameworkCore/Interceptors/WorkflowTransitionInterceptor.cs",
+      "line": 35,
+      "members": [
+        {
+          "name": "SavingChanges",
+          "kind": "method",
+          "signature": "SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)",
+          "returnType": "InterceptionResult<int>"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowApprovalRequestedEvent",
+      "fqn": "Granit.Workflow.Events.WorkflowApprovalRequestedEvent",
+      "kind": "record",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Events/WorkflowApprovalRequestedEvent.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "WorkflowStateChangedEvent",
+      "fqn": "Granit.Workflow.Events.WorkflowStateChangedEvent",
+      "kind": "record",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Events/WorkflowStateChangedEvent.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "WorkflowTransitionedEvent",
+      "fqn": "Granit.Workflow.Events.WorkflowTransitionedEvent",
+      "kind": "record",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Events/WorkflowTransitionedEvent.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "WorkflowServiceCollectionExtensions",
+      "fqn": "Granit.Workflow.Extensions.WorkflowServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Extensions/WorkflowServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitWorkflow",
+          "kind": "method",
+          "signature": "AddGranitWorkflow(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitWorkflowModule",
+      "fqn": "Granit.Workflow.GranitWorkflowModule",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/GranitWorkflowModule.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IWorkflowDefinition",
+      "fqn": "Granit.Workflow.IWorkflowDefinition",
+      "kind": "interface",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/IWorkflowDefinition.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetAllowedTransitions",
+          "kind": "method",
+          "signature": "GetAllowedTransitions(TState from)",
+          "returnType": "TState InitialState { get; } IReadOnlyList<WorkflowTransition<TState>> Transitions { get; } IReadOnlyList<WorkflowTransition<TState>>"
+        }
+      ]
+    },
+    {
+      "name": "IWorkflowHistoryQuery",
+      "fqn": "Granit.Workflow.IWorkflowHistoryQuery",
+      "kind": "interface",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/IWorkflowHistoryQuery.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "GetHistoryAsync",
+          "kind": "method",
+          "signature": "GetHistoryAsync(string entityType, string entityId, int page = 1, int pageSize = QueryingDefaults.DefaultPageSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<TransitionHistoryResponse>>"
+        }
+      ]
+    },
+    {
+      "name": "IWorkflowManager",
+      "fqn": "Granit.Workflow.IWorkflowManager",
+      "kind": "interface",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/IWorkflowManager.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetAllowedTransitionsAsync",
+          "kind": "method",
+          "signature": "GetAllowedTransitionsAsync(TState currentState, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<WorkflowTransition<TState>>>"
+        },
+        {
+          "name": "TransitionAsync",
+          "kind": "method",
+          "signature": "TransitionAsync(TState currentState, TState targetState, TransitionContext? context = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TransitionResult<TState>>"
+        }
+      ]
+    },
+    {
+      "name": "IWorkflowPermissionChecker",
+      "fqn": "Granit.Workflow.IWorkflowPermissionChecker",
+      "kind": "interface",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/IWorkflowPermissionChecker.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "IsGrantedAsync",
+          "kind": "method",
+          "signature": "IsGrantedAsync(string permissionName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "IWorkflowTransitionRecorder",
+      "fqn": "Granit.Workflow.IWorkflowTransitionRecorder",
+      "kind": "interface",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/IWorkflowTransitionRecorder.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "RecordTransitionAsync",
+          "kind": "method",
+          "signature": "RecordTransitionAsync(RecordTransitionRequest request, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Workflow.Notifications.Extensions.WorkflowNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Workflow.Notifications",
+      "file": "src/Granit.Workflow.Notifications/Extensions/WorkflowNotificationsServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitWorkflowNotifications",
+          "kind": "method",
+          "signature": "AddGranitWorkflowNotifications(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitWorkflowNotificationsModule",
+      "fqn": "Granit.Workflow.Notifications.GranitWorkflowNotificationsModule",
+      "kind": "class",
+      "project": "Granit.Workflow.Notifications",
+      "file": "src/Granit.Workflow.Notifications/GranitWorkflowNotificationsModule.cs",
+      "line": 31,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowApprovalRequestedHandler",
+      "fqn": "Granit.Workflow.Notifications.Handlers.WorkflowApprovalRequestedHandler",
+      "kind": "class",
+      "project": "Granit.Workflow.Notifications",
+      "file": "src/Granit.Workflow.Notifications/Handlers/WorkflowApprovalRequestedHandler.cs",
+      "line": 28,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(WorkflowApprovalRequestedEvent message, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowStateChangedHandler",
+      "fqn": "Granit.Workflow.Notifications.Handlers.WorkflowStateChangedHandler",
+      "kind": "class",
+      "project": "Granit.Workflow.Notifications",
+      "file": "src/Granit.Workflow.Notifications/Handlers/WorkflowStateChangedHandler.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(WorkflowStateChangedEvent message, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IApproverResolver",
+      "fqn": "Granit.Workflow.Notifications.IApproverResolver",
+      "kind": "interface",
+      "project": "Granit.Workflow.Notifications",
+      "file": "src/Granit.Workflow.Notifications/IApproverResolver.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "ResolveApproversAsync",
+          "kind": "method",
+          "signature": "ResolveApproversAsync(string requiredPermission, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<string>>"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowApprovalNotificationData",
+      "fqn": "Granit.Workflow.Notifications.WorkflowApprovalNotificationData",
+      "kind": "record",
+      "project": "Granit.Workflow.Notifications",
+      "file": "src/Granit.Workflow.Notifications/WorkflowApprovalNotificationType.cs",
+      "line": 33,
+      "members": []
+    },
+    {
+      "name": "WorkflowApprovalNotificationType",
+      "fqn": "Granit.Workflow.Notifications.WorkflowApprovalNotificationType",
+      "kind": "class",
+      "project": "Granit.Workflow.Notifications",
+      "file": "src/Granit.Workflow.Notifications/WorkflowApprovalNotificationType.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "WorkflowApprovalNotificationType Instance ="
+        },
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSeverity",
+          "kind": "property",
+          "signature": "NotificationSeverity DefaultSeverity",
+          "returnType": "NotificationSeverity"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowStateChangedNotificationData",
+      "fqn": "Granit.Workflow.Notifications.WorkflowStateChangedNotificationData",
+      "kind": "record",
+      "project": "Granit.Workflow.Notifications",
+      "file": "src/Granit.Workflow.Notifications/WorkflowStateChangedNotificationType.cs",
+      "line": 34,
+      "members": []
+    },
+    {
+      "name": "WorkflowStateChangedNotificationType",
+      "fqn": "Granit.Workflow.Notifications.WorkflowStateChangedNotificationType",
+      "kind": "class",
+      "project": "Granit.Workflow.Notifications",
+      "file": "src/Granit.Workflow.Notifications/WorkflowStateChangedNotificationType.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "WorkflowStateChangedNotificationType Instance ="
+        },
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSeverity",
+          "kind": "property",
+          "signature": "NotificationSeverity DefaultSeverity",
+          "returnType": "NotificationSeverity"
+        }
+      ]
+    },
+    {
+      "name": "RecordTransitionRequest",
+      "fqn": "Granit.Workflow.RecordTransitionRequest",
+      "kind": "record",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/IWorkflowTransitionRecorder.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "TransitionBuilder",
+      "fqn": "Granit.Workflow.TransitionBuilder",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/TransitionBuilder.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "TransitionContext",
+      "fqn": "Granit.Workflow.TransitionContext",
+      "kind": "record",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/TransitionContext.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "TransitionInfo",
+      "fqn": "Granit.Workflow.TransitionInfo",
+      "kind": "record",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/WorkflowTransitionContext.cs",
+      "line": 43,
+      "members": []
+    },
+    {
+      "name": "TransitionOutcome",
+      "fqn": "Granit.Workflow.TransitionOutcome",
+      "kind": "enum",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/TransitionResult.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "TransitionResult",
+      "fqn": "Granit.Workflow.TransitionResult",
+      "kind": "record",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/TransitionResult.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "WorkflowDefinition",
+      "fqn": "Granit.Workflow.WorkflowDefinition",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/WorkflowDefinition.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Action<WorkflowDefinitionBuilder<TState>> configure)",
+          "returnType": "WorkflowDefinition<TState>"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowDefinitionBuilder",
+      "fqn": "Granit.Workflow.WorkflowDefinitionBuilder",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/WorkflowDefinitionBuilder.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "InitialState",
+          "kind": "method",
+          "signature": "InitialState(TState state)",
+          "returnType": "WorkflowDefinitionBuilder<TState>"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowManager",
+      "fqn": "Granit.Workflow.WorkflowManager",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/WorkflowManager.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "GetAllowedTransitionsAsync",
+          "kind": "method",
+          "signature": "GetAllowedTransitionsAsync(TState currentState, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<WorkflowTransition<TState>>>"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowTransition",
+      "fqn": "Granit.Workflow.WorkflowTransition",
+      "kind": "record",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/WorkflowTransition.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "WorkflowTransitionContext",
+      "fqn": "Granit.Workflow.WorkflowTransitionContext",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/WorkflowTransitionContext.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "Current",
+          "kind": "property",
+          "signature": "TransitionInfo? Current",
+          "returnType": "TransitionInfo?"
+        },
+        {
+          "name": "SetComment",
+          "kind": "method",
+          "signature": "SetComment(string? comment)",
+          "returnType": "IDisposable"
+        }
+      ]
+    }
+  ]
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -147,6 +147,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.*" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.11.*" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.*" />
+    <PackageVersion Include="Testcontainers.Redis" Version="4.*" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.*" />
     <PackageVersion Include="xunit.v3" Version="3.2.*" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.*" />

--- a/Granit.slnx
+++ b/Granit.slnx
@@ -243,6 +243,7 @@
     <Project Path="tests/Granit.Caching.FusionCache.Tests/Granit.Caching.FusionCache.Tests.csproj" />
     <Project Path="tests/Granit.Caching.StackExchangeRedis.Tests/Granit.Caching.StackExchangeRedis.Tests.csproj" />
     <Project Path="tests/Granit.Caching.Tests/Granit.Caching.Tests.csproj" />
+    <Project Path="tests/Granit.Caching.Tests.Integration/Granit.Caching.Tests.Integration.csproj" />
     <Project Path="tests/Granit.Http.Cookies.Endpoints.Tests/Granit.Http.Cookies.Endpoints.Tests.csproj" />
     <Project Path="tests/Granit.Http.Cookies.Klaro.Tests/Granit.Http.Cookies.Klaro.Tests.csproj" />
     <Project Path="tests/Granit.Http.Cookies.Tests/Granit.Http.Cookies.Tests.csproj" />

--- a/code-index.json
+++ b/code-index.json
@@ -1,0 +1,26696 @@
+{
+  "generatedAt": "2026-03-20T21:04:26.533214+00:00",
+  "repo": "granit-dotnet",
+  "projectGraph": [
+    {
+      "name": "Granit.AI",
+      "deps": [
+        "Granit.Core",
+        "Granit.Guids"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AI.AzureOpenAI",
+      "deps": [
+        "Granit.AI"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AI.Endpoints",
+      "deps": [
+        "Granit.AI",
+        "Granit.Authorization",
+        "Granit.Querying.Endpoints",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AI.EntityFrameworkCore",
+      "deps": [
+        "Granit.AI",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AI.Extraction",
+      "deps": [
+        "Granit.AI"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AI.Ollama",
+      "deps": [
+        "Granit.AI",
+        "Granit.Http.Resilience"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AI.OpenAI",
+      "deps": [
+        "Granit.AI"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AI.VectorData",
+      "deps": [
+        "Granit.AI"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AuditLog",
+      "deps": [
+        "Granit.Core",
+        "Granit.Querying"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AuditLog.ConfigurationChanges",
+      "deps": [
+        "Granit.AuditLog",
+        "Granit.Features",
+        "Granit.Guids",
+        "Granit.Settings"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AuditLog.Endpoints",
+      "deps": [
+        "Granit.AuditLog",
+        "Granit.Http.ApiDocumentation",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.AuditLog.EntityFrameworkCore",
+      "deps": [
+        "Granit.AuditLog",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authentication.ApiKeys",
+      "deps": [
+        "Granit.Security",
+        "Granit.Timing",
+        "Granit.Guids",
+        "Granit.Http.ExceptionHandling",
+        "Granit.Querying"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authentication.ApiKeys.Endpoints",
+      "deps": [
+        "Granit.Http.ApiDocumentation",
+        "Granit.Authentication.ApiKeys",
+        "Granit.Authorization",
+        "Granit.Querying",
+        "Granit.Timing",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authentication.ApiKeys.EntityFrameworkCore",
+      "deps": [
+        "Granit.Authentication.ApiKeys",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authentication.Cognito",
+      "deps": [
+        "Granit.Authentication.JwtBearer"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authentication.EntraId",
+      "deps": [
+        "Granit.Authentication.JwtBearer"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authentication.GoogleCloud",
+      "deps": [
+        "Granit.Authentication.JwtBearer"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authentication.JwtBearer",
+      "deps": [
+        "Granit.Security"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authentication.Keycloak",
+      "deps": [
+        "Granit.Authentication.JwtBearer"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authorization",
+      "deps": [
+        "Granit.Caching",
+        "Granit.Security"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authorization.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Authorization"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authorization.Endpoints",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.Http.ApiDocumentation",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Authorization.EntityFrameworkCore",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BackgroundJobs",
+      "deps": [
+        "Granit.Core",
+        "Granit.Guids",
+        "Granit.Security",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BackgroundJobs.Endpoints",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.BackgroundJobs",
+        "Granit.Querying",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BackgroundJobs.EntityFrameworkCore",
+      "deps": [
+        "Granit.BackgroundJobs",
+        "Granit.Guids",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BackgroundJobs.Wolverine",
+      "deps": [
+        "Granit.BackgroundJobs",
+        "Granit.Wolverine"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BlobStorage",
+      "deps": [
+        "Granit.BackgroundJobs",
+        "Granit.Core",
+        "Granit.Guids"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BlobStorage.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.BlobStorage"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BlobStorage.AzureBlob",
+      "deps": [
+        "Granit.BlobStorage"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BlobStorage.DbStore",
+      "deps": [
+        "Granit.BlobStorage",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BlobStorage.Endpoints",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.BlobStorage",
+        "Granit.Querying.Endpoints",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BlobStorage.EntityFrameworkCore",
+      "deps": [
+        "Granit.BlobStorage",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BlobStorage.FileSystem",
+      "deps": [
+        "Granit.BlobStorage"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BlobStorage.GoogleCloud",
+      "deps": [
+        "Granit.BlobStorage"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BlobStorage.Proxy",
+      "deps": [
+        "Granit.BlobStorage"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.BlobStorage.S3",
+      "deps": [
+        "Granit.BlobStorage"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Caching",
+      "deps": [
+        "Granit.Core",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Caching.StackExchangeRedis",
+      "deps": [
+        "Granit.Caching"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Core",
+      "deps": [],
+      "framework": ""
+    },
+    {
+      "name": "Granit.DataExchange",
+      "deps": [
+        "Granit.EventBus",
+        "Granit.Guids",
+        "Granit.Querying",
+        "Granit.Timing",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.DataExchange.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.DataExchange"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.DataExchange.Csv",
+      "deps": [
+        "Granit.DataExchange"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.DataExchange.Endpoints",
+      "deps": [
+        "Granit.Http.ApiDocumentation",
+        "Granit.Authorization",
+        "Granit.DataExchange",
+        "Granit.Guids",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.DataExchange.EntityFrameworkCore",
+      "deps": [
+        "Granit.DataExchange",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.DataExchange.Excel",
+      "deps": [
+        "Granit.DataExchange"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.DataExchange.Wolverine",
+      "deps": [
+        "Granit.DataExchange",
+        "Granit.Wolverine"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Diagnostics",
+      "deps": [
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Diagnostics.Endpoints",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.Diagnostics",
+        "Granit.Http.ApiDocumentation",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.DocumentGeneration",
+      "deps": [
+        "Granit.Templating"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.DocumentGeneration.Excel",
+      "deps": [
+        "Granit.Templating"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.DocumentGeneration.Pdf",
+      "deps": [
+        "Granit.DocumentGeneration"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Encryption",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Encryption.EntityFrameworkCore",
+      "deps": [
+        "Granit.Core",
+        "Granit.Encryption",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Encryption.ReEncryption",
+      "deps": [
+        "Granit.Encryption.EntityFrameworkCore"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.EventBus",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.EventBus.Wolverine",
+      "deps": [
+        "Granit.EventBus",
+        "Granit.Wolverine"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Features",
+      "deps": [
+        "Granit.Caching",
+        "Granit.Localization"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Features.Endpoints",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.Features",
+        "Granit.Http.ApiDocumentation",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Features.EntityFrameworkCore",
+      "deps": [
+        "Granit.EventBus",
+        "Granit.Features",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Guids",
+      "deps": [
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.ApiDocumentation",
+      "deps": [
+        "Granit.Http.ApiVersioning",
+        "Granit.Security"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.ApiVersioning",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.Bulkhead",
+      "deps": [
+        "Granit.Core",
+        "Granit.Http.ExceptionHandling",
+        "Granit.Features",
+        "Granit.Security"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.Cookies",
+      "deps": [
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.Cookies.Endpoints",
+      "deps": [
+        "Granit.Core",
+        "Granit.Http.ApiDocumentation",
+        "Granit.Http.Cookies"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.Cookies.Klaro",
+      "deps": [
+        "Granit.Http.Cookies"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.Cors",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.ExceptionHandling",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.Idempotency",
+      "deps": [
+        "Granit.Caching",
+        "Granit.Security"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.OutputCaching",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.OutputCaching.StackExchangeRedis",
+      "deps": [
+        "Granit.Caching.StackExchangeRedis",
+        "Granit.Http.OutputCaching"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.Resilience",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Http.ResponseCompression",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Identity",
+      "deps": [
+        "Granit.Core",
+        "Granit.Querying"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Identity.Cognito",
+      "deps": [
+        "Granit.Identity"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Identity.Endpoints",
+      "deps": [
+        "Granit.Http.ApiDocumentation",
+        "Granit.Authorization",
+        "Granit.Identity",
+        "Granit.Querying",
+        "Granit.Querying.Endpoints",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Identity.EntityFrameworkCore",
+      "deps": [
+        "Granit.Identity",
+        "Granit.Persistence",
+        "Granit.Security"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Identity.EntraId",
+      "deps": [
+        "Granit.Http.Resilience",
+        "Granit.Identity",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Identity.GoogleCloud",
+      "deps": [
+        "Granit.Identity"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Identity.Keycloak",
+      "deps": [
+        "Granit.Http.Resilience",
+        "Granit.Identity",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Imaging",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Imaging.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Imaging"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Imaging.MagickNet",
+      "deps": [
+        "Granit.Imaging"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Localization",
+      "deps": [
+        "Granit.Caching",
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Localization.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Localization"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Localization.Endpoints",
+      "deps": [
+        "Granit.Http.ApiDocumentation",
+        "Granit.Authorization",
+        "Granit.Localization",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Localization.EntityFrameworkCore",
+      "deps": [
+        "Granit.Persistence",
+        "Granit.Localization"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.MultiTenancy",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications",
+      "deps": [
+        "Granit.Guids",
+        "Granit.Querying",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Brevo",
+      "deps": [
+        "Granit.Http.Resilience",
+        "Granit.Notifications.Email",
+        "Granit.Notifications.Sms",
+        "Granit.Notifications.WhatsApp"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Email",
+      "deps": [
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Email.AwsSes",
+      "deps": [
+        "Granit.Notifications.Email"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Email.AzureCommunicationServices",
+      "deps": [
+        "Granit.Notifications.Email"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Email.Scaleway",
+      "deps": [
+        "Granit.Http.Resilience",
+        "Granit.Notifications.Email"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Email.SendGrid",
+      "deps": [
+        "Granit.Http.Resilience",
+        "Granit.Notifications.Email"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Email.Smtp",
+      "deps": [
+        "Granit.Notifications.Email"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Endpoints",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.Http.ApiDocumentation",
+        "Granit.Guids",
+        "Granit.Notifications",
+        "Granit.Notifications.MobilePush",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.EntityFrameworkCore",
+      "deps": [
+        "Granit.Notifications",
+        "Granit.Notifications.MobilePush",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.MobilePush",
+      "deps": [
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.MobilePush.AwsSns",
+      "deps": [
+        "Granit.Notifications.MobilePush"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.MobilePush.AzureNotificationHubs",
+      "deps": [
+        "Granit.Notifications.MobilePush"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.MobilePush.GoogleFcm",
+      "deps": [
+        "Granit.Http.Resilience",
+        "Granit.Notifications.MobilePush"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.SignalR",
+      "deps": [
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Sms",
+      "deps": [
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Sms.AwsSns",
+      "deps": [
+        "Granit.Notifications.Sms"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Sms.AzureCommunicationServices",
+      "deps": [
+        "Granit.Notifications.Sms"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Sse",
+      "deps": [
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Twilio",
+      "deps": [
+        "Granit.Http.Resilience",
+        "Granit.Notifications.Sms",
+        "Granit.Notifications.WhatsApp"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.WebPush",
+      "deps": [
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.WhatsApp",
+      "deps": [
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Wolverine",
+      "deps": [
+        "Granit.Notifications",
+        "Granit.Wolverine"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Notifications.Zulip",
+      "deps": [
+        "Granit.Http.Resilience",
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Observability",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Observability.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Observability"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Persistence",
+      "deps": [
+        "Granit.Guids",
+        "Granit.Security",
+        "Granit.Timing",
+        "Granit.Http.ExceptionHandling"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Persistence.Hosting",
+      "deps": [
+        "Granit.Persistence",
+        "Granit.Persistence.Migrations"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Persistence.Migrations",
+      "deps": [
+        "Granit.Persistence",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Persistence.Migrations.Wolverine",
+      "deps": [
+        "Granit.Persistence.Migrations",
+        "Granit.Wolverine"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Persistence.Postgres",
+      "deps": [
+        "Granit.Persistence.Hosting"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Persistence.SqlServer",
+      "deps": [
+        "Granit.Persistence.Hosting"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Privacy",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Privacy.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Privacy"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Querying",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Querying.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Querying",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Querying.Endpoints",
+      "deps": [
+        "Granit.Http.ApiDocumentation",
+        "Granit.Authorization",
+        "Granit.Guids",
+        "Granit.Querying",
+        "Granit.Timing",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Querying.EntityFrameworkCore",
+      "deps": [
+        "Granit.Querying",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.RateLimiting",
+      "deps": [
+        "Granit.Core",
+        "Granit.Http.ExceptionHandling",
+        "Granit.Features",
+        "Granit.Security"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.ReferenceData",
+      "deps": [
+        "Granit.Core",
+        "Granit.Querying"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.ReferenceData.Endpoints",
+      "deps": [
+        "Granit.Http.ApiDocumentation",
+        "Granit.Guids",
+        "Granit.ReferenceData",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.ReferenceData.EntityFrameworkCore",
+      "deps": [
+        "Granit.Caching",
+        "Granit.Persistence",
+        "Granit.ReferenceData"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Security",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Settings",
+      "deps": [
+        "Granit.Caching",
+        "Granit.Encryption",
+        "Granit.EventBus",
+        "Granit.Security"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Settings.Endpoints",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.Http.ApiDocumentation",
+        "Granit.Settings",
+        "Granit.Timing",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Settings.EntityFrameworkCore",
+      "deps": [
+        "Granit.Persistence",
+        "Granit.Settings"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Templating",
+      "deps": [
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Templating.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Templating"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Templating.Endpoints",
+      "deps": [
+        "Granit.Http.ApiDocumentation",
+        "Granit.Authorization",
+        "Granit.Security",
+        "Granit.Templating",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Templating.EntityFrameworkCore",
+      "deps": [
+        "Granit.Guids",
+        "Granit.Persistence",
+        "Granit.Templating",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Templating.Scriban",
+      "deps": [
+        "Granit.Templating"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Templating.Workflow",
+      "deps": [
+        "Granit.Templating",
+        "Granit.Workflow"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Testing",
+      "deps": [
+        "Granit.Core",
+        "Granit.Guids",
+        "Granit.Security",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Testing.EntityFrameworkCore",
+      "deps": [
+        "Granit.Persistence",
+        "Granit.Testing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Timeline",
+      "deps": [
+        "Granit.Core",
+        "Granit.Guids",
+        "Granit.Querying",
+        "Granit.Security",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Timeline.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Timeline"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Timeline.Endpoints",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.Http.ApiDocumentation",
+        "Granit.Timeline",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Timeline.EntityFrameworkCore",
+      "deps": [
+        "Granit.Timeline",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Timeline.Notifications",
+      "deps": [
+        "Granit.Timeline",
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Timing",
+      "deps": [
+        "Granit.Core"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Validation",
+      "deps": [
+        "Granit.Http.ExceptionHandling",
+        "Granit.Localization"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Validation.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Validation.Endpoints",
+      "deps": [
+        "Granit.Http.ApiDocumentation",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Validation.Europe",
+      "deps": [
+        "Granit.Localization",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Validation.NorthAmerica",
+      "deps": [
+        "Granit.Localization",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Validation.UnitedKingdom",
+      "deps": [
+        "Granit.Localization",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Vault",
+      "deps": [
+        "Granit.Encryption"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Vault.Aws",
+      "deps": [
+        "Granit.Vault"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Vault.Azure",
+      "deps": [
+        "Granit.Vault"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Vault.GoogleCloud",
+      "deps": [
+        "Granit.Vault"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Vault.HashiCorp",
+      "deps": [
+        "Granit.Vault"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Webhooks",
+      "deps": [
+        "Granit.Core",
+        "Granit.Guids",
+        "Granit.Http.Resilience",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Webhooks.Endpoints",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.Querying.Endpoints",
+        "Granit.Validation",
+        "Granit.Webhooks"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Webhooks.EntityFrameworkCore",
+      "deps": [
+        "Granit.Webhooks",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Webhooks.Wolverine",
+      "deps": [
+        "Granit.Webhooks",
+        "Granit.Wolverine"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Wolverine",
+      "deps": [
+        "Granit.Security",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Wolverine.Postgresql",
+      "deps": [
+        "Granit.Wolverine",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Wolverine.SqlServer",
+      "deps": [
+        "Granit.Wolverine",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Workflow",
+      "deps": [
+        "Granit.Querying",
+        "Granit.Timing"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Workflow.AI",
+      "deps": [
+        "Granit.AI",
+        "Granit.Workflow"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Workflow.Endpoints",
+      "deps": [
+        "Granit.Http.ApiDocumentation",
+        "Granit.Authorization",
+        "Granit.Workflow",
+        "Granit.Validation"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Workflow.EntityFrameworkCore",
+      "deps": [
+        "Granit.Workflow",
+        "Granit.Persistence"
+      ],
+      "framework": ""
+    },
+    {
+      "name": "Granit.Workflow.Notifications",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.Identity",
+        "Granit.Workflow",
+        "Granit.Notifications"
+      ],
+      "framework": ""
+    }
+  ],
+  "symbols": [
+    {
+      "name": "AILocalizationResource",
+      "fqn": "Granit.AI.AILocalizationResource",
+      "kind": "class",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/AILocalizationResource.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "AIUsageRecord",
+      "fqn": "Granit.AI.AIUsageRecord",
+      "kind": "record",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/AIUsageRecord.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "AIAzureOpenAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.AI.AzureOpenAI.Extensions.AIAzureOpenAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AI.AzureOpenAI",
+      "file": "src/Granit.AI.AzureOpenAI/Extensions/AIAzureOpenAIHostApplicationBuilderExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "AddGranitAIAzureOpenAI",
+          "kind": "method",
+          "signature": "AddGranitAIAzureOpenAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIAzureOpenAIModule",
+      "fqn": "Granit.AI.AzureOpenAI.GranitAIAzureOpenAIModule",
+      "kind": "class",
+      "project": "Granit.AI.AzureOpenAI",
+      "file": "src/Granit.AI.AzureOpenAI/GranitAIAzureOpenAIModule.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "AzureOpenAIProviderOptions",
+      "fqn": "Granit.AI.AzureOpenAI.Options.AzureOpenAIProviderOptions",
+      "kind": "class",
+      "project": "Granit.AI.AzureOpenAI",
+      "file": "src/Granit.AI.AzureOpenAI/Options/AzureOpenAIProviderOptions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Endpoint",
+          "kind": "property",
+          "signature": "string Endpoint",
+          "returnType": "string"
+        },
+        {
+          "name": "ApiKey",
+          "kind": "property",
+          "signature": "string? ApiKey",
+          "returnType": "string?"
+        },
+        {
+          "name": "DefaultEmbeddingDeployment",
+          "kind": "property",
+          "signature": "string DefaultEmbeddingDeployment",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "AIMetrics",
+      "fqn": "Granit.AI.Diagnostics.AIMetrics",
+      "kind": "class",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Diagnostics/AIMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordTokensUsed",
+          "kind": "method",
+          "signature": "RecordTokensUsed(string? tenantId, string model, string provider, long inputTokens, long outputTokens)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AIChatMessageRequest",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIChatMessageRequest",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIChatRequest.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "AIChatRequest",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIChatRequest",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIChatRequest.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "AIChatResponse",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIChatResponse",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIChatResponse.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "AIChatUsageResponse",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIChatUsageResponse",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIChatResponse.cs",
+      "line": 24,
+      "members": []
+    },
+    {
+      "name": "AIEmbeddingDataResponse",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIEmbeddingDataResponse",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIEmbeddingResponse.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "AIEmbeddingRequest",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIEmbeddingRequest",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIEmbeddingRequest.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "AIEmbeddingResponse",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIEmbeddingResponse",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIEmbeddingResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "AIWorkspaceCreateRequest",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIWorkspaceCreateRequest",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIWorkspaceCreateRequest.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "AIWorkspaceListResponse",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIWorkspaceListResponse",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIWorkspaceListResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "AIWorkspaceResponse",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIWorkspaceResponse",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIWorkspaceResponse.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "AIWorkspaceUpdateRequest",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIWorkspaceUpdateRequest",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIWorkspaceUpdateRequest.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "AIEndpointRouteBuilderExtensions",
+      "fqn": "Granit.AI.Endpoints.Extensions.AIEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Extensions/AIEndpointRouteBuilderExtensions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "MapAIEndpoints",
+          "kind": "method",
+          "signature": "MapAIEndpoints(this IEndpointRouteBuilder endpoints, Action<AIEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIEndpointsModule",
+      "fqn": "Granit.AI.Endpoints.GranitAIEndpointsModule",
+      "kind": "class",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/GranitAIEndpointsModule.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "AIEndpointsOptions",
+      "fqn": "Granit.AI.Endpoints.Options.AIEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Options/AIEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "AdminRole",
+          "kind": "property",
+          "signature": "string AdminRole",
+          "returnType": "string"
+        },
+        {
+          "name": "UserRole",
+          "kind": "property",
+          "signature": "string UserRole",
+          "returnType": "string"
+        },
+        {
+          "name": "WorkspacesTagName",
+          "kind": "property",
+          "signature": "string WorkspacesTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "UsageTagName",
+          "kind": "property",
+          "signature": "string UsageTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "InferenceTagName",
+          "kind": "property",
+          "signature": "string InferenceTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "MaxChatMessages",
+          "kind": "property",
+          "signature": "int MaxChatMessages",
+          "returnType": "int"
+        },
+        {
+          "name": "MaxEmbeddingInputs",
+          "kind": "property",
+          "signature": "int MaxEmbeddingInputs",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "AIPermissions",
+      "fqn": "Granit.AI.Endpoints.Permissions.AIPermissions",
+      "kind": "class",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Permissions/AIPermissions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "Chat",
+      "fqn": "Granit.AI.Endpoints.Permissions.Chat",
+      "kind": "class",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Permissions/AIPermissions.cs",
+      "line": 23,
+      "members": []
+    },
+    {
+      "name": "Embeddings",
+      "fqn": "Granit.AI.Endpoints.Permissions.Embeddings",
+      "kind": "class",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Permissions/AIPermissions.cs",
+      "line": 28,
+      "members": []
+    },
+    {
+      "name": "Usage",
+      "fqn": "Granit.AI.Endpoints.Permissions.Usage",
+      "kind": "class",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Permissions/AIPermissions.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "Workspaces",
+      "fqn": "Granit.AI.Endpoints.Permissions.Workspaces",
+      "kind": "class",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Permissions/AIPermissions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "AIUsageRecordQueryDefinition",
+      "fqn": "Granit.AI.Endpoints.Queries.AIUsageRecordQueryDefinition",
+      "kind": "class",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Queries/AIUsageRecordQueryDefinition.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "AIEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.AI.EntityFrameworkCore.Extensions.AIEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AI.EntityFrameworkCore",
+      "file": "src/Granit.AI.EntityFrameworkCore/Extensions/AIEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitAIEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitAIEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "AIModelBuilderExtensions",
+      "fqn": "Granit.AI.EntityFrameworkCore.Extensions.AIModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AI.EntityFrameworkCore",
+      "file": "src/Granit.AI.EntityFrameworkCore/Extensions/AIModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureAIModule",
+          "kind": "method",
+          "signature": "ConfigureAIModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIDbProperties",
+      "fqn": "Granit.AI.EntityFrameworkCore.GranitAIDbProperties",
+      "kind": "class",
+      "project": "Granit.AI.EntityFrameworkCore",
+      "file": "src/Granit.AI.EntityFrameworkCore/GranitAIDbProperties.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIEntityFrameworkCoreModule",
+      "fqn": "Granit.AI.EntityFrameworkCore.GranitAIEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.AI.EntityFrameworkCore",
+      "file": "src/Granit.AI.EntityFrameworkCore/GranitAIEntityFrameworkCoreModule.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "AIProviderNotRegisteredException",
+      "fqn": "Granit.AI.Exceptions.AIProviderNotRegisteredException",
+      "kind": "class",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Exceptions/AIProviderNotRegisteredException.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "AIWorkspaceNotFoundException",
+      "fqn": "Granit.AI.Exceptions.AIWorkspaceNotFoundException",
+      "kind": "class",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Exceptions/AIWorkspaceNotFoundException.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "AIServiceCollectionExtensions",
+      "fqn": "Granit.AI.Extensions.AIServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Extensions/AIServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitAI",
+          "kind": "method",
+          "signature": "AddGranitAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "AIExtractionServiceCollectionExtensions",
+      "fqn": "Granit.AI.Extraction.Extensions.AIExtractionServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.AI.Extraction",
+      "file": "src/Granit.AI.Extraction/Extensions/AIExtractionServiceCollectionExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitAIExtraction",
+          "kind": "method",
+          "signature": "AddGranitAIExtraction(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "ExtractionResult",
+      "fqn": "Granit.AI.Extraction.ExtractionResult",
+      "kind": "class",
+      "project": "Granit.AI.Extraction",
+      "file": "src/Granit.AI.Extraction/ExtractionResult.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Status",
+          "kind": "property",
+          "signature": "required ExtractionStatus Status",
+          "returnType": "required ExtractionStatus"
+        }
+      ]
+    },
+    {
+      "name": "ExtractionStatus",
+      "fqn": "Granit.AI.Extraction.ExtractionStatus",
+      "kind": "enum",
+      "project": "Granit.AI.Extraction",
+      "file": "src/Granit.AI.Extraction/ExtractionStatus.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "GranitAIExtractionModule",
+      "fqn": "Granit.AI.Extraction.GranitAIExtractionModule",
+      "kind": "class",
+      "project": "Granit.AI.Extraction",
+      "file": "src/Granit.AI.Extraction/GranitAIExtractionModule.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "IDocumentExtractor",
+      "fqn": "Granit.AI.Extraction.IDocumentExtractor",
+      "kind": "interface",
+      "project": "Granit.AI.Extraction",
+      "file": "src/Granit.AI.Extraction/IDocumentExtractor.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "ExtractAsync",
+          "kind": "method",
+          "signature": "ExtractAsync(string content, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ExtractionResult<TResult>>"
+        }
+      ]
+    },
+    {
+      "name": "ExtractionOptions",
+      "fqn": "Granit.AI.Extraction.Options.ExtractionOptions",
+      "kind": "class",
+      "project": "Granit.AI.Extraction",
+      "file": "src/Granit.AI.Extraction/Options/ExtractionOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string WorkspaceName",
+          "returnType": "string"
+        },
+        {
+          "name": "ReviewThreshold",
+          "kind": "property",
+          "signature": "double ReviewThreshold",
+          "returnType": "double"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIModule",
+      "fqn": "Granit.AI.GranitAIModule",
+      "kind": "class",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/GranitAIModule.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "IAIChatClientFactory",
+      "fqn": "Granit.AI.IAIChatClientFactory",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/IAIChatClientFactory.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(string? workspaceName = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IChatClient>"
+        }
+      ]
+    },
+    {
+      "name": "IAIEmbeddingGeneratorFactory",
+      "fqn": "Granit.AI.IAIEmbeddingGeneratorFactory",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/IAIEmbeddingGeneratorFactory.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(string? workspaceName = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IEmbeddingGenerator<string, Embedding<float>>>"
+        }
+      ]
+    },
+    {
+      "name": "IAIProviderFactory",
+      "fqn": "Granit.AI.IAIProviderFactory",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/IAIProviderFactory.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "CreateChatClient",
+          "kind": "method",
+          "signature": "CreateChatClient(AIWorkspace workspace)",
+          "returnType": "string ProviderName { get; } IChatClient"
+        },
+        {
+          "name": "CreateEmbeddingGenerator",
+          "kind": "method",
+          "signature": "CreateEmbeddingGenerator(AIWorkspace workspace)",
+          "returnType": "IEmbeddingGenerator<string, Embedding<float>>?"
+        }
+      ]
+    },
+    {
+      "name": "IAIUsageQueryableProvider",
+      "fqn": "Granit.AI.IAIUsageQueryableProvider",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/IAIUsageQueryableProvider.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "GetUsageRecords",
+          "kind": "method",
+          "signature": "GetUsageRecords()",
+          "returnType": "IQueryable<AIUsageRecord>"
+        }
+      ]
+    },
+    {
+      "name": "IAIUsageTracker",
+      "fqn": "Granit.AI.IAIUsageTracker",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/IAIUsageTracker.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "RecordAsync",
+          "kind": "method",
+          "signature": "RecordAsync(AIUsageRecord record, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "AIOllamaHostApplicationBuilderExtensions",
+      "fqn": "Granit.AI.Ollama.Extensions.AIOllamaHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AI.Ollama",
+      "file": "src/Granit.AI.Ollama/Extensions/AIOllamaHostApplicationBuilderExtensions.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "AddGranitAIOllama",
+          "kind": "method",
+          "signature": "AddGranitAIOllama(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIOllamaModule",
+      "fqn": "Granit.AI.Ollama.GranitAIOllamaModule",
+      "kind": "class",
+      "project": "Granit.AI.Ollama",
+      "file": "src/Granit.AI.Ollama/GranitAIOllamaModule.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "OllamaOptions",
+      "fqn": "Granit.AI.Ollama.Options.OllamaOptions",
+      "kind": "class",
+      "project": "Granit.AI.Ollama",
+      "file": "src/Granit.AI.Ollama/Options/OllamaOptions.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "Endpoint",
+          "kind": "property",
+          "signature": "string Endpoint",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultModel",
+          "kind": "property",
+          "signature": "string DefaultModel",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "AIOpenAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.AI.OpenAI.Extensions.AIOpenAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AI.OpenAI",
+      "file": "src/Granit.AI.OpenAI/Extensions/AIOpenAIHostApplicationBuilderExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitAIOpenAI",
+          "kind": "method",
+          "signature": "AddGranitAIOpenAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIOpenAIModule",
+      "fqn": "Granit.AI.OpenAI.GranitAIOpenAIModule",
+      "kind": "class",
+      "project": "Granit.AI.OpenAI",
+      "file": "src/Granit.AI.OpenAI/GranitAIOpenAIModule.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "OpenAIProviderOptions",
+      "fqn": "Granit.AI.OpenAI.Options.OpenAIProviderOptions",
+      "kind": "class",
+      "project": "Granit.AI.OpenAI",
+      "file": "src/Granit.AI.OpenAI/Options/OpenAIProviderOptions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "ApiKey",
+          "kind": "property",
+          "signature": "string ApiKey",
+          "returnType": "string"
+        },
+        {
+          "name": "Endpoint",
+          "kind": "property",
+          "signature": "string? Endpoint",
+          "returnType": "string?"
+        },
+        {
+          "name": "DefaultEmbeddingModel",
+          "kind": "property",
+          "signature": "string DefaultEmbeddingModel",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIOptions",
+      "fqn": "Granit.AI.Options.GranitAIOptions",
+      "kind": "class",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Options/GranitAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "DefaultWorkspace",
+          "kind": "property",
+          "signature": "string DefaultWorkspace",
+          "returnType": "string"
+        },
+        {
+          "name": "EnableUsageTracking",
+          "kind": "property",
+          "signature": "bool EnableUsageTracking",
+          "returnType": "bool"
+        },
+        {
+          "name": "EnableAuditTrail",
+          "kind": "property",
+          "signature": "bool EnableAuditTrail",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "VectorDataHostApplicationBuilderExtensions",
+      "fqn": "Granit.AI.VectorData.Extensions.VectorDataHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AI.VectorData",
+      "file": "src/Granit.AI.VectorData/Extensions/VectorDataHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitAIVectorData",
+          "kind": "method",
+          "signature": "AddGranitAIVectorData(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAIVectorDataModule",
+      "fqn": "Granit.AI.VectorData.GranitAIVectorDataModule",
+      "kind": "class",
+      "project": "Granit.AI.VectorData",
+      "file": "src/Granit.AI.VectorData/GranitAIVectorDataModule.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "ISemanticSearchService",
+      "fqn": "Granit.AI.VectorData.ISemanticSearchService",
+      "kind": "interface",
+      "project": "Granit.AI.VectorData",
+      "file": "src/Granit.AI.VectorData/ISemanticSearchService.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "IndexAsync",
+          "kind": "method",
+          "signature": "IndexAsync(string collectionName, string key, string text, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SearchAsync",
+          "kind": "method",
+          "signature": "SearchAsync(string collectionName, string query, int limit = 10, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<SemanticSearchResult>>"
+        }
+      ]
+    },
+    {
+      "name": "IVectorCollection",
+      "fqn": "Granit.AI.VectorData.IVectorCollection",
+      "kind": "interface",
+      "project": "Granit.AI.VectorData",
+      "file": "src/Granit.AI.VectorData/IVectorCollection.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "UpsertAsync",
+          "kind": "method",
+          "signature": "UpsertAsync(TRecord record, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(string key, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SearchAsync",
+          "kind": "method",
+          "signature": "SearchAsync(ReadOnlyMemory<float> vector, int limit = 10, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<VectorSearchResult<TRecord>>>"
+        }
+      ]
+    },
+    {
+      "name": "IVectorCollectionFactory",
+      "fqn": "Granit.AI.VectorData.IVectorCollectionFactory",
+      "kind": "interface",
+      "project": "Granit.AI.VectorData",
+      "file": "src/Granit.AI.VectorData/IVectorCollectionFactory.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "VectorDataOptions",
+      "fqn": "Granit.AI.VectorData.Options.VectorDataOptions",
+      "kind": "class",
+      "project": "Granit.AI.VectorData",
+      "file": "src/Granit.AI.VectorData/Options/VectorDataOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "EmbeddingWorkspace",
+          "kind": "property",
+          "signature": "string EmbeddingWorkspace",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSearchLimit",
+          "kind": "property",
+          "signature": "int DefaultSearchLimit",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "SemanticSearchResult",
+      "fqn": "Granit.AI.VectorData.SemanticSearchResult",
+      "kind": "record",
+      "project": "Granit.AI.VectorData",
+      "file": "src/Granit.AI.VectorData/SemanticSearchResult.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "VectorSearchResult",
+      "fqn": "Granit.AI.VectorData.VectorSearchResult",
+      "kind": "record",
+      "project": "Granit.AI.VectorData",
+      "file": "src/Granit.AI.VectorData/VectorSearchResult.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "AIWorkspace",
+      "fqn": "Granit.AI.Workspaces.AIWorkspace",
+      "kind": "record",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Workspaces/AIWorkspace.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "required string Name",
+          "returnType": "required string"
+        },
+        {
+          "name": "TenantId",
+          "kind": "property",
+          "signature": "Guid? TenantId",
+          "returnType": "Guid?"
+        }
+      ]
+    },
+    {
+      "name": "AIWorkspaceKind",
+      "fqn": "Granit.AI.Workspaces.AIWorkspaceKind",
+      "kind": "enum",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Workspaces/AIWorkspaceKind.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "IAIWorkspaceDefinitionContext",
+      "fqn": "Granit.AI.Workspaces.IAIWorkspaceDefinitionContext",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Workspaces/IAIWorkspaceDefinitionContext.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Add",
+          "kind": "method",
+          "signature": "Add(AIWorkspace workspace)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IAIWorkspaceDefinitionProvider",
+      "fqn": "Granit.AI.Workspaces.IAIWorkspaceDefinitionProvider",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Workspaces/IAIWorkspaceDefinitionProvider.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Define",
+          "kind": "method",
+          "signature": "Define(IAIWorkspaceDefinitionContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IAIWorkspaceManager",
+      "fqn": "Granit.AI.Workspaces.IAIWorkspaceManager",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Workspaces/IAIWorkspaceManager.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(AIWorkspace workspace, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UpdateAsync",
+          "kind": "method",
+          "signature": "UpdateAsync(AIWorkspace workspace, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(string workspaceName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IAIWorkspaceProvider",
+      "fqn": "Granit.AI.Workspaces.IAIWorkspaceProvider",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Workspaces/IAIWorkspaceProvider.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(string workspaceName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<AIWorkspace?>"
+        },
+        {
+          "name": "GetAllAsync",
+          "kind": "method",
+          "signature": "GetAllAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<AIWorkspace>>"
+        }
+      ]
+    },
+    {
+      "name": "IAIWorkspaceStoreReader",
+      "fqn": "Granit.AI.Workspaces.IAIWorkspaceStoreReader",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Workspaces/IAIWorkspaceStoreReader.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "FindAsync",
+          "kind": "method",
+          "signature": "FindAsync(string workspaceName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<AIWorkspace?>"
+        },
+        {
+          "name": "GetAllAsync",
+          "kind": "method",
+          "signature": "GetAllAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<AIWorkspace>>"
+        }
+      ]
+    },
+    {
+      "name": "IAIWorkspaceStoreWriter",
+      "fqn": "Granit.AI.Workspaces.IAIWorkspaceStoreWriter",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Workspaces/IAIWorkspaceStoreWriter.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "SaveAsync",
+          "kind": "method",
+          "signature": "SaveAsync(AIWorkspace workspace, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UpdateAsync",
+          "kind": "method",
+          "signature": "UpdateAsync(AIWorkspace workspace, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(string workspaceName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "AlterColumnWithoutContractAnalyzer",
+      "fqn": "Granit.Analyzers.AlterColumnWithoutContractAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/AlterColumnWithoutContractAnalyzer.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "CrossModuleReferenceCodeFixProvider",
+      "fqn": "Granit.Analyzers.CodeFixes.CrossModuleReferenceCodeFixProvider",
+      "kind": "class",
+      "project": "Granit.Analyzers.CodeFixes",
+      "file": "src/Granit.Analyzers.CodeFixes/CrossModuleReferenceCodeFixProvider.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "FixableDiagnosticIds",
+          "kind": "property",
+          "signature": "ImmutableArray<string> FixableDiagnosticIds",
+          "returnType": "ImmutableArray<string>"
+        },
+        {
+          "name": "GetFixAllProvider",
+          "kind": "method",
+          "signature": "GetFixAllProvider()",
+          "returnType": "FixAllProvider"
+        },
+        {
+          "name": "RegisterCodeFixesAsync",
+          "kind": "method",
+          "signature": "RegisterCodeFixesAsync(CodeFixContext context)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "DateTimeNowCodeFixProvider",
+      "fqn": "Granit.Analyzers.CodeFixes.DateTimeNowCodeFixProvider",
+      "kind": "class",
+      "project": "Granit.Analyzers.CodeFixes",
+      "file": "src/Granit.Analyzers.CodeFixes/DateTimeNowCodeFixProvider.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "DependencyInjectionCodeFixProviderBase",
+      "fqn": "Granit.Analyzers.CodeFixes.DependencyInjectionCodeFixProviderBase",
+      "kind": "class",
+      "project": "Granit.Analyzers.CodeFixes",
+      "file": "src/Granit.Analyzers.CodeFixes/DependencyInjectionCodeFixProviderBase.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "FixableDiagnosticIds",
+          "kind": "property",
+          "signature": "sealed ImmutableArray<string> FixableDiagnosticIds",
+          "returnType": "sealed ImmutableArray<string>"
+        },
+        {
+          "name": "GetFixAllProvider",
+          "kind": "method",
+          "signature": "GetFixAllProvider()",
+          "returnType": "sealed FixAllProvider"
+        },
+        {
+          "name": "RegisterCodeFixesAsync",
+          "kind": "method",
+          "signature": "RegisterCodeFixesAsync(CodeFixContext context)",
+          "returnType": "sealed Task"
+        }
+      ]
+    },
+    {
+      "name": "DirectCookieAccessCodeFixProvider",
+      "fqn": "Granit.Analyzers.CodeFixes.DirectCookieAccessCodeFixProvider",
+      "kind": "class",
+      "project": "Granit.Analyzers.CodeFixes",
+      "file": "src/Granit.Analyzers.CodeFixes/DirectCookieAccessCodeFixProvider.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "GuidNewGuidCodeFixProvider",
+      "fqn": "Granit.Analyzers.CodeFixes.GuidNewGuidCodeFixProvider",
+      "kind": "class",
+      "project": "Granit.Analyzers.CodeFixes",
+      "file": "src/Granit.Analyzers.CodeFixes/GuidNewGuidCodeFixProvider.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "MinimalApiServiceParameterCodeFixProvider",
+      "fqn": "Granit.Analyzers.CodeFixes.MinimalApiServiceParameterCodeFixProvider",
+      "kind": "class",
+      "project": "Granit.Analyzers.CodeFixes",
+      "file": "src/Granit.Analyzers.CodeFixes/MinimalApiServiceParameterCodeFixProvider.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "FixableDiagnosticIds",
+          "kind": "property",
+          "signature": "ImmutableArray<string> FixableDiagnosticIds",
+          "returnType": "ImmutableArray<string>"
+        },
+        {
+          "name": "GetFixAllProvider",
+          "kind": "method",
+          "signature": "GetFixAllProvider()",
+          "returnType": "FixAllProvider"
+        },
+        {
+          "name": "RegisterCodeFixesAsync",
+          "kind": "method",
+          "signature": "RegisterCodeFixesAsync(CodeFixContext context)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "SynchronousSaveChangesCodeFixProvider",
+      "fqn": "Granit.Analyzers.CodeFixes.SynchronousSaveChangesCodeFixProvider",
+      "kind": "class",
+      "project": "Granit.Analyzers.CodeFixes",
+      "file": "src/Granit.Analyzers.CodeFixes/SynchronousSaveChangesCodeFixProvider.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "FixableDiagnosticIds",
+          "kind": "property",
+          "signature": "ImmutableArray<string> FixableDiagnosticIds",
+          "returnType": "ImmutableArray<string>"
+        },
+        {
+          "name": "GetFixAllProvider",
+          "kind": "method",
+          "signature": "GetFixAllProvider()",
+          "returnType": "FixAllProvider"
+        },
+        {
+          "name": "RegisterCodeFixesAsync",
+          "kind": "method",
+          "signature": "RegisterCodeFixesAsync(CodeFixContext context)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "TypedResultsBadRequestCodeFixProvider",
+      "fqn": "Granit.Analyzers.CodeFixes.TypedResultsBadRequestCodeFixProvider",
+      "kind": "class",
+      "project": "Granit.Analyzers.CodeFixes",
+      "file": "src/Granit.Analyzers.CodeFixes/TypedResultsBadRequestCodeFixProvider.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "FixableDiagnosticIds",
+          "kind": "property",
+          "signature": "ImmutableArray<string> FixableDiagnosticIds",
+          "returnType": "ImmutableArray<string>"
+        },
+        {
+          "name": "GetFixAllProvider",
+          "kind": "method",
+          "signature": "GetFixAllProvider()",
+          "returnType": "FixAllProvider"
+        },
+        {
+          "name": "RegisterCodeFixesAsync",
+          "kind": "method",
+          "signature": "RegisterCodeFixesAsync(CodeFixContext context)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "UntypedResultsCodeFixProvider",
+      "fqn": "Granit.Analyzers.CodeFixes.UntypedResultsCodeFixProvider",
+      "kind": "class",
+      "project": "Granit.Analyzers.CodeFixes",
+      "file": "src/Granit.Analyzers.CodeFixes/UntypedResultsCodeFixProvider.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "FixableDiagnosticIds",
+          "kind": "property",
+          "signature": "ImmutableArray<string> FixableDiagnosticIds",
+          "returnType": "ImmutableArray<string>"
+        },
+        {
+          "name": "GetFixAllProvider",
+          "kind": "method",
+          "signature": "GetFixAllProvider()",
+          "returnType": "FixAllProvider"
+        },
+        {
+          "name": "RegisterCodeFixesAsync",
+          "kind": "method",
+          "signature": "RegisterCodeFixesAsync(CodeFixContext context)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "CrossModuleReferenceAnalyzer",
+      "fqn": "Granit.Analyzers.CrossModuleReferenceAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/CrossModuleReferenceAnalyzer.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "DateTimeNowAnalyzer",
+      "fqn": "Granit.Analyzers.DateTimeNowAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/DateTimeNowAnalyzer.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "DirectCookieAccessAnalyzer",
+      "fqn": "Granit.Analyzers.DirectCookieAccessAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/DirectCookieAccessAnalyzer.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "DropColumnWithoutContractAnalyzer",
+      "fqn": "Granit.Analyzers.DropColumnWithoutContractAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/DropColumnWithoutContractAnalyzer.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "EfCoreMigrationAnalyzerBase",
+      "fqn": "Granit.Analyzers.EfCoreMigrationAnalyzerBase",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/MigrationAnalyzerBase.cs",
+      "line": 77,
+      "members": []
+    },
+    {
+      "name": "GranitMigrationAnalyzerBase",
+      "fqn": "Granit.Analyzers.GranitMigrationAnalyzerBase",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/MigrationAnalyzerBase.cs",
+      "line": 31,
+      "members": []
+    },
+    {
+      "name": "GuidNewGuidAnalyzer",
+      "fqn": "Granit.Analyzers.GuidNewGuidAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/GuidNewGuidAnalyzer.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "HardcodedSecretAnalyzer",
+      "fqn": "Granit.Analyzers.HardcodedSecretAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/HardcodedSecretAnalyzer.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "MigrationAnalyzerBase",
+      "fqn": "Granit.Analyzers.MigrationAnalyzerBase",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/MigrationAnalyzerBase.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "MinimalApiServiceParameterAnalyzer",
+      "fqn": "Granit.Analyzers.MinimalApiServiceParameterAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/MinimalApiServiceParameterAnalyzer.cs",
+      "line": 31,
+      "members": []
+    },
+    {
+      "name": "NullableColumnInExpandAnalyzer",
+      "fqn": "Granit.Analyzers.NullableColumnInExpandAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/NullableColumnInExpandAnalyzer.cs",
+      "line": 24,
+      "members": []
+    },
+    {
+      "name": "RenameColumnForbiddenAnalyzer",
+      "fqn": "Granit.Analyzers.RenameColumnForbiddenAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/RenameColumnForbiddenAnalyzer.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "SingleRuleAnalyzerBase",
+      "fqn": "Granit.Analyzers.SingleRuleAnalyzerBase",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/SingleRuleAnalyzerBase.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "Initialize",
+          "kind": "method",
+          "signature": "Initialize(AnalysisContext context)",
+          "returnType": "sealed void"
+        }
+      ]
+    },
+    {
+      "name": "SynchronousSaveChangesAnalyzer",
+      "fqn": "Granit.Analyzers.SynchronousSaveChangesAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/SynchronousSaveChangesAnalyzer.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "TypedResultsBadRequestAnalyzer",
+      "fqn": "Granit.Analyzers.TypedResultsBadRequestAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/TypedResultsBadRequestAnalyzer.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "UntypedResultsAnalyzer",
+      "fqn": "Granit.Analyzers.UntypedResultsAnalyzer",
+      "kind": "class",
+      "project": "Granit.Analyzers",
+      "file": "src/Granit.Analyzers/UntypedResultsAnalyzer.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "AuditLogQuery",
+      "fqn": "Granit.AuditLog.Abstractions.AuditLogQuery",
+      "kind": "record",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Abstractions/AuditLogQuery.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "IAuditLogEntryPublisher",
+      "fqn": "Granit.AuditLog.Abstractions.IAuditLogEntryPublisher",
+      "kind": "interface",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Abstractions/IAuditLogEntryPublisher.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "PublishAsync",
+          "kind": "method",
+          "signature": "PublishAsync(AuditLogBatch batch, CancellationToken cancellationToken = default)",
+          "returnType": "ValueTask"
+        }
+      ]
+    },
+    {
+      "name": "IAuditLogReader",
+      "fqn": "Granit.AuditLog.Abstractions.IAuditLogReader",
+      "kind": "interface",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Abstractions/IAuditLogReader.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "GetByIdAsync",
+          "kind": "method",
+          "signature": "GetByIdAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<AuditLogEntry?>"
+        },
+        {
+          "name": "GetPagedAsync",
+          "kind": "method",
+          "signature": "GetPagedAsync(AuditLogQuery query, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<AuditLogEntry>>"
+        },
+        {
+          "name": "GetByEntityAsync",
+          "kind": "method",
+          "signature": "GetByEntityAsync(string entityType, string entityId, int page = 1, int pageSize = QueryingDefaults.DefaultPageSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<AuditLogEntry>>"
+        }
+      ]
+    },
+    {
+      "name": "IAuditLogWriter",
+      "fqn": "Granit.AuditLog.Abstractions.IAuditLogWriter",
+      "kind": "interface",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Abstractions/IAuditLogWriter.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "WriteAsync",
+          "kind": "method",
+          "signature": "WriteAsync(AuditLogEntry entry, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "AuditIgnoreAttribute",
+      "fqn": "Granit.AuditLog.Attributes.AuditIgnoreAttribute",
+      "kind": "class",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Attributes/AuditIgnoreAttribute.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "AuditSensitiveAttribute",
+      "fqn": "Granit.AuditLog.Attributes.AuditSensitiveAttribute",
+      "kind": "class",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Attributes/AuditSensitiveAttribute.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "GranitAuditLogConfigurationChangesModule",
+      "fqn": "Granit.AuditLog.ConfigurationChanges.GranitAuditLogConfigurationChangesModule",
+      "kind": "class",
+      "project": "Granit.AuditLog.ConfigurationChanges",
+      "file": "src/Granit.AuditLog.ConfigurationChanges/GranitAuditLogConfigurationChangesModule.cs",
+      "line": 31,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "FeatureOverrideChangedAuditHandler",
+      "fqn": "Granit.AuditLog.ConfigurationChanges.Handlers.FeatureOverrideChangedAuditHandler",
+      "kind": "class",
+      "project": "Granit.AuditLog.ConfigurationChanges",
+      "file": "src/Granit.AuditLog.ConfigurationChanges/Handlers/FeatureOverrideChangedAuditHandler.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(FeatureOverrideChangedEvent localEvent, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "SettingChangedAuditHandler",
+      "fqn": "Granit.AuditLog.ConfigurationChanges.Handlers.SettingChangedAuditHandler",
+      "kind": "class",
+      "project": "Granit.AuditLog.ConfigurationChanges",
+      "file": "src/Granit.AuditLog.ConfigurationChanges/Handlers/SettingChangedAuditHandler.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(SettingChangedEvent localEvent, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "AuditChangeType",
+      "fqn": "Granit.AuditLog.Domain.AuditChangeType",
+      "kind": "enum",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Domain/AuditChangeType.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "AuditEntityChange",
+      "fqn": "Granit.AuditLog.Domain.AuditEntityChange",
+      "kind": "class",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Domain/AuditEntityChange.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "AuditLogEntryId",
+          "kind": "property",
+          "signature": "Guid AuditLogEntryId",
+          "returnType": "Guid"
+        },
+        {
+          "name": "EntityId",
+          "kind": "property",
+          "signature": "string EntityId",
+          "returnType": "string"
+        },
+        {
+          "name": "ChangeType",
+          "kind": "property",
+          "signature": "AuditChangeType ChangeType",
+          "returnType": "AuditChangeType"
+        }
+      ]
+    },
+    {
+      "name": "AuditLogCategory",
+      "fqn": "Granit.AuditLog.Domain.AuditLogCategory",
+      "kind": "enum",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Domain/AuditLogCategory.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "AuditLogEntry",
+      "fqn": "Granit.AuditLog.Domain.AuditLogEntry",
+      "kind": "class",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Domain/AuditLogEntry.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Timestamp",
+          "kind": "property",
+          "signature": "DateTimeOffset Timestamp",
+          "returnType": "DateTimeOffset"
+        },
+        {
+          "name": "UserName",
+          "kind": "property",
+          "signature": "string? UserName",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "AuditPersistenceMode",
+      "fqn": "Granit.AuditLog.Domain.AuditPersistenceMode",
+      "kind": "enum",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Domain/AuditPersistenceMode.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "AuditPropertyChange",
+      "fqn": "Granit.AuditLog.Domain.AuditPropertyChange",
+      "kind": "class",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Domain/AuditPropertyChange.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "AuditEntityChangeId",
+          "kind": "property",
+          "signature": "Guid AuditEntityChangeId",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "AuditEntityChangeResponse",
+      "fqn": "Granit.AuditLog.Endpoints.Dtos.AuditEntityChangeResponse",
+      "kind": "record",
+      "project": "Granit.AuditLog.Endpoints",
+      "file": "src/Granit.AuditLog.Endpoints/Dtos/AuditEntityChangeResponse.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "AuditLogEntryDetailResponse",
+      "fqn": "Granit.AuditLog.Endpoints.Dtos.AuditLogEntryDetailResponse",
+      "kind": "record",
+      "project": "Granit.AuditLog.Endpoints",
+      "file": "src/Granit.AuditLog.Endpoints/Dtos/AuditLogEntryDetailResponse.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "AuditLogEntryResponse",
+      "fqn": "Granit.AuditLog.Endpoints.Dtos.AuditLogEntryResponse",
+      "kind": "record",
+      "project": "Granit.AuditLog.Endpoints",
+      "file": "src/Granit.AuditLog.Endpoints/Dtos/AuditLogEntryResponse.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "AuditLogQueryParameters",
+      "fqn": "Granit.AuditLog.Endpoints.Dtos.AuditLogQueryParameters",
+      "kind": "class",
+      "project": "Granit.AuditLog.Endpoints",
+      "file": "src/Granit.AuditLog.Endpoints/Dtos/AuditLogQueryParameters.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "AuditPropertyChangeResponse",
+      "fqn": "Granit.AuditLog.Endpoints.Dtos.AuditPropertyChangeResponse",
+      "kind": "record",
+      "project": "Granit.AuditLog.Endpoints",
+      "file": "src/Granit.AuditLog.Endpoints/Dtos/AuditPropertyChangeResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "AuditLogEndpointRouteBuilderExtensions",
+      "fqn": "Granit.AuditLog.Endpoints.Extensions.AuditLogEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AuditLog.Endpoints",
+      "file": "src/Granit.AuditLog.Endpoints/Extensions/AuditLogEndpointRouteBuilderExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "MapAuditLogEndpoints",
+          "kind": "method",
+          "signature": "MapAuditLogEndpoints(this IEndpointRouteBuilder endpoints, Action<AuditLogEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuditLogEndpointsModule",
+      "fqn": "Granit.AuditLog.Endpoints.GranitAuditLogEndpointsModule",
+      "kind": "class",
+      "project": "Granit.AuditLog.Endpoints",
+      "file": "src/Granit.AuditLog.Endpoints/GranitAuditLogEndpointsModule.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "AuditLogEndpointsOptions",
+      "fqn": "Granit.AuditLog.Endpoints.Options.AuditLogEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.AuditLog.Endpoints",
+      "file": "src/Granit.AuditLog.Endpoints/Options/AuditLogEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "AuthorizationPolicy",
+          "kind": "property",
+          "signature": "string AuthorizationPolicy",
+          "returnType": "string"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "AuditLogMetrics",
+      "fqn": "Granit.AuditLog.EntityFrameworkCore.Diagnostics.AuditLogMetrics",
+      "kind": "class",
+      "project": "Granit.AuditLog.EntityFrameworkCore",
+      "file": "src/Granit.AuditLog.EntityFrameworkCore/Diagnostics/AuditLogMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordPurged",
+          "kind": "method",
+          "signature": "RecordPurged(long count, string category)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordCaptureError",
+          "kind": "method",
+          "signature": "RecordCaptureError(string? tenantId)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AuditLogEntityFrameworkCoreServiceCollectionExtensions",
+      "fqn": "Granit.AuditLog.EntityFrameworkCore.Extensions.AuditLogEntityFrameworkCoreServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.AuditLog.EntityFrameworkCore",
+      "file": "src/Granit.AuditLog.EntityFrameworkCore/Extensions/AuditLogEntityFrameworkCoreServiceCollectionExtensions.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "AddGranitAuditLogEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitAuditLogEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "AuditLogModelBuilderExtensions",
+      "fqn": "Granit.AuditLog.EntityFrameworkCore.Extensions.AuditLogModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.AuditLog.EntityFrameworkCore",
+      "file": "src/Granit.AuditLog.EntityFrameworkCore/Extensions/AuditLogModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureAuditLogModule",
+          "kind": "method",
+          "signature": "ConfigureAuditLogModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "DbContextOptionsBuilderAuditLogExtensions",
+      "fqn": "Granit.AuditLog.EntityFrameworkCore.Extensions.DbContextOptionsBuilderAuditLogExtensions",
+      "kind": "class",
+      "project": "Granit.AuditLog.EntityFrameworkCore",
+      "file": "src/Granit.AuditLog.EntityFrameworkCore/Extensions/DbContextOptionsBuilderAuditLogExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "UseGranitAuditLogInterceptor",
+          "kind": "method",
+          "signature": "UseGranitAuditLogInterceptor(this DbContextOptionsBuilder options, IServiceProvider serviceProvider)",
+          "returnType": "DbContextOptionsBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuditLogDbProperties",
+      "fqn": "Granit.AuditLog.EntityFrameworkCore.GranitAuditLogDbProperties",
+      "kind": "class",
+      "project": "Granit.AuditLog.EntityFrameworkCore",
+      "file": "src/Granit.AuditLog.EntityFrameworkCore/GranitAuditLogDbProperties.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuditLogEntityFrameworkCoreModule",
+      "fqn": "Granit.AuditLog.EntityFrameworkCore.GranitAuditLogEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.AuditLog.EntityFrameworkCore",
+      "file": "src/Granit.AuditLog.EntityFrameworkCore/GranitAuditLogEntityFrameworkCoreModule.cs",
+      "line": 23,
+      "members": []
+    },
+    {
+      "name": "AuditLogChangeTrackingInterceptor",
+      "fqn": "Granit.AuditLog.EntityFrameworkCore.Interceptors.AuditLogChangeTrackingInterceptor",
+      "kind": "class",
+      "project": "Granit.AuditLog.EntityFrameworkCore",
+      "file": "src/Granit.AuditLog.EntityFrameworkCore/Interceptors/AuditLogChangeTrackingInterceptor.cs",
+      "line": 32,
+      "members": [
+        {
+          "name": "SavingChanges",
+          "kind": "method",
+          "signature": "SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)",
+          "returnType": "InterceptionResult<int>"
+        }
+      ]
+    },
+    {
+      "name": "AuditLogServiceCollectionExtensions",
+      "fqn": "Granit.AuditLog.Extensions.AuditLogServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Extensions/AuditLogServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitAuditLog",
+          "kind": "method",
+          "signature": "AddGranitAuditLog(this IServiceCollection services, Action<AuditLogOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuditLogModule",
+      "fqn": "Granit.AuditLog.GranitAuditLogModule",
+      "kind": "class",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/GranitAuditLogModule.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AuditEntityChangeSnapshot",
+      "fqn": "Granit.AuditLog.Messages.AuditEntityChangeSnapshot",
+      "kind": "record",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Messages/AuditEntityChangeSnapshot.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "AuditLogBatch",
+      "fqn": "Granit.AuditLog.Messages.AuditLogBatch",
+      "kind": "record",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Messages/AuditLogBatch.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "AuditPropertyChangeSnapshot",
+      "fqn": "Granit.AuditLog.Messages.AuditPropertyChangeSnapshot",
+      "kind": "record",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Messages/AuditPropertyChangeSnapshot.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "AuditLogOptions",
+      "fqn": "Granit.AuditLog.Options.AuditLogOptions",
+      "kind": "class",
+      "project": "Granit.AuditLog",
+      "file": "src/Granit.AuditLog/Options/AuditLogOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "PersistenceMode",
+          "kind": "property",
+          "signature": "AuditPersistenceMode PersistenceMode",
+          "returnType": "AuditPersistenceMode"
+        },
+        {
+          "name": "EnablePropertyTracking",
+          "kind": "property",
+          "signature": "bool EnablePropertyTracking",
+          "returnType": "bool"
+        },
+        {
+          "name": "PersistenceBatchSize",
+          "kind": "property",
+          "signature": "int PersistenceBatchSize",
+          "returnType": "int"
+        },
+        {
+          "name": "FromDays",
+          "kind": "method",
+          "signature": "FromDays(2555)",
+          "returnType": "TimeSpan ConfigurationChangeRetention { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromDays",
+          "kind": "method",
+          "signature": "FromDays(365)",
+          "returnType": "TimeSpan DataMutationRetention { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromDays",
+          "kind": "method",
+          "signature": "FromDays(90)",
+          "returnType": "TimeSpan DataAccessRetention { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromDays",
+          "kind": "method",
+          "signature": "FromDays(2555)",
+          "returnType": "TimeSpan AccessDeniedRetention { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(30)",
+          "returnType": "TimeSpan CacheEntryTtl { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(2)",
+          "returnType": "TimeSpan CacheEntityQueryTtl { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromHours",
+          "kind": "method",
+          "signature": "FromHours(24)",
+          "returnType": "TimeSpan CleanupInterval { get; set; } = TimeSpan."
+        },
+        {
+          "name": "CleanupBatchSize",
+          "kind": "property",
+          "signature": "int CleanupBatchSize",
+          "returnType": "int"
+        },
+        {
+          "name": "GetRetention",
+          "kind": "method",
+          "signature": "GetRetention(AuditLogCategory category)",
+          "returnType": "TimeSpan"
+        }
+      ]
+    },
+    {
+      "name": "ApiKeyAuthenticationDefaults",
+      "fqn": "Granit.Authentication.ApiKeys.ApiKeyAuthenticationDefaults",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/ApiKeyAuthenticationDefaults.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ApiKeyClaimTypes",
+      "fqn": "Granit.Authentication.ApiKeys.ApiKeyClaimTypes",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/ApiKeyClaimTypes.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ApiKeyGenerationResult",
+      "fqn": "Granit.Authentication.ApiKeys.ApiKeyGenerationResult",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/IApiKeyGenerator.cs",
+      "line": 26,
+      "members": []
+    },
+    {
+      "name": "ApiKeyType",
+      "fqn": "Granit.Authentication.ApiKeys.ApiKeyType",
+      "kind": "enum",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/ApiKeyType.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "CacheBehavior",
+      "fqn": "Granit.Authentication.ApiKeys.CacheBehavior",
+      "kind": "enum",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/CacheBehavior.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "CidrValidator",
+      "fqn": "Granit.Authentication.ApiKeys.CidrValidator",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/CidrValidator.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "IsAllowed",
+          "kind": "method",
+          "signature": "IsAllowed(IPAddress? ipAddress, IReadOnlyList<string> allowedCidrs)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "ApiKeyEntry",
+      "fqn": "Granit.Authentication.ApiKeys.Domain.ApiKeyEntry",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/Domain/ApiKeyEntry.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, string name, ApiKeyType type, string environment, string hashedKey, string prefix, string lastFourChars, Guid? tenantId = null)",
+          "returnType": "ApiKeyEntry"
+        },
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Type",
+          "kind": "property",
+          "signature": "ApiKeyType Type",
+          "returnType": "ApiKeyType"
+        },
+        {
+          "name": "HashedKey",
+          "kind": "property",
+          "signature": "string HashedKey",
+          "returnType": "string"
+        },
+        {
+          "name": "Prefix",
+          "kind": "property",
+          "signature": "string Prefix",
+          "returnType": "string"
+        },
+        {
+          "name": "LastFourChars",
+          "kind": "property",
+          "signature": "string LastFourChars",
+          "returnType": "string"
+        },
+        {
+          "name": "Permissions",
+          "kind": "property",
+          "signature": "List<string> Permissions",
+          "returnType": "List<string>"
+        },
+        {
+          "name": "AllowedCidrs",
+          "kind": "property",
+          "signature": "List<string> AllowedCidrs",
+          "returnType": "List<string>"
+        },
+        {
+          "name": "UpdateAllowedCidrs",
+          "kind": "method",
+          "signature": "UpdateAllowedCidrs(List<string> cidrs)",
+          "returnType": "void"
+        },
+        {
+          "name": "SetExpiration",
+          "kind": "method",
+          "signature": "SetExpiration(DateTimeOffset? expiresAt)",
+          "returnType": "void"
+        },
+        {
+          "name": "SetCacheBehavior",
+          "kind": "method",
+          "signature": "SetCacheBehavior(CacheBehavior cacheBehavior)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ApiKeyCreateRequest",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Dtos.ApiKeyCreateRequest",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Dtos/ApiKeyCreateRequest.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "ApiKeyCreateResponse",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Dtos.ApiKeyCreateResponse",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Dtos/ApiKeyCreateResponse.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "ApiKeyResponse",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Dtos.ApiKeyResponse",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Dtos/ApiKeyResponse.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "ApiKeyRotateResponse",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Dtos.ApiKeyRotateResponse",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Dtos/ApiKeyRotateResponse.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "ApiKeyUpdateScopesRequest",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Dtos.ApiKeyUpdateScopesRequest",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Dtos/ApiKeyUpdateScopesRequest.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ApiKeysEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Extensions.ApiKeysEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Extensions/ApiKeysEndpointRouteBuilderExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "MapApiKeysEndpoints",
+          "kind": "method",
+          "signature": "MapApiKeysEndpoints(this IEndpointRouteBuilder endpoints, Action<ApiKeysEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "ApiKeysEndpointsServiceCollectionExtensions",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Extensions.ApiKeysEndpointsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Extensions/ApiKeysEndpointsServiceCollectionExtensions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "AddGranitApiKeysEndpoints",
+          "kind": "method",
+          "signature": "AddGranitApiKeysEndpoints(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthenticationApiKeysEndpointsModule",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.GranitAuthenticationApiKeysEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/GranitAuthenticationApiKeysEndpointsModule.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "ApiKeysEndpointsOptions",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Options.ApiKeysEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Options/ApiKeysEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        },
+        {
+          "name": "AllowedEnvironments",
+          "kind": "property",
+          "signature": "IReadOnlyList<string> AllowedEnvironments",
+          "returnType": "IReadOnlyList<string>"
+        }
+      ]
+    },
+    {
+      "name": "ApiKeyPermissions",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Permissions.ApiKeyPermissions",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Permissions/ApiKeyPermissions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "Keys",
+      "fqn": "Granit.Authentication.ApiKeys.Endpoints.Permissions.Keys",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.Endpoints",
+      "file": "src/Granit.Authentication.ApiKeys.Endpoints/Permissions/ApiKeyPermissions.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "ApiKeysEntityFrameworkCoreServiceCollectionExtensions",
+      "fqn": "Granit.Authentication.ApiKeys.EntityFrameworkCore.Extensions.ApiKeysEntityFrameworkCoreServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.EntityFrameworkCore",
+      "file": "src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Extensions/ApiKeysEntityFrameworkCoreServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitApiKeysEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitApiKeysEntityFrameworkCore(this IServiceCollection services, Action<DbContextOptionsBuilder> configureDbContext)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "ApiKeysModelBuilderExtensions",
+      "fqn": "Granit.Authentication.ApiKeys.EntityFrameworkCore.Extensions.ApiKeysModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.EntityFrameworkCore",
+      "file": "src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Extensions/ApiKeysModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureApiKeysModule",
+          "kind": "method",
+          "signature": "ConfigureApiKeysModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitApiKeysDbProperties",
+      "fqn": "Granit.Authentication.ApiKeys.EntityFrameworkCore.GranitApiKeysDbProperties",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.EntityFrameworkCore",
+      "file": "src/Granit.Authentication.ApiKeys.EntityFrameworkCore/GranitApiKeysDbProperties.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthenticationApiKeysEntityFrameworkCoreModule",
+      "fqn": "Granit.Authentication.ApiKeys.EntityFrameworkCore.GranitAuthenticationApiKeysEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys.EntityFrameworkCore",
+      "file": "src/Granit.Authentication.ApiKeys.EntityFrameworkCore/GranitAuthenticationApiKeysEntityFrameworkCoreModule.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "ApiKeyCreatedEvent",
+      "fqn": "Granit.Authentication.ApiKeys.Events.ApiKeyCreatedEvent",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/Events/ApiKeyCreatedEvent.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ApiKeyExpiredEvent",
+      "fqn": "Granit.Authentication.ApiKeys.Events.ApiKeyExpiredEvent",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/Events/ApiKeyExpiredEvent.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "ApiKeyRevokedEvent",
+      "fqn": "Granit.Authentication.ApiKeys.Events.ApiKeyRevokedEvent",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/Events/ApiKeyRevokedEvent.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ApiKeyRotatedEvent",
+      "fqn": "Granit.Authentication.ApiKeys.Events.ApiKeyRotatedEvent",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/Events/ApiKeyRotatedEvent.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ApiKeyScopesUpdatedEvent",
+      "fqn": "Granit.Authentication.ApiKeys.Events.ApiKeyScopesUpdatedEvent",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/Events/ApiKeyScopesUpdatedEvent.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ApiKeyUsedEto",
+      "fqn": "Granit.Authentication.ApiKeys.Events.ApiKeyUsedEto",
+      "kind": "record",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/Events/ApiKeyUsedEto.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "ApiKeyServiceCollectionExtensions",
+      "fqn": "Granit.Authentication.ApiKeys.Extensions.ApiKeyServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/Extensions/ApiKeyServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitApiKeyAuthentication",
+          "kind": "method",
+          "signature": "AddGranitApiKeyAuthentication(this IServiceCollection services, Action<ApiKeyOptions>? configureOptions = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthenticationApiKeysModule",
+      "fqn": "Granit.Authentication.ApiKeys.GranitAuthenticationApiKeysModule",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/GranitAuthenticationApiKeysModule.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IApiKeyAdminStore",
+      "fqn": "Granit.Authentication.ApiKeys.IApiKeyAdminStore",
+      "kind": "interface",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/IApiKeyAdminStore.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "FindByIdAsync",
+          "kind": "method",
+          "signature": "FindByIdAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ApiKeyEntry?>"
+        },
+        {
+          "name": "ListAsync",
+          "kind": "method",
+          "signature": "ListAsync(string? search = null, ApiKeyType? type = null, string? environment = null, bool includeRevoked = false, int page = 1, int pageSize = 20, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<ApiKeyEntry>>"
+        },
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(ApiKeyEntry entry, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RevokeAsync",
+          "kind": "method",
+          "signature": "RevokeAsync(Guid id, DateTimeOffset revokedAt, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        },
+        {
+          "name": "UpdateScopesAsync",
+          "kind": "method",
+          "signature": "UpdateScopesAsync(Guid id, List<string> permissions, List<string> allowedCidrs, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "IApiKeyCacheService",
+      "fqn": "Granit.Authentication.ApiKeys.IApiKeyCacheService",
+      "kind": "interface",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/IApiKeyCacheService.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "GetOrLoadAsync",
+          "kind": "method",
+          "signature": "GetOrLoadAsync(string hashedKey, Func<CancellationToken, Task<ApiKeyEntry?>> factory, TimeSpan duration, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ApiKeyEntry?>"
+        },
+        {
+          "name": "RemoveAsync",
+          "kind": "method",
+          "signature": "RemoveAsync(string hashedKey, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IApiKeyGenerator",
+      "fqn": "Granit.Authentication.ApiKeys.IApiKeyGenerator",
+      "kind": "interface",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/IApiKeyGenerator.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Generate",
+          "kind": "method",
+          "signature": "Generate(ApiKeyType type, string environment)",
+          "returnType": "ApiKeyGenerationResult"
+        }
+      ]
+    },
+    {
+      "name": "IApiKeyStore",
+      "fqn": "Granit.Authentication.ApiKeys.IApiKeyStore",
+      "kind": "interface",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/IApiKeyStore.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "FindByHashAsync",
+          "kind": "method",
+          "signature": "FindByHashAsync(string hashedKey, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ApiKeyEntry?>"
+        },
+        {
+          "name": "UpdateLastUsedAsync",
+          "kind": "method",
+          "signature": "UpdateLastUsedAsync(Guid id, DateTimeOffset usedAt, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ApiKeyOptions",
+      "fqn": "Granit.Authentication.ApiKeys.Options.ApiKeyOptions",
+      "kind": "class",
+      "project": "Granit.Authentication.ApiKeys",
+      "file": "src/Granit.Authentication.ApiKeys/Options/ApiKeyOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(5)",
+          "returnType": "TimeSpan CacheDuration { get; set; } = TimeSpan."
+        },
+        {
+          "name": "TrackLastUsed",
+          "kind": "property",
+          "signature": "bool TrackLastUsed",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "CognitoClaimsTransformation",
+      "fqn": "Granit.Authentication.Cognito.Authentication.CognitoClaimsTransformation",
+      "kind": "class",
+      "project": "Granit.Authentication.Cognito",
+      "file": "src/Granit.Authentication.Cognito/Authentication/CognitoClaimsTransformation.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "TransformAsync",
+          "kind": "method",
+          "signature": "TransformAsync(ClaimsPrincipal principal)",
+          "returnType": "Task<ClaimsPrincipal>"
+        }
+      ]
+    },
+    {
+      "name": "CognitoServiceCollectionExtensions",
+      "fqn": "Granit.Authentication.Cognito.Extensions.CognitoServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.Cognito",
+      "file": "src/Granit.Authentication.Cognito/Extensions/CognitoServiceCollectionExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitCognito",
+          "kind": "method",
+          "signature": "AddGranitCognito(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthenticationCognitoModule",
+      "fqn": "Granit.Authentication.Cognito.GranitAuthenticationCognitoModule",
+      "kind": "class",
+      "project": "Granit.Authentication.Cognito",
+      "file": "src/Granit.Authentication.Cognito/GranitAuthenticationCognitoModule.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "CognitoOptions",
+      "fqn": "Granit.Authentication.Cognito.Options.CognitoOptions",
+      "kind": "class",
+      "project": "Granit.Authentication.Cognito",
+      "file": "src/Granit.Authentication.Cognito/Options/CognitoOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Authority",
+          "kind": "property",
+          "signature": "string Authority",
+          "returnType": "string"
+        },
+        {
+          "name": "ClientId",
+          "kind": "property",
+          "signature": "string ClientId",
+          "returnType": "string"
+        },
+        {
+          "name": "RequireHttpsMetadata",
+          "kind": "property",
+          "signature": "bool RequireHttpsMetadata",
+          "returnType": "bool"
+        },
+        {
+          "name": "Audience",
+          "kind": "property",
+          "signature": "string? Audience",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "EntraIdClaimsTransformation",
+      "fqn": "Granit.Authentication.EntraId.Authentication.EntraIdClaimsTransformation",
+      "kind": "class",
+      "project": "Granit.Authentication.EntraId",
+      "file": "src/Granit.Authentication.EntraId/Authentication/EntraIdClaimsTransformation.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "TransformAsync",
+          "kind": "method",
+          "signature": "TransformAsync(ClaimsPrincipal principal)",
+          "returnType": "Task<ClaimsPrincipal>"
+        }
+      ]
+    },
+    {
+      "name": "EntraIdServiceCollectionExtensions",
+      "fqn": "Granit.Authentication.EntraId.Extensions.EntraIdServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.EntraId",
+      "file": "src/Granit.Authentication.EntraId/Extensions/EntraIdServiceCollectionExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitEntraId",
+          "kind": "method",
+          "signature": "AddGranitEntraId(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthenticationEntraIdModule",
+      "fqn": "Granit.Authentication.EntraId.GranitAuthenticationEntraIdModule",
+      "kind": "class",
+      "project": "Granit.Authentication.EntraId",
+      "file": "src/Granit.Authentication.EntraId/GranitAuthenticationEntraIdModule.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "EntraIdOptions",
+      "fqn": "Granit.Authentication.EntraId.Options.EntraIdOptions",
+      "kind": "class",
+      "project": "Granit.Authentication.EntraId",
+      "file": "src/Granit.Authentication.EntraId/Options/EntraIdOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Instance",
+          "kind": "property",
+          "signature": "string Instance",
+          "returnType": "string"
+        },
+        {
+          "name": "TenantId",
+          "kind": "property",
+          "signature": "string TenantId",
+          "returnType": "string"
+        },
+        {
+          "name": "ClientId",
+          "kind": "property",
+          "signature": "string ClientId",
+          "returnType": "string"
+        },
+        {
+          "name": "RequireHttpsMetadata",
+          "kind": "property",
+          "signature": "bool RequireHttpsMetadata",
+          "returnType": "bool"
+        },
+        {
+          "name": "AdminRole",
+          "kind": "property",
+          "signature": "string AdminRole",
+          "returnType": "string"
+        },
+        {
+          "name": "TrimEnd",
+          "kind": "method",
+          "signature": "TrimEnd('/')",
+          "returnType": "string Authority => $\"{Instance."
+        }
+      ]
+    },
+    {
+      "name": "GoogleCloudClaimsTransformation",
+      "fqn": "Granit.Authentication.GoogleCloud.Authentication.GoogleCloudClaimsTransformation",
+      "kind": "class",
+      "project": "Granit.Authentication.GoogleCloud",
+      "file": "src/Granit.Authentication.GoogleCloud/Authentication/GoogleCloudClaimsTransformation.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "TransformAsync",
+          "kind": "method",
+          "signature": "TransformAsync(ClaimsPrincipal principal)",
+          "returnType": "Task<ClaimsPrincipal>"
+        }
+      ]
+    },
+    {
+      "name": "GoogleCloudAuthenticationServiceCollectionExtensions",
+      "fqn": "Granit.Authentication.GoogleCloud.Extensions.GoogleCloudAuthenticationServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.GoogleCloud",
+      "file": "src/Granit.Authentication.GoogleCloud/Extensions/GoogleCloudAuthenticationServiceCollectionExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitGoogleCloudAuthentication",
+          "kind": "method",
+          "signature": "AddGranitGoogleCloudAuthentication(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthenticationGoogleCloudModule",
+      "fqn": "Granit.Authentication.GoogleCloud.GranitAuthenticationGoogleCloudModule",
+      "kind": "class",
+      "project": "Granit.Authentication.GoogleCloud",
+      "file": "src/Granit.Authentication.GoogleCloud/GranitAuthenticationGoogleCloudModule.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GoogleCloudAuthenticationOptions",
+      "fqn": "Granit.Authentication.GoogleCloud.Options.GoogleCloudAuthenticationOptions",
+      "kind": "class",
+      "project": "Granit.Authentication.GoogleCloud",
+      "file": "src/Granit.Authentication.GoogleCloud/Options/GoogleCloudAuthenticationOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ProjectId",
+          "kind": "property",
+          "signature": "string ProjectId",
+          "returnType": "string"
+        },
+        {
+          "name": "RequireHttpsMetadata",
+          "kind": "property",
+          "signature": "bool RequireHttpsMetadata",
+          "returnType": "bool"
+        },
+        {
+          "name": "AdminRole",
+          "kind": "property",
+          "signature": "string AdminRole",
+          "returnType": "string"
+        },
+        {
+          "name": "RolesClaimKey",
+          "kind": "property",
+          "signature": "string RolesClaimKey",
+          "returnType": "string"
+        },
+        {
+          "name": "Authority",
+          "kind": "property",
+          "signature": "string Authority",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "CurrentUserService",
+      "fqn": "Granit.Authentication.JwtBearer.Authentication.CurrentUserService",
+      "kind": "class",
+      "project": "Granit.Authentication.JwtBearer",
+      "file": "src/Granit.Authentication.JwtBearer/Authentication/CurrentUserService.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "FindFirstValue",
+          "kind": "method",
+          "signature": "FindFirstValue(ClaimTypes.NameIdentifier)",
+          "returnType": "string? UserId => User?."
+        },
+        {
+          "name": "UserName",
+          "kind": "property",
+          "signature": "string? UserName",
+          "returnType": "string?"
+        },
+        {
+          "name": "FindFirstValue",
+          "kind": "method",
+          "signature": "FindFirstValue(ClaimTypes.Email)",
+          "returnType": "string? Email => User?."
+        },
+        {
+          "name": "FindFirstValue",
+          "kind": "method",
+          "signature": "FindFirstValue(ClaimTypes.GivenName)",
+          "returnType": "string? FirstName => User?."
+        },
+        {
+          "name": "FindFirstValue",
+          "kind": "method",
+          "signature": "FindFirstValue(ClaimTypes.Surname)",
+          "returnType": "string? LastName => User?."
+        },
+        {
+          "name": "IsAuthenticated",
+          "kind": "property",
+          "signature": "bool IsAuthenticated",
+          "returnType": "bool"
+        },
+        {
+          "name": "GetRoles",
+          "kind": "method",
+          "signature": "GetRoles()",
+          "returnType": "IReadOnlyList<string>"
+        }
+      ]
+    },
+    {
+      "name": "BackChannelLogoutResult",
+      "fqn": "Granit.Authentication.JwtBearer.BackChannelLogout.BackChannelLogoutResult",
+      "kind": "record",
+      "project": "Granit.Authentication.JwtBearer",
+      "file": "src/Granit.Authentication.JwtBearer/BackChannelLogout/BackChannelLogoutResult.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "IRevokedSessionStore",
+      "fqn": "Granit.Authentication.JwtBearer.BackChannelLogout.IRevokedSessionStore",
+      "kind": "interface",
+      "project": "Granit.Authentication.JwtBearer",
+      "file": "src/Granit.Authentication.JwtBearer/BackChannelLogout/IRevokedSessionStore.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RevokeSessionAsync",
+          "kind": "method",
+          "signature": "RevokeSessionAsync(string sessionId, TimeSpan ttl, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "IsSessionRevokedAsync",
+          "kind": "method",
+          "signature": "IsSessionRevokedAsync(string sessionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "JwtBearerEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Authentication.JwtBearer.Extensions.JwtBearerEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.JwtBearer",
+      "file": "src/Granit.Authentication.JwtBearer/Extensions/JwtBearerEndpointRouteBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "MapBackChannelLogout",
+          "kind": "method",
+          "signature": "MapBackChannelLogout(this IEndpointRouteBuilder endpoints)",
+          "returnType": "IEndpointRouteBuilder"
+        }
+      ]
+    },
+    {
+      "name": "JwtBearerServiceCollectionExtensions",
+      "fqn": "Granit.Authentication.JwtBearer.Extensions.JwtBearerServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.JwtBearer",
+      "file": "src/Granit.Authentication.JwtBearer/Extensions/JwtBearerServiceCollectionExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "AddGranitJwtBearer",
+          "kind": "method",
+          "signature": "AddGranitJwtBearer(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitJwtBearerModule",
+      "fqn": "Granit.Authentication.JwtBearer.GranitJwtBearerModule",
+      "kind": "class",
+      "project": "Granit.Authentication.JwtBearer",
+      "file": "src/Granit.Authentication.JwtBearer/GranitJwtBearerModule.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "BackChannelLogoutOptions",
+      "fqn": "Granit.Authentication.JwtBearer.Options.BackChannelLogoutOptions",
+      "kind": "class",
+      "project": "Granit.Authentication.JwtBearer",
+      "file": "src/Granit.Authentication.JwtBearer/Options/BackChannelLogoutOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Enabled",
+          "kind": "property",
+          "signature": "bool Enabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "FromHours",
+          "kind": "method",
+          "signature": "FromHours(1)",
+          "returnType": "TimeSpan SessionRevocationTtl { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "JwtBearerAuthOptions",
+      "fqn": "Granit.Authentication.JwtBearer.Options.JwtBearerAuthOptions",
+      "kind": "class",
+      "project": "Granit.Authentication.JwtBearer",
+      "file": "src/Granit.Authentication.JwtBearer/Options/JwtBearerAuthOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Authority",
+          "kind": "property",
+          "signature": "string Authority",
+          "returnType": "string"
+        },
+        {
+          "name": "Audience",
+          "kind": "property",
+          "signature": "string Audience",
+          "returnType": "string"
+        },
+        {
+          "name": "RequireHttpsMetadata",
+          "kind": "property",
+          "signature": "bool RequireHttpsMetadata",
+          "returnType": "bool"
+        },
+        {
+          "name": "NameClaimType",
+          "kind": "property",
+          "signature": "string NameClaimType",
+          "returnType": "string"
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "BackChannelLogoutOptions BackChannelLogout { get; set; } ="
+        }
+      ]
+    },
+    {
+      "name": "KeycloakClaimsTransformation",
+      "fqn": "Granit.Authentication.Keycloak.Authentication.KeycloakClaimsTransformation",
+      "kind": "class",
+      "project": "Granit.Authentication.Keycloak",
+      "file": "src/Granit.Authentication.Keycloak/Authentication/KeycloakClaimsTransformation.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "TransformAsync",
+          "kind": "method",
+          "signature": "TransformAsync(ClaimsPrincipal principal)",
+          "returnType": "Task<ClaimsPrincipal>"
+        }
+      ]
+    },
+    {
+      "name": "KeycloakServiceCollectionExtensions",
+      "fqn": "Granit.Authentication.Keycloak.Extensions.KeycloakServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Authentication.Keycloak",
+      "file": "src/Granit.Authentication.Keycloak/Extensions/KeycloakServiceCollectionExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitKeycloak",
+          "kind": "method",
+          "signature": "AddGranitKeycloak(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthenticationKeycloakModule",
+      "fqn": "Granit.Authentication.Keycloak.GranitAuthenticationKeycloakModule",
+      "kind": "class",
+      "project": "Granit.Authentication.Keycloak",
+      "file": "src/Granit.Authentication.Keycloak/GranitAuthenticationKeycloakModule.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "KeycloakOptions",
+      "fqn": "Granit.Authentication.Keycloak.Options.KeycloakOptions",
+      "kind": "class",
+      "project": "Granit.Authentication.Keycloak",
+      "file": "src/Granit.Authentication.Keycloak/Options/KeycloakOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Authority",
+          "kind": "property",
+          "signature": "string Authority",
+          "returnType": "string"
+        },
+        {
+          "name": "ClientId",
+          "kind": "property",
+          "signature": "string ClientId",
+          "returnType": "string"
+        },
+        {
+          "name": "ClientSecret",
+          "kind": "property",
+          "signature": "string ClientSecret",
+          "returnType": "string"
+        },
+        {
+          "name": "RequireHttpsMetadata",
+          "kind": "property",
+          "signature": "bool RequireHttpsMetadata",
+          "returnType": "bool"
+        },
+        {
+          "name": "Audience",
+          "kind": "property",
+          "signature": "string? Audience",
+          "returnType": "string?"
+        },
+        {
+          "name": "RoleClaimsSource",
+          "kind": "property",
+          "signature": "string RoleClaimsSource",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "AccessRiskScore",
+      "fqn": "Granit.Authorization.AI.AccessRiskScore",
+      "kind": "record",
+      "project": "Granit.Authorization.AI",
+      "file": "src/Granit.Authorization.AI/AccessRiskScore.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "AuthorizationAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Authorization.AI.Extensions.AuthorizationAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Authorization.AI",
+      "file": "src/Granit.Authorization.AI/Extensions/AuthorizationAIHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitAuthorizationAI",
+          "kind": "method",
+          "signature": "AddGranitAuthorizationAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthorizationAIModule",
+      "fqn": "Granit.Authorization.AI.GranitAuthorizationAIModule",
+      "kind": "class",
+      "project": "Granit.Authorization.AI",
+      "file": "src/Granit.Authorization.AI/GranitAuthorizationAIModule.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "IAIAccessAnomalyDetector",
+      "fqn": "Granit.Authorization.AI.IAIAccessAnomalyDetector",
+      "kind": "interface",
+      "project": "Granit.Authorization.AI",
+      "file": "src/Granit.Authorization.AI/IAIAccessAnomalyDetector.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "EvaluateAccessAsync",
+          "kind": "method",
+          "signature": "EvaluateAccessAsync(string userId, string permission, string? context = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<AccessRiskScore>"
+        }
+      ]
+    },
+    {
+      "name": "AuthorizationAIOptions",
+      "fqn": "Granit.Authorization.AI.Options.AuthorizationAIOptions",
+      "kind": "class",
+      "project": "Granit.Authorization.AI",
+      "file": "src/Granit.Authorization.AI/Options/AuthorizationAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string WorkspaceName",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "IPermissionChecker",
+      "fqn": "Granit.Authorization.Abstractions.IPermissionChecker",
+      "kind": "interface",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Abstractions/IPermissionChecker.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "IsGrantedAsync",
+          "kind": "method",
+          "signature": "IsGrantedAsync(string permissionName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "IPermissionDefinitionContext",
+      "fqn": "Granit.Authorization.Abstractions.IPermissionDefinitionContext",
+      "kind": "interface",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Abstractions/IPermissionDefinitionContext.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "AddGroup",
+          "kind": "method",
+          "signature": "AddGroup(string name, LocalizableString? displayName = null)",
+          "returnType": "PermissionGroup"
+        }
+      ]
+    },
+    {
+      "name": "IPermissionDefinitionManager",
+      "fqn": "Granit.Authorization.Abstractions.IPermissionDefinitionManager",
+      "kind": "interface",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Abstractions/IPermissionDefinitionManager.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Exists",
+          "kind": "method",
+          "signature": "Exists(string name)",
+          "returnType": "bool"
+        },
+        {
+          "name": "Find",
+          "kind": "method",
+          "signature": "Find(string name)",
+          "returnType": "PermissionDefinition?"
+        },
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IReadOnlyList<PermissionDefinition>"
+        },
+        {
+          "name": "GetGroups",
+          "kind": "method",
+          "signature": "GetGroups()",
+          "returnType": "IReadOnlyList<PermissionGroup>"
+        }
+      ]
+    },
+    {
+      "name": "IPermissionDefinitionProvider",
+      "fqn": "Granit.Authorization.Abstractions.IPermissionDefinitionProvider",
+      "kind": "interface",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Abstractions/IPermissionDefinitionProvider.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "DefinePermissions",
+          "kind": "method",
+          "signature": "DefinePermissions(IPermissionDefinitionContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IPermissionGrantStore",
+      "fqn": "Granit.Authorization.Abstractions.IPermissionGrantStore",
+      "kind": "interface",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Abstractions/IPermissionGrantStore.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "IsGrantedAsync",
+          "kind": "method",
+          "signature": "IsGrantedAsync(string roleName, string permissionName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "IPermissionManagerReader",
+      "fqn": "Granit.Authorization.Abstractions.IPermissionManagerReader",
+      "kind": "interface",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Abstractions/IPermissionManagerReader.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "IsGrantedAsync",
+          "kind": "method",
+          "signature": "IsGrantedAsync(string permissionName, string roleName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        },
+        {
+          "name": "GetGrantedPermissionsAsync",
+          "kind": "method",
+          "signature": "GetGrantedPermissionsAsync(string roleName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<string>>"
+        },
+        {
+          "name": "GetGrantedRolesAsync",
+          "kind": "method",
+          "signature": "GetGrantedRolesAsync(string permissionName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<string>>"
+        }
+      ]
+    },
+    {
+      "name": "IPermissionManagerWriter",
+      "fqn": "Granit.Authorization.Abstractions.IPermissionManagerWriter",
+      "kind": "interface",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Abstractions/IPermissionManagerWriter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "SetAsync",
+          "kind": "method",
+          "signature": "SetAsync(string permissionName, string roleName, Guid? tenantId, bool isGranted, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "PermissionDefinition",
+      "fqn": "Granit.Authorization.Abstractions.PermissionDefinition",
+      "kind": "record",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Abstractions/PermissionDefinition.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "PermissionGroup",
+      "fqn": "Granit.Authorization.Abstractions.PermissionGroup",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Abstractions/PermissionGroup.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "DisplayName",
+          "kind": "property",
+          "signature": "LocalizableString? DisplayName",
+          "returnType": "LocalizableString?"
+        },
+        {
+          "name": "AsReadOnly",
+          "kind": "method",
+          "signature": "AsReadOnly()",
+          "returnType": "IReadOnlyList<PermissionDefinition> Permissions => _permissions."
+        },
+        {
+          "name": "AddPermission",
+          "kind": "method",
+          "signature": "AddPermission(string name, LocalizableString? displayName = null)",
+          "returnType": "PermissionDefinition"
+        }
+      ]
+    },
+    {
+      "name": "PermissionAttribute",
+      "fqn": "Granit.Authorization.Attributes.PermissionAttribute",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Attributes/PermissionAttribute.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "PermissionRequirement",
+      "fqn": "Granit.Authorization.Authorization.PermissionRequirement",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Authorization/PermissionRequirement.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "PermissionName",
+          "kind": "property",
+          "signature": "string PermissionName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "PermissionCacheInvalidationHandler",
+      "fqn": "Granit.Authorization.Cache.PermissionCacheInvalidationHandler",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Cache/PermissionCacheInvalidationHandler.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(PermissionGrantChangedEvent @event, IFusionCache cache, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "PermissionGrantCacheItem",
+      "fqn": "Granit.Authorization.Cache.PermissionGrantCacheItem",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Cache/PermissionGrantCacheItem.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "MyPermissionsResponse",
+      "fqn": "Granit.Authorization.Endpoints.Dtos.MyPermissionsResponse",
+      "kind": "record",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/Dtos/MyPermissionsResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "PermissionDefinitionResponse",
+      "fqn": "Granit.Authorization.Endpoints.Dtos.PermissionDefinitionResponse",
+      "kind": "record",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/Dtos/PermissionDefinitionResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "PermissionGrantResponse",
+      "fqn": "Granit.Authorization.Endpoints.Dtos.PermissionGrantResponse",
+      "kind": "record",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/Dtos/PermissionGrantResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "PermissionGroupResponse",
+      "fqn": "Granit.Authorization.Endpoints.Dtos.PermissionGroupResponse",
+      "kind": "record",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/Dtos/PermissionGroupResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "AuthorizationEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Authorization.Endpoints.Extensions.AuthorizationEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/Extensions/AuthorizationEndpointRouteBuilderExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "MapAuthorizationEndpoints",
+          "kind": "method",
+          "signature": "MapAuthorizationEndpoints(this IEndpointRouteBuilder endpoints, Action<AuthorizationEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthorizationEndpointsModule",
+      "fqn": "Granit.Authorization.Endpoints.GranitAuthorizationEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/GranitAuthorizationEndpointsModule.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "AuthorizationEndpointsOptions",
+      "fqn": "Granit.Authorization.Endpoints.Options.AuthorizationEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/Options/AuthorizationEndpointsOptions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "AuthorizationEndpointsPermissions",
+      "fqn": "Granit.Authorization.Endpoints.Permissions.AuthorizationEndpointsPermissions",
+      "kind": "class",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/Permissions/AuthorizationEndpointsPermissions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "Definitions",
+      "fqn": "Granit.Authorization.Endpoints.Permissions.Definitions",
+      "kind": "class",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/Permissions/AuthorizationEndpointsPermissions.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "Grants",
+      "fqn": "Granit.Authorization.Endpoints.Permissions.Grants",
+      "kind": "class",
+      "project": "Granit.Authorization.Endpoints",
+      "file": "src/Granit.Authorization.Endpoints/Permissions/AuthorizationEndpointsPermissions.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "IPermissionGrantDbContext",
+      "fqn": "Granit.Authorization.EntityFrameworkCore.DbContext.IPermissionGrantDbContext",
+      "kind": "interface",
+      "project": "Granit.Authorization.EntityFrameworkCore",
+      "file": "src/Granit.Authorization.EntityFrameworkCore/DbContext/IPermissionGrantDbContext.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "PermissionGrantModelBuilderExtensions",
+      "fqn": "Granit.Authorization.EntityFrameworkCore.DbContext.PermissionGrantModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Authorization.EntityFrameworkCore",
+      "file": "src/Granit.Authorization.EntityFrameworkCore/DbContext/PermissionGrantModelBuilderExtensions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "ConfigureAuthorizationModule",
+          "kind": "method",
+          "signature": "ConfigureAuthorizationModule(this ModelBuilder builder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "PermissionGrant",
+      "fqn": "Granit.Authorization.EntityFrameworkCore.Entities.PermissionGrant",
+      "kind": "class",
+      "project": "Granit.Authorization.EntityFrameworkCore",
+      "file": "src/Granit.Authorization.EntityFrameworkCore/Entities/PermissionGrant.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "RoleName",
+          "kind": "property",
+          "signature": "string RoleName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "AuthorizationEfCoreServiceCollectionExtensions",
+      "fqn": "Granit.Authorization.EntityFrameworkCore.Extensions.AuthorizationEfCoreServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Authorization.EntityFrameworkCore",
+      "file": "src/Granit.Authorization.EntityFrameworkCore/Extensions/AuthorizationEfCoreServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "GranitAuthorizationDbProperties",
+      "fqn": "Granit.Authorization.EntityFrameworkCore.GranitAuthorizationDbProperties",
+      "kind": "class",
+      "project": "Granit.Authorization.EntityFrameworkCore",
+      "file": "src/Granit.Authorization.EntityFrameworkCore/GranitAuthorizationDbProperties.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthorizationEntityFrameworkCoreModule",
+      "fqn": "Granit.Authorization.EntityFrameworkCore.GranitAuthorizationEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Authorization.EntityFrameworkCore",
+      "file": "src/Granit.Authorization.EntityFrameworkCore/GranitAuthorizationEntityFrameworkCoreModule.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "PermissionGrantChangedEvent",
+      "fqn": "Granit.Authorization.Events.PermissionGrantChangedEvent",
+      "kind": "record",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Events/PermissionGrantChangedEvent.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "AuthorizationServiceCollectionExtensions",
+      "fqn": "Granit.Authorization.Extensions.AuthorizationServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Extensions/AuthorizationServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitAuthorization",
+          "kind": "method",
+          "signature": "AddGranitAuthorization(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthorizationModule",
+      "fqn": "Granit.Authorization.GranitAuthorizationModule",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/GranitAuthorizationModule.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GranitAuthorizationOptions",
+      "fqn": "Granit.Authorization.Options.GranitAuthorizationOptions",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Options/GranitAuthorizationOptions.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "AdminRoles",
+          "kind": "property",
+          "signature": "IList<string> AdminRoles",
+          "returnType": "IList<string>"
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(5)",
+          "returnType": "TimeSpan CacheDuration { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "IBackgroundJobDispatcher",
+      "fqn": "Granit.BackgroundJobs.Abstractions.IBackgroundJobDispatcher",
+      "kind": "interface",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Abstractions/IBackgroundJobDispatcher.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "PublishAsync",
+          "kind": "method",
+          "signature": "PublishAsync(object message, IDictionary<string, string>? headers = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "ScheduleAsync",
+          "kind": "method",
+          "signature": "ScheduleAsync(object message, DateTimeOffset scheduledTime, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IDeadLetterQueueInspector",
+      "fqn": "Granit.BackgroundJobs.Abstractions.IDeadLetterQueueInspector",
+      "kind": "interface",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Abstractions/IDeadLetterQueueInspector.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "GetCountsAsync",
+          "kind": "method",
+          "signature": "GetCountsAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyDictionary<string, long>>"
+        }
+      ]
+    },
+    {
+      "name": "BackgroundJobHeaders",
+      "fqn": "Granit.BackgroundJobs.BackgroundJobHeaders",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/BackgroundJobHeaders.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobStatus",
+      "fqn": "Granit.BackgroundJobs.BackgroundJobStatus",
+      "kind": "record",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/BackgroundJobStatus.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobsMetrics",
+      "fqn": "Granit.BackgroundJobs.Diagnostics.BackgroundJobsMetrics",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Diagnostics/BackgroundJobsMetrics.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobDefinition",
+      "fqn": "Granit.BackgroundJobs.Domain.BackgroundJobDefinition",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Domain/BackgroundJobDefinition.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, string jobName, string cronExpression, string messageType)",
+          "returnType": "BackgroundJobDefinition"
+        },
+        {
+          "name": "JobName",
+          "kind": "property",
+          "signature": "string JobName",
+          "returnType": "string"
+        },
+        {
+          "name": "MessageType",
+          "kind": "property",
+          "signature": "string MessageType",
+          "returnType": "string"
+        },
+        {
+          "name": "CronExpression",
+          "kind": "property",
+          "signature": "string CronExpression",
+          "returnType": "string"
+        },
+        {
+          "name": "IsEnabled",
+          "kind": "property",
+          "signature": "bool IsEnabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "UpdateDefinition",
+          "kind": "method",
+          "signature": "UpdateDefinition(string cronExpression, string messageType)",
+          "returnType": "DateTimeOffset? LastExecutedAt { get; private set; } public DateTimeOffset? NextExecutionAt { get; private set; } public int ConsecutiveFailureCount { get; private set; } public string? LastErrorMessage { get; private set; } public string? TriggeredBy { get; private set; } internal void"
+        }
+      ]
+    },
+    {
+      "name": "JobStoreMode",
+      "fqn": "Granit.BackgroundJobs.Domain.JobStoreMode",
+      "kind": "enum",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Domain/JobStoreMode.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "RecurringJobRegistration",
+      "fqn": "Granit.BackgroundJobs.Domain.RecurringJobRegistration",
+      "kind": "record",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Domain/RecurringJobRegistration.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "CronSchedule",
+      "fqn": "Granit.BackgroundJobs.Domain.ValueObjects.CronSchedule",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Domain/ValueObjects/CronSchedule.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(string value)",
+          "returnType": "required string Value { get; init; } public CronSchedule"
+        },
+        {
+          "name": "CronSchedule",
+          "kind": "method",
+          "signature": "CronSchedule(string value)",
+          "returnType": "implicit operator"
+        }
+      ]
+    },
+    {
+      "name": "BackgroundJobsEndpointRouteBuilderExtensions",
+      "fqn": "Granit.BackgroundJobs.Endpoints.Extensions.BackgroundJobsEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.Endpoints",
+      "file": "src/Granit.BackgroundJobs.Endpoints/Extensions/BackgroundJobsEndpointRouteBuilderExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "MapBackgroundJobsEndpoints",
+          "kind": "method",
+          "signature": "MapBackgroundJobsEndpoints(this IEndpointRouteBuilder endpoints, Action<BackgroundJobsEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBackgroundJobsEndpointsModule",
+      "fqn": "Granit.BackgroundJobs.Endpoints.GranitBackgroundJobsEndpointsModule",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.Endpoints",
+      "file": "src/Granit.BackgroundJobs.Endpoints/GranitBackgroundJobsEndpointsModule.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobsAuthorizationPolicy",
+      "fqn": "Granit.BackgroundJobs.Endpoints.Internal.BackgroundJobsAuthorizationPolicy",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.Endpoints",
+      "file": "src/Granit.BackgroundJobs.Endpoints/Internal/BackgroundJobsAuthorizationPolicy.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobsEndpointsOptions",
+      "fqn": "Granit.BackgroundJobs.Endpoints.Options.BackgroundJobsEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.Endpoints",
+      "file": "src/Granit.BackgroundJobs.Endpoints/Options/BackgroundJobsEndpointsOptions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "BackgroundJobsPermissions",
+      "fqn": "Granit.BackgroundJobs.Endpoints.Permissions.BackgroundJobsPermissions",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.Endpoints",
+      "file": "src/Granit.BackgroundJobs.Endpoints/Permissions/BackgroundJobsPermissions.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "Jobs",
+      "fqn": "Granit.BackgroundJobs.Endpoints.Permissions.Jobs",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.Endpoints",
+      "file": "src/Granit.BackgroundJobs.Endpoints/Permissions/BackgroundJobsPermissions.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobsEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.BackgroundJobs.EntityFrameworkCore.Extensions.BackgroundJobsEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.EntityFrameworkCore",
+      "file": "src/Granit.BackgroundJobs.EntityFrameworkCore/Extensions/BackgroundJobsEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitBackgroundJobsEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitBackgroundJobsEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "BackgroundJobsModelBuilderExtensions",
+      "fqn": "Granit.BackgroundJobs.EntityFrameworkCore.Extensions.BackgroundJobsModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.EntityFrameworkCore",
+      "file": "src/Granit.BackgroundJobs.EntityFrameworkCore/Extensions/BackgroundJobsModelBuilderExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "ConfigureBackgroundJobsModule",
+          "kind": "method",
+          "signature": "ConfigureBackgroundJobsModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBackgroundJobsDbProperties",
+      "fqn": "Granit.BackgroundJobs.EntityFrameworkCore.GranitBackgroundJobsDbProperties",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.EntityFrameworkCore",
+      "file": "src/Granit.BackgroundJobs.EntityFrameworkCore/GranitBackgroundJobsDbProperties.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitBackgroundJobsEntityFrameworkCoreModule",
+      "fqn": "Granit.BackgroundJobs.EntityFrameworkCore.GranitBackgroundJobsEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.EntityFrameworkCore",
+      "file": "src/Granit.BackgroundJobs.EntityFrameworkCore/GranitBackgroundJobsEntityFrameworkCoreModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobDefinitionChangedEvent",
+      "fqn": "Granit.BackgroundJobs.Events.BackgroundJobDefinitionChangedEvent",
+      "kind": "record",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Events/BackgroundJobDefinitionChangedEvent.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobExecutionStartedEto",
+      "fqn": "Granit.BackgroundJobs.Events.BackgroundJobExecutionStartedEto",
+      "kind": "record",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Events/BackgroundJobExecutionStartedEto.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobFailureThresholdExceededEto",
+      "fqn": "Granit.BackgroundJobs.Events.BackgroundJobFailureThresholdExceededEto",
+      "kind": "record",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Events/BackgroundJobFailureThresholdExceededEto.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobPausedEvent",
+      "fqn": "Granit.BackgroundJobs.Events.BackgroundJobPausedEvent",
+      "kind": "record",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Events/BackgroundJobPausedEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobResumedEvent",
+      "fqn": "Granit.BackgroundJobs.Events.BackgroundJobResumedEvent",
+      "kind": "record",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Events/BackgroundJobResumedEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "BackgroundJobsHostApplicationBuilderExtensions",
+      "fqn": "Granit.BackgroundJobs.Extensions.BackgroundJobsHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Extensions/BackgroundJobsHostApplicationBuilderExtensions.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "AddGranitBackgroundJobs",
+          "kind": "method",
+          "signature": "AddGranitBackgroundJobs(this IHostApplicationBuilder builder, IEnumerable<Assembly>? additionalAssemblies = null)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBackgroundJobsModule",
+      "fqn": "Granit.BackgroundJobs.GranitBackgroundJobsModule",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/GranitBackgroundJobsModule.cs",
+      "line": 30,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IBackgroundJob",
+      "fqn": "Granit.BackgroundJobs.IBackgroundJob",
+      "kind": "interface",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/IBackgroundJob.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "IBackgroundJobReader",
+      "fqn": "Granit.BackgroundJobs.IBackgroundJobReader",
+      "kind": "interface",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/IBackgroundJobReader.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetAllAsync",
+          "kind": "method",
+          "signature": "GetAllAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<BackgroundJobStatus>>"
+        },
+        {
+          "name": "FindAsync",
+          "kind": "method",
+          "signature": "FindAsync(string jobName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<BackgroundJobStatus?>"
+        }
+      ]
+    },
+    {
+      "name": "IBackgroundJobStoreReader",
+      "fqn": "Granit.BackgroundJobs.IBackgroundJobStoreReader",
+      "kind": "interface",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/IBackgroundJobStoreReader.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "FindAsync",
+          "kind": "method",
+          "signature": "FindAsync(string jobName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<BackgroundJobDefinition?>"
+        },
+        {
+          "name": "GetEnabledJobsAsync",
+          "kind": "method",
+          "signature": "GetEnabledJobsAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<BackgroundJobDefinition>>"
+        },
+        {
+          "name": "GetAllJobsAsync",
+          "kind": "method",
+          "signature": "GetAllJobsAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<BackgroundJobDefinition>>"
+        }
+      ]
+    },
+    {
+      "name": "IBackgroundJobStoreWriter",
+      "fqn": "Granit.BackgroundJobs.IBackgroundJobStoreWriter",
+      "kind": "interface",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/IBackgroundJobStoreWriter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "SeedJobsAsync",
+          "kind": "method",
+          "signature": "SeedJobsAsync(IEnumerable<RecurringJobRegistration> registrations, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RecordExecutionStartAsync",
+          "kind": "method",
+          "signature": "RecordExecutionStartAsync(string jobName, DateTimeOffset startedAt, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RecordNextExecutionAsync",
+          "kind": "method",
+          "signature": "RecordNextExecutionAsync(string jobName, DateTimeOffset nextExecution, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RecordExecutionFailureAsync",
+          "kind": "method",
+          "signature": "RecordExecutionFailureAsync(string jobName, string errorMessage, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SetEnabledAsync",
+          "kind": "method",
+          "signature": "SetEnabledAsync(string jobName, bool enabled, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SetTriggeredByAsync",
+          "kind": "method",
+          "signature": "SetTriggeredByAsync(string jobName, string? triggeredBy, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IBackgroundJobWriter",
+      "fqn": "Granit.BackgroundJobs.IBackgroundJobWriter",
+      "kind": "interface",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/IBackgroundJobWriter.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "PauseAsync",
+          "kind": "method",
+          "signature": "PauseAsync(string jobName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "ResumeAsync",
+          "kind": "method",
+          "signature": "ResumeAsync(string jobName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "TriggerNowAsync",
+          "kind": "method",
+          "signature": "TriggerNowAsync(string jobName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "BackgroundJobsOptions",
+      "fqn": "Granit.BackgroundJobs.Options.BackgroundJobsOptions",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/Options/BackgroundJobsOptions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "Mode",
+          "kind": "property",
+          "signature": "JobStoreMode Mode",
+          "returnType": "JobStoreMode"
+        },
+        {
+          "name": "ConnectionString",
+          "kind": "property",
+          "signature": "string ConnectionString",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "RecurringJobAttribute",
+      "fqn": "Granit.BackgroundJobs.RecurringJobAttribute",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs",
+      "file": "src/Granit.BackgroundJobs/RecurringJobAttribute.cs",
+      "line": 34,
+      "members": []
+    },
+    {
+      "name": "GranitBackgroundJobsWolverineModule",
+      "fqn": "Granit.BackgroundJobs.Wolverine.GranitBackgroundJobsWolverineModule",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.Wolverine",
+      "file": "src/Granit.BackgroundJobs.Wolverine/GranitBackgroundJobsWolverineModule.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "RecurringJobSchedulingMiddleware",
+      "fqn": "Granit.BackgroundJobs.Wolverine.RecurringJobSchedulingMiddleware",
+      "kind": "class",
+      "project": "Granit.BackgroundJobs.Wolverine",
+      "file": "src/Granit.BackgroundJobs.Wolverine/RecurringJobSchedulingMiddleware.cs",
+      "line": 33,
+      "members": [
+        {
+          "name": "BeforeAsync",
+          "kind": "method",
+          "signature": "BeforeAsync(Envelope envelope, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "BlobClassification",
+      "fqn": "Granit.BlobStorage.AI.BlobClassification",
+      "kind": "record",
+      "project": "Granit.BlobStorage.AI",
+      "file": "src/Granit.BlobStorage.AI/BlobClassification.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "BlobStorageAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.BlobStorage.AI.Extensions.BlobStorageAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.AI",
+      "file": "src/Granit.BlobStorage.AI/Extensions/BlobStorageAIHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitBlobStorageAI",
+          "kind": "method",
+          "signature": "AddGranitBlobStorageAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageAIModule",
+      "fqn": "Granit.BlobStorage.AI.GranitBlobStorageAIModule",
+      "kind": "class",
+      "project": "Granit.BlobStorage.AI",
+      "file": "src/Granit.BlobStorage.AI/GranitBlobStorageAIModule.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "IAIBlobClassifier",
+      "fqn": "Granit.BlobStorage.AI.IAIBlobClassifier",
+      "kind": "interface",
+      "project": "Granit.BlobStorage.AI",
+      "file": "src/Granit.BlobStorage.AI/IAIBlobClassifier.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ClassifyAsync",
+          "kind": "method",
+          "signature": "ClassifyAsync(string fileName, string contentType, CancellationToken cancellationToken = default)",
+          "returnType": "Task<BlobClassification>"
+        }
+      ]
+    },
+    {
+      "name": "BlobStorageAIOptions",
+      "fqn": "Granit.BlobStorage.AI.Options.BlobStorageAIOptions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.AI",
+      "file": "src/Granit.BlobStorage.AI/Options/BlobStorageAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string? WorkspaceName",
+          "returnType": "string?"
+        },
+        {
+          "name": "EnablePiiDetection",
+          "kind": "property",
+          "signature": "bool EnablePiiDetection",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "BlobTenantIsolation",
+      "fqn": "Granit.BlobStorage.AzureBlob.BlobTenantIsolation",
+      "kind": "enum",
+      "project": "Granit.BlobStorage.AzureBlob",
+      "file": "src/Granit.BlobStorage.AzureBlob/BlobTenantIsolation.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "BlobStorageAzureBlobHostApplicationBuilderExtensions",
+      "fqn": "Granit.BlobStorage.AzureBlob.Extensions.BlobStorageAzureBlobHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.AzureBlob",
+      "file": "src/Granit.BlobStorage.AzureBlob/Extensions/BlobStorageAzureBlobHostApplicationBuilderExtensions.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "AddGranitBlobStorageAzureBlob",
+          "kind": "method",
+          "signature": "AddGranitBlobStorageAzureBlob(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageAzureBlobModule",
+      "fqn": "Granit.BlobStorage.AzureBlob.GranitBlobStorageAzureBlobModule",
+      "kind": "class",
+      "project": "Granit.BlobStorage.AzureBlob",
+      "file": "src/Granit.BlobStorage.AzureBlob/GranitBlobStorageAzureBlobModule.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "AzureBlobOptions",
+      "fqn": "Granit.BlobStorage.AzureBlob.Options.AzureBlobOptions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.AzureBlob",
+      "file": "src/Granit.BlobStorage.AzureBlob/Options/AzureBlobOptions.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "ConnectionString",
+          "kind": "property",
+          "signature": "string ConnectionString",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultContainer",
+          "kind": "property",
+          "signature": "string DefaultContainer",
+          "returnType": "string"
+        },
+        {
+          "name": "UseManagedIdentity",
+          "kind": "property",
+          "signature": "bool UseManagedIdentity",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "BlobConfirmationResult",
+      "fqn": "Granit.BlobStorage.BlobConfirmationResult",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/BlobConfirmationResult.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "BlobStorageLocalizationResource",
+      "fqn": "Granit.BlobStorage.BlobStorageLocalizationResource",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/BlobStorageLocalizationResource.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "BlobUploadRequest",
+      "fqn": "Granit.BlobStorage.BlobUploadRequest",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/BlobUploadRequest.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "BlobValidationContext",
+      "fqn": "Granit.BlobStorage.BlobValidationContext",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/BlobValidationContext.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "BlobValidationResult",
+      "fqn": "Granit.BlobStorage.BlobValidationResult",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/BlobValidationResult.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Success",
+          "kind": "method",
+          "signature": "Success(string? verifiedContentType = null)",
+          "returnType": "bool IsValid { get; private init; } public string? FailureReason { get; private init; } public string? VerifiedContentType { get; private init; } public BlobValidationResult"
+        },
+        {
+          "name": "Failure",
+          "kind": "method",
+          "signature": "Failure(string reason)",
+          "returnType": "BlobValidationResult"
+        }
+      ]
+    },
+    {
+      "name": "DbStoreBlobContent",
+      "fqn": "Granit.BlobStorage.DbStore.Entities.DbStoreBlobContent",
+      "kind": "class",
+      "project": "Granit.BlobStorage.DbStore",
+      "file": "src/Granit.BlobStorage.DbStore/Entities/DbStoreBlobContent.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "Id",
+          "kind": "property",
+          "signature": "Guid Id",
+          "returnType": "Guid"
+        },
+        {
+          "name": "Content",
+          "kind": "property",
+          "signature": "byte[] Content",
+          "returnType": "byte[]"
+        }
+      ]
+    },
+    {
+      "name": "BlobStorageDbStoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.BlobStorage.DbStore.Extensions.BlobStorageDbStoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.DbStore",
+      "file": "src/Granit.BlobStorage.DbStore/Extensions/BlobStorageDbStoreHostApplicationBuilderExtensions.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "AddGranitBlobStorageDbStore",
+          "kind": "method",
+          "signature": "AddGranitBlobStorageDbStore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageDbStoreModule",
+      "fqn": "Granit.BlobStorage.DbStore.GranitBlobStorageDbStoreModule",
+      "kind": "class",
+      "project": "Granit.BlobStorage.DbStore",
+      "file": "src/Granit.BlobStorage.DbStore/GranitBlobStorageDbStoreModule.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "DbStoreBlobOptions",
+      "fqn": "Granit.BlobStorage.DbStore.Options.DbStoreBlobOptions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.DbStore",
+      "file": "src/Granit.BlobStorage.DbStore/Options/DbStoreBlobOptions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "MaxBlobSizeBytes",
+          "kind": "property",
+          "signature": "long MaxBlobSizeBytes",
+          "returnType": "long"
+        }
+      ]
+    },
+    {
+      "name": "BlobStorageMetrics",
+      "fqn": "Granit.BlobStorage.Diagnostics.BlobStorageMetrics",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Diagnostics/BlobStorageMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordValidationCompleted",
+          "kind": "method",
+          "signature": "RecordValidationCompleted(string? tenantId, string status, string container)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordValidationFailed",
+          "kind": "method",
+          "signature": "RecordValidationFailed(string? tenantId, string reason, string container)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordDeleted",
+          "kind": "method",
+          "signature": "RecordDeleted(string? tenantId, string container)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordOrphanCleaned",
+          "kind": "method",
+          "signature": "RecordOrphanCleaned(string? tenantId)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordConfirmDuration",
+          "kind": "method",
+          "signature": "RecordConfirmDuration(string? tenantId, string status, string container, TimeSpan duration)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "BlobDescriptor",
+      "fqn": "Granit.BlobStorage.Domain.BlobDescriptor",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Domain/BlobDescriptor.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, Guid? tenantId, string containerName, string objectKey, BlobUploadRequest request, DateTimeOffset createdAt)",
+          "returnType": "BlobDescriptor"
+        },
+        {
+          "name": "ObjectKey",
+          "kind": "property",
+          "signature": "string ObjectKey",
+          "returnType": "string"
+        },
+        {
+          "name": "OriginalFileName",
+          "kind": "property",
+          "signature": "string OriginalFileName",
+          "returnType": "string"
+        },
+        {
+          "name": "DeclaredContentType",
+          "kind": "property",
+          "signature": "string DeclaredContentType",
+          "returnType": "string"
+        },
+        {
+          "name": "MarkAsUploading",
+          "kind": "method",
+          "signature": "MarkAsUploading()",
+          "returnType": "long MaxAllowedBytes { get; private set; } public string? VerifiedContentType { get; private set; } public long? SizeBytes { get; private set; } public BlobStatus Status { get; private set; } public DateTimeOffset CreatedAt { get; private set; } public DateTimeOffset? ValidatedAt { get; private set; } public DateTimeOffset? DeletedAt { get; private set; } public string? RejectionReason { get; private set; } public string? DeletionReason { get; private set; } public void"
+        }
+      ]
+    },
+    {
+      "name": "BlobStatus",
+      "fqn": "Granit.BlobStorage.Domain.BlobStatus",
+      "kind": "enum",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Domain/BlobStatus.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "BlobCleanupOrphansResponse",
+      "fqn": "Granit.BlobStorage.Endpoints.Dtos.BlobCleanupOrphansResponse",
+      "kind": "record",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Dtos/BlobCleanupOrphansResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "BlobConfirmUploadRequest",
+      "fqn": "Granit.BlobStorage.Endpoints.Dtos.BlobConfirmUploadRequest",
+      "kind": "record",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Dtos/BlobConfirmUploadRequest.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "BlobConfirmUploadResponse",
+      "fqn": "Granit.BlobStorage.Endpoints.Dtos.BlobConfirmUploadResponse",
+      "kind": "record",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Dtos/BlobConfirmUploadResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "BlobDeleteRequest",
+      "fqn": "Granit.BlobStorage.Endpoints.Dtos.BlobDeleteRequest",
+      "kind": "record",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Dtos/BlobDeleteRequest.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "BlobDescriptorResponse",
+      "fqn": "Granit.BlobStorage.Endpoints.Dtos.BlobDescriptorResponse",
+      "kind": "record",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Dtos/BlobDescriptorResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "BlobDownloadUrlRequest",
+      "fqn": "Granit.BlobStorage.Endpoints.Dtos.BlobDownloadUrlRequest",
+      "kind": "record",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Dtos/BlobDownloadUrlRequest.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "BlobDownloadUrlResponse",
+      "fqn": "Granit.BlobStorage.Endpoints.Dtos.BlobDownloadUrlResponse",
+      "kind": "record",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Dtos/BlobDownloadUrlResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "BlobUploadInitiateRequest",
+      "fqn": "Granit.BlobStorage.Endpoints.Dtos.BlobUploadInitiateRequest",
+      "kind": "record",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Dtos/BlobUploadInitiateRequest.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "BlobUploadInitiateResponse",
+      "fqn": "Granit.BlobStorage.Endpoints.Dtos.BlobUploadInitiateResponse",
+      "kind": "record",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Dtos/BlobUploadInitiateResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "BlobStorageEndpointRouteBuilderExtensions",
+      "fqn": "Granit.BlobStorage.Endpoints.Extensions.BlobStorageEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Extensions/BlobStorageEndpointRouteBuilderExtensions.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "MapBlobStorageEndpoints",
+          "kind": "method",
+          "signature": "MapBlobStorageEndpoints(this IEndpointRouteBuilder endpoints, Action<BlobStorageEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageEndpointsModule",
+      "fqn": "Granit.BlobStorage.Endpoints.GranitBlobStorageEndpointsModule",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/GranitBlobStorageEndpointsModule.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "BlobStorageEndpointsOptions",
+      "fqn": "Granit.BlobStorage.Endpoints.Options.BlobStorageEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Options/BlobStorageEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "BlobStoragePermissions",
+      "fqn": "Granit.BlobStorage.Endpoints.Permissions.BlobStoragePermissions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Permissions/BlobStoragePermissions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "Blobs",
+      "fqn": "Granit.BlobStorage.Endpoints.Permissions.Blobs",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Permissions/BlobStoragePermissions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "BlobStorageEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.BlobStorage.EntityFrameworkCore.Extensions.BlobStorageEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.EntityFrameworkCore",
+      "file": "src/Granit.BlobStorage.EntityFrameworkCore/Extensions/BlobStorageEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitBlobStorageEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitBlobStorageEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "BlobStorageModelBuilderExtensions",
+      "fqn": "Granit.BlobStorage.EntityFrameworkCore.Extensions.BlobStorageModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.EntityFrameworkCore",
+      "file": "src/Granit.BlobStorage.EntityFrameworkCore/Extensions/BlobStorageModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureBlobStorageModule",
+          "kind": "method",
+          "signature": "ConfigureBlobStorageModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageDbProperties",
+      "fqn": "Granit.BlobStorage.EntityFrameworkCore.GranitBlobStorageDbProperties",
+      "kind": "class",
+      "project": "Granit.BlobStorage.EntityFrameworkCore",
+      "file": "src/Granit.BlobStorage.EntityFrameworkCore/GranitBlobStorageDbProperties.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageEntityFrameworkCoreModule",
+      "fqn": "Granit.BlobStorage.EntityFrameworkCore.GranitBlobStorageEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.BlobStorage.EntityFrameworkCore",
+      "file": "src/Granit.BlobStorage.EntityFrameworkCore/GranitBlobStorageEntityFrameworkCoreModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "BlobDeletedEvent",
+      "fqn": "Granit.BlobStorage.Events.BlobDeletedEvent",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Events/BlobDeletedEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "BlobRejectedEvent",
+      "fqn": "Granit.BlobStorage.Events.BlobRejectedEvent",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Events/BlobRejectedEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "BlobUploadStartedEvent",
+      "fqn": "Granit.BlobStorage.Events.BlobUploadStartedEvent",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Events/BlobUploadStartedEvent.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "BlobValidatedEvent",
+      "fqn": "Granit.BlobStorage.Events.BlobValidatedEvent",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Events/BlobValidatedEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "BlobNotFoundException",
+      "fqn": "Granit.BlobStorage.Exceptions.BlobNotFoundException",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Exceptions/BlobNotFoundException.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "BlobId",
+          "kind": "property",
+          "signature": "Guid BlobId",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "BlobNotValidException",
+      "fqn": "Granit.BlobStorage.Exceptions.BlobNotValidException",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Exceptions/BlobNotValidException.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "BlobId",
+          "kind": "property",
+          "signature": "Guid BlobId",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "BlobStorageFileSystemHostApplicationBuilderExtensions",
+      "fqn": "Granit.BlobStorage.FileSystem.Extensions.BlobStorageFileSystemHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.FileSystem",
+      "file": "src/Granit.BlobStorage.FileSystem/Extensions/BlobStorageFileSystemHostApplicationBuilderExtensions.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "AddGranitBlobStorageFileSystem",
+          "kind": "method",
+          "signature": "AddGranitBlobStorageFileSystem(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageFileSystemModule",
+      "fqn": "Granit.BlobStorage.FileSystem.GranitBlobStorageFileSystemModule",
+      "kind": "class",
+      "project": "Granit.BlobStorage.FileSystem",
+      "file": "src/Granit.BlobStorage.FileSystem/GranitBlobStorageFileSystemModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "FileSystemBlobOptions",
+      "fqn": "Granit.BlobStorage.FileSystem.Options.FileSystemBlobOptions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.FileSystem",
+      "file": "src/Granit.BlobStorage.FileSystem/Options/FileSystemBlobOptions.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "BasePath",
+          "kind": "property",
+          "signature": "string BasePath",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "BlobTenantIsolation",
+      "fqn": "Granit.BlobStorage.GoogleCloud.BlobTenantIsolation",
+      "kind": "enum",
+      "project": "Granit.BlobStorage.GoogleCloud",
+      "file": "src/Granit.BlobStorage.GoogleCloud/BlobTenantIsolation.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "BlobStorageGoogleCloudHostApplicationBuilderExtensions",
+      "fqn": "Granit.BlobStorage.GoogleCloud.Extensions.BlobStorageGoogleCloudHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.GoogleCloud",
+      "file": "src/Granit.BlobStorage.GoogleCloud/Extensions/BlobStorageGoogleCloudHostApplicationBuilderExtensions.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "AddGranitBlobStorageGoogleCloud",
+          "kind": "method",
+          "signature": "AddGranitBlobStorageGoogleCloud(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageGoogleCloudModule",
+      "fqn": "Granit.BlobStorage.GoogleCloud.GranitBlobStorageGoogleCloudModule",
+      "kind": "class",
+      "project": "Granit.BlobStorage.GoogleCloud",
+      "file": "src/Granit.BlobStorage.GoogleCloud/GranitBlobStorageGoogleCloudModule.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "GoogleCloudStorageOptions",
+      "fqn": "Granit.BlobStorage.GoogleCloud.Options.GoogleCloudStorageOptions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.GoogleCloud",
+      "file": "src/Granit.BlobStorage.GoogleCloud/Options/GoogleCloudStorageOptions.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "ProjectId",
+          "kind": "property",
+          "signature": "string ProjectId",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultBucket",
+          "kind": "property",
+          "signature": "string DefaultBucket",
+          "returnType": "string"
+        },
+        {
+          "name": "CredentialFilePath",
+          "kind": "property",
+          "signature": "string? CredentialFilePath",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageModule",
+      "fqn": "Granit.BlobStorage.GranitBlobStorageModule",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/GranitBlobStorageModule.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IBlobDescriptorReader",
+      "fqn": "Granit.BlobStorage.IBlobDescriptorReader",
+      "kind": "interface",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/IBlobDescriptorReader.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "FindAsync",
+          "kind": "method",
+          "signature": "FindAsync(Guid blobId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<BlobDescriptor?>"
+        },
+        {
+          "name": "FindOrphanedAsync",
+          "kind": "method",
+          "signature": "FindOrphanedAsync(DateTimeOffset cutoff, int batchSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<BlobDescriptor>>"
+        },
+        {
+          "name": "FindByContainerBeforeAsync",
+          "kind": "method",
+          "signature": "FindByContainerBeforeAsync(string containerName, DateTimeOffset cutoff, int batchSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<BlobDescriptor>>"
+        }
+      ]
+    },
+    {
+      "name": "IBlobDescriptorStore",
+      "fqn": "Granit.BlobStorage.IBlobDescriptorStore",
+      "kind": "interface",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/IBlobDescriptorStore.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "IBlobDescriptorWriter",
+      "fqn": "Granit.BlobStorage.IBlobDescriptorWriter",
+      "kind": "interface",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/IBlobDescriptorWriter.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "SaveAsync",
+          "kind": "method",
+          "signature": "SaveAsync(BlobDescriptor descriptor, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UpdateAsync",
+          "kind": "method",
+          "signature": "UpdateAsync(BlobDescriptor descriptor, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IBlobKeyStrategy",
+      "fqn": "Granit.BlobStorage.IBlobKeyStrategy",
+      "kind": "interface",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/IBlobKeyStrategy.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "BuildObjectKey",
+          "kind": "method",
+          "signature": "BuildObjectKey(string containerName, Guid blobId)",
+          "returnType": "string"
+        },
+        {
+          "name": "ResolveBucketName",
+          "kind": "method",
+          "signature": "ResolveBucketName(string containerName)",
+          "returnType": "string"
+        },
+        {
+          "name": "TryExtractTenantId",
+          "kind": "method",
+          "signature": "TryExtractTenantId(string objectKey, out string? tenantId)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "IBlobQueryableProvider",
+      "fqn": "Granit.BlobStorage.IBlobQueryableProvider",
+      "kind": "interface",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/IBlobQueryableProvider.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "GetDescriptors",
+          "kind": "method",
+          "signature": "GetDescriptors()",
+          "returnType": "IQueryable<BlobDescriptor>"
+        }
+      ]
+    },
+    {
+      "name": "IBlobStorage",
+      "fqn": "Granit.BlobStorage.IBlobStorage",
+      "kind": "interface",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/IBlobStorage.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "InitiateUploadAsync",
+          "kind": "method",
+          "signature": "InitiateUploadAsync(string containerName, BlobUploadRequest request, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PresignedUploadTicket>"
+        },
+        {
+          "name": "CreateDownloadUrlAsync",
+          "kind": "method",
+          "signature": "CreateDownloadUrlAsync(string containerName, Guid blobId, DownloadUrlOptions? options = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PresignedDownloadUrl>"
+        },
+        {
+          "name": "GetDescriptorAsync",
+          "kind": "method",
+          "signature": "GetDescriptorAsync(string containerName, Guid blobId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<BlobDescriptor?>"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(string containerName, Guid blobId, string? deletionReason = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "ConfirmUploadAsync",
+          "kind": "method",
+          "signature": "ConfirmUploadAsync(string containerName, Guid blobId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<BlobConfirmationResult>"
+        },
+        {
+          "name": "CleanupOrphansAsync",
+          "kind": "method",
+          "signature": "CleanupOrphansAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        }
+      ]
+    },
+    {
+      "name": "IBlobValidator",
+      "fqn": "Granit.BlobStorage.IBlobValidator",
+      "kind": "interface",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/IBlobValidator.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "ValidateAsync",
+          "kind": "method",
+          "signature": "ValidateAsync(BlobValidationContext context, CancellationToken cancellationToken = default)",
+          "returnType": "int Order { get; } Task<BlobValidationResult>"
+        }
+      ]
+    },
+    {
+      "name": "OrphanBlobCleanupJob",
+      "fqn": "Granit.BlobStorage.Jobs.OrphanBlobCleanupJob",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Jobs/OrphanBlobCleanupJob.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "BlobStorageOptions",
+      "fqn": "Granit.BlobStorage.Options.BlobStorageOptions",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Options/BlobStorageOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(15)",
+          "returnType": "TimeSpan UploadUrlExpiry { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(5)",
+          "returnType": "TimeSpan DownloadUrlExpiry { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "DownloadUrlOptions",
+      "fqn": "Granit.BlobStorage.Options.DownloadUrlOptions",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Options/DownloadUrlOptions.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "PresignedDownloadUrl",
+      "fqn": "Granit.BlobStorage.PresignedDownloadUrl",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/PresignedDownloadUrl.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "PresignedUploadTicket",
+      "fqn": "Granit.BlobStorage.PresignedUploadTicket",
+      "kind": "record",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/PresignedUploadTicket.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "BlobStorageProxyLocalizationResource",
+      "fqn": "Granit.BlobStorage.Proxy.BlobStorageProxyLocalizationResource",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Proxy",
+      "file": "src/Granit.BlobStorage.Proxy/BlobStorageProxyLocalizationResource.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "BlobStorageProxyEndpointRouteBuilderExtensions",
+      "fqn": "Granit.BlobStorage.Proxy.Extensions.BlobStorageProxyEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Proxy",
+      "file": "src/Granit.BlobStorage.Proxy/Extensions/BlobStorageProxyEndpointRouteBuilderExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "MapGranitBlobProxyEndpoints",
+          "kind": "method",
+          "signature": "MapGranitBlobProxyEndpoints(this IEndpointRouteBuilder endpoints)",
+          "returnType": "IEndpointRouteBuilder"
+        }
+      ]
+    },
+    {
+      "name": "BlobStorageProxyHostApplicationBuilderExtensions",
+      "fqn": "Granit.BlobStorage.Proxy.Extensions.BlobStorageProxyHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Proxy",
+      "file": "src/Granit.BlobStorage.Proxy/Extensions/BlobStorageProxyHostApplicationBuilderExtensions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "AddGranitBlobStorageProxy",
+          "kind": "method",
+          "signature": "AddGranitBlobStorageProxy(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageProxyModule",
+      "fqn": "Granit.BlobStorage.Proxy.GranitBlobStorageProxyModule",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Proxy",
+      "file": "src/Granit.BlobStorage.Proxy/GranitBlobStorageProxyModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "ProxyBlobOptions",
+      "fqn": "Granit.BlobStorage.Proxy.Options.ProxyBlobOptions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Proxy",
+      "file": "src/Granit.BlobStorage.Proxy/Options/ProxyBlobOptions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "BaseUrl",
+          "kind": "property",
+          "signature": "string BaseUrl",
+          "returnType": "string"
+        },
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "MaxUploadBytes",
+          "kind": "property",
+          "signature": "long MaxUploadBytes",
+          "returnType": "long"
+        }
+      ]
+    },
+    {
+      "name": "BlobTenantIsolation",
+      "fqn": "Granit.BlobStorage.S3.BlobTenantIsolation",
+      "kind": "enum",
+      "project": "Granit.BlobStorage.S3",
+      "file": "src/Granit.BlobStorage.S3/BlobTenantIsolation.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "BlobStorageS3HostApplicationBuilderExtensions",
+      "fqn": "Granit.BlobStorage.S3.Extensions.BlobStorageS3HostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.S3",
+      "file": "src/Granit.BlobStorage.S3/Extensions/BlobStorageS3HostApplicationBuilderExtensions.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "AddGranitBlobStorageS3",
+          "kind": "method",
+          "signature": "AddGranitBlobStorageS3(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitBlobStorageS3Module",
+      "fqn": "Granit.BlobStorage.S3.GranitBlobStorageS3Module",
+      "kind": "class",
+      "project": "Granit.BlobStorage.S3",
+      "file": "src/Granit.BlobStorage.S3/GranitBlobStorageS3Module.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "S3BlobOptions",
+      "fqn": "Granit.BlobStorage.S3.Options.S3BlobOptions",
+      "kind": "class",
+      "project": "Granit.BlobStorage.S3",
+      "file": "src/Granit.BlobStorage.S3/Options/S3BlobOptions.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "ServiceUrl",
+          "kind": "property",
+          "signature": "string ServiceUrl",
+          "returnType": "string"
+        },
+        {
+          "name": "AccessKey",
+          "kind": "property",
+          "signature": "string AccessKey",
+          "returnType": "string"
+        },
+        {
+          "name": "SecretKey",
+          "kind": "property",
+          "signature": "string SecretKey",
+          "returnType": "string"
+        },
+        {
+          "name": "Region",
+          "kind": "property",
+          "signature": "string Region",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultBucket",
+          "kind": "property",
+          "signature": "string DefaultBucket",
+          "returnType": "string"
+        },
+        {
+          "name": "ForcePathStyle",
+          "kind": "property",
+          "signature": "bool ForcePathStyle",
+          "returnType": "bool"
+        },
+        {
+          "name": "TenantIsolation",
+          "kind": "property",
+          "signature": "BlobTenantIsolation TenantIsolation",
+          "returnType": "BlobTenantIsolation"
+        }
+      ]
+    },
+    {
+      "name": "TenantPrefixBlobKeyStrategy",
+      "fqn": "Granit.BlobStorage.TenantPrefixBlobKeyStrategy",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/TenantPrefixBlobKeyStrategy.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "BuildObjectKey",
+          "kind": "method",
+          "signature": "BuildObjectKey(string containerName, Guid blobId)",
+          "returnType": "string"
+        },
+        {
+          "name": "TryExtractTenantId",
+          "kind": "method",
+          "signature": "TryExtractTenantId(string objectKey, out string? tenantId)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "MagicBytesValidator",
+      "fqn": "Granit.BlobStorage.Validators.MagicBytesValidator",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Validators/MagicBytesValidator.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "Order",
+          "kind": "property",
+          "signature": "int Order",
+          "returnType": "int"
+        },
+        {
+          "name": "ValidateAsync",
+          "kind": "method",
+          "signature": "ValidateAsync(BlobValidationContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task<BlobValidationResult>"
+        }
+      ]
+    },
+    {
+      "name": "MaxSizeValidator",
+      "fqn": "Granit.BlobStorage.Validators.MaxSizeValidator",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Validators/MaxSizeValidator.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "Order",
+          "kind": "property",
+          "signature": "int Order",
+          "returnType": "int"
+        },
+        {
+          "name": "ValidateAsync",
+          "kind": "method",
+          "signature": "ValidateAsync(BlobValidationContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task<BlobValidationResult>"
+        }
+      ]
+    },
+    {
+      "name": "AesCacheValueEncryptor",
+      "fqn": "Granit.Caching.AesCacheValueEncryptor",
+      "kind": "class",
+      "project": "Granit.Caching",
+      "file": "src/Granit.Caching/AesCacheValueEncryptor.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "CacheEncryptedAttribute",
+      "fqn": "Granit.Caching.CacheEncryptedAttribute",
+      "kind": "class",
+      "project": "Granit.Caching",
+      "file": "src/Granit.Caching/CacheEncryptedAttribute.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "Encrypt",
+          "kind": "property",
+          "signature": "bool Encrypt",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "CachingServiceCollectionExtensions",
+      "fqn": "Granit.Caching.Extensions.CachingServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Caching",
+      "file": "src/Granit.Caching/Extensions/CachingServiceCollectionExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitCaching",
+          "kind": "method",
+          "signature": "AddGranitCaching(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitCachingModule",
+      "fqn": "Granit.Caching.GranitCachingModule",
+      "kind": "class",
+      "project": "Granit.Caching",
+      "file": "src/Granit.Caching/GranitCachingModule.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ICacheValueEncryptor",
+      "fqn": "Granit.Caching.ICacheValueEncryptor",
+      "kind": "interface",
+      "project": "Granit.Caching",
+      "file": "src/Granit.Caching/ICacheValueEncryptor.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "Encrypt",
+          "kind": "method",
+          "signature": "Encrypt(byte[] plaintext)",
+          "returnType": "byte[]"
+        },
+        {
+          "name": "Decrypt",
+          "kind": "method",
+          "signature": "Decrypt(byte[] ciphertext)",
+          "returnType": "byte[]"
+        }
+      ]
+    },
+    {
+      "name": "NullCacheValueEncryptor",
+      "fqn": "Granit.Caching.NullCacheValueEncryptor",
+      "kind": "class",
+      "project": "Granit.Caching",
+      "file": "src/Granit.Caching/NullCacheValueEncryptor.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "Encrypt",
+          "kind": "method",
+          "signature": "Encrypt(byte[] plaintext)",
+          "returnType": "byte[]"
+        },
+        {
+          "name": "Decrypt",
+          "kind": "method",
+          "signature": "Decrypt(byte[] ciphertext)",
+          "returnType": "byte[]"
+        }
+      ]
+    },
+    {
+      "name": "CacheEncryptionOptions",
+      "fqn": "Granit.Caching.Options.CacheEncryptionOptions",
+      "kind": "class",
+      "project": "Granit.Caching",
+      "file": "src/Granit.Caching/Options/CacheEncryptionOptions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "CachingOptions",
+      "fqn": "Granit.Caching.Options.CachingOptions",
+      "kind": "class",
+      "project": "Granit.Caching",
+      "file": "src/Granit.Caching/Options/CachingOptions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "KeyPrefix",
+          "kind": "property",
+          "signature": "string KeyPrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "FromHours",
+          "kind": "method",
+          "signature": "FromHours(1)",
+          "returnType": "TimeSpan? DefaultAbsoluteExpirationRelativeToNow { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(20)",
+          "returnType": "TimeSpan? DefaultSlidingExpiration { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "FusionCachingOptions",
+      "fqn": "Granit.Caching.Options.FusionCachingOptions",
+      "kind": "class",
+      "project": "Granit.Caching",
+      "file": "src/Granit.Caching/Options/FusionCachingOptions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "FailSafeIsEnabled",
+          "kind": "property",
+          "signature": "bool FailSafeIsEnabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "FromHours",
+          "kind": "method",
+          "signature": "FromHours(2)",
+          "returnType": "TimeSpan FailSafeMaxDuration { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(30)",
+          "returnType": "TimeSpan FailSafeThrottleDuration { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(2)",
+          "returnType": "TimeSpan FactorySoftTimeout { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(10)",
+          "returnType": "TimeSpan FactoryHardTimeout { get; set; } = TimeSpan."
+        },
+        {
+          "name": "EagerRefreshThreshold",
+          "kind": "property",
+          "signature": "float EagerRefreshThreshold",
+          "returnType": "float"
+        },
+        {
+          "name": "BackplaneChannelPrefix",
+          "kind": "property",
+          "signature": "string BackplaneChannelPrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "RedisCachingServiceCollectionExtensions",
+      "fqn": "Granit.Caching.StackExchangeRedis.Extensions.RedisCachingServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Caching.StackExchangeRedis",
+      "file": "src/Granit.Caching.StackExchangeRedis/Extensions/RedisCachingServiceCollectionExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "AddGranitCachingRedis",
+          "kind": "method",
+          "signature": "AddGranitCachingRedis(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitCachingRedisModule",
+      "fqn": "Granit.Caching.StackExchangeRedis.GranitCachingRedisModule",
+      "kind": "class",
+      "project": "Granit.Caching.StackExchangeRedis",
+      "file": "src/Granit.Caching.StackExchangeRedis/GranitCachingRedisModule.cs",
+      "line": 30,
+      "members": [
+        {
+          "name": "IsEnabled",
+          "kind": "method",
+          "signature": "IsEnabled(ServiceConfigurationContext context)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "RedisCachingOptions",
+      "fqn": "Granit.Caching.StackExchangeRedis.Options.RedisCachingOptions",
+      "kind": "class",
+      "project": "Granit.Caching.StackExchangeRedis",
+      "file": "src/Granit.Caching.StackExchangeRedis/Options/RedisCachingOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "IsEnabled",
+          "kind": "property",
+          "signature": "bool IsEnabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "Configuration",
+          "kind": "property",
+          "signature": "string Configuration",
+          "returnType": "string"
+        },
+        {
+          "name": "InstanceName",
+          "kind": "property",
+          "signature": "string InstanceName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "DataFilter",
+      "fqn": "Granit.Core.DataFiltering.DataFilter",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/DataFiltering/DataFilter.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "class",
+          "kind": "property",
+          "signature": "IDisposable Disable<TFilter>() where TFilter : class",
+          "returnType": "IDisposable Disable<TFilter>() where TFilter :"
+        },
+        {
+          "name": "class",
+          "kind": "property",
+          "signature": "IDisposable Enable<TFilter>() where TFilter : class",
+          "returnType": "IDisposable Enable<TFilter>() where TFilter :"
+        },
+        {
+          "name": "class",
+          "kind": "property",
+          "signature": "bool IsEnabled<TFilter>() where TFilter : class",
+          "returnType": "bool IsEnabled<TFilter>() where TFilter :"
+        }
+      ]
+    },
+    {
+      "name": "IDataFilter",
+      "fqn": "Granit.Core.DataFiltering.IDataFilter",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/DataFiltering/IDataFilter.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "GranitActivitySourceRegistry",
+      "fqn": "Granit.Core.Diagnostics.GranitActivitySourceRegistry",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Diagnostics/GranitActivitySourceRegistry.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "Register",
+          "kind": "method",
+          "signature": "Register(string sourceName)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AggregateRoot",
+      "fqn": "Granit.Core.Domain.AggregateRoot",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/AggregateRoot.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "AsReadOnly",
+          "kind": "method",
+          "signature": "AsReadOnly()",
+          "returnType": "IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents."
+        },
+        {
+          "name": "AsReadOnly",
+          "kind": "method",
+          "signature": "AsReadOnly()",
+          "returnType": "IReadOnlyCollection<IIntegrationEvent> IntegrationEvents => _integrationEvents."
+        },
+        {
+          "name": "ClearIntegrationEvents",
+          "kind": "method",
+          "signature": "ClearIntegrationEvents()",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AuditableEntity",
+      "fqn": "Granit.Core.Domain.AuditableEntity",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/AuditableEntity.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Id",
+          "kind": "property",
+          "signature": "Guid Id",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "AuditedAggregateRoot",
+      "fqn": "Granit.Core.Domain.AuditedAggregateRoot",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/AuditedAggregateRoot.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "AuditedEntity",
+      "fqn": "Granit.Core.Domain.AuditedEntity",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/AuditedEntity.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "AuditedTranslation",
+      "fqn": "Granit.Core.Domain.AuditedTranslation",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/AuditedTranslation.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "ParentId",
+          "kind": "property",
+          "signature": "Guid ParentId",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "CreationAuditedAggregateRoot",
+      "fqn": "Granit.Core.Domain.CreationAuditedAggregateRoot",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/CreationAuditedAggregateRoot.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AsReadOnly",
+          "kind": "method",
+          "signature": "AsReadOnly()",
+          "returnType": "IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents."
+        },
+        {
+          "name": "AsReadOnly",
+          "kind": "method",
+          "signature": "AsReadOnly()",
+          "returnType": "IReadOnlyCollection<IIntegrationEvent> IntegrationEvents => _integrationEvents."
+        },
+        {
+          "name": "ClearIntegrationEvents",
+          "kind": "method",
+          "signature": "ClearIntegrationEvents()",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "CreationAuditedEntity",
+      "fqn": "Granit.Core.Domain.CreationAuditedEntity",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/CreationAuditedEntity.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "CreatedAt",
+          "kind": "property",
+          "signature": "DateTimeOffset CreatedAt",
+          "returnType": "DateTimeOffset"
+        }
+      ]
+    },
+    {
+      "name": "Entity",
+      "fqn": "Granit.Core.Domain.Entity",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/Entity.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "FullAuditedAggregateRoot",
+      "fqn": "Granit.Core.Domain.FullAuditedAggregateRoot",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/FullAuditedAggregateRoot.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "FullAuditedEntity",
+      "fqn": "Granit.Core.Domain.FullAuditedEntity",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/FullAuditedEntity.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "IActive",
+      "fqn": "Granit.Core.Domain.IActive",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/IActive.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "IConcurrencyAware",
+      "fqn": "Granit.Core.Domain.IConcurrencyAware",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/IConcurrencyAware.cs",
+      "line": 26,
+      "members": []
+    },
+    {
+      "name": "IConcurrencyStampRequest",
+      "fqn": "Granit.Core.Domain.IConcurrencyStampRequest",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/IConcurrencyStampRequest.cs",
+      "line": 26,
+      "members": []
+    },
+    {
+      "name": "IEmitEntityLifecycleEvents",
+      "fqn": "Granit.Core.Domain.IEmitEntityLifecycleEvents",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/IEmitEntityLifecycleEvents.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "IEntityEtoProvider",
+      "fqn": "Granit.Core.Domain.IEntityEtoProvider",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/IEntityEtoProvider.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "IHasEntityEto",
+      "fqn": "Granit.Core.Domain.IHasEntityEto",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/IHasEntityEto.cs",
+      "line": 33,
+      "members": [
+        {
+          "name": "ToEto",
+          "kind": "method",
+          "signature": "ToEto()",
+          "returnType": "TEto"
+        }
+      ]
+    },
+    {
+      "name": "IMultiTenant",
+      "fqn": "Granit.Core.Domain.IMultiTenant",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/IMultiTenant.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "IProcessingRestrictable",
+      "fqn": "Granit.Core.Domain.IProcessingRestrictable",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/IProcessingRestrictable.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "IPublishable",
+      "fqn": "Granit.Core.Domain.IPublishable",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/IPublishable.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "ISoftDeletable",
+      "fqn": "Granit.Core.Domain.ISoftDeletable",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/ISoftDeletable.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ITranslatable",
+      "fqn": "Granit.Core.Domain.ITranslatable",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/ITranslatable.cs",
+      "line": 34,
+      "members": []
+    },
+    {
+      "name": "ITranslation",
+      "fqn": "Granit.Core.Domain.ITranslation",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/ITranslation.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "IVersioned",
+      "fqn": "Granit.Core.Domain.IVersioned",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/IVersioned.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "SingleValueObject",
+      "fqn": "Granit.Core.Domain.SingleValueObject",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/SingleValueObject.cs",
+      "line": 26,
+      "members": [
+        {
+          "name": "GetEqualityComponents",
+          "kind": "method",
+          "signature": "GetEqualityComponents()",
+          "returnType": "T Value { get; init; } protected sealed IEnumerable<object?>"
+        }
+      ]
+    },
+    {
+      "name": "TranslatableExtensions",
+      "fqn": "Granit.Core.Domain.TranslatableExtensions",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/TranslatableExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "Translation",
+      "fqn": "Granit.Core.Domain.Translation",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/Translation.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "ParentId",
+          "kind": "property",
+          "signature": "Guid ParentId",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "ValueObject",
+      "fqn": "Granit.Core.Domain.ValueObject",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/ValueObject.cs",
+      "line": 32,
+      "members": [
+        {
+          "name": "Equals",
+          "kind": "method",
+          "signature": "Equals(ValueObject? other)",
+          "returnType": "bool"
+        },
+        {
+          "name": "GetHashCode",
+          "kind": "method",
+          "signature": "GetHashCode()",
+          "returnType": "sealed int"
+        },
+        {
+          "name": "operator",
+          "kind": "property",
+          "signature": "bool operator",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "ContentType",
+      "fqn": "Granit.Core.Domain.ValueObjects.ContentType",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/ValueObjects/ContentType.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(string value)",
+          "returnType": "required string Value { get; init; } public ContentType"
+        },
+        {
+          "name": "ContentType",
+          "kind": "method",
+          "signature": "ContentType(string value)",
+          "returnType": "implicit operator"
+        }
+      ]
+    },
+    {
+      "name": "EntityTypeName",
+      "fqn": "Granit.Core.Domain.ValueObjects.EntityTypeName",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/ValueObjects/EntityTypeName.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(string value)",
+          "returnType": "required string Value { get; init; } public EntityTypeName"
+        },
+        {
+          "name": "EntityTypeName",
+          "kind": "method",
+          "signature": "EntityTypeName(string value)",
+          "returnType": "implicit operator"
+        }
+      ]
+    },
+    {
+      "name": "FileName",
+      "fqn": "Granit.Core.Domain.ValueObjects.FileName",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/ValueObjects/FileName.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(string value)",
+          "returnType": "required string Value { get; init; } public FileName"
+        },
+        {
+          "name": "FileName",
+          "kind": "method",
+          "signature": "FileName(string value)",
+          "returnType": "implicit operator"
+        }
+      ]
+    },
+    {
+      "name": "HttpsUrl",
+      "fqn": "Granit.Core.Domain.ValueObjects.HttpsUrl",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Domain/ValueObjects/HttpsUrl.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(string value)",
+          "returnType": "required string Value { get; init; } public HttpsUrl"
+        },
+        {
+          "name": "HttpsUrl",
+          "kind": "method",
+          "signature": "HttpsUrl(string value)",
+          "returnType": "implicit operator"
+        }
+      ]
+    },
+    {
+      "name": "BatchItemResult",
+      "fqn": "Granit.Core.Endpoints.BatchItemResult",
+      "kind": "record",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Endpoints/BatchResult.cs",
+      "line": 28,
+      "members": []
+    },
+    {
+      "name": "BatchResult",
+      "fqn": "Granit.Core.Endpoints.BatchResult",
+      "kind": "record",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Endpoints/BatchResult.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "BatchResultHelper",
+      "fqn": "Granit.Core.Endpoints.BatchResultHelper",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Endpoints/BatchResultHelper.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "statusCode",
+          "kind": "property",
+          "signature": "BatchItemResult<T> Failure<T>(string detail, int statusCode",
+          "returnType": "BatchItemResult<T> Failure<T>(string detail, int"
+        }
+      ]
+    },
+    {
+      "name": "ModuleConfigEndpointExtensions",
+      "fqn": "Granit.Core.Endpoints.ModuleConfigEndpointExtensions",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Endpoints/ModuleConfigEndpointExtensions.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "EntityCreatedEto",
+      "fqn": "Granit.Core.Events.EntityCreatedEto",
+      "kind": "record",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/EntityCreatedEto.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "EntityCreatedEvent",
+      "fqn": "Granit.Core.Events.EntityCreatedEvent",
+      "kind": "record",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/EntityCreatedEvent.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "EntityDeletedEto",
+      "fqn": "Granit.Core.Events.EntityDeletedEto",
+      "kind": "record",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/EntityDeletedEto.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "EntityDeletedEvent",
+      "fqn": "Granit.Core.Events.EntityDeletedEvent",
+      "kind": "record",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/EntityDeletedEvent.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "EntityUpdatedEto",
+      "fqn": "Granit.Core.Events.EntityUpdatedEto",
+      "kind": "record",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/EntityUpdatedEto.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "EntityUpdatedEvent",
+      "fqn": "Granit.Core.Events.EntityUpdatedEvent",
+      "kind": "record",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/EntityUpdatedEvent.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "IDistributedEventBus",
+      "fqn": "Granit.Core.Events.IDistributedEventBus",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/IDistributedEventBus.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "IDistributedEventHandler",
+      "fqn": "Granit.Core.Events.IDistributedEventHandler",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/IDistributedEventHandler.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(TEvent integrationEvent, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IDomainEvent",
+      "fqn": "Granit.Core.Events.IDomainEvent",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/IDomainEvent.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "IDomainEventDispatcher",
+      "fqn": "Granit.Core.Events.IDomainEventDispatcher",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/IDomainEventDispatcher.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "DispatchAsync",
+          "kind": "method",
+          "signature": "DispatchAsync(IReadOnlyList<IDomainEvent> domainEvents, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IDomainEventSource",
+      "fqn": "Granit.Core.Events.IDomainEventSource",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/IDomainEventSource.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ClearDomainEvents",
+          "kind": "method",
+          "signature": "ClearDomainEvents()",
+          "returnType": "IReadOnlyCollection<IDomainEvent> DomainEvents { get; } void"
+        }
+      ]
+    },
+    {
+      "name": "IIntegrationEvent",
+      "fqn": "Granit.Core.Events.IIntegrationEvent",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/IIntegrationEvent.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "IIntegrationEventDispatcher",
+      "fqn": "Granit.Core.Events.IIntegrationEventDispatcher",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/IIntegrationEventDispatcher.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "DispatchAsync",
+          "kind": "method",
+          "signature": "DispatchAsync(IReadOnlyList<IIntegrationEvent> integrationEvents, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IIntegrationEventSource",
+      "fqn": "Granit.Core.Events.IIntegrationEventSource",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/IIntegrationEventSource.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "ClearIntegrationEvents",
+          "kind": "method",
+          "signature": "ClearIntegrationEvents()",
+          "returnType": "IReadOnlyCollection<IIntegrationEvent> IntegrationEvents { get; } void"
+        }
+      ]
+    },
+    {
+      "name": "ILocalEventBus",
+      "fqn": "Granit.Core.Events.ILocalEventBus",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/ILocalEventBus.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "ILocalEventHandler",
+      "fqn": "Granit.Core.Events.ILocalEventHandler",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/ILocalEventHandler.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(TEvent localEvent, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "NullDomainEventDispatcher",
+      "fqn": "Granit.Core.Events.NullDomainEventDispatcher",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Events/NullDomainEventDispatcher.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "DispatchAsync",
+          "kind": "method",
+          "signature": "DispatchAsync(IReadOnlyList<IDomainEvent> domainEvents, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "BusinessException",
+      "fqn": "Granit.Core.Exceptions.BusinessException",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Exceptions/BusinessException.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "BusinessException",
+          "kind": "method",
+          "signature": "BusinessException(string errorCode, string? message = null, Exception? innerException = null)",
+          "returnType": "string ErrorCode { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "BusinessRuleViolationException",
+      "fqn": "Granit.Core.Exceptions.BusinessRuleViolationException",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Exceptions/BusinessRuleViolationException.cs",
+      "line": 23,
+      "members": []
+    },
+    {
+      "name": "ConflictException",
+      "fqn": "Granit.Core.Exceptions.ConflictException",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Exceptions/ConflictException.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "ConflictException",
+          "kind": "method",
+          "signature": "ConflictException(string errorCode, string? message = null, Exception? innerException = null)",
+          "returnType": "string ErrorCode { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "EntityNotFoundException",
+      "fqn": "Granit.Core.Exceptions.EntityNotFoundException",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Exceptions/EntityNotFoundException.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "EntityNotFoundException",
+          "kind": "method",
+          "signature": "EntityNotFoundException(Type entityType, object id)",
+          "returnType": "Type EntityType { get; } public object EntityId { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "ForbiddenException",
+      "fqn": "Granit.Core.Exceptions.ForbiddenException",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Exceptions/ForbiddenException.cs",
+      "line": 26,
+      "members": []
+    },
+    {
+      "name": "IHasErrorCode",
+      "fqn": "Granit.Core.Exceptions.IHasErrorCode",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Exceptions/IHasErrorCode.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "IHasValidationErrors",
+      "fqn": "Granit.Core.Exceptions.IHasValidationErrors",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Exceptions/IHasValidationErrors.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "IUserFriendlyException",
+      "fqn": "Granit.Core.Exceptions.IUserFriendlyException",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Exceptions/IUserFriendlyException.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "NotFoundException",
+      "fqn": "Granit.Core.Exceptions.NotFoundException",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Exceptions/NotFoundException.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "ValidationException",
+      "fqn": "Granit.Core.Exceptions.ValidationException",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Exceptions/ValidationException.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "ValidationException",
+          "kind": "method",
+          "signature": "ValidationException(IReadOnlyDictionary<string, string[]> validationErrors)",
+          "returnType": "IReadOnlyDictionary<string, string[]> ValidationErrors { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "GranitApplicationExtensions",
+      "fqn": "Granit.Core.Extensions.GranitApplicationExtensions",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Extensions/GranitApplicationExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "UseGranit",
+          "kind": "method",
+          "signature": "UseGranit(this IApplicationBuilder app)",
+          "returnType": "IApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitHostBuilderExtensions",
+      "fqn": "Granit.Core.Extensions.GranitHostBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Extensions/GranitHostBuilderExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranit",
+          "kind": "method",
+          "signature": "AddGranit(this IHostApplicationBuilder builder, Action<GranitBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        },
+        {
+          "name": "AddGranitAsync",
+          "kind": "method",
+          "signature": "AddGranitAsync(this IHostApplicationBuilder builder, Action<GranitBuilder> configure)",
+          "returnType": "Task<IHostApplicationBuilder>"
+        }
+      ]
+    },
+    {
+      "name": "SingleValueObjectJsonConverterFactory",
+      "fqn": "Granit.Core.Json.SingleValueObjectJsonConverterFactory",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Json/SingleValueObjectJsonConverterFactory.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "CanConvert",
+          "kind": "method",
+          "signature": "CanConvert(Type typeToConvert)",
+          "returnType": "bool"
+        },
+        {
+          "name": "CreateConverter",
+          "kind": "method",
+          "signature": "CreateConverter(Type typeToConvert, JsonSerializerOptions options)",
+          "returnType": "JsonConverter"
+        }
+      ]
+    },
+    {
+      "name": "InheritResourceAttribute",
+      "fqn": "Granit.Core.Localization.InheritResourceAttribute",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Localization/InheritResourceAttribute.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "BaseResourceTypes",
+          "kind": "property",
+          "signature": "Type[] BaseResourceTypes",
+          "returnType": "Type[]"
+        }
+      ]
+    },
+    {
+      "name": "LocalizableString",
+      "fqn": "Granit.Core.Localization.LocalizableString",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Localization/LocalizableString.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Localize",
+          "kind": "method",
+          "signature": "Localize(IStringLocalizerFactory? localizerFactory)",
+          "returnType": "string"
+        },
+        {
+          "name": "Fixed",
+          "kind": "method",
+          "signature": "Fixed(string value)",
+          "returnType": "LocalizableString"
+        }
+      ]
+    },
+    {
+      "name": "LocalizationResourceNameAttribute",
+      "fqn": "Granit.Core.Localization.LocalizationResourceNameAttribute",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Localization/LocalizationResourceNameAttribute.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultCulture",
+          "kind": "property",
+          "signature": "string DefaultCulture",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "ApplicationInitializationContext",
+      "fqn": "Granit.Core.Modularity.ApplicationInitializationContext",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Modularity/ApplicationInitializationContext.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ServiceProvider",
+          "kind": "property",
+          "signature": "IServiceProvider ServiceProvider",
+          "returnType": "IServiceProvider"
+        }
+      ]
+    },
+    {
+      "name": "DependsOnAttribute",
+      "fqn": "Granit.Core.Modularity.DependsOnAttribute",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Modularity/DependsOnAttribute.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "DependedTypes",
+          "kind": "property",
+          "signature": "Type[] DependedTypes",
+          "returnType": "Type[]"
+        }
+      ]
+    },
+    {
+      "name": "GranitApplication",
+      "fqn": "Granit.Core.Modularity.GranitApplication",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Modularity/GranitApplication.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetModuleInstances",
+          "kind": "method",
+          "signature": "GetModuleInstances()",
+          "returnType": "IReadOnlyList<GranitModule>"
+        }
+      ]
+    },
+    {
+      "name": "GranitBuilder",
+      "fqn": "Granit.Core.Modularity.GranitBuilder",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Modularity/GranitBuilder.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "GranitModule",
+      "fqn": "Granit.Core.Modularity.GranitModule",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Modularity/GranitModule.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "IsEnabled",
+          "kind": "method",
+          "signature": "IsEnabled(ServiceConfigurationContext context)",
+          "returnType": "bool"
+        },
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IModuleConfigProvider",
+      "fqn": "Granit.Core.Modularity.IModuleConfigProvider",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Modularity/IModuleConfigProvider.cs",
+      "line": 31,
+      "members": [
+        {
+          "name": "GetConfig",
+          "kind": "method",
+          "signature": "GetConfig()",
+          "returnType": "TResponse"
+        }
+      ]
+    },
+    {
+      "name": "ServiceConfigurationContext",
+      "fqn": "Granit.Core.Modularity.ServiceConfigurationContext",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/Modularity/ServiceConfigurationContext.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "Services",
+          "kind": "property",
+          "signature": "IServiceCollection Services",
+          "returnType": "IServiceCollection"
+        },
+        {
+          "name": "Configuration",
+          "kind": "property",
+          "signature": "IConfiguration Configuration",
+          "returnType": "IConfiguration"
+        },
+        {
+          "name": "Builder",
+          "kind": "property",
+          "signature": "IHostApplicationBuilder Builder",
+          "returnType": "IHostApplicationBuilder"
+        },
+        {
+          "name": "ModuleAssemblies",
+          "kind": "property",
+          "signature": "IReadOnlyList<Assembly> ModuleAssemblies",
+          "returnType": "IReadOnlyList<Assembly>"
+        },
+        {
+          "name": "Items",
+          "kind": "property",
+          "signature": "IDictionary<string, object?> Items",
+          "returnType": "IDictionary<string, object?>"
+        }
+      ]
+    },
+    {
+      "name": "AllowAnonymousTenantAttribute",
+      "fqn": "Granit.Core.MultiTenancy.AllowAnonymousTenantAttribute",
+      "kind": "class",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/MultiTenancy/AllowAnonymousTenantAttribute.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ICurrentTenant",
+      "fqn": "Granit.Core.MultiTenancy.ICurrentTenant",
+      "kind": "interface",
+      "project": "Granit.Core",
+      "file": "src/Granit.Core/MultiTenancy/ICurrentTenant.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "Change",
+          "kind": "method",
+          "signature": "Change(Guid? id, string? name = null)",
+          "returnType": "bool IsAvailable { get; } Guid? Id { get; } string? Name { get; } IDisposable"
+        }
+      ]
+    },
+    {
+      "name": "DataExchangeAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.DataExchange.AI.Extensions.DataExchangeAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.DataExchange.AI",
+      "file": "src/Granit.DataExchange.AI/Extensions/DataExchangeAIHostApplicationBuilderExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitDataExchangeAI",
+          "kind": "method",
+          "signature": "AddGranitDataExchangeAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitDataExchangeAIModule",
+      "fqn": "Granit.DataExchange.AI.GranitDataExchangeAIModule",
+      "kind": "class",
+      "project": "Granit.DataExchange.AI",
+      "file": "src/Granit.DataExchange.AI/GranitDataExchangeAIModule.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "DataExchangeAIOptions",
+      "fqn": "Granit.DataExchange.AI.Options.DataExchangeAIOptions",
+      "kind": "class",
+      "project": "Granit.DataExchange.AI",
+      "file": "src/Granit.DataExchange.AI/Options/DataExchangeAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string WorkspaceName",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        },
+        {
+          "name": "MinConfidenceScore",
+          "kind": "property",
+          "signature": "double MinConfidenceScore",
+          "returnType": "double"
+        },
+        {
+          "name": "IncludePreviewRows",
+          "kind": "property",
+          "signature": "bool IncludePreviewRows",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.DataExchange.Csv.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.DataExchange.Csv",
+      "file": "src/Granit.DataExchange.Csv/Extensions/ServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitDataExchangeCsv",
+          "kind": "method",
+          "signature": "AddGranitDataExchangeCsv(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitDataExchangeCsvModule",
+      "fqn": "Granit.DataExchange.Csv.GranitDataExchangeCsvModule",
+      "kind": "class",
+      "project": "Granit.DataExchange.Csv",
+      "file": "src/Granit.DataExchange.Csv/GranitDataExchangeCsvModule.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "DataExchangeMetrics",
+      "fqn": "Granit.DataExchange.Diagnostics.DataExchangeMetrics",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Diagnostics/DataExchangeMetrics.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "CreateExportJobRequest",
+      "fqn": "Granit.DataExchange.Endpoints.Dtos.Export.CreateExportJobRequest",
+      "kind": "record",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Dtos/Export/CreateExportJobRequest.cs",
+      "line": 24,
+      "members": []
+    },
+    {
+      "name": "ExportDefinitionResponse",
+      "fqn": "Granit.DataExchange.Endpoints.Dtos.Export.ExportDefinitionResponse",
+      "kind": "record",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Dtos/Export/ExportDefinitionResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ExportFieldResponse",
+      "fqn": "Granit.DataExchange.Endpoints.Dtos.Export.ExportFieldResponse",
+      "kind": "record",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Dtos/Export/ExportFieldResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ExportJobResponse",
+      "fqn": "Granit.DataExchange.Endpoints.Dtos.Export.ExportJobResponse",
+      "kind": "record",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Dtos/Export/ExportJobResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ExportPresetResponse",
+      "fqn": "Granit.DataExchange.Endpoints.Dtos.Export.ExportPresetResponse",
+      "kind": "record",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Dtos/Export/ExportPresetResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "SaveExportPresetRequest",
+      "fqn": "Granit.DataExchange.Endpoints.Dtos.Export.SaveExportPresetRequest",
+      "kind": "record",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Dtos/Export/SaveExportPresetRequest.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "ConfirmMappingsRequest",
+      "fqn": "Granit.DataExchange.Endpoints.Dtos.Import.ConfirmMappingsRequest",
+      "kind": "record",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Dtos/Import/ConfirmMappingsRequest.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ImportJobResponse",
+      "fqn": "Granit.DataExchange.Endpoints.Dtos.Import.ImportJobResponse",
+      "kind": "record",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Dtos/Import/ImportJobResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ImportPreviewResponse",
+      "fqn": "Granit.DataExchange.Endpoints.Dtos.Import.ImportPreviewResponse",
+      "kind": "record",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Dtos/Import/ImportPreviewResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ImportReportResponse",
+      "fqn": "Granit.DataExchange.Endpoints.Dtos.Import.ImportReportResponse",
+      "kind": "record",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Dtos/Import/ImportReportResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "DataExchangeEndpointRouteBuilderExtensions",
+      "fqn": "Granit.DataExchange.Endpoints.Extensions.DataExchangeEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Extensions/DataExchangeEndpointRouteBuilderExtensions.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "MapDataExchangeEndpoints",
+          "kind": "method",
+          "signature": "MapDataExchangeEndpoints(this IEndpointRouteBuilder endpoints, Action<DataExchangeEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitDataExchangeEndpointsModule",
+      "fqn": "Granit.DataExchange.Endpoints.GranitDataExchangeEndpointsModule",
+      "kind": "class",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/GranitDataExchangeEndpointsModule.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "ImportAuthorizationPolicy",
+      "fqn": "Granit.DataExchange.Endpoints.Internal.Import.ImportAuthorizationPolicy",
+      "kind": "class",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Internal/Import/ImportAuthorizationPolicy.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "DataExchangeEndpointsOptions",
+      "fqn": "Granit.DataExchange.Endpoints.Options.DataExchangeEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Options/DataExchangeEndpointsOptions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "DataExchangePermissions",
+      "fqn": "Granit.DataExchange.Endpoints.Permissions.DataExchangePermissions",
+      "kind": "class",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Permissions/DataExchangePermissions.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "Exports",
+      "fqn": "Granit.DataExchange.Endpoints.Permissions.Exports",
+      "kind": "class",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Permissions/DataExchangePermissions.cs",
+      "line": 30,
+      "members": []
+    },
+    {
+      "name": "Imports",
+      "fqn": "Granit.DataExchange.Endpoints.Permissions.Imports",
+      "kind": "class",
+      "project": "Granit.DataExchange.Endpoints",
+      "file": "src/Granit.DataExchange.Endpoints/Permissions/DataExchangePermissions.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "DataExchangeEfCoreHostBuilderExtensions",
+      "fqn": "Granit.DataExchange.EntityFrameworkCore.Extensions.DataExchangeEfCoreHostBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.DataExchange.EntityFrameworkCore",
+      "file": "src/Granit.DataExchange.EntityFrameworkCore/Extensions/DataExchangeEfCoreHostBuilderExtensions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "AddGranitDataExchangeEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitDataExchangeEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "DataExchangeEfCoreServiceCollectionExtensions",
+      "fqn": "Granit.DataExchange.EntityFrameworkCore.Extensions.DataExchangeEfCoreServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.DataExchange.EntityFrameworkCore",
+      "file": "src/Granit.DataExchange.EntityFrameworkCore/Extensions/DataExchangeEfCoreServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "DataExchangeModelBuilderExtensions",
+      "fqn": "Granit.DataExchange.EntityFrameworkCore.Extensions.DataExchangeModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.DataExchange.EntityFrameworkCore",
+      "file": "src/Granit.DataExchange.EntityFrameworkCore/Extensions/DataExchangeModelBuilderExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureDataExchangeModule",
+          "kind": "method",
+          "signature": "ConfigureDataExchangeModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitDataExchangeDbProperties",
+      "fqn": "Granit.DataExchange.EntityFrameworkCore.GranitDataExchangeDbProperties",
+      "kind": "class",
+      "project": "Granit.DataExchange.EntityFrameworkCore",
+      "file": "src/Granit.DataExchange.EntityFrameworkCore/GranitDataExchangeDbProperties.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitDataExchangeEntityFrameworkCoreModule",
+      "fqn": "Granit.DataExchange.EntityFrameworkCore.GranitDataExchangeEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.DataExchange.EntityFrameworkCore",
+      "file": "src/Granit.DataExchange.EntityFrameworkCore/GranitDataExchangeEntityFrameworkCoreModule.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "OnApplicationInitializationAsync",
+          "kind": "method",
+          "signature": "OnApplicationInitializationAsync(ApplicationInitializationContext context)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.DataExchange.Excel.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.DataExchange.Excel",
+      "file": "src/Granit.DataExchange.Excel/Extensions/ServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitDataExchangeExcel",
+          "kind": "method",
+          "signature": "AddGranitDataExchangeExcel(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitDataExchangeExcelModule",
+      "fqn": "Granit.DataExchange.Excel.GranitDataExchangeExcelModule",
+      "kind": "class",
+      "project": "Granit.DataExchange.Excel",
+      "file": "src/Granit.DataExchange.Excel/GranitDataExchangeExcelModule.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ExportJob",
+      "fqn": "Granit.DataExchange.Export.Domain.ExportJob",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/Domain/ExportJob.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, string definitionName, string format, string requestJson, Guid? tenantId = null)",
+          "returnType": "ExportJob"
+        },
+        {
+          "name": "DefinitionName",
+          "kind": "property",
+          "signature": "string DefinitionName",
+          "returnType": "string"
+        },
+        {
+          "name": "Format",
+          "kind": "property",
+          "signature": "string Format",
+          "returnType": "string"
+        },
+        {
+          "name": "RequestJson",
+          "kind": "property",
+          "signature": "string RequestJson",
+          "returnType": "string"
+        },
+        {
+          "name": "Status",
+          "kind": "property",
+          "signature": "ExportJobStatus Status",
+          "returnType": "ExportJobStatus"
+        },
+        {
+          "name": "MarkAsExporting",
+          "kind": "method",
+          "signature": "MarkAsExporting()",
+          "returnType": "string? BlobReference { get; private set; } public string? FileName { get; private set; } public int? RowCount { get; private set; } public string? ErrorMessage { get; private set; } public DateTimeOffset? CompletedAt { get; private set; } public Guid? TenantId { get; private set; } internal void"
+        }
+      ]
+    },
+    {
+      "name": "ExportJobFailedEto",
+      "fqn": "Granit.DataExchange.Export.Events.ExportJobFailedEto",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/Events/ExportJobFailedEto.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "ExportDefinition",
+      "fqn": "Granit.DataExchange.Export.ExportDefinition",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/ExportDefinition.cs",
+      "line": 42,
+      "members": [
+        {
+          "name": "typeof",
+          "kind": "method",
+          "signature": "typeof(TEntity)",
+          "returnType": "string Name { get; } public Type EntityType =>"
+        },
+        {
+          "name": "QueryDefinitionName",
+          "kind": "property",
+          "signature": "string? QueryDefinitionName",
+          "returnType": "string?"
+        },
+        {
+          "name": "SupportedFormats",
+          "kind": "property",
+          "signature": "IReadOnlyList<string> SupportedFormats",
+          "returnType": "IReadOnlyList<string>"
+        },
+        {
+          "name": "GetIncludeId",
+          "kind": "method",
+          "signature": "GetIncludeId()",
+          "returnType": "bool"
+        },
+        {
+          "name": "GetIncludeBusinessKey",
+          "kind": "method",
+          "signature": "GetIncludeBusinessKey()",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "ExportDefinitionBuilder",
+      "fqn": "Granit.DataExchange.Export.ExportDefinitionBuilder",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/ExportDefinitionBuilder.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "ExportDownload",
+      "fqn": "Granit.DataExchange.Export.ExportDownload",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/IExportOrchestrator.cs",
+      "line": 62,
+      "members": []
+    },
+    {
+      "name": "ExportFieldBuilder",
+      "fqn": "Granit.DataExchange.Export.ExportFieldBuilder",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/ExportFieldBuilder.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ExportFieldDescriptor",
+      "fqn": "Granit.DataExchange.Export.ExportFieldDescriptor",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/ExportFieldDescriptor.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "ExportJobResult",
+      "fqn": "Granit.DataExchange.Export.ExportJobResult",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/ExportJobResult.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "ExportJobStatus",
+      "fqn": "Granit.DataExchange.Export.ExportJobStatus",
+      "kind": "enum",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/ExportJobStatus.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ExportOptions",
+      "fqn": "Granit.DataExchange.Export.ExportOptions",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/ExportOptions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "BackgroundThreshold",
+          "kind": "property",
+          "signature": "int BackgroundThreshold",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "ExportPreset",
+      "fqn": "Granit.DataExchange.Export.ExportPreset",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/ExportPreset.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "ExportRequest",
+      "fqn": "Granit.DataExchange.Export.ExportRequest",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/ExportRequest.cs",
+      "line": 33,
+      "members": []
+    },
+    {
+      "name": "IExportCommandDispatcher",
+      "fqn": "Granit.DataExchange.Export.IExportCommandDispatcher",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/IExportCommandDispatcher.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "DispatchAsync",
+          "kind": "method",
+          "signature": "DispatchAsync(ExecuteExportCommand command, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IExportDataSource",
+      "fqn": "Granit.DataExchange.Export.IExportDataSource",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/IExportDataSource.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "GetQueryable",
+          "kind": "method",
+          "signature": "GetQueryable()",
+          "returnType": "IQueryable<TEntity>"
+        }
+      ]
+    },
+    {
+      "name": "IExportDefinitionDescriptor",
+      "fqn": "Granit.DataExchange.Export.IExportDefinitionDescriptor",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/IExportDefinitionDescriptor.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "GetFields",
+          "kind": "method",
+          "signature": "GetFields()",
+          "returnType": "string Name { get; } Type EntityType { get; } string? QueryDefinitionName { get; } IReadOnlyList<string> SupportedFormats { get; } IReadOnlyList<ExportFieldDescriptor>"
+        }
+      ]
+    },
+    {
+      "name": "IExportJobReader",
+      "fqn": "Granit.DataExchange.Export.IExportJobReader",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/IExportJobReader.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ExportJob?>"
+        },
+        {
+          "name": "ListAsync",
+          "kind": "method",
+          "signature": "ListAsync(ExportJobStatus? status = null, int page = 1, int pageSize = 20, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<ExportJob>>"
+        }
+      ]
+    },
+    {
+      "name": "IExportJobWriter",
+      "fqn": "Granit.DataExchange.Export.IExportJobWriter",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/IExportJobWriter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(ExportJob job, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UpdateAsync",
+          "kind": "method",
+          "signature": "UpdateAsync(ExportJob job, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IExportOrchestrator",
+      "fqn": "Granit.DataExchange.Export.IExportOrchestrator",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/IExportOrchestrator.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "ExportAsync",
+          "kind": "method",
+          "signature": "ExportAsync(ExportRequest request, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ExportJobResult>"
+        },
+        {
+          "name": "ExecuteAsync",
+          "kind": "method",
+          "signature": "ExecuteAsync(Guid jobId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "GetJobAsync",
+          "kind": "method",
+          "signature": "GetJobAsync(Guid jobId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ExportJob?>"
+        },
+        {
+          "name": "GetDownloadAsync",
+          "kind": "method",
+          "signature": "GetDownloadAsync(Guid jobId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ExportDownload?>"
+        }
+      ]
+    },
+    {
+      "name": "IExportPresetReader",
+      "fqn": "Granit.DataExchange.Export.IExportPresetReader",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/IExportPresetReader.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(string definitionName, string presetName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ExportPreset?>"
+        },
+        {
+          "name": "ListAsync",
+          "kind": "method",
+          "signature": "ListAsync(string definitionName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<ExportPreset>>"
+        }
+      ]
+    },
+    {
+      "name": "IExportPresetWriter",
+      "fqn": "Granit.DataExchange.Export.IExportPresetWriter",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/IExportPresetWriter.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SaveAsync",
+          "kind": "method",
+          "signature": "SaveAsync(ExportPreset preset, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(string definitionName, string presetName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IExportWriter",
+      "fqn": "Granit.DataExchange.Export.IExportWriter",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/IExportWriter.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "CanWrite",
+          "kind": "method",
+          "signature": "CanWrite(string format)",
+          "returnType": "bool"
+        },
+        {
+          "name": "WriteAsync",
+          "kind": "method",
+          "signature": "WriteAsync(Stream output, IReadOnlyList<ExportFieldDescriptor> fields, IAsyncEnumerable<IReadOnlyDictionary<string, object?>> rows, CancellationToken cancellationToken = default)",
+          "returnType": "string MimeType { get; } string FileExtension { get; } Task"
+        }
+      ]
+    },
+    {
+      "name": "ExecuteExportCommand",
+      "fqn": "Granit.DataExchange.Export.Messages.ExecuteExportCommand",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/Messages/ExecuteExportCommand.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ExportJobCompletedEvent",
+      "fqn": "Granit.DataExchange.Export.Messages.ExportJobCompletedEvent",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Export/Messages/ExportJobCompletedEvent.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.DataExchange.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Extensions/ServiceCollectionExtensions.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "AddGranitDataImport",
+          "kind": "method",
+          "signature": "AddGranitDataImport(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitDataExchangeModule",
+      "fqn": "Granit.DataExchange.GranitDataExchangeModule",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/GranitDataExchangeModule.cs",
+      "line": 35,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ImportJob",
+      "fqn": "Granit.DataExchange.Import.Domain.ImportJob",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Domain/ImportJob.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, string definitionName, string entityTypeName, string originalFileName, string mimeType, long fileSizeBytes, string blobReference, Guid? tenantId = null)",
+          "returnType": "ImportJob"
+        },
+        {
+          "name": "DefinitionName",
+          "kind": "property",
+          "signature": "string DefinitionName",
+          "returnType": "string"
+        },
+        {
+          "name": "EntityTypeName",
+          "kind": "property",
+          "signature": "string EntityTypeName",
+          "returnType": "string"
+        },
+        {
+          "name": "OriginalFileName",
+          "kind": "property",
+          "signature": "string OriginalFileName",
+          "returnType": "string"
+        },
+        {
+          "name": "MimeType",
+          "kind": "property",
+          "signature": "string MimeType",
+          "returnType": "string"
+        },
+        {
+          "name": "FileSizeBytes",
+          "kind": "property",
+          "signature": "long FileSizeBytes",
+          "returnType": "long"
+        },
+        {
+          "name": "Status",
+          "kind": "property",
+          "signature": "ImportJobStatus Status",
+          "returnType": "ImportJobStatus"
+        },
+        {
+          "name": "SetMappings",
+          "kind": "method",
+          "signature": "SetMappings(string mappingsJson)",
+          "returnType": "string? MappingsJson { get; private set; } public string? ReportJson { get; private set; } public DateTimeOffset? CompletedAt { get; private set; } public Guid? TenantId { get; private set; } internal void"
+        }
+      ]
+    },
+    {
+      "name": "ImportJobStatus",
+      "fqn": "Granit.DataExchange.Import.Domain.ImportJobStatus",
+      "kind": "enum",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Domain/ImportJobStatus.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ImportJobCancelledEvent",
+      "fqn": "Granit.DataExchange.Import.Events.ImportJobCancelledEvent",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Events/ImportJobCancelledEvent.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "IImportExecutor",
+      "fqn": "Granit.DataExchange.Import.Execution.IImportExecutor",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Execution/IImportExecutor.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "ExecuteAsync",
+          "kind": "method",
+          "signature": "ExecuteAsync(IAsyncEnumerable<ValidatedRow<TEntity>> entities, ImportExecutionOptions options, IProgress<ImportProgress>? progress = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImportReport>"
+        }
+      ]
+    },
+    {
+      "name": "ImportErrorBehavior",
+      "fqn": "Granit.DataExchange.Import.Execution.ImportErrorBehavior",
+      "kind": "enum",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Execution/ImportErrorBehavior.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ImportExecutionOptions",
+      "fqn": "Granit.DataExchange.Import.Execution.ImportExecutionOptions",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Execution/ImportExecutionOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "BatchSize",
+          "kind": "property",
+          "signature": "int BatchSize",
+          "returnType": "int"
+        },
+        {
+          "name": "DryRun",
+          "kind": "property",
+          "signature": "bool DryRun",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "ValidatedRow",
+      "fqn": "Granit.DataExchange.Import.Execution.ValidatedRow",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Execution/ValidatedRow.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "GroupedRows",
+      "fqn": "Granit.DataExchange.Import.Grouping.GroupedRows",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Grouping/GroupedRows.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "IRowGrouper",
+      "fqn": "Granit.DataExchange.Import.Grouping.IRowGrouper",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Grouping/IRowGrouper.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "GroupAsync",
+          "kind": "method",
+          "signature": "GroupAsync(IAsyncEnumerable<RawImportRow> rows, CancellationToken cancellationToken = default)",
+          "returnType": "IAsyncEnumerable<GroupedRows>"
+        }
+      ]
+    },
+    {
+      "name": "IRecordIdentityResolver",
+      "fqn": "Granit.DataExchange.Import.Identity.IRecordIdentityResolver",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Identity/IRecordIdentityResolver.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "ResolveAsync",
+          "kind": "method",
+          "signature": "ResolveAsync(TEntity entity, CancellationToken cancellationToken = default)",
+          "returnType": "Task<RecordIdentity<TEntity>>"
+        }
+      ]
+    },
+    {
+      "name": "RecordIdentity",
+      "fqn": "Granit.DataExchange.Import.Identity.RecordIdentity",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Identity/RecordIdentity.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "RecordOperation",
+      "fqn": "Granit.DataExchange.Import.Identity.RecordOperation",
+      "kind": "enum",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Identity/RecordOperation.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ImportOptions",
+      "fqn": "Granit.DataExchange.Import.ImportOptions",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/ImportOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "DefaultMaxFileSizeMb",
+          "kind": "property",
+          "signature": "int DefaultMaxFileSizeMb",
+          "returnType": "int"
+        },
+        {
+          "name": "DefaultBatchSize",
+          "kind": "property",
+          "signature": "int DefaultBatchSize",
+          "returnType": "int"
+        },
+        {
+          "name": "FuzzyMatchThreshold",
+          "kind": "property",
+          "signature": "double FuzzyMatchThreshold",
+          "returnType": "double"
+        }
+      ]
+    },
+    {
+      "name": "CellConversionError",
+      "fqn": "Granit.DataExchange.Import.Mapping.CellConversionError",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/CellConversionError.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "ChildCollectionBuilder",
+      "fqn": "Granit.DataExchange.Import.Mapping.ChildCollectionBuilder",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/ChildCollectionBuilder.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "IDataMapper",
+      "fqn": "Granit.DataExchange.Import.Mapping.IDataMapper",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/IDataMapper.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "MapAsync",
+          "kind": "method",
+          "signature": "MapAsync(RawImportRow row, IReadOnlyList<ImportColumnMapping> mappings, ImportOptions options, CancellationToken cancellationToken = default)",
+          "returnType": "Task<MappingResult<TEntity>>"
+        }
+      ]
+    },
+    {
+      "name": "IImportDefinitionDescriptor",
+      "fqn": "Granit.DataExchange.Import.Mapping.IImportDefinitionDescriptor",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/IImportDefinitionDescriptor.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "GetFieldMetadata",
+          "kind": "method",
+          "signature": "GetFieldMetadata()",
+          "returnType": "string Name { get; } Type EntityType { get; } int MaxFileSizeMb { get; } IReadOnlyList<string> AllowedMimeTypes { get; } IReadOnlyList<ImportFieldMetadata>"
+        }
+      ]
+    },
+    {
+      "name": "IMappingReader",
+      "fqn": "Granit.DataExchange.Import.Mapping.IMappingReader",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/IMappingReader.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "LoadAsync",
+          "kind": "method",
+          "signature": "LoadAsync(string definitionName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<ImportColumnMapping>>"
+        }
+      ]
+    },
+    {
+      "name": "IMappingSuggestionService",
+      "fqn": "Granit.DataExchange.Import.Mapping.IMappingSuggestionService",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/IMappingSuggestionService.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "IMappingWriter",
+      "fqn": "Granit.DataExchange.Import.Mapping.IMappingWriter",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/IMappingWriter.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SaveAsync",
+          "kind": "method",
+          "signature": "SaveAsync(string definitionName, IReadOnlyList<ImportColumnMapping> mappings, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ISemanticMappingService",
+      "fqn": "Granit.DataExchange.Import.Mapping.ISemanticMappingService",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/ISemanticMappingService.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "SuggestSemanticMappingsAsync",
+          "kind": "method",
+          "signature": "SuggestSemanticMappingsAsync(IReadOnlyList<string> headers, IReadOnlyList<ImportFieldMetadata> targetFields, CancellationToken cancellationToken = default)",
+          "returnType": "bool IsAvailable { get; } Task<IReadOnlyList<SemanticMappingSuggestion>>"
+        },
+        {
+          "name": "SuggestSemanticMappingsAsync",
+          "kind": "method",
+          "signature": "SuggestSemanticMappingsAsync(IReadOnlyList<string> headers, IReadOnlyList<ImportFieldMetadata> targetFields, IReadOnlyList<string[]>? previewRows, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<SemanticMappingSuggestion>>"
+        },
+        {
+          "name": "SuggestSemanticMappingsAsync",
+          "kind": "method",
+          "signature": "SuggestSemanticMappingsAsync(headers, targetFields, cancellationToken)",
+          "returnType": "=>"
+        }
+      ]
+    },
+    {
+      "name": "ImportColumnMapping",
+      "fqn": "Granit.DataExchange.Import.Mapping.ImportColumnMapping",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/ImportColumnMapping.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "ImportDefinition",
+      "fqn": "Granit.DataExchange.Import.Mapping.ImportDefinition",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/ImportDefinition.cs",
+      "line": 31,
+      "members": [
+        {
+          "name": "typeof",
+          "kind": "method",
+          "signature": "typeof(TEntity)",
+          "returnType": "string Name { get; } public Type EntityType =>"
+        },
+        {
+          "name": "MaxFileSizeMb",
+          "kind": "property",
+          "signature": "int MaxFileSizeMb",
+          "returnType": "int"
+        },
+        {
+          "name": "AllowedMimeTypes",
+          "kind": "property",
+          "signature": "IReadOnlyList<string> AllowedMimeTypes",
+          "returnType": "IReadOnlyList<string>"
+        },
+        {
+          "name": "GetFieldMetadata",
+          "kind": "method",
+          "signature": "GetFieldMetadata()",
+          "returnType": "IReadOnlyList<ImportFieldMetadata>"
+        },
+        {
+          "name": "GetBusinessKeyProperties",
+          "kind": "method",
+          "signature": "GetBusinessKeyProperties()",
+          "returnType": "IReadOnlyList<string>"
+        },
+        {
+          "name": "GetExcludedOnUpdateProperties",
+          "kind": "method",
+          "signature": "GetExcludedOnUpdateProperties()",
+          "returnType": "IReadOnlyList<string>"
+        },
+        {
+          "name": "GetGroupByColumn",
+          "kind": "method",
+          "signature": "GetGroupByColumn()",
+          "returnType": "string?"
+        },
+        {
+          "name": "GetHasExternalId",
+          "kind": "method",
+          "signature": "GetHasExternalId()",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "ImportDefinitionBuilder",
+      "fqn": "Granit.DataExchange.Import.Mapping.ImportDefinitionBuilder",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/ImportDefinitionBuilder.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ImportFieldMetadata",
+      "fqn": "Granit.DataExchange.Import.Mapping.ImportFieldMetadata",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/ImportFieldMetadata.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "MappingConfidence",
+      "fqn": "Granit.DataExchange.Import.Mapping.MappingConfidence",
+      "kind": "enum",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/MappingConfidence.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "MappingResult",
+      "fqn": "Granit.DataExchange.Import.Mapping.MappingResult",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/MappingResult.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Entity",
+          "kind": "property",
+          "signature": "TEntity? Entity",
+          "returnType": "TEntity?"
+        },
+        {
+          "name": "Succeeded",
+          "kind": "property",
+          "signature": "bool Succeeded",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "PropertyMapping",
+      "fqn": "Granit.DataExchange.Import.Mapping.PropertyMapping",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/PropertyMapping.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "PropertyPath",
+          "kind": "property",
+          "signature": "required string PropertyPath",
+          "returnType": "required string"
+        },
+        {
+          "name": "ToFieldMetadata",
+          "kind": "method",
+          "signature": "ToFieldMetadata()",
+          "returnType": "bool IsRequired { get; init; } public string? Format { get; init; } public bool IsChildCollection { get; init; } internal ImportFieldMetadata"
+        }
+      ]
+    },
+    {
+      "name": "PropertyMappingBuilder",
+      "fqn": "Granit.DataExchange.Import.Mapping.PropertyMappingBuilder",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/PropertyMappingBuilder.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "SemanticMappingSuggestion",
+      "fqn": "Granit.DataExchange.Import.Mapping.SemanticMappingSuggestion",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Mapping/SemanticMappingSuggestion.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ExecuteImportCommand",
+      "fqn": "Granit.DataExchange.Import.Messages.ExecuteImportCommand",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Messages/ExecuteImportCommand.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ImportJobCompletedEvent",
+      "fqn": "Granit.DataExchange.Import.Messages.ImportJobCompletedEvent",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Messages/ImportJobCompletedEvent.cs",
+      "line": 24,
+      "members": []
+    },
+    {
+      "name": "FileParsingOptions",
+      "fqn": "Granit.DataExchange.Import.Parsing.FileParsingOptions",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Parsing/FileParsingOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Encoding",
+          "kind": "property",
+          "signature": "string? Encoding",
+          "returnType": "string?"
+        },
+        {
+          "name": "QuoteChar",
+          "kind": "property",
+          "signature": "string QuoteChar",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "IFileParser",
+      "fqn": "Granit.DataExchange.Import.Parsing.IFileParser",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Parsing/IFileParser.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "CanParse",
+          "kind": "method",
+          "signature": "CanParse(string mimeType)",
+          "returnType": "bool"
+        },
+        {
+          "name": "ExtractHeadersAsync",
+          "kind": "method",
+          "signature": "ExtractHeadersAsync(Stream stream, FileParsingOptions options, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<string>>"
+        },
+        {
+          "name": "ReadPreviewAsync",
+          "kind": "method",
+          "signature": "ReadPreviewAsync(Stream stream, FileParsingOptions options, int maxRows = 10, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<string[]>>"
+        },
+        {
+          "name": "ParseAsync",
+          "kind": "method",
+          "signature": "ParseAsync(Stream stream, FileParsingOptions options, CancellationToken cancellationToken = default)",
+          "returnType": "IAsyncEnumerable<RawImportRow>"
+        }
+      ]
+    },
+    {
+      "name": "RawImportRow",
+      "fqn": "Granit.DataExchange.Import.Parsing.RawImportRow",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Parsing/RawImportRow.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "IImportCommandDispatcher",
+      "fqn": "Granit.DataExchange.Import.Pipeline.IImportCommandDispatcher",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Pipeline/IImportCommandDispatcher.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "DispatchAsync",
+          "kind": "method",
+          "signature": "DispatchAsync(ExecuteImportCommand command, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IImportFileProvider",
+      "fqn": "Granit.DataExchange.Import.Pipeline.IImportFileProvider",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Pipeline/IImportFileProvider.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "OpenAsync",
+          "kind": "method",
+          "signature": "OpenAsync(string blobReference, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Stream>"
+        },
+        {
+          "name": "SaveAsync",
+          "kind": "method",
+          "signature": "SaveAsync(string fileName, Stream content, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(string blobReference, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IImportJobReader",
+      "fqn": "Granit.DataExchange.Import.Pipeline.IImportJobReader",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Pipeline/IImportJobReader.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImportJob?>"
+        },
+        {
+          "name": "ListAsync",
+          "kind": "method",
+          "signature": "ListAsync(ImportJobStatus? status = null, int page = 1, int pageSize = 20, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<ImportJob>>"
+        }
+      ]
+    },
+    {
+      "name": "IImportJobWriter",
+      "fqn": "Granit.DataExchange.Import.Pipeline.IImportJobWriter",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Pipeline/IImportJobWriter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(ImportJob job, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UpdateAsync",
+          "kind": "method",
+          "signature": "UpdateAsync(ImportJob job, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IImportOrchestrator",
+      "fqn": "Granit.DataExchange.Import.Pipeline.IImportOrchestrator",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Pipeline/IImportOrchestrator.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "ExecuteAsync",
+          "kind": "method",
+          "signature": "ExecuteAsync(Guid importJobId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImportReport>"
+        },
+        {
+          "name": "DryRunAsync",
+          "kind": "method",
+          "signature": "DryRunAsync(Guid importJobId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImportReport>"
+        }
+      ]
+    },
+    {
+      "name": "ICorrectionFileGenerator",
+      "fqn": "Granit.DataExchange.Import.Reporting.ICorrectionFileGenerator",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Reporting/ICorrectionFileGenerator.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "GenerateAsync",
+          "kind": "method",
+          "signature": "GenerateAsync(Stream originalFileStream, string mimeType, ImportReport report, FileParsingOptions parsingOptions, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Stream>"
+        }
+      ]
+    },
+    {
+      "name": "ImportProgress",
+      "fqn": "Granit.DataExchange.Import.Reporting.ImportProgress",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Reporting/ImportProgress.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ImportReport",
+      "fqn": "Granit.DataExchange.Import.Reporting.ImportReport",
+      "kind": "class",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Reporting/ImportReport.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "ImportRowError",
+      "fqn": "Granit.DataExchange.Import.Reporting.ImportRowError",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Reporting/ImportRowError.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ImportRowErrorKind",
+      "fqn": "Granit.DataExchange.Import.Reporting.ImportRowErrorKind",
+      "kind": "enum",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Reporting/ImportRowErrorKind.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IRowValidator",
+      "fqn": "Granit.DataExchange.Import.Validation.IRowValidator",
+      "kind": "interface",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Validation/IRowValidator.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "ValidateAsync",
+          "kind": "method",
+          "signature": "ValidateAsync(TEntity entity, int rowNumber, CancellationToken cancellationToken = default)",
+          "returnType": "Task<RowValidationResult>"
+        }
+      ]
+    },
+    {
+      "name": "RowFieldError",
+      "fqn": "Granit.DataExchange.Import.Validation.RowFieldError",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Validation/RowFieldError.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "RowValidationResult",
+      "fqn": "Granit.DataExchange.Import.Validation.RowValidationResult",
+      "kind": "record",
+      "project": "Granit.DataExchange",
+      "file": "src/Granit.DataExchange/Import/Validation/RowValidationResult.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "IsValid",
+          "kind": "property",
+          "signature": "bool IsValid",
+          "returnType": "bool"
+        },
+        {
+          "name": "Errors",
+          "kind": "property",
+          "signature": "IReadOnlyList<RowFieldError> Errors",
+          "returnType": "IReadOnlyList<RowFieldError>"
+        }
+      ]
+    },
+    {
+      "name": "GranitDataExchangeWolverineModule",
+      "fqn": "Granit.DataExchange.Wolverine.GranitDataExchangeWolverineModule",
+      "kind": "class",
+      "project": "Granit.DataExchange.Wolverine",
+      "file": "src/Granit.DataExchange.Wolverine/GranitDataExchangeWolverineModule.cs",
+      "line": 29,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IHealthCheckAggregator",
+      "fqn": "Granit.Diagnostics.Abstractions.IHealthCheckAggregator",
+      "kind": "interface",
+      "project": "Granit.Diagnostics",
+      "file": "src/Granit.Diagnostics/Abstractions/IHealthCheckAggregator.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "CheckAllAsync",
+          "kind": "method",
+          "signature": "CheckAllAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<MonitoringHealthResponse>"
+        }
+      ]
+    },
+    {
+      "name": "CachedHealthCheck",
+      "fqn": "Granit.Diagnostics.Caching.CachedHealthCheck",
+      "kind": "class",
+      "project": "Granit.Diagnostics",
+      "file": "src/Granit.Diagnostics/Caching/CachedHealthCheck.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "CheckHealthAsync",
+          "kind": "method",
+          "signature": "CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task<HealthCheckResult>"
+        }
+      ]
+    },
+    {
+      "name": "MonitoringHealthResponse",
+      "fqn": "Granit.Diagnostics.Dtos.MonitoringHealthResponse",
+      "kind": "record",
+      "project": "Granit.Diagnostics",
+      "file": "src/Granit.Diagnostics/Dtos/MonitoringHealthResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ServiceHealthResponse",
+      "fqn": "Granit.Diagnostics.Dtos.ServiceHealthResponse",
+      "kind": "record",
+      "project": "Granit.Diagnostics",
+      "file": "src/Granit.Diagnostics/Dtos/MonitoringHealthResponse.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "DiagnosticsEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Diagnostics.Endpoints.Extensions.DiagnosticsEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Diagnostics.Endpoints",
+      "file": "src/Granit.Diagnostics.Endpoints/Extensions/DiagnosticsEndpointRouteBuilderExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "MapGranitDiagnosticsMonitoring",
+          "kind": "method",
+          "signature": "MapGranitDiagnosticsMonitoring(this IEndpointRouteBuilder endpoints, Action<DiagnosticsEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitDiagnosticsEndpointsModule",
+      "fqn": "Granit.Diagnostics.Endpoints.GranitDiagnosticsEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Diagnostics.Endpoints",
+      "file": "src/Granit.Diagnostics.Endpoints/GranitDiagnosticsEndpointsModule.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "DiagnosticsEndpointsOptions",
+      "fqn": "Granit.Diagnostics.Endpoints.Options.DiagnosticsEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Diagnostics.Endpoints",
+      "file": "src/Granit.Diagnostics.Endpoints/Options/DiagnosticsEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "DiagnosticsPermissions",
+      "fqn": "Granit.Diagnostics.Endpoints.Permissions.DiagnosticsPermissions",
+      "kind": "class",
+      "project": "Granit.Diagnostics.Endpoints",
+      "file": "src/Granit.Diagnostics.Endpoints/Permissions/DiagnosticsPermissions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "Monitoring",
+      "fqn": "Granit.Diagnostics.Endpoints.Permissions.Monitoring",
+      "kind": "class",
+      "project": "Granit.Diagnostics.Endpoints",
+      "file": "src/Granit.Diagnostics.Endpoints/Permissions/DiagnosticsPermissions.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "DiagnosticsEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Diagnostics.Extensions.DiagnosticsEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Diagnostics",
+      "file": "src/Granit.Diagnostics/Extensions/DiagnosticsEndpointRouteBuilderExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "MapGranitHealthChecks",
+          "kind": "method",
+          "signature": "MapGranitHealthChecks(this IEndpointRouteBuilder endpoints, Action<DiagnosticsOptions>? configure = null)",
+          "returnType": "IEndpointRouteBuilder"
+        }
+      ]
+    },
+    {
+      "name": "DiagnosticsServiceCollectionExtensions",
+      "fqn": "Granit.Diagnostics.Extensions.DiagnosticsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Diagnostics",
+      "file": "src/Granit.Diagnostics/Extensions/DiagnosticsServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitDiagnostics",
+          "kind": "method",
+          "signature": "AddGranitDiagnostics(this IServiceCollection services, Action<DiagnosticsOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitDiagnosticsModule",
+      "fqn": "Granit.Diagnostics.GranitDiagnosticsModule",
+      "kind": "class",
+      "project": "Granit.Diagnostics",
+      "file": "src/Granit.Diagnostics/GranitDiagnosticsModule.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "DiagnosticsOptions",
+      "fqn": "Granit.Diagnostics.Options.DiagnosticsOptions",
+      "kind": "class",
+      "project": "Granit.Diagnostics",
+      "file": "src/Granit.Diagnostics/Options/DiagnosticsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "LivenessPath",
+          "kind": "property",
+          "signature": "string LivenessPath",
+          "returnType": "string"
+        },
+        {
+          "name": "ReadinessPath",
+          "kind": "property",
+          "signature": "string ReadinessPath",
+          "returnType": "string"
+        },
+        {
+          "name": "StartupPath",
+          "kind": "property",
+          "signature": "string StartupPath",
+          "returnType": "string"
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(10)",
+          "returnType": "TimeSpan DefaultCacheDuration { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(30)",
+          "returnType": "TimeSpan MonitoringCacheDuration { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "GranitHealthCheckWriter",
+      "fqn": "Granit.Diagnostics.ResponseWriters.GranitHealthCheckWriter",
+      "kind": "class",
+      "project": "Granit.Diagnostics",
+      "file": "src/Granit.Diagnostics/ResponseWriters/GranitHealthCheckWriter.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "WriteAsync",
+          "kind": "method",
+          "signature": "WriteAsync(HttpContext context, HealthReport report)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.DocumentGeneration.Excel.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.DocumentGeneration.Excel",
+      "file": "src/Granit.DocumentGeneration.Excel/Extensions/ServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitDocumentGenerationExcel",
+          "kind": "method",
+          "signature": "AddGranitDocumentGenerationExcel(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitDocumentGenerationExcelModule",
+      "fqn": "Granit.DocumentGeneration.Excel.GranitDocumentGenerationExcelModule",
+      "kind": "class",
+      "project": "Granit.DocumentGeneration.Excel",
+      "file": "src/Granit.DocumentGeneration.Excel/GranitDocumentGenerationExcelModule.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "DocumentRendererNotFoundException",
+      "fqn": "Granit.DocumentGeneration.Exceptions.DocumentRendererNotFoundException",
+      "kind": "class",
+      "project": "Granit.DocumentGeneration",
+      "file": "src/Granit.DocumentGeneration/Exceptions/DocumentRendererNotFoundException.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "DocumentRendererNotFoundException",
+          "kind": "method",
+          "signature": "DocumentRendererNotFoundException(DocumentFormat format)",
+          "returnType": "DocumentFormat Format { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.DocumentGeneration.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.DocumentGeneration",
+      "file": "src/Granit.DocumentGeneration/Extensions/ServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitDocumentGeneration",
+          "kind": "method",
+          "signature": "AddGranitDocumentGeneration(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitDocumentGenerationModule",
+      "fqn": "Granit.DocumentGeneration.GranitDocumentGenerationModule",
+      "kind": "class",
+      "project": "Granit.DocumentGeneration",
+      "file": "src/Granit.DocumentGeneration/GranitDocumentGenerationModule.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.DocumentGeneration.Pdf.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.DocumentGeneration.Pdf",
+      "file": "src/Granit.DocumentGeneration.Pdf/Extensions/ServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitDocumentGenerationPdf",
+          "kind": "method",
+          "signature": "AddGranitDocumentGenerationPdf(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitDocumentGenerationPdfModule",
+      "fqn": "Granit.DocumentGeneration.Pdf.GranitDocumentGenerationPdfModule",
+      "kind": "class",
+      "project": "Granit.DocumentGeneration.Pdf",
+      "file": "src/Granit.DocumentGeneration.Pdf/GranitDocumentGenerationPdfModule.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "PdfRenderOptions",
+      "fqn": "Granit.DocumentGeneration.Pdf.Options.PdfRenderOptions",
+      "kind": "class",
+      "project": "Granit.DocumentGeneration.Pdf",
+      "file": "src/Granit.DocumentGeneration.Pdf/Options/PdfRenderOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "PaperFormat",
+          "kind": "property",
+          "signature": "string PaperFormat",
+          "returnType": "string"
+        },
+        {
+          "name": "Landscape",
+          "kind": "property",
+          "signature": "bool Landscape",
+          "returnType": "bool"
+        },
+        {
+          "name": "MarginBottom",
+          "kind": "property",
+          "signature": "string MarginBottom",
+          "returnType": "string"
+        },
+        {
+          "name": "MarginLeft",
+          "kind": "property",
+          "signature": "string MarginLeft",
+          "returnType": "string"
+        },
+        {
+          "name": "MarginRight",
+          "kind": "property",
+          "signature": "string MarginRight",
+          "returnType": "string"
+        },
+        {
+          "name": "HeaderTemplate",
+          "kind": "property",
+          "signature": "string? HeaderTemplate",
+          "returnType": "string?"
+        },
+        {
+          "name": "ChromiumExecutablePath",
+          "kind": "property",
+          "signature": "string? ChromiumExecutablePath",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "IPdfAConverter",
+      "fqn": "Granit.DocumentGeneration.Pdf.PdfA.IPdfAConverter",
+      "kind": "interface",
+      "project": "Granit.DocumentGeneration.Pdf",
+      "file": "src/Granit.DocumentGeneration.Pdf/PdfA/IPdfAConverter.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "ConvertToPdfAAsync",
+          "kind": "method",
+          "signature": "ConvertToPdfAAsync(DocumentResult pdfResult, PdfAConversionOptions options, CancellationToken cancellationToken = default)",
+          "returnType": "Task<DocumentResult>"
+        }
+      ]
+    },
+    {
+      "name": "PdfAConformanceLevel",
+      "fqn": "Granit.DocumentGeneration.Pdf.PdfA.PdfAConformanceLevel",
+      "kind": "enum",
+      "project": "Granit.DocumentGeneration.Pdf",
+      "file": "src/Granit.DocumentGeneration.Pdf/PdfA/PdfAConversionOptions.cs",
+      "line": 40,
+      "members": []
+    },
+    {
+      "name": "PdfAConversionOptions",
+      "fqn": "Granit.DocumentGeneration.Pdf.PdfA.PdfAConversionOptions",
+      "kind": "class",
+      "project": "Granit.DocumentGeneration.Pdf",
+      "file": "src/Granit.DocumentGeneration.Pdf/PdfA/PdfAConversionOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ConformanceLevel",
+          "kind": "property",
+          "signature": "PdfAConformanceLevel ConformanceLevel",
+          "returnType": "PdfAConformanceLevel"
+        }
+      ]
+    },
+    {
+      "name": "DocumentResult",
+      "fqn": "Granit.DocumentGeneration.Pipeline.DocumentResult",
+      "kind": "record",
+      "project": "Granit.DocumentGeneration",
+      "file": "src/Granit.DocumentGeneration/Pipeline/DocumentResult.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "DocumentTemplateType",
+      "fqn": "Granit.DocumentGeneration.Pipeline.DocumentTemplateType",
+      "kind": "class",
+      "project": "Granit.DocumentGeneration",
+      "file": "src/Granit.DocumentGeneration/Pipeline/DocumentTemplateType.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "DefaultFormat",
+          "kind": "property",
+          "signature": "DocumentFormat DefaultFormat",
+          "returnType": "DocumentFormat"
+        }
+      ]
+    },
+    {
+      "name": "IDocumentGenerator",
+      "fqn": "Granit.DocumentGeneration.Pipeline.IDocumentGenerator",
+      "kind": "interface",
+      "project": "Granit.DocumentGeneration",
+      "file": "src/Granit.DocumentGeneration/Pipeline/IDocumentGenerator.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "IDocumentRenderer",
+      "fqn": "Granit.DocumentGeneration.Pipeline.IDocumentRenderer",
+      "kind": "interface",
+      "project": "Granit.DocumentGeneration",
+      "file": "src/Granit.DocumentGeneration/Pipeline/IDocumentRenderer.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "CanRender",
+          "kind": "method",
+          "signature": "CanRender(DocumentFormat targetFormat)",
+          "returnType": "bool"
+        },
+        {
+          "name": "RenderAsync",
+          "kind": "method",
+          "signature": "RenderAsync(string html, DocumentFormat targetFormat, CancellationToken cancellationToken = default)",
+          "returnType": "Task<DocumentResult>"
+        }
+      ]
+    },
+    {
+      "name": "EncryptedAttribute",
+      "fqn": "Granit.Encryption.EntityFrameworkCore.EncryptedAttribute",
+      "kind": "class",
+      "project": "Granit.Encryption.EntityFrameworkCore",
+      "file": "src/Granit.Encryption.EntityFrameworkCore/EncryptedAttribute.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "EncryptedStringConverter",
+      "fqn": "Granit.Encryption.EntityFrameworkCore.EncryptedStringConverter",
+      "kind": "class",
+      "project": "Granit.Encryption.EntityFrameworkCore",
+      "file": "src/Granit.Encryption.EntityFrameworkCore/EncryptedStringConverter.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "ModelBuilderEncryptionExtensions",
+      "fqn": "Granit.Encryption.EntityFrameworkCore.Extensions.ModelBuilderEncryptionExtensions",
+      "kind": "class",
+      "project": "Granit.Encryption.EntityFrameworkCore",
+      "file": "src/Granit.Encryption.EntityFrameworkCore/Extensions/ModelBuilderEncryptionExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "ApplyEncryptionConventions",
+          "kind": "method",
+          "signature": "ApplyEncryptionConventions(this ModelBuilder modelBuilder, IStringEncryptionService encryptionService)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitEncryptionEntityFrameworkCoreModule",
+      "fqn": "Granit.Encryption.EntityFrameworkCore.GranitEncryptionEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Encryption.EntityFrameworkCore",
+      "file": "src/Granit.Encryption.EntityFrameworkCore/GranitEncryptionEntityFrameworkCoreModule.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "EncryptionServiceCollectionExtensions",
+      "fqn": "Granit.Encryption.Extensions.EncryptionServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Encryption",
+      "file": "src/Granit.Encryption/Extensions/EncryptionServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitEncryption",
+          "kind": "method",
+          "signature": "AddGranitEncryption(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitEncryptionModule",
+      "fqn": "Granit.Encryption.GranitEncryptionModule",
+      "kind": "class",
+      "project": "Granit.Encryption",
+      "file": "src/Granit.Encryption/GranitEncryptionModule.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IStringEncryptionProvider",
+      "fqn": "Granit.Encryption.IStringEncryptionProvider",
+      "kind": "interface",
+      "project": "Granit.Encryption",
+      "file": "src/Granit.Encryption/IStringEncryptionProvider.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Encrypt",
+          "kind": "method",
+          "signature": "Encrypt(string plainText)",
+          "returnType": "string ProviderName { get; } string"
+        },
+        {
+          "name": "Decrypt",
+          "kind": "method",
+          "signature": "Decrypt(string cipherText)",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "IStringEncryptionService",
+      "fqn": "Granit.Encryption.IStringEncryptionService",
+      "kind": "interface",
+      "project": "Granit.Encryption",
+      "file": "src/Granit.Encryption/IStringEncryptionService.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Encrypt",
+          "kind": "method",
+          "signature": "Encrypt(string plainText)",
+          "returnType": "string"
+        },
+        {
+          "name": "Decrypt",
+          "kind": "method",
+          "signature": "Decrypt(string cipherText)",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "StringEncryptionOptions",
+      "fqn": "Granit.Encryption.Options.StringEncryptionOptions",
+      "kind": "class",
+      "project": "Granit.Encryption",
+      "file": "src/Granit.Encryption/Options/StringEncryptionOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "PassPhrase",
+          "kind": "property",
+          "signature": "string PassPhrase",
+          "returnType": "string"
+        },
+        {
+          "name": "KeySize",
+          "kind": "property",
+          "signature": "int KeySize",
+          "returnType": "int"
+        },
+        {
+          "name": "ProviderName",
+          "kind": "property",
+          "signature": "string ProviderName",
+          "returnType": "string"
+        },
+        {
+          "name": "VaultKeyName",
+          "kind": "property",
+          "signature": "string VaultKeyName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "AesStringEncryptionProvider",
+      "fqn": "Granit.Encryption.Providers.AesStringEncryptionProvider",
+      "kind": "class",
+      "project": "Granit.Encryption",
+      "file": "src/Granit.Encryption/Providers/AesStringEncryptionProvider.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "ProviderName",
+          "kind": "property",
+          "signature": "string ProviderName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "DefaultReEncryptionJob",
+      "fqn": "Granit.Encryption.ReEncryption.DefaultReEncryptionJob",
+      "kind": "class",
+      "project": "Granit.Encryption.ReEncryption",
+      "file": "src/Granit.Encryption.ReEncryption/DefaultReEncryptionJob.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "ReEncryptionServiceCollectionExtensions",
+      "fqn": "Granit.Encryption.ReEncryption.Extensions.ReEncryptionServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Encryption.ReEncryption",
+      "file": "src/Granit.Encryption.ReEncryption/Extensions/ReEncryptionServiceCollectionExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "GranitEncryptionReEncryptionModule",
+      "fqn": "Granit.Encryption.ReEncryption.GranitEncryptionReEncryptionModule",
+      "kind": "class",
+      "project": "Granit.Encryption.ReEncryption",
+      "file": "src/Granit.Encryption.ReEncryption/GranitEncryptionReEncryptionModule.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "IReEncryptionJob",
+      "fqn": "Granit.Encryption.ReEncryption.IReEncryptionJob",
+      "kind": "interface",
+      "project": "Granit.Encryption.ReEncryption",
+      "file": "src/Granit.Encryption.ReEncryption/IReEncryptionJob.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "DefaultStringEncryptionService",
+      "fqn": "Granit.Encryption.Services.DefaultStringEncryptionService",
+      "kind": "class",
+      "project": "Granit.Encryption",
+      "file": "src/Granit.Encryption/Services/DefaultStringEncryptionService.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "Decrypt",
+          "kind": "method",
+          "signature": "Decrypt(string cipherText)",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "EventBusMetrics",
+      "fqn": "Granit.EventBus.Diagnostics.EventBusMetrics",
+      "kind": "class",
+      "project": "Granit.EventBus",
+      "file": "src/Granit.EventBus/Diagnostics/EventBusMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordHandlerExecuted",
+          "kind": "method",
+          "signature": "RecordHandlerExecuted(string? tenantId, string eventType, string status)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "EventBusServiceCollectionExtensions",
+      "fqn": "Granit.EventBus.Extensions.EventBusServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.EventBus",
+      "file": "src/Granit.EventBus/Extensions/EventBusServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitEventBus",
+          "kind": "method",
+          "signature": "AddGranitEventBus(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitEventBusModule",
+      "fqn": "Granit.EventBus.GranitEventBusModule",
+      "kind": "class",
+      "project": "Granit.EventBus",
+      "file": "src/Granit.EventBus/GranitEventBusModule.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GranitEventBusWolverineModule",
+      "fqn": "Granit.EventBus.Wolverine.GranitEventBusWolverineModule",
+      "kind": "class",
+      "project": "Granit.EventBus.Wolverine",
+      "file": "src/Granit.EventBus.Wolverine/GranitEventBusWolverineModule.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "FeatureEndpointConventionBuilderExtensions",
+      "fqn": "Granit.Features.AspNetCore.FeatureEndpointConventionBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/AspNetCore/FeatureEndpointConventionBuilderExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "RequiresFeature",
+          "kind": "method",
+          "signature": "RequiresFeature(this IEndpointConventionBuilder builder, string featureName)",
+          "returnType": "IEndpointConventionBuilder"
+        }
+      ]
+    },
+    {
+      "name": "FeatureCacheInvalidationHandler",
+      "fqn": "Granit.Features.Cache.FeatureCacheInvalidationHandler",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Cache/FeatureCacheInvalidationHandler.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(FeatureValueChangedEvent @event, IFusionCache cache, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "FeatureDefinition",
+      "fqn": "Granit.Features.Definitions.FeatureDefinition",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Definitions/FeatureDefinition.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "FeatureDefinition",
+          "kind": "method",
+          "signature": "FeatureDefinition(string name, string defaultValue, FeatureValueType valueType)",
+          "returnType": "string Name { get; } public string DefaultValue { get; } public FeatureValueType ValueType { get; } public NumericConstraint? NumericConstraint { get; init; } public SelectionValues? SelectionValues { get; init; } public string? DisplayName { get; init; } public string? Description { get; init; } public"
+        }
+      ]
+    },
+    {
+      "name": "FeatureGroupDefinition",
+      "fqn": "Granit.Features.Definitions.FeatureGroupDefinition",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Definitions/FeatureGroupDefinition.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Features",
+          "kind": "property",
+          "signature": "IReadOnlyList<FeatureDefinition> Features",
+          "returnType": "IReadOnlyList<FeatureDefinition>"
+        }
+      ]
+    },
+    {
+      "name": "IFeatureDefinitionContext",
+      "fqn": "Granit.Features.Definitions.IFeatureDefinitionContext",
+      "kind": "interface",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Definitions/IFeatureDefinitionContext.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "AddGroup",
+          "kind": "method",
+          "signature": "AddGroup(string name, string? displayName = null)",
+          "returnType": "FeatureGroupDefinition"
+        }
+      ]
+    },
+    {
+      "name": "IFeatureDefinitionProvider",
+      "fqn": "Granit.Features.Definitions.IFeatureDefinitionProvider",
+      "kind": "interface",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Definitions/FeatureDefinitionProvider.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "Define",
+          "kind": "method",
+          "signature": "Define(IFeatureDefinitionContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IFeatureDefinitionStore",
+      "fqn": "Granit.Features.Definitions.IFeatureDefinitionStore",
+      "kind": "interface",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Definitions/IFeatureDefinitionStore.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetRequired",
+          "kind": "method",
+          "signature": "GetRequired(string featureName)",
+          "returnType": "FeatureDefinition"
+        },
+        {
+          "name": "GetOrNull",
+          "kind": "method",
+          "signature": "GetOrNull(string featureName)",
+          "returnType": "FeatureDefinition?"
+        },
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IReadOnlyList<FeatureDefinition>"
+        }
+      ]
+    },
+    {
+      "name": "FeatureDefinitionResponse",
+      "fqn": "Granit.Features.Endpoints.Dtos.FeatureDefinitionResponse",
+      "kind": "record",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/Dtos/FeatureDefinitionResponse.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "FeatureGroupResponse",
+      "fqn": "Granit.Features.Endpoints.Dtos.FeatureGroupResponse",
+      "kind": "record",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/Dtos/FeatureGroupResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "FeatureNumericConstraintResponse",
+      "fqn": "Granit.Features.Endpoints.Dtos.FeatureNumericConstraintResponse",
+      "kind": "record",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/Dtos/FeatureDefinitionResponse.cs",
+      "line": 27,
+      "members": []
+    },
+    {
+      "name": "FeatureValueResponse",
+      "fqn": "Granit.Features.Endpoints.Dtos.FeatureValueResponse",
+      "kind": "record",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/Dtos/FeatureValueResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "SetFeatureOverrideRequest",
+      "fqn": "Granit.Features.Endpoints.Dtos.SetFeatureOverrideRequest",
+      "kind": "record",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/Dtos/SetFeatureOverrideRequest.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "FeaturesEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Features.Endpoints.Extensions.FeaturesEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/Extensions/FeaturesEndpointRouteBuilderExtensions.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "MapGranitFeatures",
+          "kind": "method",
+          "signature": "MapGranitFeatures(this IEndpointRouteBuilder endpoints, Action<FeaturesEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitFeaturesEndpointsModule",
+      "fqn": "Granit.Features.Endpoints.GranitFeaturesEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/GranitFeaturesEndpointsModule.cs",
+      "line": 26,
+      "members": []
+    },
+    {
+      "name": "FeaturesEndpointsOptions",
+      "fqn": "Granit.Features.Endpoints.Options.FeaturesEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/Options/FeaturesEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "FeaturesPermissions",
+      "fqn": "Granit.Features.Endpoints.Permissions.FeaturesPermissions",
+      "kind": "class",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/Permissions/FeaturesPermissions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "Flags",
+      "fqn": "Granit.Features.Endpoints.Permissions.Flags",
+      "kind": "class",
+      "project": "Granit.Features.Endpoints",
+      "file": "src/Granit.Features.Endpoints/Permissions/FeaturesPermissions.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "FeaturesEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.Features.EntityFrameworkCore.Extensions.FeaturesEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Features.EntityFrameworkCore",
+      "file": "src/Granit.Features.EntityFrameworkCore/Extensions/FeaturesEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitFeaturesEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitFeaturesEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "FeaturesModelBuilderExtensions",
+      "fqn": "Granit.Features.EntityFrameworkCore.Extensions.FeaturesModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Features.EntityFrameworkCore",
+      "file": "src/Granit.Features.EntityFrameworkCore/Extensions/FeaturesModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureFeaturesModule",
+          "kind": "method",
+          "signature": "ConfigureFeaturesModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitFeaturesDbProperties",
+      "fqn": "Granit.Features.EntityFrameworkCore.GranitFeaturesDbProperties",
+      "kind": "class",
+      "project": "Granit.Features.EntityFrameworkCore",
+      "file": "src/Granit.Features.EntityFrameworkCore/GranitFeaturesDbProperties.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitFeaturesEntityFrameworkCoreModule",
+      "fqn": "Granit.Features.EntityFrameworkCore.GranitFeaturesEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Features.EntityFrameworkCore",
+      "file": "src/Granit.Features.EntityFrameworkCore/GranitFeaturesEntityFrameworkCoreModule.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "FeatureOverrideChangedEvent",
+      "fqn": "Granit.Features.Events.FeatureOverrideChangedEvent",
+      "kind": "record",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Events/FeatureOverrideChangedEvent.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "FeatureValueChangedEvent",
+      "fqn": "Granit.Features.Events.FeatureValueChangedEvent",
+      "kind": "record",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Events/FeatureValueChangedEvent.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "FeatureLimitExceededException",
+      "fqn": "Granit.Features.Exceptions.FeatureLimitExceededException",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Exceptions/FeatureLimitExceededException.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "FeatureName",
+          "kind": "property",
+          "signature": "string FeatureName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "FeatureNotEnabledException",
+      "fqn": "Granit.Features.Exceptions.FeatureNotEnabledException",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Exceptions/FeatureNotEnabledException.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "FeatureName",
+          "kind": "property",
+          "signature": "string FeatureName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "FeatureNotFoundException",
+      "fqn": "Granit.Features.Exceptions.FeatureNotFoundException",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Exceptions/FeatureNotFoundException.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "FeatureNotFoundException",
+          "kind": "method",
+          "signature": "FeatureNotFoundException(string featureName)",
+          "returnType": "string FeatureName { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "FeatureValueValidationException",
+      "fqn": "Granit.Features.Exceptions.FeatureValueValidationException",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Exceptions/FeatureValueValidationException.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "FeatureValueValidationException",
+          "kind": "method",
+          "signature": "FeatureValueValidationException(string featureName, string invalidValue, string reason)",
+          "returnType": "string FeatureName { get; } public string InvalidValue { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.Features.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Extensions/ServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitFeatures",
+          "kind": "method",
+          "signature": "AddGranitFeatures(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "FeaturesLocalizationResource",
+      "fqn": "Granit.Features.FeaturesLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/FeaturesLocalizationResource.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "GranitFeaturesModule",
+      "fqn": "Granit.Features.GranitFeaturesModule",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/GranitFeaturesModule.cs",
+      "line": 33,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IFeatureChecker",
+      "fqn": "Granit.Features.IFeatureChecker",
+      "kind": "interface",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/IFeatureChecker.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "IsEnabledAsync",
+          "kind": "method",
+          "signature": "IsEnabledAsync(string featureName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        },
+        {
+          "name": "GetNumericAsync",
+          "kind": "method",
+          "signature": "GetNumericAsync(string featureName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<long>"
+        },
+        {
+          "name": "GetValueAsync",
+          "kind": "method",
+          "signature": "GetValueAsync(string featureName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
+        },
+        {
+          "name": "RequireEnabledAsync",
+          "kind": "method",
+          "signature": "RequireEnabledAsync(string featureName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IFeatureLimitGuard",
+      "fqn": "Granit.Features.IFeatureLimitGuard",
+      "kind": "interface",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/IFeatureLimitGuard.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "CheckAsync",
+          "kind": "method",
+          "signature": "CheckAsync(string featureName, long currentCount, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "GetLimitAsync",
+          "kind": "method",
+          "signature": "GetLimitAsync(string featureName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<long>"
+        }
+      ]
+    },
+    {
+      "name": "IFeatureStoreReader",
+      "fqn": "Granit.Features.IFeatureStoreReader",
+      "kind": "interface",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/IFeatureStoreReader.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(string featureName, string? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string?>"
+        }
+      ]
+    },
+    {
+      "name": "IFeatureStoreWriter",
+      "fqn": "Granit.Features.IFeatureStoreWriter",
+      "kind": "interface",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/IFeatureStoreWriter.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SetAsync",
+          "kind": "method",
+          "signature": "SetAsync(string featureName, string? tenantId, string value, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(string featureName, string? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IPlanFeatureStore",
+      "fqn": "Granit.Features.Plans.IPlanFeatureStore",
+      "kind": "interface",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Plans/IPlanFeatureStore.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(string planId, string featureName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string?>"
+        }
+      ]
+    },
+    {
+      "name": "IPlanIdProvider",
+      "fqn": "Granit.Features.Plans.IPlanIdProvider",
+      "kind": "interface",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Plans/IPlanIdProvider.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "GetCurrentPlanIdAsync",
+          "kind": "method",
+          "signature": "GetCurrentPlanIdAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<string?>"
+        }
+      ]
+    },
+    {
+      "name": "RequiresFeatureAttribute",
+      "fqn": "Granit.Features.RequiresFeatureAttribute",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/RequiresFeatureAttribute.cs",
+      "line": 41,
+      "members": [
+        {
+          "name": "FeatureName",
+          "kind": "property",
+          "signature": "string FeatureName",
+          "returnType": "string"
+        },
+        {
+          "name": "IsReusable",
+          "kind": "property",
+          "signature": "bool IsReusable",
+          "returnType": "bool"
+        },
+        {
+          "name": "CreateInstance",
+          "kind": "method",
+          "signature": "CreateInstance(IServiceProvider serviceProvider)",
+          "returnType": "IFilterMetadata"
+        }
+      ]
+    },
+    {
+      "name": "IFeatureValueProvider",
+      "fqn": "Granit.Features.ValueProviders.IFeatureValueProvider",
+      "kind": "interface",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/ValueProviders/IFeatureValueProvider.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(FeatureDefinition definition, CancellationToken cancellationToken = default)",
+          "returnType": "string Name { get; } int Order { get; } Task<string?>"
+        }
+      ]
+    },
+    {
+      "name": "FeatureValueType",
+      "fqn": "Granit.Features.ValueTypes.FeatureValueType",
+      "kind": "enum",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/ValueTypes/FeatureValueType.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "NumericConstraint",
+      "fqn": "Granit.Features.ValueTypes.NumericConstraint",
+      "kind": "record",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/ValueTypes/NumericConstraint.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Validate",
+          "kind": "method",
+          "signature": "Validate(string featureName, string rawValue)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "SelectionValues",
+      "fqn": "Granit.Features.ValueTypes.SelectionValues",
+      "kind": "record",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/ValueTypes/SelectionValues.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Validate",
+          "kind": "method",
+          "signature": "Validate(string featureName, string rawValue)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "RequiresFeatureMiddleware",
+      "fqn": "Granit.Features.Wolverine.RequiresFeatureMiddleware",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Wolverine/RequiresFeatureMiddleware.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "BeforeAsync",
+          "kind": "method",
+          "signature": "BeforeAsync(object message, IFeatureChecker featureChecker, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "GuidsServiceCollectionExtensions",
+      "fqn": "Granit.Guids.Extensions.GuidsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Guids",
+      "file": "src/Granit.Guids/Extensions/GuidsServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitGuids",
+          "kind": "method",
+          "signature": "AddGranitGuids(this IServiceCollection services, Action<GuidGeneratorOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitGuidsModule",
+      "fqn": "Granit.Guids.GranitGuidsModule",
+      "kind": "class",
+      "project": "Granit.Guids",
+      "file": "src/Granit.Guids/GranitGuidsModule.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GuidStrategy",
+      "fqn": "Granit.Guids.GuidStrategy",
+      "kind": "enum",
+      "project": "Granit.Guids",
+      "file": "src/Granit.Guids/GuidStrategy.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IGuidGenerator",
+      "fqn": "Granit.Guids.IGuidGenerator",
+      "kind": "interface",
+      "project": "Granit.Guids",
+      "file": "src/Granit.Guids/IGuidGenerator.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create()",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "GuidGeneratorOptions",
+      "fqn": "Granit.Guids.Options.GuidGeneratorOptions",
+      "kind": "class",
+      "project": "Granit.Guids",
+      "file": "src/Granit.Guids/Options/GuidGeneratorOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Strategy",
+          "kind": "property",
+          "signature": "GuidStrategy Strategy",
+          "returnType": "GuidStrategy"
+        },
+        {
+          "name": "GetDefaultSequentialGuidType",
+          "kind": "method",
+          "signature": "GetDefaultSequentialGuidType()",
+          "returnType": "SequentialGuidType? DefaultSequentialGuidType { get; set; } public SequentialGuidType"
+        }
+      ]
+    },
+    {
+      "name": "SequentialGuidGenerator",
+      "fqn": "Granit.Guids.SequentialGuidGenerator",
+      "kind": "class",
+      "project": "Granit.Guids",
+      "file": "src/Granit.Guids/SequentialGuidGenerator.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create()",
+          "returnType": "Guid"
+        },
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(SequentialGuidType guidType)",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "SequentialGuidType",
+      "fqn": "Granit.Guids.SequentialGuidType",
+      "kind": "enum",
+      "project": "Granit.Guids",
+      "file": "src/Granit.Guids/SequentialGuidType.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "SimpleGuidGenerator",
+      "fqn": "Granit.Guids.SimpleGuidGenerator",
+      "kind": "class",
+      "project": "Granit.Guids",
+      "file": "src/Granit.Guids/SimpleGuidGenerator.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "SimpleGuidGenerator Instance { get; } ="
+        },
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create()",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "UuidV7GuidGenerator",
+      "fqn": "Granit.Guids.UuidV7GuidGenerator",
+      "kind": "class",
+      "project": "Granit.Guids",
+      "file": "src/Granit.Guids/UuidV7GuidGenerator.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create()",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "InternalApiAttribute",
+      "fqn": "Granit.Http.ApiDocumentation.Attributes.InternalApiAttribute",
+      "kind": "class",
+      "project": "Granit.Http.ApiDocumentation",
+      "file": "src/Granit.Http.ApiDocumentation/Attributes/InternalApiAttribute.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ApiDocumentationApplicationBuilderExtensions",
+      "fqn": "Granit.Http.ApiDocumentation.Extensions.ApiDocumentationApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.ApiDocumentation",
+      "file": "src/Granit.Http.ApiDocumentation/Extensions/ApiDocumentationApplicationBuilderExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "UseGranitApiDocumentation",
+          "kind": "method",
+          "signature": "UseGranitApiDocumentation(this WebApplication app)",
+          "returnType": "WebApplication"
+        }
+      ]
+    },
+    {
+      "name": "ApiDocumentationServiceCollectionExtensions",
+      "fqn": "Granit.Http.ApiDocumentation.Extensions.ApiDocumentationServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.ApiDocumentation",
+      "file": "src/Granit.Http.ApiDocumentation/Extensions/ApiDocumentationServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitApiDocumentation",
+          "kind": "method",
+          "signature": "AddGranitApiDocumentation(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpApiDocumentationModule",
+      "fqn": "Granit.Http.ApiDocumentation.GranitHttpApiDocumentationModule",
+      "kind": "class",
+      "project": "Granit.Http.ApiDocumentation",
+      "file": "src/Granit.Http.ApiDocumentation/GranitHttpApiDocumentationModule.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ISchemaExampleProvider",
+      "fqn": "Granit.Http.ApiDocumentation.ISchemaExampleProvider",
+      "kind": "interface",
+      "project": "Granit.Http.ApiDocumentation",
+      "file": "src/Granit.Http.ApiDocumentation/ISchemaExampleProvider.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetExamples",
+          "kind": "method",
+          "signature": "GetExamples()",
+          "returnType": "IReadOnlyDictionary<Type, JsonNode>"
+        }
+      ]
+    },
+    {
+      "name": "ApiDocumentationOptions",
+      "fqn": "Granit.Http.ApiDocumentation.Options.ApiDocumentationOptions",
+      "kind": "class",
+      "project": "Granit.Http.ApiDocumentation",
+      "file": "src/Granit.Http.ApiDocumentation/Options/ApiDocumentationOptions.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "MajorVersions",
+          "kind": "property",
+          "signature": "IList<int> MajorVersions",
+          "returnType": "IList<int>"
+        },
+        {
+          "name": "Title",
+          "kind": "property",
+          "signature": "string Title",
+          "returnType": "string"
+        },
+        {
+          "name": "Description",
+          "kind": "property",
+          "signature": "string? Description",
+          "returnType": "string?"
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "string? AuthorizationPolicy { get; set; } public OAuth2Options OAuth2 { get; set; } ="
+        }
+      ]
+    },
+    {
+      "name": "OAuth2Options",
+      "fqn": "Granit.Http.ApiDocumentation.Options.OAuth2Options",
+      "kind": "class",
+      "project": "Granit.Http.ApiDocumentation",
+      "file": "src/Granit.Http.ApiDocumentation/Options/OAuth2Options.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "AuthorizationUrl",
+          "kind": "property",
+          "signature": "string? AuthorizationUrl",
+          "returnType": "string?"
+        },
+        {
+          "name": "Scopes",
+          "kind": "property",
+          "signature": "IList<string> Scopes",
+          "returnType": "IList<string>"
+        }
+      ]
+    },
+    {
+      "name": "DeprecatedAttribute",
+      "fqn": "Granit.Http.ApiVersioning.Deprecation.DeprecatedAttribute",
+      "kind": "class",
+      "project": "Granit.Http.ApiVersioning",
+      "file": "src/Granit.Http.ApiVersioning/Deprecation/DeprecatedAttribute.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "DeprecationEndpointExtensions",
+      "fqn": "Granit.Http.ApiVersioning.Deprecation.DeprecationEndpointExtensions",
+      "kind": "class",
+      "project": "Granit.Http.ApiVersioning",
+      "file": "src/Granit.Http.ApiVersioning/Deprecation/DeprecationEndpointExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Deprecated",
+          "kind": "method",
+          "signature": "Deprecated(this RouteHandlerBuilder builder, string? sunsetDate = null, string? link = null)",
+          "returnType": "RouteHandlerBuilder"
+        }
+      ]
+    },
+    {
+      "name": "ApiVersioningServiceCollectionExtensions",
+      "fqn": "Granit.Http.ApiVersioning.Extensions.ApiVersioningServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.ApiVersioning",
+      "file": "src/Granit.Http.ApiVersioning/Extensions/ApiVersioningServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitApiVersioning",
+          "kind": "method",
+          "signature": "AddGranitApiVersioning(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpApiVersioningModule",
+      "fqn": "Granit.Http.ApiVersioning.GranitHttpApiVersioningModule",
+      "kind": "class",
+      "project": "Granit.Http.ApiVersioning",
+      "file": "src/Granit.Http.ApiVersioning/GranitHttpApiVersioningModule.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GranitApiVersioningOptions",
+      "fqn": "Granit.Http.ApiVersioning.Options.GranitApiVersioningOptions",
+      "kind": "class",
+      "project": "Granit.Http.ApiVersioning",
+      "file": "src/Granit.Http.ApiVersioning/Options/GranitApiVersioningOptions.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "DefaultMajorVersion",
+          "kind": "property",
+          "signature": "int DefaultMajorVersion",
+          "returnType": "int"
+        },
+        {
+          "name": "ReportApiVersions",
+          "kind": "property",
+          "signature": "bool ReportApiVersions",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "BulkheadLease",
+      "fqn": "Granit.Http.Bulkhead.Abstractions.BulkheadLease",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/Abstractions/BulkheadLease.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(null, null)",
+          "returnType": "BulkheadLease NoOp ="
+        }
+      ]
+    },
+    {
+      "name": "IBulkheadQuotaProvider",
+      "fqn": "Granit.Http.Bulkhead.Abstractions.IBulkheadQuotaProvider",
+      "kind": "interface",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/Abstractions/IBulkheadQuotaProvider.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "GetPermitLimitAsync",
+          "kind": "method",
+          "signature": "GetPermitLimitAsync(string policyName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int?>"
+        }
+      ]
+    },
+    {
+      "name": "BulkheadEndpointExtensions",
+      "fqn": "Granit.Http.Bulkhead.AspNetCore.BulkheadEndpointExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/AspNetCore/BulkheadEndpointExtensions.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "BulkheadAttribute",
+      "fqn": "Granit.Http.Bulkhead.Attributes.BulkheadAttribute",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/Attributes/BulkheadAttribute.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "PolicyName",
+          "kind": "property",
+          "signature": "string PolicyName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "ConcurrencyLimiterRegistry",
+      "fqn": "Granit.Http.Bulkhead.ConcurrencyLimiterRegistry",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/ConcurrencyLimiterRegistry.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "AcquireAsync",
+          "kind": "method",
+          "signature": "AcquireAsync(string key, int permitLimit, int queueLimit, CancellationToken cancellationToken)",
+          "returnType": "ValueTask<RateLimitLease>"
+        },
+        {
+          "name": "Dispose",
+          "kind": "method",
+          "signature": "Dispose()",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "BulkheadMetrics",
+      "fqn": "Granit.Http.Bulkhead.Diagnostics.BulkheadMetrics",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/Diagnostics/BulkheadMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordReleased",
+          "kind": "method",
+          "signature": "RecordReleased(string policyName, string? tenantId)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordRejected",
+          "kind": "method",
+          "signature": "RecordRejected(string policyName, string? tenantId)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "BulkheadRejectedException",
+      "fqn": "Granit.Http.Bulkhead.Exceptions.BulkheadRejectedException",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/Exceptions/BulkheadRejectedException.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "BulkheadServiceCollectionExtensions",
+      "fqn": "Granit.Http.Bulkhead.Extensions.BulkheadServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/Extensions/BulkheadServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitBulkhead",
+          "kind": "method",
+          "signature": "AddGranitBulkhead(this IServiceCollection services, Action<GranitBulkheadOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpBulkheadModule",
+      "fqn": "Granit.Http.Bulkhead.GranitHttpBulkheadModule",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/GranitHttpBulkheadModule.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "BulkheadPolicyOptions",
+      "fqn": "Granit.Http.Bulkhead.Options.BulkheadPolicyOptions",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/Options/BulkheadPolicyOptions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "PermitLimit",
+          "kind": "property",
+          "signature": "int PermitLimit",
+          "returnType": "int"
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(30)",
+          "returnType": "int QueueLimit { get; set; } public TimeSpan QueueTimeout { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "GranitBulkheadOptions",
+      "fqn": "Granit.Http.Bulkhead.Options.GranitBulkheadOptions",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/Options/GranitBulkheadOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Enabled",
+          "kind": "property",
+          "signature": "bool Enabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "BypassRoles",
+          "kind": "property",
+          "signature": "string[] BypassRoles",
+          "returnType": "string[]"
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(StringComparer.OrdinalIgnoreCase)",
+          "returnType": "bool UseFeatureBasedQuotas { get; set; } public Dictionary<string, BulkheadPolicyOptions> Policies { get; set; } ="
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(30)",
+          "returnType": "TimeSpan IdleTimeout { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(5)",
+          "returnType": "TimeSpan CleanupInterval { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "TenantPartitionedBulkhead",
+      "fqn": "Granit.Http.Bulkhead.TenantPartitionedBulkhead",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/TenantPartitionedBulkhead.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "AcquireAsync",
+          "kind": "method",
+          "signature": "AcquireAsync(string policyName, CancellationToken cancellationToken)",
+          "returnType": "Task<BulkheadLease>"
+        }
+      ]
+    },
+    {
+      "name": "BulkheadMiddleware",
+      "fqn": "Granit.Http.Bulkhead.Wolverine.BulkheadMiddleware",
+      "kind": "class",
+      "project": "Granit.Http.Bulkhead",
+      "file": "src/Granit.Http.Bulkhead/Wolverine/BulkheadMiddleware.cs",
+      "line": 29,
+      "members": [
+        {
+          "name": "BeforeAsync",
+          "kind": "method",
+          "signature": "BeforeAsync(object message, TenantPartitionedBulkhead bulkhead, CancellationToken cancellationToken)",
+          "returnType": "Task<BulkheadLease>"
+        }
+      ]
+    },
+    {
+      "name": "CookieCategory",
+      "fqn": "Granit.Http.Cookies.CookieCategory",
+      "kind": "enum",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/CookieCategory.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "CookieDefinition",
+      "fqn": "Granit.Http.Cookies.CookieDefinition",
+      "kind": "record",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/CookieDefinition.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "CookiesLocalizationResource",
+      "fqn": "Granit.Http.Cookies.CookiesLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/CookiesLocalizationResource.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "CookieConsentConfigResponse",
+      "fqn": "Granit.Http.Cookies.Endpoints.Dtos.CookieConsentConfigResponse",
+      "kind": "record",
+      "project": "Granit.Http.Cookies.Endpoints",
+      "file": "src/Granit.Http.Cookies.Endpoints/Dtos/CookieConsentConfigResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "CookieDefinitionResponse",
+      "fqn": "Granit.Http.Cookies.Endpoints.Dtos.CookieDefinitionResponse",
+      "kind": "record",
+      "project": "Granit.Http.Cookies.Endpoints",
+      "file": "src/Granit.Http.Cookies.Endpoints/Dtos/CookieConsentConfigResponse.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "ThirdPartyServiceResponse",
+      "fqn": "Granit.Http.Cookies.Endpoints.Dtos.ThirdPartyServiceResponse",
+      "kind": "record",
+      "project": "Granit.Http.Cookies.Endpoints",
+      "file": "src/Granit.Http.Cookies.Endpoints/Dtos/CookieConsentConfigResponse.cs",
+      "line": 32,
+      "members": []
+    },
+    {
+      "name": "CookieConsentEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Http.Cookies.Endpoints.Extensions.CookieConsentEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Cookies.Endpoints",
+      "file": "src/Granit.Http.Cookies.Endpoints/Extensions/CookieConsentEndpointRouteBuilderExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "MapGranitCookieConsent",
+          "kind": "method",
+          "signature": "MapGranitCookieConsent(this IEndpointRouteBuilder endpoints, Action<CookieConsentEndpointsOptions>? configure = null)",
+          "returnType": "IEndpointRouteBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpCookiesEndpointsModule",
+      "fqn": "Granit.Http.Cookies.Endpoints.GranitHttpCookiesEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Http.Cookies.Endpoints",
+      "file": "src/Granit.Http.Cookies.Endpoints/GranitHttpCookiesEndpointsModule.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "CookieConsentEndpointsOptions",
+      "fqn": "Granit.Http.Cookies.Endpoints.Options.CookieConsentEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Http.Cookies.Endpoints",
+      "file": "src/Granit.Http.Cookies.Endpoints/Options/CookieConsentEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "UnregisteredCookieException",
+      "fqn": "Granit.Http.Cookies.Exceptions.UnregisteredCookieException",
+      "kind": "class",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/Exceptions/UnregisteredCookieException.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "UnregisteredCookieException",
+          "kind": "method",
+          "signature": "UnregisteredCookieException(string cookieName)",
+          "returnType": "string CookieName { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "CookiesServiceCollectionExtensions",
+      "fqn": "Granit.Http.Cookies.Extensions.CookiesServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/Extensions/CookiesServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitCookies",
+          "kind": "method",
+          "signature": "AddGranitCookies(this IServiceCollection services, Action<GranitCookiesBuilder> configure)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitCookiesBuilder",
+      "fqn": "Granit.Http.Cookies.GranitCookiesBuilder",
+      "kind": "class",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/GranitCookiesBuilder.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "RegisterCookie",
+          "kind": "method",
+          "signature": "RegisterCookie(CookieDefinition definition)",
+          "returnType": "GranitCookiesBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpCookiesModule",
+      "fqn": "Granit.Http.Cookies.GranitHttpCookiesModule",
+      "kind": "class",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/GranitHttpCookiesModule.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "IConsentResolver",
+      "fqn": "Granit.Http.Cookies.IConsentResolver",
+      "kind": "interface",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/IConsentResolver.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "ResolveAsync",
+          "kind": "method",
+          "signature": "ResolveAsync(HttpContext httpContext, CookieCategory category)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "ICookieRegistry",
+      "fqn": "Granit.Http.Cookies.ICookieRegistry",
+      "kind": "interface",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/ICookieRegistry.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Register",
+          "kind": "method",
+          "signature": "Register(CookieDefinition definition)",
+          "returnType": "void"
+        },
+        {
+          "name": "GetDefinition",
+          "kind": "method",
+          "signature": "GetDefinition(string cookieName)",
+          "returnType": "CookieDefinition?"
+        },
+        {
+          "name": "GetByCategory",
+          "kind": "method",
+          "signature": "GetByCategory(CookieCategory category)",
+          "returnType": "IReadOnlyList<CookieDefinition>"
+        },
+        {
+          "name": "IsRegistered",
+          "kind": "method",
+          "signature": "IsRegistered(string cookieName)",
+          "returnType": "bool"
+        },
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IReadOnlyList<CookieDefinition>"
+        }
+      ]
+    },
+    {
+      "name": "IGranitCookieManager",
+      "fqn": "Granit.Http.Cookies.IGranitCookieManager",
+      "kind": "interface",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/IGranitCookieManager.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "SetCookieAsync",
+          "kind": "method",
+          "signature": "SetCookieAsync(HttpContext httpContext, string cookieName, string value)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RevokeCategoryAsync",
+          "kind": "method",
+          "signature": "RevokeCategoryAsync(HttpContext httpContext, CookieCategory category)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteCookie",
+          "kind": "method",
+          "signature": "DeleteCookie(HttpContext httpContext, string cookieName)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IThirdPartyServiceRegistry",
+      "fqn": "Granit.Http.Cookies.IThirdPartyServiceRegistry",
+      "kind": "interface",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/IThirdPartyServiceRegistry.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IReadOnlyList<ThirdPartyServiceDefinition>"
+        },
+        {
+          "name": "GetByCategory",
+          "kind": "method",
+          "signature": "GetByCategory(CookieCategory category)",
+          "returnType": "IReadOnlyList<ThirdPartyServiceDefinition>"
+        }
+      ]
+    },
+    {
+      "name": "GranitCookiesBuilderExtensions",
+      "fqn": "Granit.Http.Cookies.Klaro.Extensions.GranitCookiesBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Cookies.Klaro",
+      "file": "src/Granit.Http.Cookies.Klaro/Extensions/GranitCookiesBuilderExtensions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "UseKlaro",
+          "kind": "method",
+          "signature": "UseKlaro(this GranitCookiesBuilder builder)",
+          "returnType": "GranitCookiesBuilder"
+        }
+      ]
+    },
+    {
+      "name": "KlaroServiceCollectionExtensions",
+      "fqn": "Granit.Http.Cookies.Klaro.Extensions.KlaroServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Cookies.Klaro",
+      "file": "src/Granit.Http.Cookies.Klaro/Extensions/KlaroServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitCookiesKlaro",
+          "kind": "method",
+          "signature": "AddGranitCookiesKlaro(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpCookiesKlaroModule",
+      "fqn": "Granit.Http.Cookies.Klaro.GranitHttpCookiesKlaroModule",
+      "kind": "class",
+      "project": "Granit.Http.Cookies.Klaro",
+      "file": "src/Granit.Http.Cookies.Klaro/GranitHttpCookiesKlaroModule.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "KlaroOptions",
+      "fqn": "Granit.Http.Cookies.Klaro.Options.KlaroOptions",
+      "kind": "class",
+      "project": "Granit.Http.Cookies.Klaro",
+      "file": "src/Granit.Http.Cookies.Klaro/Options/KlaroOptions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "CookieName",
+          "kind": "property",
+          "signature": "string CookieName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitCookiesOptions",
+      "fqn": "Granit.Http.Cookies.Options.GranitCookiesOptions",
+      "kind": "class",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/Options/GranitCookiesOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ThrowOnUnregistered",
+          "kind": "property",
+          "signature": "bool ThrowOnUnregistered",
+          "returnType": "bool"
+        },
+        {
+          "name": "DefaultRetentionDays",
+          "kind": "property",
+          "signature": "int DefaultRetentionDays",
+          "returnType": "int"
+        },
+        {
+          "name": "ThirdPartyServices",
+          "kind": "property",
+          "signature": "List<ThirdPartyServiceOptions> ThirdPartyServices",
+          "returnType": "List<ThirdPartyServiceOptions>"
+        }
+      ]
+    },
+    {
+      "name": "ThirdPartyServiceOptions",
+      "fqn": "Granit.Http.Cookies.Options.ThirdPartyServiceOptions",
+      "kind": "class",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/Options/GranitCookiesOptions.cs",
+      "line": 43,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "required string Name",
+          "returnType": "required string"
+        }
+      ]
+    },
+    {
+      "name": "ThirdPartyServiceDefinition",
+      "fqn": "Granit.Http.Cookies.ThirdPartyServiceDefinition",
+      "kind": "record",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/ThirdPartyServiceDefinition.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "CorsHostApplicationBuilderExtensions",
+      "fqn": "Granit.Http.Cors.Extensions.CorsHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Cors",
+      "file": "src/Granit.Http.Cors/Extensions/CorsHostApplicationBuilderExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitCors",
+          "kind": "method",
+          "signature": "AddGranitCors(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpCorsModule",
+      "fqn": "Granit.Http.Cors.GranitHttpCorsModule",
+      "kind": "class",
+      "project": "Granit.Http.Cors",
+      "file": "src/Granit.Http.Cors/GranitHttpCorsModule.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GranitCorsOptions",
+      "fqn": "Granit.Http.Cors.Options.GranitCorsOptions",
+      "kind": "class",
+      "project": "Granit.Http.Cors",
+      "file": "src/Granit.Http.Cors/Options/GranitCorsOptions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AllowedOrigins",
+          "kind": "property",
+          "signature": "string[] AllowedOrigins",
+          "returnType": "string[]"
+        }
+      ]
+    },
+    {
+      "name": "ExceptionHandlingApplicationBuilderExtensions",
+      "fqn": "Granit.Http.ExceptionHandling.Extensions.ExceptionHandlingApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.ExceptionHandling",
+      "file": "src/Granit.Http.ExceptionHandling/Extensions/ExceptionHandlingApplicationBuilderExtensions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "UseGranitExceptionHandling",
+          "kind": "method",
+          "signature": "UseGranitExceptionHandling(this IApplicationBuilder app)",
+          "returnType": "IApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "ExceptionHandlingServiceCollectionExtensions",
+      "fqn": "Granit.Http.ExceptionHandling.Extensions.ExceptionHandlingServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.ExceptionHandling",
+      "file": "src/Granit.Http.ExceptionHandling/Extensions/ExceptionHandlingServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitExceptionHandling",
+          "kind": "method",
+          "signature": "AddGranitExceptionHandling(this IServiceCollection services, Action<ExceptionHandlingOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitExceptionHandlingModule",
+      "fqn": "Granit.Http.ExceptionHandling.GranitExceptionHandlingModule",
+      "kind": "class",
+      "project": "Granit.Http.ExceptionHandling",
+      "file": "src/Granit.Http.ExceptionHandling/GranitExceptionHandlingModule.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IExceptionStatusCodeMapper",
+      "fqn": "Granit.Http.ExceptionHandling.IExceptionStatusCodeMapper",
+      "kind": "interface",
+      "project": "Granit.Http.ExceptionHandling",
+      "file": "src/Granit.Http.ExceptionHandling/IExceptionStatusCodeMapper.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "TryGetStatusCode",
+          "kind": "method",
+          "signature": "TryGetStatusCode(Exception exception)",
+          "returnType": "int?"
+        }
+      ]
+    },
+    {
+      "name": "ExceptionHandlingOptions",
+      "fqn": "Granit.Http.ExceptionHandling.Options.ExceptionHandlingOptions",
+      "kind": "class",
+      "project": "Granit.Http.ExceptionHandling",
+      "file": "src/Granit.Http.ExceptionHandling/Options/ExceptionHandlingOptions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IIdempotencyMetadata",
+      "fqn": "Granit.Http.Idempotency.Abstractions.IIdempotencyMetadata",
+      "kind": "interface",
+      "project": "Granit.Http.Idempotency",
+      "file": "src/Granit.Http.Idempotency/Abstractions/IIdempotencyMetadata.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "IIdempotencyStore",
+      "fqn": "Granit.Http.Idempotency.Abstractions.IIdempotencyStore",
+      "kind": "interface",
+      "project": "Granit.Http.Idempotency",
+      "file": "src/Granit.Http.Idempotency/Abstractions/IIdempotencyStore.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "TryAcquireAsync",
+          "kind": "method",
+          "signature": "TryAcquireAsync(string key, IdempotencyEntry entry, TimeSpan ttl, CancellationToken cancellationToken)",
+          "returnType": "Task<bool>"
+        },
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(string key, CancellationToken cancellationToken)",
+          "returnType": "Task<IdempotencyEntry?>"
+        },
+        {
+          "name": "SetCompletedAsync",
+          "kind": "method",
+          "signature": "SetCompletedAsync(string key, IdempotencyEntry entry, TimeSpan ttl, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(string key, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IdempotentAttribute",
+      "fqn": "Granit.Http.Idempotency.Attributes.IdempotentAttribute",
+      "kind": "class",
+      "project": "Granit.Http.Idempotency",
+      "file": "src/Granit.Http.Idempotency/Attributes/IdempotentAttribute.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Required",
+          "kind": "property",
+          "signature": "bool Required",
+          "returnType": "bool"
+        },
+        {
+          "name": "CompletedTtlSeconds",
+          "kind": "property",
+          "signature": "int CompletedTtlSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "IdempotencyApplicationBuilderExtensions",
+      "fqn": "Granit.Http.Idempotency.Extensions.IdempotencyApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Idempotency",
+      "file": "src/Granit.Http.Idempotency/Extensions/IdempotencyApplicationBuilderExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "UseGranitIdempotency",
+          "kind": "method",
+          "signature": "UseGranitIdempotency(this IApplicationBuilder app)",
+          "returnType": "IApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "IdempotencyServiceCollectionExtensions",
+      "fqn": "Granit.Http.Idempotency.Extensions.IdempotencyServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Idempotency",
+      "file": "src/Granit.Http.Idempotency/Extensions/IdempotencyServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitIdempotency",
+          "kind": "method",
+          "signature": "AddGranitIdempotency(this IServiceCollection services, IConfigurationSection configurationSection)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitIdempotencyModule",
+      "fqn": "Granit.Http.Idempotency.GranitIdempotencyModule",
+      "kind": "class",
+      "project": "Granit.Http.Idempotency",
+      "file": "src/Granit.Http.Idempotency/GranitIdempotencyModule.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IdempotencyEntry",
+      "fqn": "Granit.Http.Idempotency.Models.IdempotencyEntry",
+      "kind": "record",
+      "project": "Granit.Http.Idempotency",
+      "file": "src/Granit.Http.Idempotency/Models/IdempotencyEntry.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IdempotencyOptions",
+      "fqn": "Granit.Http.Idempotency.Models.IdempotencyOptions",
+      "kind": "class",
+      "project": "Granit.Http.Idempotency",
+      "file": "src/Granit.Http.Idempotency/Models/IdempotencyOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "HeaderName",
+          "kind": "property",
+          "signature": "string HeaderName",
+          "returnType": "string"
+        },
+        {
+          "name": "KeyPrefix",
+          "kind": "property",
+          "signature": "string KeyPrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "FromHours",
+          "kind": "method",
+          "signature": "FromHours(24)",
+          "returnType": "TimeSpan CompletedTtl { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(30)",
+          "returnType": "TimeSpan InProgressTtl { get; set; } = TimeSpan."
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(25)",
+          "returnType": "TimeSpan ExecutionTimeout { get; set; } = TimeSpan."
+        },
+        {
+          "name": "MaxBodySizeBytes",
+          "kind": "property",
+          "signature": "int MaxBodySizeBytes",
+          "returnType": "int"
+        },
+        {
+          "name": "is",
+          "kind": "method",
+          "signature": "is(>= 200 and < 300)",
+          "returnType": "Func<int, bool> ShouldCacheStatusCode { get; set; } = sc => sc"
+        }
+      ]
+    },
+    {
+      "name": "IdempotencyState",
+      "fqn": "Granit.Http.Idempotency.Models.IdempotencyState",
+      "kind": "enum",
+      "project": "Granit.Http.Idempotency",
+      "file": "src/Granit.Http.Idempotency/Models/IdempotencyState.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IOutputCacheEvictionService",
+      "fqn": "Granit.Http.OutputCaching.Eviction.IOutputCacheEvictionService",
+      "kind": "interface",
+      "project": "Granit.Http.OutputCaching",
+      "file": "src/Granit.Http.OutputCaching/Eviction/IOutputCacheEvictionService.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "EvictModuleCacheAsync",
+          "kind": "method",
+          "signature": "EvictModuleCacheAsync(string moduleName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "EvictTenantCacheAsync",
+          "kind": "method",
+          "signature": "EvictTenantCacheAsync(Guid tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "EvictByTagAsync",
+          "kind": "method",
+          "signature": "EvictByTagAsync(string tag, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "OutputCachingApplicationBuilderExtensions",
+      "fqn": "Granit.Http.OutputCaching.Extensions.OutputCachingApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.OutputCaching",
+      "file": "src/Granit.Http.OutputCaching/Extensions/OutputCachingApplicationBuilderExtensions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "UseGranitOutputCaching",
+          "kind": "method",
+          "signature": "UseGranitOutputCaching(this IApplicationBuilder app)",
+          "returnType": "IApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "OutputCachingServiceCollectionExtensions",
+      "fqn": "Granit.Http.OutputCaching.Extensions.OutputCachingServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.OutputCaching",
+      "file": "src/Granit.Http.OutputCaching/Extensions/OutputCachingServiceCollectionExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitOutputCaching",
+          "kind": "method",
+          "signature": "AddGranitOutputCaching(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpOutputCachingModule",
+      "fqn": "Granit.Http.OutputCaching.GranitHttpOutputCachingModule",
+      "kind": "class",
+      "project": "Granit.Http.OutputCaching",
+      "file": "src/Granit.Http.OutputCaching/GranitHttpOutputCachingModule.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "OutputCachingOptions",
+      "fqn": "Granit.Http.OutputCaching.Options.OutputCachingOptions",
+      "kind": "class",
+      "project": "Granit.Http.OutputCaching",
+      "file": "src/Granit.Http.OutputCaching/Options/OutputCachingOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(60)",
+          "returnType": "TimeSpan DefaultExpiration { get; set; } = TimeSpan."
+        },
+        {
+          "name": "VaryByQueryKeys",
+          "kind": "property",
+          "signature": "string[] VaryByQueryKeys",
+          "returnType": "string[]"
+        },
+        {
+          "name": "ExcludeAuthenticatedResponses",
+          "kind": "property",
+          "signature": "bool ExcludeAuthenticatedResponses",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "GranitOutputCachePolicyNames",
+      "fqn": "Granit.Http.OutputCaching.Policies.GranitOutputCachePolicyNames",
+      "kind": "class",
+      "project": "Granit.Http.OutputCaching",
+      "file": "src/Granit.Http.OutputCaching/Policies/GranitOutputCachePolicyNames.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "RedisOutputCachingServiceCollectionExtensions",
+      "fqn": "Granit.Http.OutputCaching.StackExchangeRedis.Extensions.RedisOutputCachingServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.OutputCaching.StackExchangeRedis",
+      "file": "src/Granit.Http.OutputCaching.StackExchangeRedis/Extensions/RedisOutputCachingServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitRedisOutputCache",
+          "kind": "method",
+          "signature": "AddGranitRedisOutputCache(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpOutputCachingStackExchangeRedisModule",
+      "fqn": "Granit.Http.OutputCaching.StackExchangeRedis.GranitHttpOutputCachingStackExchangeRedisModule",
+      "kind": "class",
+      "project": "Granit.Http.OutputCaching.StackExchangeRedis",
+      "file": "src/Granit.Http.OutputCaching.StackExchangeRedis/GranitHttpOutputCachingStackExchangeRedisModule.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "IsEnabled",
+          "kind": "method",
+          "signature": "IsEnabled(ServiceConfigurationContext context)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "RedisOutputCachingOptions",
+      "fqn": "Granit.Http.OutputCaching.StackExchangeRedis.Options.RedisOutputCachingOptions",
+      "kind": "class",
+      "project": "Granit.Http.OutputCaching.StackExchangeRedis",
+      "file": "src/Granit.Http.OutputCaching.StackExchangeRedis/Options/RedisOutputCachingOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "IsEnabled",
+          "kind": "property",
+          "signature": "bool IsEnabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "Configuration",
+          "kind": "property",
+          "signature": "string Configuration",
+          "returnType": "string"
+        },
+        {
+          "name": "InstanceName",
+          "kind": "property",
+          "signature": "string InstanceName",
+          "returnType": "string"
+        },
+        {
+          "name": "RequireTls",
+          "kind": "property",
+          "signature": "bool RequireTls",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "HttpResilienceServiceCollectionExtensions",
+      "fqn": "Granit.Http.Resilience.Extensions.HttpResilienceServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Resilience",
+      "file": "src/Granit.Http.Resilience/Extensions/HttpResilienceServiceCollectionExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitHttpClient",
+          "kind": "method",
+          "signature": "AddGranitHttpClient(this IServiceCollection services, string name, Action<IServiceProvider, HttpClient>? configure = null)",
+          "returnType": "IHttpClientBuilder"
+        },
+        {
+          "name": "AddAuthTokenPropagation",
+          "kind": "method",
+          "signature": "AddAuthTokenPropagation(this IHttpClientBuilder builder)",
+          "returnType": "IHttpClientBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpResilienceModule",
+      "fqn": "Granit.Http.Resilience.GranitHttpResilienceModule",
+      "kind": "class",
+      "project": "Granit.Http.Resilience",
+      "file": "src/Granit.Http.Resilience/GranitHttpResilienceModule.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "HttpResilienceOptions",
+      "fqn": "Granit.Http.Resilience.Options.HttpResilienceOptions",
+      "kind": "class",
+      "project": "Granit.Http.Resilience",
+      "file": "src/Granit.Http.Resilience/Options/HttpResilienceOptions.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "ResponseCompressionApplicationBuilderExtensions",
+      "fqn": "Granit.Http.ResponseCompression.Extensions.ResponseCompressionApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.ResponseCompression",
+      "file": "src/Granit.Http.ResponseCompression/Extensions/ResponseCompressionApplicationBuilderExtensions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "UseGranitResponseCompression",
+          "kind": "method",
+          "signature": "UseGranitResponseCompression(this IApplicationBuilder app)",
+          "returnType": "IApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "ResponseCompressionHostApplicationBuilderExtensions",
+      "fqn": "Granit.Http.ResponseCompression.Extensions.ResponseCompressionHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.ResponseCompression",
+      "file": "src/Granit.Http.ResponseCompression/Extensions/ResponseCompressionHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitResponseCompression",
+          "kind": "method",
+          "signature": "AddGranitResponseCompression(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpResponseCompressionModule",
+      "fqn": "Granit.Http.ResponseCompression.GranitHttpResponseCompressionModule",
+      "kind": "class",
+      "project": "Granit.Http.ResponseCompression",
+      "file": "src/Granit.Http.ResponseCompression/GranitHttpResponseCompressionModule.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GranitResponseCompressionOptions",
+      "fqn": "Granit.Http.ResponseCompression.Options.GranitResponseCompressionOptions",
+      "kind": "class",
+      "project": "Granit.Http.ResponseCompression",
+      "file": "src/Granit.Http.ResponseCompression/Options/GranitResponseCompressionOptions.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "EnableForHttps",
+          "kind": "property",
+          "signature": "bool EnableForHttps",
+          "returnType": "bool"
+        },
+        {
+          "name": "EnableBrotli",
+          "kind": "property",
+          "signature": "bool EnableBrotli",
+          "returnType": "bool"
+        },
+        {
+          "name": "EnableGzip",
+          "kind": "property",
+          "signature": "bool EnableGzip",
+          "returnType": "bool"
+        },
+        {
+          "name": "BrotliLevel",
+          "kind": "property",
+          "signature": "CompressionLevel BrotliLevel",
+          "returnType": "CompressionLevel"
+        },
+        {
+          "name": "GzipLevel",
+          "kind": "property",
+          "signature": "CompressionLevel GzipLevel",
+          "returnType": "CompressionLevel"
+        }
+      ]
+    },
+    {
+      "name": "IdentityCognitoServiceCollectionExtensions",
+      "fqn": "Granit.Identity.Cognito.Extensions.IdentityCognitoServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.Cognito",
+      "file": "src/Granit.Identity.Cognito/Extensions/IdentityCognitoServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitIdentityCognito",
+          "kind": "method",
+          "signature": "AddGranitIdentityCognito(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitIdentityCognitoModule",
+      "fqn": "Granit.Identity.Cognito.GranitIdentityCognitoModule",
+      "kind": "class",
+      "project": "Granit.Identity.Cognito",
+      "file": "src/Granit.Identity.Cognito/GranitIdentityCognitoModule.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "CognitoAdminOptions",
+      "fqn": "Granit.Identity.Cognito.Options.CognitoAdminOptions",
+      "kind": "class",
+      "project": "Granit.Identity.Cognito",
+      "file": "src/Granit.Identity.Cognito/Options/CognitoAdminOptions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "Region",
+          "kind": "property",
+          "signature": "string Region",
+          "returnType": "string"
+        },
+        {
+          "name": "UserPoolId",
+          "kind": "property",
+          "signature": "string UserPoolId",
+          "returnType": "string"
+        },
+        {
+          "name": "AppClientId",
+          "kind": "property",
+          "signature": "string? AppClientId",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "IdentityMetrics",
+      "fqn": "Granit.Identity.Diagnostics.IdentityMetrics",
+      "kind": "class",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Diagnostics/IdentityMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordOperationError",
+          "kind": "method",
+          "signature": "RecordOperationError(string? tenantId, string operation, string provider)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordOperationDuration",
+          "kind": "method",
+          "signature": "RecordOperationDuration(string? tenantId, string operation, string provider, TimeSpan duration)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IdentityPasswordChangedAtResponse",
+      "fqn": "Granit.Identity.Endpoints.Dtos.IdentityPasswordChangedAtResponse",
+      "kind": "record",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Dtos/IdentityPasswordChangedAtResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IdentityProviderCapabilitiesResponse",
+      "fqn": "Granit.Identity.Endpoints.Dtos.IdentityProviderCapabilitiesResponse",
+      "kind": "record",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Dtos/IdentityProviderCapabilitiesResponse.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "IdentitySetTemporaryPasswordRequest",
+      "fqn": "Granit.Identity.Endpoints.Dtos.IdentitySetTemporaryPasswordRequest",
+      "kind": "record",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Dtos/IdentitySetTemporaryPasswordRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IdentityUserCacheBatchRequest",
+      "fqn": "Granit.Identity.Endpoints.Dtos.IdentityUserCacheBatchRequest",
+      "kind": "record",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Dtos/IdentityUserCacheBatchRequest.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "IdentityUserCacheStatsResponse",
+      "fqn": "Granit.Identity.Endpoints.Dtos.IdentityUserCacheStatsResponse",
+      "kind": "record",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Dtos/IdentityUserCacheStatsResponse.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "IdentityUserCacheSyncRequest",
+      "fqn": "Granit.Identity.Endpoints.Dtos.IdentityUserCacheSyncRequest",
+      "kind": "record",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Dtos/IdentityUserCacheSyncRequest.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "IdentityUserCreateRequest",
+      "fqn": "Granit.Identity.Endpoints.Dtos.IdentityUserCreateRequest",
+      "kind": "record",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Dtos/IdentityUserCreateRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IdentityUserSetEnabledRequest",
+      "fqn": "Granit.Identity.Endpoints.Dtos.IdentityUserSetEnabledRequest",
+      "kind": "record",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Dtos/IdentityUserSetEnabledRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IdentityUserUpdateRequest",
+      "fqn": "Granit.Identity.Endpoints.Dtos.IdentityUserUpdateRequest",
+      "kind": "record",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Dtos/IdentityUserUpdateRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IdentityWebhookPayload",
+      "fqn": "Granit.Identity.Endpoints.Dtos.IdentityWebhookPayload",
+      "kind": "record",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Dtos/IdentityWebhookPayload.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "IdentityEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Identity.Endpoints.Extensions.IdentityEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Extensions/IdentityEndpointRouteBuilderExtensions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "MapIdentityUserCacheEndpoints",
+          "kind": "method",
+          "signature": "MapIdentityUserCacheEndpoints(this IEndpointRouteBuilder endpoints, Action<IdentityEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "IdentityEndpointsServiceCollectionExtensions",
+      "fqn": "Granit.Identity.Endpoints.Extensions.IdentityEndpointsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Extensions/IdentityEndpointsServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitIdentityEndpoints",
+          "kind": "method",
+          "signature": "AddGranitIdentityEndpoints(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "IdentityProviderEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Identity.Endpoints.Extensions.IdentityProviderEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Extensions/IdentityProviderEndpointRouteBuilderExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "MapIdentityProviderEndpoints",
+          "kind": "method",
+          "signature": "MapIdentityProviderEndpoints(this IEndpointRouteBuilder endpoints, Action<IdentityProviderEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitIdentityEndpointsModule",
+      "fqn": "Granit.Identity.Endpoints.GranitIdentityEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/GranitIdentityEndpointsModule.cs",
+      "line": 29,
+      "members": []
+    },
+    {
+      "name": "IdentityEndpointsOptions",
+      "fqn": "Granit.Identity.Endpoints.Options.IdentityEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Options/IdentityEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "IdentityProviderEndpointsOptions",
+      "fqn": "Granit.Identity.Endpoints.Options.IdentityProviderEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Options/IdentityProviderEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "IdentityWebhookOptions",
+      "fqn": "Granit.Identity.Endpoints.Options.IdentityWebhookOptions",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Options/IdentityWebhookOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Secret",
+          "kind": "property",
+          "signature": "string Secret",
+          "returnType": "string"
+        },
+        {
+          "name": "SignatureHeaderName",
+          "kind": "property",
+          "signature": "string SignatureHeaderName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "Groups",
+      "fqn": "Granit.Identity.Endpoints.Permissions.Groups",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityProviderPermissions.cs",
+      "line": 36,
+      "members": []
+    },
+    {
+      "name": "IdentityProviderPermissions",
+      "fqn": "Granit.Identity.Endpoints.Permissions.IdentityProviderPermissions",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityProviderPermissions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "IdentityUserCachePermissions",
+      "fqn": "Granit.Identity.Endpoints.Permissions.IdentityUserCachePermissions",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityUserCachePermissions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "Passwords",
+      "fqn": "Granit.Identity.Endpoints.Permissions.Passwords",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityProviderPermissions.cs",
+      "line": 56,
+      "members": []
+    },
+    {
+      "name": "Roles",
+      "fqn": "Granit.Identity.Endpoints.Permissions.Roles",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityProviderPermissions.cs",
+      "line": 26,
+      "members": []
+    },
+    {
+      "name": "Sessions",
+      "fqn": "Granit.Identity.Endpoints.Permissions.Sessions",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityProviderPermissions.cs",
+      "line": 46,
+      "members": []
+    },
+    {
+      "name": "UserCache",
+      "fqn": "Granit.Identity.Endpoints.Permissions.UserCache",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityUserCachePermissions.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "Users",
+      "fqn": "Granit.Identity.Endpoints.Permissions.Users",
+      "kind": "class",
+      "project": "Granit.Identity.Endpoints",
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityProviderPermissions.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "IUserCacheDbContext",
+      "fqn": "Granit.Identity.EntityFrameworkCore.DbContext.IUserCacheDbContext",
+      "kind": "interface",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/DbContext/IUserCacheDbContext.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "UserCacheModelBuilderExtensions",
+      "fqn": "Granit.Identity.EntityFrameworkCore.DbContext.UserCacheModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/DbContext/UserCacheModelBuilderExtensions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "ConfigureIdentityModule",
+          "kind": "method",
+          "signature": "ConfigureIdentityModule(this ModelBuilder builder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "UserCacheEntry",
+      "fqn": "Granit.Identity.EntityFrameworkCore.Entities.UserCacheEntry",
+      "kind": "class",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/Entities/UserCacheEntry.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "ExternalUserId",
+          "kind": "property",
+          "signature": "string ExternalUserId",
+          "returnType": "string"
+        },
+        {
+          "name": "Username",
+          "kind": "property",
+          "signature": "string? Username",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "IdentityUserDeletedEvent",
+      "fqn": "Granit.Identity.EntityFrameworkCore.Events.IdentityUserDeletedEvent",
+      "kind": "record",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/Events/IdentityUserDeletedEvent.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "IdentityUserUpdatedEvent",
+      "fqn": "Granit.Identity.EntityFrameworkCore.Events.IdentityUserUpdatedEvent",
+      "kind": "record",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/Events/IdentityUserUpdatedEvent.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "UserCacheEntryErasedEvent",
+      "fqn": "Granit.Identity.EntityFrameworkCore.Events.UserCacheEntryErasedEvent",
+      "kind": "record",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/Events/UserCacheEntryErasedEvent.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "IdentityEfCoreApplicationBuilderExtensions",
+      "fqn": "Granit.Identity.EntityFrameworkCore.Extensions.IdentityEfCoreApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityEfCoreApplicationBuilderExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "UseGranitIdentityUserCacheSync",
+          "kind": "method",
+          "signature": "UseGranitIdentityUserCacheSync(this IApplicationBuilder app)",
+          "returnType": "IApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "IdentityEfCoreServiceCollectionExtensions",
+      "fqn": "Granit.Identity.EntityFrameworkCore.Extensions.IdentityEfCoreServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/Extensions/IdentityEfCoreServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "GranitIdentityDbProperties",
+      "fqn": "Granit.Identity.EntityFrameworkCore.GranitIdentityDbProperties",
+      "kind": "class",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/GranitIdentityDbProperties.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitIdentityEntityFrameworkCoreModule",
+      "fqn": "Granit.Identity.EntityFrameworkCore.GranitIdentityEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/GranitIdentityEntityFrameworkCoreModule.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "UserCacheOptions",
+      "fqn": "Granit.Identity.EntityFrameworkCore.Options.UserCacheOptions",
+      "kind": "class",
+      "project": "Granit.Identity.EntityFrameworkCore",
+      "file": "src/Granit.Identity.EntityFrameworkCore/Options/UserCacheOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "FromHours",
+          "kind": "method",
+          "signature": "FromHours(24)",
+          "returnType": "TimeSpan StalenessThreshold { get; set; } = TimeSpan."
+        },
+        {
+          "name": "EnableLoginTimeSync",
+          "kind": "property",
+          "signature": "bool EnableLoginTimeSync",
+          "returnType": "bool"
+        },
+        {
+          "name": "IncrementalSyncBatchSize",
+          "kind": "property",
+          "signature": "int IncrementalSyncBatchSize",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "IdentityEntraIdServiceCollectionExtensions",
+      "fqn": "Granit.Identity.EntraId.Extensions.IdentityEntraIdServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.EntraId",
+      "file": "src/Granit.Identity.EntraId/Extensions/IdentityEntraIdServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitIdentityEntraId",
+          "kind": "method",
+          "signature": "AddGranitIdentityEntraId(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitIdentityEntraIdModule",
+      "fqn": "Granit.Identity.EntraId.GranitIdentityEntraIdModule",
+      "kind": "class",
+      "project": "Granit.Identity.EntraId",
+      "file": "src/Granit.Identity.EntraId/GranitIdentityEntraIdModule.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IPasswordResetNotifier",
+      "fqn": "Granit.Identity.EntraId.IPasswordResetNotifier",
+      "kind": "interface",
+      "project": "Granit.Identity.EntraId",
+      "file": "src/Granit.Identity.EntraId/IPasswordResetNotifier.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "NotifyAsync",
+          "kind": "method",
+          "signature": "NotifyAsync(string userId, string temporaryPassword, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "EntraIdAdminOptions",
+      "fqn": "Granit.Identity.EntraId.Options.EntraIdAdminOptions",
+      "kind": "class",
+      "project": "Granit.Identity.EntraId",
+      "file": "src/Granit.Identity.EntraId/Options/EntraIdAdminOptions.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "TenantId",
+          "kind": "property",
+          "signature": "string TenantId",
+          "returnType": "string"
+        },
+        {
+          "name": "ClientId",
+          "kind": "property",
+          "signature": "string ClientId",
+          "returnType": "string"
+        },
+        {
+          "name": "ClientSecret",
+          "kind": "property",
+          "signature": "string ClientSecret",
+          "returnType": "string"
+        },
+        {
+          "name": "ServicePrincipalObjectId",
+          "kind": "property",
+          "signature": "string ServicePrincipalObjectId",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultDomain",
+          "kind": "property",
+          "signature": "string? DefaultDomain",
+          "returnType": "string?"
+        },
+        {
+          "name": "GraphBaseUrl",
+          "kind": "property",
+          "signature": "string GraphBaseUrl",
+          "returnType": "string"
+        },
+        {
+          "name": "GetTokenEndpoint",
+          "kind": "method",
+          "signature": "GetTokenEndpoint()",
+          "returnType": "string? RopcClientId { get; set; } internal string"
+        }
+      ]
+    },
+    {
+      "name": "IdentityGroupMembershipChangedEvent",
+      "fqn": "Granit.Identity.Events.IdentityGroupMembershipChangedEvent",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Events/IdentityEvents.cs",
+      "line": 47,
+      "members": []
+    },
+    {
+      "name": "IdentityPasswordResetEvent",
+      "fqn": "Granit.Identity.Events.IdentityPasswordResetEvent",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Events/IdentityEvents.cs",
+      "line": 53,
+      "members": []
+    },
+    {
+      "name": "IdentityRoleAssignedEvent",
+      "fqn": "Granit.Identity.Events.IdentityRoleAssignedEvent",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Events/IdentityEvents.cs",
+      "line": 32,
+      "members": []
+    },
+    {
+      "name": "IdentityRoleRemovedEvent",
+      "fqn": "Granit.Identity.Events.IdentityRoleRemovedEvent",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Events/IdentityEvents.cs",
+      "line": 39,
+      "members": []
+    },
+    {
+      "name": "IdentitySessionsRevokedEvent",
+      "fqn": "Granit.Identity.Events.IdentitySessionsRevokedEvent",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Events/IdentityEvents.cs",
+      "line": 59,
+      "members": []
+    },
+    {
+      "name": "IdentityUserCreatedEvent",
+      "fqn": "Granit.Identity.Events.IdentityUserCreatedEvent",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Events/IdentityEvents.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "IdentityUserEnabledChangedEvent",
+      "fqn": "Granit.Identity.Events.IdentityUserEnabledChangedEvent",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Events/IdentityEvents.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "IdentityUserProfileUpdatedEvent",
+      "fqn": "Granit.Identity.Events.IdentityUserProfileUpdatedEvent",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Events/IdentityEvents.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "UserCacheSyncedEto",
+      "fqn": "Granit.Identity.Events.UserCacheSyncedEto",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Events/UserCacheSyncedEto.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "IdentityServiceCollectionExtensions",
+      "fqn": "Granit.Identity.Extensions.IdentityServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Extensions/IdentityServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitIdentity",
+          "kind": "method",
+          "signature": "AddGranitIdentity(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "IdentityGoogleCloudServiceCollectionExtensions",
+      "fqn": "Granit.Identity.GoogleCloud.Extensions.IdentityGoogleCloudServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.GoogleCloud",
+      "file": "src/Granit.Identity.GoogleCloud/Extensions/IdentityGoogleCloudServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitIdentityGoogleCloud",
+          "kind": "method",
+          "signature": "AddGranitIdentityGoogleCloud(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitIdentityGoogleCloudModule",
+      "fqn": "Granit.Identity.GoogleCloud.GranitIdentityGoogleCloudModule",
+      "kind": "class",
+      "project": "Granit.Identity.GoogleCloud",
+      "file": "src/Granit.Identity.GoogleCloud/GranitIdentityGoogleCloudModule.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GoogleCloudIdentityOptions",
+      "fqn": "Granit.Identity.GoogleCloud.Options.GoogleCloudIdentityOptions",
+      "kind": "class",
+      "project": "Granit.Identity.GoogleCloud",
+      "file": "src/Granit.Identity.GoogleCloud/Options/GoogleCloudIdentityOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ProjectId",
+          "kind": "property",
+          "signature": "string ProjectId",
+          "returnType": "string"
+        },
+        {
+          "name": "CredentialFilePath",
+          "kind": "property",
+          "signature": "string? CredentialFilePath",
+          "returnType": "string?"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "GranitIdentityModule",
+      "fqn": "Granit.Identity.GranitIdentityModule",
+      "kind": "class",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/GranitIdentityModule.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IIdentityCredentialVerifier",
+      "fqn": "Granit.Identity.IIdentityCredentialVerifier",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IIdentityCredentialVerifier.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "VerifyUserCredentialsAsync",
+          "kind": "method",
+          "signature": "VerifyUserCredentialsAsync(string username, string password, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "IIdentityEventPublisher",
+      "fqn": "Granit.Identity.IIdentityEventPublisher",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IIdentityEventPublisher.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "IIdentityGroupManager",
+      "fqn": "Granit.Identity.IIdentityGroupManager",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IIdentityGroupManager.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetGroupsAsync",
+          "kind": "method",
+          "signature": "GetGroupsAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<IdentityGroup>>"
+        },
+        {
+          "name": "GetUserGroupsAsync",
+          "kind": "method",
+          "signature": "GetUserGroupsAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<IdentityGroup>>"
+        },
+        {
+          "name": "AddUserToGroupAsync",
+          "kind": "method",
+          "signature": "AddUserToGroupAsync(string userId, string groupId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RemoveUserFromGroupAsync",
+          "kind": "method",
+          "signature": "RemoveUserFromGroupAsync(string userId, string groupId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IIdentityPasswordManager",
+      "fqn": "Granit.Identity.IIdentityPasswordManager",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IIdentityPasswordManager.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetPasswordChangedAtAsync",
+          "kind": "method",
+          "signature": "GetPasswordChangedAtAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<DateTimeOffset?>"
+        },
+        {
+          "name": "SendPasswordResetEmailAsync",
+          "kind": "method",
+          "signature": "SendPasswordResetEmailAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SetTemporaryPasswordAsync",
+          "kind": "method",
+          "signature": "SetTemporaryPasswordAsync(string userId, string temporaryPassword, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IIdentityProvider",
+      "fqn": "Granit.Identity.IIdentityProvider",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IIdentityProvider.cs",
+      "line": 27,
+      "members": []
+    },
+    {
+      "name": "IIdentityProviderCapabilities",
+      "fqn": "Granit.Identity.IIdentityProviderCapabilities",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IIdentityProviderCapabilities.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "IIdentityRoleManager",
+      "fqn": "Granit.Identity.IIdentityRoleManager",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IIdentityRoleManager.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetRolesAsync",
+          "kind": "method",
+          "signature": "GetRolesAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<IdentityRole>>"
+        },
+        {
+          "name": "GetRoleMembersAsync",
+          "kind": "method",
+          "signature": "GetRoleMembersAsync(string roleName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<IdentityUser>>"
+        },
+        {
+          "name": "GetUserRolesAsync",
+          "kind": "method",
+          "signature": "GetUserRolesAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<IdentityRole>>"
+        },
+        {
+          "name": "AssignRoleAsync",
+          "kind": "method",
+          "signature": "AssignRoleAsync(string userId, string roleName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RemoveRoleAsync",
+          "kind": "method",
+          "signature": "RemoveRoleAsync(string userId, string roleName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IIdentitySessionManager",
+      "fqn": "Granit.Identity.IIdentitySessionManager",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IIdentitySessionManager.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetUserSessionsAsync",
+          "kind": "method",
+          "signature": "GetUserSessionsAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<IdentitySession>>"
+        },
+        {
+          "name": "GetUserDeviceActivityAsync",
+          "kind": "method",
+          "signature": "GetUserDeviceActivityAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<IdentityDeviceActivity>>"
+        },
+        {
+          "name": "TerminateSessionAsync",
+          "kind": "method",
+          "signature": "TerminateSessionAsync(string userId, string sessionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "TerminateAllSessionsAsync",
+          "kind": "method",
+          "signature": "TerminateAllSessionsAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IIdentityUserReader",
+      "fqn": "Granit.Identity.IIdentityUserReader",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IIdentityUserReader.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetUsersAsync",
+          "kind": "method",
+          "signature": "GetUsersAsync(string? search = null, int? first = null, int? max = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<IdentityUser>>"
+        },
+        {
+          "name": "GetUserAsync",
+          "kind": "method",
+          "signature": "GetUserAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IdentityUser?>"
+        }
+      ]
+    },
+    {
+      "name": "IIdentityUserWriter",
+      "fqn": "Granit.Identity.IIdentityUserWriter",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IIdentityUserWriter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "SetUserEnabledAsync",
+          "kind": "method",
+          "signature": "SetUserEnabledAsync(string userId, bool enabled, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UpdateUserAsync",
+          "kind": "method",
+          "signature": "UpdateUserAsync(string userId, IdentityUserUpdate update, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "CreateUserAsync",
+          "kind": "method",
+          "signature": "CreateUserAsync(IdentityUserCreate user, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IdentityUser>"
+        }
+      ]
+    },
+    {
+      "name": "IUserCacheStats",
+      "fqn": "Granit.Identity.IUserCacheStats",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IUserCacheStats.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetCountAsync",
+          "kind": "method",
+          "signature": "GetCountAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        },
+        {
+          "name": "GetStaleCountAsync",
+          "kind": "method",
+          "signature": "GetStaleCountAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        }
+      ]
+    },
+    {
+      "name": "IUserLookupService",
+      "fqn": "Granit.Identity.IUserLookupService",
+      "kind": "interface",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/IUserLookupService.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "FindByIdAsync",
+          "kind": "method",
+          "signature": "FindByIdAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IdentityUser?>"
+        },
+        {
+          "name": "FindByIdsAsync",
+          "kind": "method",
+          "signature": "FindByIdsAsync(IReadOnlyCollection<string> userIds, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<IdentityUser>>"
+        },
+        {
+          "name": "SearchAsync",
+          "kind": "method",
+          "signature": "SearchAsync(string searchTerm, int page = 1, int pageSize = QueryingDefaults.DefaultPageSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<IdentityUser>>"
+        },
+        {
+          "name": "RefreshByIdAsync",
+          "kind": "method",
+          "signature": "RefreshByIdAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IdentityUser?>"
+        },
+        {
+          "name": "RefreshAllAsync",
+          "kind": "method",
+          "signature": "RefreshAllAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        },
+        {
+          "name": "RefreshStaleAsync",
+          "kind": "method",
+          "signature": "RefreshStaleAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        },
+        {
+          "name": "DeleteByIdAsync",
+          "kind": "method",
+          "signature": "DeleteByIdAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "PseudonymizeByIdAsync",
+          "kind": "method",
+          "signature": "PseudonymizeByIdAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IdentityKeycloakServiceCollectionExtensions",
+      "fqn": "Granit.Identity.Keycloak.Extensions.IdentityKeycloakServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.Keycloak",
+      "file": "src/Granit.Identity.Keycloak/Extensions/IdentityKeycloakServiceCollectionExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "AddGranitIdentityKeycloak",
+          "kind": "method",
+          "signature": "AddGranitIdentityKeycloak(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitIdentityKeycloakModule",
+      "fqn": "Granit.Identity.Keycloak.GranitIdentityKeycloakModule",
+      "kind": "class",
+      "project": "Granit.Identity.Keycloak",
+      "file": "src/Granit.Identity.Keycloak/GranitIdentityKeycloakModule.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "KeycloakAdminOptions",
+      "fqn": "Granit.Identity.Keycloak.Options.KeycloakAdminOptions",
+      "kind": "class",
+      "project": "Granit.Identity.Keycloak",
+      "file": "src/Granit.Identity.Keycloak/Options/KeycloakAdminOptions.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "BaseUrl",
+          "kind": "property",
+          "signature": "string BaseUrl",
+          "returnType": "string"
+        },
+        {
+          "name": "Realm",
+          "kind": "property",
+          "signature": "string Realm",
+          "returnType": "string"
+        },
+        {
+          "name": "ClientId",
+          "kind": "property",
+          "signature": "string ClientId",
+          "returnType": "string"
+        },
+        {
+          "name": "ClientSecret",
+          "kind": "property",
+          "signature": "string ClientSecret",
+          "returnType": "string"
+        },
+        {
+          "name": "UseTokenExchangeForDeviceActivity",
+          "kind": "property",
+          "signature": "bool UseTokenExchangeForDeviceActivity",
+          "returnType": "bool"
+        },
+        {
+          "name": "GetTokenEndpoint",
+          "kind": "method",
+          "signature": "GetTokenEndpoint()",
+          "returnType": "string? DirectAccessClientId { get; set; } internal string"
+        }
+      ]
+    },
+    {
+      "name": "IdentityDeviceActivity",
+      "fqn": "Granit.Identity.Models.IdentityDeviceActivity",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Models/IdentityDeviceActivity.cs",
+      "line": 27,
+      "members": []
+    },
+    {
+      "name": "IdentityGroup",
+      "fqn": "Granit.Identity.Models.IdentityGroup",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Models/IdentityGroup.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "IdentityRole",
+      "fqn": "Granit.Identity.Models.IdentityRole",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Models/IdentityRole.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "IdentitySession",
+      "fqn": "Granit.Identity.Models.IdentitySession",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Models/IdentitySession.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "IdentityUser",
+      "fqn": "Granit.Identity.Models.IdentityUser",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Models/IdentityUser.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "IdentityUserCreate",
+      "fqn": "Granit.Identity.Models.IdentityUserCreate",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Models/IdentityUserCreate.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "IdentityUserUpdate",
+      "fqn": "Granit.Identity.Models.IdentityUserUpdate",
+      "kind": "record",
+      "project": "Granit.Identity",
+      "file": "src/Granit.Identity/Models/IdentityUserUpdate.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "ImagingAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Imaging.AI.Extensions.ImagingAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Imaging.AI",
+      "file": "src/Granit.Imaging.AI/Extensions/ImagingAIHostApplicationBuilderExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "AddGranitImagingAI",
+          "kind": "method",
+          "signature": "AddGranitImagingAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitImagingAIModule",
+      "fqn": "Granit.Imaging.AI.GranitImagingAIModule",
+      "kind": "class",
+      "project": "Granit.Imaging.AI",
+      "file": "src/Granit.Imaging.AI/GranitImagingAIModule.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IAIImageAnalyzer",
+      "fqn": "Granit.Imaging.AI.IAIImageAnalyzer",
+      "kind": "interface",
+      "project": "Granit.Imaging.AI",
+      "file": "src/Granit.Imaging.AI/IAIImageAnalyzer.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AnalyzeAsync",
+          "kind": "method",
+          "signature": "AnalyzeAsync(ReadOnlyMemory<byte> imageData, string contentType, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImageAnalysis>"
+        }
+      ]
+    },
+    {
+      "name": "ImageAnalysis",
+      "fqn": "Granit.Imaging.AI.ImageAnalysis",
+      "kind": "record",
+      "project": "Granit.Imaging.AI",
+      "file": "src/Granit.Imaging.AI/ImageAnalysis.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ImagingAIOptions",
+      "fqn": "Granit.Imaging.AI.Options.ImagingAIOptions",
+      "kind": "class",
+      "project": "Granit.Imaging.AI",
+      "file": "src/Granit.Imaging.AI/Options/ImagingAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string? WorkspaceName",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "UnsupportedImageFormatException",
+      "fqn": "Granit.Imaging.Exceptions.UnsupportedImageFormatException",
+      "kind": "class",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/Exceptions/UnsupportedImageFormatException.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "UnsupportedImageFormatException",
+          "kind": "method",
+          "signature": "UnsupportedImageFormatException(string detectedFormat)",
+          "returnType": "string DetectedFormat { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "ImagePipelineExtensions",
+      "fqn": "Granit.Imaging.Extensions.ImagePipelineExtensions",
+      "kind": "class",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/Extensions/ImagePipelineExtensions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SaveAsJpegAsync",
+          "kind": "method",
+          "signature": "SaveAsJpegAsync(this IImagePipeline pipeline, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImageResult>"
+        },
+        {
+          "name": "SaveAsPngAsync",
+          "kind": "method",
+          "signature": "SaveAsPngAsync(this IImagePipeline pipeline, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImageResult>"
+        },
+        {
+          "name": "SaveAsWebPAsync",
+          "kind": "method",
+          "signature": "SaveAsWebPAsync(this IImagePipeline pipeline, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImageResult>"
+        },
+        {
+          "name": "SaveAsAvifAsync",
+          "kind": "method",
+          "signature": "SaveAsAvifAsync(this IImagePipeline pipeline, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImageResult>"
+        }
+      ]
+    },
+    {
+      "name": "ImagingServiceCollectionExtensions",
+      "fqn": "Granit.Imaging.Extensions.ImagingServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/Extensions/ImagingServiceCollectionExtensions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "AddGranitImaging",
+          "kind": "method",
+          "signature": "AddGranitImaging(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitImagingModule",
+      "fqn": "Granit.Imaging.GranitImagingModule",
+      "kind": "class",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/GranitImagingModule.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "IImagePipeline",
+      "fqn": "Granit.Imaging.IImagePipeline",
+      "kind": "interface",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/IImagePipeline.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "Resize",
+          "kind": "method",
+          "signature": "Resize(int width, int height, ResizeMode mode = ResizeMode.Max)",
+          "returnType": "ImageSize SourceSize { get; } ImageFormat SourceFormat { get; } IImagePipeline"
+        },
+        {
+          "name": "Crop",
+          "kind": "method",
+          "signature": "Crop(CropRectangle rectangle)",
+          "returnType": "IImagePipeline"
+        },
+        {
+          "name": "Compress",
+          "kind": "method",
+          "signature": "Compress(int quality)",
+          "returnType": "IImagePipeline"
+        },
+        {
+          "name": "ConvertTo",
+          "kind": "method",
+          "signature": "ConvertTo(ImageFormat format)",
+          "returnType": "IImagePipeline"
+        },
+        {
+          "name": "Watermark",
+          "kind": "method",
+          "signature": "Watermark(ReadOnlyMemory<byte> watermark, WatermarkPosition position = WatermarkPosition.BottomRight, float opacity = 0.5f)",
+          "returnType": "IImagePipeline"
+        },
+        {
+          "name": "Watermark",
+          "kind": "method",
+          "signature": "Watermark(Stream watermark, WatermarkPosition position = WatermarkPosition.BottomRight, float opacity = 0.5f)",
+          "returnType": "IImagePipeline"
+        },
+        {
+          "name": "StripMetadata",
+          "kind": "method",
+          "signature": "StripMetadata()",
+          "returnType": "IImagePipeline"
+        },
+        {
+          "name": "ToResultAsync",
+          "kind": "method",
+          "signature": "ToResultAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<ImageResult>"
+        },
+        {
+          "name": "SaveToStreamAsync",
+          "kind": "method",
+          "signature": "SaveToStreamAsync(Stream destination, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IImageProcessor",
+      "fqn": "Granit.Imaging.IImageProcessor",
+      "kind": "interface",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/IImageProcessor.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "Load",
+          "kind": "method",
+          "signature": "Load(Stream source)",
+          "returnType": "IImagePipeline"
+        },
+        {
+          "name": "Load",
+          "kind": "method",
+          "signature": "Load(ReadOnlyMemory<byte> source)",
+          "returnType": "IImagePipeline"
+        }
+      ]
+    },
+    {
+      "name": "ImageFormat",
+      "fqn": "Granit.Imaging.ImageFormat",
+      "kind": "enum",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/ImageFormat.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ImageResult",
+      "fqn": "Granit.Imaging.ImageResult",
+      "kind": "record",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/ImageResult.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "ImagingMagickNetServiceCollectionExtensions",
+      "fqn": "Granit.Imaging.MagickNet.Extensions.ImagingMagickNetServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Imaging.MagickNet",
+      "file": "src/Granit.Imaging.MagickNet/Extensions/ImagingMagickNetServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitImagingMagickNet",
+          "kind": "method",
+          "signature": "AddGranitImagingMagickNet(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitImagingMagickNetModule",
+      "fqn": "Granit.Imaging.MagickNet.GranitImagingMagickNetModule",
+      "kind": "class",
+      "project": "Granit.Imaging.MagickNet",
+      "file": "src/Granit.Imaging.MagickNet/GranitImagingMagickNetModule.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ResizeMode",
+      "fqn": "Granit.Imaging.ResizeMode",
+      "kind": "enum",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/ResizeMode.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WatermarkPosition",
+      "fqn": "Granit.Imaging.WatermarkPosition",
+      "kind": "enum",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/WatermarkPosition.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "struct",
+      "fqn": "Granit.Imaging.struct",
+      "kind": "record",
+      "project": "Granit.Imaging",
+      "file": "src/Granit.Imaging/CropRectangle.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "LocalizationAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Localization.AI.Extensions.LocalizationAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Localization.AI",
+      "file": "src/Granit.Localization.AI/Extensions/LocalizationAIHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitLocalizationAI",
+          "kind": "method",
+          "signature": "AddGranitLocalizationAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitLocalizationAIModule",
+      "fqn": "Granit.Localization.AI.GranitLocalizationAIModule",
+      "kind": "class",
+      "project": "Granit.Localization.AI",
+      "file": "src/Granit.Localization.AI/GranitLocalizationAIModule.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "ITranslationSuggestionService",
+      "fqn": "Granit.Localization.AI.ITranslationSuggestionService",
+      "kind": "interface",
+      "project": "Granit.Localization.AI",
+      "file": "src/Granit.Localization.AI/ITranslationSuggestionService.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SuggestTranslationsAsync",
+          "kind": "method",
+          "signature": "SuggestTranslationsAsync(string key, string sourceValue, string sourceCulture, IReadOnlyList<string> targetCultures, TranslationContext context = TranslationContext.UiLabel, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<TranslationSuggestion>>"
+        }
+      ]
+    },
+    {
+      "name": "LocalizationAIOptions",
+      "fqn": "Granit.Localization.AI.Options.LocalizationAIOptions",
+      "kind": "class",
+      "project": "Granit.Localization.AI",
+      "file": "src/Granit.Localization.AI/Options/LocalizationAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string WorkspaceName",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "TranslationContext",
+      "fqn": "Granit.Localization.AI.TranslationContext",
+      "kind": "enum",
+      "project": "Granit.Localization.AI",
+      "file": "src/Granit.Localization.AI/TranslationContext.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "TranslationSuggestion",
+      "fqn": "Granit.Localization.AI.TranslationSuggestion",
+      "kind": "record",
+      "project": "Granit.Localization.AI",
+      "file": "src/Granit.Localization.AI/TranslationSuggestion.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ApplicationLocalizationResponse",
+      "fqn": "Granit.Localization.Endpoints.Dtos.ApplicationLocalizationResponse",
+      "kind": "record",
+      "project": "Granit.Localization.Endpoints",
+      "file": "src/Granit.Localization.Endpoints/Dtos/ApplicationLocalizationResponse.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "LanguageInfoResponse",
+      "fqn": "Granit.Localization.Endpoints.Dtos.LanguageInfoResponse",
+      "kind": "record",
+      "project": "Granit.Localization.Endpoints",
+      "file": "src/Granit.Localization.Endpoints/Dtos/LanguageInfoResponse.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "SetLocalizationOverrideRequest",
+      "fqn": "Granit.Localization.Endpoints.Dtos.SetLocalizationOverrideRequest",
+      "kind": "record",
+      "project": "Granit.Localization.Endpoints",
+      "file": "src/Granit.Localization.Endpoints/Dtos/SetLocalizationOverrideRequest.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "LocalizationApplicationBuilderExtensions",
+      "fqn": "Granit.Localization.Endpoints.Extensions.LocalizationApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Localization.Endpoints",
+      "file": "src/Granit.Localization.Endpoints/Extensions/LocalizationApplicationBuilderExtensions.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "UseGranitRequestLocalization",
+          "kind": "method",
+          "signature": "UseGranitRequestLocalization(this IApplicationBuilder app, Action<RequestLocalizationOptions>? configure = null)",
+          "returnType": "IApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "LocalizationEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Localization.Endpoints.Extensions.LocalizationEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Localization.Endpoints",
+      "file": "src/Granit.Localization.Endpoints/Extensions/LocalizationEndpointRouteBuilderExtensions.cs",
+      "line": 31,
+      "members": [
+        {
+          "name": "MapGranitLocalization",
+          "kind": "method",
+          "signature": "MapGranitLocalization(this IEndpointRouteBuilder endpoints, Action<LocalizationEndpointsOptions>? configure = null)",
+          "returnType": "IEndpointRouteBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitLocalizationEndpointsModule",
+      "fqn": "Granit.Localization.Endpoints.GranitLocalizationEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Localization.Endpoints",
+      "file": "src/Granit.Localization.Endpoints/GranitLocalizationEndpointsModule.cs",
+      "line": 27,
+      "members": []
+    },
+    {
+      "name": "LocalizationEndpointsOptions",
+      "fqn": "Granit.Localization.Endpoints.Options.LocalizationEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Localization.Endpoints",
+      "file": "src/Granit.Localization.Endpoints/Options/LocalizationEndpointsOptions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "LocalizationOverridesPermissions",
+      "fqn": "Granit.Localization.Endpoints.Permissions.LocalizationOverridesPermissions",
+      "kind": "class",
+      "project": "Granit.Localization.Endpoints",
+      "file": "src/Granit.Localization.Endpoints/Permissions/LocalizationOverridesPermissions.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "LocalizationOverride",
+      "fqn": "Granit.Localization.EntityFrameworkCore.Entities.LocalizationOverride",
+      "kind": "class",
+      "project": "Granit.Localization.EntityFrameworkCore",
+      "file": "src/Granit.Localization.EntityFrameworkCore/Entities/LocalizationOverride.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "TenantId",
+          "kind": "property",
+          "signature": "Guid? TenantId",
+          "returnType": "Guid?"
+        },
+        {
+          "name": "CultureName",
+          "kind": "property",
+          "signature": "string CultureName",
+          "returnType": "string"
+        },
+        {
+          "name": "Key",
+          "kind": "property",
+          "signature": "string Key",
+          "returnType": "string"
+        },
+        {
+          "name": "Value",
+          "kind": "property",
+          "signature": "string Value",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "LocalizationEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.Localization.EntityFrameworkCore.Extensions.LocalizationEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Localization.EntityFrameworkCore",
+      "file": "src/Granit.Localization.EntityFrameworkCore/Extensions/LocalizationEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitLocalizationEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitLocalizationEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "LocalizationModelBuilderExtensions",
+      "fqn": "Granit.Localization.EntityFrameworkCore.Extensions.LocalizationModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Localization.EntityFrameworkCore",
+      "file": "src/Granit.Localization.EntityFrameworkCore/Extensions/LocalizationModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureLocalizationModule",
+          "kind": "method",
+          "signature": "ConfigureLocalizationModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitLocalizationDbProperties",
+      "fqn": "Granit.Localization.EntityFrameworkCore.GranitLocalizationDbProperties",
+      "kind": "class",
+      "project": "Granit.Localization.EntityFrameworkCore",
+      "file": "src/Granit.Localization.EntityFrameworkCore/GranitLocalizationDbProperties.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitLocalizationEntityFrameworkCoreModule",
+      "fqn": "Granit.Localization.EntityFrameworkCore.GranitLocalizationEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Localization.EntityFrameworkCore",
+      "file": "src/Granit.Localization.EntityFrameworkCore/GranitLocalizationEntityFrameworkCoreModule.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "LocalizationServiceCollectionExtensions",
+      "fqn": "Granit.Localization.Extensions.LocalizationServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Localization",
+      "file": "src/Granit.Localization/Extensions/LocalizationServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitLocalization",
+          "kind": "method",
+          "signature": "AddGranitLocalization(this IServiceCollection services, Action<GranitLocalizationOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitLocalizationModule",
+      "fqn": "Granit.Localization.GranitLocalizationModule",
+      "kind": "class",
+      "project": "Granit.Localization",
+      "file": "src/Granit.Localization/GranitLocalizationModule.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GranitLocalizationResource",
+      "fqn": "Granit.Localization.GranitLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Localization",
+      "file": "src/Granit.Localization/GranitLocalizationResource.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "ILocalizationOverrideStoreReader",
+      "fqn": "Granit.Localization.ILocalizationOverrideStoreReader",
+      "kind": "interface",
+      "project": "Granit.Localization",
+      "file": "src/Granit.Localization/ILocalizationOverrideStoreReader.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetOverridesAsync",
+          "kind": "method",
+          "signature": "GetOverridesAsync(string resourceName, string culture, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyDictionary<string, string>>"
+        }
+      ]
+    },
+    {
+      "name": "ILocalizationOverrideStoreWriter",
+      "fqn": "Granit.Localization.ILocalizationOverrideStoreWriter",
+      "kind": "interface",
+      "project": "Granit.Localization",
+      "file": "src/Granit.Localization/ILocalizationOverrideStoreWriter.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SetOverrideAsync",
+          "kind": "method",
+          "signature": "SetOverrideAsync(string resourceName, string culture, string key, string value, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RemoveOverrideAsync",
+          "kind": "method",
+          "signature": "RemoveOverrideAsync(string resourceName, string culture, string key, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "LanguageInfo",
+      "fqn": "Granit.Localization.LanguageInfo",
+      "kind": "class",
+      "project": "Granit.Localization",
+      "file": "src/Granit.Localization/LanguageInfo.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "CultureName",
+          "kind": "property",
+          "signature": "string CultureName",
+          "returnType": "string"
+        },
+        {
+          "name": "DisplayName",
+          "kind": "property",
+          "signature": "string DisplayName",
+          "returnType": "string"
+        },
+        {
+          "name": "FlagIcon",
+          "kind": "property",
+          "signature": "string? FlagIcon",
+          "returnType": "string?"
+        },
+        {
+          "name": "IsDefault",
+          "kind": "property",
+          "signature": "bool IsDefault",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "LocalizationResourceInfo",
+      "fqn": "Granit.Localization.LocalizationResourceInfo",
+      "kind": "class",
+      "project": "Granit.Localization",
+      "file": "src/Granit.Localization/LocalizationResourceInfo.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "ResourceType",
+          "kind": "property",
+          "signature": "Type ResourceType",
+          "returnType": "Type"
+        },
+        {
+          "name": "DefaultCulture",
+          "kind": "property",
+          "signature": "string DefaultCulture",
+          "returnType": "string"
+        },
+        {
+          "name": "BaseTypes",
+          "kind": "property",
+          "signature": "List<Type> BaseTypes",
+          "returnType": "List<Type>"
+        },
+        {
+          "name": "AddJson",
+          "kind": "method",
+          "signature": "AddJson(Assembly assembly, string embeddedResourcePrefix)",
+          "returnType": "LocalizationResourceInfo"
+        }
+      ]
+    },
+    {
+      "name": "LocalizationResourceStore",
+      "fqn": "Granit.Localization.LocalizationResourceStore",
+      "kind": "class",
+      "project": "Granit.Localization",
+      "file": "src/Granit.Localization/LocalizationResourceStore.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "Add",
+          "kind": "method",
+          "signature": "Add(Type resourceType, string defaultCulture = \"fr\")",
+          "returnType": "LocalizationResourceInfo"
+        },
+        {
+          "name": "TryGetValue",
+          "kind": "method",
+          "signature": "TryGetValue(Type resourceType, [NotNullWhen(true)",
+          "returnType": "bool"
+        },
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IEnumerable<LocalizationResourceInfo>"
+        }
+      ]
+    },
+    {
+      "name": "GranitLocalizationOptions",
+      "fqn": "Granit.Localization.Options.GranitLocalizationOptions",
+      "kind": "class",
+      "project": "Granit.Localization",
+      "file": "src/Granit.Localization/Options/GranitLocalizationOptions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "LocalizationResourceStore Resources { get; } ="
+        },
+        {
+          "name": "DefaultResourceType",
+          "kind": "property",
+          "signature": "Type? DefaultResourceType",
+          "returnType": "Type?"
+        },
+        {
+          "name": "FormattingCultures",
+          "kind": "property",
+          "signature": "List<CultureInfo> FormattingCultures",
+          "returnType": "List<CultureInfo>"
+        }
+      ]
+    },
+    {
+      "name": "LocalizationOverridesCacheOptions",
+      "fqn": "Granit.Localization.Options.LocalizationOverridesCacheOptions",
+      "kind": "class",
+      "project": "Granit.Localization",
+      "file": "src/Granit.Localization/Options/LocalizationOverridesCacheOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(5)",
+          "returnType": "TimeSpan CacheTtl { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "LocalizationKeysGenerator",
+      "fqn": "Granit.Localization.SourceGenerator.LocalizationKeysGenerator",
+      "kind": "class",
+      "project": "Granit.Localization.SourceGenerator",
+      "file": "src/Granit.Localization.SourceGenerator/LocalizationKeysGenerator.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "Initialize",
+          "kind": "method",
+          "signature": "Initialize(IncrementalGeneratorInitializationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "CurrentTenant",
+      "fqn": "Granit.MultiTenancy.CurrentTenant",
+      "kind": "class",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/CurrentTenant.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "IsAvailable",
+          "kind": "property",
+          "signature": "bool IsAvailable",
+          "returnType": "bool"
+        },
+        {
+          "name": "Id",
+          "kind": "property",
+          "signature": "Guid? Id",
+          "returnType": "Guid?"
+        },
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string? Name",
+          "returnType": "string?"
+        },
+        {
+          "name": "Change",
+          "kind": "method",
+          "signature": "Change(Guid? id, string? name = null)",
+          "returnType": "IDisposable"
+        }
+      ]
+    },
+    {
+      "name": "MultiTenancyApplicationBuilderExtensions",
+      "fqn": "Granit.MultiTenancy.Extensions.MultiTenancyApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/Extensions/MultiTenancyApplicationBuilderExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "UseGranitMultiTenancy",
+          "kind": "method",
+          "signature": "UseGranitMultiTenancy(this IApplicationBuilder app)",
+          "returnType": "IApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "MultiTenancyServiceCollectionExtensions",
+      "fqn": "Granit.MultiTenancy.Extensions.MultiTenancyServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/Extensions/MultiTenancyServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitMultiTenancy",
+          "kind": "method",
+          "signature": "AddGranitMultiTenancy(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitMultiTenancyModule",
+      "fqn": "Granit.MultiTenancy.GranitMultiTenancyModule",
+      "kind": "class",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/GranitMultiTenancyModule.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ITenantInfo",
+      "fqn": "Granit.MultiTenancy.ITenantInfo",
+      "kind": "interface",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/ITenantInfo.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "TenantResolutionMiddleware",
+      "fqn": "Granit.MultiTenancy.Middleware.TenantResolutionMiddleware",
+      "kind": "class",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/Middleware/TenantResolutionMiddleware.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "InvokeAsync",
+          "kind": "method",
+          "signature": "InvokeAsync(HttpContext context, RequestDelegate next)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "MultiTenancyOptions",
+      "fqn": "Granit.MultiTenancy.Options.MultiTenancyOptions",
+      "kind": "class",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/Options/MultiTenancyOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "IsEnabled",
+          "kind": "property",
+          "signature": "bool IsEnabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "TenantIdClaimType",
+          "kind": "property",
+          "signature": "string TenantIdClaimType",
+          "returnType": "string"
+        },
+        {
+          "name": "TenantIdHeaderName",
+          "kind": "property",
+          "signature": "string TenantIdHeaderName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "TenantResolverPipeline",
+      "fqn": "Granit.MultiTenancy.Pipeline.TenantResolverPipeline",
+      "kind": "class",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/Pipeline/TenantResolverPipeline.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ResolveAsync",
+          "kind": "method",
+          "signature": "ResolveAsync(HttpContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TenantInfo?>"
+        }
+      ]
+    },
+    {
+      "name": "HeaderTenantResolver",
+      "fqn": "Granit.MultiTenancy.Resolvers.HeaderTenantResolver",
+      "kind": "class",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/Resolvers/HeaderTenantResolver.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "Order",
+          "kind": "property",
+          "signature": "int Order",
+          "returnType": "int"
+        },
+        {
+          "name": "ResolveAsync",
+          "kind": "method",
+          "signature": "ResolveAsync(HttpContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TenantInfo?>"
+        }
+      ]
+    },
+    {
+      "name": "ITenantResolver",
+      "fqn": "Granit.MultiTenancy.Resolvers.ITenantResolver",
+      "kind": "interface",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/Resolvers/ITenantResolver.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "ResolveAsync",
+          "kind": "method",
+          "signature": "ResolveAsync(HttpContext context, CancellationToken cancellationToken = default)",
+          "returnType": "int Order { get; } Task<TenantInfo?>"
+        }
+      ]
+    },
+    {
+      "name": "JwtClaimTenantResolver",
+      "fqn": "Granit.MultiTenancy.Resolvers.JwtClaimTenantResolver",
+      "kind": "class",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/Resolvers/JwtClaimTenantResolver.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "Order",
+          "kind": "property",
+          "signature": "int Order",
+          "returnType": "int"
+        },
+        {
+          "name": "ResolveAsync",
+          "kind": "method",
+          "signature": "ResolveAsync(HttpContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TenantInfo?>"
+        }
+      ]
+    },
+    {
+      "name": "TenantInfo",
+      "fqn": "Granit.MultiTenancy.TenantInfo",
+      "kind": "record",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/TenantInfo.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "NotificationsAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Notifications.AI.Extensions.NotificationsAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.AI",
+      "file": "src/Granit.Notifications.AI/Extensions/NotificationsAIHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitNotificationsAI",
+          "kind": "method",
+          "signature": "AddGranitNotificationsAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsAIModule",
+      "fqn": "Granit.Notifications.AI.GranitNotificationsAIModule",
+      "kind": "class",
+      "project": "Granit.Notifications.AI",
+      "file": "src/Granit.Notifications.AI/GranitNotificationsAIModule.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "IAIChannelSelector",
+      "fqn": "Granit.Notifications.AI.IAIChannelSelector",
+      "kind": "interface",
+      "project": "Granit.Notifications.AI",
+      "file": "src/Granit.Notifications.AI/IAIChannelSelector.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "SelectChannelsAsync",
+          "kind": "method",
+          "signature": "SelectChannelsAsync(NotificationDeliveryContext context, IReadOnlyList<string> availableChannels, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<string>>"
+        }
+      ]
+    },
+    {
+      "name": "IAINotificationContentGenerator",
+      "fqn": "Granit.Notifications.AI.IAINotificationContentGenerator",
+      "kind": "interface",
+      "project": "Granit.Notifications.AI",
+      "file": "src/Granit.Notifications.AI/IAINotificationContentGenerator.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GenerateAsync",
+          "kind": "method",
+          "signature": "GenerateAsync(NotificationDeliveryContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task<NotificationContent?>"
+        }
+      ]
+    },
+    {
+      "name": "NotificationContent",
+      "fqn": "Granit.Notifications.AI.NotificationContent",
+      "kind": "record",
+      "project": "Granit.Notifications.AI",
+      "file": "src/Granit.Notifications.AI/NotificationContent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "NotificationsAIOptions",
+      "fqn": "Granit.Notifications.AI.Options.NotificationsAIOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.AI",
+      "file": "src/Granit.Notifications.AI/Options/NotificationsAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string? WorkspaceName",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "INotificationChannel",
+      "fqn": "Granit.Notifications.Abstractions.INotificationChannel",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/INotificationChannel.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SendAsync",
+          "kind": "method",
+          "signature": "SendAsync(NotificationDeliveryContext context, CancellationToken cancellationToken = default)",
+          "returnType": "string Name { get; } Task"
+        }
+      ]
+    },
+    {
+      "name": "INotificationDefinitionContext",
+      "fqn": "Granit.Notifications.Abstractions.INotificationDefinitionContext",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/INotificationDefinitionContext.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Add",
+          "kind": "method",
+          "signature": "Add(NotificationDefinition definition)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "INotificationDefinitionProvider",
+      "fqn": "Granit.Notifications.Abstractions.INotificationDefinitionProvider",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/INotificationDefinitionProvider.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Define",
+          "kind": "method",
+          "signature": "Define(INotificationDefinitionContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "INotificationDefinitionStore",
+      "fqn": "Granit.Notifications.Abstractions.INotificationDefinitionStore",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/INotificationDefinitionStore.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IReadOnlyList<NotificationDefinition>"
+        },
+        {
+          "name": "Get",
+          "kind": "method",
+          "signature": "Get(string notificationTypeName)",
+          "returnType": "NotificationDefinition?"
+        }
+      ]
+    },
+    {
+      "name": "INotificationDeliveryWriter",
+      "fqn": "Granit.Notifications.Abstractions.INotificationDeliveryWriter",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/INotificationDeliveryWriter.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "RecordAsync",
+          "kind": "method",
+          "signature": "RecordAsync(NotificationDeliveryAttempt attempt, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteBeforeAsync",
+          "kind": "method",
+          "signature": "DeleteBeforeAsync(DateTimeOffset cutoff, int batchSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        }
+      ]
+    },
+    {
+      "name": "INotificationPreferenceReader",
+      "fqn": "Granit.Notifications.Abstractions.INotificationPreferenceReader",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/INotificationPreferenceReader.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetListAsync",
+          "kind": "method",
+          "signature": "GetListAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<NotificationPreference>>"
+        },
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(string userId, string notificationTypeName, string channelName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<NotificationPreference?>"
+        },
+        {
+          "name": "IsChannelEnabledAsync",
+          "kind": "method",
+          "signature": "IsChannelEnabledAsync(string userId, string notificationTypeName, string channelName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "INotificationPreferenceWriter",
+      "fqn": "Granit.Notifications.Abstractions.INotificationPreferenceWriter",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/INotificationPreferenceWriter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "SetAsync",
+          "kind": "method",
+          "signature": "SetAsync(NotificationPreference preference, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "INotificationPublisher",
+      "fqn": "Granit.Notifications.Abstractions.INotificationPublisher",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/INotificationPublisher.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "INotificationSubscriptionReader",
+      "fqn": "Granit.Notifications.Abstractions.INotificationSubscriptionReader",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/INotificationSubscriptionReader.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetSubscriberIdsAsync",
+          "kind": "method",
+          "signature": "GetSubscriberIdsAsync(string notificationTypeName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<string>>"
+        },
+        {
+          "name": "GetUserSubscriptionsAsync",
+          "kind": "method",
+          "signature": "GetUserSubscriptionsAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<NotificationSubscription>>"
+        },
+        {
+          "name": "GetEntityFollowerIdsAsync",
+          "kind": "method",
+          "signature": "GetEntityFollowerIdsAsync(string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<string>>"
+        },
+        {
+          "name": "GetEntityFollowersAsync",
+          "kind": "method",
+          "signature": "GetEntityFollowersAsync(string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<NotificationSubscription>>"
+        },
+        {
+          "name": "IsFollowingEntityAsync",
+          "kind": "method",
+          "signature": "IsFollowingEntityAsync(string userId, string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "INotificationSubscriptionWriter",
+      "fqn": "Granit.Notifications.Abstractions.INotificationSubscriptionWriter",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/INotificationSubscriptionWriter.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SubscribeAsync",
+          "kind": "method",
+          "signature": "SubscribeAsync(string userId, string notificationTypeName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UnsubscribeAsync",
+          "kind": "method",
+          "signature": "UnsubscribeAsync(string userId, string notificationTypeName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "FollowEntityAsync",
+          "kind": "method",
+          "signature": "FollowEntityAsync(string userId, string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UnfollowEntityAsync",
+          "kind": "method",
+          "signature": "UnfollowEntityAsync(string userId, string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IRecipientResolver",
+      "fqn": "Granit.Notifications.Abstractions.IRecipientResolver",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/IRecipientResolver.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "ResolveAsync",
+          "kind": "method",
+          "signature": "ResolveAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<RecipientInfo?>"
+        }
+      ]
+    },
+    {
+      "name": "IUserNotificationReader",
+      "fqn": "Granit.Notifications.Abstractions.IUserNotificationReader",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/IUserNotificationReader.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<UserNotification?>"
+        },
+        {
+          "name": "GetListAsync",
+          "kind": "method",
+          "signature": "GetListAsync(string recipientUserId, Guid? tenantId, int page = 1, int pageSize = QueryingDefaults.DefaultPageSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<UserNotification>>"
+        },
+        {
+          "name": "GetUnreadCountAsync",
+          "kind": "method",
+          "signature": "GetUnreadCountAsync(string recipientUserId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        },
+        {
+          "name": "GetByEntityAsync",
+          "kind": "method",
+          "signature": "GetByEntityAsync(string entityType, string entityId, Guid? tenantId, int page = 1, int pageSize = QueryingDefaults.DefaultPageSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<UserNotification>>"
+        }
+      ]
+    },
+    {
+      "name": "IUserNotificationWriter",
+      "fqn": "Granit.Notifications.Abstractions.IUserNotificationWriter",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Abstractions/IUserNotificationWriter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "InsertAsync",
+          "kind": "method",
+          "signature": "InsertAsync(UserNotification notification, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "MarkAsReadAsync",
+          "kind": "method",
+          "signature": "MarkAsReadAsync(Guid id, DateTimeOffset readAt, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "MarkAllAsReadAsync",
+          "kind": "method",
+          "signature": "MarkAllAsReadAsync(string recipientUserId, Guid? tenantId, DateTimeOffset readAt, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "BrevoNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Brevo.Extensions.BrevoNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Brevo",
+      "file": "src/Granit.Notifications.Brevo/Extensions/BrevoNotificationsServiceCollectionExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitNotificationsBrevo",
+          "kind": "method",
+          "signature": "AddGranitNotificationsBrevo(this IServiceCollection services, Action<BrevoOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsBrevoModule",
+      "fqn": "Granit.Notifications.Brevo.GranitNotificationsBrevoModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Brevo",
+      "file": "src/Granit.Notifications.Brevo/GranitNotificationsBrevoModule.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "BrevoOptions",
+      "fqn": "Granit.Notifications.Brevo.Options.BrevoOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Brevo",
+      "file": "src/Granit.Notifications.Brevo/Options/BrevoOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ApiKey",
+          "kind": "property",
+          "signature": "string ApiKey",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSenderEmail",
+          "kind": "property",
+          "signature": "string DefaultSenderEmail",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSenderName",
+          "kind": "property",
+          "signature": "string DefaultSenderName",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSmsSenderId",
+          "kind": "property",
+          "signature": "string DefaultSmsSenderId",
+          "returnType": "string"
+        },
+        {
+          "name": "BaseUrl",
+          "kind": "property",
+          "signature": "string BaseUrl",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "NotificationsMetrics",
+      "fqn": "Granit.Notifications.Diagnostics.NotificationsMetrics",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Diagnostics/NotificationsMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordDeliverySucceeded",
+          "kind": "method",
+          "signature": "RecordDeliverySucceeded(string? tenantId, string channel, string notificationType)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordDeliveryFailed",
+          "kind": "method",
+          "signature": "RecordDeliveryFailed(string? tenantId, string channel, string notificationType)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordDeliveryDuration",
+          "kind": "method",
+          "signature": "RecordDeliveryDuration(string? tenantId, string channel, string status, TimeSpan duration)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "NotificationDeliveryAttempt",
+      "fqn": "Granit.Notifications.Domain.NotificationDeliveryAttempt",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Domain/NotificationDeliveryAttempt.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "DeliveryId",
+          "kind": "property",
+          "signature": "Guid DeliveryId",
+          "returnType": "Guid"
+        },
+        {
+          "name": "ChannelName",
+          "kind": "property",
+          "signature": "string ChannelName",
+          "returnType": "string"
+        },
+        {
+          "name": "RecipientUserId",
+          "kind": "property",
+          "signature": "string RecipientUserId",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "NotificationPreference",
+      "fqn": "Granit.Notifications.Domain.NotificationPreference",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Domain/NotificationPreference.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "UserId",
+          "kind": "property",
+          "signature": "string UserId",
+          "returnType": "string"
+        },
+        {
+          "name": "NotificationTypeName",
+          "kind": "property",
+          "signature": "string NotificationTypeName",
+          "returnType": "string"
+        },
+        {
+          "name": "ChannelName",
+          "kind": "property",
+          "signature": "string ChannelName",
+          "returnType": "string"
+        },
+        {
+          "name": "IsEnabled",
+          "kind": "property",
+          "signature": "bool IsEnabled",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "NotificationSubscription",
+      "fqn": "Granit.Notifications.Domain.NotificationSubscription",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Domain/NotificationSubscription.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "UserId",
+          "kind": "property",
+          "signature": "string UserId",
+          "returnType": "string"
+        },
+        {
+          "name": "NotificationTypeName",
+          "kind": "property",
+          "signature": "string NotificationTypeName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "UserNotification",
+      "fqn": "Granit.Notifications.Domain.UserNotification",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Domain/UserNotification.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, Guid notificationId, string notificationTypeName, NotificationSeverity severity, string recipientUserId, System.Text.Json.JsonElement data, DateTimeOffset createdAt, Guid? tenantId = null, string? relatedEntityType = null, string? relatedEntityId = null)",
+          "returnType": "UserNotification"
+        },
+        {
+          "name": "NotificationId",
+          "kind": "property",
+          "signature": "Guid NotificationId",
+          "returnType": "Guid"
+        },
+        {
+          "name": "Severity",
+          "kind": "property",
+          "signature": "NotificationSeverity Severity",
+          "returnType": "NotificationSeverity"
+        },
+        {
+          "name": "Data",
+          "kind": "property",
+          "signature": "System.Text.Json.JsonElement Data",
+          "returnType": "System.Text.Json.JsonElement"
+        },
+        {
+          "name": "MarkAsRead",
+          "kind": "method",
+          "signature": "MarkAsRead(DateTimeOffset readAt)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "UserNotificationState",
+      "fqn": "Granit.Notifications.Domain.UserNotificationState",
+      "kind": "enum",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Domain/UserNotificationState.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "SesEmailServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Email.AwsSes.Extensions.SesEmailServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.AwsSes",
+      "file": "src/Granit.Notifications.Email.AwsSes/Extensions/SesEmailServiceCollectionExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitNotificationsEmailAwsSes",
+          "kind": "method",
+          "signature": "AddGranitNotificationsEmailAwsSes(this IServiceCollection services, Action<AwsSesOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsEmailAwsSesModule",
+      "fqn": "Granit.Notifications.Email.AwsSes.GranitNotificationsEmailAwsSesModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.AwsSes",
+      "file": "src/Granit.Notifications.Email.AwsSes/GranitNotificationsEmailAwsSesModule.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AwsSesOptions",
+      "fqn": "Granit.Notifications.Email.AwsSes.Options.AwsSesOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.AwsSes",
+      "file": "src/Granit.Notifications.Email.AwsSes/Options/AwsSesOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Region",
+          "kind": "property",
+          "signature": "string Region",
+          "returnType": "string"
+        },
+        {
+          "name": "FromAddress",
+          "kind": "property",
+          "signature": "string? FromAddress",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "AcsEmailServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Email.AzureCommunicationServices.Extensions.AcsEmailServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.AzureCommunicationServices",
+      "file": "src/Granit.Notifications.Email.AzureCommunicationServices/Extensions/AcsEmailServiceCollectionExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitNotificationsEmailAcs",
+          "kind": "method",
+          "signature": "AddGranitNotificationsEmailAcs(this IServiceCollection services, Action<AcsEmailOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsEmailAcsModule",
+      "fqn": "Granit.Notifications.Email.AzureCommunicationServices.GranitNotificationsEmailAcsModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.AzureCommunicationServices",
+      "file": "src/Granit.Notifications.Email.AzureCommunicationServices/GranitNotificationsEmailAcsModule.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AcsEmailOptions",
+      "fqn": "Granit.Notifications.Email.AzureCommunicationServices.Options.AcsEmailOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.AzureCommunicationServices",
+      "file": "src/Granit.Notifications.Email.AzureCommunicationServices/Options/AcsEmailOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ConnectionString",
+          "kind": "property",
+          "signature": "string? ConnectionString",
+          "returnType": "string?"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "EmailMessage",
+      "fqn": "Granit.Notifications.Email.EmailMessage",
+      "kind": "record",
+      "project": "Granit.Notifications.Email",
+      "file": "src/Granit.Notifications.Email/EmailMessage.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "EmailNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Email.Extensions.EmailNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email",
+      "file": "src/Granit.Notifications.Email/Extensions/EmailNotificationsServiceCollectionExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "AddGranitNotificationsEmail",
+          "kind": "method",
+          "signature": "AddGranitNotificationsEmail(this IServiceCollection services, Action<EmailChannelOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsEmailModule",
+      "fqn": "Granit.Notifications.Email.GranitNotificationsEmailModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Email",
+      "file": "src/Granit.Notifications.Email/GranitNotificationsEmailModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "IEmailSender",
+      "fqn": "Granit.Notifications.Email.IEmailSender",
+      "kind": "interface",
+      "project": "Granit.Notifications.Email",
+      "file": "src/Granit.Notifications.Email/IEmailSender.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "SendAsync",
+          "kind": "method",
+          "signature": "SendAsync(EmailMessage message, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "EmailChannelOptions",
+      "fqn": "Granit.Notifications.Email.Options.EmailChannelOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email",
+      "file": "src/Granit.Notifications.Email/Options/EmailChannelOptions.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "Provider",
+          "kind": "property",
+          "signature": "string Provider",
+          "returnType": "string"
+        },
+        {
+          "name": "SenderAddress",
+          "kind": "property",
+          "signature": "string SenderAddress",
+          "returnType": "string"
+        },
+        {
+          "name": "SenderName",
+          "kind": "property",
+          "signature": "string SenderName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "ScalewayEmailServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Email.Scaleway.Extensions.ScalewayEmailServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.Scaleway",
+      "file": "src/Granit.Notifications.Email.Scaleway/Extensions/ScalewayEmailServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitNotificationsEmailScaleway",
+          "kind": "method",
+          "signature": "AddGranitNotificationsEmailScaleway(this IServiceCollection services, Action<ScalewayEmailOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsEmailScalewayModule",
+      "fqn": "Granit.Notifications.Email.Scaleway.GranitNotificationsEmailScalewayModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.Scaleway",
+      "file": "src/Granit.Notifications.Email.Scaleway/GranitNotificationsEmailScalewayModule.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ScalewayEmailOptions",
+      "fqn": "Granit.Notifications.Email.Scaleway.Options.ScalewayEmailOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.Scaleway",
+      "file": "src/Granit.Notifications.Email.Scaleway/Options/ScalewayEmailOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SecretKey",
+          "kind": "property",
+          "signature": "string SecretKey",
+          "returnType": "string"
+        },
+        {
+          "name": "ProjectId",
+          "kind": "property",
+          "signature": "string ProjectId",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSenderEmail",
+          "kind": "property",
+          "signature": "string DefaultSenderEmail",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSenderName",
+          "kind": "property",
+          "signature": "string DefaultSenderName",
+          "returnType": "string"
+        },
+        {
+          "name": "Region",
+          "kind": "property",
+          "signature": "string Region",
+          "returnType": "string"
+        },
+        {
+          "name": "BaseUrl",
+          "kind": "property",
+          "signature": "string BaseUrl",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "SendGridEmailServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Email.SendGrid.Extensions.SendGridEmailServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.SendGrid",
+      "file": "src/Granit.Notifications.Email.SendGrid/Extensions/SendGridEmailServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitNotificationsEmailSendGrid",
+          "kind": "method",
+          "signature": "AddGranitNotificationsEmailSendGrid(this IServiceCollection services, Action<SendGridEmailOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsEmailSendGridModule",
+      "fqn": "Granit.Notifications.Email.SendGrid.GranitNotificationsEmailSendGridModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.SendGrid",
+      "file": "src/Granit.Notifications.Email.SendGrid/GranitNotificationsEmailSendGridModule.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "SendGridEmailOptions",
+      "fqn": "Granit.Notifications.Email.SendGrid.Options.SendGridEmailOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.SendGrid",
+      "file": "src/Granit.Notifications.Email.SendGrid/Options/SendGridEmailOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ApiKey",
+          "kind": "property",
+          "signature": "string ApiKey",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSenderEmail",
+          "kind": "property",
+          "signature": "string DefaultSenderEmail",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSenderName",
+          "kind": "property",
+          "signature": "string DefaultSenderName",
+          "returnType": "string"
+        },
+        {
+          "name": "BaseUrl",
+          "kind": "property",
+          "signature": "string BaseUrl",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "SmtpEmailServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Email.Smtp.Extensions.SmtpEmailServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.Smtp",
+      "file": "src/Granit.Notifications.Email.Smtp/Extensions/SmtpEmailServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitNotificationsEmailSmtp",
+          "kind": "method",
+          "signature": "AddGranitNotificationsEmailSmtp(this IServiceCollection services, Action<SmtpOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsEmailSmtpModule",
+      "fqn": "Granit.Notifications.Email.Smtp.GranitNotificationsEmailSmtpModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.Smtp",
+      "file": "src/Granit.Notifications.Email.Smtp/GranitNotificationsEmailSmtpModule.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "SmtpOptions",
+      "fqn": "Granit.Notifications.Email.Smtp.Options.SmtpOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Email.Smtp",
+      "file": "src/Granit.Notifications.Email.Smtp/Options/SmtpOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Host",
+          "kind": "property",
+          "signature": "string Host",
+          "returnType": "string"
+        },
+        {
+          "name": "Port",
+          "kind": "property",
+          "signature": "int Port",
+          "returnType": "int"
+        },
+        {
+          "name": "UseSsl",
+          "kind": "property",
+          "signature": "bool UseSsl",
+          "returnType": "bool"
+        },
+        {
+          "name": "Username",
+          "kind": "property",
+          "signature": "string? Username",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "NotificationPreferenceResponse",
+      "fqn": "Granit.Notifications.Endpoints.Dtos.NotificationPreferenceResponse",
+      "kind": "record",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Dtos/NotificationPreferenceResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "NotificationPreferenceUpdateRequest",
+      "fqn": "Granit.Notifications.Endpoints.Dtos.NotificationPreferenceUpdateRequest",
+      "kind": "record",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Dtos/NotificationPreferenceUpdateRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "NotificationSubscriptionResponse",
+      "fqn": "Granit.Notifications.Endpoints.Dtos.NotificationSubscriptionResponse",
+      "kind": "record",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Dtos/NotificationSubscriptionResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "UnreadCountResponse",
+      "fqn": "Granit.Notifications.Endpoints.Dtos.UnreadCountResponse",
+      "kind": "record",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Dtos/UnreadCountResponse.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "UserNotificationResponse",
+      "fqn": "Granit.Notifications.Endpoints.Dtos.UserNotificationResponse",
+      "kind": "record",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Dtos/UserNotificationResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "MobilePushTokenEndpoints",
+      "fqn": "Granit.Notifications.Endpoints.Endpoints.MobilePushTokenEndpoints",
+      "kind": "class",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Endpoints/MobilePushTokenEndpoints.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "MapMobilePushTokenEndpoints",
+          "kind": "method",
+          "signature": "MapMobilePushTokenEndpoints(this IEndpointRouteBuilder endpoints, string prefix = \"api/notifications/mobile-push/tokens\")",
+          "returnType": "IEndpointRouteBuilder"
+        }
+      ]
+    },
+    {
+      "name": "MobilePushTokenRegisterRequest",
+      "fqn": "Granit.Notifications.Endpoints.Endpoints.MobilePushTokenRegisterRequest",
+      "kind": "record",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Endpoints/MobilePushTokenEndpoints.cs",
+      "line": 119,
+      "members": []
+    },
+    {
+      "name": "MobilePushTokenResponse",
+      "fqn": "Granit.Notifications.Endpoints.Endpoints.MobilePushTokenResponse",
+      "kind": "record",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Endpoints/MobilePushTokenEndpoints.cs",
+      "line": 129,
+      "members": []
+    },
+    {
+      "name": "NotificationEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Notifications.Endpoints.Extensions.NotificationEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Extensions/NotificationEndpointRouteBuilderExtensions.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "MapGranitNotificationEndpoints",
+          "kind": "method",
+          "signature": "MapGranitNotificationEndpoints(this IEndpointRouteBuilder endpoints, Action<NotificationEndpointsOptions>? configure = null)",
+          "returnType": "IEndpointRouteBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsEndpointsModule",
+      "fqn": "Granit.Notifications.Endpoints.GranitNotificationsEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/GranitNotificationsEndpointsModule.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "NotificationEndpointsOptions",
+      "fqn": "Granit.Notifications.Endpoints.Options.NotificationEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Options/NotificationEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "NotificationPermissions",
+      "fqn": "Granit.Notifications.Endpoints.Permissions.NotificationPermissions",
+      "kind": "class",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Permissions/NotificationPermissions.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "Notifications",
+      "fqn": "Granit.Notifications.Endpoints.Permissions.Notifications",
+      "kind": "class",
+      "project": "Granit.Notifications.Endpoints",
+      "file": "src/Granit.Notifications.Endpoints/Permissions/NotificationPermissions.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "MobilePushTokenEntity",
+      "fqn": "Granit.Notifications.EntityFrameworkCore.Entities.MobilePushTokenEntity",
+      "kind": "class",
+      "project": "Granit.Notifications.EntityFrameworkCore",
+      "file": "src/Granit.Notifications.EntityFrameworkCore/Entities/MobilePushTokenEntity.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "UserId",
+          "kind": "property",
+          "signature": "string UserId",
+          "returnType": "string"
+        },
+        {
+          "name": "DeviceToken",
+          "kind": "property",
+          "signature": "string DeviceToken",
+          "returnType": "string"
+        },
+        {
+          "name": "ToTokenInfo",
+          "kind": "method",
+          "signature": "ToTokenInfo()",
+          "returnType": "MobilePlatform Platform { get; set; } public Guid? TenantId { get; set; } internal MobilePushTokenInfo"
+        }
+      ]
+    },
+    {
+      "name": "NotificationsEfCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.Notifications.EntityFrameworkCore.Extensions.NotificationsEfCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.EntityFrameworkCore",
+      "file": "src/Granit.Notifications.EntityFrameworkCore/Extensions/NotificationsEfCoreHostApplicationBuilderExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitNotificationsEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitNotificationsEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "NotificationsModelBuilderExtensions",
+      "fqn": "Granit.Notifications.EntityFrameworkCore.Extensions.NotificationsModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.EntityFrameworkCore",
+      "file": "src/Granit.Notifications.EntityFrameworkCore/Extensions/NotificationsModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureNotificationsModule",
+          "kind": "method",
+          "signature": "ConfigureNotificationsModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsDbProperties",
+      "fqn": "Granit.Notifications.EntityFrameworkCore.GranitNotificationsDbProperties",
+      "kind": "class",
+      "project": "Granit.Notifications.EntityFrameworkCore",
+      "file": "src/Granit.Notifications.EntityFrameworkCore/GranitNotificationsDbProperties.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsEntityFrameworkCoreModule",
+      "fqn": "Granit.Notifications.EntityFrameworkCore.GranitNotificationsEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Notifications.EntityFrameworkCore",
+      "file": "src/Granit.Notifications.EntityFrameworkCore/GranitNotificationsEntityFrameworkCoreModule.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "EntityReference",
+      "fqn": "Granit.Notifications.EntityReference",
+      "kind": "record",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/EntityReference.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "EntityStateChangedData",
+      "fqn": "Granit.Notifications.EntityStateChangedData",
+      "kind": "record",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/EntityStateChangedData.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "UserNotificationCreatedEvent",
+      "fqn": "Granit.Notifications.Events.UserNotificationCreatedEvent",
+      "kind": "record",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Events/UserNotificationCreatedEvent.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "UserNotificationReadEvent",
+      "fqn": "Granit.Notifications.Events.UserNotificationReadEvent",
+      "kind": "record",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Events/UserNotificationReadEvent.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "NotificationDeliveryException",
+      "fqn": "Granit.Notifications.Exceptions.NotificationDeliveryException",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Exceptions/NotificationDeliveryException.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "NotificationsHostApplicationBuilderExtensions",
+      "fqn": "Granit.Notifications.Extensions.NotificationsHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Extensions/NotificationsHostApplicationBuilderExtensions.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "AddGranitNotifications",
+          "kind": "method",
+          "signature": "AddGranitNotifications(this IHostApplicationBuilder builder, Action<NotificationsOptions>? configure = null)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsModule",
+      "fqn": "Granit.Notifications.GranitNotificationsModule",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/GranitNotificationsModule.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "NotificationDeliveryHandler",
+      "fqn": "Granit.Notifications.Handlers.NotificationDeliveryHandler",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Handlers/NotificationDeliveryHandler.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(DeliverNotificationCommand command, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "NotificationFanoutHandler",
+      "fqn": "Granit.Notifications.Handlers.NotificationFanoutHandler",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Handlers/NotificationFanoutHandler.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(NotificationTrigger trigger, CancellationToken cancellationToken)",
+          "returnType": "Task<IEnumerable<DeliverNotificationCommand>>"
+        }
+      ]
+    },
+    {
+      "name": "ITrackedEntity",
+      "fqn": "Granit.Notifications.ITrackedEntity",
+      "kind": "interface",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/ITrackedEntity.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "GetEntityId",
+          "kind": "method",
+          "signature": "GetEntityId()",
+          "returnType": "string EntityTypeName { get; } string"
+        }
+      ]
+    },
+    {
+      "name": "DeliverNotificationCommand",
+      "fqn": "Granit.Notifications.Messages.DeliverNotificationCommand",
+      "kind": "record",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Messages/DeliverNotificationCommand.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "NotificationTrigger",
+      "fqn": "Granit.Notifications.Messages.NotificationTrigger",
+      "kind": "record",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Messages/NotificationTrigger.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "NewGuid",
+          "kind": "method",
+          "signature": "NewGuid()",
+          "returnType": "Guid NotificationId { get; init; } = Guid."
+        },
+        {
+          "name": "NotificationTypeName",
+          "kind": "property",
+          "signature": "required string NotificationTypeName",
+          "returnType": "required string"
+        }
+      ]
+    },
+    {
+      "name": "AwsSnsMobilePushServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.MobilePush.AwsSns.Extensions.AwsSnsMobilePushServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush.AwsSns",
+      "file": "src/Granit.Notifications.MobilePush.AwsSns/Extensions/AwsSnsMobilePushServiceCollectionExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitNotificationsMobilePushAwsSns",
+          "kind": "method",
+          "signature": "AddGranitNotificationsMobilePushAwsSns(this IServiceCollection services, Action<AwsSnsMobilePushOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsMobilePushAwsSnsModule",
+      "fqn": "Granit.Notifications.MobilePush.AwsSns.GranitNotificationsMobilePushAwsSnsModule",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush.AwsSns",
+      "file": "src/Granit.Notifications.MobilePush.AwsSns/GranitNotificationsMobilePushAwsSnsModule.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AwsSnsMobilePushOptions",
+      "fqn": "Granit.Notifications.MobilePush.AwsSns.Options.AwsSnsMobilePushOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush.AwsSns",
+      "file": "src/Granit.Notifications.MobilePush.AwsSns/Options/AwsSnsMobilePushOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Region",
+          "kind": "property",
+          "signature": "string Region",
+          "returnType": "string"
+        },
+        {
+          "name": "PlatformApplicationArn",
+          "kind": "property",
+          "signature": "string PlatformApplicationArn",
+          "returnType": "string"
+        },
+        {
+          "name": "AccessKeyId",
+          "kind": "property",
+          "signature": "string? AccessKeyId",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "AzureNotificationHubsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.MobilePush.AzureNotificationHubs.Extensions.AzureNotificationHubsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush.AzureNotificationHubs",
+      "file": "src/Granit.Notifications.MobilePush.AzureNotificationHubs/Extensions/AzureNotificationHubsServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitNotificationsMobilePushAzureNotificationHubs",
+          "kind": "method",
+          "signature": "AddGranitNotificationsMobilePushAzureNotificationHubs(this IServiceCollection services, Action<AzureNotificationHubsOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsMobilePushAnhModule",
+      "fqn": "Granit.Notifications.MobilePush.AzureNotificationHubs.GranitNotificationsMobilePushAnhModule",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush.AzureNotificationHubs",
+      "file": "src/Granit.Notifications.MobilePush.AzureNotificationHubs/GranitNotificationsMobilePushAnhModule.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AzureNotificationHubsOptions",
+      "fqn": "Granit.Notifications.MobilePush.AzureNotificationHubs.Options.AzureNotificationHubsOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush.AzureNotificationHubs",
+      "file": "src/Granit.Notifications.MobilePush.AzureNotificationHubs/Options/AzureNotificationHubsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ConnectionString",
+          "kind": "property",
+          "signature": "string ConnectionString",
+          "returnType": "string"
+        },
+        {
+          "name": "HubName",
+          "kind": "property",
+          "signature": "string HubName",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "MobilePushNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.MobilePush.Extensions.MobilePushNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/Extensions/MobilePushNotificationsServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitNotificationsMobilePush",
+          "kind": "method",
+          "signature": "AddGranitNotificationsMobilePush(this IServiceCollection services, Action<MobilePushChannelOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GoogleFcmMobilePushServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.MobilePush.GoogleFcm.Extensions.GoogleFcmMobilePushServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush.GoogleFcm",
+      "file": "src/Granit.Notifications.MobilePush.GoogleFcm/Extensions/GoogleFcmMobilePushServiceCollectionExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "AddGranitNotificationsMobilePushGoogleFcm",
+          "kind": "method",
+          "signature": "AddGranitNotificationsMobilePushGoogleFcm(this IServiceCollection services, Action<GoogleFcmOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsMobilePushGoogleFcmModule",
+      "fqn": "Granit.Notifications.MobilePush.GoogleFcm.GranitNotificationsMobilePushGoogleFcmModule",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush.GoogleFcm",
+      "file": "src/Granit.Notifications.MobilePush.GoogleFcm/GranitNotificationsMobilePushGoogleFcmModule.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "GoogleFcmOptions",
+      "fqn": "Granit.Notifications.MobilePush.GoogleFcm.Options.GoogleFcmOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush.GoogleFcm",
+      "file": "src/Granit.Notifications.MobilePush.GoogleFcm/Options/GoogleFcmOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ProjectId",
+          "kind": "property",
+          "signature": "string ProjectId",
+          "returnType": "string"
+        },
+        {
+          "name": "ServiceAccountJson",
+          "kind": "property",
+          "signature": "string ServiceAccountJson",
+          "returnType": "string"
+        },
+        {
+          "name": "BaseAddress",
+          "kind": "property",
+          "signature": "string BaseAddress",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsMobilePushModule",
+      "fqn": "Granit.Notifications.MobilePush.GranitNotificationsMobilePushModule",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/GranitNotificationsMobilePushModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "IMobilePushEventPublisher",
+      "fqn": "Granit.Notifications.MobilePush.IMobilePushEventPublisher",
+      "kind": "interface",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/IMobilePushEventPublisher.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "PublishTokenInvalidatedAsync",
+          "kind": "method",
+          "signature": "PublishTokenInvalidatedAsync(MobilePushTokenInvalidated tokenInvalidated, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IMobilePushSender",
+      "fqn": "Granit.Notifications.MobilePush.IMobilePushSender",
+      "kind": "interface",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/IMobilePushSender.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "SendAsync",
+          "kind": "method",
+          "signature": "SendAsync(MobilePushMessage message, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IMobilePushTokenReader",
+      "fqn": "Granit.Notifications.MobilePush.IMobilePushTokenReader",
+      "kind": "interface",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/IMobilePushTokenReader.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "GetTokensAsync",
+          "kind": "method",
+          "signature": "GetTokensAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<MobilePushTokenInfo>>"
+        }
+      ]
+    },
+    {
+      "name": "IMobilePushTokenWriter",
+      "fqn": "Granit.Notifications.MobilePush.IMobilePushTokenWriter",
+      "kind": "interface",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/IMobilePushTokenWriter.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "RegisterAsync",
+          "kind": "method",
+          "signature": "RegisterAsync(MobilePushTokenInfo tokenInfo, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RemoveAsync",
+          "kind": "method",
+          "signature": "RemoveAsync(string deviceToken, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "MobilePlatform",
+      "fqn": "Granit.Notifications.MobilePush.MobilePlatform",
+      "kind": "enum",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/MobilePlatform.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "MobilePushMessage",
+      "fqn": "Granit.Notifications.MobilePush.MobilePushMessage",
+      "kind": "record",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/MobilePushMessage.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "MobilePushTokenInfo",
+      "fqn": "Granit.Notifications.MobilePush.MobilePushTokenInfo",
+      "kind": "record",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/MobilePushTokenInfo.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "MobilePushTokenInvalidated",
+      "fqn": "Granit.Notifications.MobilePush.MobilePushTokenInvalidated",
+      "kind": "record",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/MobilePushTokenInvalidated.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "MobilePushChannelOptions",
+      "fqn": "Granit.Notifications.MobilePush.Options.MobilePushChannelOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.MobilePush",
+      "file": "src/Granit.Notifications.MobilePush/Options/MobilePushChannelOptions.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "Provider",
+          "kind": "property",
+          "signature": "string Provider",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "NotificationChannels",
+      "fqn": "Granit.Notifications.NotificationChannels",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/NotificationChannels.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "NotificationDefinition",
+      "fqn": "Granit.Notifications.NotificationDefinition",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/NotificationDefinition.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultChannels",
+          "kind": "property",
+          "signature": "IReadOnlyList<string> DefaultChannels",
+          "returnType": "IReadOnlyList<string>"
+        },
+        {
+          "name": "DisplayName",
+          "kind": "property",
+          "signature": "string? DisplayName",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "NotificationDeliveryContext",
+      "fqn": "Granit.Notifications.NotificationDeliveryContext",
+      "kind": "record",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/NotificationDeliveryContext.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "NotificationSeverity",
+      "fqn": "Granit.Notifications.NotificationSeverity",
+      "kind": "enum",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/NotificationSeverity.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "NotificationType",
+      "fqn": "Granit.Notifications.NotificationType",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/NotificationType.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "typeof",
+          "kind": "method",
+          "signature": "typeof(TData)",
+          "returnType": "Type DataType =>"
+        },
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "NotificationsOptions",
+      "fqn": "Granit.Notifications.Options.NotificationsOptions",
+      "kind": "class",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/Options/NotificationsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "MaxParallelDeliveries",
+          "kind": "property",
+          "signature": "int MaxParallelDeliveries",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "RecipientInfo",
+      "fqn": "Granit.Notifications.RecipientInfo",
+      "kind": "record",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/RecipientInfo.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "SignalRNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.SignalR.Extensions.SignalRNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.SignalR",
+      "file": "src/Granit.Notifications.SignalR/Extensions/SignalRNotificationsServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitNotificationsSignalR",
+          "kind": "method",
+          "signature": "AddGranitNotificationsSignalR(this IServiceCollection services, Action<SignalRChannelOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsSignalRModule",
+      "fqn": "Granit.Notifications.SignalR.GranitNotificationsSignalRModule",
+      "kind": "class",
+      "project": "Granit.Notifications.SignalR",
+      "file": "src/Granit.Notifications.SignalR/GranitNotificationsSignalRModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "NotificationHub",
+      "fqn": "Granit.Notifications.SignalR.NotificationHub",
+      "kind": "class",
+      "project": "Granit.Notifications.SignalR",
+      "file": "src/Granit.Notifications.SignalR/NotificationHub.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "OnConnectedAsync",
+          "kind": "method",
+          "signature": "OnConnectedAsync()",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "SignalRChannelOptions",
+      "fqn": "Granit.Notifications.SignalR.Options.SignalRChannelOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.SignalR",
+      "file": "src/Granit.Notifications.SignalR/Options/SignalRChannelOptions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "SignalRNotificationMessage",
+      "fqn": "Granit.Notifications.SignalR.SignalRNotificationMessage",
+      "kind": "record",
+      "project": "Granit.Notifications.SignalR",
+      "file": "src/Granit.Notifications.SignalR/SignalRNotificationMessage.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "NotificationId",
+          "kind": "property",
+          "signature": "Guid NotificationId",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "SnsSmsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Sms.AwsSns.Extensions.SnsSmsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Sms.AwsSns",
+      "file": "src/Granit.Notifications.Sms.AwsSns/Extensions/SnsSmsServiceCollectionExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitNotificationsSmsAwsSns",
+          "kind": "method",
+          "signature": "AddGranitNotificationsSmsAwsSns(this IServiceCollection services, Action<AwsSnsSmsOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsSmsAwsSnsModule",
+      "fqn": "Granit.Notifications.Sms.AwsSns.GranitNotificationsSmsAwsSnsModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Sms.AwsSns",
+      "file": "src/Granit.Notifications.Sms.AwsSns/GranitNotificationsSmsAwsSnsModule.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AwsSnsSmsOptions",
+      "fqn": "Granit.Notifications.Sms.AwsSns.Options.AwsSnsSmsOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Sms.AwsSns",
+      "file": "src/Granit.Notifications.Sms.AwsSns/Options/AwsSnsSmsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Region",
+          "kind": "property",
+          "signature": "string Region",
+          "returnType": "string"
+        },
+        {
+          "name": "SenderId",
+          "kind": "property",
+          "signature": "string? SenderId",
+          "returnType": "string?"
+        },
+        {
+          "name": "OriginationNumber",
+          "kind": "property",
+          "signature": "string? OriginationNumber",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "AcsSmsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Sms.AzureCommunicationServices.Extensions.AcsSmsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Sms.AzureCommunicationServices",
+      "file": "src/Granit.Notifications.Sms.AzureCommunicationServices/Extensions/AcsSmsServiceCollectionExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitNotificationsSmsAcs",
+          "kind": "method",
+          "signature": "AddGranitNotificationsSmsAcs(this IServiceCollection services, Action<AcsSmsOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsSmsAcsModule",
+      "fqn": "Granit.Notifications.Sms.AzureCommunicationServices.GranitNotificationsSmsAcsModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Sms.AzureCommunicationServices",
+      "file": "src/Granit.Notifications.Sms.AzureCommunicationServices/GranitNotificationsSmsAcsModule.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AcsSmsOptions",
+      "fqn": "Granit.Notifications.Sms.AzureCommunicationServices.Options.AcsSmsOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Sms.AzureCommunicationServices",
+      "file": "src/Granit.Notifications.Sms.AzureCommunicationServices/Options/AcsSmsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ConnectionString",
+          "kind": "property",
+          "signature": "string? ConnectionString",
+          "returnType": "string?"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "SmsNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Sms.Extensions.SmsNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Sms",
+      "file": "src/Granit.Notifications.Sms/Extensions/SmsNotificationsServiceCollectionExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "AddGranitNotificationsSms",
+          "kind": "method",
+          "signature": "AddGranitNotificationsSms(this IServiceCollection services, Action<SmsChannelOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsSmsModule",
+      "fqn": "Granit.Notifications.Sms.GranitNotificationsSmsModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Sms",
+      "file": "src/Granit.Notifications.Sms/GranitNotificationsSmsModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "ISmsSender",
+      "fqn": "Granit.Notifications.Sms.ISmsSender",
+      "kind": "interface",
+      "project": "Granit.Notifications.Sms",
+      "file": "src/Granit.Notifications.Sms/ISmsSender.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "SendAsync",
+          "kind": "method",
+          "signature": "SendAsync(SmsMessage message, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "SmsChannelOptions",
+      "fqn": "Granit.Notifications.Sms.Options.SmsChannelOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Sms",
+      "file": "src/Granit.Notifications.Sms/Options/SmsChannelOptions.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "Provider",
+          "kind": "property",
+          "signature": "string Provider",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "SmsMessage",
+      "fqn": "Granit.Notifications.Sms.SmsMessage",
+      "kind": "record",
+      "project": "Granit.Notifications.Sms",
+      "file": "src/Granit.Notifications.Sms/SmsMessage.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "SseNotificationEndpoints",
+      "fqn": "Granit.Notifications.Sse.Endpoints.SseNotificationEndpoints",
+      "kind": "class",
+      "project": "Granit.Notifications.Sse",
+      "file": "src/Granit.Notifications.Sse/Endpoints/SseNotificationEndpoints.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "MapGranitSseNotificationEndpoints",
+          "kind": "method",
+          "signature": "MapGranitSseNotificationEndpoints(this IEndpointRouteBuilder endpoints)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "SseNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Sse.Extensions.SseNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Sse",
+      "file": "src/Granit.Notifications.Sse/Extensions/SseNotificationsServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitNotificationsSse",
+          "kind": "method",
+          "signature": "AddGranitNotificationsSse(this IServiceCollection services, Action<SseChannelOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsSseModule",
+      "fqn": "Granit.Notifications.Sse.GranitNotificationsSseModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Sse",
+      "file": "src/Granit.Notifications.Sse/GranitNotificationsSseModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "ISseConnectionManager",
+      "fqn": "Granit.Notifications.Sse.ISseConnectionManager",
+      "kind": "interface",
+      "project": "Granit.Notifications.Sse",
+      "file": "src/Granit.Notifications.Sse/ISseConnectionManager.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Connect",
+          "kind": "method",
+          "signature": "Connect(string userId)",
+          "returnType": "SseConnection"
+        },
+        {
+          "name": "Disconnect",
+          "kind": "method",
+          "signature": "Disconnect(SseConnection connection)",
+          "returnType": "void"
+        },
+        {
+          "name": "SendToUserAsync",
+          "kind": "method",
+          "signature": "SendToUserAsync(string userId, SseNotificationMessage message, CancellationToken cancellationToken = default)",
+          "returnType": "ValueTask"
+        },
+        {
+          "name": "GetConnectionCount",
+          "kind": "method",
+          "signature": "GetConnectionCount(string userId)",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "SseChannelOptions",
+      "fqn": "Granit.Notifications.Sse.Options.SseChannelOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Sse",
+      "file": "src/Granit.Notifications.Sse/Options/SseChannelOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "HeartbeatIntervalSeconds",
+          "kind": "property",
+          "signature": "int HeartbeatIntervalSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "SseConnection",
+      "fqn": "Granit.Notifications.Sse.SseConnection",
+      "kind": "record",
+      "project": "Granit.Notifications.Sse",
+      "file": "src/Granit.Notifications.Sse/SseConnection.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "Reader",
+          "kind": "property",
+          "signature": "ChannelReader<SseNotificationMessage> Reader",
+          "returnType": "ChannelReader<SseNotificationMessage>"
+        }
+      ]
+    },
+    {
+      "name": "SseNotificationMessage",
+      "fqn": "Granit.Notifications.Sse.SseNotificationMessage",
+      "kind": "record",
+      "project": "Granit.Notifications.Sse",
+      "file": "src/Granit.Notifications.Sse/SseNotificationMessage.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "NotificationId",
+          "kind": "property",
+          "signature": "Guid NotificationId",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "TrackedPropertyConfig",
+      "fqn": "Granit.Notifications.TrackedPropertyConfig",
+      "kind": "record",
+      "project": "Granit.Notifications",
+      "file": "src/Granit.Notifications/TrackedPropertyConfig.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "NotificationTypeName",
+          "kind": "property",
+          "signature": "required string NotificationTypeName",
+          "returnType": "required string"
+        }
+      ]
+    },
+    {
+      "name": "TwilioNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Twilio.Extensions.TwilioNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Twilio",
+      "file": "src/Granit.Notifications.Twilio/Extensions/TwilioNotificationsServiceCollectionExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitNotificationsTwilio",
+          "kind": "method",
+          "signature": "AddGranitNotificationsTwilio(this IServiceCollection services, Action<TwilioOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsTwilioModule",
+      "fqn": "Granit.Notifications.Twilio.GranitNotificationsTwilioModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Twilio",
+      "file": "src/Granit.Notifications.Twilio/GranitNotificationsTwilioModule.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "TwilioOptions",
+      "fqn": "Granit.Notifications.Twilio.Options.TwilioOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Twilio",
+      "file": "src/Granit.Notifications.Twilio/Options/TwilioOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "AccountSid",
+          "kind": "property",
+          "signature": "string AccountSid",
+          "returnType": "string"
+        },
+        {
+          "name": "AuthToken",
+          "kind": "property",
+          "signature": "string AuthToken",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSmsFromNumber",
+          "kind": "property",
+          "signature": "string DefaultSmsFromNumber",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultWhatsAppFromNumber",
+          "kind": "property",
+          "signature": "string? DefaultWhatsAppFromNumber",
+          "returnType": "string?"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "PushNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.WebPush.Extensions.PushNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.WebPush",
+      "file": "src/Granit.Notifications.WebPush/Extensions/PushNotificationsServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitNotificationsPush",
+          "kind": "method",
+          "signature": "AddGranitNotificationsPush(this IServiceCollection services, Action<PushChannelOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsWebPushModule",
+      "fqn": "Granit.Notifications.WebPush.GranitNotificationsWebPushModule",
+      "kind": "class",
+      "project": "Granit.Notifications.WebPush",
+      "file": "src/Granit.Notifications.WebPush/GranitNotificationsWebPushModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "IPushSubscriptionReader",
+      "fqn": "Granit.Notifications.WebPush.IPushSubscriptionReader",
+      "kind": "interface",
+      "project": "Granit.Notifications.WebPush",
+      "file": "src/Granit.Notifications.WebPush/IPushSubscriptionReader.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "GetSubscriptionsAsync",
+          "kind": "method",
+          "signature": "GetSubscriptionsAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<PushSubscriptionInfo>>"
+        }
+      ]
+    },
+    {
+      "name": "IPushSubscriptionWriter",
+      "fqn": "Granit.Notifications.WebPush.IPushSubscriptionWriter",
+      "kind": "interface",
+      "project": "Granit.Notifications.WebPush",
+      "file": "src/Granit.Notifications.WebPush/IPushSubscriptionWriter.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "SaveSubscriptionAsync",
+          "kind": "method",
+          "signature": "SaveSubscriptionAsync(string userId, PushSubscriptionInfo subscription, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RemoveSubscriptionAsync",
+          "kind": "method",
+          "signature": "RemoveSubscriptionAsync(string endpoint, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "PushChannelOptions",
+      "fqn": "Granit.Notifications.WebPush.Options.PushChannelOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.WebPush",
+      "file": "src/Granit.Notifications.WebPush/Options/PushChannelOptions.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "VapidSubject",
+          "kind": "property",
+          "signature": "string VapidSubject",
+          "returnType": "string"
+        },
+        {
+          "name": "VapidPublicKey",
+          "kind": "property",
+          "signature": "string VapidPublicKey",
+          "returnType": "string"
+        },
+        {
+          "name": "VapidPrivateKey",
+          "kind": "property",
+          "signature": "string VapidPrivateKey",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "PushNotificationPayload",
+      "fqn": "Granit.Notifications.WebPush.PushNotificationPayload",
+      "kind": "record",
+      "project": "Granit.Notifications.WebPush",
+      "file": "src/Granit.Notifications.WebPush/PushNotificationPayload.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "PushSubscriptionInfo",
+      "fqn": "Granit.Notifications.WebPush.PushSubscriptionInfo",
+      "kind": "record",
+      "project": "Granit.Notifications.WebPush",
+      "file": "src/Granit.Notifications.WebPush/PushSubscriptionInfo.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "WhatsAppNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.WhatsApp.Extensions.WhatsAppNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.WhatsApp",
+      "file": "src/Granit.Notifications.WhatsApp/Extensions/WhatsAppNotificationsServiceCollectionExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "AddGranitNotificationsWhatsApp",
+          "kind": "method",
+          "signature": "AddGranitNotificationsWhatsApp(this IServiceCollection services, Action<WhatsAppChannelOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsWhatsAppModule",
+      "fqn": "Granit.Notifications.WhatsApp.GranitNotificationsWhatsAppModule",
+      "kind": "class",
+      "project": "Granit.Notifications.WhatsApp",
+      "file": "src/Granit.Notifications.WhatsApp/GranitNotificationsWhatsAppModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "IWhatsAppSender",
+      "fqn": "Granit.Notifications.WhatsApp.IWhatsAppSender",
+      "kind": "interface",
+      "project": "Granit.Notifications.WhatsApp",
+      "file": "src/Granit.Notifications.WhatsApp/IWhatsAppSender.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "SendAsync",
+          "kind": "method",
+          "signature": "SendAsync(WhatsAppMessage message, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "WhatsAppChannelOptions",
+      "fqn": "Granit.Notifications.WhatsApp.Options.WhatsAppChannelOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.WhatsApp",
+      "file": "src/Granit.Notifications.WhatsApp/Options/WhatsAppChannelOptions.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "Provider",
+          "kind": "property",
+          "signature": "string Provider",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "WhatsAppMessage",
+      "fqn": "Granit.Notifications.WhatsApp.WhatsAppMessage",
+      "kind": "record",
+      "project": "Granit.Notifications.WhatsApp",
+      "file": "src/Granit.Notifications.WhatsApp/WhatsAppMessage.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "To",
+          "kind": "property",
+          "signature": "required string To",
+          "returnType": "required string"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsWolverineModule",
+      "fqn": "Granit.Notifications.Wolverine.GranitNotificationsWolverineModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Wolverine",
+      "file": "src/Granit.Notifications.Wolverine/GranitNotificationsWolverineModule.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ZulipNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Notifications.Zulip.Extensions.ZulipNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Notifications.Zulip",
+      "file": "src/Granit.Notifications.Zulip/Extensions/ZulipNotificationsServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitNotificationsZulip",
+          "kind": "method",
+          "signature": "AddGranitNotificationsZulip(this IServiceCollection services, Action<ZulipChannelOptions>? configureChannel = null, Action<ZulipBotOptions>? configureBot = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitNotificationsZulipModule",
+      "fqn": "Granit.Notifications.Zulip.GranitNotificationsZulipModule",
+      "kind": "class",
+      "project": "Granit.Notifications.Zulip",
+      "file": "src/Granit.Notifications.Zulip/GranitNotificationsZulipModule.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "IZulipSender",
+      "fqn": "Granit.Notifications.Zulip.IZulipSender",
+      "kind": "interface",
+      "project": "Granit.Notifications.Zulip",
+      "file": "src/Granit.Notifications.Zulip/IZulipSender.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "SendAsync",
+          "kind": "method",
+          "signature": "SendAsync(ZulipMessage message, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ZulipBotOptions",
+      "fqn": "Granit.Notifications.Zulip.Options.ZulipBotOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Zulip",
+      "file": "src/Granit.Notifications.Zulip/Options/ZulipBotOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "BaseUrl",
+          "kind": "property",
+          "signature": "string BaseUrl",
+          "returnType": "string"
+        },
+        {
+          "name": "BotEmail",
+          "kind": "property",
+          "signature": "string BotEmail",
+          "returnType": "string"
+        },
+        {
+          "name": "ApiKey",
+          "kind": "property",
+          "signature": "string ApiKey",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "ZulipChannelOptions",
+      "fqn": "Granit.Notifications.Zulip.Options.ZulipChannelOptions",
+      "kind": "class",
+      "project": "Granit.Notifications.Zulip",
+      "file": "src/Granit.Notifications.Zulip/Options/ZulipChannelOptions.cs",
+      "line": 4,
+      "members": [
+        {
+          "name": "DefaultStream",
+          "kind": "property",
+          "signature": "string DefaultStream",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultTopic",
+          "kind": "property",
+          "signature": "string DefaultTopic",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "ZulipMessage",
+      "fqn": "Granit.Notifications.Zulip.ZulipMessage",
+      "kind": "record",
+      "project": "Granit.Notifications.Zulip",
+      "file": "src/Granit.Notifications.Zulip/ZulipMessage.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "ObservabilityAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Observability.AI.Extensions.ObservabilityAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Observability.AI",
+      "file": "src/Granit.Observability.AI/Extensions/ObservabilityAIHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitObservabilityAI",
+          "kind": "method",
+          "signature": "AddGranitObservabilityAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitObservabilityAIModule",
+      "fqn": "Granit.Observability.AI.GranitObservabilityAIModule",
+      "kind": "class",
+      "project": "Granit.Observability.AI",
+      "file": "src/Granit.Observability.AI/GranitObservabilityAIModule.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IAILogAnalyzer",
+      "fqn": "Granit.Observability.AI.IAILogAnalyzer",
+      "kind": "interface",
+      "project": "Granit.Observability.AI",
+      "file": "src/Granit.Observability.AI/IAILogAnalyzer.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AnalyzeAsync",
+          "kind": "method",
+          "signature": "AnalyzeAsync(IReadOnlyList<LogEntry> entries, CancellationToken cancellationToken = default)",
+          "returnType": "Task<LogAnalysisReport>"
+        }
+      ]
+    },
+    {
+      "name": "LogAnalysisReport",
+      "fqn": "Granit.Observability.AI.LogAnalysisReport",
+      "kind": "record",
+      "project": "Granit.Observability.AI",
+      "file": "src/Granit.Observability.AI/LogAnalysisReport.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "LogEntry",
+      "fqn": "Granit.Observability.AI.LogEntry",
+      "kind": "record",
+      "project": "Granit.Observability.AI",
+      "file": "src/Granit.Observability.AI/LogEntry.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "LogInsight",
+      "fqn": "Granit.Observability.AI.LogInsight",
+      "kind": "record",
+      "project": "Granit.Observability.AI",
+      "file": "src/Granit.Observability.AI/LogInsight.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ObservabilityAIOptions",
+      "fqn": "Granit.Observability.AI.Options.ObservabilityAIOptions",
+      "kind": "class",
+      "project": "Granit.Observability.AI",
+      "file": "src/Granit.Observability.AI/Options/ObservabilityAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string? WorkspaceName",
+          "returnType": "string?"
+        },
+        {
+          "name": "MaxLogEntries",
+          "kind": "property",
+          "signature": "int MaxLogEntries",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "ObservabilityServiceCollectionExtensions",
+      "fqn": "Granit.Observability.Extensions.ObservabilityServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Observability",
+      "file": "src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "AddGranitObservability",
+          "kind": "method",
+          "signature": "AddGranitObservability(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitObservabilityModule",
+      "fqn": "Granit.Observability.GranitObservabilityModule",
+      "kind": "class",
+      "project": "Granit.Observability",
+      "file": "src/Granit.Observability/GranitObservabilityModule.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ObservabilityOptions",
+      "fqn": "Granit.Observability.Options.ObservabilityOptions",
+      "kind": "class",
+      "project": "Granit.Observability",
+      "file": "src/Granit.Observability/Options/ObservabilityOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ServiceName",
+          "kind": "property",
+          "signature": "string ServiceName",
+          "returnType": "string"
+        },
+        {
+          "name": "ServiceVersion",
+          "kind": "property",
+          "signature": "string ServiceVersion",
+          "returnType": "string"
+        },
+        {
+          "name": "OtlpEndpoint",
+          "kind": "property",
+          "signature": "string OtlpEndpoint",
+          "returnType": "string"
+        },
+        {
+          "name": "ServiceNamespace",
+          "kind": "property",
+          "signature": "string ServiceNamespace",
+          "returnType": "string"
+        },
+        {
+          "name": "Environment",
+          "kind": "property",
+          "signature": "string Environment",
+          "returnType": "string"
+        },
+        {
+          "name": "EnableTracing",
+          "kind": "property",
+          "signature": "bool EnableTracing",
+          "returnType": "bool"
+        },
+        {
+          "name": "EnableMetrics",
+          "kind": "property",
+          "signature": "bool EnableMetrics",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "DataSeedContext",
+      "fqn": "Granit.Persistence.DataSeeding.DataSeedContext",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/DataSeeding/DataSeedContext.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "IDataSeedContributor",
+      "fqn": "Granit.Persistence.DataSeeding.IDataSeedContributor",
+      "kind": "interface",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/DataSeeding/IDataSeedContributor.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "SeedAsync",
+          "kind": "method",
+          "signature": "SeedAsync(DataSeedContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IDataSeeder",
+      "fqn": "Granit.Persistence.DataSeeding.IDataSeeder",
+      "kind": "interface",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/DataSeeding/IDataSeeder.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "SeedAsync",
+          "kind": "method",
+          "signature": "SeedAsync(DataSeedContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "DbContextOptionsBuilderExtensions",
+      "fqn": "Granit.Persistence.Extensions.DbContextOptionsBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Extensions/DbContextOptionsBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "UseGranitInterceptors",
+          "kind": "method",
+          "signature": "UseGranitInterceptors(this DbContextOptionsBuilder options, IServiceProvider serviceProvider)",
+          "returnType": "DbContextOptionsBuilder"
+        }
+      ]
+    },
+    {
+      "name": "DbContextPurgeExtensions",
+      "fqn": "Granit.Persistence.Extensions.DbContextPurgeExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Extensions/DbContextPurgeExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "PurgeSoftDeletedBeforeAsync",
+          "kind": "method",
+          "signature": "PurgeSoftDeletedBeforeAsync(this DbContext context, DateTimeOffset cutoff, int batchSize = 1000, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        }
+      ]
+    },
+    {
+      "name": "ModelBuilderExtensions",
+      "fqn": "Granit.Persistence.Extensions.ModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Extensions/ModelBuilderExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "ApplyGranitConventions",
+          "kind": "method",
+          "signature": "ApplyGranitConventions(this ModelBuilder modelBuilder, ICurrentTenant? currentTenant = null, IDataFilter? dataFilter = null)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "PersistenceDbContextServiceCollectionExtensions",
+      "fqn": "Granit.Persistence.Extensions.PersistenceDbContextServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Extensions/PersistenceDbContextServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "PersistenceServiceCollectionExtensions",
+      "fqn": "Granit.Persistence.Extensions.PersistenceServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Extensions/PersistenceServiceCollectionExtensions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "AddGranitPersistence",
+          "kind": "method",
+          "signature": "AddGranitPersistence(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "PersistenceTenantExtensions",
+      "fqn": "Granit.Persistence.Extensions.PersistenceTenantExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Extensions/PersistenceTenantExtensions.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "TranslatableQueryExtensions",
+      "fqn": "Granit.Persistence.Extensions.TranslatableQueryExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Extensions/TranslatableQueryExtensions.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "GranitFilterNames",
+      "fqn": "Granit.Persistence.GranitFilterNames",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/GranitFilterNames.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "GranitPersistenceModule",
+      "fqn": "Granit.Persistence.GranitPersistenceModule",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/GranitPersistenceModule.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "PersistenceHostingHostApplicationBuilderExtensions",
+      "fqn": "Granit.Persistence.Hosting.Extensions.PersistenceHostingHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.Hosting",
+      "file": "src/Granit.Persistence.Hosting/Extensions/PersistenceHostingHostApplicationBuilderExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitMigrateSupport",
+          "kind": "method",
+          "signature": "AddGranitMigrateSupport(this IHostApplicationBuilder builder, Action<GranitMigrateOptions>? configure = null)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "PersistenceHostingWebApplicationExtensions",
+      "fqn": "Granit.Persistence.Hosting.Extensions.PersistenceHostingWebApplicationExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.Hosting",
+      "file": "src/Granit.Persistence.Hosting/Extensions/PersistenceHostingWebApplicationExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "HasGranitMigrateFlag",
+          "kind": "method",
+          "signature": "HasGranitMigrateFlag(this WebApplication app)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "GranitPersistenceHostingModule",
+      "fqn": "Granit.Persistence.Hosting.GranitPersistenceHostingModule",
+      "kind": "class",
+      "project": "Granit.Persistence.Hosting",
+      "file": "src/Granit.Persistence.Hosting/GranitPersistenceHostingModule.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IGranitMigrationLock",
+      "fqn": "Granit.Persistence.Hosting.IGranitMigrationLock",
+      "kind": "interface",
+      "project": "Granit.Persistence.Hosting",
+      "file": "src/Granit.Persistence.Hosting/IGranitMigrationLock.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "TryAcquireAsync",
+          "kind": "method",
+          "signature": "TryAcquireAsync(string resource, CancellationToken cancellationToken)",
+          "returnType": "Task<IAsyncDisposable?>"
+        }
+      ]
+    },
+    {
+      "name": "IGranitMigrationRunner",
+      "fqn": "Granit.Persistence.Hosting.IGranitMigrationRunner",
+      "kind": "interface",
+      "project": "Granit.Persistence.Hosting",
+      "file": "src/Granit.Persistence.Hosting/IGranitMigrationRunner.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "RunAsync",
+          "kind": "method",
+          "signature": "RunAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        }
+      ]
+    },
+    {
+      "name": "IMigratableModule",
+      "fqn": "Granit.Persistence.Hosting.IMigratableModule",
+      "kind": "interface",
+      "project": "Granit.Persistence.Hosting",
+      "file": "src/Granit.Persistence.Hosting/IMigratableModule.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "typeof",
+          "kind": "method",
+          "signature": "typeof(TContext)",
+          "returnType": "Type IMigratableModule.DbContextType =>"
+        }
+      ]
+    },
+    {
+      "name": "GranitMigrateOptions",
+      "fqn": "Granit.Persistence.Hosting.Options.GranitMigrateOptions",
+      "kind": "class",
+      "project": "Granit.Persistence.Hosting",
+      "file": "src/Granit.Persistence.Hosting/Options/GranitMigrateOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "CliFlag",
+          "kind": "property",
+          "signature": "string CliFlag",
+          "returnType": "string"
+        },
+        {
+          "name": "SeedAfterMigration",
+          "kind": "property",
+          "signature": "bool SeedAfterMigration",
+          "returnType": "bool"
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(5)",
+          "returnType": "TimeSpan Timeout { get; set; } = TimeSpan."
+        },
+        {
+          "name": "SeedOnStartup",
+          "kind": "property",
+          "signature": "bool SeedOnStartup",
+          "returnType": "bool"
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(5)",
+          "returnType": "TimeSpan RetryDelay { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "ISoftDeletePurgeTarget",
+      "fqn": "Granit.Persistence.ISoftDeletePurgeTarget",
+      "kind": "interface",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/ISoftDeletePurgeTarget.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "PurgeAsync",
+          "kind": "method",
+          "signature": "PurgeAsync(DateTimeOffset cutoff, int batchSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        }
+      ]
+    },
+    {
+      "name": "AuditedEntityInterceptor",
+      "fqn": "Granit.Persistence.Interceptors.AuditedEntityInterceptor",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Interceptors/AuditedEntityInterceptor.cs",
+      "line": 26,
+      "members": [
+        {
+          "name": "SavingChanges",
+          "kind": "method",
+          "signature": "SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)",
+          "returnType": "InterceptionResult<int>"
+        }
+      ]
+    },
+    {
+      "name": "ConcurrencyStampInterceptor",
+      "fqn": "Granit.Persistence.Interceptors.ConcurrencyStampInterceptor",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Interceptors/ConcurrencyStampInterceptor.cs",
+      "line": 33,
+      "members": [
+        {
+          "name": "SavingChanges",
+          "kind": "method",
+          "signature": "SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)",
+          "returnType": "InterceptionResult<int>"
+        }
+      ]
+    },
+    {
+      "name": "DomainEventDispatcherInterceptor",
+      "fqn": "Granit.Persistence.Interceptors.DomainEventDispatcherInterceptor",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Interceptors/DomainEventDispatcherInterceptor.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "SavingChanges",
+          "kind": "method",
+          "signature": "SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)",
+          "returnType": "InterceptionResult<int>"
+        }
+      ]
+    },
+    {
+      "name": "EntityLifecycleEventInterceptor",
+      "fqn": "Granit.Persistence.Interceptors.EntityLifecycleEventInterceptor",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Interceptors/EntityLifecycleEventInterceptor.cs",
+      "line": 40,
+      "members": [
+        {
+          "name": "SavingChanges",
+          "kind": "method",
+          "signature": "SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)",
+          "returnType": "InterceptionResult<int>"
+        }
+      ]
+    },
+    {
+      "name": "SoftDeleteInterceptor",
+      "fqn": "Granit.Persistence.Interceptors.SoftDeleteInterceptor",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Interceptors/SoftDeleteInterceptor.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "SavingChanges",
+          "kind": "method",
+          "signature": "SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)",
+          "returnType": "InterceptionResult<int>"
+        }
+      ]
+    },
+    {
+      "name": "VersioningInterceptor",
+      "fqn": "Granit.Persistence.Interceptors.VersioningInterceptor",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/Interceptors/VersioningInterceptor.cs",
+      "line": 32,
+      "members": [
+        {
+          "name": "SavingChanges",
+          "kind": "method",
+          "signature": "SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)",
+          "returnType": "InterceptionResult<int>"
+        }
+      ]
+    },
+    {
+      "name": "MigrationCycleRegistryExtensions",
+      "fqn": "Granit.Persistence.Migrations.Extensions.MigrationCycleRegistryExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/Extensions/MigrationCycleRegistryExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "PersistenceMigrationsHostApplicationBuilderExtensions",
+      "fqn": "Granit.Persistence.Migrations.Extensions.PersistenceMigrationsHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/Extensions/PersistenceMigrationsHostApplicationBuilderExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitPersistenceMigrations",
+          "kind": "method",
+          "signature": "AddGranitPersistenceMigrations(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configureProgressDb)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitPersistenceMigrationsModule",
+      "fqn": "Granit.Persistence.Migrations.GranitPersistenceMigrationsModule",
+      "kind": "class",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/GranitPersistenceMigrationsModule.cs",
+      "line": 35,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IMigrationBatchDispatcher",
+      "fqn": "Granit.Persistence.Migrations.IMigrationBatchDispatcher",
+      "kind": "interface",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/IMigrationBatchDispatcher.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "DispatchAsync",
+          "kind": "method",
+          "signature": "DispatchAsync(RunMigrationBatchCommand command, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DispatchAsync",
+          "kind": "method",
+          "signature": "DispatchAsync(IEnumerable<RunMigrationBatchCommand> commands, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IMigrationCycleRegistry",
+      "fqn": "Granit.Persistence.Migrations.IMigrationCycleRegistry",
+      "kind": "interface",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/IMigrationCycleRegistry.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Register",
+          "kind": "method",
+          "signature": "Register(string cycleId, Type dbContextType, BatchMigrationDelegate migration)",
+          "returnType": "void"
+        },
+        {
+          "name": "Find",
+          "kind": "method",
+          "signature": "Find(string cycleId)",
+          "returnType": "MigrationCycleRegistration?"
+        }
+      ]
+    },
+    {
+      "name": "IMigrationProgressDbEnsurer",
+      "fqn": "Granit.Persistence.Migrations.IMigrationProgressDbEnsurer",
+      "kind": "interface",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/IMigrationProgressDbEnsurer.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "EnsureCreatedAsync",
+          "kind": "method",
+          "signature": "EnsureCreatedAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ITenantDbIsolator",
+      "fqn": "Granit.Persistence.Migrations.ITenantDbIsolator",
+      "kind": "interface",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/ITenantDbIsolator.cs",
+      "line": 39,
+      "members": [
+        {
+          "name": "IsolateAsync",
+          "kind": "method",
+          "signature": "IsolateAsync(DbContext context, Guid tenantId, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ITenantEnumerator",
+      "fqn": "Granit.Persistence.Migrations.ITenantEnumerator",
+      "kind": "interface",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/ITenantEnumerator.cs",
+      "line": 45,
+      "members": [
+        {
+          "name": "GetActiveTenantIdsAsync",
+          "kind": "method",
+          "signature": "GetActiveTenantIdsAsync(CancellationToken cancellationToken)",
+          "returnType": "IAsyncEnumerable<Guid>"
+        }
+      ]
+    },
+    {
+      "name": "RunMigrationBatchCommand",
+      "fqn": "Granit.Persistence.Migrations.Messages.RunMigrationBatchCommand",
+      "kind": "record",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/Messages/RunMigrationBatchCommand.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "MigrationBatchContext",
+      "fqn": "Granit.Persistence.Migrations.MigrationBatchContext",
+      "kind": "record",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/MigrationBatchContext.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "MigrationBatchResult",
+      "fqn": "Granit.Persistence.Migrations.MigrationBatchResult",
+      "kind": "record",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/MigrationBatchResult.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "MigrationCycleAttribute",
+      "fqn": "Granit.Persistence.Migrations.MigrationCycleAttribute",
+      "kind": "class",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/MigrationCycleAttribute.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "Phase",
+          "kind": "property",
+          "signature": "MigrationPhase Phase",
+          "returnType": "MigrationPhase"
+        },
+        {
+          "name": "CycleId",
+          "kind": "property",
+          "signature": "string CycleId",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "MigrationCycleRegistration",
+      "fqn": "Granit.Persistence.Migrations.MigrationCycleRegistration",
+      "kind": "record",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/MigrationCycleRegistration.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "MigrationPhase",
+      "fqn": "Granit.Persistence.Migrations.MigrationPhase",
+      "kind": "enum",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/MigrationPhase.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "MigrationStatus",
+      "fqn": "Granit.Persistence.Migrations.MigrationStatus",
+      "kind": "enum",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/MigrationStatus.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "MigrationStartupOptions",
+      "fqn": "Granit.Persistence.Migrations.Options.MigrationStartupOptions",
+      "kind": "class",
+      "project": "Granit.Persistence.Migrations",
+      "file": "src/Granit.Persistence.Migrations/Options/MigrationStartupOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "DefaultBatchSize",
+          "kind": "property",
+          "signature": "int DefaultBatchSize",
+          "returnType": "int"
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(5)",
+          "returnType": "TimeSpan BatchExecutionTimeout { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "GranitPersistenceMigrationsWolverineModule",
+      "fqn": "Granit.Persistence.Migrations.Wolverine.GranitPersistenceMigrationsWolverineModule",
+      "kind": "class",
+      "project": "Granit.Persistence.Migrations.Wolverine",
+      "file": "src/Granit.Persistence.Migrations.Wolverine/GranitPersistenceMigrationsWolverineModule.cs",
+      "line": 28,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ITenantConnectionStringProvider",
+      "fqn": "Granit.Persistence.MultiTenancy.ITenantConnectionStringProvider",
+      "kind": "interface",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/MultiTenancy/ITenantConnectionStringProvider.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "GetConnectionStringAsync",
+          "kind": "method",
+          "signature": "GetConnectionStringAsync(Guid tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
+        }
+      ]
+    },
+    {
+      "name": "ITenantIsolationStrategyProvider",
+      "fqn": "Granit.Persistence.MultiTenancy.ITenantIsolationStrategyProvider",
+      "kind": "interface",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/MultiTenancy/ITenantIsolationStrategyProvider.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "GetStrategyAsync",
+          "kind": "method",
+          "signature": "GetStrategyAsync(Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "ValueTask<TenantIsolationStrategy>"
+        }
+      ]
+    },
+    {
+      "name": "ITenantSchemaActivator",
+      "fqn": "Granit.Persistence.MultiTenancy.ITenantSchemaActivator",
+      "kind": "interface",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/MultiTenancy/ITenantSchemaActivator.cs",
+      "line": 40,
+      "members": [
+        {
+          "name": "ActivateSchema",
+          "kind": "method",
+          "signature": "ActivateSchema(DbConnection connection, string schemaName)",
+          "returnType": "void"
+        },
+        {
+          "name": "ActivateSchemaAsync",
+          "kind": "method",
+          "signature": "ActivateSchemaAsync(DbConnection connection, string schemaName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ITenantSchemaProvider",
+      "fqn": "Granit.Persistence.MultiTenancy.ITenantSchemaProvider",
+      "kind": "interface",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/MultiTenancy/ITenantSchemaProvider.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "GetSchemaNameAsync",
+          "kind": "method",
+          "signature": "GetSchemaNameAsync(Guid tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "ValueTask<string>"
+        }
+      ]
+    },
+    {
+      "name": "TenantIsolationOptions",
+      "fqn": "Granit.Persistence.MultiTenancy.TenantIsolationOptions",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/MultiTenancy/TenantIsolationOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Strategy",
+          "kind": "property",
+          "signature": "TenantIsolationStrategy Strategy",
+          "returnType": "TenantIsolationStrategy"
+        }
+      ]
+    },
+    {
+      "name": "TenantIsolationStrategy",
+      "fqn": "Granit.Persistence.MultiTenancy.TenantIsolationStrategy",
+      "kind": "enum",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/MultiTenancy/TenantIsolationStrategy.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "TenantSchemaNamingConvention",
+      "fqn": "Granit.Persistence.MultiTenancy.TenantSchemaNamingConvention",
+      "kind": "enum",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/MultiTenancy/TenantSchemaOptions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "TenantSchemaOptions",
+      "fqn": "Granit.Persistence.MultiTenancy.TenantSchemaOptions",
+      "kind": "class",
+      "project": "Granit.Persistence",
+      "file": "src/Granit.Persistence/MultiTenancy/TenantSchemaOptions.cs",
+      "line": 31,
+      "members": [
+        {
+          "name": "NamingConvention",
+          "kind": "property",
+          "signature": "TenantSchemaNamingConvention NamingConvention",
+          "returnType": "TenantSchemaNamingConvention"
+        },
+        {
+          "name": "Prefix",
+          "kind": "property",
+          "signature": "string Prefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "NpgsqlDbContextOptionsExtensions",
+      "fqn": "Granit.Persistence.Postgres.Extensions.NpgsqlDbContextOptionsExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.Postgres",
+      "file": "src/Granit.Persistence.Postgres/Extensions/NpgsqlDbContextOptionsExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "UseGranitNpgsql",
+          "kind": "method",
+          "signature": "UseGranitNpgsql(this DbContextOptionsBuilder optionsBuilder, string connectionString, Action<NpgsqlDbContextOptionsBuilder>? npgsqlOptionsAction = null)",
+          "returnType": "DbContextOptionsBuilder"
+        }
+      ]
+    },
+    {
+      "name": "NpgsqlHealthChecksBuilderExtensions",
+      "fqn": "Granit.Persistence.Postgres.Extensions.NpgsqlHealthChecksBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.Postgres",
+      "file": "src/Granit.Persistence.Postgres/Extensions/NpgsqlHealthChecksBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitPostgresHealthCheck",
+          "kind": "method",
+          "signature": "AddGranitPostgresHealthCheck(this IHealthChecksBuilder builder, string connectionString, string name = \"postgres\", HealthStatus failureStatus = HealthStatus.Unhealthy, IEnumerable<string>? tags = null)",
+          "returnType": "IHealthChecksBuilder"
+        }
+      ]
+    },
+    {
+      "name": "PersistencePostgresHostApplicationBuilderExtensions",
+      "fqn": "Granit.Persistence.Postgres.Extensions.PersistencePostgresHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.Postgres",
+      "file": "src/Granit.Persistence.Postgres/Extensions/PersistencePostgresHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitPostgres",
+          "kind": "method",
+          "signature": "AddGranitPostgres(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitPersistencePostgresModule",
+      "fqn": "Granit.Persistence.Postgres.GranitPersistencePostgresModule",
+      "kind": "class",
+      "project": "Granit.Persistence.Postgres",
+      "file": "src/Granit.Persistence.Postgres/GranitPersistencePostgresModule.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "PersistenceSqlServerHostApplicationBuilderExtensions",
+      "fqn": "Granit.Persistence.SqlServer.Extensions.PersistenceSqlServerHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.SqlServer",
+      "file": "src/Granit.Persistence.SqlServer/Extensions/PersistenceSqlServerHostApplicationBuilderExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitSqlServer",
+          "kind": "method",
+          "signature": "AddGranitSqlServer(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "SqlServerDbContextOptionsExtensions",
+      "fqn": "Granit.Persistence.SqlServer.Extensions.SqlServerDbContextOptionsExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.SqlServer",
+      "file": "src/Granit.Persistence.SqlServer/Extensions/SqlServerDbContextOptionsExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "UseGranitSqlServer",
+          "kind": "method",
+          "signature": "UseGranitSqlServer(this DbContextOptionsBuilder optionsBuilder, string connectionString, Action<SqlServerDbContextOptionsBuilder>? sqlServerOptionsAction = null)",
+          "returnType": "DbContextOptionsBuilder"
+        }
+      ]
+    },
+    {
+      "name": "SqlServerHealthChecksBuilderExtensions",
+      "fqn": "Granit.Persistence.SqlServer.Extensions.SqlServerHealthChecksBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.SqlServer",
+      "file": "src/Granit.Persistence.SqlServer/Extensions/SqlServerHealthChecksBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitSqlServerHealthCheck",
+          "kind": "method",
+          "signature": "AddGranitSqlServerHealthCheck(this IHealthChecksBuilder builder, string connectionString, string name = \"sqlserver\", HealthStatus failureStatus = HealthStatus.Unhealthy, IEnumerable<string>? tags = null)",
+          "returnType": "IHealthChecksBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitPersistenceSqlServerModule",
+      "fqn": "Granit.Persistence.SqlServer.GranitPersistenceSqlServerModule",
+      "kind": "class",
+      "project": "Granit.Persistence.SqlServer",
+      "file": "src/Granit.Persistence.SqlServer/GranitPersistenceSqlServerModule.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "DetectedPii",
+      "fqn": "Granit.Privacy.AI.DetectedPii",
+      "kind": "record",
+      "project": "Granit.Privacy.AI",
+      "file": "src/Granit.Privacy.AI/PiiDetectionResult.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "PrivacyAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Privacy.AI.Extensions.PrivacyAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Privacy.AI",
+      "file": "src/Granit.Privacy.AI/Extensions/PrivacyAIHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitPrivacyAI",
+          "kind": "method",
+          "signature": "AddGranitPrivacyAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitPrivacyAIModule",
+      "fqn": "Granit.Privacy.AI.GranitPrivacyAIModule",
+      "kind": "class",
+      "project": "Granit.Privacy.AI",
+      "file": "src/Granit.Privacy.AI/GranitPrivacyAIModule.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "IAIPiiDetector",
+      "fqn": "Granit.Privacy.AI.IAIPiiDetector",
+      "kind": "interface",
+      "project": "Granit.Privacy.AI",
+      "file": "src/Granit.Privacy.AI/IAIPiiDetector.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "ScanAsync",
+          "kind": "method",
+          "signature": "ScanAsync(string text, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PiiDetectionResult>"
+        }
+      ]
+    },
+    {
+      "name": "PrivacyAIOptions",
+      "fqn": "Granit.Privacy.AI.Options.PrivacyAIOptions",
+      "kind": "class",
+      "project": "Granit.Privacy.AI",
+      "file": "src/Granit.Privacy.AI/Options/PrivacyAIOptions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string WorkspaceName",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "PiiDetectionResult",
+      "fqn": "Granit.Privacy.AI.PiiDetectionResult",
+      "kind": "record",
+      "project": "Granit.Privacy.AI",
+      "file": "src/Granit.Privacy.AI/PiiDetectionResult.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "PiiType",
+      "fqn": "Granit.Privacy.AI.PiiType",
+      "kind": "enum",
+      "project": "Granit.Privacy.AI",
+      "file": "src/Granit.Privacy.AI/PiiDetectionResult.cs",
+      "line": 30,
+      "members": []
+    },
+    {
+      "name": "DeletionAction",
+      "fqn": "Granit.Privacy.DataDeletion.DeletionAction",
+      "kind": "enum",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataDeletion/DeletionAction.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "PersonalDataDeletedEto",
+      "fqn": "Granit.Privacy.DataDeletion.Events.PersonalDataDeletedEto",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataDeletion/Events/PersonalDataDeletedEto.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "PersonalDataDeletionRequestedEto",
+      "fqn": "Granit.Privacy.DataDeletion.Events.PersonalDataDeletionRequestedEto",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataDeletion/Events/PersonalDataDeletionRequestedEto.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ExportCompletedEto",
+      "fqn": "Granit.Privacy.DataExport.Events.ExportCompletedEto",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/Events/ExportCompletedEto.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ExportTimedOutEvent",
+      "fqn": "Granit.Privacy.DataExport.Events.ExportTimedOutEvent",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/Events/ExportTimedOutEvent.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "PersonalDataPreparedEto",
+      "fqn": "Granit.Privacy.DataExport.Events.PersonalDataPreparedEto",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/Events/PersonalDataPreparedEto.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "PersonalDataRequestedEto",
+      "fqn": "Granit.Privacy.DataExport.Events.PersonalDataRequestedEto",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/Events/PersonalDataRequestedEto.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "GdprExportSaga",
+      "fqn": "Granit.Privacy.DataExport.GdprExportSaga",
+      "kind": "class",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/GdprExportSaga.cs",
+      "line": 36,
+      "members": [
+        {
+          "name": "Id",
+          "kind": "property",
+          "signature": "Guid Id",
+          "returnType": "Guid"
+        },
+        {
+          "name": "PendingProviders",
+          "kind": "property",
+          "signature": "List<string> PendingProviders",
+          "returnType": "List<string>"
+        },
+        {
+          "name": "StartAsync",
+          "kind": "method",
+          "signature": "StartAsync(PersonalDataRequestedEto @event, IDataProviderRegistry registry, IOptions<GranitPrivacyOptions> options, IMessageContext context, PrivacyMetrics metrics)",
+          "returnType": "Task<ExportCompletedEto?>"
+        }
+      ]
+    },
+    {
+      "name": "GdprExportSagaState",
+      "fqn": "Granit.Privacy.DataExport.GdprExportSagaState",
+      "kind": "class",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/GdprExportSagaState.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "RequestId",
+          "kind": "property",
+          "signature": "Guid RequestId",
+          "returnType": "Guid"
+        },
+        {
+          "name": "AllProviders",
+          "kind": "property",
+          "signature": "List<string> AllProviders",
+          "returnType": "List<string>"
+        }
+      ]
+    },
+    {
+      "name": "IDataProviderRegistry",
+      "fqn": "Granit.Privacy.DataExport.IDataProviderRegistry",
+      "kind": "interface",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/IDataProviderRegistry.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "Register",
+          "kind": "method",
+          "signature": "Register(string providerName)",
+          "returnType": "void"
+        },
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IReadOnlyList<string>"
+        }
+      ]
+    },
+    {
+      "name": "ReceivedFragment",
+      "fqn": "Granit.Privacy.DataExport.ReceivedFragment",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/GdprExportSagaState.cs",
+      "line": 31,
+      "members": []
+    },
+    {
+      "name": "PrivacyMetrics",
+      "fqn": "Granit.Privacy.Diagnostics.PrivacyMetrics",
+      "kind": "class",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/Diagnostics/PrivacyMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordFragmentReceived",
+          "kind": "method",
+          "signature": "RecordFragmentReceived(string? tenantId, string provider)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordDeletionRequested",
+          "kind": "method",
+          "signature": "RecordDeletionRequested(string? tenantId)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordExportCompleted",
+          "kind": "method",
+          "signature": "RecordExportCompleted(string? tenantId, string status, TimeSpan duration)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "PrivacyServiceCollectionExtensions",
+      "fqn": "Granit.Privacy.Extensions.PrivacyServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/Extensions/PrivacyServiceCollectionExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "AddGranitPrivacy",
+          "kind": "method",
+          "signature": "AddGranitPrivacy(this IServiceCollection services, Action<GranitPrivacyBuilder> configure)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitPrivacyBuilder",
+      "fqn": "Granit.Privacy.GranitPrivacyBuilder",
+      "kind": "class",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/GranitPrivacyBuilder.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "RegisterDataProvider",
+          "kind": "method",
+          "signature": "RegisterDataProvider(string providerName)",
+          "returnType": "GranitPrivacyBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitPrivacyModule",
+      "fqn": "Granit.Privacy.GranitPrivacyModule",
+      "kind": "class",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/GranitPrivacyModule.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "LegalAgreementBase",
+      "fqn": "Granit.Privacy.LegalAgreements.Domain.LegalAgreementBase",
+      "kind": "class",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/LegalAgreements/Domain/LegalAgreementBase.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "UserId",
+          "kind": "property",
+          "signature": "Guid UserId",
+          "returnType": "Guid"
+        },
+        {
+          "name": "Version",
+          "kind": "property",
+          "signature": "string Version",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "LegalAgreementAcceptedEto",
+      "fqn": "Granit.Privacy.LegalAgreements.Events.LegalAgreementAcceptedEto",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/LegalAgreements/Events/LegalAgreementAcceptedEto.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "LegalAgreementObsoleteEto",
+      "fqn": "Granit.Privacy.LegalAgreements.Events.LegalAgreementObsoleteEto",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/LegalAgreements/Events/LegalAgreementObsoleteEto.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "ILegalAgreementChecker",
+      "fqn": "Granit.Privacy.LegalAgreements.ILegalAgreementChecker",
+      "kind": "interface",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/LegalAgreements/ILegalAgreementChecker.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "HasAcceptedLatestAsync",
+          "kind": "method",
+          "signature": "HasAcceptedLatestAsync(Guid userId, string documentId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        },
+        {
+          "name": "GetUserAgreementsAsync",
+          "kind": "method",
+          "signature": "GetUserAgreementsAsync(Guid userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<LegalAgreementBase>>"
+        }
+      ]
+    },
+    {
+      "name": "ILegalAgreementStoreReader",
+      "fqn": "Granit.Privacy.LegalAgreements.ILegalAgreementStoreReader",
+      "kind": "interface",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/LegalAgreements/ILegalAgreementStoreReader.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "FindLatestAsync",
+          "kind": "method",
+          "signature": "FindLatestAsync(Guid userId, string documentId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<LegalAgreementBase?>"
+        },
+        {
+          "name": "FindAllByUserAsync",
+          "kind": "method",
+          "signature": "FindAllByUserAsync(Guid userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<LegalAgreementBase>>"
+        }
+      ]
+    },
+    {
+      "name": "ILegalAgreementStoreWriter",
+      "fqn": "Granit.Privacy.LegalAgreements.ILegalAgreementStoreWriter",
+      "kind": "interface",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/LegalAgreements/ILegalAgreementStoreWriter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "RecordAsync",
+          "kind": "method",
+          "signature": "RecordAsync(LegalAgreementBase agreement, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ILegalDocumentRegistry",
+      "fqn": "Granit.Privacy.LegalAgreements.ILegalDocumentRegistry",
+      "kind": "interface",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/LegalAgreements/ILegalDocumentRegistry.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetDefinition",
+          "kind": "method",
+          "signature": "GetDefinition(string documentId)",
+          "returnType": "LegalDocumentDefinition?"
+        },
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IReadOnlyList<LegalDocumentDefinition>"
+        }
+      ]
+    },
+    {
+      "name": "LegalDocumentDefinition",
+      "fqn": "Granit.Privacy.LegalAgreements.LegalDocumentDefinition",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/LegalAgreements/LegalDocumentDefinition.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "GranitPrivacyOptions",
+      "fqn": "Granit.Privacy.Options.GranitPrivacyOptions",
+      "kind": "class",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/Options/GranitPrivacyOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ExportTimeoutMinutes",
+          "kind": "property",
+          "signature": "int ExportTimeoutMinutes",
+          "returnType": "int"
+        },
+        {
+          "name": "ExportMaxSizeMb",
+          "kind": "property",
+          "signature": "int ExportMaxSizeMb",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "QueryingAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Querying.AI.Extensions.QueryingAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Querying.AI",
+      "file": "src/Granit.Querying.AI/Extensions/QueryingAIHostApplicationBuilderExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitQueryingAI",
+          "kind": "method",
+          "signature": "AddGranitQueryingAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitQueryingAIModule",
+      "fqn": "Granit.Querying.AI.GranitQueryingAIModule",
+      "kind": "class",
+      "project": "Granit.Querying.AI",
+      "file": "src/Granit.Querying.AI/GranitQueryingAIModule.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "INaturalLanguageQueryTranslator",
+      "fqn": "Granit.Querying.AI.INaturalLanguageQueryTranslator",
+      "kind": "interface",
+      "project": "Granit.Querying.AI",
+      "file": "src/Granit.Querying.AI/INaturalLanguageQueryTranslator.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "TranslateAsync",
+          "kind": "method",
+          "signature": "TranslateAsync(string naturalLanguage, QueryMetadata metadata, CancellationToken cancellationToken = default)",
+          "returnType": "Task<QueryRequest?>"
+        }
+      ]
+    },
+    {
+      "name": "QueryingAIOptions",
+      "fqn": "Granit.Querying.AI.Options.QueryingAIOptions",
+      "kind": "class",
+      "project": "Granit.Querying.AI",
+      "file": "src/Granit.Querying.AI/Options/QueryingAIOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string WorkspaceName",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "ColumnBuilder",
+      "fqn": "Granit.Querying.ColumnBuilder",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/ColumnBuilder.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "ColumnDescriptor",
+      "fqn": "Granit.Querying.ColumnDescriptor",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/ColumnDescriptor.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "PropertyName",
+          "kind": "property",
+          "signature": "required string PropertyName",
+          "returnType": "required string"
+        }
+      ]
+    },
+    {
+      "name": "DatePeriod",
+      "fqn": "Granit.Querying.DatePeriod",
+      "kind": "enum",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/DatePeriod.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "QueryRequestBinder",
+      "fqn": "Granit.Querying.Endpoints.Binding.QueryRequestBinder",
+      "kind": "class",
+      "project": "Granit.Querying.Endpoints",
+      "file": "src/Granit.Querying.Endpoints/Binding/QueryRequestBinder.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "BindAsync",
+          "kind": "method",
+          "signature": "BindAsync(HttpContext context, ParameterInfo parameter)",
+          "returnType": "ValueTask<QueryRequest?>"
+        }
+      ]
+    },
+    {
+      "name": "BindableQueryRequest",
+      "fqn": "Granit.Querying.Endpoints.Dtos.BindableQueryRequest",
+      "kind": "class",
+      "project": "Granit.Querying.Endpoints",
+      "file": "src/Granit.Querying.Endpoints/Dtos/BindableQueryRequest.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "BindableQueryRequest",
+          "kind": "method",
+          "signature": "BindableQueryRequest(QueryRequest value)",
+          "returnType": "QueryRequest Value { get; } private"
+        },
+        {
+          "name": "BindAsync",
+          "kind": "method",
+          "signature": "BindAsync(HttpContext context, ParameterInfo parameter)",
+          "returnType": "ValueTask<BindableQueryRequest?>"
+        }
+      ]
+    },
+    {
+      "name": "SavedViewResponse",
+      "fqn": "Granit.Querying.Endpoints.Dtos.SavedViewResponse",
+      "kind": "record",
+      "project": "Granit.Querying.Endpoints",
+      "file": "src/Granit.Querying.Endpoints/Dtos/SavedViewResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "QueryEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Querying.Endpoints.Extensions.QueryEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Querying.Endpoints",
+      "file": "src/Granit.Querying.Endpoints/Extensions/QueryEndpointRouteBuilderExtensions.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "GranitQueryingEndpointsModule",
+      "fqn": "Granit.Querying.Endpoints.GranitQueryingEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Querying.Endpoints",
+      "file": "src/Granit.Querying.Endpoints/GranitQueryingEndpointsModule.cs",
+      "line": 28,
+      "members": []
+    },
+    {
+      "name": "QueryEndpointOptions",
+      "fqn": "Granit.Querying.Endpoints.Options.QueryEndpointOptions",
+      "kind": "class",
+      "project": "Granit.Querying.Endpoints",
+      "file": "src/Granit.Querying.Endpoints/Options/QueryEndpointOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string? TagName",
+          "returnType": "string?"
+        },
+        {
+          "name": "IncludeSavedViewEndpoints",
+          "kind": "property",
+          "signature": "bool IncludeSavedViewEndpoints",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "QueryingEfCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.Querying.EntityFrameworkCore.Extensions.QueryingEfCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Querying.EntityFrameworkCore",
+      "file": "src/Granit.Querying.EntityFrameworkCore/Extensions/QueryingEfCoreHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitQueryingEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitQueryingEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "QueryingModelBuilderExtensions",
+      "fqn": "Granit.Querying.EntityFrameworkCore.Extensions.QueryingModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Querying.EntityFrameworkCore",
+      "file": "src/Granit.Querying.EntityFrameworkCore/Extensions/QueryingModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureQueryingModule",
+          "kind": "method",
+          "signature": "ConfigureQueryingModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitQueryingDbProperties",
+      "fqn": "Granit.Querying.EntityFrameworkCore.GranitQueryingDbProperties",
+      "kind": "class",
+      "project": "Granit.Querying.EntityFrameworkCore",
+      "file": "src/Granit.Querying.EntityFrameworkCore/GranitQueryingDbProperties.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitQueryingEntityFrameworkCoreModule",
+      "fqn": "Granit.Querying.EntityFrameworkCore.GranitQueryingEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Querying.EntityFrameworkCore",
+      "file": "src/Granit.Querying.EntityFrameworkCore/GranitQueryingEntityFrameworkCoreModule.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.Querying.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Extensions/ServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitQuerying",
+          "kind": "method",
+          "signature": "AddGranitQuerying(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "AggregateDescriptor",
+      "fqn": "Granit.Querying.Filtering.AggregateDescriptor",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/AggregateDescriptor.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "AggregateFunction",
+      "fqn": "Granit.Querying.Filtering.AggregateFunction",
+      "kind": "enum",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/AggregateFunction.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "DateFilterDescriptor",
+      "fqn": "Granit.Querying.Filtering.DateFilterDescriptor",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/DateFilterDescriptor.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "FilterCriteria",
+      "fqn": "Granit.Querying.Filtering.FilterCriteria",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/FilterCriteria.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "FilterGroupBuilder",
+      "fqn": "Granit.Querying.Filtering.FilterGroupBuilder",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/FilterGroupBuilder.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Preset",
+          "kind": "method",
+          "signature": "Preset(string name, Expression<Func<TEntity, bool>> predicate, bool isDefault = false)",
+          "returnType": "FilterGroupBuilder<TEntity>"
+        }
+      ]
+    },
+    {
+      "name": "FilterGroupDescriptor",
+      "fqn": "Granit.Querying.Filtering.FilterGroupDescriptor",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/FilterGroupDescriptor.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "FilterOperator",
+      "fqn": "Granit.Querying.Filtering.FilterOperator",
+      "kind": "enum",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/FilterOperator.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "FilterOperatorInference",
+      "fqn": "Granit.Querying.Filtering.FilterOperatorInference",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/FilterOperatorInference.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetOperators",
+          "kind": "method",
+          "signature": "GetOperators(Type clrType)",
+          "returnType": "IReadOnlyList<FilterOperator>"
+        }
+      ]
+    },
+    {
+      "name": "GroupByDescriptor",
+      "fqn": "Granit.Querying.Filtering.GroupByDescriptor",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/GroupByDescriptor.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IQueryFilter",
+      "fqn": "Granit.Querying.Filtering.IQueryFilter",
+      "kind": "interface",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/IQueryFilter.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Apply",
+          "kind": "method",
+          "signature": "Apply(string value)",
+          "returnType": "string Name { get; } Expression<Func<TEntity, bool>>"
+        }
+      ]
+    },
+    {
+      "name": "PresetDescriptor",
+      "fqn": "Granit.Querying.Filtering.PresetDescriptor",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/PresetDescriptor.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "QuickFilterDescriptor",
+      "fqn": "Granit.Querying.Filtering.QuickFilterDescriptor",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Filtering/QuickFilterDescriptor.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "GranitQueryingModule",
+      "fqn": "Granit.Querying.GranitQueryingModule",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/GranitQueryingModule.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GroupEntry",
+      "fqn": "Granit.Querying.GroupEntry",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/GroupedResult.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "GroupedResult",
+      "fqn": "Granit.Querying.GroupedResult",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/GroupedResult.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "IQueryDefinitionDescriptor",
+      "fqn": "Granit.Querying.IQueryDefinitionDescriptor",
+      "kind": "interface",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/IQueryDefinitionDescriptor.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "IQueryEngine",
+      "fqn": "Granit.Querying.IQueryEngine",
+      "kind": "interface",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/IQueryEngine.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ExecuteAsync",
+          "kind": "method",
+          "signature": "ExecuteAsync(IQueryable<TEntity> source, QueryRequest request, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<TEntity>>"
+        },
+        {
+          "name": "ExecuteGroupedAsync",
+          "kind": "method",
+          "signature": "ExecuteGroupedAsync(IQueryable<TEntity> source, QueryRequest request, CancellationToken cancellationToken = default)",
+          "returnType": "Task<GroupedResult<TEntity>>"
+        },
+        {
+          "name": "ExecuteStreamAsync",
+          "kind": "method",
+          "signature": "ExecuteStreamAsync(IQueryable<TEntity> source, QueryRequest request, CancellationToken cancellationToken = default)",
+          "returnType": "IAsyncEnumerable<TEntity>"
+        },
+        {
+          "name": "GetMetadata",
+          "kind": "method",
+          "signature": "GetMetadata(IReadOnlyList<SavedViewSummary>? savedViews = null)",
+          "returnType": "QueryMetadata"
+        }
+      ]
+    },
+    {
+      "name": "ColumnDefinition",
+      "fqn": "Granit.Querying.Meta.ColumnDefinition",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Meta/ColumnDefinition.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "DateFilterMeta",
+      "fqn": "Granit.Querying.Meta.DateFilterMeta",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Meta/DateFilterMeta.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "FilterGroupMeta",
+      "fqn": "Granit.Querying.Meta.FilterGroupMeta",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Meta/FilterGroupMeta.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "FilterableField",
+      "fqn": "Granit.Querying.Meta.FilterableField",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Meta/FilterableField.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "GroupByField",
+      "fqn": "Granit.Querying.Meta.GroupByField",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Meta/GroupByField.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "PaginationMeta",
+      "fqn": "Granit.Querying.Meta.PaginationMeta",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Meta/PaginationMeta.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "PresetMeta",
+      "fqn": "Granit.Querying.Meta.PresetMeta",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Meta/FilterGroupMeta.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "QueryMetadata",
+      "fqn": "Granit.Querying.Meta.QueryMetadata",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Meta/QueryMetadata.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "QuickFilterMeta",
+      "fqn": "Granit.Querying.Meta.QuickFilterMeta",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Meta/QuickFilterMeta.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "SortableField",
+      "fqn": "Granit.Querying.Meta.SortableField",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Meta/SortableField.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "QueryingOptions",
+      "fqn": "Granit.Querying.Options.QueryingOptions",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/Options/QueryingOptions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "DefaultPageSize",
+          "kind": "property",
+          "signature": "int DefaultPageSize",
+          "returnType": "int"
+        },
+        {
+          "name": "MaxPageSize",
+          "kind": "property",
+          "signature": "int MaxPageSize",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "PagedResult",
+      "fqn": "Granit.Querying.PagedResult",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/PagedResult.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "QueryDefinition",
+      "fqn": "Granit.Querying.QueryDefinition",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/QueryDefinition.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "typeof",
+          "kind": "method",
+          "signature": "typeof(TEntity)",
+          "returnType": "string Name { get; } public Type EntityType =>"
+        },
+        {
+          "name": "GetFilterGroups",
+          "kind": "method",
+          "signature": "GetFilterGroups()",
+          "returnType": "IReadOnlyList<Filtering.FilterGroupDescriptor>"
+        },
+        {
+          "name": "GetDateFilters",
+          "kind": "method",
+          "signature": "GetDateFilters()",
+          "returnType": "IReadOnlyList<Filtering.DateFilterDescriptor>"
+        },
+        {
+          "name": "GetGroupByFields",
+          "kind": "method",
+          "signature": "GetGroupByFields()",
+          "returnType": "IReadOnlyList<Filtering.GroupByDescriptor>"
+        },
+        {
+          "name": "GetAggregates",
+          "kind": "method",
+          "signature": "GetAggregates()",
+          "returnType": "IReadOnlyList<Filtering.AggregateDescriptor>"
+        },
+        {
+          "name": "GetQuickFilters",
+          "kind": "method",
+          "signature": "GetQuickFilters()",
+          "returnType": "IReadOnlyList<Filtering.QuickFilterDescriptor>"
+        },
+        {
+          "name": "GetGlobalSearchProperties",
+          "kind": "method",
+          "signature": "GetGlobalSearchProperties()",
+          "returnType": "IReadOnlyList<string>"
+        },
+        {
+          "name": "GetDefaultPageSize",
+          "kind": "method",
+          "signature": "GetDefaultPageSize()",
+          "returnType": "int"
+        },
+        {
+          "name": "GetMaxPageSize",
+          "kind": "method",
+          "signature": "GetMaxPageSize()",
+          "returnType": "int"
+        },
+        {
+          "name": "GetCursorProperty",
+          "kind": "method",
+          "signature": "GetCursorProperty()",
+          "returnType": "string?"
+        },
+        {
+          "name": "GetDefaultSort",
+          "kind": "method",
+          "signature": "GetDefaultSort()",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "QueryDefinitionBuilder",
+      "fqn": "Granit.Querying.QueryDefinitionBuilder",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/QueryDefinitionBuilder.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "QueryRequest",
+      "fqn": "Granit.Querying.QueryRequest",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/QueryRequest.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "QueryingDefaults",
+      "fqn": "Granit.Querying.QueryingDefaults",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/QueryingDefaults.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "CreateSavedViewRequest",
+      "fqn": "Granit.Querying.SavedViews.CreateSavedViewRequest",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/SavedViews/CreateSavedViewRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "SavedView",
+      "fqn": "Granit.Querying.SavedViews.Domain.SavedView",
+      "kind": "class",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/SavedViews/Domain/SavedView.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ISavedViewStoreReader",
+      "fqn": "Granit.Querying.SavedViews.ISavedViewStoreReader",
+      "kind": "interface",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/SavedViews/ISavedViewStoreReader.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetListAsync",
+          "kind": "method",
+          "signature": "GetListAsync(string entityType, string userId, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<SavedView>>"
+        },
+        {
+          "name": "GetAsync",
+          "kind": "method",
+          "signature": "GetAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<SavedView?>"
+        }
+      ]
+    },
+    {
+      "name": "ISavedViewStoreWriter",
+      "fqn": "Granit.Querying.SavedViews.ISavedViewStoreWriter",
+      "kind": "interface",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/SavedViews/ISavedViewStoreWriter.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(SavedView view, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UpdateAsync",
+          "kind": "method",
+          "signature": "UpdateAsync(SavedView view, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SetDefaultAsync",
+          "kind": "method",
+          "signature": "SetDefaultAsync(Guid id, string userId, string entityType, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "SavedViewSummary",
+      "fqn": "Granit.Querying.SavedViews.SavedViewSummary",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/SavedViews/SavedViewSummary.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "UpdateSavedViewRequest",
+      "fqn": "Granit.Querying.SavedViews.UpdateSavedViewRequest",
+      "kind": "record",
+      "project": "Granit.Querying",
+      "file": "src/Granit.Querying/SavedViews/UpdateSavedViewRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "IRateLimitCounterStore",
+      "fqn": "Granit.RateLimiting.Abstractions.IRateLimitCounterStore",
+      "kind": "interface",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Abstractions/IRateLimitCounterStore.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "CheckAndIncrementAsync",
+          "kind": "method",
+          "signature": "CheckAndIncrementAsync(string key, int permitLimit, TimeSpan window, RateLimitAlgorithm algorithm, RateLimitPolicyOptions policyOptions, CancellationToken cancellationToken)",
+          "returnType": "Task<RateLimitResult>"
+        }
+      ]
+    },
+    {
+      "name": "IRateLimitQuotaProvider",
+      "fqn": "Granit.RateLimiting.Abstractions.IRateLimitQuotaProvider",
+      "kind": "interface",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Abstractions/IRateLimitQuotaProvider.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "GetPermitLimitAsync",
+          "kind": "method",
+          "signature": "GetPermitLimitAsync(string policyName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int?>"
+        }
+      ]
+    },
+    {
+      "name": "RateLimitResult",
+      "fqn": "Granit.RateLimiting.Abstractions.RateLimitResult",
+      "kind": "record",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Abstractions/RateLimitResult.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "RateLimitEndpointExtensions",
+      "fqn": "Granit.RateLimiting.AspNetCore.RateLimitEndpointExtensions",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/AspNetCore/RateLimitEndpointExtensions.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "RateLimitedAttribute",
+      "fqn": "Granit.RateLimiting.Attributes.RateLimitedAttribute",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Attributes/RateLimitedAttribute.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "PolicyName",
+          "kind": "property",
+          "signature": "string PolicyName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "RateLimitingMetrics",
+      "fqn": "Granit.RateLimiting.Diagnostics.RateLimitingMetrics",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Diagnostics/RateLimitingMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordRejected",
+          "kind": "method",
+          "signature": "RecordRejected(string policyName, string? tenantId)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "RateLimitExceededException",
+      "fqn": "Granit.RateLimiting.Exceptions.RateLimitExceededException",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Exceptions/RateLimitExceededException.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "RateLimitingApplicationBuilderExtensions",
+      "fqn": "Granit.RateLimiting.Extensions.RateLimitingApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Extensions/RateLimitingApplicationBuilderExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "UseGranitRateLimiting",
+          "kind": "method",
+          "signature": "UseGranitRateLimiting(this IApplicationBuilder app)",
+          "returnType": "IApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "RateLimitingServiceCollectionExtensions",
+      "fqn": "Granit.RateLimiting.Extensions.RateLimitingServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Extensions/RateLimitingServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitRateLimiting",
+          "kind": "method",
+          "signature": "AddGranitRateLimiting(this IServiceCollection services, Action<GranitRateLimitingOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitRateLimitingModule",
+      "fqn": "Granit.RateLimiting.GranitRateLimitingModule",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/GranitRateLimitingModule.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "CounterStoreFailureBehavior",
+      "fqn": "Granit.RateLimiting.Options.CounterStoreFailureBehavior",
+      "kind": "enum",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Options/CounterStoreFailureBehavior.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "GranitRateLimitingOptions",
+      "fqn": "Granit.RateLimiting.Options.GranitRateLimitingOptions",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Options/GranitRateLimitingOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Enabled",
+          "kind": "property",
+          "signature": "bool Enabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "KeyPrefix",
+          "kind": "property",
+          "signature": "string KeyPrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "FallbackOnCounterStoreFailure",
+          "kind": "property",
+          "signature": "CounterStoreFailureBehavior FallbackOnCounterStoreFailure",
+          "returnType": "CounterStoreFailureBehavior"
+        },
+        {
+          "name": "BypassRoles",
+          "kind": "property",
+          "signature": "string[] BypassRoles",
+          "returnType": "string[]"
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(StringComparer.OrdinalIgnoreCase)",
+          "returnType": "Dictionary<string, RateLimitPolicyOptions> Policies { get; set; } ="
+        }
+      ]
+    },
+    {
+      "name": "RateLimitAlgorithm",
+      "fqn": "Granit.RateLimiting.Options.RateLimitAlgorithm",
+      "kind": "enum",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Options/RateLimitAlgorithm.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "RateLimitPolicyOptions",
+      "fqn": "Granit.RateLimiting.Options.RateLimitPolicyOptions",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Options/RateLimitPolicyOptions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "Algorithm",
+          "kind": "property",
+          "signature": "RateLimitAlgorithm Algorithm",
+          "returnType": "RateLimitAlgorithm"
+        },
+        {
+          "name": "PermitLimit",
+          "kind": "property",
+          "signature": "int PermitLimit",
+          "returnType": "int"
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(1)",
+          "returnType": "TimeSpan Window { get; set; } = TimeSpan."
+        },
+        {
+          "name": "SegmentsPerWindow",
+          "kind": "property",
+          "signature": "int SegmentsPerWindow",
+          "returnType": "int"
+        },
+        {
+          "name": "TokenLimit",
+          "kind": "property",
+          "signature": "int TokenLimit",
+          "returnType": "int"
+        },
+        {
+          "name": "TokensPerPeriod",
+          "kind": "property",
+          "signature": "int TokensPerPeriod",
+          "returnType": "int"
+        },
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(10)",
+          "returnType": "TimeSpan ReplenishmentPeriod { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "TenantPartitionedRateLimiter",
+      "fqn": "Granit.RateLimiting.TenantPartitionedRateLimiter",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/TenantPartitionedRateLimiter.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "CheckAsync",
+          "kind": "method",
+          "signature": "CheckAsync(string policyName, CancellationToken cancellationToken)",
+          "returnType": "Task<RateLimitResult?>"
+        }
+      ]
+    },
+    {
+      "name": "RateLimitMiddleware",
+      "fqn": "Granit.RateLimiting.Wolverine.RateLimitMiddleware",
+      "kind": "class",
+      "project": "Granit.RateLimiting",
+      "file": "src/Granit.RateLimiting/Wolverine/RateLimitMiddleware.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "BeforeAsync",
+          "kind": "method",
+          "signature": "BeforeAsync(object message, TenantPartitionedRateLimiter limiter, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ReferenceDataEntity",
+      "fqn": "Granit.ReferenceData.Domain.ReferenceDataEntity",
+      "kind": "class",
+      "project": "Granit.ReferenceData",
+      "file": "src/Granit.ReferenceData/Domain/ReferenceDataEntity.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "Code",
+          "kind": "property",
+          "signature": "string Code",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelEn",
+          "kind": "property",
+          "signature": "string LabelEn",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelFr",
+          "kind": "property",
+          "signature": "string LabelFr",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelNl",
+          "kind": "property",
+          "signature": "string LabelNl",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelDe",
+          "kind": "property",
+          "signature": "string LabelDe",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelEs",
+          "kind": "property",
+          "signature": "string LabelEs",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelIt",
+          "kind": "property",
+          "signature": "string LabelIt",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelPt",
+          "kind": "property",
+          "signature": "string LabelPt",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelZh",
+          "kind": "property",
+          "signature": "string LabelZh",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelJa",
+          "kind": "property",
+          "signature": "string LabelJa",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelPl",
+          "kind": "property",
+          "signature": "string LabelPl",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelTr",
+          "kind": "property",
+          "signature": "string LabelTr",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelKo",
+          "kind": "property",
+          "signature": "string LabelKo",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelSv",
+          "kind": "property",
+          "signature": "string LabelSv",
+          "returnType": "string"
+        },
+        {
+          "name": "LabelCs",
+          "kind": "property",
+          "signature": "string LabelCs",
+          "returnType": "string"
+        },
+        {
+          "name": "Label",
+          "kind": "property",
+          "signature": "string Label",
+          "returnType": "string"
+        },
+        {
+          "name": "IsActive",
+          "kind": "property",
+          "signature": "bool IsActive",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "ReferenceDataCreateRequest",
+      "fqn": "Granit.ReferenceData.Endpoints.Dtos.ReferenceDataCreateRequest",
+      "kind": "record",
+      "project": "Granit.ReferenceData.Endpoints",
+      "file": "src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataCreateRequest.cs",
+      "line": 24,
+      "members": []
+    },
+    {
+      "name": "ReferenceDataUpdateRequest",
+      "fqn": "Granit.ReferenceData.Endpoints.Dtos.ReferenceDataUpdateRequest",
+      "kind": "record",
+      "project": "Granit.ReferenceData.Endpoints",
+      "file": "src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataUpdateRequest.cs",
+      "line": 24,
+      "members": []
+    },
+    {
+      "name": "ReferenceDataEndpointRouteBuilderExtensions",
+      "fqn": "Granit.ReferenceData.Endpoints.Extensions.ReferenceDataEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.ReferenceData.Endpoints",
+      "file": "src/Granit.ReferenceData.Endpoints/Extensions/ReferenceDataEndpointRouteBuilderExtensions.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "GranitReferenceDataEndpointsModule",
+      "fqn": "Granit.ReferenceData.Endpoints.GranitReferenceDataEndpointsModule",
+      "kind": "class",
+      "project": "Granit.ReferenceData.Endpoints",
+      "file": "src/Granit.ReferenceData.Endpoints/GranitReferenceDataEndpointsModule.cs",
+      "line": 23,
+      "members": []
+    },
+    {
+      "name": "ReferenceDataEndpointsOptions",
+      "fqn": "Granit.ReferenceData.Endpoints.Options.ReferenceDataEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.ReferenceData.Endpoints",
+      "file": "src/Granit.ReferenceData.Endpoints/Options/ReferenceDataEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        },
+        {
+          "name": "AdminPolicyName",
+          "kind": "property",
+          "signature": "string? AdminPolicyName",
+          "returnType": "string?"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "ModelBuilderExtensions",
+      "fqn": "Granit.ReferenceData.EntityFrameworkCore.Extensions.ModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.ReferenceData.EntityFrameworkCore",
+      "file": "src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ReferenceDataEfCoreServiceCollectionExtensions",
+      "fqn": "Granit.ReferenceData.EntityFrameworkCore.Extensions.ReferenceDataEfCoreServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.ReferenceData.EntityFrameworkCore",
+      "file": "src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ReferenceDataEfCoreServiceCollectionExtensions.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "GranitReferenceDataEntityFrameworkCoreModule",
+      "fqn": "Granit.ReferenceData.EntityFrameworkCore.GranitReferenceDataEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.ReferenceData.EntityFrameworkCore",
+      "file": "src/Granit.ReferenceData.EntityFrameworkCore/GranitReferenceDataEntityFrameworkCoreModule.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "ReferenceDataEntityTypeConfiguration",
+      "fqn": "Granit.ReferenceData.EntityFrameworkCore.Internal.ReferenceDataEntityTypeConfiguration",
+      "kind": "class",
+      "project": "Granit.ReferenceData.EntityFrameworkCore",
+      "file": "src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataEntityTypeConfiguration.cs",
+      "line": 33,
+      "members": []
+    },
+    {
+      "name": "ReferenceDataServiceCollectionExtensions",
+      "fqn": "Granit.ReferenceData.Extensions.ReferenceDataServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.ReferenceData",
+      "file": "src/Granit.ReferenceData/Extensions/ReferenceDataServiceCollectionExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "AddGranitReferenceData",
+          "kind": "method",
+          "signature": "AddGranitReferenceData(this IServiceCollection services, Action<ReferenceDataOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitReferenceDataModule",
+      "fqn": "Granit.ReferenceData.GranitReferenceDataModule",
+      "kind": "class",
+      "project": "Granit.ReferenceData",
+      "file": "src/Granit.ReferenceData/GranitReferenceDataModule.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IReferenceDataSeeder",
+      "fqn": "Granit.ReferenceData.IReferenceDataSeeder",
+      "kind": "interface",
+      "project": "Granit.ReferenceData",
+      "file": "src/Granit.ReferenceData/IReferenceDataSeeder.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "SeedAsync",
+          "kind": "method",
+          "signature": "SeedAsync(IReferenceDataStoreReader<TEntity> storeReader, IReferenceDataStoreWriter<TEntity> storeWriter, CancellationToken cancellationToken = default)",
+          "returnType": "int Order { get; } Task"
+        }
+      ]
+    },
+    {
+      "name": "IReferenceDataStoreReader",
+      "fqn": "Granit.ReferenceData.IReferenceDataStoreReader",
+      "kind": "interface",
+      "project": "Granit.ReferenceData",
+      "file": "src/Granit.ReferenceData/IReferenceDataStoreReader.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetAllAsync",
+          "kind": "method",
+          "signature": "GetAllAsync(ReferenceDataQuery? query = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<TEntity>>"
+        },
+        {
+          "name": "GetByCodeAsync",
+          "kind": "method",
+          "signature": "GetByCodeAsync(string code, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TEntity?>"
+        }
+      ]
+    },
+    {
+      "name": "IReferenceDataStoreWriter",
+      "fqn": "Granit.ReferenceData.IReferenceDataStoreWriter",
+      "kind": "interface",
+      "project": "Granit.ReferenceData",
+      "file": "src/Granit.ReferenceData/IReferenceDataStoreWriter.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(TEntity entity, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UpdateAsync",
+          "kind": "method",
+          "signature": "UpdateAsync(TEntity entity, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SetActiveAsync",
+          "kind": "method",
+          "signature": "SetActiveAsync(string code, bool isActive, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ReferenceDataOptions",
+      "fqn": "Granit.ReferenceData.Options.ReferenceDataOptions",
+      "kind": "class",
+      "project": "Granit.ReferenceData",
+      "file": "src/Granit.ReferenceData/Options/ReferenceDataOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "FromHours",
+          "kind": "method",
+          "signature": "FromHours(1)",
+          "returnType": "TimeSpan CacheTimeToLive { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "ReferenceDataQuery",
+      "fqn": "Granit.ReferenceData.ReferenceDataQuery",
+      "kind": "record",
+      "project": "Granit.ReferenceData",
+      "file": "src/Granit.ReferenceData/ReferenceDataQuery.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "ActorKind",
+      "fqn": "Granit.Security.ActorKind",
+      "kind": "enum",
+      "project": "Granit.Security",
+      "file": "src/Granit.Security/ActorKind.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "GranitSecurityModule",
+      "fqn": "Granit.Security.GranitSecurityModule",
+      "kind": "class",
+      "project": "Granit.Security",
+      "file": "src/Granit.Security/GranitSecurityModule.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ICurrentUserService",
+      "fqn": "Granit.Security.ICurrentUserService",
+      "kind": "interface",
+      "project": "Granit.Security",
+      "file": "src/Granit.Security/ICurrentUserService.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "GetRoles",
+          "kind": "method",
+          "signature": "GetRoles()",
+          "returnType": "string? UserId { get; } string? UserName { get; } string? Email { get; } string? FirstName { get; } string? LastName { get; } bool IsAuthenticated { get; } IReadOnlyList<string>"
+        },
+        {
+          "name": "IsInRole",
+          "kind": "method",
+          "signature": "IsInRole(string role)",
+          "returnType": "bool"
+        },
+        {
+          "name": "ActorKind",
+          "kind": "property",
+          "signature": "ActorKind ActorKind",
+          "returnType": "ActorKind"
+        },
+        {
+          "name": "IsMachine",
+          "kind": "property",
+          "signature": "bool IsMachine",
+          "returnType": "bool"
+        },
+        {
+          "name": "ApiKeyId",
+          "kind": "property",
+          "signature": "Guid? ApiKeyId",
+          "returnType": "Guid?"
+        }
+      ]
+    },
+    {
+      "name": "SystemCurrentUserService",
+      "fqn": "Granit.Security.SystemCurrentUserService",
+      "kind": "class",
+      "project": "Granit.Security",
+      "file": "src/Granit.Security/SystemCurrentUserService.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "UserId",
+          "kind": "property",
+          "signature": "string? UserId",
+          "returnType": "string?"
+        },
+        {
+          "name": "UserName",
+          "kind": "property",
+          "signature": "string? UserName",
+          "returnType": "string?"
+        },
+        {
+          "name": "Email",
+          "kind": "property",
+          "signature": "string? Email",
+          "returnType": "string?"
+        },
+        {
+          "name": "FirstName",
+          "kind": "property",
+          "signature": "string? FirstName",
+          "returnType": "string?"
+        },
+        {
+          "name": "LastName",
+          "kind": "property",
+          "signature": "string? LastName",
+          "returnType": "string?"
+        },
+        {
+          "name": "IsAuthenticated",
+          "kind": "property",
+          "signature": "bool IsAuthenticated",
+          "returnType": "bool"
+        },
+        {
+          "name": "GetRoles",
+          "kind": "method",
+          "signature": "GetRoles()",
+          "returnType": "IReadOnlyList<string>"
+        },
+        {
+          "name": "IsInRole",
+          "kind": "method",
+          "signature": "IsInRole(string role)",
+          "returnType": "bool"
+        },
+        {
+          "name": "ActorKind",
+          "kind": "property",
+          "signature": "ActorKind ActorKind",
+          "returnType": "ActorKind"
+        },
+        {
+          "name": "IsMachine",
+          "kind": "property",
+          "signature": "bool IsMachine",
+          "returnType": "bool"
+        },
+        {
+          "name": "ApiKeyId",
+          "kind": "property",
+          "signature": "Guid? ApiKeyId",
+          "returnType": "Guid?"
+        }
+      ]
+    },
+    {
+      "name": "ISettingDefinitionContext",
+      "fqn": "Granit.Settings.Definitions.ISettingDefinitionContext",
+      "kind": "interface",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Definitions/ISettingDefinitionContext.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Add",
+          "kind": "method",
+          "signature": "Add(SettingDefinition definition)",
+          "returnType": "void"
+        },
+        {
+          "name": "GetOrNull",
+          "kind": "method",
+          "signature": "GetOrNull(string name)",
+          "returnType": "SettingDefinition?"
+        }
+      ]
+    },
+    {
+      "name": "ISettingDefinitionProvider",
+      "fqn": "Granit.Settings.Definitions.ISettingDefinitionProvider",
+      "kind": "interface",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Definitions/ISettingDefinitionProvider.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Define",
+          "kind": "method",
+          "signature": "Define(ISettingDefinitionContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "SettingDefinition",
+      "fqn": "Granit.Settings.Definitions.SettingDefinition",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Definitions/SettingDefinition.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Providers",
+          "kind": "property",
+          "signature": "IList<string> Providers",
+          "returnType": "IList<string>"
+        },
+        {
+          "name": "SettingDefinition",
+          "kind": "method",
+          "signature": "SettingDefinition(string name)",
+          "returnType": "string? DisplayName { get; init; } public string? Description { get; init; } public"
+        }
+      ]
+    },
+    {
+      "name": "SettingDefinitionManager",
+      "fqn": "Granit.Settings.Definitions.SettingDefinitionManager",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Definitions/SettingDefinitionManager.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetOrNull",
+          "kind": "method",
+          "signature": "GetOrNull(string name)",
+          "returnType": "SettingDefinition?"
+        },
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IReadOnlyCollection<SettingDefinition>"
+        }
+      ]
+    },
+    {
+      "name": "SettingValueResponse",
+      "fqn": "Granit.Settings.Endpoints.Dtos.SettingValueResponse",
+      "kind": "record",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/Dtos/SettingValueResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "UpdateSettingValueRequest",
+      "fqn": "Granit.Settings.Endpoints.Dtos.UpdateSettingValueRequest",
+      "kind": "record",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/Dtos/UpdateSettingValueRequest.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "AdminSettingsEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Settings.Endpoints.Extensions.AdminSettingsEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/Extensions/AdminSettingsEndpointRouteBuilderExtensions.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "MapGranitGlobalSettings",
+          "kind": "method",
+          "signature": "MapGranitGlobalSettings(this IEndpointRouteBuilder endpoints, Action<SettingsEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "UserSettingsEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Settings.Endpoints.Extensions.UserSettingsEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/Extensions/UserSettingsEndpointRouteBuilderExtensions.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "MapGranitUserSettings",
+          "kind": "method",
+          "signature": "MapGranitUserSettings(this IEndpointRouteBuilder endpoints, Action<SettingsEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitSettingsEndpointsModule",
+      "fqn": "Granit.Settings.Endpoints.GranitSettingsEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/GranitSettingsEndpointsModule.cs",
+      "line": 32,
+      "members": []
+    },
+    {
+      "name": "WellKnownSettingNames",
+      "fqn": "Granit.Settings.Endpoints.Internal.WellKnownSettingNames",
+      "kind": "class",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/Internal/WellKnownSettingNames.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "SettingsCultureMiddleware",
+      "fqn": "Granit.Settings.Endpoints.Middleware.SettingsCultureMiddleware",
+      "kind": "class",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/Middleware/SettingsCultureMiddleware.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "InvokeAsync",
+          "kind": "method",
+          "signature": "InvokeAsync(HttpContext context)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "SettingsEndpointsOptions",
+      "fqn": "Granit.Settings.Endpoints.Options.SettingsEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/Options/SettingsEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "UserRoutePrefix",
+          "kind": "property",
+          "signature": "string UserRoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "GlobalRoutePrefix",
+          "kind": "property",
+          "signature": "string GlobalRoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TenantRoutePrefix",
+          "kind": "property",
+          "signature": "string TenantRoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "SettingsPermissions",
+      "fqn": "Granit.Settings.Endpoints.Permissions.SettingsPermissions",
+      "kind": "class",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/Permissions/SettingsPermissions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "SettingRecord",
+      "fqn": "Granit.Settings.EntityFrameworkCore.Entities.SettingRecord",
+      "kind": "class",
+      "project": "Granit.Settings.EntityFrameworkCore",
+      "file": "src/Granit.Settings.EntityFrameworkCore/Entities/SettingRecord.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ProviderName",
+          "kind": "property",
+          "signature": "string ProviderName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "ModelBuilderExtensions",
+      "fqn": "Granit.Settings.EntityFrameworkCore.Extensions.ModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Settings.EntityFrameworkCore",
+      "file": "src/Granit.Settings.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "ConfigureSettingsModule",
+          "kind": "method",
+          "signature": "ConfigureSettingsModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "SettingsEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.Settings.EntityFrameworkCore.Extensions.SettingsEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Settings.EntityFrameworkCore",
+      "file": "src/Granit.Settings.EntityFrameworkCore/Extensions/SettingsEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "GranitSettingsDbProperties",
+      "fqn": "Granit.Settings.EntityFrameworkCore.GranitSettingsDbProperties",
+      "kind": "class",
+      "project": "Granit.Settings.EntityFrameworkCore",
+      "file": "src/Granit.Settings.EntityFrameworkCore/GranitSettingsDbProperties.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitSettingsEntityFrameworkCoreModule",
+      "fqn": "Granit.Settings.EntityFrameworkCore.GranitSettingsEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Settings.EntityFrameworkCore",
+      "file": "src/Granit.Settings.EntityFrameworkCore/GranitSettingsEntityFrameworkCoreModule.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "ISettingsDbContext",
+      "fqn": "Granit.Settings.EntityFrameworkCore.ISettingsDbContext",
+      "kind": "interface",
+      "project": "Granit.Settings.EntityFrameworkCore",
+      "file": "src/Granit.Settings.EntityFrameworkCore/ISettingsDbContext.cs",
+      "line": 30,
+      "members": []
+    },
+    {
+      "name": "SettingChangedEvent",
+      "fqn": "Granit.Settings.Events.SettingChangedEvent",
+      "kind": "record",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Events/SettingChangedEvent.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "SettingsServiceCollectionExtensions",
+      "fqn": "Granit.Settings.Extensions.SettingsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Extensions/SettingsServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitSettings",
+          "kind": "method",
+          "signature": "AddGranitSettings(this IServiceCollection services, IConfigurationSection? configuration = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitSettingsModule",
+      "fqn": "Granit.Settings.GranitSettingsModule",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/GranitSettingsModule.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "SettingsOptions",
+      "fqn": "Granit.Settings.Options.SettingsOptions",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Options/SettingsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(30)",
+          "returnType": "TimeSpan CacheExpiration { get; set; } = TimeSpan."
+        }
+      ]
+    },
+    {
+      "name": "ConfigurationSettingValueProvider",
+      "fqn": "Granit.Settings.Providers.ConfigurationSettingValueProvider",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Providers/ConfigurationSettingValueProvider.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Order",
+          "kind": "property",
+          "signature": "int Order",
+          "returnType": "int"
+        },
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(SettingDefinition definition, CancellationToken cancellationToken = default)",
+          "returnType": "Task<SettingValue?>"
+        },
+        {
+          "name": "ClearAsync",
+          "kind": "method",
+          "signature": "ClearAsync(SettingDefinition definition, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "DefaultValueSettingValueProvider",
+      "fqn": "Granit.Settings.Providers.DefaultValueSettingValueProvider",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Providers/DefaultValueSettingValueProvider.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Order",
+          "kind": "property",
+          "signature": "int Order",
+          "returnType": "int"
+        },
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(SettingDefinition definition, CancellationToken cancellationToken = default)",
+          "returnType": "Task<SettingValue?>"
+        },
+        {
+          "name": "ClearAsync",
+          "kind": "method",
+          "signature": "ClearAsync(SettingDefinition definition, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "GlobalSettingValueProvider",
+      "fqn": "Granit.Settings.Providers.GlobalSettingValueProvider",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Providers/GlobalSettingValueProvider.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Order",
+          "kind": "property",
+          "signature": "int Order",
+          "returnType": "int"
+        },
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(SettingDefinition definition, CancellationToken cancellationToken = default)",
+          "returnType": "Task<SettingValue?>"
+        }
+      ]
+    },
+    {
+      "name": "ISettingValueProvider",
+      "fqn": "Granit.Settings.Providers.ISettingValueProvider",
+      "kind": "interface",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Providers/ISettingValueProvider.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(SettingDefinition definition, CancellationToken cancellationToken = default)",
+          "returnType": "string Name { get; } int Order { get; } Task<SettingValue?>"
+        },
+        {
+          "name": "SetAsync",
+          "kind": "method",
+          "signature": "SetAsync(SettingDefinition definition, string? value, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "ClearAsync",
+          "kind": "method",
+          "signature": "ClearAsync(SettingDefinition definition, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "SettingValueProviderManager",
+      "fqn": "Granit.Settings.Providers.SettingValueProviderManager",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Providers/SettingValueProviderManager.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "OrderBy",
+          "kind": "method",
+          "signature": "OrderBy(p => p.Order)",
+          "returnType": "IReadOnlyList<ISettingValueProvider> Providers { get; } = [.. providers."
+        },
+        {
+          "name": "GetOrNull",
+          "kind": "method",
+          "signature": "GetOrNull(string name)",
+          "returnType": "ISettingValueProvider?"
+        }
+      ]
+    },
+    {
+      "name": "TenantSettingValueProvider",
+      "fqn": "Granit.Settings.Providers.TenantSettingValueProvider",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Providers/TenantSettingValueProvider.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Order",
+          "kind": "property",
+          "signature": "int Order",
+          "returnType": "int"
+        },
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(SettingDefinition definition, CancellationToken cancellationToken = default)",
+          "returnType": "Task<SettingValue?>"
+        }
+      ]
+    },
+    {
+      "name": "UserSettingValueProvider",
+      "fqn": "Granit.Settings.Providers.UserSettingValueProvider",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Providers/UserSettingValueProvider.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "Order",
+          "kind": "property",
+          "signature": "int Order",
+          "returnType": "int"
+        },
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(SettingDefinition definition, CancellationToken cancellationToken = default)",
+          "returnType": "Task<SettingValue?>"
+        }
+      ]
+    },
+    {
+      "name": "ISettingManager",
+      "fqn": "Granit.Settings.Services.ISettingManager",
+      "kind": "interface",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Services/ISettingManager.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SetGlobalAsync",
+          "kind": "method",
+          "signature": "SetGlobalAsync(string name, string? value, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SetForTenantAsync",
+          "kind": "method",
+          "signature": "SetForTenantAsync(Guid tenantId, string name, string? value, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SetForUserAsync",
+          "kind": "method",
+          "signature": "SetForUserAsync(string userId, string name, string? value, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(string name, string providerName, string? providerKey = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ISettingProvider",
+      "fqn": "Granit.Settings.Services.ISettingProvider",
+      "kind": "interface",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Services/ISettingProvider.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(string name, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string?>"
+        },
+        {
+          "name": "GetAllAsync",
+          "kind": "method",
+          "signature": "GetAllAsync(string[] names, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<SettingValue>>"
+        }
+      ]
+    },
+    {
+      "name": "SettingManager",
+      "fqn": "Granit.Settings.Services.SettingManager",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Services/SettingManager.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "SetGlobalAsync",
+          "kind": "method",
+          "signature": "SetGlobalAsync(string name, string? value, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "SettingProvider",
+      "fqn": "Granit.Settings.Services.SettingProvider",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Services/SettingProvider.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(string name, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string?>"
+        }
+      ]
+    },
+    {
+      "name": "InMemorySettingStore",
+      "fqn": "Granit.Settings.Stores.InMemorySettingStore",
+      "kind": "class",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Stores/InMemorySettingStore.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(string name, string providerName, string? providerKey, CancellationToken cancellationToken = default)",
+          "returnType": "Task<SettingValue?>"
+        }
+      ]
+    },
+    {
+      "name": "ISettingStoreReader",
+      "fqn": "Granit.Settings.Values.ISettingStoreReader",
+      "kind": "interface",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Values/ISettingStoreReader.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetOrNullAsync",
+          "kind": "method",
+          "signature": "GetOrNullAsync(string name, string providerName, string? providerKey, CancellationToken cancellationToken = default)",
+          "returnType": "Task<SettingValue?>"
+        },
+        {
+          "name": "GetListAsync",
+          "kind": "method",
+          "signature": "GetListAsync(string providerName, string? providerKey, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<SettingValue>>"
+        }
+      ]
+    },
+    {
+      "name": "ISettingStoreWriter",
+      "fqn": "Granit.Settings.Values.ISettingStoreWriter",
+      "kind": "interface",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Values/ISettingStoreWriter.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "SetAsync",
+          "kind": "method",
+          "signature": "SetAsync(string name, string providerName, string? providerKey, string? value, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(string name, string providerName, string? providerKey, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "SettingValue",
+      "fqn": "Granit.Settings.Values.SettingValue",
+      "kind": "record",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Values/SettingValue.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "AITemplateDataEnricher",
+      "fqn": "Granit.Templating.AI.AITemplateDataEnricher",
+      "kind": "class",
+      "project": "Granit.Templating.AI",
+      "file": "src/Granit.Templating.AI/AITemplateDataEnricher.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "BuildPrompt",
+          "kind": "method",
+          "signature": "BuildPrompt(TData data)",
+          "returnType": "int Order { get; } protected string"
+        },
+        {
+          "name": "EnrichAsync",
+          "kind": "method",
+          "signature": "EnrichAsync(TData data, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TData>"
+        }
+      ]
+    },
+    {
+      "name": "TemplatingAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Templating.AI.Extensions.TemplatingAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Templating.AI",
+      "file": "src/Granit.Templating.AI/Extensions/TemplatingAIHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitTemplatingAI",
+          "kind": "method",
+          "signature": "AddGranitTemplatingAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitTemplatingAIModule",
+      "fqn": "Granit.Templating.AI.GranitTemplatingAIModule",
+      "kind": "class",
+      "project": "Granit.Templating.AI",
+      "file": "src/Granit.Templating.AI/GranitTemplatingAIModule.cs",
+      "line": 24,
+      "members": []
+    },
+    {
+      "name": "IAITemplateAssistant",
+      "fqn": "Granit.Templating.AI.IAITemplateAssistant",
+      "kind": "interface",
+      "project": "Granit.Templating.AI",
+      "file": "src/Granit.Templating.AI/IAITemplateAssistant.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GenerateDraftAsync",
+          "kind": "method",
+          "signature": "GenerateDraftAsync(string description, Type dataType, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string?>"
+        }
+      ]
+    },
+    {
+      "name": "TemplatingAIOptions",
+      "fqn": "Granit.Templating.AI.Options.TemplatingAIOptions",
+      "kind": "class",
+      "project": "Granit.Templating.AI",
+      "file": "src/Granit.Templating.AI/Options/TemplatingAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string WorkspaceName",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "SaveTemplateCategoryRequest",
+      "fqn": "Granit.Templating.Endpoints.Dtos.SaveTemplateCategoryRequest",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/SaveTemplateCategoryRequest.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "SaveTemplateRequest",
+      "fqn": "Granit.Templating.Endpoints.Dtos.SaveTemplateRequest",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/SaveTemplateRequest.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "TemplateCategoryResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplateCategoryResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplateCategoryResponse.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "TemplateDetailResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplateDetailResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplateDetailResponse.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "TemplateHistoryResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplateHistoryResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplateHistoryResponse.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "TemplateLifecycleResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplateLifecycleResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplateLifecycleResponse.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "TemplateListItemResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplateListItemResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplateListItemResponse.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "TemplateListResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplateListResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplateListResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "TemplatePreviewRequest",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplatePreviewRequest",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplatePreviewRequest.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "TemplatePreviewResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplatePreviewResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplatePreviewResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "TemplateRevisionResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplateRevisionResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplateRevisionResponse.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "TemplateRevisionSummaryResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplateRevisionSummaryResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplateRevisionSummaryResponse.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "TemplateVariableItemResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplateVariableItemResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplateVariableItemResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "TemplateVariablesResponse",
+      "fqn": "Granit.Templating.Endpoints.Dtos.TemplateVariablesResponse",
+      "kind": "record",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Dtos/TemplateVariablesResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "TemplatingEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Templating.Endpoints.Extensions.TemplatingEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Extensions/TemplatingEndpointRouteBuilderExtensions.cs",
+      "line": 35,
+      "members": [
+        {
+          "name": "MapGranitTemplatingAdmin",
+          "kind": "method",
+          "signature": "MapGranitTemplatingAdmin(this IEndpointRouteBuilder endpoints, Action<TemplatingEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitTemplatingEndpointsModule",
+      "fqn": "Granit.Templating.Endpoints.GranitTemplatingEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/GranitTemplatingEndpointsModule.cs",
+      "line": 28,
+      "members": []
+    },
+    {
+      "name": "TemplatingEndpointsOptions",
+      "fqn": "Granit.Templating.Endpoints.Options.TemplatingEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Options/TemplatingEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "Templates",
+      "fqn": "Granit.Templating.Endpoints.Permissions.Templates",
+      "kind": "class",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Permissions/TemplatingPermissions.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "TemplatingPermissions",
+      "fqn": "Granit.Templating.Endpoints.Permissions.TemplatingPermissions",
+      "kind": "class",
+      "project": "Granit.Templating.Endpoints",
+      "file": "src/Granit.Templating.Endpoints/Permissions/TemplatingPermissions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ITemplateDataEnricher",
+      "fqn": "Granit.Templating.Enrichment.ITemplateDataEnricher",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Enrichment/ITemplateDataEnricher.cs",
+      "line": 35,
+      "members": [
+        {
+          "name": "EnrichAsync",
+          "kind": "method",
+          "signature": "EnrichAsync(TData data, CancellationToken cancellationToken = default)",
+          "returnType": "int Order { get; } Task<TData>"
+        }
+      ]
+    },
+    {
+      "name": "TemplatingEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.Templating.EntityFrameworkCore.Extensions.TemplatingEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Templating.EntityFrameworkCore",
+      "file": "src/Granit.Templating.EntityFrameworkCore/Extensions/TemplatingEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitTemplatingEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitTemplatingEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "TemplatingModelBuilderExtensions",
+      "fqn": "Granit.Templating.EntityFrameworkCore.Extensions.TemplatingModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Templating.EntityFrameworkCore",
+      "file": "src/Granit.Templating.EntityFrameworkCore/Extensions/TemplatingModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureTemplatingModule",
+          "kind": "method",
+          "signature": "ConfigureTemplatingModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitTemplatingDbProperties",
+      "fqn": "Granit.Templating.EntityFrameworkCore.GranitTemplatingDbProperties",
+      "kind": "class",
+      "project": "Granit.Templating.EntityFrameworkCore",
+      "file": "src/Granit.Templating.EntityFrameworkCore/GranitTemplatingDbProperties.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitTemplatingEntityFrameworkCoreModule",
+      "fqn": "Granit.Templating.EntityFrameworkCore.GranitTemplatingEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Templating.EntityFrameworkCore",
+      "file": "src/Granit.Templating.EntityFrameworkCore/GranitTemplatingEntityFrameworkCoreModule.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "TemplateNotFoundException",
+      "fqn": "Granit.Templating.Exceptions.TemplateNotFoundException",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Exceptions/TemplateNotFoundException.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "TemplateNotFoundException",
+          "kind": "method",
+          "signature": "TemplateNotFoundException(string templateName, string? culture = null)",
+          "returnType": "string TemplateName { get; } public string? Culture { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "TemplateTransitionDeniedException",
+      "fqn": "Granit.Templating.Exceptions.TemplateTransitionDeniedException",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Exceptions/TemplateTransitionDeniedException.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "TemplateTransitionDeniedException",
+          "kind": "method",
+          "signature": "TemplateTransitionDeniedException(TemplateLifecycleStatus from, TemplateLifecycleStatus to)",
+          "returnType": "TemplateLifecycleStatus From { get; } public TemplateLifecycleStatus To { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.Templating.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Extensions/ServiceCollectionExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "AddGranitTemplating",
+          "kind": "method",
+          "signature": "AddGranitTemplating(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "ITemplateGlobalContext",
+      "fqn": "Granit.Templating.GlobalContext.ITemplateGlobalContext",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/GlobalContext/ITemplateGlobalContext.cs",
+      "line": 36,
+      "members": [
+        {
+          "name": "Resolve",
+          "kind": "method",
+          "signature": "Resolve()",
+          "returnType": "string ContextName { get; } object"
+        }
+      ]
+    },
+    {
+      "name": "GranitTemplatingModule",
+      "fqn": "Granit.Templating.GranitTemplatingModule",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/GranitTemplatingModule.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "DocumentFormat",
+      "fqn": "Granit.Templating.Keys.DocumentFormat",
+      "kind": "enum",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Keys/DocumentFormat.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "TemplateKey",
+      "fqn": "Granit.Templating.Keys.TemplateKey",
+      "kind": "record",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Keys/TemplateKey.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "TemplateType",
+      "fqn": "Granit.Templating.Keys.TemplateType",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Keys/TemplateType.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "typeof",
+          "kind": "method",
+          "signature": "typeof(TData)",
+          "returnType": "string Name { get; } public Type DataType =>"
+        },
+        {
+          "name": "GetType",
+          "kind": "method",
+          "signature": "GetType()",
+          "returnType": "Assembly ResourceAssembly =>"
+        }
+      ]
+    },
+    {
+      "name": "TextTemplateType",
+      "fqn": "Granit.Templating.Keys.TextTemplateType",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Keys/TextTemplateType.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "BinaryRenderedContent",
+      "fqn": "Granit.Templating.Pipeline.BinaryRenderedContent",
+      "kind": "record",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Pipeline/RenderedContent.cs",
+      "line": 45,
+      "members": []
+    },
+    {
+      "name": "ITemplateEngine",
+      "fqn": "Granit.Templating.Pipeline.ITemplateEngine",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Pipeline/ITemplateEngine.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "CanRender",
+          "kind": "method",
+          "signature": "CanRender(TemplateDescriptor descriptor)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "ITemplateResolver",
+      "fqn": "Granit.Templating.Pipeline.ITemplateResolver",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Pipeline/ITemplateResolver.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "TryResolveAsync",
+          "kind": "method",
+          "signature": "TryResolveAsync(TemplateKey key, CancellationToken cancellationToken = default)",
+          "returnType": "int Priority { get; } Task<TemplateDescriptor?>"
+        }
+      ]
+    },
+    {
+      "name": "ITextTemplateRenderer",
+      "fqn": "Granit.Templating.Pipeline.ITextTemplateRenderer",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Pipeline/ITextTemplateRenderer.cs",
+      "line": 30,
+      "members": []
+    },
+    {
+      "name": "RenderedContent",
+      "fqn": "Granit.Templating.Pipeline.RenderedContent",
+      "kind": "record",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Pipeline/RenderedContent.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "RenderedTextResult",
+      "fqn": "Granit.Templating.Pipeline.RenderedTextResult",
+      "kind": "record",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Pipeline/RenderedTextResult.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "TemplateDescriptor",
+      "fqn": "Granit.Templating.Pipeline.TemplateDescriptor",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Pipeline/TemplateDescriptor.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "TextRenderedContent",
+      "fqn": "Granit.Templating.Pipeline.TextRenderedContent",
+      "kind": "record",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Pipeline/RenderedContent.cs",
+      "line": 37,
+      "members": []
+    },
+    {
+      "name": "TemplateParseException",
+      "fqn": "Granit.Templating.Scriban.Exceptions.TemplateParseException",
+      "kind": "class",
+      "project": "Granit.Templating.Scriban",
+      "file": "src/Granit.Templating.Scriban/Exceptions/TemplateParseException.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "TemplateParseException",
+          "kind": "method",
+          "signature": "TemplateParseException(IReadOnlyList<LogMessage> errors)",
+          "returnType": "IReadOnlyList<LogMessage> Errors { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.Templating.Scriban.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Templating.Scriban",
+      "file": "src/Granit.Templating.Scriban/Extensions/ServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitTemplatingWithScriban",
+          "kind": "method",
+          "signature": "AddGranitTemplatingWithScriban(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitTemplatingScribanModule",
+      "fqn": "Granit.Templating.Scriban.GranitTemplatingScribanModule",
+      "kind": "class",
+      "project": "Granit.Templating.Scriban",
+      "file": "src/Granit.Templating.Scriban/GranitTemplatingScribanModule.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IDocumentTemplateStoreReader",
+      "fqn": "Granit.Templating.Store.IDocumentTemplateStoreReader",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/IDocumentTemplateStoreReader.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "TryGetPublishedAsync",
+          "kind": "method",
+          "signature": "TryGetPublishedAsync(TemplateKey key, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TemplateDescriptor?>"
+        },
+        {
+          "name": "TryGetDraftAsync",
+          "kind": "method",
+          "signature": "TryGetDraftAsync(TemplateKey key, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TemplateRevision?>"
+        },
+        {
+          "name": "ListTemplatesAsync",
+          "kind": "method",
+          "signature": "ListTemplatesAsync(TemplateListFilter filter, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedTemplateResult>"
+        },
+        {
+          "name": "GetHistoryAsync",
+          "kind": "method",
+          "signature": "GetHistoryAsync(TemplateKey key, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<TemplateRevision>>"
+        }
+      ]
+    },
+    {
+      "name": "IDocumentTemplateStoreWriter",
+      "fqn": "Granit.Templating.Store.IDocumentTemplateStoreWriter",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/IDocumentTemplateStoreWriter.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "SaveDraftAsync",
+          "kind": "method",
+          "signature": "SaveDraftAsync(TemplateKey key, string content, string mimeType, string updatedBy, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "PublishAsync",
+          "kind": "method",
+          "signature": "PublishAsync(TemplateKey key, string publishedBy, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UnpublishAsync",
+          "kind": "method",
+          "signature": "UnpublishAsync(TemplateKey key, string unpublishedBy, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteDraftAsync",
+          "kind": "method",
+          "signature": "DeleteDraftAsync(TemplateKey key, string deletedBy, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ITemplateCategoryStoreReader",
+      "fqn": "Granit.Templating.Store.ITemplateCategoryStoreReader",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/ITemplateCategoryStoreReader.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ListCategoriesAsync",
+          "kind": "method",
+          "signature": "ListCategoriesAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<TemplateCategory>>"
+        },
+        {
+          "name": "GetCategoryAsync",
+          "kind": "method",
+          "signature": "GetCategoryAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TemplateCategory?>"
+        }
+      ]
+    },
+    {
+      "name": "ITemplateCategoryStoreWriter",
+      "fqn": "Granit.Templating.Store.ITemplateCategoryStoreWriter",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/ITemplateCategoryStoreWriter.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "CreateCategoryAsync",
+          "kind": "method",
+          "signature": "CreateCategoryAsync(string name, string? description, string? icon, int sortOrder, string createdBy, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TemplateCategory>"
+        },
+        {
+          "name": "UpdateCategoryAsync",
+          "kind": "method",
+          "signature": "UpdateCategoryAsync(Guid id, string name, string? description, string? icon, int sortOrder, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TemplateCategory>"
+        },
+        {
+          "name": "DeleteCategoryAsync",
+          "kind": "method",
+          "signature": "DeleteCategoryAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ITemplateTransitionHook",
+      "fqn": "Granit.Templating.Store.ITemplateTransitionHook",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/ITemplateTransitionHook.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "CanTransitionAsync",
+          "kind": "method",
+          "signature": "CanTransitionAsync(TemplateLifecycleStatus from, TemplateLifecycleStatus target, CancellationToken cancellationToken = default)",
+          "returnType": "bool IsWorkflowEnabled { get; } Task<bool>"
+        },
+        {
+          "name": "OnTransitionedAsync",
+          "kind": "method",
+          "signature": "OnTransitionedAsync(Guid revisionId, TemplateLifecycleStatus from, TemplateLifecycleStatus target, string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "PagedTemplateResult",
+      "fqn": "Granit.Templating.Store.PagedTemplateResult",
+      "kind": "record",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/PagedTemplateResult.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "TemplateCategory",
+      "fqn": "Granit.Templating.Store.TemplateCategory",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/TemplateCategory.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "TemplateLifecycleStatus",
+      "fqn": "Granit.Templating.Store.TemplateLifecycleStatus",
+      "kind": "enum",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/TemplateLifecycleStatus.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "TemplateListFilter",
+      "fqn": "Granit.Templating.Store.TemplateListFilter",
+      "kind": "record",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/TemplateListFilter.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "TemplateRevision",
+      "fqn": "Granit.Templating.Store.TemplateRevision",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/TemplateRevision.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "TemplateSummary",
+      "fqn": "Granit.Templating.Store.TemplateSummary",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Store/TemplateSummary.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "TemplateCategoryLocalizationResource",
+      "fqn": "Granit.Templating.TemplateCategoryLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/TemplateCategoryLocalizationResource.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "TemplateLocalizationResource",
+      "fqn": "Granit.Templating.TemplateLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/TemplateLocalizationResource.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.Templating.Workflow.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Templating.Workflow",
+      "file": "src/Granit.Templating.Workflow/Extensions/ServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitTemplatingWorkflow",
+          "kind": "method",
+          "signature": "AddGranitTemplatingWorkflow(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitTemplatingWorkflowModule",
+      "fqn": "Granit.Templating.Workflow.GranitTemplatingWorkflowModule",
+      "kind": "class",
+      "project": "Granit.Templating.Workflow",
+      "file": "src/Granit.Templating.Workflow/GranitTemplatingWorkflowModule.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "TestDbContextServiceCollectionExtensions",
+      "fqn": "Granit.Testing.EntityFrameworkCore.Extensions.TestDbContextServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Testing.EntityFrameworkCore",
+      "file": "src/Granit.Testing.EntityFrameworkCore/Extensions/TestDbContextServiceCollectionExtensions.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "GranitTestingEntityFrameworkCoreModule",
+      "fqn": "Granit.Testing.EntityFrameworkCore.GranitTestingEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Testing.EntityFrameworkCore",
+      "file": "src/Granit.Testing.EntityFrameworkCore/GranitTestingEntityFrameworkCoreModule.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "InMemoryDbContextFactory",
+      "fqn": "Granit.Testing.EntityFrameworkCore.InMemoryDbContextFactory",
+      "kind": "class",
+      "project": "Granit.Testing.EntityFrameworkCore",
+      "file": "src/Granit.Testing.EntityFrameworkCore/InMemoryDbContextFactory.cs",
+      "line": 29,
+      "members": []
+    },
+    {
+      "name": "SqliteDbContextFactory",
+      "fqn": "Granit.Testing.EntityFrameworkCore.SqliteDbContextFactory",
+      "kind": "class",
+      "project": "Granit.Testing.EntityFrameworkCore",
+      "file": "src/Granit.Testing.EntityFrameworkCore/SqliteDbContextFactory.cs",
+      "line": 29,
+      "members": []
+    },
+    {
+      "name": "FakeClock",
+      "fqn": "Granit.Testing.Fakes.FakeClock",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/Fakes/FakeClock.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "Normalize",
+          "kind": "method",
+          "signature": "Normalize(DateTimeOffset dateTime)",
+          "returnType": "DateTimeOffset"
+        },
+        {
+          "name": "ConvertToUserTime",
+          "kind": "method",
+          "signature": "ConvertToUserTime(DateTimeOffset utcDateTime)",
+          "returnType": "DateTimeOffset"
+        },
+        {
+          "name": "ConvertToUtc",
+          "kind": "method",
+          "signature": "ConvertToUtc(DateTimeOffset dateTime)",
+          "returnType": "DateTimeOffset"
+        },
+        {
+          "name": "Advance",
+          "kind": "method",
+          "signature": "Advance(TimeSpan duration)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "FakeCurrentTenant",
+      "fqn": "Granit.Testing.Fakes.FakeCurrentTenant",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/Fakes/FakeCurrentTenant.cs",
+      "line": 20,
+      "members": []
+    },
+    {
+      "name": "FakeCurrentUser",
+      "fqn": "Granit.Testing.Fakes.FakeCurrentUser",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/Fakes/FakeCurrentUser.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "IsInRole",
+          "kind": "method",
+          "signature": "IsInRole(string role)",
+          "returnType": "bool"
+        },
+        {
+          "name": "AddRole",
+          "kind": "method",
+          "signature": "AddRole(string role)",
+          "returnType": "void"
+        },
+        {
+          "name": "ClearRoles",
+          "kind": "method",
+          "signature": "ClearRoles()",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "FakeGuidGenerator",
+      "fqn": "Granit.Testing.Fakes.FakeGuidGenerator",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/Fakes/FakeGuidGenerator.cs",
+      "line": 28,
+      "members": []
+    },
+    {
+      "name": "GranitEntityFakerExtensions",
+      "fqn": "Granit.Testing.Generators.GranitEntityFakerExtensions",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/Generators/GranitEntityFakerExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "GranitFaker",
+      "fqn": "Granit.Testing.Generators.GranitFaker",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/Generators/GranitFaker.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "CurrentUser",
+          "kind": "method",
+          "signature": "CurrentUser()",
+          "returnType": "Faker<FakeCurrentUser>"
+        },
+        {
+          "name": "Tenant",
+          "kind": "method",
+          "signature": "Tenant()",
+          "returnType": "Faker<FakeCurrentTenant>"
+        }
+      ]
+    },
+    {
+      "name": "GranitTestFixture",
+      "fqn": "Granit.Testing.GranitTestFixture",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/GranitTestFixture.cs",
+      "line": 35,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "FakeCurrentTenant Tenant { get; } ="
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "FakeCurrentUser User { get; } ="
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "FakeClock Clock { get; } ="
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "FakeGuidGenerator GuidGenerator { get; } ="
+        },
+        {
+          "name": "ServiceProvider",
+          "kind": "property",
+          "signature": "IServiceProvider ServiceProvider",
+          "returnType": "IServiceProvider"
+        },
+        {
+          "name": "BuildAsync",
+          "kind": "method",
+          "signature": "BuildAsync(Action<IServiceCollection>? configureServices = null)",
+          "returnType": "Task"
+        },
+        {
+          "name": "Dispose",
+          "kind": "method",
+          "signature": "Dispose()",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GranitTestingModule",
+      "fqn": "Granit.Testing.GranitTestingModule",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/GranitTestingModule.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "GranitWebApplicationFactory",
+      "fqn": "Granit.Testing.GranitWebApplicationFactory",
+      "kind": "class",
+      "project": "Granit.Testing",
+      "file": "src/Granit.Testing/GranitWebApplicationFactory.cs",
+      "line": 33,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "FakeCurrentTenant Tenant { get; } ="
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "FakeCurrentUser User { get; } ="
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "FakeClock Clock { get; } ="
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "FakeGuidGenerator GuidGenerator { get; } ="
+        }
+      ]
+    },
+    {
+      "name": "AnomalyReport",
+      "fqn": "Granit.Timeline.AI.AnomalyReport",
+      "kind": "record",
+      "project": "Granit.Timeline.AI",
+      "file": "src/Granit.Timeline.AI/AnomalyReport.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "TimelineAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Timeline.AI.Extensions.TimelineAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Timeline.AI",
+      "file": "src/Granit.Timeline.AI/Extensions/TimelineAIHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitTimelineAI",
+          "kind": "method",
+          "signature": "AddGranitTimelineAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitTimelineAIModule",
+      "fqn": "Granit.Timeline.AI.GranitTimelineAIModule",
+      "kind": "class",
+      "project": "Granit.Timeline.AI",
+      "file": "src/Granit.Timeline.AI/GranitTimelineAIModule.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "ITimelineAnomalyDetector",
+      "fqn": "Granit.Timeline.AI.ITimelineAnomalyDetector",
+      "kind": "interface",
+      "project": "Granit.Timeline.AI",
+      "file": "src/Granit.Timeline.AI/ITimelineAnomalyDetector.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "DetectAnomaliesAsync",
+          "kind": "method",
+          "signature": "DetectAnomaliesAsync(string entityType, Guid entityId, CancellationToken ct = default)",
+          "returnType": "Task<AnomalyReport>"
+        }
+      ]
+    },
+    {
+      "name": "ITimelineSummarizer",
+      "fqn": "Granit.Timeline.AI.ITimelineSummarizer",
+      "kind": "interface",
+      "project": "Granit.Timeline.AI",
+      "file": "src/Granit.Timeline.AI/ITimelineSummarizer.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SummarizeAsync",
+          "kind": "method",
+          "signature": "SummarizeAsync(string entityType, Guid entityId, DateTimeOffset? since = null, CancellationToken ct = default)",
+          "returnType": "Task<TimelineSummary>"
+        }
+      ]
+    },
+    {
+      "name": "TimelineAIOptions",
+      "fqn": "Granit.Timeline.AI.Options.TimelineAIOptions",
+      "kind": "class",
+      "project": "Granit.Timeline.AI",
+      "file": "src/Granit.Timeline.AI/Options/TimelineAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string? WorkspaceName",
+          "returnType": "string?"
+        },
+        {
+          "name": "MaxEntriesToAnalyze",
+          "kind": "property",
+          "signature": "int MaxEntriesToAnalyze",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "TimelineAnomaly",
+      "fqn": "Granit.Timeline.AI.TimelineAnomaly",
+      "kind": "record",
+      "project": "Granit.Timeline.AI",
+      "file": "src/Granit.Timeline.AI/TimelineAnomaly.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "TimelineSummary",
+      "fqn": "Granit.Timeline.AI.TimelineSummary",
+      "kind": "record",
+      "project": "Granit.Timeline.AI",
+      "file": "src/Granit.Timeline.AI/TimelineSummary.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ITimelineFollowerService",
+      "fqn": "Granit.Timeline.Abstractions.ITimelineFollowerService",
+      "kind": "interface",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Abstractions/ITimelineFollowerService.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "FollowAsync",
+          "kind": "method",
+          "signature": "FollowAsync(string userId, string entityType, string entityId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UnfollowAsync",
+          "kind": "method",
+          "signature": "UnfollowAsync(string userId, string entityType, string entityId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "GetFollowerIdsAsync",
+          "kind": "method",
+          "signature": "GetFollowerIdsAsync(string entityType, string entityId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<string>>"
+        },
+        {
+          "name": "IsFollowingAsync",
+          "kind": "method",
+          "signature": "IsFollowingAsync(string userId, string entityType, string entityId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "ITimelineNotifier",
+      "fqn": "Granit.Timeline.Abstractions.ITimelineNotifier",
+      "kind": "interface",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Abstractions/ITimelineNotifier.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "NotifyEntryPostedAsync",
+          "kind": "method",
+          "signature": "NotifyEntryPostedAsync(TimelineEntry entry, IReadOnlyList<string> followerUserIds, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "NotifyMentionedUsersAsync",
+          "kind": "method",
+          "signature": "NotifyMentionedUsersAsync(TimelineEntry entry, IReadOnlyList<string> mentionedUserIds, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ITimelineReader",
+      "fqn": "Granit.Timeline.Abstractions.ITimelineReader",
+      "kind": "interface",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Abstractions/ITimelineReader.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "GetStreamAsync",
+          "kind": "method",
+          "signature": "GetStreamAsync(string entityType, string entityId, int page = 1, int pageSize = QueryingDefaults.DefaultPageSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<TimelineStreamEntry>>"
+        }
+      ]
+    },
+    {
+      "name": "ITimelineWriter",
+      "fqn": "Granit.Timeline.Abstractions.ITimelineWriter",
+      "kind": "interface",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Abstractions/ITimelineWriter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "PostEntryAsync",
+          "kind": "method",
+          "signature": "PostEntryAsync(string entityType, string entityId, TimelineEntryType entryType, string body, Guid? parentEntryId = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TimelineEntry>"
+        },
+        {
+          "name": "DeleteEntryAsync",
+          "kind": "method",
+          "signature": "DeleteEntryAsync(Guid entryId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "AddAttachmentAsync",
+          "kind": "method",
+          "signature": "AddAttachmentAsync(Guid entryId, Guid blobId, string fileName, string contentType, long sizeBytes, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TimelineAttachment>"
+        }
+      ]
+    },
+    {
+      "name": "TimelineAttachment",
+      "fqn": "Granit.Timeline.Domain.TimelineAttachment",
+      "kind": "class",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Domain/TimelineAttachment.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "EntryId",
+          "kind": "property",
+          "signature": "Guid EntryId",
+          "returnType": "Guid"
+        },
+        {
+          "name": "ContentType",
+          "kind": "property",
+          "signature": "string ContentType",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "TimelineEntry",
+      "fqn": "Granit.Timeline.Domain.TimelineEntry",
+      "kind": "class",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Domain/TimelineEntry.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, string entityType, string entityId, TimelineEntryType entryType, string body, string authorId, string authorName, DateTimeOffset createdAt, string createdBy, Guid? tenantId = null, Guid? parentEntryId = null)",
+          "returnType": "TimelineEntry"
+        },
+        {
+          "name": "EntityType",
+          "kind": "property",
+          "signature": "string EntityType",
+          "returnType": "string"
+        },
+        {
+          "name": "EntityId",
+          "kind": "property",
+          "signature": "string EntityId",
+          "returnType": "string"
+        },
+        {
+          "name": "EntryType",
+          "kind": "property",
+          "signature": "TimelineEntryType EntryType",
+          "returnType": "TimelineEntryType"
+        },
+        {
+          "name": "AuthorId",
+          "kind": "property",
+          "signature": "string AuthorId",
+          "returnType": "string"
+        },
+        {
+          "name": "AuthorName",
+          "kind": "property",
+          "signature": "string AuthorName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "TimelineEntryType",
+      "fqn": "Granit.Timeline.Domain.TimelineEntryType",
+      "kind": "enum",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Domain/TimelineEntryType.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "TimelineEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Timeline.Endpoints.Extensions.TimelineEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Timeline.Endpoints",
+      "file": "src/Granit.Timeline.Endpoints/Extensions/TimelineEndpointRouteBuilderExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "MapTimelineEndpoints",
+          "kind": "method",
+          "signature": "MapTimelineEndpoints(this IEndpointRouteBuilder endpoints, Action<TimelineEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitTimelineEndpointsModule",
+      "fqn": "Granit.Timeline.Endpoints.GranitTimelineEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Timeline.Endpoints",
+      "file": "src/Granit.Timeline.Endpoints/GranitTimelineEndpointsModule.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "TimelineAuthorizationPolicy",
+      "fqn": "Granit.Timeline.Endpoints.Internal.TimelineAuthorizationPolicy",
+      "kind": "class",
+      "project": "Granit.Timeline.Endpoints",
+      "file": "src/Granit.Timeline.Endpoints/Internal/TimelineAuthorizationPolicy.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "TimelineEndpointsOptions",
+      "fqn": "Granit.Timeline.Endpoints.Options.TimelineEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Timeline.Endpoints",
+      "file": "src/Granit.Timeline.Endpoints/Options/TimelineEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "Entries",
+      "fqn": "Granit.Timeline.Endpoints.Permissions.Entries",
+      "kind": "class",
+      "project": "Granit.Timeline.Endpoints",
+      "file": "src/Granit.Timeline.Endpoints/Permissions/TimelinePermissions.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "TimelinePermissions",
+      "fqn": "Granit.Timeline.Endpoints.Permissions.TimelinePermissions",
+      "kind": "class",
+      "project": "Granit.Timeline.Endpoints",
+      "file": "src/Granit.Timeline.Endpoints/Permissions/TimelinePermissions.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "TimelineEfCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.Timeline.EntityFrameworkCore.Extensions.TimelineEfCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Timeline.EntityFrameworkCore",
+      "file": "src/Granit.Timeline.EntityFrameworkCore/Extensions/TimelineEfCoreHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitTimelineEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitTimelineEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "TimelineModelBuilderExtensions",
+      "fqn": "Granit.Timeline.EntityFrameworkCore.Extensions.TimelineModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Timeline.EntityFrameworkCore",
+      "file": "src/Granit.Timeline.EntityFrameworkCore/Extensions/TimelineModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureTimelineModule",
+          "kind": "method",
+          "signature": "ConfigureTimelineModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitTimelineDbProperties",
+      "fqn": "Granit.Timeline.EntityFrameworkCore.GranitTimelineDbProperties",
+      "kind": "class",
+      "project": "Granit.Timeline.EntityFrameworkCore",
+      "file": "src/Granit.Timeline.EntityFrameworkCore/GranitTimelineDbProperties.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitTimelineEntityFrameworkCoreModule",
+      "fqn": "Granit.Timeline.EntityFrameworkCore.GranitTimelineEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Timeline.EntityFrameworkCore",
+      "file": "src/Granit.Timeline.EntityFrameworkCore/GranitTimelineEntityFrameworkCoreModule.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "TimelineEntryPostedEvent",
+      "fqn": "Granit.Timeline.Events.TimelineEntryPostedEvent",
+      "kind": "record",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Events/TimelineEntryPostedEvent.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "TimelineEntrySoftDeletedEvent",
+      "fqn": "Granit.Timeline.Events.TimelineEntrySoftDeletedEvent",
+      "kind": "record",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Events/TimelineEntrySoftDeletedEvent.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "TimelineServiceCollectionExtensions",
+      "fqn": "Granit.Timeline.Extensions.TimelineServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Extensions/TimelineServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitTimeline",
+          "kind": "method",
+          "signature": "AddGranitTimeline(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitTimelineModule",
+      "fqn": "Granit.Timeline.GranitTimelineModule",
+      "kind": "class",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/GranitTimelineModule.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ITimelined",
+      "fqn": "Granit.Timeline.ITimelined",
+      "kind": "interface",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/ITimelined.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "MentionParser",
+      "fqn": "Granit.Timeline.Internal.MentionParser",
+      "kind": "class",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/Internal/MentionParser.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "ExtractMentionedUserIds",
+          "kind": "method",
+          "signature": "ExtractMentionedUserIds(string body)",
+          "returnType": "IReadOnlyList<string>"
+        }
+      ]
+    },
+    {
+      "name": "TimelineNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Timeline.Notifications.Extensions.TimelineNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Timeline.Notifications",
+      "file": "src/Granit.Timeline.Notifications/Extensions/TimelineNotificationsServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitTimelineNotifications",
+          "kind": "method",
+          "signature": "AddGranitTimelineNotifications(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitTimelineNotificationsModule",
+      "fqn": "Granit.Timeline.Notifications.GranitTimelineNotificationsModule",
+      "kind": "class",
+      "project": "Granit.Timeline.Notifications",
+      "file": "src/Granit.Timeline.Notifications/GranitTimelineNotificationsModule.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "TimelineCommentNotificationData",
+      "fqn": "Granit.Timeline.Notifications.TimelineCommentNotificationData",
+      "kind": "record",
+      "project": "Granit.Timeline.Notifications",
+      "file": "src/Granit.Timeline.Notifications/TimelineCommentNotificationType.cs",
+      "line": 31,
+      "members": []
+    },
+    {
+      "name": "TimelineCommentNotificationType",
+      "fqn": "Granit.Timeline.Notifications.TimelineCommentNotificationType",
+      "kind": "class",
+      "project": "Granit.Timeline.Notifications",
+      "file": "src/Granit.Timeline.Notifications/TimelineCommentNotificationType.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "TimelineCommentNotificationType Instance ="
+        },
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "TimelineMentionNotificationData",
+      "fqn": "Granit.Timeline.Notifications.TimelineMentionNotificationData",
+      "kind": "record",
+      "project": "Granit.Timeline.Notifications",
+      "file": "src/Granit.Timeline.Notifications/TimelineMentionNotificationType.cs",
+      "line": 31,
+      "members": []
+    },
+    {
+      "name": "TimelineMentionNotificationType",
+      "fqn": "Granit.Timeline.Notifications.TimelineMentionNotificationType",
+      "kind": "class",
+      "project": "Granit.Timeline.Notifications",
+      "file": "src/Granit.Timeline.Notifications/TimelineMentionNotificationType.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "TimelineMentionNotificationType Instance ="
+        },
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "PostTimelineEntryRequest",
+      "fqn": "Granit.Timeline.PostTimelineEntryRequest",
+      "kind": "record",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/PostTimelineEntryRequest.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "TimelineAttachmentInfo",
+      "fqn": "Granit.Timeline.TimelineAttachmentInfo",
+      "kind": "record",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/TimelineAttachmentInfo.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "TimelineStreamEntry",
+      "fqn": "Granit.Timeline.TimelineStreamEntry",
+      "kind": "record",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/TimelineStreamEntry.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Id",
+          "kind": "property",
+          "signature": "required Guid Id",
+          "returnType": "required Guid"
+        },
+        {
+          "name": "Attachments",
+          "kind": "property",
+          "signature": "IReadOnlyList<TimelineAttachmentInfo> Attachments",
+          "returnType": "IReadOnlyList<TimelineAttachmentInfo>"
+        }
+      ]
+    },
+    {
+      "name": "TimelineStreamEntryType",
+      "fqn": "Granit.Timeline.TimelineStreamEntryType",
+      "kind": "enum",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/TimelineStreamEntryType.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "TimelinedAttribute",
+      "fqn": "Granit.Timeline.TimelinedAttribute",
+      "kind": "class",
+      "project": "Granit.Timeline",
+      "file": "src/Granit.Timeline/TimelinedAttribute.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "EntityTypeName",
+          "kind": "property",
+          "signature": "string EntityTypeName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "Clock",
+      "fqn": "Granit.Timing.Clock",
+      "kind": "class",
+      "project": "Granit.Timing",
+      "file": "src/Granit.Timing/Clock.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetUtcNow",
+          "kind": "method",
+          "signature": "GetUtcNow()",
+          "returnType": "DateTimeOffset Now => _timeProvider."
+        },
+        {
+          "name": "SupportsMultipleTimezone",
+          "kind": "property",
+          "signature": "bool SupportsMultipleTimezone",
+          "returnType": "bool"
+        },
+        {
+          "name": "Normalize",
+          "kind": "method",
+          "signature": "Normalize(DateTimeOffset dateTime)",
+          "returnType": "DateTimeOffset"
+        },
+        {
+          "name": "ConvertToUserTime",
+          "kind": "method",
+          "signature": "ConvertToUserTime(DateTimeOffset utcDateTime)",
+          "returnType": "DateTimeOffset"
+        }
+      ]
+    },
+    {
+      "name": "CurrentTimezoneProvider",
+      "fqn": "Granit.Timing.CurrentTimezoneProvider",
+      "kind": "class",
+      "project": "Granit.Timing",
+      "file": "src/Granit.Timing/CurrentTimezoneProvider.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "DisableDateTimeNormalizationAttribute",
+      "fqn": "Granit.Timing.DisableDateTimeNormalizationAttribute",
+      "kind": "class",
+      "project": "Granit.Timing",
+      "file": "src/Granit.Timing/DisableDateTimeNormalizationAttribute.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "TimingServiceCollectionExtensions",
+      "fqn": "Granit.Timing.Extensions.TimingServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Timing",
+      "file": "src/Granit.Timing/Extensions/TimingServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitTiming",
+          "kind": "method",
+          "signature": "AddGranitTiming(this IServiceCollection services, Action<ClockOptions>? configure = null)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitTimingModule",
+      "fqn": "Granit.Timing.GranitTimingModule",
+      "kind": "class",
+      "project": "Granit.Timing",
+      "file": "src/Granit.Timing/GranitTimingModule.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IClock",
+      "fqn": "Granit.Timing.IClock",
+      "kind": "interface",
+      "project": "Granit.Timing",
+      "file": "src/Granit.Timing/IClock.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Normalize",
+          "kind": "method",
+          "signature": "Normalize(DateTimeOffset dateTime)",
+          "returnType": "DateTimeOffset Now { get; } bool SupportsMultipleTimezone { get; } DateTimeOffset"
+        },
+        {
+          "name": "ConvertToUserTime",
+          "kind": "method",
+          "signature": "ConvertToUserTime(DateTimeOffset utcDateTime)",
+          "returnType": "DateTimeOffset"
+        },
+        {
+          "name": "ConvertToUtc",
+          "kind": "method",
+          "signature": "ConvertToUtc(DateTimeOffset dateTime)",
+          "returnType": "DateTimeOffset"
+        }
+      ]
+    },
+    {
+      "name": "ICurrentTimezoneProvider",
+      "fqn": "Granit.Timing.ICurrentTimezoneProvider",
+      "kind": "interface",
+      "project": "Granit.Timing",
+      "file": "src/Granit.Timing/ICurrentTimezoneProvider.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ClockOptions",
+      "fqn": "Granit.Timing.Options.ClockOptions",
+      "kind": "class",
+      "project": "Granit.Timing",
+      "file": "src/Granit.Timing/Options/ClockOptions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ValidationAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Validation.AI.Extensions.ValidationAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.AI",
+      "file": "src/Granit.Validation.AI/Extensions/ValidationAIHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitValidationAI",
+          "kind": "method",
+          "signature": "AddGranitValidationAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitValidationAIModule",
+      "fqn": "Granit.Validation.AI.GranitValidationAIModule",
+      "kind": "class",
+      "project": "Granit.Validation.AI",
+      "file": "src/Granit.Validation.AI/GranitValidationAIModule.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "IAIContentModerator",
+      "fqn": "Granit.Validation.AI.IAIContentModerator",
+      "kind": "interface",
+      "project": "Granit.Validation.AI",
+      "file": "src/Granit.Validation.AI/IAIContentModerator.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "ModerateAsync",
+          "kind": "method",
+          "signature": "ModerateAsync(string text, string? context = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ModerationResult>"
+        }
+      ]
+    },
+    {
+      "name": "ModerationCategory",
+      "fqn": "Granit.Validation.AI.ModerationCategory",
+      "kind": "enum",
+      "project": "Granit.Validation.AI",
+      "file": "src/Granit.Validation.AI/ModerationResult.cs",
+      "line": 30,
+      "members": []
+    },
+    {
+      "name": "ModerationFlag",
+      "fqn": "Granit.Validation.AI.ModerationFlag",
+      "kind": "record",
+      "project": "Granit.Validation.AI",
+      "file": "src/Granit.Validation.AI/ModerationResult.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "ModerationResult",
+      "fqn": "Granit.Validation.AI.ModerationResult",
+      "kind": "record",
+      "project": "Granit.Validation.AI",
+      "file": "src/Granit.Validation.AI/ModerationResult.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ValidationAIOptions",
+      "fqn": "Granit.Validation.AI.Options.ValidationAIOptions",
+      "kind": "class",
+      "project": "Granit.Validation.AI",
+      "file": "src/Granit.Validation.AI/Options/ValidationAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string WorkspaceName",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        },
+        {
+          "name": "SeverityThreshold",
+          "kind": "property",
+          "signature": "double SeverityThreshold",
+          "returnType": "double"
+        }
+      ]
+    },
+    {
+      "name": "GranitEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Validation.AspNetCore.GranitEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/AspNetCore/GranitEndpointRouteBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "MapGranitGroup",
+          "kind": "method",
+          "signature": "MapGranitGroup(this IEndpointRouteBuilder endpoints, string prefix)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "SkipAutoValidationAttribute",
+      "fqn": "Granit.Validation.AspNetCore.SkipAutoValidationAttribute",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/AspNetCore/SkipAutoValidationAttribute.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "ValidationFieldStatus",
+      "fqn": "Granit.Validation.Endpoints.Dtos.ValidationFieldStatus",
+      "kind": "enum",
+      "project": "Granit.Validation.Endpoints",
+      "file": "src/Granit.Validation.Endpoints/Dtos/ValidationFieldStatus.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ValidationFieldValidateBatchRequest",
+      "fqn": "Granit.Validation.Endpoints.Dtos.ValidationFieldValidateBatchRequest",
+      "kind": "record",
+      "project": "Granit.Validation.Endpoints",
+      "file": "src/Granit.Validation.Endpoints/Dtos/ValidationFieldValidateBatchRequest.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "ValidationFieldValidateBatchResponse",
+      "fqn": "Granit.Validation.Endpoints.Dtos.ValidationFieldValidateBatchResponse",
+      "kind": "record",
+      "project": "Granit.Validation.Endpoints",
+      "file": "src/Granit.Validation.Endpoints/Dtos/ValidationFieldValidateBatchResponse.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ValidationFieldValidateRequest",
+      "fqn": "Granit.Validation.Endpoints.Dtos.ValidationFieldValidateRequest",
+      "kind": "record",
+      "project": "Granit.Validation.Endpoints",
+      "file": "src/Granit.Validation.Endpoints/Dtos/ValidationFieldValidateRequest.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "ValidationFieldValidateResponse",
+      "fqn": "Granit.Validation.Endpoints.Dtos.ValidationFieldValidateResponse",
+      "kind": "record",
+      "project": "Granit.Validation.Endpoints",
+      "file": "src/Granit.Validation.Endpoints/Dtos/ValidationFieldValidateResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ValidationEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Validation.Endpoints.Extensions.ValidationEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Endpoints",
+      "file": "src/Granit.Validation.Endpoints/Extensions/ValidationEndpointRouteBuilderExtensions.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "MapGranitValidation",
+          "kind": "method",
+          "signature": "MapGranitValidation(this IEndpointRouteBuilder endpoints, Action<ValidationEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitValidationEndpointsModule",
+      "fqn": "Granit.Validation.Endpoints.GranitValidationEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Validation.Endpoints",
+      "file": "src/Granit.Validation.Endpoints/GranitValidationEndpointsModule.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "ValidationEndpointsOptions",
+      "fqn": "Granit.Validation.Endpoints.Options.ValidationEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Validation.Endpoints",
+      "file": "src/Granit.Validation.Endpoints/Options/ValidationEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "AddressValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.AddressValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/AddressValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "CompanyIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.CompanyIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/CompanyIdentifierValidatorExtensions.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "DutchIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.DutchIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/DutchIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "EuropeanIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.EuropeanIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/EuropeanIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "EuropeanPaymentValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.EuropeanPaymentValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/EuropeanPaymentValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "GermanIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.GermanIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/GermanIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ItalianIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.ItalianIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/ItalianIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "LuxembourgishIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.LuxembourgishIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/LuxembourgishIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "PersonalIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.PersonalIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/PersonalIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ProfessionalRegistryValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.ProfessionalRegistryValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/ProfessionalRegistryValidatorExtensions.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "SpanishIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.SpanishIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/SpanishIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "TaxIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.Europe.Extensions.TaxIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/Extensions/TaxIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "GranitValidationEuropeModule",
+      "fqn": "Granit.Validation.Europe.GranitValidationEuropeModule",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/GranitValidationEuropeModule.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ValidationEuropeLocalizationResource",
+      "fqn": "Granit.Validation.Europe.ValidationEuropeLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Validation.Europe",
+      "file": "src/Granit.Validation.Europe/ValidationEuropeLocalizationResource.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "ContactValidatorExtensions",
+      "fqn": "Granit.Validation.Extensions.ContactValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/ContactValidatorExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "FinancialValidatorExtensions",
+      "fqn": "Granit.Validation.Extensions.FinancialValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/FinancialValidatorExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "FormatValidatorExtensions",
+      "fqn": "Granit.Validation.Extensions.FormatValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/FormatValidatorExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "GeoValidatorExtensions",
+      "fqn": "Granit.Validation.Extensions.GeoValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/GeoValidatorExtensions.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "LocaleValidatorExtensions",
+      "fqn": "Granit.Validation.Extensions.LocaleValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/LocaleValidatorExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "NetworkValidatorExtensions",
+      "fqn": "Granit.Validation.Extensions.NetworkValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/NetworkValidatorExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "PaymentValidatorExtensions",
+      "fqn": "Granit.Validation.Extensions.PaymentValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/PaymentValidatorExtensions.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "RuleBuilderExtensions",
+      "fqn": "Granit.Validation.Extensions.RuleBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/RuleBuilderExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "StandardValidatorExtensions",
+      "fqn": "Granit.Validation.Extensions.StandardValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/StandardValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ValidationServiceCollectionExtensions",
+      "fqn": "Granit.Validation.Extensions.ValidationServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/ValidationServiceCollectionExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "AddGranitValidation",
+          "kind": "method",
+          "signature": "AddGranitValidation(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitValidationModule",
+      "fqn": "Granit.Validation.GranitValidationModule",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/GranitValidationModule.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GranitValidator",
+      "fqn": "Granit.Validation.GranitValidator",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/GranitValidator.cs",
+      "line": 23,
+      "members": []
+    },
+    {
+      "name": "AmericanAddressValidatorExtensions",
+      "fqn": "Granit.Validation.NorthAmerica.Extensions.AmericanAddressValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.NorthAmerica",
+      "file": "src/Granit.Validation.NorthAmerica/Extensions/AmericanAddressValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "AmericanIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.NorthAmerica.Extensions.AmericanIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.NorthAmerica",
+      "file": "src/Granit.Validation.NorthAmerica/Extensions/AmericanIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "CanadianAddressValidatorExtensions",
+      "fqn": "Granit.Validation.NorthAmerica.Extensions.CanadianAddressValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.NorthAmerica",
+      "file": "src/Granit.Validation.NorthAmerica/Extensions/CanadianAddressValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "CanadianIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.NorthAmerica.Extensions.CanadianIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.NorthAmerica",
+      "file": "src/Granit.Validation.NorthAmerica/Extensions/CanadianIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "GranitValidationNorthAmericaModule",
+      "fqn": "Granit.Validation.NorthAmerica.GranitValidationNorthAmericaModule",
+      "kind": "class",
+      "project": "Granit.Validation.NorthAmerica",
+      "file": "src/Granit.Validation.NorthAmerica/GranitValidationNorthAmericaModule.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ValidationNorthAmericaLocalizationResource",
+      "fqn": "Granit.Validation.NorthAmerica.ValidationNorthAmericaLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Validation.NorthAmerica",
+      "file": "src/Granit.Validation.NorthAmerica/ValidationNorthAmericaLocalizationResource.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "IPatternHintProvider",
+      "fqn": "Granit.Validation.OpenApi.IPatternHintProvider",
+      "kind": "interface",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/OpenApi/IPatternHintProvider.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "PatternHintValidator",
+      "fqn": "Granit.Validation.OpenApi.PatternHintValidator",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/OpenApi/PatternHintValidator.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "ArgumentNullException",
+          "kind": "method",
+          "signature": "ArgumentNullException(nameof(hintKey)",
+          "returnType": "string HintKey { get; } = hintKey ?? throw"
+        },
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "IsValid",
+          "kind": "method",
+          "signature": "IsValid(ValidationContext<T> context, TProperty value)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "DelegatingServerValidator",
+      "fqn": "Granit.Validation.ServerValidation.DelegatingServerValidator",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/ServerValidation/DelegatingServerValidator.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ArgumentNullException",
+          "kind": "method",
+          "signature": "ArgumentNullException(nameof(errorCode)",
+          "returnType": "string ErrorCode { get; } = errorCode ?? throw"
+        },
+        {
+          "name": "Validate",
+          "kind": "method",
+          "signature": "Validate(string? value)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "IServerValidator",
+      "fqn": "Granit.Validation.ServerValidation.IServerValidator",
+      "kind": "interface",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/ServerValidation/IServerValidator.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "Validate",
+          "kind": "method",
+          "signature": "Validate(string? value)",
+          "returnType": "string ErrorCode { get; } bool"
+        }
+      ]
+    },
+    {
+      "name": "IServerValidatorContributor",
+      "fqn": "Granit.Validation.ServerValidation.IServerValidatorContributor",
+      "kind": "interface",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/ServerValidation/IServerValidatorContributor.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "GetValidators",
+          "kind": "method",
+          "signature": "GetValidators()",
+          "returnType": "IEnumerable<IServerValidator>"
+        }
+      ]
+    },
+    {
+      "name": "ServerValidatorRegistry",
+      "fqn": "Granit.Validation.ServerValidation.ServerValidatorRegistry",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/ServerValidation/ServerValidatorRegistry.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetAllErrorCodes",
+          "kind": "method",
+          "signature": "GetAllErrorCodes()",
+          "returnType": "IReadOnlyCollection<string>"
+        }
+      ]
+    },
+    {
+      "name": "BritishAddressValidatorExtensions",
+      "fqn": "Granit.Validation.UnitedKingdom.Extensions.BritishAddressValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.UnitedKingdom",
+      "file": "src/Granit.Validation.UnitedKingdom/Extensions/BritishAddressValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "BritishIdentifierValidatorExtensions",
+      "fqn": "Granit.Validation.UnitedKingdom.Extensions.BritishIdentifierValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.UnitedKingdom",
+      "file": "src/Granit.Validation.UnitedKingdom/Extensions/BritishIdentifierValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "BritishPaymentValidatorExtensions",
+      "fqn": "Granit.Validation.UnitedKingdom.Extensions.BritishPaymentValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.UnitedKingdom",
+      "file": "src/Granit.Validation.UnitedKingdom/Extensions/BritishPaymentValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "BritishTaxValidatorExtensions",
+      "fqn": "Granit.Validation.UnitedKingdom.Extensions.BritishTaxValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation.UnitedKingdom",
+      "file": "src/Granit.Validation.UnitedKingdom/Extensions/BritishTaxValidatorExtensions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "GranitValidationUnitedKingdomModule",
+      "fqn": "Granit.Validation.UnitedKingdom.GranitValidationUnitedKingdomModule",
+      "kind": "class",
+      "project": "Granit.Validation.UnitedKingdom",
+      "file": "src/Granit.Validation.UnitedKingdom/GranitValidationUnitedKingdomModule.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ValidationUnitedKingdomLocalizationResource",
+      "fqn": "Granit.Validation.UnitedKingdom.ValidationUnitedKingdomLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Validation.UnitedKingdom",
+      "file": "src/Granit.Validation.UnitedKingdom/ValidationUnitedKingdomLocalizationResource.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "ValidationLocalizationResource",
+      "fqn": "Granit.Validation.ValidationLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/ValidationLocalizationResource.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "AwsVaultServiceCollectionExtensions",
+      "fqn": "Granit.Vault.Aws.Extensions.AwsVaultServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Vault.Aws",
+      "file": "src/Granit.Vault.Aws/Extensions/AwsVaultServiceCollectionExtensions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "AddGranitVaultAws",
+          "kind": "method",
+          "signature": "AddGranitVaultAws(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitVaultAwsModule",
+      "fqn": "Granit.Vault.Aws.GranitVaultAwsModule",
+      "kind": "class",
+      "project": "Granit.Vault.Aws",
+      "file": "src/Granit.Vault.Aws/GranitVaultAwsModule.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "IsEnabled",
+          "kind": "method",
+          "signature": "IsEnabled(ServiceConfigurationContext context)",
+          "returnType": "bool"
+        },
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AwsVaultOptions",
+      "fqn": "Granit.Vault.Aws.Options.AwsVaultOptions",
+      "kind": "class",
+      "project": "Granit.Vault.Aws",
+      "file": "src/Granit.Vault.Aws/Options/AwsVaultOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Region",
+          "kind": "property",
+          "signature": "string Region",
+          "returnType": "string"
+        },
+        {
+          "name": "KmsKeyId",
+          "kind": "property",
+          "signature": "string KmsKeyId",
+          "returnType": "string"
+        },
+        {
+          "name": "DatabaseSecretArn",
+          "kind": "property",
+          "signature": "string? DatabaseSecretArn",
+          "returnType": "string?"
+        },
+        {
+          "name": "AccessKeyId",
+          "kind": "property",
+          "signature": "string? AccessKeyId",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "AzureKeyVaultServiceCollectionExtensions",
+      "fqn": "Granit.Vault.Azure.Extensions.AzureKeyVaultServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Vault.Azure",
+      "file": "src/Granit.Vault.Azure/Extensions/AzureKeyVaultServiceCollectionExtensions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "AddGranitVaultAzure",
+          "kind": "method",
+          "signature": "AddGranitVaultAzure(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitVaultAzureModule",
+      "fqn": "Granit.Vault.Azure.GranitVaultAzureModule",
+      "kind": "class",
+      "project": "Granit.Vault.Azure",
+      "file": "src/Granit.Vault.Azure/GranitVaultAzureModule.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "IsEnabled",
+          "kind": "method",
+          "signature": "IsEnabled(ServiceConfigurationContext context)",
+          "returnType": "bool"
+        },
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AzureKeyVaultOptions",
+      "fqn": "Granit.Vault.Azure.Options.AzureKeyVaultOptions",
+      "kind": "class",
+      "project": "Granit.Vault.Azure",
+      "file": "src/Granit.Vault.Azure/Options/AzureKeyVaultOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "VaultUri",
+          "kind": "property",
+          "signature": "string VaultUri",
+          "returnType": "string"
+        },
+        {
+          "name": "EncryptionKeyName",
+          "kind": "property",
+          "signature": "string EncryptionKeyName",
+          "returnType": "string"
+        },
+        {
+          "name": "EncryptionAlgorithm",
+          "kind": "property",
+          "signature": "string EncryptionAlgorithm",
+          "returnType": "string"
+        },
+        {
+          "name": "DatabaseSecretName",
+          "kind": "property",
+          "signature": "string? DatabaseSecretName",
+          "returnType": "string?"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "VaultMetrics",
+      "fqn": "Granit.Vault.Diagnostics.VaultMetrics",
+      "kind": "class",
+      "project": "Granit.Vault",
+      "file": "src/Granit.Vault/Diagnostics/VaultMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordOperationError",
+          "kind": "method",
+          "signature": "RecordOperationError(string? tenantId, string operation, string provider)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordOperationDuration",
+          "kind": "method",
+          "signature": "RecordOperationDuration(string? tenantId, string operation, string provider, TimeSpan duration)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordRotationDetected",
+          "kind": "method",
+          "signature": "RecordRotationDetected(string provider)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "RetiredKeyVersionException",
+      "fqn": "Granit.Vault.Exceptions.RetiredKeyVersionException",
+      "kind": "class",
+      "project": "Granit.Vault",
+      "file": "src/Granit.Vault/Exceptions/RetiredKeyVersionException.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "RetiredKeyVersionException",
+          "kind": "method",
+          "signature": "RetiredKeyVersionException(string keyVersion)",
+          "returnType": "string KeyVersion { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "GoogleCloudVaultServiceCollectionExtensions",
+      "fqn": "Granit.Vault.GoogleCloud.Extensions.GoogleCloudVaultServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Vault.GoogleCloud",
+      "file": "src/Granit.Vault.GoogleCloud/Extensions/GoogleCloudVaultServiceCollectionExtensions.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "AddGranitVaultGoogleCloud",
+          "kind": "method",
+          "signature": "AddGranitVaultGoogleCloud(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitVaultGoogleCloudModule",
+      "fqn": "Granit.Vault.GoogleCloud.GranitVaultGoogleCloudModule",
+      "kind": "class",
+      "project": "Granit.Vault.GoogleCloud",
+      "file": "src/Granit.Vault.GoogleCloud/GranitVaultGoogleCloudModule.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "IsEnabled",
+          "kind": "method",
+          "signature": "IsEnabled(ServiceConfigurationContext context)",
+          "returnType": "bool"
+        },
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GoogleCloudVaultOptions",
+      "fqn": "Granit.Vault.GoogleCloud.Options.GoogleCloudVaultOptions",
+      "kind": "class",
+      "project": "Granit.Vault.GoogleCloud",
+      "file": "src/Granit.Vault.GoogleCloud/Options/GoogleCloudVaultOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ProjectId",
+          "kind": "property",
+          "signature": "string ProjectId",
+          "returnType": "string"
+        },
+        {
+          "name": "Location",
+          "kind": "property",
+          "signature": "string Location",
+          "returnType": "string"
+        },
+        {
+          "name": "KeyRing",
+          "kind": "property",
+          "signature": "string KeyRing",
+          "returnType": "string"
+        },
+        {
+          "name": "CryptoKey",
+          "kind": "property",
+          "signature": "string CryptoKey",
+          "returnType": "string"
+        },
+        {
+          "name": "DatabaseSecretName",
+          "kind": "property",
+          "signature": "string? DatabaseSecretName",
+          "returnType": "string?"
+        },
+        {
+          "name": "CredentialFilePath",
+          "kind": "property",
+          "signature": "string? CredentialFilePath",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "GranitVaultModule",
+      "fqn": "Granit.Vault.GranitVaultModule",
+      "kind": "class",
+      "project": "Granit.Vault",
+      "file": "src/Granit.Vault/GranitVaultModule.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "HashiCorpVaultConfigurationException",
+      "fqn": "Granit.Vault.HashiCorp.Exceptions.HashiCorpVaultConfigurationException",
+      "kind": "class",
+      "project": "Granit.Vault.HashiCorp",
+      "file": "src/Granit.Vault.HashiCorp/Exceptions/HashiCorpVaultConfigurationException.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "HashiCorpVaultConfigurationException",
+          "kind": "method",
+          "signature": "HashiCorpVaultConfigurationException(string errorCode, string message)",
+          "returnType": "string ErrorCode { get; } public"
+        }
+      ]
+    },
+    {
+      "name": "HashiCorpVaultServiceCollectionExtensions",
+      "fqn": "Granit.Vault.HashiCorp.Extensions.HashiCorpVaultServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Vault.HashiCorp",
+      "file": "src/Granit.Vault.HashiCorp/Extensions/HashiCorpVaultServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitVaultHashiCorp",
+          "kind": "method",
+          "signature": "AddGranitVaultHashiCorp(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitVaultHashiCorpModule",
+      "fqn": "Granit.Vault.HashiCorp.GranitVaultHashiCorpModule",
+      "kind": "class",
+      "project": "Granit.Vault.HashiCorp",
+      "file": "src/Granit.Vault.HashiCorp/GranitVaultHashiCorpModule.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "IsEnabled",
+          "kind": "method",
+          "signature": "IsEnabled(ServiceConfigurationContext context)",
+          "returnType": "bool"
+        },
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "HashiCorpVaultOptions",
+      "fqn": "Granit.Vault.HashiCorp.Options.HashiCorpVaultOptions",
+      "kind": "class",
+      "project": "Granit.Vault.HashiCorp",
+      "file": "src/Granit.Vault.HashiCorp/Options/HashiCorpVaultOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Address",
+          "kind": "property",
+          "signature": "string Address",
+          "returnType": "string"
+        },
+        {
+          "name": "AuthMethod",
+          "kind": "property",
+          "signature": "string AuthMethod",
+          "returnType": "string"
+        },
+        {
+          "name": "Token",
+          "kind": "property",
+          "signature": "string? Token",
+          "returnType": "string?"
+        },
+        {
+          "name": "KubernetesTokenPath",
+          "kind": "property",
+          "signature": "string KubernetesTokenPath",
+          "returnType": "string"
+        },
+        {
+          "name": "DatabaseMountPoint",
+          "kind": "property",
+          "signature": "string DatabaseMountPoint",
+          "returnType": "string"
+        },
+        {
+          "name": "DatabaseRoleName",
+          "kind": "property",
+          "signature": "string DatabaseRoleName",
+          "returnType": "string"
+        },
+        {
+          "name": "TransitMountPoint",
+          "kind": "property",
+          "signature": "string TransitMountPoint",
+          "returnType": "string"
+        },
+        {
+          "name": "LeaseRenewalThreshold",
+          "kind": "property",
+          "signature": "double LeaseRenewalThreshold",
+          "returnType": "double"
+        }
+      ]
+    },
+    {
+      "name": "HashiCorpVaultStringEncryptionProvider",
+      "fqn": "Granit.Vault.HashiCorp.Providers.HashiCorpVaultStringEncryptionProvider",
+      "kind": "class",
+      "project": "Granit.Vault.HashiCorp",
+      "file": "src/Granit.Vault.HashiCorp/Providers/HashiCorpVaultStringEncryptionProvider.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "ProviderName",
+          "kind": "property",
+          "signature": "string ProviderName",
+          "returnType": "string"
+        },
+        {
+          "name": "Encrypt",
+          "kind": "method",
+          "signature": "Encrypt(string plainText)",
+          "returnType": "string"
+        },
+        {
+          "name": "Decrypt",
+          "kind": "method",
+          "signature": "Decrypt(string cipherText)",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "HashiCorpTransitEncryptionService",
+      "fqn": "Granit.Vault.HashiCorp.Services.HashiCorpTransitEncryptionService",
+      "kind": "class",
+      "project": "Granit.Vault.HashiCorp",
+      "file": "src/Granit.Vault.HashiCorp/Services/HashiCorpTransitEncryptionService.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "EncryptAsync",
+          "kind": "method",
+          "signature": "EncryptAsync(string keyName, string plaintext, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
+        }
+      ]
+    },
+    {
+      "name": "VaultClientFactory",
+      "fqn": "Granit.Vault.HashiCorp.Services.VaultClientFactory",
+      "kind": "class",
+      "project": "Granit.Vault.HashiCorp",
+      "file": "src/Granit.Vault.HashiCorp/Services/VaultClientFactory.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create()",
+          "returnType": "IVaultClient"
+        }
+      ]
+    },
+    {
+      "name": "VaultCredentialLeaseManager",
+      "fqn": "Granit.Vault.HashiCorp.Services.VaultCredentialLeaseManager",
+      "kind": "class",
+      "project": "Granit.Vault.HashiCorp",
+      "file": "src/Granit.Vault.HashiCorp/Services/VaultCredentialLeaseManager.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "Username",
+          "kind": "property",
+          "signature": "string Username",
+          "returnType": "string"
+        },
+        {
+          "name": "Password",
+          "kind": "property",
+          "signature": "string Password",
+          "returnType": "string"
+        },
+        {
+          "name": "IsNullOrEmpty",
+          "kind": "method",
+          "signature": "IsNullOrEmpty(_username)",
+          "returnType": "bool IsReady => !string."
+        }
+      ]
+    },
+    {
+      "name": "IDatabaseCredentialProvider",
+      "fqn": "Granit.Vault.IDatabaseCredentialProvider",
+      "kind": "interface",
+      "project": "Granit.Vault",
+      "file": "src/Granit.Vault/IDatabaseCredentialProvider.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "ITransitEncryptionService",
+      "fqn": "Granit.Vault.ITransitEncryptionService",
+      "kind": "interface",
+      "project": "Granit.Vault",
+      "file": "src/Granit.Vault/ITransitEncryptionService.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "EncryptAsync",
+          "kind": "method",
+          "signature": "EncryptAsync(string keyName, string plaintext, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
+        },
+        {
+          "name": "DecryptAsync",
+          "kind": "method",
+          "signature": "DecryptAsync(string keyName, string ciphertext, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
+        },
+        {
+          "name": "RewrapAsync",
+          "kind": "method",
+          "signature": "RewrapAsync(string keyName, string ciphertext, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
+        },
+        {
+          "name": "GetKeyVersion",
+          "kind": "method",
+          "signature": "GetKeyVersion(string ciphertext)",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "ReEncryptionOptions",
+      "fqn": "Granit.Vault.Options.ReEncryptionOptions",
+      "kind": "class",
+      "project": "Granit.Vault",
+      "file": "src/Granit.Vault/Options/ReEncryptionOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RetiredKeyVersions",
+          "kind": "property",
+          "signature": "ISet<string> RetiredKeyVersions",
+          "returnType": "ISet<string>"
+        },
+        {
+          "name": "BatchSize",
+          "kind": "property",
+          "signature": "int BatchSize",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "VaultLocalizationResource",
+      "fqn": "Granit.Vault.VaultLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Vault",
+      "file": "src/Granit.Vault/VaultLocalizationResource.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "IWebhookCommandDispatcher",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookCommandDispatcher",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookCommandDispatcher.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "DispatchAsync",
+          "kind": "method",
+          "signature": "DispatchAsync(SendWebhookCommand command, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IWebhookDeliveryReader",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookDeliveryReader",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookDeliveryReader.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "FindByDeliveryIdAsync",
+          "kind": "method",
+          "signature": "FindByDeliveryIdAsync(Guid deliveryId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<WebhookDeliveryAttempt?>"
+        },
+        {
+          "name": "CountBeforeAsync",
+          "kind": "method",
+          "signature": "CountBeforeAsync(DateTimeOffset cutoff, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        }
+      ]
+    },
+    {
+      "name": "IWebhookDeliveryWriter",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookDeliveryWriter",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookDeliveryWriter.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "RecordSuccessAsync",
+          "kind": "method",
+          "signature": "RecordSuccessAsync(SendWebhookCommand command, int httpStatusCode, long durationMs, string payloadHash, string? payload, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RecordFailureAsync",
+          "kind": "method",
+          "signature": "RecordFailureAsync(SendWebhookCommand command, int? httpStatusCode, long durationMs, string errorMessage, string? payload, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SuspendSubscriptionAsync",
+          "kind": "method",
+          "signature": "SuspendSubscriptionAsync(Guid subscriptionId, string reason, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteBeforeAsync",
+          "kind": "method",
+          "signature": "DeleteBeforeAsync(DateTimeOffset cutoff, int batchSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<int>"
+        }
+      ]
+    },
+    {
+      "name": "IWebhookPublisher",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookPublisher",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookPublisher.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "IWebhookQueryableProvider",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookQueryableProvider",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookQueryableProvider.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "GetSubscriptions",
+          "kind": "method",
+          "signature": "GetSubscriptions()",
+          "returnType": "IQueryable<WebhookSubscription>"
+        },
+        {
+          "name": "GetDeliveryAttempts",
+          "kind": "method",
+          "signature": "GetDeliveryAttempts()",
+          "returnType": "IQueryable<WebhookDeliveryAttempt>"
+        }
+      ]
+    },
+    {
+      "name": "IWebhookSecretProtector",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookSecretProtector",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookSecretProtector.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "ProtectAsync",
+          "kind": "method",
+          "signature": "ProtectAsync(string plainSecret, CancellationToken cancellationToken = default)",
+          "returnType": "ValueTask<string>"
+        },
+        {
+          "name": "UnprotectAsync",
+          "kind": "method",
+          "signature": "UnprotectAsync(string protectedSecret, CancellationToken cancellationToken = default)",
+          "returnType": "ValueTask<string>"
+        }
+      ]
+    },
+    {
+      "name": "IWebhookStatsReader",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookStatsReader",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookStatsReader.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GetStatsAsync",
+          "kind": "method",
+          "signature": "GetStatsAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<WebhookStats>"
+        }
+      ]
+    },
+    {
+      "name": "IWebhookSubscriptionReader",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookSubscriptionReader",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookSubscriptionReader.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetActiveSubscriptionsAsync",
+          "kind": "method",
+          "signature": "GetActiveSubscriptionsAsync(string eventType, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<WebhookSubscription>>"
+        },
+        {
+          "name": "FindByIdAsync",
+          "kind": "method",
+          "signature": "FindByIdAsync(Guid subscriptionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<WebhookSubscription?>"
+        },
+        {
+          "name": "GetAllAsync",
+          "kind": "method",
+          "signature": "GetAllAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<WebhookSubscription>>"
+        }
+      ]
+    },
+    {
+      "name": "IWebhookSubscriptionWriter",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookSubscriptionWriter",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookSubscriptionWriter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(HttpsUrl targetUrl, string eventType, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<WebhookSubscriptionCreatedResult>"
+        },
+        {
+          "name": "UpdateTargetUrlAsync",
+          "kind": "method",
+          "signature": "UpdateTargetUrlAsync(Guid subscriptionId, HttpsUrl targetUrl, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "ActivateAsync",
+          "kind": "method",
+          "signature": "ActivateAsync(Guid subscriptionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SuspendAsync",
+          "kind": "method",
+          "signature": "SuspendAsync(Guid subscriptionId, string suspendedBy, string reason, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeactivateAsync",
+          "kind": "method",
+          "signature": "DeactivateAsync(Guid subscriptionId, string reason, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(Guid subscriptionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RotateSecretAsync",
+          "kind": "method",
+          "signature": "RotateSecretAsync(Guid subscriptionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
+        }
+      ]
+    },
+    {
+      "name": "IWebhookTestPingService",
+      "fqn": "Granit.Webhooks.Abstractions.IWebhookTestPingService",
+      "kind": "interface",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/IWebhookTestPingService.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SendTestPingAsync",
+          "kind": "method",
+          "signature": "SendTestPingAsync(Guid subscriptionId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<WebhookTestPingResult>"
+        }
+      ]
+    },
+    {
+      "name": "WebhookStats",
+      "fqn": "Granit.Webhooks.Abstractions.WebhookStats",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/WebhookStats.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionCreatedResult",
+      "fqn": "Granit.Webhooks.Abstractions.WebhookSubscriptionCreatedResult",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/WebhookSubscriptionCreatedResult.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "WebhookTestPingResult",
+      "fqn": "Granit.Webhooks.Abstractions.WebhookTestPingResult",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Abstractions/WebhookTestPingResult.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "WebhooksMetrics",
+      "fqn": "Granit.Webhooks.Diagnostics.WebhooksMetrics",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Diagnostics/WebhooksMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordDeliverySucceeded",
+          "kind": "method",
+          "signature": "RecordDeliverySucceeded(string? tenantId, string eventType)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordDeliveryFailed",
+          "kind": "method",
+          "signature": "RecordDeliveryFailed(string? tenantId, string eventType, int? httpStatus)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordSubscriptionSuspended",
+          "kind": "method",
+          "signature": "RecordSubscriptionSuspended(string? tenantId, int httpStatus)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordDeliveryDuration",
+          "kind": "method",
+          "signature": "RecordDeliveryDuration(string? tenantId, string eventType, string status, TimeSpan duration)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "EventTypeName",
+      "fqn": "Granit.Webhooks.Domain.ValueObjects.EventTypeName",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Domain/ValueObjects/EventTypeName.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(string value)",
+          "returnType": "required string Value { get; init; } public EventTypeName"
+        },
+        {
+          "name": "EventTypeName",
+          "kind": "method",
+          "signature": "EventTypeName(string value)",
+          "returnType": "implicit operator"
+        }
+      ]
+    },
+    {
+      "name": "WebhookDeliveryAttempt",
+      "fqn": "Granit.Webhooks.Domain.WebhookDeliveryAttempt",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Domain/WebhookDeliveryAttempt.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "DeliveryId",
+          "kind": "property",
+          "signature": "Guid DeliveryId",
+          "returnType": "Guid"
+        },
+        {
+          "name": "TargetUrl",
+          "kind": "property",
+          "signature": "string TargetUrl",
+          "returnType": "string"
+        },
+        {
+          "name": "HttpStatusCode",
+          "kind": "property",
+          "signature": "int? HttpStatusCode",
+          "returnType": "int?"
+        }
+      ]
+    },
+    {
+      "name": "WebhookSubscription",
+      "fqn": "Granit.Webhooks.Domain.WebhookSubscription",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Domain/WebhookSubscription.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, HttpsUrl targetUrl, string eventType, string signingSecret, Guid? tenantId = null)",
+          "returnType": "WebhookSubscription"
+        },
+        {
+          "name": "EventType",
+          "kind": "property",
+          "signature": "string EventType",
+          "returnType": "string"
+        },
+        {
+          "name": "SigningSecret",
+          "kind": "property",
+          "signature": "string SigningSecret",
+          "returnType": "string"
+        },
+        {
+          "name": "TenantId",
+          "kind": "property",
+          "signature": "Guid? TenantId",
+          "returnType": "Guid?"
+        },
+        {
+          "name": "RecordSuccess",
+          "kind": "method",
+          "signature": "RecordSuccess(DateTimeOffset at)",
+          "returnType": "string? DeactivationReason { get; private set; } public int ConsecutiveFailureCount { get; private set; } public DateTimeOffset? LastSuccessAt { get; private set; } public DateTimeOffset? SuspendedAt { get; private set; } public string? SuspendedBy { get; private set; } internal void"
+        }
+      ]
+    },
+    {
+      "name": "WebhookSubscriptionStatus",
+      "fqn": "Granit.Webhooks.Domain.WebhookSubscriptionStatus",
+      "kind": "enum",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Domain/WebhookSubscriptionStatus.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhookModuleConfigResponse",
+      "fqn": "Granit.Webhooks.Dtos.WebhookModuleConfigResponse",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Dtos/WebhookModuleConfigResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionCreateRequest",
+      "fqn": "Granit.Webhooks.Endpoints.Dtos.WebhookSubscriptionCreateRequest",
+      "kind": "record",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionCreateRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionCreatedResponse",
+      "fqn": "Granit.Webhooks.Endpoints.Dtos.WebhookSubscriptionCreatedResponse",
+      "kind": "record",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionCreatedResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionDeactivateRequest",
+      "fqn": "Granit.Webhooks.Endpoints.Dtos.WebhookSubscriptionDeactivateRequest",
+      "kind": "record",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionDeactivateRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionResponse",
+      "fqn": "Granit.Webhooks.Endpoints.Dtos.WebhookSubscriptionResponse",
+      "kind": "record",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionRotateSecretResponse",
+      "fqn": "Granit.Webhooks.Endpoints.Dtos.WebhookSubscriptionRotateSecretResponse",
+      "kind": "record",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionRotateSecretResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionStatsResponse",
+      "fqn": "Granit.Webhooks.Endpoints.Dtos.WebhookSubscriptionStatsResponse",
+      "kind": "record",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionStatsResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionTestPingResponse",
+      "fqn": "Granit.Webhooks.Endpoints.Dtos.WebhookSubscriptionTestPingResponse",
+      "kind": "record",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionTestPingResponse.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionUpdateRequest",
+      "fqn": "Granit.Webhooks.Endpoints.Dtos.WebhookSubscriptionUpdateRequest",
+      "kind": "record",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Dtos/WebhookSubscriptionUpdateRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhooksEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Webhooks.Endpoints.Extensions.WebhooksEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Extensions/WebhooksEndpointRouteBuilderExtensions.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "MapWebhooksEndpoints",
+          "kind": "method",
+          "signature": "MapWebhooksEndpoints(this IEndpointRouteBuilder endpoints, Action<WebhooksEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitWebhooksEndpointsModule",
+      "fqn": "Granit.Webhooks.Endpoints.GranitWebhooksEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/GranitWebhooksEndpointsModule.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "WebhooksEndpointsOptions",
+      "fqn": "Granit.Webhooks.Endpoints.Options.WebhooksEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Options/WebhooksEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "Subscriptions",
+      "fqn": "Granit.Webhooks.Endpoints.Permissions.Subscriptions",
+      "kind": "class",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Permissions/WebhooksPermissions.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "WebhooksPermissions",
+      "fqn": "Granit.Webhooks.Endpoints.Permissions.WebhooksPermissions",
+      "kind": "class",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Permissions/WebhooksPermissions.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WebhookTargetUrlValidatorExtensions",
+      "fqn": "Granit.Webhooks.Endpoints.Validators.WebhookTargetUrlValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Validators/WebhookTargetUrlValidatorExtensions.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "WebhookConfigEndpoint",
+      "fqn": "Granit.Webhooks.Endpoints.WebhookConfigEndpoint",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Endpoints/WebhookConfigEndpoint.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "MapGranitWebhooksConfig",
+          "kind": "method",
+          "signature": "MapGranitWebhooksConfig(this IEndpointRouteBuilder endpoints, string routePrefix = \"webhooks\")",
+          "returnType": "IEndpointRouteBuilder"
+        }
+      ]
+    },
+    {
+      "name": "WebhookRedeliveryEndpoint",
+      "fqn": "Granit.Webhooks.Endpoints.WebhookRedeliveryEndpoint",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Endpoints/WebhookRedeliveryEndpoint.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "MapGranitWebhooksRedelivery",
+          "kind": "method",
+          "signature": "MapGranitWebhooksRedelivery(this IEndpointRouteBuilder endpoints, string routePrefix = \"webhooks\")",
+          "returnType": "IEndpointRouteBuilder"
+        }
+      ]
+    },
+    {
+      "name": "WebhooksEfCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.Webhooks.EntityFrameworkCore.Extensions.WebhooksEfCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Webhooks.EntityFrameworkCore",
+      "file": "src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksEfCoreHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitWebhooksEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitWebhooksEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "WebhooksModelBuilderExtensions",
+      "fqn": "Granit.Webhooks.EntityFrameworkCore.Extensions.WebhooksModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Webhooks.EntityFrameworkCore",
+      "file": "src/Granit.Webhooks.EntityFrameworkCore/Extensions/WebhooksModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureWebhooksModule",
+          "kind": "method",
+          "signature": "ConfigureWebhooksModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitWebhooksDbProperties",
+      "fqn": "Granit.Webhooks.EntityFrameworkCore.GranitWebhooksDbProperties",
+      "kind": "class",
+      "project": "Granit.Webhooks.EntityFrameworkCore",
+      "file": "src/Granit.Webhooks.EntityFrameworkCore/GranitWebhooksDbProperties.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitWebhooksEntityFrameworkCoreModule",
+      "fqn": "Granit.Webhooks.EntityFrameworkCore.GranitWebhooksEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Webhooks.EntityFrameworkCore",
+      "file": "src/Granit.Webhooks.EntityFrameworkCore/GranitWebhooksEntityFrameworkCoreModule.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "WebhookDeliveryFailureThresholdExceededEto",
+      "fqn": "Granit.Webhooks.Events.WebhookDeliveryFailureThresholdExceededEto",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Events/WebhookDeliveryFailureThresholdExceededEto.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "WebhookDeliverySucceededEvent",
+      "fqn": "Granit.Webhooks.Events.WebhookDeliverySucceededEvent",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Events/WebhookDeliverySucceededEvent.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionActivatedEvent",
+      "fqn": "Granit.Webhooks.Events.WebhookSubscriptionActivatedEvent",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Events/WebhookSubscriptionActivatedEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionCreatedEvent",
+      "fqn": "Granit.Webhooks.Events.WebhookSubscriptionCreatedEvent",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Events/WebhookSubscriptionCreatedEvent.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionDeactivatedEvent",
+      "fqn": "Granit.Webhooks.Events.WebhookSubscriptionDeactivatedEvent",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Events/WebhookSubscriptionDeactivatedEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "WebhookSubscriptionSuspendedEvent",
+      "fqn": "Granit.Webhooks.Events.WebhookSubscriptionSuspendedEvent",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Events/WebhookSubscriptionSuspendedEvent.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "WebhookDeliveryException",
+      "fqn": "Granit.Webhooks.Exceptions.WebhookDeliveryException",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Exceptions/WebhookDeliveryException.cs",
+      "line": 24,
+      "members": []
+    },
+    {
+      "name": "WebhooksHostApplicationBuilderExtensions",
+      "fqn": "Granit.Webhooks.Extensions.WebhooksHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Extensions/WebhooksHostApplicationBuilderExtensions.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "AddGranitWebhooks",
+          "kind": "method",
+          "signature": "AddGranitWebhooks(this IHostApplicationBuilder builder, Action<WebhooksOptions>? configure = null)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitWebhooksModule",
+      "fqn": "Granit.Webhooks.GranitWebhooksModule",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/GranitWebhooksModule.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "RetryWebhookErrorKind",
+      "fqn": "Granit.Webhooks.Handlers.RetryWebhookErrorKind",
+      "kind": "enum",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Handlers/RetryWebhookHandler.cs",
+      "line": 135,
+      "members": []
+    },
+    {
+      "name": "RetryWebhookHandler",
+      "fqn": "Granit.Webhooks.Handlers.RetryWebhookHandler",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Handlers/RetryWebhookHandler.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(Guid deliveryId, CancellationToken cancellationToken)",
+          "returnType": "Task<RetryWebhookResult>"
+        }
+      ]
+    },
+    {
+      "name": "RetryWebhookResult",
+      "fqn": "Granit.Webhooks.Handlers.RetryWebhookResult",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Handlers/RetryWebhookHandler.cs",
+      "line": 104,
+      "members": []
+    },
+    {
+      "name": "SendWebhookHandler",
+      "fqn": "Granit.Webhooks.Handlers.SendWebhookHandler",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Handlers/SendWebhookHandler.cs",
+      "line": 43,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(SendWebhookCommand command, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "WebhookFanoutHandler",
+      "fqn": "Granit.Webhooks.Handlers.WebhookFanoutHandler",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Handlers/WebhookFanoutHandler.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(WebhookTrigger trigger, CancellationToken cancellationToken)",
+          "returnType": "Task<IEnumerable<SendWebhookCommand>>"
+        }
+      ]
+    },
+    {
+      "name": "SendWebhookCommand",
+      "fqn": "Granit.Webhooks.Messages.SendWebhookCommand",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Messages/SendWebhookCommand.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "WebhookEnvelope",
+      "fqn": "Granit.Webhooks.Messages.WebhookEnvelope",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Messages/WebhookEnvelope.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "WebhookTrigger",
+      "fqn": "Granit.Webhooks.Messages.WebhookTrigger",
+      "kind": "record",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Messages/WebhookTrigger.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "NewGuid",
+          "kind": "method",
+          "signature": "NewGuid()",
+          "returnType": "Guid EventId { get; init; } = Guid."
+        }
+      ]
+    },
+    {
+      "name": "WebhooksOptions",
+      "fqn": "Granit.Webhooks.Options.WebhooksOptions",
+      "kind": "class",
+      "project": "Granit.Webhooks",
+      "file": "src/Granit.Webhooks/Options/WebhooksOptions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "HttpTimeoutSeconds",
+          "kind": "property",
+          "signature": "int HttpTimeoutSeconds",
+          "returnType": "int"
+        },
+        {
+          "name": "MaxParallelDeliveries",
+          "kind": "property",
+          "signature": "int MaxParallelDeliveries",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "GranitWebhooksWolverineModule",
+      "fqn": "Granit.Webhooks.Wolverine.GranitWebhooksWolverineModule",
+      "kind": "class",
+      "project": "Granit.Webhooks.Wolverine",
+      "file": "src/Granit.Webhooks.Wolverine/GranitWebhooksWolverineModule.cs",
+      "line": 28,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "TenantContextBehavior",
+      "fqn": "Granit.Wolverine.Behaviors.TenantContextBehavior",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/Behaviors/TenantContextBehavior.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "Before",
+          "kind": "method",
+          "signature": "Before(Envelope envelope)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "TraceContextBehavior",
+      "fqn": "Granit.Wolverine.Behaviors.TraceContextBehavior",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/Behaviors/TraceContextBehavior.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "Before",
+          "kind": "method",
+          "signature": "Before(Envelope envelope)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "UserContextBehavior",
+      "fqn": "Granit.Wolverine.Behaviors.UserContextBehavior",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/Behaviors/UserContextBehavior.cs",
+      "line": 28,
+      "members": [
+        {
+          "name": "Before",
+          "kind": "method",
+          "signature": "Before(Envelope envelope)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ClaimCheckExtensions",
+      "fqn": "Granit.Wolverine.ClaimCheck.ClaimCheckExtensions",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/ClaimCheck/ClaimCheckExtensions.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "ClaimCheckReference",
+      "fqn": "Granit.Wolverine.ClaimCheck.ClaimCheckReference",
+      "kind": "record",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/ClaimCheck/ClaimCheckReference.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "ClaimCheckServiceCollectionExtensions",
+      "fqn": "Granit.Wolverine.ClaimCheck.ClaimCheckServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/ClaimCheck/ClaimCheckServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddInMemoryClaimCheckStore",
+          "kind": "method",
+          "signature": "AddInMemoryClaimCheckStore(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "IClaimCheckStore",
+      "fqn": "Granit.Wolverine.ClaimCheck.IClaimCheckStore",
+      "kind": "interface",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/ClaimCheck/IClaimCheckStore.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "StoreAsync",
+          "kind": "method",
+          "signature": "StoreAsync(ReadOnlyMemory<byte> data, string? contentType = null, TimeSpan? expiry = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Guid>"
+        },
+        {
+          "name": "RetrieveAsync",
+          "kind": "method",
+          "signature": "RetrieveAsync(Guid referenceId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<byte[]?>"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(Guid referenceId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "WolverineHostApplicationBuilderExtensions",
+      "fqn": "Granit.Wolverine.Extensions.WolverineHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "AddGranitWolverine",
+          "kind": "method",
+          "signature": "AddGranitWolverine(this IHostApplicationBuilder builder, Action<WolverineOptions>? configure = null)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "WolverineValidationServiceCollectionExtensions",
+      "fqn": "Granit.Wolverine.Extensions.WolverineValidationServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/Extensions/WolverineValidationServiceCollectionExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitValidatorsFromWolverineHandlerModules",
+          "kind": "method",
+          "signature": "AddGranitValidatorsFromWolverineHandlerModules(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitWolverineModule",
+      "fqn": "Granit.Wolverine.GranitWolverineModule",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/GranitWolverineModule.cs",
+      "line": 24,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IWolverineUserContextSetter",
+      "fqn": "Granit.Wolverine.Internal.IWolverineUserContextSetter",
+      "kind": "interface",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/Internal/IWolverineUserContextSetter.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Change",
+          "kind": "method",
+          "signature": "Change(string? userId, string? firstName = null, string? lastName = null, ActorKind actorKind = ActorKind.User, Guid? apiKeyId = null)",
+          "returnType": "IDisposable"
+        }
+      ]
+    },
+    {
+      "name": "OutgoingContextMiddleware",
+      "fqn": "Granit.Wolverine.Middleware.OutgoingContextMiddleware",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/Middleware/OutgoingContextMiddleware.cs",
+      "line": 29,
+      "members": [
+        {
+          "name": "Before",
+          "kind": "method",
+          "signature": "Before(Envelope envelope)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "WolverineMessagingOptions",
+      "fqn": "Granit.Wolverine.Options.WolverineMessagingOptions",
+      "kind": "class",
+      "project": "Granit.Wolverine",
+      "file": "src/Granit.Wolverine/Options/WolverineMessagingOptions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "FromSeconds",
+          "kind": "method",
+          "signature": "FromSeconds(5)",
+          "returnType": "TimeSpan[] RetryDelays { get; set; } = TimeSpan."
+        },
+        {
+          "name": "MaxRetryAttempts",
+          "kind": "property",
+          "signature": "int MaxRetryAttempts",
+          "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "WolverinePostgresqlHostApplicationBuilderExtensions",
+      "fqn": "Granit.Wolverine.Postgresql.Extensions.WolverinePostgresqlHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Wolverine.Postgresql",
+      "file": "src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "AddGranitWolverineWithPostgresql",
+          "kind": "method",
+          "signature": "AddGranitWolverineWithPostgresql(this IHostApplicationBuilder builder, Action<WolverineOptions>? configure = null)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitWolverinePostgresqlModule",
+      "fqn": "Granit.Wolverine.Postgresql.GranitWolverinePostgresqlModule",
+      "kind": "class",
+      "project": "Granit.Wolverine.Postgresql",
+      "file": "src/Granit.Wolverine.Postgresql/GranitWolverinePostgresqlModule.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "WolverinePostgresqlOptions",
+      "fqn": "Granit.Wolverine.Postgresql.Options.WolverinePostgresqlOptions",
+      "kind": "class",
+      "project": "Granit.Wolverine.Postgresql",
+      "file": "src/Granit.Wolverine.Postgresql/Options/WolverinePostgresqlOptions.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "TransportConnectionStringName",
+          "kind": "property",
+          "signature": "string? TransportConnectionStringName",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "WolverineSqlServerHostApplicationBuilderExtensions",
+      "fqn": "Granit.Wolverine.SqlServer.Extensions.WolverineSqlServerHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Wolverine.SqlServer",
+      "file": "src/Granit.Wolverine.SqlServer/Extensions/WolverineSqlServerHostApplicationBuilderExtensions.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "AddGranitWolverineWithSqlServer",
+          "kind": "method",
+          "signature": "AddGranitWolverineWithSqlServer(this IHostApplicationBuilder builder, Action<WolverineOptions>? configure = null)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitWolverineSqlServerModule",
+      "fqn": "Granit.Wolverine.SqlServer.GranitWolverineSqlServerModule",
+      "kind": "class",
+      "project": "Granit.Wolverine.SqlServer",
+      "file": "src/Granit.Wolverine.SqlServer/GranitWolverineSqlServerModule.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "WolverineSqlServerOptions",
+      "fqn": "Granit.Wolverine.SqlServer.Options.WolverineSqlServerOptions",
+      "kind": "class",
+      "project": "Granit.Wolverine.SqlServer",
+      "file": "src/Granit.Wolverine.SqlServer/Options/WolverineSqlServerOptions.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "TransportConnectionString",
+          "kind": "property",
+          "signature": "string TransportConnectionString",
+          "returnType": "string"
+        },
+        {
+          "name": "TransactionMode",
+          "kind": "property",
+          "signature": "TransactionMiddlewareMode TransactionMode",
+          "returnType": "TransactionMiddlewareMode"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowAIHostApplicationBuilderExtensions",
+      "fqn": "Granit.Workflow.AI.Extensions.WorkflowAIHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Workflow.AI",
+      "file": "src/Granit.Workflow.AI/Extensions/WorkflowAIHostApplicationBuilderExtensions.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "AddGranitWorkflowAI",
+          "kind": "method",
+          "signature": "AddGranitWorkflowAI(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitWorkflowAIModule",
+      "fqn": "Granit.Workflow.AI.GranitWorkflowAIModule",
+      "kind": "class",
+      "project": "Granit.Workflow.AI",
+      "file": "src/Granit.Workflow.AI/GranitWorkflowAIModule.cs",
+      "line": 27,
+      "members": []
+    },
+    {
+      "name": "IAIApprovalEvaluator",
+      "fqn": "Granit.Workflow.AI.IAIApprovalEvaluator",
+      "kind": "interface",
+      "project": "Granit.Workflow.AI",
+      "file": "src/Granit.Workflow.AI/IAIApprovalEvaluator.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "EvaluateRiskAsync",
+          "kind": "method",
+          "signature": "EvaluateRiskAsync(string entityType, string transition, string entityContext, CancellationToken cancellationToken = default)",
+          "returnType": "Task<RiskAssessment>"
+        }
+      ]
+    },
+    {
+      "name": "IAITransitionAdvisor",
+      "fqn": "Granit.Workflow.AI.IAITransitionAdvisor",
+      "kind": "interface",
+      "project": "Granit.Workflow.AI",
+      "file": "src/Granit.Workflow.AI/IAITransitionAdvisor.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "RecommendAsync",
+          "kind": "method",
+          "signature": "RecommendAsync(string entityType, string currentState, string entityContext, IReadOnlyList<string> allowedTransitions, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TransitionRecommendation?>"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowAIOptions",
+      "fqn": "Granit.Workflow.AI.Options.WorkflowAIOptions",
+      "kind": "class",
+      "project": "Granit.Workflow.AI",
+      "file": "src/Granit.Workflow.AI/Options/WorkflowAIOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "WorkspaceName",
+          "kind": "property",
+          "signature": "string WorkspaceName",
+          "returnType": "string"
+        },
+        {
+          "name": "TimeoutSeconds",
+          "kind": "property",
+          "signature": "int TimeoutSeconds",
+          "returnType": "int"
+        },
+        {
+          "name": "AutoApprovalThreshold",
+          "kind": "property",
+          "signature": "double AutoApprovalThreshold",
+          "returnType": "double"
+        }
+      ]
+    },
+    {
+      "name": "RiskAssessment",
+      "fqn": "Granit.Workflow.AI.RiskAssessment",
+      "kind": "record",
+      "project": "Granit.Workflow.AI",
+      "file": "src/Granit.Workflow.AI/RiskAssessment.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "TransitionRecommendation",
+      "fqn": "Granit.Workflow.AI.TransitionRecommendation",
+      "kind": "record",
+      "project": "Granit.Workflow.AI",
+      "file": "src/Granit.Workflow.AI/TransitionRecommendation.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "PublicationWorkflow",
+      "fqn": "Granit.Workflow.Definitions.PublicationWorkflow",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Definitions/PublicationWorkflow.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "Default",
+          "kind": "property",
+          "signature": "WorkflowDefinition<WorkflowLifecycleStatus> Default",
+          "returnType": "WorkflowDefinition<WorkflowLifecycleStatus>"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowMetrics",
+      "fqn": "Granit.Workflow.Diagnostics.WorkflowMetrics",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Diagnostics/WorkflowMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordTransitionDuration",
+          "kind": "method",
+          "signature": "RecordTransitionDuration(string? tenantId, string outcome, TimeSpan duration)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IVersionedEntity",
+      "fqn": "Granit.Workflow.Domain.IVersionedEntity",
+      "kind": "interface",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Domain/IVersionedEntity.cs",
+      "line": 23,
+      "members": []
+    },
+    {
+      "name": "IWorkflowStateful",
+      "fqn": "Granit.Workflow.Domain.IWorkflowStateful",
+      "kind": "interface",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Domain/IWorkflowStateful.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "GetWorkflowEntityId",
+          "kind": "method",
+          "signature": "GetWorkflowEntityId()",
+          "returnType": "string StatusPropertyName { get; } string WorkflowEntityType { get; } string"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowStateName",
+      "fqn": "Granit.Workflow.Domain.ValueObjects.WorkflowStateName",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Domain/ValueObjects/WorkflowStateName.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(string value)",
+          "returnType": "required string Value { get; init; } public WorkflowStateName"
+        },
+        {
+          "name": "WorkflowStateName",
+          "kind": "method",
+          "signature": "WorkflowStateName(string value)",
+          "returnType": "implicit operator"
+        }
+      ]
+    },
+    {
+      "name": "VersionedWorkflowEntity",
+      "fqn": "Granit.Workflow.Domain.VersionedWorkflowEntity",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Domain/VersionedWorkflowEntity.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "GetWorkflowEntityId",
+          "kind": "method",
+          "signature": "GetWorkflowEntityId()",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowLifecycleStatus",
+      "fqn": "Granit.Workflow.Domain.WorkflowLifecycleStatus",
+      "kind": "enum",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Domain/WorkflowLifecycleStatus.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "WorkflowTransitionRecord",
+      "fqn": "Granit.Workflow.Domain.WorkflowTransitionRecord",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Domain/WorkflowTransitionRecord.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "EntityType",
+          "kind": "property",
+          "signature": "string EntityType",
+          "returnType": "string"
+        },
+        {
+          "name": "EntityId",
+          "kind": "property",
+          "signature": "string EntityId",
+          "returnType": "string"
+        },
+        {
+          "name": "PreviousState",
+          "kind": "property",
+          "signature": "string PreviousState",
+          "returnType": "string"
+        },
+        {
+          "name": "NewState",
+          "kind": "property",
+          "signature": "string NewState",
+          "returnType": "string"
+        },
+        {
+          "name": "TransitionedAt",
+          "kind": "property",
+          "signature": "DateTimeOffset TransitionedAt",
+          "returnType": "DateTimeOffset"
+        }
+      ]
+    },
+    {
+      "name": "TransitionHistoryResponse",
+      "fqn": "Granit.Workflow.Dtos.TransitionHistoryResponse",
+      "kind": "record",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Dtos/TransitionHistoryResponse.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "WorkflowStatusResponse",
+      "fqn": "Granit.Workflow.Endpoints.Dtos.WorkflowStatusResponse",
+      "kind": "record",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Dtos/WorkflowStatusResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "WorkflowTransitionRequest",
+      "fqn": "Granit.Workflow.Endpoints.Dtos.WorkflowTransitionRequest",
+      "kind": "record",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Dtos/WorkflowTransitionRequest.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "WorkflowTransitionResponse",
+      "fqn": "Granit.Workflow.Endpoints.Dtos.WorkflowTransitionResponse",
+      "kind": "record",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Dtos/WorkflowTransitionResponse.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "WorkflowTransitionResultResponse",
+      "fqn": "Granit.Workflow.Endpoints.Dtos.WorkflowTransitionResultResponse",
+      "kind": "record",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Dtos/WorkflowTransitionResultResponse.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "WorkflowEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Workflow.Endpoints.Extensions.WorkflowEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Extensions/WorkflowEndpointRouteBuilderExtensions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "MapWorkflowEndpoints",
+          "kind": "method",
+          "signature": "MapWorkflowEndpoints(this IEndpointRouteBuilder endpoints, Action<WorkflowEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowEndpointsServiceCollectionExtensions",
+      "fqn": "Granit.Workflow.Endpoints.Extensions.WorkflowEndpointsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Extensions/WorkflowEndpointsServiceCollectionExtensions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "AddGranitWorkflowEndpoints",
+          "kind": "method",
+          "signature": "AddGranitWorkflowEndpoints(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitWorkflowEndpointsModule",
+      "fqn": "Granit.Workflow.Endpoints.GranitWorkflowEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/GranitWorkflowEndpointsModule.cs",
+      "line": 32,
+      "members": []
+    },
+    {
+      "name": "WorkflowAuthorizationPolicy",
+      "fqn": "Granit.Workflow.Endpoints.Internal.WorkflowAuthorizationPolicy",
+      "kind": "class",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Internal/WorkflowAuthorizationPolicy.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "WorkflowEndpointsOptions",
+      "fqn": "Granit.Workflow.Endpoints.Options.WorkflowEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Options/WorkflowEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "RequiredRole",
+          "kind": "property",
+          "signature": "string RequiredRole",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "History",
+      "fqn": "Granit.Workflow.Endpoints.Permissions.History",
+      "kind": "class",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Permissions/WorkflowPermissions.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "Transitions",
+      "fqn": "Granit.Workflow.Endpoints.Permissions.Transitions",
+      "kind": "class",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Permissions/WorkflowPermissions.cs",
+      "line": 23,
+      "members": []
+    },
+    {
+      "name": "WorkflowPermissions",
+      "fqn": "Granit.Workflow.Endpoints.Permissions.WorkflowPermissions",
+      "kind": "class",
+      "project": "Granit.Workflow.Endpoints",
+      "file": "src/Granit.Workflow.Endpoints/Permissions/WorkflowPermissions.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "WorkflowEfCoreServiceCollectionExtensions",
+      "fqn": "Granit.Workflow.EntityFrameworkCore.Extensions.WorkflowEfCoreServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Workflow.EntityFrameworkCore",
+      "file": "src/Granit.Workflow.EntityFrameworkCore/Extensions/WorkflowEfCoreServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "WorkflowModelBuilderExtensions",
+      "fqn": "Granit.Workflow.EntityFrameworkCore.Extensions.WorkflowModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Workflow.EntityFrameworkCore",
+      "file": "src/Granit.Workflow.EntityFrameworkCore/Extensions/WorkflowModelBuilderExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "ConfigureWorkflowModule",
+          "kind": "method",
+          "signature": "ConfigureWorkflowModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitWorkflowDbProperties",
+      "fqn": "Granit.Workflow.EntityFrameworkCore.GranitWorkflowDbProperties",
+      "kind": "class",
+      "project": "Granit.Workflow.EntityFrameworkCore",
+      "file": "src/Granit.Workflow.EntityFrameworkCore/GranitWorkflowDbProperties.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitWorkflowEntityFrameworkCoreModule",
+      "fqn": "Granit.Workflow.EntityFrameworkCore.GranitWorkflowEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.Workflow.EntityFrameworkCore",
+      "file": "src/Granit.Workflow.EntityFrameworkCore/GranitWorkflowEntityFrameworkCoreModule.cs",
+      "line": 29,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IWorkflowDbContext",
+      "fqn": "Granit.Workflow.EntityFrameworkCore.IWorkflowDbContext",
+      "kind": "interface",
+      "project": "Granit.Workflow.EntityFrameworkCore",
+      "file": "src/Granit.Workflow.EntityFrameworkCore/IWorkflowDbContext.cs",
+      "line": 29,
+      "members": []
+    },
+    {
+      "name": "WorkflowTransitionInterceptor",
+      "fqn": "Granit.Workflow.EntityFrameworkCore.Interceptors.WorkflowTransitionInterceptor",
+      "kind": "class",
+      "project": "Granit.Workflow.EntityFrameworkCore",
+      "file": "src/Granit.Workflow.EntityFrameworkCore/Interceptors/WorkflowTransitionInterceptor.cs",
+      "line": 35,
+      "members": [
+        {
+          "name": "SavingChanges",
+          "kind": "method",
+          "signature": "SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)",
+          "returnType": "InterceptionResult<int>"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowApprovalRequestedEvent",
+      "fqn": "Granit.Workflow.Events.WorkflowApprovalRequestedEvent",
+      "kind": "record",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Events/WorkflowApprovalRequestedEvent.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "WorkflowStateChangedEvent",
+      "fqn": "Granit.Workflow.Events.WorkflowStateChangedEvent",
+      "kind": "record",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Events/WorkflowStateChangedEvent.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "WorkflowTransitionedEvent",
+      "fqn": "Granit.Workflow.Events.WorkflowTransitionedEvent",
+      "kind": "record",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Events/WorkflowTransitionedEvent.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "WorkflowServiceCollectionExtensions",
+      "fqn": "Granit.Workflow.Extensions.WorkflowServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/Extensions/WorkflowServiceCollectionExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "AddGranitWorkflow",
+          "kind": "method",
+          "signature": "AddGranitWorkflow(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitWorkflowModule",
+      "fqn": "Granit.Workflow.GranitWorkflowModule",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/GranitWorkflowModule.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "IWorkflowDefinition",
+      "fqn": "Granit.Workflow.IWorkflowDefinition",
+      "kind": "interface",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/IWorkflowDefinition.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetAllowedTransitions",
+          "kind": "method",
+          "signature": "GetAllowedTransitions(TState from)",
+          "returnType": "TState InitialState { get; } IReadOnlyList<WorkflowTransition<TState>> Transitions { get; } IReadOnlyList<WorkflowTransition<TState>>"
+        }
+      ]
+    },
+    {
+      "name": "IWorkflowHistoryQuery",
+      "fqn": "Granit.Workflow.IWorkflowHistoryQuery",
+      "kind": "interface",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/IWorkflowHistoryQuery.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "GetHistoryAsync",
+          "kind": "method",
+          "signature": "GetHistoryAsync(string entityType, string entityId, int page = 1, int pageSize = QueryingDefaults.DefaultPageSize, CancellationToken cancellationToken = default)",
+          "returnType": "Task<PagedResult<TransitionHistoryResponse>>"
+        }
+      ]
+    },
+    {
+      "name": "IWorkflowManager",
+      "fqn": "Granit.Workflow.IWorkflowManager",
+      "kind": "interface",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/IWorkflowManager.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetAllowedTransitionsAsync",
+          "kind": "method",
+          "signature": "GetAllowedTransitionsAsync(TState currentState, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<WorkflowTransition<TState>>>"
+        },
+        {
+          "name": "TransitionAsync",
+          "kind": "method",
+          "signature": "TransitionAsync(TState currentState, TState targetState, TransitionContext? context = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TransitionResult<TState>>"
+        }
+      ]
+    },
+    {
+      "name": "IWorkflowPermissionChecker",
+      "fqn": "Granit.Workflow.IWorkflowPermissionChecker",
+      "kind": "interface",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/IWorkflowPermissionChecker.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "IsGrantedAsync",
+          "kind": "method",
+          "signature": "IsGrantedAsync(string permissionName, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "IWorkflowTransitionRecorder",
+      "fqn": "Granit.Workflow.IWorkflowTransitionRecorder",
+      "kind": "interface",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/IWorkflowTransitionRecorder.cs",
+      "line": 34,
+      "members": [
+        {
+          "name": "RecordTransitionAsync",
+          "kind": "method",
+          "signature": "RecordTransitionAsync(RecordTransitionRequest request, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowNotificationsServiceCollectionExtensions",
+      "fqn": "Granit.Workflow.Notifications.Extensions.WorkflowNotificationsServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Workflow.Notifications",
+      "file": "src/Granit.Workflow.Notifications/Extensions/WorkflowNotificationsServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitWorkflowNotifications",
+          "kind": "method",
+          "signature": "AddGranitWorkflowNotifications(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitWorkflowNotificationsModule",
+      "fqn": "Granit.Workflow.Notifications.GranitWorkflowNotificationsModule",
+      "kind": "class",
+      "project": "Granit.Workflow.Notifications",
+      "file": "src/Granit.Workflow.Notifications/GranitWorkflowNotificationsModule.cs",
+      "line": 31,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowApprovalRequestedHandler",
+      "fqn": "Granit.Workflow.Notifications.Handlers.WorkflowApprovalRequestedHandler",
+      "kind": "class",
+      "project": "Granit.Workflow.Notifications",
+      "file": "src/Granit.Workflow.Notifications/Handlers/WorkflowApprovalRequestedHandler.cs",
+      "line": 28,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(WorkflowApprovalRequestedEvent message, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowStateChangedHandler",
+      "fqn": "Granit.Workflow.Notifications.Handlers.WorkflowStateChangedHandler",
+      "kind": "class",
+      "project": "Granit.Workflow.Notifications",
+      "file": "src/Granit.Workflow.Notifications/Handlers/WorkflowStateChangedHandler.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(WorkflowStateChangedEvent message, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IApproverResolver",
+      "fqn": "Granit.Workflow.Notifications.IApproverResolver",
+      "kind": "interface",
+      "project": "Granit.Workflow.Notifications",
+      "file": "src/Granit.Workflow.Notifications/IApproverResolver.cs",
+      "line": 19,
+      "members": [
+        {
+          "name": "ResolveApproversAsync",
+          "kind": "method",
+          "signature": "ResolveApproversAsync(string requiredPermission, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<string>>"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowApprovalNotificationData",
+      "fqn": "Granit.Workflow.Notifications.WorkflowApprovalNotificationData",
+      "kind": "record",
+      "project": "Granit.Workflow.Notifications",
+      "file": "src/Granit.Workflow.Notifications/WorkflowApprovalNotificationType.cs",
+      "line": 33,
+      "members": []
+    },
+    {
+      "name": "WorkflowApprovalNotificationType",
+      "fqn": "Granit.Workflow.Notifications.WorkflowApprovalNotificationType",
+      "kind": "class",
+      "project": "Granit.Workflow.Notifications",
+      "file": "src/Granit.Workflow.Notifications/WorkflowApprovalNotificationType.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "WorkflowApprovalNotificationType Instance ="
+        },
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSeverity",
+          "kind": "property",
+          "signature": "NotificationSeverity DefaultSeverity",
+          "returnType": "NotificationSeverity"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowStateChangedNotificationData",
+      "fqn": "Granit.Workflow.Notifications.WorkflowStateChangedNotificationData",
+      "kind": "record",
+      "project": "Granit.Workflow.Notifications",
+      "file": "src/Granit.Workflow.Notifications/WorkflowStateChangedNotificationType.cs",
+      "line": 34,
+      "members": []
+    },
+    {
+      "name": "WorkflowStateChangedNotificationType",
+      "fqn": "Granit.Workflow.Notifications.WorkflowStateChangedNotificationType",
+      "kind": "class",
+      "project": "Granit.Workflow.Notifications",
+      "file": "src/Granit.Workflow.Notifications/WorkflowStateChangedNotificationType.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "WorkflowStateChangedNotificationType Instance ="
+        },
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "DefaultSeverity",
+          "kind": "property",
+          "signature": "NotificationSeverity DefaultSeverity",
+          "returnType": "NotificationSeverity"
+        }
+      ]
+    },
+    {
+      "name": "RecordTransitionRequest",
+      "fqn": "Granit.Workflow.RecordTransitionRequest",
+      "kind": "record",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/IWorkflowTransitionRecorder.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "TransitionBuilder",
+      "fqn": "Granit.Workflow.TransitionBuilder",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/TransitionBuilder.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "TransitionContext",
+      "fqn": "Granit.Workflow.TransitionContext",
+      "kind": "record",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/TransitionContext.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "TransitionInfo",
+      "fqn": "Granit.Workflow.TransitionInfo",
+      "kind": "record",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/WorkflowTransitionContext.cs",
+      "line": 43,
+      "members": []
+    },
+    {
+      "name": "TransitionOutcome",
+      "fqn": "Granit.Workflow.TransitionOutcome",
+      "kind": "enum",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/TransitionResult.cs",
+      "line": 25,
+      "members": []
+    },
+    {
+      "name": "TransitionResult",
+      "fqn": "Granit.Workflow.TransitionResult",
+      "kind": "record",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/TransitionResult.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "WorkflowDefinition",
+      "fqn": "Granit.Workflow.WorkflowDefinition",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/WorkflowDefinition.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Action<WorkflowDefinitionBuilder<TState>> configure)",
+          "returnType": "WorkflowDefinition<TState>"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowDefinitionBuilder",
+      "fqn": "Granit.Workflow.WorkflowDefinitionBuilder",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/WorkflowDefinitionBuilder.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "InitialState",
+          "kind": "method",
+          "signature": "InitialState(TState state)",
+          "returnType": "WorkflowDefinitionBuilder<TState>"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowManager",
+      "fqn": "Granit.Workflow.WorkflowManager",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/WorkflowManager.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "GetAllowedTransitionsAsync",
+          "kind": "method",
+          "signature": "GetAllowedTransitionsAsync(TState currentState, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<WorkflowTransition<TState>>>"
+        }
+      ]
+    },
+    {
+      "name": "WorkflowTransition",
+      "fqn": "Granit.Workflow.WorkflowTransition",
+      "kind": "record",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/WorkflowTransition.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "WorkflowTransitionContext",
+      "fqn": "Granit.Workflow.WorkflowTransitionContext",
+      "kind": "class",
+      "project": "Granit.Workflow",
+      "file": "src/Granit.Workflow/WorkflowTransitionContext.cs",
+      "line": 22,
+      "members": [
+        {
+          "name": "Current",
+          "kind": "property",
+          "signature": "TransitionInfo? Current",
+          "returnType": "TransitionInfo?"
+        },
+        {
+          "name": "SetComment",
+          "kind": "method",
+          "signature": "SetComment(string? comment)",
+          "returnType": "IDisposable"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Granit.Caching.Tests.Integration/BackplaneIntegrationTests.cs
+++ b/tests/Granit.Caching.Tests.Integration/BackplaneIntegrationTests.cs
@@ -1,0 +1,173 @@
+// =============================================================================
+// Integration tests — FusionCache Redis backplane
+// =============================================================================
+// Validates cross-instance L1 cache invalidation via Redis pub/sub backplane.
+// Two independent FusionCache instances share the same Redis L2 + backplane.
+//
+// Requires Docker (Testcontainers spins up a Redis container).
+// The container is shared across the class via IClassFixture.
+// =============================================================================
+
+using Microsoft.Extensions.Caching.StackExchangeRedis;
+using Shouldly;
+using StackExchange.Redis;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion;
+using ZiggyCreatures.Caching.Fusion.Backplane.StackExchangeRedis;
+using ZiggyCreatures.Caching.Fusion.Serialization.SystemTextJson;
+using MsOptions = Microsoft.Extensions.Options.Options;
+
+namespace Granit.Caching.Tests.Integration;
+
+public sealed class BackplaneIntegrationTests(
+    RedisContainerFixture redis) : IClassFixture<RedisContainerFixture>, IAsyncDisposable
+{
+    private readonly List<IFusionCache> _caches = [];
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (IFusionCache cache in _caches)
+        {
+            if (cache is IAsyncDisposable d)
+            {
+                await d.DisposeAsync();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task SetOnInstanceA_IsReadableOnInstanceB_ViaL2()
+    {
+        // Arrange
+        (IFusionCache cacheA, IFusionCache cacheB) = await CreatePairAsync(TestContext.Current.CancellationToken);
+
+        // Act — write on A
+        await cacheA.SetAsync("shared-key", "hello-from-A",
+            token: TestContext.Current.CancellationToken);
+
+        // Assert — B reads from L2 (Redis) on cache miss
+        string? value = await cacheB.GetOrDefaultAsync<string>("shared-key",
+            token: TestContext.Current.CancellationToken);
+
+        value.ShouldBe("hello-from-A");
+    }
+
+    [Fact]
+    public async Task ExpireOnInstanceA_InvalidatesL1OnInstanceB_ViaBackplane()
+    {
+        // Arrange
+        (IFusionCache cacheA, IFusionCache cacheB) = await CreatePairAsync(TestContext.Current.CancellationToken);
+
+        // Populate on both instances (both have L1 populated)
+        await cacheA.SetAsync("bp-key", "original",
+            token: TestContext.Current.CancellationToken);
+
+        // Force B to read and populate its L1
+        string? warmup = await cacheB.GetOrDefaultAsync<string>("bp-key",
+            token: TestContext.Current.CancellationToken);
+        warmup.ShouldBe("original");
+
+        // Act — expire on A (backplane notifies B)
+        await cacheA.ExpireAsync("bp-key",
+            token: TestContext.Current.CancellationToken);
+
+        // Wait for backplane notification propagation
+        await Task.Delay(500, TestContext.Current.CancellationToken);
+
+        // Assert — B's next read should trigger factory (L1 invalidated by backplane)
+        bool factoryCalled = false;
+        string? result = await cacheB.GetOrSetAsync<string>("bp-key",
+            async (_, ct) =>
+            {
+                factoryCalled = true;
+                return "refreshed";
+            },
+            token: TestContext.Current.CancellationToken);
+
+        factoryCalled.ShouldBeTrue("Backplane should have invalidated B's L1, triggering the factory");
+        result.ShouldBe("refreshed");
+    }
+
+    [Fact]
+    public async Task RemoveOnInstanceA_DeletesFromL2_InstanceBGetsMiss()
+    {
+        // Arrange
+        (IFusionCache cacheA, IFusionCache cacheB) = await CreatePairAsync(TestContext.Current.CancellationToken);
+
+        await cacheA.SetAsync("rm-key", "to-delete",
+            token: TestContext.Current.CancellationToken);
+
+        // Verify B can read it
+        string? before = await cacheB.GetOrDefaultAsync<string>("rm-key",
+            token: TestContext.Current.CancellationToken);
+        before.ShouldBe("to-delete");
+
+        // Act — hard remove on A
+        await cacheA.RemoveAsync("rm-key",
+            token: TestContext.Current.CancellationToken);
+
+        // Wait for backplane
+        await Task.Delay(500, TestContext.Current.CancellationToken);
+
+        // Assert — B gets null (entry gone from L2)
+        string? after = await cacheB.GetOrDefaultAsync<string>("rm-key",
+            token: TestContext.Current.CancellationToken);
+        after.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// Creates two independent FusionCache instances sharing the same Redis L2 + backplane.
+    /// Each has its own L1 memory cache (simulating two pods).
+    /// </summary>
+    private async Task<(IFusionCache A, IFusionCache B)> CreatePairAsync(
+        CancellationToken cancellationToken)
+    {
+        IFusionCache a = await CreateInstanceAsync("instance-a", cancellationToken);
+        IFusionCache b = await CreateInstanceAsync("instance-b", cancellationToken);
+        _caches.Add(a);
+        _caches.Add(b);
+        return (a, b);
+    }
+
+    private async Task<IFusionCache> CreateInstanceAsync(string instanceName,
+        CancellationToken cancellationToken)
+    {
+        IConnectionMultiplexer mux = await ConnectionMultiplexer.ConnectAsync(
+            redis.ConnectionString);
+
+        var redisCache = new RedisCache(MsOptions.Create(new RedisCacheOptions
+        {
+            ConnectionMultiplexerFactory = () => Task.FromResult(mux),
+            InstanceName = "test:",
+        }));
+
+        var backplane = new RedisBackplane(
+            MsOptions.Create(new RedisBackplaneOptions
+            {
+                ConnectionMultiplexerFactory = () => Task.FromResult(mux),
+            }));
+
+        var cache = new FusionCache(
+            new FusionCacheOptions
+            {
+                CacheName = instanceName,
+                DefaultEntryOptions = new FusionCacheEntryOptions
+                {
+                    Duration = TimeSpan.FromMinutes(5),
+                    IsFailSafeEnabled = true,
+                    FailSafeMaxDuration = TimeSpan.FromHours(1),
+                },
+                EnableAutoRecovery = true,
+                BackplaneChannelPrefix = "test:bp",
+            });
+
+        cache.SetupSerializer(new FusionCacheSystemTextJsonSerializer());
+        cache.SetupDistributedCache(redisCache);
+        cache.SetupBackplane(backplane);
+
+        // Allow backplane subscription to settle
+        await Task.Delay(200, cancellationToken);
+
+        return cache;
+    }
+}

--- a/tests/Granit.Caching.Tests.Integration/FailSafeIntegrationTests.cs
+++ b/tests/Granit.Caching.Tests.Integration/FailSafeIntegrationTests.cs
@@ -1,0 +1,185 @@
+// =============================================================================
+// Integration tests — FusionCache fail-safe and factory timeouts
+// =============================================================================
+// Validates fail-safe behavior (stale data on factory failure) and factory
+// soft/hard timeouts with a real Redis L2 backend.
+//
+// Requires Docker (Testcontainers spins up a Redis container).
+// =============================================================================
+
+using Microsoft.Extensions.Caching.StackExchangeRedis;
+using Shouldly;
+using StackExchange.Redis;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion;
+using ZiggyCreatures.Caching.Fusion.Serialization.SystemTextJson;
+using MsOptions = Microsoft.Extensions.Options.Options;
+
+namespace Granit.Caching.Tests.Integration;
+
+public sealed class FailSafeIntegrationTests(
+    RedisContainerFixture redis) : IClassFixture<RedisContainerFixture>, IAsyncDisposable
+{
+    private IFusionCache? _cache;
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_cache is IAsyncDisposable d)
+        {
+            await d.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task FailSafe_WhenFactoryThrows_ReturnsStaleValue()
+    {
+        // Arrange
+        _cache = await CreateCacheAsync(failSafe: true, duration: TimeSpan.FromMilliseconds(100));
+
+        // Populate cache with a value
+        await _cache.SetAsync("fs-key", "original-value",
+            new FusionCacheEntryOptions
+            {
+                Duration = TimeSpan.FromMilliseconds(100),
+                IsFailSafeEnabled = true,
+                FailSafeMaxDuration = TimeSpan.FromHours(1),
+            },
+            token: TestContext.Current.CancellationToken);
+
+        // Wait for entry to expire
+        await Task.Delay(200, TestContext.Current.CancellationToken);
+
+        // Act — factory throws, fail-safe should return stale value
+        string? result = await _cache.GetOrSetAsync<string>("fs-key",
+            (_, _) => throw new InvalidOperationException("DB is down"),
+            new FusionCacheEntryOptions
+            {
+                Duration = TimeSpan.FromMinutes(5),
+                IsFailSafeEnabled = true,
+                FailSafeMaxDuration = TimeSpan.FromHours(1),
+            },
+            token: TestContext.Current.CancellationToken);
+
+        // Assert
+        result.ShouldBe("original-value");
+    }
+
+    [Fact]
+    public async Task FailSafe_WhenNoStaleValueAndFactoryThrows_ReturnsDefault()
+    {
+        // Arrange
+        _cache = await CreateCacheAsync(failSafe: true, duration: TimeSpan.FromMinutes(5));
+
+        // Act — no stale value exists, factory throws
+        string? result = await _cache.GetOrDefaultAsync<string>("no-stale-key",
+            token: TestContext.Current.CancellationToken);
+
+        // Assert — no stale, no factory, returns default
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task FactorySoftTimeout_WhenFactoryIsSlow_ReturnsStaleWithinTimeout()
+    {
+        // Arrange
+        _cache = await CreateCacheAsync(failSafe: true, duration: TimeSpan.FromMilliseconds(100));
+
+        // Populate cache
+        await _cache.SetAsync("timeout-key", "stale-value",
+            new FusionCacheEntryOptions
+            {
+                Duration = TimeSpan.FromMilliseconds(100),
+                IsFailSafeEnabled = true,
+                FailSafeMaxDuration = TimeSpan.FromHours(1),
+            },
+            token: TestContext.Current.CancellationToken);
+
+        // Wait for expiration
+        await Task.Delay(200, TestContext.Current.CancellationToken);
+
+        // Act — factory is slow (3s), soft timeout is 500ms
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        string? result = await _cache.GetOrSetAsync<string>("timeout-key",
+            async (_, ct) =>
+            {
+                await Task.Delay(3000, ct);
+                return "fresh-value";
+            },
+            new FusionCacheEntryOptions
+            {
+                Duration = TimeSpan.FromMinutes(5),
+                IsFailSafeEnabled = true,
+                FailSafeMaxDuration = TimeSpan.FromHours(1),
+                FactorySoftTimeout = TimeSpan.FromMilliseconds(500),
+                FactoryHardTimeout = TimeSpan.FromSeconds(10),
+                AllowBackgroundDistributedCacheOperations = true,
+            },
+            token: TestContext.Current.CancellationToken);
+        sw.Stop();
+
+        // Assert — stale value returned within soft timeout (not 3s)
+        result.ShouldBe("stale-value");
+        sw.ElapsedMilliseconds.ShouldBeLessThan(2000,
+            "Should return stale value within soft timeout, not wait for slow factory");
+    }
+
+    [Fact]
+    public async Task FailSafe_Disabled_WhenFactoryThrows_PropagatesException()
+    {
+        // Arrange
+        _cache = await CreateCacheAsync(failSafe: false, duration: TimeSpan.FromMilliseconds(100));
+
+        await _cache.SetAsync("no-fs-key", "value",
+            new FusionCacheEntryOptions
+            {
+                Duration = TimeSpan.FromMilliseconds(100),
+                IsFailSafeEnabled = false,
+            },
+            token: TestContext.Current.CancellationToken);
+
+        await Task.Delay(200, TestContext.Current.CancellationToken);
+
+        // Act & Assert — without fail-safe, exception propagates
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+        {
+            await _cache.GetOrSetAsync<string>("no-fs-key",
+                (_, _) => throw new InvalidOperationException("DB is down"),
+                new FusionCacheEntryOptions
+                {
+                    Duration = TimeSpan.FromMinutes(5),
+                    IsFailSafeEnabled = false,
+                },
+                token: TestContext.Current.CancellationToken);
+        });
+    }
+
+    private async Task<IFusionCache> CreateCacheAsync(bool failSafe, TimeSpan duration)
+    {
+        IConnectionMultiplexer mux = await ConnectionMultiplexer.ConnectAsync(
+            redis.ConnectionString);
+
+        var redisCache = new RedisCache(MsOptions.Create(new RedisCacheOptions
+        {
+            ConnectionMultiplexerFactory = () => Task.FromResult(mux),
+            InstanceName = "fs-test:",
+        }));
+
+        var cache = new FusionCache(
+            new FusionCacheOptions
+            {
+                CacheName = $"failsafe-{Guid.NewGuid():N}",
+                DefaultEntryOptions = new FusionCacheEntryOptions
+                {
+                    Duration = duration,
+                    IsFailSafeEnabled = failSafe,
+                    FailSafeMaxDuration = TimeSpan.FromHours(1),
+                    FailSafeThrottleDuration = TimeSpan.FromSeconds(1),
+                },
+            });
+
+        cache.SetupSerializer(new FusionCacheSystemTextJsonSerializer());
+        cache.SetupDistributedCache(redisCache);
+
+        return cache;
+    }
+}

--- a/tests/Granit.Caching.Tests.Integration/Granit.Caching.Tests.Integration.csproj
+++ b/tests/Granit.Caching.Tests.Integration/Granit.Caching.Tests.Integration.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <!-- Exclude from dotnet test in CI unit-test job (no Docker available). -->
+    <IsTestProject Condition="'$(SkipIntegrationTests)' == 'true'">false</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Testcontainers.Redis" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Caching.StackExchangeRedis\Granit.Caching.StackExchangeRedis.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.Caching.Tests.Integration/RedisContainerFixture.cs
+++ b/tests/Granit.Caching.Tests.Integration/RedisContainerFixture.cs
@@ -1,0 +1,21 @@
+using Testcontainers.Redis;
+using Xunit;
+
+namespace Granit.Caching.Tests.Integration;
+
+/// <summary>
+/// Shared fixture — starts a single Redis container once per test class.
+/// Amortizes the ~2 s startup cost across all tests in the class.
+/// </summary>
+public sealed class RedisContainerFixture : IAsyncLifetime
+{
+    private readonly RedisContainer _container = new RedisBuilder("redis:7-alpine")
+        .Build();
+
+    /// <summary>Redis connection string (e.g. <c>"localhost:32768"</c>).</summary>
+    public string ConnectionString => _container.GetConnectionString();
+
+    public ValueTask InitializeAsync() => new(_container.StartAsync());
+
+    public ValueTask DisposeAsync() => _container.DisposeAsync();
+}

--- a/tests/Granit.Caching.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Caching.Tests.Integration/packages.lock.json
@@ -1,0 +1,484 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[8.*, )",
+        "resolved": "8.0.1",
+        "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.*, )",
+        "resolved": "18.3.0",
+        "contentHash": "xW3kXuWRQtgoxJp4J+gdhHSQyK+6Wb/AZDSd7lMvuMRYlZ1tnpkojyfZlWilB5G4dmZ0Y0ZxU/M23TlubndNkw==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.3.0",
+          "Microsoft.TestPlatform.TestHost": "18.3.0"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "Testcontainers.Redis": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.11.0",
+        "contentHash": "nw7no/3yfjRZFdYju9Wa5TMWlbnXNUVq5qfePrLjaWMYbcXGkT88ZPw82v4HLGSQPGPug24OlC1IT6Kf+4j//Q==",
+        "dependencies": {
+          "Testcontainers": "4.11.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "hGLHCNUsQbT2Ab/HUznRnNqYZQs40zInXa3eLwYjeNyfUYbw1pqqDGqcOLl5uGepS8IuigEYakEdAcVT/2ezYg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "8FU7zmttFQzp0xb0EPupxQ0nGtC2cTpukgh3jMxMT8luj5TSDyzIKTnroDpXCjpg9P2fV+6JIvC+IetsMEfyBA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "23BNy/vziREC20Wwhb50K7+kZe0m07KlLWDQv4qjJ9tt3QjpDpDIqJFrhYHmMEo9xDkuSp55U/8h4bMF7MiB+g=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "AEIEX2aWdPO9XbtR96eBaJxmXRD9vaI9uQ1T/JbPEKlTAZwYx0ZrMzKyULMdh/HH9Sg03kXCoN7LszQ90o6nPQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "twmsoelXnp1uWMU3VGip9f0Jr1mZ0PZqgJdF35CIrdYgYrkHIJMV1m8uKyhcdjLdsQDESHAgkR7KhS9i1qpJag==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.3.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Pipelines.Sockets.Unofficial": {
+        "type": "Transitive",
+        "resolved": "2.2.8",
+        "contentHash": "zG2FApP5zxSx6OcdJQLbZDk2AVlN2BNQD6MorwIfV6gVj0RRxWPEp2LXAxqDGZqeNV1Zp0BNPcNaey/GXmTdvQ=="
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2025.1.0",
+        "contentHash": "jrnbtf0ItVaXAe6jE8X/kSLa6uC+0C+7W1vepcnRQB/rD88qy4IxG7Lf1FIbWmkoc4iVXv0pKrz+Wc6J4ngmHw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.6.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "AKJknIFi9O3+rGExxTry188JPvUoZAPcCtS2qdqyFhIzsxQ1Ap94BeGDG0VzVEHakhmRxmJtVih6TsHoghIt/g=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "Testcontainers": {
+        "type": "Transitive",
+        "resolved": "4.11.0",
+        "contentHash": "9pBNaK9Ra3GVnr5h6gaDJOBH0txA5G3Juho5WANPuyu38l5xyr2lCvf11oA5/uSd+Lh4Wtng34nKp3nMiea02g==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1",
+          "Docker.DotNet.Enhanced.X509": "3.131.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2025.1.0",
+          "SharpZipLib": "1.4.2"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.caching.stackexchangeredis": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.StackExchangeRedis": "[10.*, )",
+          "StackExchange.Redis": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis": "[2.*, )"
+        }
+      },
+      "granit.core": {
+        "type": "Project"
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "k/QDdQ94/0Shi0KfU+e12m73jfQo+3JpErTtgpZfsCIqkvdEEO0XIx6R+iTbN55rNPaNhOqNY4/sB+jZ8XxVPw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "jUEXmkBUPdOS/MP9areK/sbKhdklq9+tEhvwfxGalZVnmyLUO5rrheNNutUBtvbZ7J8ECkG7/r2KXi/IFC06cA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Caching.StackExchangeRedis": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "zXb143/TpEKOLQuWGw2CkJgb9F4XXh2XbevMvppzsIHr1/pjML0zjc+vzXcpCV8YUwpW5NIaScZhzFSm621B3Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "StackExchange.Redis": "2.7.27"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.14.0",
+        "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "StackExchange.Redis": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.12.4",
+        "contentHash": "KNyzLp0aTcvWSxnbS6rCxX+2e+Q3goXhW80Iu7dwMkCQbENkoBw418I/UpgIxGzmS4gV10a5CdfdY4O0tO9Nrg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Pipelines.Sockets.Unofficial": "2.2.8",
+          "System.IO.Hashing": "10.0.2"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "GHzTt4OVBzVcajgFUJ8oHLmBZJPF+pi044LKG5rTS44ECcSxfzzvSnVZoTPrECbPl3tG96TyiLM+P4uIvzZWPQ==",
+        "dependencies": {
+          "StackExchange.Redis": "2.10.1",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add 7 FusionCache integration tests with Testcontainers Redis (#534)
- Validate backplane cross-pod invalidation and fail-safe behavior with a real Redis instance

### Tests

**BackplaneIntegrationTests** (3 tests) — two independent FusionCache instances sharing Redis L2 + backplane:
- `SetOnInstanceA_IsReadableOnInstanceB_ViaL2`
- `ExpireOnInstanceA_InvalidatesL1OnInstanceB_ViaBackplane`
- `RemoveOnInstanceA_DeletesFromL2_InstanceBGetsMiss`

**FailSafeIntegrationTests** (4 tests) — fail-safe and factory timeouts with real Redis:
- `FailSafe_WhenFactoryThrows_ReturnsStaleValue`
- `FailSafe_WhenNoStaleValueAndFactoryThrows_ReturnsDefault`
- `FactorySoftTimeout_WhenFactoryIsSlow_ReturnsStaleWithinTimeout`
- `FailSafe_Disabled_WhenFactoryThrows_PropagatesException`

Closes #534

## Test plan

- [x] All 7 integration tests pass with Docker (Testcontainers Redis 7-alpine)
- [x] `dotnet build` — 0 errors
- [x] Excluded from CI unit-test job via `SkipIntegrationTests` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
