### PR TITLE
chore(ci): upgrade actions/checkout to v6 in code-index job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,7 +473,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Regenerate .mcp-code-index.json
         run: python3 scripts/generate-code-index.py

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-21T11:39:14.693948+00:00",
+  "generatedAt": "2026-03-21T12:04:37.905885+00:00",
   "repo": "granit-dotnet",
   "projectGraph": [
     {

--- a/tests/Granit.DataExchange.Endpoints.Tests/Dtos/Export/ExportDtoMappingTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Dtos/Export/ExportDtoMappingTests.cs
@@ -58,7 +58,7 @@ public sealed class ExportDtoMappingTests
         IExportDefinitionDescriptor descriptor = Substitute.For<IExportDefinitionDescriptor>();
         descriptor.Name.Returns("Acme.PatientExport");
         descriptor.EntityType.Returns(typeof(TestEntity));
-        descriptor.SupportedFormats.Returns(new List<string> { "xlsx", "csv" });
+        descriptor.SupportedFormats.Returns(["xlsx", "csv"]);
 
         var response = ExportDefinitionResponse.FromDescriptor(descriptor);
 

--- a/tests/Granit.Http.ApiDocumentation.Tests/DictionarySchemaExampleOperationTransformerTests.cs
+++ b/tests/Granit.Http.ApiDocumentation.Tests/DictionarySchemaExampleOperationTransformerTests.cs
@@ -27,7 +27,7 @@ public sealed class DictionarySchemaExampleOperationTransformerTests
     [Fact]
     public async Task TransformAsync_EmptyResponses_DoesNotThrow()
     {
-        OpenApiOperation operation = new() { Responses = new OpenApiResponses() };
+        OpenApiOperation operation = new() { Responses = [] };
 
         await _sut.TransformAsync(operation, BuildContext(), TestContext.Current.CancellationToken);
 

--- a/tests/Granit.Observability.Tests/ObservabilityOptionsTests.cs
+++ b/tests/Granit.Observability.Tests/ObservabilityOptionsTests.cs
@@ -150,7 +150,7 @@ public sealed class ObservabilityOptionsTests
     {
         // Arrange — section exists but is empty
         IConfigurationRoot config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .AddInMemoryCollection([])
             .Build();
 
         // Act

--- a/tests/Granit.Querying.EntityFrameworkCore.Tests/Internal/CompositeCursorBuilderTests.cs
+++ b/tests/Granit.Querying.EntityFrameworkCore.Tests/Internal/CompositeCursorBuilderTests.cs
@@ -92,7 +92,7 @@ public sealed class CompositeCursorBuilderTests
     public void BuildCursorPredicate_returns_null_when_no_sort_fields()
     {
         Expression<Func<TestProduct, bool>>? result = CompositeCursorBuilder.BuildCursorPredicate<TestProduct>(
-            [], new Dictionary<string, string>());
+            [], []);
 
         result.ShouldBeNull();
     }
@@ -104,7 +104,7 @@ public sealed class CompositeCursorBuilderTests
             CompositeCursorBuilder.ParseSortFields<TestProduct>("Price");
 
         Expression<Func<TestProduct, bool>>? result = CompositeCursorBuilder.BuildCursorPredicate<TestProduct>(
-            fields, new Dictionary<string, string>());
+            fields, []);
 
         result.ShouldBeNull();
     }


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` from v4 to v6 in the `code-index` CI job to fix Node.js 20 deprecation warning

## Context

GitHub Actions will force Node.js 24 by default starting June 2nd, 2026. The `code-index` job was the only remaining job using `actions/checkout@v4` (Node.js 20). All other jobs already use `@v6`.

## Test plan

- [ ] CI `code-index` job passes without Node.js deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)