### PR TITLE
feat(privacy): add Privacy.Endpoints + enforce audit compliance across 25 modules

### DIFF
--- a/.github/test-shards.json
+++ b/.github/test-shards.json
@@ -213,6 +213,7 @@
         "tests/Granit.Identity.Keycloak.Tests",
         "tests/Granit.Identity.Tests",
         "tests/Granit.Privacy.Tests",
+        "tests/Granit.Privacy.Endpoints.Tests",
         "tests/Granit.Security.Tests",
         "tests/Granit.Vault.Aws.Tests",
         "tests/Granit.Vault.Azure.Tests",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,7 +473,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Regenerate .mcp-code-index.json
         run: python3 scripts/generate-code-index.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,8 @@ jobs:
 
   trivy:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v6
 

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-21T15:02:28.498558+00:00",
+  "generatedAt": "2026-03-21T15:04:58.833243+00:00",
   "repo": "granit-dotnet",
   "projectGraph": [
     {

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-21T15:04:58.833243+00:00",
+  "generatedAt": "2026-03-21T15:15:16.521902+00:00",
   "repo": "granit-dotnet",
   "projectGraph": [
     {
@@ -933,6 +933,19 @@
       "deps": [
         "Granit.AI",
         "Granit.Observability"
+      ],
+      "framework": "net10.0"
+    },
+    {
+      "name": "Granit.OpenIddict",
+      "deps": [
+        "Granit.Core",
+        "Granit.EventBus",
+        "Granit.Guids",
+        "Granit.Identity",
+        "Granit.Querying",
+        "Granit.Security",
+        "Granit.Timing"
       ],
       "framework": "net10.0"
     },
@@ -17828,6 +17841,266 @@
           "returnType": "bool"
         }
       ]
+    },
+    {
+      "name": "AccountDeletedEto",
+      "fqn": "Granit.OpenIddict.Events.AccountDeletedEto",
+      "kind": "record",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Events/AccountDeletedEto.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "UserImpersonatedEto",
+      "fqn": "Granit.OpenIddict.Events.UserImpersonatedEto",
+      "kind": "record",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Events/UserImpersonatedEto.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "UserRegisteredEto",
+      "fqn": "Granit.OpenIddict.Events.UserRegisteredEto",
+      "kind": "record",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Events/UserRegisteredEto.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "CurrentUserServiceExtensions",
+      "fqn": "Granit.OpenIddict.Extensions.CurrentUserServiceExtensions",
+      "kind": "class",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Extensions/CurrentUserServiceExtensions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "IsImpersonated",
+          "kind": "method",
+          "signature": "IsImpersonated(this ICurrentUserService user)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "GranitOpenIddictModule",
+      "fqn": "Granit.OpenIddict.GranitOpenIddictModule",
+      "kind": "class",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/GranitOpenIddictModule.cs",
+      "line": 22,
+      "members": []
+    },
+    {
+      "name": "OpenIddictFeatureNames",
+      "fqn": "Granit.OpenIddict.OpenIddictFeatureNames",
+      "kind": "class",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/OpenIddictFeatureNames.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "OpenIddictSettingNames",
+      "fqn": "Granit.OpenIddict.OpenIddictSettingNames",
+      "kind": "class",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/OpenIddictSettingNames.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "GranitOpenIddictOptions",
+      "fqn": "Granit.OpenIddict.Options.GranitOpenIddictOptions",
+      "kind": "class",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Options/GranitOpenIddictOptions.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "Applications",
+      "fqn": "Granit.OpenIddict.Permissions.Applications",
+      "kind": "class",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Permissions/OpenIddictPermissions.cs",
+      "line": 65,
+      "members": []
+    },
+    {
+      "name": "Authorizations",
+      "fqn": "Granit.OpenIddict.Permissions.Authorizations",
+      "kind": "class",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Permissions/OpenIddictPermissions.cs",
+      "line": 100,
+      "members": []
+    },
+    {
+      "name": "Groups",
+      "fqn": "Granit.OpenIddict.Permissions.Groups",
+      "kind": "class",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Permissions/OpenIddictPermissions.cs",
+      "line": 49,
+      "members": []
+    },
+    {
+      "name": "OpenIddictPermissions",
+      "fqn": "Granit.OpenIddict.Permissions.OpenIddictPermissions",
+      "kind": "class",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Permissions/OpenIddictPermissions.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "Roles",
+      "fqn": "Granit.OpenIddict.Permissions.Roles",
+      "kind": "class",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Permissions/OpenIddictPermissions.cs",
+      "line": 36,
+      "members": []
+    },
+    {
+      "name": "Scopes",
+      "fqn": "Granit.OpenIddict.Permissions.Scopes",
+      "kind": "class",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Permissions/OpenIddictPermissions.cs",
+      "line": 84,
+      "members": []
+    },
+    {
+      "name": "Users",
+      "fqn": "Granit.OpenIddict.Permissions.Users",
+      "kind": "class",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Permissions/OpenIddictPermissions.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "ExternalLoginInfo",
+      "fqn": "Granit.OpenIddict.Services.ExternalLoginInfo",
+      "kind": "record",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Services/IExternalLoginService.cs",
+      "line": 51,
+      "members": []
+    },
+    {
+      "name": "IAccountDeletionService",
+      "fqn": "Granit.OpenIddict.Services.IAccountDeletionService",
+      "kind": "interface",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Services/IAccountDeletionService.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "InitiateAsync",
+          "kind": "method",
+          "signature": "InitiateAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IEmailConfirmationService",
+      "fqn": "Granit.OpenIddict.Services.IEmailConfirmationService",
+      "kind": "interface",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Services/IEmailConfirmationService.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "SendConfirmationEmailAsync",
+          "kind": "method",
+          "signature": "SendConfirmationEmailAsync(string userId, string email, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "ConfirmAsync",
+          "kind": "method",
+          "signature": "ConfirmAsync(string userId, string token, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
+        }
+      ]
+    },
+    {
+      "name": "IExternalLoginService",
+      "fqn": "Granit.OpenIddict.Services.IExternalLoginService",
+      "kind": "interface",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Services/IExternalLoginService.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "GetLoginsAsync",
+          "kind": "method",
+          "signature": "GetLoginsAsync(string userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<ExternalLoginInfo>>"
+        },
+        {
+          "name": "AddLoginAsync",
+          "kind": "method",
+          "signature": "AddLoginAsync(string userId, ExternalLoginInfo info, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RemoveLoginAsync",
+          "kind": "method",
+          "signature": "RemoveLoginAsync(string userId, string provider, string providerKey, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "ProcessCallbackAsync",
+          "kind": "method",
+          "signature": "ProcessCallbackAsync(ClaimsPrincipal principal, string provider, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ProcessCallbackResult>"
+        }
+      ]
+    },
+    {
+      "name": "ITotpService",
+      "fqn": "Granit.OpenIddict.Services.ITotpService",
+      "kind": "interface",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Services/ITotpService.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "GenerateSharedKey",
+          "kind": "method",
+          "signature": "GenerateSharedKey()",
+          "returnType": "string"
+        },
+        {
+          "name": "GetQrCodeUri",
+          "kind": "method",
+          "signature": "GetQrCodeUri(string email, string sharedKey)",
+          "returnType": "string"
+        },
+        {
+          "name": "ValidateCode",
+          "kind": "method",
+          "signature": "ValidateCode(string sharedKey, string code)",
+          "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "ProcessCallbackResult",
+      "fqn": "Granit.OpenIddict.Services.ProcessCallbackResult",
+      "kind": "record",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Services/IExternalLoginService.cs",
+      "line": 58,
+      "members": []
     },
     {
       "name": "DataSeedContext",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-21T15:15:16.521902+00:00",
+  "generatedAt": "2026-03-21T15:36:15.918018+00:00",
   "repo": "granit-dotnet",
   "projectGraph": [
     {
@@ -946,6 +946,65 @@
         "Granit.Querying",
         "Granit.Security",
         "Granit.Timing"
+      ],
+      "framework": "net10.0"
+    },
+    {
+      "name": "Granit.OpenIddict.BackgroundJobs",
+      "deps": [
+        "Granit.BackgroundJobs",
+        "Granit.OpenIddict"
+      ],
+      "framework": "net10.0"
+    },
+    {
+      "name": "Granit.OpenIddict.Client",
+      "deps": [
+        "Granit.OpenIddict"
+      ],
+      "framework": "net10.0"
+    },
+    {
+      "name": "Granit.OpenIddict.Endpoints",
+      "deps": [
+        "Granit.Http.ApiDocumentation",
+        "Granit.OpenIddict",
+        "Granit.Authorization",
+        "Granit.Querying",
+        "Granit.Validation"
+      ],
+      "framework": "net10.0"
+    },
+    {
+      "name": "Granit.OpenIddict.EntityFrameworkCore",
+      "deps": [
+        "Granit.MultiTenancy",
+        "Granit.OpenIddict",
+        "Granit.Persistence"
+      ],
+      "framework": "net10.0"
+    },
+    {
+      "name": "Granit.OpenIddict.Identity",
+      "deps": [
+        "Granit.Identity",
+        "Granit.OpenIddict.EntityFrameworkCore"
+      ],
+      "framework": "net10.0"
+    },
+    {
+      "name": "Granit.OpenIddict.Passkeys",
+      "deps": [
+        "Granit.OpenIddict",
+        "Granit.OpenIddict.EntityFrameworkCore"
+      ],
+      "framework": "net10.0"
+    },
+    {
+      "name": "Granit.OpenIddict.Seeding",
+      "deps": [
+        "Granit.OpenIddict",
+        "Granit.Persistence"
       ],
       "framework": "net10.0"
     },
@@ -17843,6 +17902,390 @@
       ]
     },
     {
+      "name": "GranitOpenIddictBackgroundJobsModule",
+      "fqn": "Granit.OpenIddict.BackgroundJobs.GranitOpenIddictBackgroundJobsModule",
+      "kind": "class",
+      "project": "Granit.OpenIddict.BackgroundJobs",
+      "file": "src/Granit.OpenIddict.BackgroundJobs/GranitOpenIddictBackgroundJobsModule.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "OpenIddictIdleSessionEnforcementJob",
+      "fqn": "Granit.OpenIddict.BackgroundJobs.Jobs.OpenIddictIdleSessionEnforcementJob",
+      "kind": "record",
+      "project": "Granit.OpenIddict.BackgroundJobs",
+      "file": "src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictIdleSessionEnforcementJob.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "OpenIddictTokenCleanupJob",
+      "fqn": "Granit.OpenIddict.BackgroundJobs.Jobs.OpenIddictTokenCleanupJob",
+      "kind": "record",
+      "project": "Granit.OpenIddict.BackgroundJobs",
+      "file": "src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictTokenCleanupJob.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "ExternalClaimsMapper",
+      "fqn": "Granit.OpenIddict.Client.ExternalClaimsMapper",
+      "kind": "class",
+      "project": "Granit.OpenIddict.Client",
+      "file": "src/Granit.OpenIddict.Client/ExternalClaimsMapper.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "MapToUserProperties",
+          "kind": "method",
+          "signature": "MapToUserProperties(ClaimsPrincipal principal, string provider)",
+          "returnType": "ExternalUserProperties"
+        }
+      ]
+    },
+    {
+      "name": "ExternalUserProperties",
+      "fqn": "Granit.OpenIddict.Client.ExternalUserProperties",
+      "kind": "class",
+      "project": "Granit.OpenIddict.Client",
+      "file": "src/Granit.OpenIddict.Client/ExternalClaimsMapper.cs",
+      "line": 42,
+      "members": []
+    },
+    {
+      "name": "GranitOpenIddictClientModule",
+      "fqn": "Granit.OpenIddict.Client.GranitOpenIddictClientModule",
+      "kind": "class",
+      "project": "Granit.OpenIddict.Client",
+      "file": "src/Granit.OpenIddict.Client/GranitOpenIddictClientModule.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "ExternalProviderOptions",
+      "fqn": "Granit.OpenIddict.Client.Options.ExternalProviderOptions",
+      "kind": "class",
+      "project": "Granit.OpenIddict.Client",
+      "file": "src/Granit.OpenIddict.Client/Options/GranitOpenIddictClientOptions.cs",
+      "line": 29,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "ClientId",
+          "kind": "property",
+          "signature": "string ClientId",
+          "returnType": "string"
+        },
+        {
+          "name": "ClientSecret",
+          "kind": "property",
+          "signature": "string ClientSecret",
+          "returnType": "string"
+        },
+        {
+          "name": "Scopes",
+          "kind": "property",
+          "signature": "string[] Scopes",
+          "returnType": "string[]"
+        }
+      ]
+    },
+    {
+      "name": "GranitOpenIddictClientOptions",
+      "fqn": "Granit.OpenIddict.Client.Options.GranitOpenIddictClientOptions",
+      "kind": "class",
+      "project": "Granit.OpenIddict.Client",
+      "file": "src/Granit.OpenIddict.Client/Options/GranitOpenIddictClientOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "AutoRegisterExternalUsers",
+          "kind": "property",
+          "signature": "bool AutoRegisterExternalUsers",
+          "returnType": "bool"
+        },
+        {
+          "name": "Providers",
+          "kind": "property",
+          "signature": "ExternalProviderOptions[] Providers",
+          "returnType": "ExternalProviderOptions[]"
+        }
+      ]
+    },
+    {
+      "name": "OpenIddictMetrics",
+      "fqn": "Granit.OpenIddict.Diagnostics.OpenIddictMetrics",
+      "kind": "class",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Diagnostics/OpenIddictMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordTokenRevoked",
+          "kind": "method",
+          "signature": "RecordTokenRevoked(string? tenantId, string reason)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordAuthenticationFailure",
+          "kind": "method",
+          "signature": "RecordAuthenticationFailure(string? tenantId, string reason)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordRegistration",
+          "kind": "method",
+          "signature": "RecordRegistration(string? tenantId)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordTokenIssuanceDuration",
+          "kind": "method",
+          "signature": "RecordTokenIssuanceDuration(string? tenantId, string grantType, TimeSpan duration)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "AccountAuthenticatorKeyResponse",
+      "fqn": "Granit.OpenIddict.Endpoints.Dtos.AccountAuthenticatorKeyResponse",
+      "kind": "record",
+      "project": "Granit.OpenIddict.Endpoints",
+      "file": "src/Granit.OpenIddict.Endpoints/Dtos/AccountTwoFactorDtos.cs",
+      "line": 19,
+      "members": []
+    },
+    {
+      "name": "AccountDeleteRequest",
+      "fqn": "Granit.OpenIddict.Endpoints.Dtos.AccountDeleteRequest",
+      "kind": "record",
+      "project": "Granit.OpenIddict.Endpoints",
+      "file": "src/Granit.OpenIddict.Endpoints/Dtos/AccountDeleteRequest.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "AccountForgotPasswordRequest",
+      "fqn": "Granit.OpenIddict.Endpoints.Dtos.AccountForgotPasswordRequest",
+      "kind": "record",
+      "project": "Granit.OpenIddict.Endpoints",
+      "file": "src/Granit.OpenIddict.Endpoints/Dtos/AccountPasswordRequests.cs",
+      "line": 16,
+      "members": []
+    },
+    {
+      "name": "AccountPasswordChangeRequest",
+      "fqn": "Granit.OpenIddict.Endpoints.Dtos.AccountPasswordChangeRequest",
+      "kind": "record",
+      "project": "Granit.OpenIddict.Endpoints",
+      "file": "src/Granit.OpenIddict.Endpoints/Dtos/AccountPasswordRequests.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "AccountPasswordResetRequest",
+      "fqn": "Granit.OpenIddict.Endpoints.Dtos.AccountPasswordResetRequest",
+      "kind": "record",
+      "project": "Granit.OpenIddict.Endpoints",
+      "file": "src/Granit.OpenIddict.Endpoints/Dtos/AccountPasswordRequests.cs",
+      "line": 24,
+      "members": []
+    },
+    {
+      "name": "AccountProfileResponse",
+      "fqn": "Granit.OpenIddict.Endpoints.Dtos.AccountProfileResponse",
+      "kind": "record",
+      "project": "Granit.OpenIddict.Endpoints",
+      "file": "src/Granit.OpenIddict.Endpoints/Dtos/AccountProfileResponse.cs",
+      "line": 14,
+      "members": []
+    },
+    {
+      "name": "AccountProfileUpdateRequest",
+      "fqn": "Granit.OpenIddict.Endpoints.Dtos.AccountProfileUpdateRequest",
+      "kind": "record",
+      "project": "Granit.OpenIddict.Endpoints",
+      "file": "src/Granit.OpenIddict.Endpoints/Dtos/AccountProfileResponse.cs",
+      "line": 29,
+      "members": []
+    },
+    {
+      "name": "AccountRecoveryCodesResponse",
+      "fqn": "Granit.OpenIddict.Endpoints.Dtos.AccountRecoveryCodesResponse",
+      "kind": "record",
+      "project": "Granit.OpenIddict.Endpoints",
+      "file": "src/Granit.OpenIddict.Endpoints/Dtos/AccountTwoFactorDtos.cs",
+      "line": 39,
+      "members": []
+    },
+    {
+      "name": "AccountRegisterRequest",
+      "fqn": "Granit.OpenIddict.Endpoints.Dtos.AccountRegisterRequest",
+      "kind": "record",
+      "project": "Granit.OpenIddict.Endpoints",
+      "file": "src/Granit.OpenIddict.Endpoints/Dtos/AccountRegisterRequest.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "AccountRegisterResponse",
+      "fqn": "Granit.OpenIddict.Endpoints.Dtos.AccountRegisterResponse",
+      "kind": "record",
+      "project": "Granit.OpenIddict.Endpoints",
+      "file": "src/Granit.OpenIddict.Endpoints/Dtos/AccountRegisterRequest.cs",
+      "line": 21,
+      "members": []
+    },
+    {
+      "name": "AccountTwoFactorEnableRequest",
+      "fqn": "Granit.OpenIddict.Endpoints.Dtos.AccountTwoFactorEnableRequest",
+      "kind": "record",
+      "project": "Granit.OpenIddict.Endpoints",
+      "file": "src/Granit.OpenIddict.Endpoints/Dtos/AccountTwoFactorDtos.cs",
+      "line": 27,
+      "members": []
+    },
+    {
+      "name": "AccountTwoFactorEnableResponse",
+      "fqn": "Granit.OpenIddict.Endpoints.Dtos.AccountTwoFactorEnableResponse",
+      "kind": "record",
+      "project": "Granit.OpenIddict.Endpoints",
+      "file": "src/Granit.OpenIddict.Endpoints/Dtos/AccountTwoFactorDtos.cs",
+      "line": 33,
+      "members": []
+    },
+    {
+      "name": "AccountTwoFactorStatusResponse",
+      "fqn": "Granit.OpenIddict.Endpoints.Dtos.AccountTwoFactorStatusResponse",
+      "kind": "record",
+      "project": "Granit.OpenIddict.Endpoints",
+      "file": "src/Granit.OpenIddict.Endpoints/Dtos/AccountTwoFactorDtos.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "GranitOpenIddictEndpointsModule",
+      "fqn": "Granit.OpenIddict.Endpoints.GranitOpenIddictEndpointsModule",
+      "kind": "class",
+      "project": "Granit.OpenIddict.Endpoints",
+      "file": "src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs",
+      "line": 27,
+      "members": []
+    },
+    {
+      "name": "GranitRole",
+      "fqn": "Granit.OpenIddict.EntityFrameworkCore.Entities.GranitRole",
+      "kind": "class",
+      "project": "Granit.OpenIddict.EntityFrameworkCore",
+      "file": "src/Granit.OpenIddict.EntityFrameworkCore/Entities/GranitRole.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "GranitUser",
+      "fqn": "Granit.OpenIddict.EntityFrameworkCore.Entities.GranitUser",
+      "kind": "class",
+      "project": "Granit.OpenIddict.EntityFrameworkCore",
+      "file": "src/Granit.OpenIddict.EntityFrameworkCore/Entities/GranitUser.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "FirstName",
+          "kind": "property",
+          "signature": "string? FirstName",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "GranitUserGroup",
+      "fqn": "Granit.OpenIddict.EntityFrameworkCore.Entities.GranitUserGroup",
+      "kind": "class",
+      "project": "Granit.OpenIddict.EntityFrameworkCore",
+      "file": "src/Granit.OpenIddict.EntityFrameworkCore/Entities/GranitUserGroup.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitUserGroupMember",
+      "fqn": "Granit.OpenIddict.EntityFrameworkCore.Entities.GranitUserGroupMember",
+      "kind": "class",
+      "project": "Granit.OpenIddict.EntityFrameworkCore",
+      "file": "src/Granit.OpenIddict.EntityFrameworkCore/Entities/GranitUserGroupMember.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "OpenIddictEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.OpenIddict.EntityFrameworkCore.Extensions.OpenIddictEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.OpenIddict.EntityFrameworkCore",
+      "file": "src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "AddGranitOpenIddictEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitOpenIddictEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "OpenIddictModelBuilderExtensions",
+      "fqn": "Granit.OpenIddict.EntityFrameworkCore.Extensions.OpenIddictModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.OpenIddict.EntityFrameworkCore",
+      "file": "src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureOpenIddictModule",
+          "kind": "method",
+          "signature": "ConfigureOpenIddictModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitOpenIddictDbProperties",
+      "fqn": "Granit.OpenIddict.EntityFrameworkCore.GranitOpenIddictDbProperties",
+      "kind": "class",
+      "project": "Granit.OpenIddict.EntityFrameworkCore",
+      "file": "src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictDbProperties.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "DbTablePrefix",
+          "kind": "property",
+          "signature": "string DbTablePrefix",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "GranitOpenIddictEntityFrameworkCoreModule",
+      "fqn": "Granit.OpenIddict.EntityFrameworkCore.GranitOpenIddictEntityFrameworkCoreModule",
+      "kind": "class",
+      "project": "Granit.OpenIddict.EntityFrameworkCore",
+      "file": "src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs",
+      "line": 25,
+      "members": []
+    },
+    {
       "name": "AccountDeletedEto",
       "fqn": "Granit.OpenIddict.Events.AccountDeletedEto",
       "kind": "record",
@@ -17870,17 +18313,17 @@
       "members": []
     },
     {
-      "name": "CurrentUserServiceExtensions",
-      "fqn": "Granit.OpenIddict.Extensions.CurrentUserServiceExtensions",
+      "name": "ClaimsPrincipalExtensions",
+      "fqn": "Granit.OpenIddict.Extensions.ClaimsPrincipalExtensions",
       "kind": "class",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/Extensions/CurrentUserServiceExtensions.cs",
-      "line": 8,
+      "line": 9,
       "members": [
         {
           "name": "IsImpersonated",
           "kind": "method",
-          "signature": "IsImpersonated(this ICurrentUserService user)",
+          "signature": "IsImpersonated(this ClaimsPrincipal principal)",
           "returnType": "bool"
         }
       ]
@@ -17893,6 +18336,22 @@
       "file": "src/Granit.OpenIddict/GranitOpenIddictModule.cs",
       "line": 22,
       "members": []
+    },
+    {
+      "name": "GranitOpenIddictIdentityModule",
+      "fqn": "Granit.OpenIddict.Identity.GranitOpenIddictIdentityModule",
+      "kind": "class",
+      "project": "Granit.OpenIddict.Identity",
+      "file": "src/Granit.OpenIddict.Identity/GranitOpenIddictIdentityModule.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "OpenIddictFeatureNames",
@@ -17909,7 +18368,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/OpenIddictSettingNames.cs",
-      "line": 11,
+      "line": 12,
       "members": []
     },
     {
@@ -17920,6 +18379,50 @@
       "file": "src/Granit.OpenIddict/Options/GranitOpenIddictOptions.cs",
       "line": 10,
       "members": []
+    },
+    {
+      "name": "GranitOpenIddictPasskeysModule",
+      "fqn": "Granit.OpenIddict.Passkeys.GranitOpenIddictPasskeysModule",
+      "kind": "class",
+      "project": "Granit.OpenIddict.Passkeys",
+      "file": "src/Granit.OpenIddict.Passkeys/GranitOpenIddictPasskeysModule.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "OnApplicationInitialization",
+          "kind": "method",
+          "signature": "OnApplicationInitialization(ApplicationInitializationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GranitPasskeyOptions",
+      "fqn": "Granit.OpenIddict.Passkeys.Options.GranitPasskeyOptions",
+      "kind": "class",
+      "project": "Granit.OpenIddict.Passkeys",
+      "file": "src/Granit.OpenIddict.Passkeys/Options/GranitPasskeyOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ServerDomain",
+          "kind": "property",
+          "signature": "string ServerDomain",
+          "returnType": "string"
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(5)",
+          "returnType": "TimeSpan AuthenticatorTimeout { get; set; } = TimeSpan."
+        },
+        {
+          "name": "ChallengeSize",
+          "kind": "property",
+          "signature": "int ChallengeSize",
+          "returnType": "int"
+        }
+      ]
     },
     {
       "name": "Applications",
@@ -17982,6 +18485,62 @@
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/Permissions/OpenIddictPermissions.cs",
       "line": 17,
+      "members": []
+    },
+    {
+      "name": "GranitOpenIddictSeedingModule",
+      "fqn": "Granit.OpenIddict.Seeding.GranitOpenIddictSeedingModule",
+      "kind": "class",
+      "project": "Granit.OpenIddict.Seeding",
+      "file": "src/Granit.OpenIddict.Seeding/GranitOpenIddictSeedingModule.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GranitOpenIddictSeedingOptions",
+      "fqn": "Granit.OpenIddict.Seeding.Options.GranitOpenIddictSeedingOptions",
+      "kind": "class",
+      "project": "Granit.OpenIddict.Seeding",
+      "file": "src/Granit.OpenIddict.Seeding/Options/GranitOpenIddictSeedingOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Applications",
+          "kind": "property",
+          "signature": "OidcApplicationSeedDescriptor[] Applications",
+          "returnType": "OidcApplicationSeedDescriptor[]"
+        },
+        {
+          "name": "Scopes",
+          "kind": "property",
+          "signature": "OidcScopeSeedDescriptor[] Scopes",
+          "returnType": "OidcScopeSeedDescriptor[]"
+        }
+      ]
+    },
+    {
+      "name": "OidcApplicationSeedDescriptor",
+      "fqn": "Granit.OpenIddict.Seeding.Options.OidcApplicationSeedDescriptor",
+      "kind": "record",
+      "project": "Granit.OpenIddict.Seeding",
+      "file": "src/Granit.OpenIddict.Seeding/Options/GranitOpenIddictSeedingOptions.cs",
+      "line": 28,
+      "members": []
+    },
+    {
+      "name": "OidcScopeSeedDescriptor",
+      "fqn": "Granit.OpenIddict.Seeding.Options.OidcScopeSeedDescriptor",
+      "kind": "record",
+      "project": "Granit.OpenIddict.Seeding",
+      "file": "src/Granit.OpenIddict.Seeding/Options/GranitOpenIddictSeedingOptions.cs",
+      "line": 42,
       "members": []
     },
     {

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-21T11:39:14.693948+00:00",
+  "generatedAt": "2026-03-21T13:49:07.649838+00:00",
   "repo": "granit-dotnet",
   "projectGraph": [
     {
@@ -3458,12 +3458,6 @@
           "returnType": "ApiKeyEntry"
         },
         {
-          "name": "Name",
-          "kind": "property",
-          "signature": "string Name",
-          "returnType": "string"
-        },
-        {
           "name": "Type",
           "kind": "property",
           "signature": "ApiKeyType Type",
@@ -3498,12 +3492,6 @@
           "kind": "property",
           "signature": "List<string> AllowedCidrs",
           "returnType": "List<string>"
-        },
-        {
-          "name": "UpdateAllowedCidrs",
-          "kind": "method",
-          "signature": "UpdateAllowedCidrs(List<string> cidrs)",
-          "returnType": "void"
         },
         {
           "name": "SetExpiration",
@@ -3715,12 +3703,12 @@
       "members": []
     },
     {
-      "name": "ApiKeyCreatedEvent",
-      "fqn": "Granit.Authentication.ApiKeys.Events.ApiKeyCreatedEvent",
+      "name": "ApiKeyCreatedEto",
+      "fqn": "Granit.Authentication.ApiKeys.Events.ApiKeyCreatedEto",
       "kind": "record",
       "project": "Granit.Authentication.ApiKeys",
       "file": "src/Granit.Authentication.ApiKeys/Events/ApiKeyCreatedEvent.cs",
-      "line": 10,
+      "line": 12,
       "members": []
     },
     {
@@ -3738,25 +3726,25 @@
       "kind": "record",
       "project": "Granit.Authentication.ApiKeys",
       "file": "src/Granit.Authentication.ApiKeys/Events/ApiKeyRevokedEvent.cs",
-      "line": 9,
+      "line": 11,
       "members": []
     },
     {
-      "name": "ApiKeyRotatedEvent",
-      "fqn": "Granit.Authentication.ApiKeys.Events.ApiKeyRotatedEvent",
+      "name": "ApiKeyRotatedEto",
+      "fqn": "Granit.Authentication.ApiKeys.Events.ApiKeyRotatedEto",
       "kind": "record",
       "project": "Granit.Authentication.ApiKeys",
       "file": "src/Granit.Authentication.ApiKeys/Events/ApiKeyRotatedEvent.cs",
-      "line": 10,
+      "line": 12,
       "members": []
     },
     {
-      "name": "ApiKeyScopesUpdatedEvent",
-      "fqn": "Granit.Authentication.ApiKeys.Events.ApiKeyScopesUpdatedEvent",
+      "name": "ApiKeyScopesUpdatedEto",
+      "fqn": "Granit.Authentication.ApiKeys.Events.ApiKeyScopesUpdatedEto",
       "kind": "record",
       "project": "Granit.Authentication.ApiKeys",
       "file": "src/Granit.Authentication.ApiKeys/Events/ApiKeyScopesUpdatedEvent.cs",
-      "line": 9,
+      "line": 11,
       "members": []
     },
     {
@@ -8933,12 +8921,12 @@
       "members": []
     },
     {
-      "name": "ExportJobCompletedEvent",
-      "fqn": "Granit.DataExchange.Export.Messages.ExportJobCompletedEvent",
+      "name": "ExportJobCompletedEto",
+      "fqn": "Granit.DataExchange.Export.Messages.ExportJobCompletedEto",
       "kind": "record",
       "project": "Granit.DataExchange",
       "file": "src/Granit.DataExchange/Export/Messages/ExportJobCompletedEvent.cs",
-      "line": 17,
+      "line": 19,
       "members": []
     },
     {
@@ -9477,12 +9465,12 @@
       "members": []
     },
     {
-      "name": "ImportJobCompletedEvent",
-      "fqn": "Granit.DataExchange.Import.Messages.ImportJobCompletedEvent",
+      "name": "ImportJobCompletedEto",
+      "fqn": "Granit.DataExchange.Import.Messages.ImportJobCompletedEto",
       "kind": "record",
       "project": "Granit.DataExchange",
       "file": "src/Granit.DataExchange/Import/Messages/ImportJobCompletedEvent.cs",
-      "line": 24,
+      "line": 25,
       "members": []
     },
     {
@@ -13198,21 +13186,21 @@
       ]
     },
     {
-      "name": "IdentityUserDeletedEvent",
-      "fqn": "Granit.Identity.EntityFrameworkCore.Events.IdentityUserDeletedEvent",
+      "name": "IdentityUserDeletedEto",
+      "fqn": "Granit.Identity.EntityFrameworkCore.Events.IdentityUserDeletedEto",
       "kind": "record",
       "project": "Granit.Identity.EntityFrameworkCore",
       "file": "src/Granit.Identity.EntityFrameworkCore/Events/IdentityUserDeletedEvent.cs",
-      "line": 11,
+      "line": 13,
       "members": []
     },
     {
-      "name": "IdentityUserUpdatedEvent",
-      "fqn": "Granit.Identity.EntityFrameworkCore.Events.IdentityUserUpdatedEvent",
+      "name": "IdentityUserUpdatedEto",
+      "fqn": "Granit.Identity.EntityFrameworkCore.Events.IdentityUserUpdatedEto",
       "kind": "record",
       "project": "Granit.Identity.EntityFrameworkCore",
       "file": "src/Granit.Identity.EntityFrameworkCore/Events/IdentityUserUpdatedEvent.cs",
-      "line": 9,
+      "line": 11,
       "members": []
     },
     {
@@ -13403,75 +13391,75 @@
       ]
     },
     {
-      "name": "IdentityGroupMembershipChangedEvent",
-      "fqn": "Granit.Identity.Events.IdentityGroupMembershipChangedEvent",
+      "name": "IdentityGroupMembershipChangedEto",
+      "fqn": "Granit.Identity.Events.IdentityGroupMembershipChangedEto",
       "kind": "record",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/Events/IdentityEvents.cs",
-      "line": 47,
+      "line": 48,
       "members": []
     },
     {
-      "name": "IdentityPasswordResetEvent",
-      "fqn": "Granit.Identity.Events.IdentityPasswordResetEvent",
+      "name": "IdentityPasswordResetEto",
+      "fqn": "Granit.Identity.Events.IdentityPasswordResetEto",
       "kind": "record",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/Events/IdentityEvents.cs",
-      "line": 53,
+      "line": 54,
       "members": []
     },
     {
-      "name": "IdentityRoleAssignedEvent",
-      "fqn": "Granit.Identity.Events.IdentityRoleAssignedEvent",
+      "name": "IdentityRoleAssignedEto",
+      "fqn": "Granit.Identity.Events.IdentityRoleAssignedEto",
       "kind": "record",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/Events/IdentityEvents.cs",
-      "line": 32,
+      "line": 33,
       "members": []
     },
     {
-      "name": "IdentityRoleRemovedEvent",
-      "fqn": "Granit.Identity.Events.IdentityRoleRemovedEvent",
+      "name": "IdentityRoleRemovedEto",
+      "fqn": "Granit.Identity.Events.IdentityRoleRemovedEto",
       "kind": "record",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/Events/IdentityEvents.cs",
-      "line": 39,
+      "line": 40,
       "members": []
     },
     {
-      "name": "IdentitySessionsRevokedEvent",
-      "fqn": "Granit.Identity.Events.IdentitySessionsRevokedEvent",
+      "name": "IdentitySessionsRevokedEto",
+      "fqn": "Granit.Identity.Events.IdentitySessionsRevokedEto",
       "kind": "record",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/Events/IdentityEvents.cs",
-      "line": 59,
+      "line": 60,
       "members": []
     },
     {
-      "name": "IdentityUserCreatedEvent",
-      "fqn": "Granit.Identity.Events.IdentityUserCreatedEvent",
+      "name": "IdentityUserCreatedEto",
+      "fqn": "Granit.Identity.Events.IdentityUserCreatedEto",
       "kind": "record",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/Events/IdentityEvents.cs",
-      "line": 11,
+      "line": 12,
       "members": []
     },
     {
-      "name": "IdentityUserEnabledChangedEvent",
-      "fqn": "Granit.Identity.Events.IdentityUserEnabledChangedEvent",
+      "name": "IdentityUserEnabledChangedEto",
+      "fqn": "Granit.Identity.Events.IdentityUserEnabledChangedEto",
       "kind": "record",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/Events/IdentityEvents.cs",
-      "line": 25,
+      "line": 26,
       "members": []
     },
     {
-      "name": "IdentityUserProfileUpdatedEvent",
-      "fqn": "Granit.Identity.Events.IdentityUserProfileUpdatedEvent",
+      "name": "IdentityUserProfileUpdatedEto",
+      "fqn": "Granit.Identity.Events.IdentityUserProfileUpdatedEto",
       "kind": "record",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/Events/IdentityEvents.cs",
-      "line": 18,
+      "line": 19,
       "members": []
     },
     {
@@ -13597,7 +13585,7 @@
       "kind": "interface",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/IIdentityEventPublisher.cs",
-      "line": 17,
+      "line": 15,
       "members": []
     },
     {
@@ -14514,6 +14502,15 @@
       "project": "Granit.Localization.Endpoints",
       "file": "src/Granit.Localization.Endpoints/Permissions/LocalizationOverridesPermissions.cs",
       "line": 8,
+      "members": []
+    },
+    {
+      "name": "Overrides",
+      "fqn": "Granit.Localization.Endpoints.Permissions.Overrides",
+      "kind": "class",
+      "project": "Granit.Localization.Endpoints",
+      "file": "src/Granit.Localization.Endpoints/Permissions/LocalizationOverridesPermissions.cs",
+      "line": 16,
       "members": []
     },
     {
@@ -15679,7 +15676,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Email.AwsSes",
       "file": "src/Granit.Notifications.Email.AwsSes/Extensions/SesEmailServiceCollectionExtensions.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitNotificationsEmailAwsSes",
@@ -15733,7 +15730,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Email.AzureCommunicationServices",
       "file": "src/Granit.Notifications.Email.AzureCommunicationServices/Extensions/AcsEmailServiceCollectionExtensions.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitNotificationsEmailAcs",
@@ -15865,7 +15862,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Email.Scaleway",
       "file": "src/Granit.Notifications.Email.Scaleway/Extensions/ScalewayEmailServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitNotificationsEmailScaleway",
@@ -15949,7 +15946,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Email.SendGrid",
       "file": "src/Granit.Notifications.Email.SendGrid/Extensions/SendGridEmailServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitNotificationsEmailSendGrid",
@@ -16465,7 +16462,7 @@
       "kind": "class",
       "project": "Granit.Notifications.MobilePush.AwsSns",
       "file": "src/Granit.Notifications.MobilePush.AwsSns/Extensions/AwsSnsMobilePushServiceCollectionExtensions.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitNotificationsMobilePushAwsSns",
@@ -16525,7 +16522,7 @@
       "kind": "class",
       "project": "Granit.Notifications.MobilePush.AzureNotificationHubs",
       "file": "src/Granit.Notifications.MobilePush.AzureNotificationHubs/Extensions/AzureNotificationHubsServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitNotificationsMobilePushAzureNotificationHubs",
@@ -16959,7 +16956,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Sms.AwsSns",
       "file": "src/Granit.Notifications.Sms.AwsSns/Extensions/SnsSmsServiceCollectionExtensions.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitNotificationsSmsAwsSns",
@@ -17019,7 +17016,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Sms.AzureCommunicationServices",
       "file": "src/Granit.Notifications.Sms.AzureCommunicationServices/Extensions/AcsSmsServiceCollectionExtensions.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitNotificationsSmsAcs",
@@ -19431,7 +19428,7 @@
       "kind": "class",
       "project": "Granit.Querying.EntityFrameworkCore",
       "file": "src/Granit.Querying.EntityFrameworkCore/GranitQueryingEntityFrameworkCoreModule.cs",
-      "line": 17,
+      "line": 18,
       "members": [
         {
           "name": "ConfigureServices",
@@ -20964,12 +20961,30 @@
       ]
     },
     {
+      "name": "Global",
+      "fqn": "Granit.Settings.Endpoints.Permissions.Global",
+      "kind": "class",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/Permissions/SettingsPermissions.cs",
+      "line": 14,
+      "members": []
+    },
+    {
       "name": "SettingsPermissions",
       "fqn": "Granit.Settings.Endpoints.Permissions.SettingsPermissions",
       "kind": "class",
       "project": "Granit.Settings.Endpoints",
       "file": "src/Granit.Settings.Endpoints/Permissions/SettingsPermissions.cs",
       "line": 6,
+      "members": []
+    },
+    {
+      "name": "Tenant",
+      "fqn": "Granit.Settings.Endpoints.Permissions.Tenant",
+      "kind": "class",
+      "project": "Granit.Settings.Endpoints",
+      "file": "src/Granit.Settings.Endpoints/Permissions/SettingsPermissions.cs",
+      "line": 24,
       "members": []
     },
     {
@@ -24056,7 +24071,7 @@
       "kind": "class",
       "project": "Granit.Vault.Aws",
       "file": "src/Granit.Vault.Aws/Extensions/AwsVaultServiceCollectionExtensions.cs",
-      "line": 18,
+      "line": 19,
       "members": [
         {
           "name": "AddGranitVaultAws",
@@ -24128,7 +24143,7 @@
       "kind": "class",
       "project": "Granit.Vault.Azure",
       "file": "src/Granit.Vault.Azure/Extensions/AzureKeyVaultServiceCollectionExtensions.cs",
-      "line": 18,
+      "line": 19,
       "members": [
         {
           "name": "AddGranitVaultAzure",
@@ -24250,7 +24265,7 @@
       "kind": "class",
       "project": "Granit.Vault.GoogleCloud",
       "file": "src/Granit.Vault.GoogleCloud/Extensions/GoogleCloudVaultServiceCollectionExtensions.cs",
-      "line": 17,
+      "line": 18,
       "members": [
         {
           "name": "AddGranitVaultGoogleCloud",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-21T13:53:18.209114+00:00",
+  "generatedAt": "2026-03-21T15:02:28.498558+00:00",
   "repo": "granit-dotnet",
   "projectGraph": [
     {
@@ -996,6 +996,16 @@
       "deps": [
         "Granit.AI",
         "Granit.Privacy"
+      ],
+      "framework": "net10.0"
+    },
+    {
+      "name": "Granit.Privacy.Endpoints",
+      "deps": [
+        "Granit.Authorization",
+        "Granit.Http.ApiDocumentation",
+        "Granit.Privacy",
+        "Granit.Validation"
       ],
       "framework": "net10.0"
     },
@@ -18879,6 +18889,24 @@
       "members": []
     },
     {
+      "name": "ExportRequestState",
+      "fqn": "Granit.Privacy.DataExport.ExportRequestState",
+      "kind": "enum",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/ExportRequestState.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "ExportRequestStatus",
+      "fqn": "Granit.Privacy.DataExport.ExportRequestStatus",
+      "kind": "record",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/ExportRequestStatus.cs",
+      "line": 16,
+      "members": []
+    },
+    {
       "name": "GdprExportSaga",
       "fqn": "Granit.Privacy.DataExport.GdprExportSaga",
       "kind": "class",
@@ -18951,6 +18979,50 @@
       ]
     },
     {
+      "name": "IExportRequestTrackerReader",
+      "fqn": "Granit.Privacy.DataExport.IExportRequestTrackerReader",
+      "kind": "interface",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/IExportRequestTrackerReader.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "GetStatusAsync",
+          "kind": "method",
+          "signature": "GetStatusAsync(Guid requestId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ExportRequestStatus?>"
+        },
+        {
+          "name": "GetByUserAsync",
+          "kind": "method",
+          "signature": "GetByUserAsync(Guid userId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<ExportRequestStatus>>"
+        }
+      ]
+    },
+    {
+      "name": "IExportRequestTrackerWriter",
+      "fqn": "Granit.Privacy.DataExport.IExportRequestTrackerWriter",
+      "kind": "interface",
+      "project": "Granit.Privacy",
+      "file": "src/Granit.Privacy/DataExport/IExportRequestTrackerWriter.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "RecordRequestAsync",
+          "kind": "method",
+          "signature": "RecordRequestAsync(Guid requestId, Guid userId, DateTimeOffset requestedAt, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "MarkCompletedAsync",
+          "kind": "method",
+          "signature": "MarkCompletedAsync(Guid requestId, ExportRequestState state, string? archiveBlobReferenceId, IReadOnlyList<string>? missingProviders, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "ReceivedFragment",
       "fqn": "Granit.Privacy.DataExport.ReceivedFragment",
       "kind": "record",
@@ -18986,6 +19058,152 @@
           "returnType": "void"
         }
       ]
+    },
+    {
+      "name": "PrivacyAcceptAgreementRequest",
+      "fqn": "Granit.Privacy.Endpoints.Dtos.PrivacyAcceptAgreementRequest",
+      "kind": "record",
+      "project": "Granit.Privacy.Endpoints",
+      "file": "src/Granit.Privacy.Endpoints/Dtos/PrivacyAcceptAgreementRequest.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "PrivacyConsentStatusResponse",
+      "fqn": "Granit.Privacy.Endpoints.Dtos.PrivacyConsentStatusResponse",
+      "kind": "record",
+      "project": "Granit.Privacy.Endpoints",
+      "file": "src/Granit.Privacy.Endpoints/Dtos/PrivacyConsentStatusResponse.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "PrivacyDeletionRequest",
+      "fqn": "Granit.Privacy.Endpoints.Dtos.PrivacyDeletionRequest",
+      "kind": "record",
+      "project": "Granit.Privacy.Endpoints",
+      "file": "src/Granit.Privacy.Endpoints/Dtos/PrivacyDeletionRequest.cs",
+      "line": 7,
+      "members": []
+    },
+    {
+      "name": "PrivacyExportRequestResponse",
+      "fqn": "Granit.Privacy.Endpoints.Dtos.PrivacyExportRequestResponse",
+      "kind": "record",
+      "project": "Granit.Privacy.Endpoints",
+      "file": "src/Granit.Privacy.Endpoints/Dtos/PrivacyExportRequestResponse.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "PrivacyExportStatusResponse",
+      "fqn": "Granit.Privacy.Endpoints.Dtos.PrivacyExportStatusResponse",
+      "kind": "record",
+      "project": "Granit.Privacy.Endpoints",
+      "file": "src/Granit.Privacy.Endpoints/Dtos/PrivacyExportStatusResponse.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "PrivacyLegalDocumentResponse",
+      "fqn": "Granit.Privacy.Endpoints.Dtos.PrivacyLegalDocumentResponse",
+      "kind": "record",
+      "project": "Granit.Privacy.Endpoints",
+      "file": "src/Granit.Privacy.Endpoints/Dtos/PrivacyLegalDocumentResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
+      "name": "PrivacyUserAgreementResponse",
+      "fqn": "Granit.Privacy.Endpoints.Dtos.PrivacyUserAgreementResponse",
+      "kind": "record",
+      "project": "Granit.Privacy.Endpoints",
+      "file": "src/Granit.Privacy.Endpoints/Dtos/PrivacyUserAgreementResponse.cs",
+      "line": 11,
+      "members": []
+    },
+    {
+      "name": "PrivacyEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Privacy.Endpoints.Extensions.PrivacyEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Privacy.Endpoints",
+      "file": "src/Granit.Privacy.Endpoints/Extensions/PrivacyEndpointRouteBuilderExtensions.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "MapGranitPrivacy",
+          "kind": "method",
+          "signature": "MapGranitPrivacy(this IEndpointRouteBuilder endpoints, Action<PrivacyEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitPrivacyEndpointsModule",
+      "fqn": "Granit.Privacy.Endpoints.GranitPrivacyEndpointsModule",
+      "kind": "class",
+      "project": "Granit.Privacy.Endpoints",
+      "file": "src/Granit.Privacy.Endpoints/GranitPrivacyEndpointsModule.cs",
+      "line": 30,
+      "members": []
+    },
+    {
+      "name": "PrivacyEndpointsOptions",
+      "fqn": "Granit.Privacy.Endpoints.Options.PrivacyEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Privacy.Endpoints",
+      "file": "src/Granit.Privacy.Endpoints/Options/PrivacyEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "Agreements",
+      "fqn": "Granit.Privacy.Endpoints.Permissions.Agreements",
+      "kind": "class",
+      "project": "Granit.Privacy.Endpoints",
+      "file": "src/Granit.Privacy.Endpoints/Permissions/PrivacyPermissions.cs",
+      "line": 30,
+      "members": []
+    },
+    {
+      "name": "Deletion",
+      "fqn": "Granit.Privacy.Endpoints.Permissions.Deletion",
+      "kind": "class",
+      "project": "Granit.Privacy.Endpoints",
+      "file": "src/Granit.Privacy.Endpoints/Permissions/PrivacyPermissions.cs",
+      "line": 23,
+      "members": []
+    },
+    {
+      "name": "Export",
+      "fqn": "Granit.Privacy.Endpoints.Permissions.Export",
+      "kind": "class",
+      "project": "Granit.Privacy.Endpoints",
+      "file": "src/Granit.Privacy.Endpoints/Permissions/PrivacyPermissions.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "PrivacyPermissions",
+      "fqn": "Granit.Privacy.Endpoints.Permissions.PrivacyPermissions",
+      "kind": "class",
+      "project": "Granit.Privacy.Endpoints",
+      "file": "src/Granit.Privacy.Endpoints/Permissions/PrivacyPermissions.cs",
+      "line": 7,
+      "members": []
     },
     {
       "name": "PrivacyServiceCollectionExtensions",
@@ -19124,6 +19342,12 @@
           "name": "RecordAsync",
           "kind": "method",
           "signature": "RecordAsync(LegalAgreementBase agreement, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RecordConsentAsync",
+          "kind": "method",
+          "signature": "RecordConsentAsync(Guid userId, string documentId, string version, string? ipAddress, DateTimeOffset acceptedAt, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         }
       ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,20 +168,30 @@ segments). Enforced across all `*.Endpoints` modules.
 - **Provider class**: `internal sealed class {Module}PermissionDefinitionProvider : IPermissionDefinitionProvider`
 - **Localization resource**: `internal sealed class {Module}EndpointsLocalizationResource` with `[LocalizationResourceName]`
 - **Auto-discovery**: providers are auto-discovered by `GranitAuthorizationModule` (no manual registration)
-- **Standard actions**: use `Read` for consultation (never `View`), `Manage` for grouped write operations, `Execute` for single actions
+- **Standard actions**: `Read` (consultation, never `View`), `Manage` (grouped writes),
+  `Execute` (single actions), `Create` (resource creation). Domain-specific actions
+  (`Upload`, `Download`, `Delete`, `Revoke`, `Rotate`, `Sync`) are allowed when
+  `Manage` would be too coarse for least-privilege (ISO 27001 A.9.4)
+
 ### Events — naming convention (STRICT)
 
-Two event categories with **mandatory suffixes** — enforced by architecture tests:
+Two suffixes, three dispatch mechanisms — enforced by architecture tests:
 
-| Scope | Interface | Suffix | Example | Dispatched |
-| ----- | --------- | ------ | ------- | ---------- |
-| Domain (local, in-process) | `IDomainEvent` | `*Event` | `BlobValidatedEvent` | After commit (`SavedChanges`) |
-| Integration (distributed, outbox) | `IIntegrationEvent` | `*Eto` | `PersonalDataDeletedEto` | Before commit (`SavingChanges`) for Wolverine outbox |
+| Suffix | Interface | Dispatch | Example |
+| ------ | --------- | -------- | ------- |
+| `*Event` | `IDomainEvent` | `AddDomainEvent()` on aggregate root → after commit | `BlobValidatedEvent` |
+| `*Event` | _(none)_ | `ILocalEventBus.PublishAsync()` in services → explicit call | `SettingChangedEvent` |
+| `*Eto` | `IIntegrationEvent` | `AddDistributedEvent()` on aggregate root → Wolverine outbox | `PersonalDataDeletedEto` |
+| `*Eto` | `IIntegrationEvent` | `IDistributedEventBus.PublishAsync()` in services → outbox | `IdentityUserCreatedEto` |
 
-- **`*Event`**: raised via `AddDomainEvent()` — synchronous, same transaction, handlers
-  run after commit. Past-tense verb + `Event` suffix.
-- **`*Eto`** (Event Transfer Object): raised via `AddDistributedEvent()` — durable,
-  persisted in Wolverine outbox atomically. Past-tense verb + `Eto` suffix.
+- **`*Event`** (local, in-process): either raised via `AddDomainEvent()` on an aggregate
+  root (dispatched after commit by `SavedChanges` interceptor), or published explicitly
+  via `ILocalEventBus.PublishAsync()` in service classes that operate on plain entities
+  without DDD behavior (Settings, Features, Authorization). Past-tense verb + `Event` suffix.
+- **`*Eto`** (Event Transfer Object, distributed): either raised via `AddDistributedEvent()`
+  on an aggregate root (persisted atomically in Wolverine outbox), or published explicitly
+  via `IDistributedEventBus.PublishAsync()` in services (at-least-once delivery, survives
+  pod crashes). Must implement `IIntegrationEvent`. Past-tense verb + `Eto` suffix.
 - **Generic lifecycle**: `EntityCreatedEvent<T>`, `EntityCreatedEto<T>` — automatic via
   `IEmitEntityLifecycleEvents` marker interface.
 - **NEVER** use bare past-tense names without suffix (`BlobValidated` is wrong,

--- a/Granit.slnx
+++ b/Granit.slnx
@@ -132,6 +132,7 @@
     <Project Path="src/Granit.Persistence/Granit.Persistence.csproj" />
     <Project Path="src/Granit.Privacy/Granit.Privacy.csproj" />
     <Project Path="src/Granit.Privacy.AI/Granit.Privacy.AI.csproj" />
+    <Project Path="src/Granit.Privacy.Endpoints/Granit.Privacy.Endpoints.csproj" />
     <Project Path="src/Granit.Querying.Endpoints/Granit.Querying.Endpoints.csproj" />
     <Project Path="src/Granit.Querying.EntityFrameworkCore/Granit.Querying.EntityFrameworkCore.csproj" />
     <Project Path="src/Granit.Querying/Granit.Querying.csproj" />
@@ -324,6 +325,7 @@
     <Project Path="tests/Granit.Persistence.Tests/Granit.Persistence.Tests.csproj" />
     <Project Path="tests/Granit.Privacy.Tests/Granit.Privacy.Tests.csproj" />
     <Project Path="tests/Granit.Privacy.AI.Tests/Granit.Privacy.AI.Tests.csproj" />
+    <Project Path="tests/Granit.Privacy.Endpoints.Tests/Granit.Privacy.Endpoints.Tests.csproj" />
     <Project Path="tests/Granit.Querying.Endpoints.Tests.Integration/Granit.Querying.Endpoints.Tests.Integration.csproj" />
     <Project Path="tests/Granit.Querying.Endpoints.Tests/Granit.Querying.Endpoints.Tests.csproj" />
     <Project Path="tests/Granit.Querying.AI.Tests/Granit.Querying.AI.Tests.csproj" />

--- a/docs-site/src/content/docs/dotnet/api/endpoint-registry.mdx
+++ b/docs-site/src/content/docs/dotnet/api/endpoint-registry.mdx
@@ -1,0 +1,485 @@
+---
+title: "Endpoint Registry — All API Routes"
+description: Complete inventory of all HTTP endpoints exposed by Granit framework modules — routes, methods, operation IDs, permissions, and authentication requirements.
+sidebar:
+  label: Endpoint Registry
+  order: 1
+---
+
+import { Aside, Badge } from "@astrojs/starlight/components";
+
+Complete inventory of all HTTP endpoints exposed by Granit framework modules.
+All route prefixes are **configurable** via each module's `*EndpointsOptions` class —
+the values below are the defaults.
+
+<Aside type="tip">
+Use this page to verify that your frontend API client matches the backend routes.
+The OpenAPI schema (available at `/openapi/v1.json`) is the authoritative source
+for request/response types — this page focuses on **routes, methods, and permissions**.
+</Aside>
+
+## Conventions
+
+- **Default prefix:** `/api/granit/\{module-kebab-case\}`
+- **Permissions:** follow `[Group].[Resource].[Action]` (three segments)
+- **Error responses:** all endpoints return RFC 7807 Problem Details on errors
+- **Query endpoints** (`MapQueryEndpoints<T>`) are registered by the **application**,
+  not the framework — the route pattern is app-defined
+
+---
+
+## Authentication & API Keys
+
+**Module:** `Granit.Authentication.ApiKeys.Endpoints`
+**Prefix:** `/api/granit/api-keys`
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/` | ListApiKeys | `ApiKeys.Keys.Read` |
+| <Badge text="GET" variant="note" /> | `/{id:guid}` | GetApiKeyById | `ApiKeys.Keys.Read` |
+| <Badge text="POST" variant="success" /> | `/` | CreateApiKey | `ApiKeys.Keys.Create` |
+| <Badge text="POST" variant="success" /> | `/{id:guid}/revoke` | RevokeApiKey | `ApiKeys.Keys.Revoke` |
+| <Badge text="POST" variant="success" /> | `/{id:guid}/rotate` | RotateApiKey | `ApiKeys.Keys.Rotate` |
+| <Badge text="PUT" variant="caution" /> | `/{id:guid}/scopes` | UpdateApiKeyScopes | `ApiKeys.Keys.UpdateScopes` |
+
+---
+
+## Authorization
+
+**Module:** `Granit.Authorization.Endpoints`
+**Prefix:** `/api/granit/authorization`
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/me` | GetMyPermissions | Authenticated |
+| <Badge text="GET" variant="note" /> | `/definitions` | GetPermissionDefinitions | Admin |
+| <Badge text="GET" variant="note" /> | `/roles/{roleName}` | GetRolePermissions | Admin |
+| <Badge text="PUT" variant="caution" /> | `/roles/{roleName}/{permissionName}` | GrantPermission | Admin |
+| <Badge text="DELETE" variant="danger" /> | `/roles/{roleName}/{permissionName}` | RevokePermission | Admin |
+
+---
+
+## Background Jobs
+
+**Module:** `Granit.BackgroundJobs.Endpoints`
+**Prefix:** `/api/granit/background-jobs`
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/` | GetAllBackgroundJobs | `BackgroundJobs.Jobs.Manage` |
+| <Badge text="GET" variant="note" /> | `/{name}` | GetBackgroundJobByName | `BackgroundJobs.Jobs.Manage` |
+| <Badge text="POST" variant="success" /> | `/{name}/pause` | PauseBackgroundJob | `BackgroundJobs.Jobs.Manage` |
+| <Badge text="POST" variant="success" /> | `/{name}/resume` | ResumeBackgroundJob | `BackgroundJobs.Jobs.Manage` |
+| <Badge text="POST" variant="success" /> | `/{name}/trigger` | TriggerBackgroundJob | `BackgroundJobs.Jobs.Manage` |
+
+---
+
+## Blob Storage
+
+**Module:** `Granit.BlobStorage.Endpoints`
+**Prefix:** `/api/granit/blobs`
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/{id:guid}` | GetBlobDescriptor | `BlobStorage.Blobs.Manage` |
+| <Badge text="POST" variant="success" /> | `/` | UploadBlob | `BlobStorage.Blobs.Manage` |
+| <Badge text="DELETE" variant="danger" /> | `/{id:guid}` | DeleteBlob | `BlobStorage.Blobs.Manage` |
+| <Badge text="POST" variant="success" /> | `/operations/validate-name` | ValidateBlobName | `BlobStorage.Blobs.Manage` |
+
+### Blob Proxy
+
+**Module:** `Granit.BlobStorage.Proxy`
+**Prefix:** `/api/granit/blobs/proxy`
+
+| Method | Route | Operation | Auth |
+|--------|-------|-----------|------|
+| <Badge text="PUT" variant="caution" /> | `/upload/{token}` | BlobProxyUpload | Token-based |
+| <Badge text="GET" variant="note" /> | `/download/{token}` | BlobProxyDownload | Token-based |
+
+---
+
+## Cookie Consent
+
+**Module:** `Granit.Http.Cookies.Endpoints`
+**Prefix:** `/api/granit`
+
+| Method | Route | Operation | Auth |
+|--------|-------|-----------|------|
+| <Badge text="GET" variant="note" /> | `/cookies/config` | GetCookieConsentConfig | Anonymous |
+
+---
+
+## Data Exchange
+
+**Module:** `Granit.DataExchange.Endpoints`
+**Prefix:** `/api/granit/data-exchange`
+
+### Import
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/jobs` | ListImportJobs | `DataExchange.Import.*` |
+| <Badge text="POST" variant="success" /> | `/` | CreateImportJob | `DataExchange.Import.*` |
+| <Badge text="POST" variant="success" /> | `/{jobId}/preview` | PreviewImportJob | `DataExchange.Import.*` |
+| <Badge text="PUT" variant="caution" /> | `/{jobId}/mappings` | ConfirmImportMappings | `DataExchange.Import.*` |
+| <Badge text="POST" variant="success" /> | `/{jobId}/execute` | ExecuteImportJob | `DataExchange.Import.*` |
+| <Badge text="POST" variant="success" /> | `/{jobId}/dry-run` | DryRunImportJob | `DataExchange.Import.*` |
+| <Badge text="GET" variant="note" /> | `/{jobId}` | GetImportJob | `DataExchange.Import.*` |
+| <Badge text="DELETE" variant="danger" /> | `/{jobId}` | DeleteImportJob | `DataExchange.Import.*` |
+| <Badge text="GET" variant="note" /> | `/{jobId}/report` | GetImportReport | `DataExchange.Import.*` |
+| <Badge text="GET" variant="note" /> | `/{jobId}/correction-file` | DownloadImportCorrectionFile | `DataExchange.Import.*` |
+
+### Export
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/export/jobs` | ListExportJobs | `DataExchange.Export.*` |
+| <Badge text="POST" variant="success" /> | `/export/jobs` | CreateExportJob | `DataExchange.Export.*` |
+| <Badge text="GET" variant="note" /> | `/export/jobs/{id}` | GetExportJob | `DataExchange.Export.*` |
+| <Badge text="GET" variant="note" /> | `/export/jobs/{id}/download` | DownloadExportFile | `DataExchange.Export.*` |
+
+### Metadata
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/metadata/definitions` | GetExportDefinitions | `DataExchange.Export.*` |
+| <Badge text="GET" variant="note" /> | `/metadata/definitions/{name}/fields` | GetExportDefinitionFields | `DataExchange.Export.*` |
+| <Badge text="GET" variant="note" /> | `/metadata/presets/{definitionName}` | ListExportPresets | `DataExchange.Export.*` |
+| <Badge text="POST" variant="success" /> | `/metadata/presets` | SaveExportPreset | `DataExchange.Export.*` |
+| <Badge text="DELETE" variant="danger" /> | `/metadata/presets/{definitionName}/{presetName}` | DeleteExportPreset | `DataExchange.Export.*` |
+
+---
+
+## Features
+
+**Module:** `Granit.Features.Endpoints`
+**Prefix:** `/api/granit/features`
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/definitions` | GetFeatureDefinitions | `Features.Flags.Read` |
+| <Badge text="GET" variant="note" /> | `/values` | GetAllFeatureValues | Authenticated |
+| <Badge text="GET" variant="note" /> | `/values/{name}` | GetFeatureValue | Authenticated |
+| <Badge text="PUT" variant="caution" /> | `/overrides/{name}` | SetFeatureOverride | `Features.Flags.Manage` |
+| <Badge text="DELETE" variant="danger" /> | `/overrides/{name}` | DeleteFeatureOverride | `Features.Flags.Manage` |
+
+---
+
+## Identity
+
+**Module:** `Granit.Identity.Endpoints`
+**Prefix:** `/api/granit/identity`
+
+### User Cache
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/search` | SearchIdentityUsers | `Identity.UserCache.Read` |
+| <Badge text="GET" variant="note" /> | `/{userId}` | GetIdentityUser | `Identity.UserCache.Read` |
+| <Badge text="POST" variant="success" /> | `/batch` | BatchResolveIdentityUsers | `Identity.UserCache.Read` |
+| <Badge text="GET" variant="note" /> | `/stats` | GetIdentityUserCacheStats | `Identity.UserCache.Read` |
+| <Badge text="POST" variant="success" /> | `/sync` | SyncIdentityUsers | `Identity.UserCache.Sync` |
+| <Badge text="POST" variant="success" /> | `/sync-all` | SyncAllIdentityUsers | `Identity.UserCache.Sync` |
+| <Badge text="POST" variant="success" /> | `/erase` | EraseIdentityUserData | `Identity.UserCache.Delete` |
+| <Badge text="POST" variant="success" /> | `/pseudonymize` | PseudonymizeIdentityUser | `Identity.UserCache.Delete` |
+
+### Provider Users
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/users` | ListProviderUsers | `Identity.Users.Read` |
+| <Badge text="GET" variant="note" /> | `/users/{userId}` | GetProviderUser | `Identity.Users.Read` |
+| <Badge text="POST" variant="success" /> | `/users` | CreateProviderUser | `Identity.Users.Manage` |
+| <Badge text="PUT" variant="caution" /> | `/users/{userId}` | UpdateProviderUser | `Identity.Users.Manage` |
+| <Badge text="DELETE" variant="danger" /> | `/users/{userId}` | DeleteProviderUser | `Identity.Users.Manage` |
+
+### Roles
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/roles` | ListProviderRoles | `Identity.Roles.Read` |
+| <Badge text="GET" variant="note" /> | `/users/{userId}/roles` | GetUserRoles | `Identity.Roles.Read` |
+| <Badge text="POST" variant="success" /> | `/users/{userId}/roles` | AssignUserRole | `Identity.Roles.Manage` |
+| <Badge text="DELETE" variant="danger" /> | `/users/{userId}/roles/{roleId}` | RemoveUserRole | `Identity.Roles.Manage` |
+
+### Groups
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/groups` | ListProviderGroups | `Identity.Groups.Read` |
+| <Badge text="GET" variant="note" /> | `/users/{userId}/groups` | GetUserGroups | `Identity.Groups.Read` |
+| <Badge text="POST" variant="success" /> | `/users/{userId}/groups` | AddUserToGroup | `Identity.Groups.Manage` |
+| <Badge text="DELETE" variant="danger" /> | `/users/{userId}/groups/{groupId}` | RemoveUserFromGroup | `Identity.Groups.Manage` |
+
+### Sessions
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/users/{userId}/sessions` | ListUserSessions | `Identity.Sessions.Read` |
+| <Badge text="DELETE" variant="danger" /> | `/users/{userId}/sessions/{sessionId}` | RevokeUserSession | `Identity.Sessions.Manage` |
+
+### Passwords
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="POST" variant="success" /> | `/users/{userId}/password/reset` | ResetUserPassword | `Identity.Passwords.Manage` |
+| <Badge text="POST" variant="success" /> | `/users/{userId}/password/force-change` | ForcePasswordChange | `Identity.Passwords.Manage` |
+
+### Webhook
+
+| Method | Route | Operation | Auth |
+|--------|-------|-----------|------|
+| <Badge text="POST" variant="success" /> | `/webhook` | IdentityWebhook | Signature-validated |
+
+---
+
+## Localization
+
+**Module:** `Granit.Localization.Endpoints`
+**Prefix:** `/api/granit`
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/localization` | GetGranitLocalization | Anonymous |
+| <Badge text="GET" variant="note" /> | `/localization/overrides` | GetLocalizationOverrides | `Localization.Overrides.Manage` |
+| <Badge text="PUT" variant="caution" /> | `/localization/overrides/{resourceName}/{cultureName}/{key}` | PutLocalizationOverride | `Localization.Overrides.Manage` |
+| <Badge text="DELETE" variant="danger" /> | `/localization/overrides/{resourceName}/{cultureName}/{key}` | DeleteLocalizationOverride | `Localization.Overrides.Manage` |
+
+---
+
+## Notifications
+
+**Module:** `Granit.Notifications.Endpoints`
+**Prefix:** `/api/granit/notifications`
+
+### Inbox
+
+| Method | Route | Operation | Auth |
+|--------|-------|-----------|------|
+| <Badge text="GET" variant="note" /> | `/` | GetNotifications | Authenticated |
+| <Badge text="GET" variant="note" /> | `/unread/count` | GetUnreadCount | Authenticated |
+| <Badge text="POST" variant="success" /> | `/{id:guid}/read` | MarkAsRead | Authenticated |
+| <Badge text="POST" variant="success" /> | `/read-all` | MarkAllAsRead | Authenticated |
+
+### Activity Feed
+
+| Method | Route | Operation | Auth |
+|--------|-------|-----------|------|
+| <Badge text="GET" variant="note" /> | `/entity/{entityType}/{entityId}` | GetEntityActivityFeed | Authenticated |
+
+### Preferences & Subscriptions
+
+| Method | Route | Operation | Auth |
+|--------|-------|-----------|------|
+| <Badge text="GET" variant="note" /> | `/preferences` | GetPreferences | Authenticated |
+| <Badge text="PUT" variant="caution" /> | `/preferences` | UpdatePreference | Authenticated |
+| <Badge text="GET" variant="note" /> | `/types` | GetNotificationTypes | Authenticated |
+| <Badge text="GET" variant="note" /> | `/subscriptions` | GetSubscriptions | Authenticated |
+| <Badge text="POST" variant="success" /> | `/subscriptions/{typeName}` | Subscribe | Authenticated |
+| <Badge text="DELETE" variant="danger" /> | `/subscriptions/{typeName}` | Unsubscribe | Authenticated |
+
+### Entity Followers
+
+| Method | Route | Operation | Auth |
+|--------|-------|-----------|------|
+| <Badge text="POST" variant="success" /> | `/entity/{entityType}/{entityId}/follow` | FollowEntity | Authenticated |
+| <Badge text="DELETE" variant="danger" /> | `/entity/{entityType}/{entityId}/follow` | UnfollowEntity | Authenticated |
+| <Badge text="GET" variant="note" /> | `/entity/{entityType}/{entityId}/followers` | GetEntityFollowers | Authenticated |
+
+---
+
+## Querying
+
+**Module:** `Granit.Querying.Endpoints`
+**Prefix:** app-defined via `MapQueryEndpoints<T>(pattern)`
+
+<Aside type="caution">
+Querying endpoints are registered by the **application**, not the framework.
+The route pattern is passed to `MapQueryEndpoints<T>()`. For consistency,
+use the same prefix as the module's CRUD endpoints (e.g., `/localization/overrides`).
+</Aside>
+
+| Method | Route | Operation |
+|--------|-------|-----------|
+| <Badge text="GET" variant="note" /> | `/{pattern}` | Query\{EntityName\} |
+| <Badge text="GET" variant="note" /> | `/{pattern}/meta` | Get\{EntityName\}Meta |
+| <Badge text="GET" variant="note" /> | `/{pattern}/saved-views` | GetSavedViews |
+| <Badge text="POST" variant="success" /> | `/{pattern}/saved-views` | CreateSavedView |
+| <Badge text="PUT" variant="caution" /> | `/{pattern}/saved-views/{id}` | UpdateSavedView |
+| <Badge text="DELETE" variant="danger" /> | `/{pattern}/saved-views/{id}` | DeleteSavedView |
+| <Badge text="POST" variant="success" /> | `/{pattern}/saved-views/{id}/set-default` | SetDefaultSavedView |
+
+---
+
+## Settings
+
+**Module:** `Granit.Settings.Endpoints`
+**Prefix:** `/api/granit/settings`
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/user` | GetAllUserSettings | Authenticated |
+| <Badge text="GET" variant="note" /> | `/user/{name}` | GetUserSetting | Authenticated |
+| <Badge text="PUT" variant="caution" /> | `/user/{name}` | UpdateUserSetting | Authenticated |
+| <Badge text="DELETE" variant="danger" /> | `/user/{name}` | DeleteUserSetting | Authenticated |
+| <Badge text="GET" variant="note" /> | `/tenant` | GetAllTenantSettings | `Settings.Tenant.Read` |
+| <Badge text="PUT" variant="caution" /> | `/tenant/{name}` | UpdateTenantSetting | `Settings.Tenant.Manage` |
+| <Badge text="GET" variant="note" /> | `/global` | GetAllGlobalSettings | `Settings.Global.Read` |
+| <Badge text="PUT" variant="caution" /> | `/global/{name}` | UpdateGlobalSetting | `Settings.Global.Manage` |
+
+---
+
+## Templating
+
+**Module:** `Granit.Templating.Endpoints`
+**Prefix:** `/api/granit/templates`
+
+### Templates
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/` | ListTemplates | `Templates.Templates.Manage` |
+| <Badge text="GET" variant="note" /> | `/{name}` | GetTemplateDetail | `Templates.Templates.Manage` |
+| <Badge text="POST" variant="success" /> | `/` | CreateTemplateDraft | `Templates.Templates.Manage` |
+| <Badge text="PUT" variant="caution" /> | `/{name}` | UpdateTemplateDraft | `Templates.Templates.Manage` |
+| <Badge text="DELETE" variant="danger" /> | `/{name}/draft` | DeleteTemplateDraft | `Templates.Templates.Manage` |
+| <Badge text="POST" variant="success" /> | `/{name}/publish` | PublishTemplate | `Templates.Templates.Manage` |
+| <Badge text="POST" variant="success" /> | `/{name}/unpublish` | UnpublishTemplate | `Templates.Templates.Manage` |
+| <Badge text="GET" variant="note" /> | `/{name}/lifecycle` | GetTemplateLifecycle | `Templates.Templates.Manage` |
+| <Badge text="POST" variant="success" /> | `/{name}/preview` | PreviewTemplate | `Templates.Templates.Manage` |
+| <Badge text="GET" variant="note" /> | `/{name}/variables` | GetTemplateVariables | `Templates.Templates.Manage` |
+| <Badge text="GET" variant="note" /> | `/{name}/history` | GetTemplateHistory | `Templates.Templates.Manage` |
+| <Badge text="GET" variant="note" /> | `/{name}/history/{revisionId:guid}` | GetTemplateRevisionDetail | `Templates.Templates.Manage` |
+
+### Categories
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/categories` | ListTemplateCategories | `Templates.Templates.Manage` |
+| <Badge text="POST" variant="success" /> | `/categories` | CreateTemplateCategory | `Templates.Templates.Manage` |
+| <Badge text="PUT" variant="caution" /> | `/categories/{id}` | UpdateTemplateCategory | `Templates.Templates.Manage` |
+| <Badge text="DELETE" variant="danger" /> | `/categories/{id}` | DeleteTemplateCategory | `Templates.Templates.Manage` |
+
+---
+
+## Timeline
+
+**Module:** `Granit.Timeline.Endpoints`
+**Prefix:** `/api/granit/timeline`
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/{entityType}/{entityId}/history` | GetEntityStream | `Timeline.Entries.Read` |
+| <Badge text="POST" variant="success" /> | `/{entityType}/{entityId}/entries` | PostTimelineEntry | `Timeline.Entries.Read` |
+| <Badge text="DELETE" variant="danger" /> | `/{entityType}/{entityId}/entries/{id}` | DeleteTimelineEntry | `Timeline.Entries.Read` |
+
+---
+
+## Validation
+
+**Module:** `Granit.Validation.Endpoints`
+**Prefix:** `/api/granit/validation`
+
+| Method | Route | Operation | Auth |
+|--------|-------|-----------|------|
+| <Badge text="POST" variant="success" /> | `/validate` | ValidateField | Anonymous |
+| <Badge text="POST" variant="success" /> | `/validate-batch` | ValidateFieldBatch | Anonymous |
+| <Badge text="GET" variant="note" /> | `/validators` | GetRegisteredValidators | Anonymous |
+
+---
+
+## Webhooks
+
+**Module:** `Granit.Webhooks.Endpoints`
+**Prefix:** `/api/granit/webhooks`
+
+### Event Types
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/event-types` | GetWebhookEventTypes | `Webhooks.Subscriptions.Manage` |
+| <Badge text="POST" variant="success" /> | `/event-types/{eventTypeName}/discover` | DiscoverWebhookEventType | `Webhooks.Subscriptions.Manage` |
+
+### Subscriptions
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/subscriptions` | ListWebhookSubscriptions | `Webhooks.Subscriptions.Manage` |
+| <Badge text="GET" variant="note" /> | `/subscriptions/{id}` | GetWebhookSubscription | `Webhooks.Subscriptions.Manage` |
+| <Badge text="POST" variant="success" /> | `/subscriptions` | CreateWebhookSubscription | `Webhooks.Subscriptions.Manage` |
+| <Badge text="PUT" variant="caution" /> | `/subscriptions/{id}` | UpdateWebhookSubscription | `Webhooks.Subscriptions.Manage` |
+| <Badge text="DELETE" variant="danger" /> | `/subscriptions/{id}` | DeleteWebhookSubscription | `Webhooks.Subscriptions.Manage` |
+| <Badge text="POST" variant="success" /> | `/subscriptions/{id}/activate` | ActivateWebhookSubscription | `Webhooks.Subscriptions.Manage` |
+| <Badge text="POST" variant="success" /> | `/subscriptions/{id}/deactivate` | DeactivateWebhookSubscription | `Webhooks.Subscriptions.Manage` |
+| <Badge text="POST" variant="success" /> | `/subscriptions/{id}/test` | TestWebhookSubscription | `Webhooks.Subscriptions.Manage` |
+
+### Delivery Attempts
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/deliveries/query` | QueryWebhookDeliveries | `Webhooks.Subscriptions.Manage` |
+| <Badge text="POST" variant="success" /> | `/subscriptions/{id}/retry` | RetryWebhookDelivery | `Webhooks.Subscriptions.Manage` |
+
+---
+
+## Workflow
+
+**Module:** `Granit.Workflow.Endpoints`
+**Prefix:** `/api/granit/workflow`
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/{entityType}/{entityId}/history` | GetWorkflowHistory | `Workflow.History` |
+| <Badge text="GET" variant="note" /> | `/{entityType}/{entityId}/status` | GetWorkflowStatus | `Workflow.History` |
+| <Badge text="GET" variant="note" /> | `/transitions` | GetAvailableTransitions | `Workflow.History` |
+| <Badge text="POST" variant="success" /> | `/transitions` | ExecuteWorkflowTransition | `Workflow.History` |
+
+---
+
+## AI
+
+**Module:** `Granit.AI.Endpoints`
+**Prefix:** `/api/granit/ai`
+
+### Workspaces (Admin)
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/workspaces` | ListAIWorkspaces | `AI.Workspaces.*` |
+| <Badge text="POST" variant="success" /> | `/workspaces` | CreateAIWorkspace | `AI.Workspaces.*` |
+| <Badge text="PUT" variant="caution" /> | `/workspaces/{id}` | UpdateAIWorkspace | `AI.Workspaces.*` |
+| <Badge text="DELETE" variant="danger" /> | `/workspaces/{id}` | DeleteAIWorkspace | `AI.Workspaces.*` |
+
+### Chat & Embeddings
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="POST" variant="success" /> | `/chat/completions` | CreateChatCompletion | `AI.Chat.Execute` |
+| <Badge text="POST" variant="success" /> | `/chat/stream` | StreamChatCompletion | `AI.Chat.Execute` |
+| <Badge text="POST" variant="success" /> | `/embeddings` | GenerateEmbedding | `AI.Embedding.Generate` |
+
+---
+
+## Summary
+
+| Module | Endpoints | Auth model |
+|--------|-----------|------------|
+| API Keys | 6 | Permission-based |
+| Authorization | 5 | Admin + Authenticated |
+| Background Jobs | 5 | Permission-based |
+| Blob Storage | 4 + 2 proxy | Permission + Token |
+| Cookie Consent | 1 | Anonymous |
+| Data Exchange | 19 | Permission-based |
+| Features | 5 | Permission + Authenticated |
+| Identity | 23 | Permission-based (7 groups) |
+| Localization | 4 | Anonymous + Permission |
+| Notifications | 14 | Authenticated |
+| Querying | 7 per entity | App-defined |
+| Settings | 8 | Authenticated + Permission |
+| Templating | 16 | Permission-based |
+| Timeline | 3 | Permission-based |
+| Validation | 3 | Anonymous |
+| Webhooks | 12 | Permission-based |
+| Workflow | 4 | Permission-based |
+| AI | 7 | Permission-based |
+| **Total** | **~150+** | |

--- a/docs-site/src/content/docs/dotnet/api/endpoint-registry.mdx
+++ b/docs-site/src/content/docs/dotnet/api/endpoint-registry.mdx
@@ -93,9 +93,11 @@ api.MapGranitIdentityEndpoints();      // → /api/v1/identity/users/...
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
 | <Badge text="GET" variant="note" /> | `/{id:guid}` | GetBlobDescriptor | `BlobStorage.Blobs.Manage` |
-| <Badge text="POST" variant="success" /> | `/` | UploadBlob | `BlobStorage.Blobs.Manage` |
+| <Badge text="POST" variant="success" /> | `/upload` | InitiateBlobUpload | `BlobStorage.Blobs.Manage` |
+| <Badge text="POST" variant="success" /> | `/{id:guid}/confirm` | ConfirmBlobUpload | `BlobStorage.Blobs.Manage` |
+| <Badge text="POST" variant="success" /> | `/{id:guid}/download-url` | GenerateBlobDownloadUrl | `BlobStorage.Blobs.Manage` |
 | <Badge text="DELETE" variant="danger" /> | `/{id:guid}` | DeleteBlob | `BlobStorage.Blobs.Manage` |
-| <Badge text="POST" variant="success" /> | `/operations/validate-name` | ValidateBlobName | `BlobStorage.Blobs.Manage` |
+| <Badge text="POST" variant="success" /> | `/cleanup-orphans` | CleanupOrphanedBlobs | `BlobStorage.Blobs.Manage` |
 
 ### Blob Proxy
 
@@ -178,23 +180,31 @@ api.MapGranitIdentityEndpoints();      // → /api/v1/identity/users/...
 
 ## Identity
 
-**Module:** `Granit.Identity.Endpoints`
-**Prefix:** `identity/users`
+Identity uses **two separate endpoint groups** with distinct prefixes.
 
-### User Cache
+### User Cache (`identity/users`)
+
+**Module:** `Granit.Identity.Endpoints` — `MapGranitIdentityEndpoints()`
+**Prefix:** `identity/users`
 
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
-| <Badge text="GET" variant="note" /> | `/search` | SearchIdentityUsers | `Identity.UserCache.Read` |
+| <Badge text="GET" variant="note" /> | `/` | SearchIdentityUsers | `Identity.UserCache.Read` |
 | <Badge text="GET" variant="note" /> | `/{userId}` | GetIdentityUser | `Identity.UserCache.Read` |
 | <Badge text="POST" variant="success" /> | `/batch` | BatchResolveIdentityUsers | `Identity.UserCache.Read` |
 | <Badge text="GET" variant="note" /> | `/stats` | GetIdentityUserCacheStats | `Identity.UserCache.Read` |
+| <Badge text="GET" variant="note" /> | `/capabilities` | GetCapabilities | `Identity.UserCache.Read` |
 | <Badge text="POST" variant="success" /> | `/sync` | SyncIdentityUsers | `Identity.UserCache.Sync` |
 | <Badge text="POST" variant="success" /> | `/sync-all` | SyncAllIdentityUsers | `Identity.UserCache.Sync` |
-| <Badge text="POST" variant="success" /> | `/erase` | EraseIdentityUserData | `Identity.UserCache.Delete` |
-| <Badge text="POST" variant="success" /> | `/pseudonymize` | PseudonymizeIdentityUser | `Identity.UserCache.Delete` |
+| <Badge text="POST" variant="success" /> | `/sync-stale` | SyncStaleIdentityUsers | `Identity.UserCache.Sync` |
+| <Badge text="DELETE" variant="danger" /> | `/{userId}` | EraseIdentityUserData | `Identity.UserCache.Delete` |
 
-### Provider Users
+### Identity Provider (`identity/provider`)
+
+**Module:** `Granit.Identity.Endpoints` — `MapGranitIdentityProviderEndpoints()`
+**Prefix:** `identity/provider`
+
+#### Users
 
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
@@ -202,39 +212,42 @@ api.MapGranitIdentityEndpoints();      // → /api/v1/identity/users/...
 | <Badge text="GET" variant="note" /> | `/users/{userId}` | GetProviderUser | `Identity.Users.Read` |
 | <Badge text="POST" variant="success" /> | `/users` | CreateProviderUser | `Identity.Users.Manage` |
 | <Badge text="PUT" variant="caution" /> | `/users/{userId}` | UpdateProviderUser | `Identity.Users.Manage` |
-| <Badge text="DELETE" variant="danger" /> | `/users/{userId}` | DeleteProviderUser | `Identity.Users.Manage` |
 
-### Roles
+#### Roles
 
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
 | <Badge text="GET" variant="note" /> | `/roles` | ListProviderRoles | `Identity.Roles.Read` |
+| <Badge text="GET" variant="note" /> | `/roles/{roleName}/members` | GetRoleMembers | `Identity.Roles.Read` |
 | <Badge text="GET" variant="note" /> | `/users/{userId}/roles` | GetUserRoles | `Identity.Roles.Read` |
-| <Badge text="POST" variant="success" /> | `/users/{userId}/roles` | AssignUserRole | `Identity.Roles.Manage` |
-| <Badge text="DELETE" variant="danger" /> | `/users/{userId}/roles/{roleId}` | RemoveUserRole | `Identity.Roles.Manage` |
+| <Badge text="PUT" variant="caution" /> | `/users/{userId}/roles/{roleName}` | AssignUserRole | `Identity.Roles.Manage` |
+| <Badge text="DELETE" variant="danger" /> | `/users/{userId}/roles/{roleName}` | RemoveUserRole | `Identity.Roles.Manage` |
 
-### Groups
+#### Groups
 
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
 | <Badge text="GET" variant="note" /> | `/groups` | ListProviderGroups | `Identity.Groups.Read` |
 | <Badge text="GET" variant="note" /> | `/users/{userId}/groups` | GetUserGroups | `Identity.Groups.Read` |
-| <Badge text="POST" variant="success" /> | `/users/{userId}/groups` | AddUserToGroup | `Identity.Groups.Manage` |
+| <Badge text="PUT" variant="caution" /> | `/users/{userId}/groups/{groupId}` | AddUserToGroup | `Identity.Groups.Manage` |
 | <Badge text="DELETE" variant="danger" /> | `/users/{userId}/groups/{groupId}` | RemoveUserFromGroup | `Identity.Groups.Manage` |
 
-### Sessions
+#### Sessions & Devices
 
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
 | <Badge text="GET" variant="note" /> | `/users/{userId}/sessions` | ListUserSessions | `Identity.Sessions.Read` |
-| <Badge text="DELETE" variant="danger" /> | `/users/{userId}/sessions/{sessionId}` | RevokeUserSession | `Identity.Sessions.Manage` |
+| <Badge text="DELETE" variant="danger" /> | `/users/{userId}/sessions/{sessionId}` | TerminateSession | `Identity.Sessions.Manage` |
+| <Badge text="DELETE" variant="danger" /> | `/users/{userId}/sessions` | TerminateAllSessions | `Identity.Sessions.Manage` |
+| <Badge text="GET" variant="note" /> | `/users/{userId}/devices` | GetUserDeviceActivity | `Identity.Sessions.Read` |
 
-### Passwords
+#### Passwords
 
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
-| <Badge text="POST" variant="success" /> | `/users/{userId}/password/reset` | ResetUserPassword | `Identity.Passwords.Manage` |
-| <Badge text="POST" variant="success" /> | `/users/{userId}/password/force-change` | ForcePasswordChange | `Identity.Passwords.Manage` |
+| <Badge text="GET" variant="note" /> | `/users/{userId}/password/changed-at` | GetPasswordChangedAt | `Identity.Passwords.Read` |
+| <Badge text="POST" variant="success" /> | `/users/{userId}/password/reset-email` | SendPasswordResetEmail | `Identity.Passwords.Manage` |
+| <Badge text="POST" variant="success" /> | `/users/{userId}/password/temporary` | SetTemporaryPassword | `Identity.Passwords.Manage` |
 
 ### Webhook
 
@@ -296,6 +309,36 @@ api.MapGranitIdentityEndpoints();      // → /api/v1/identity/users/...
 | <Badge text="POST" variant="success" /> | `/entity/{entityType}/{entityId}/follow` | FollowEntity | Authenticated |
 | <Badge text="DELETE" variant="danger" /> | `/entity/{entityType}/{entityId}/follow` | UnfollowEntity | Authenticated |
 | <Badge text="GET" variant="note" /> | `/entity/{entityType}/{entityId}/followers` | GetEntityFollowers | Authenticated |
+
+---
+
+## Privacy (GDPR)
+
+**Module:** `Granit.Privacy.Endpoints`
+**Prefix:** `privacy`
+
+### Data Export (Art. 15/20)
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="POST" variant="success" /> | `/export` | RequestPrivacyExport | `Privacy.Export.Execute` |
+| <Badge text="GET" variant="note" /> | `/export/{requestId}` | GetPrivacyExportStatus | `Privacy.Export.Read` |
+| <Badge text="GET" variant="note" /> | `/export` | ListPrivacyExports | `Privacy.Export.Read` |
+
+### Data Deletion (Art. 17)
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="POST" variant="success" /> | `/deletion` | RequestPrivacyDeletion | `Privacy.Deletion.Execute` |
+
+### Legal Agreements (Art. 7)
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/agreements/documents` | ListPrivacyLegalDocuments | `Privacy.Agreements.Read` |
+| <Badge text="GET" variant="note" /> | `/agreements/status` | GetPrivacyConsentStatus | `Privacy.Agreements.Read` |
+| <Badge text="GET" variant="note" /> | `/agreements/history` | ListPrivacyAgreementHistory | `Privacy.Agreements.Read` |
+| <Badge text="POST" variant="success" /> | `/agreements/accept` | AcceptPrivacyAgreement | `Privacy.Agreements.Create` |
 
 ---
 
@@ -415,7 +458,6 @@ use the same prefix as the module's CRUD endpoints (e.g., `/localization/overrid
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
 | <Badge text="GET" variant="note" /> | `/event-types` | GetWebhookEventTypes | `Webhooks.Subscriptions.Manage` |
-| <Badge text="POST" variant="success" /> | `/event-types/{eventTypeName}/discover` | DiscoverWebhookEventType | `Webhooks.Subscriptions.Manage` |
 
 ### Subscriptions — CRUD
 
@@ -458,10 +500,9 @@ use the same prefix as the module's CRUD endpoints (e.g., `/localization/overrid
 
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
-| <Badge text="GET" variant="note" /> | `/{entityType}/{entityId}/history` | GetWorkflowHistory | `Workflow.History` |
-| <Badge text="GET" variant="note" /> | `/{entityType}/{entityId}/status` | GetWorkflowStatus | `Workflow.History` |
+| <Badge text="GET" variant="note" /> | `/{entityType}/{entityId}/history` | GetTransitionHistory | `Workflow.History` |
 | <Badge text="GET" variant="note" /> | `/transitions` | GetAvailableTransitions | `Workflow.History` |
-| <Badge text="POST" variant="success" /> | `/transitions` | ExecuteWorkflowTransition | `Workflow.History` |
+| <Badge text="POST" variant="success" /> | `/transitions` | ExecuteTransition | `Workflow.History` |
 
 ---
 
@@ -489,26 +530,76 @@ use the same prefix as the module's CRUD endpoints (e.g., `/localization/overrid
 
 ---
 
+## Audit Log
+
+**Module:** `Granit.AuditLog.Endpoints`
+**Prefix:** `audit-log`
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/` | GetAuditLogEntries | `AuditLog.Entries.Read` |
+| <Badge text="GET" variant="note" /> | `/{id:guid}` | GetAuditLogEntry | `AuditLog.Entries.Read` |
+| <Badge text="GET" variant="note" /> | `/entity/{entityType}/{entityId}` | GetAuditLogByEntity | `AuditLog.Entries.Read` |
+
+---
+
+## Diagnostics
+
+**Module:** `Granit.Diagnostics.Endpoints`
+**Prefix:** `diagnostics`
+
+| Method | Route | Operation | Auth |
+|--------|-------|-----------|------|
+| <Badge text="GET" variant="note" /> | `/health` | GetSystemHealth | Authenticated |
+
+---
+
+## Reference Data
+
+**Module:** `Granit.ReferenceData.Endpoints`
+**Prefix:** `reference-data`
+
+<Aside type="caution">
+Reference Data endpoints are registered per entity type by the **application**
+via `MapGranitReferenceDataEndpoints<T>()`. Each entity gets its own sub-group
+under the prefix.
+</Aside>
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/` | GetReferenceDataList | Read |
+| <Badge text="GET" variant="note" /> | `/{code}` | GetReferenceDataByCode | Read |
+| <Badge text="POST" variant="success" /> | `/` | CreateReferenceData | Admin |
+| <Badge text="PUT" variant="caution" /> | `/{code}` | UpdateReferenceData | Admin |
+| <Badge text="DELETE" variant="danger" /> | `/{code}` | DeactivateReferenceData | Admin |
+
+---
+
 ## Summary
 
 | Module | Endpoints | Auth model |
 |--------|-----------|------------|
 | API Keys | 6 | Permission-based |
+| Audit Log | 3 | Permission-based |
 | Authorization | 5 | Admin + Authenticated |
 | Background Jobs | 5 | Permission-based |
-| Blob Storage | 4 + 2 proxy | Permission + Token |
+| Blob Storage | 6 + 2 proxy | Permission + Token |
 | Cookie Consent | 1 | Anonymous |
 | Data Exchange | 19 | Permission-based |
+| Diagnostics | 1 | Authenticated |
 | Features | 5 | Permission + Authenticated |
-| Identity | 23 | Permission-based (7 groups) |
+| Identity — Cache | 9 | Permission-based |
+| Identity — Provider | 18 + webhook | Permission-based |
 | Localization | 4 | Anonymous + Permission |
 | Notifications | 14 | Authenticated |
+| Privacy (GDPR) | 8 | Permission-based |
 | Querying | 7 per entity | App-defined |
+| Reference Data | 5 per entity | App-defined |
 | Settings | 8 | Authenticated + Permission |
 | Templating | 16 | Permission-based |
 | Timeline | 3 | Permission-based |
 | Validation | 3 | Anonymous |
-| Webhooks | 16 | Permission-based |
-| Workflow | 4 | Permission-based |
+| Webhooks | 15 | Permission-based |
+| Workflow | 3 | Permission-based |
 | AI | 7 | Permission-based |
-| **Total** | **~150+** | |
+| **Total** | **~168+** | |

--- a/docs-site/src/content/docs/dotnet/api/endpoint-registry.mdx
+++ b/docs-site/src/content/docs/dotnet/api/endpoint-registry.mdx
@@ -9,8 +9,6 @@ sidebar:
 import { Aside, Badge } from "@astrojs/starlight/components";
 
 Complete inventory of all HTTP endpoints exposed by Granit framework modules.
-All route prefixes are **configurable** via each module's `*EndpointsOptions` class —
-the values below are the defaults.
 
 <Aside type="tip">
 Use this page to verify that your frontend API client matches the backend routes.
@@ -20,18 +18,31 @@ for request/response types — this page focuses on **routes, methods, and permi
 
 ## Conventions
 
-- **Default prefix:** `/api/granit/\{module-kebab-case\}`
+- **Route prefixes are relative** — each module defines a short prefix (e.g., `"templates"`,
+  `"blobs"`, `"identity/users"`) via its `*EndpointsOptions` class. The **application**
+  composes the full path by mounting modules under a versioned group:
+
+```csharp
+// Application startup (e.g., Program.cs)
+RouteGroupBuilder api = app.MapGroup("api/v{version:apiVersion}");
+
+api.MapGranitBlobStorageEndpoints();   // → /api/v1/blobs/...
+api.MapGranitTemplatingEndpoints();    // → /api/v1/templates/...
+api.MapGranitIdentityEndpoints();      // → /api/v1/identity/users/...
+```
+
 - **Permissions:** follow `[Group].[Resource].[Action]` (three segments)
 - **Error responses:** all endpoints return RFC 7807 Problem Details on errors
 - **Query endpoints** (`MapQueryEndpoints<T>`) are registered by the **application**,
   not the framework — the route pattern is app-defined
+- **Routes below** show only the module-relative path (without the app prefix)
 
 ---
 
 ## Authentication & API Keys
 
 **Module:** `Granit.Authentication.ApiKeys.Endpoints`
-**Prefix:** `/api/granit/api-keys`
+**Prefix:** `api-keys`
 
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
@@ -47,7 +58,7 @@ for request/response types — this page focuses on **routes, methods, and permi
 ## Authorization
 
 **Module:** `Granit.Authorization.Endpoints`
-**Prefix:** `/api/granit/authorization`
+**Prefix:** `auth`
 
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
@@ -62,7 +73,7 @@ for request/response types — this page focuses on **routes, methods, and permi
 ## Background Jobs
 
 **Module:** `Granit.BackgroundJobs.Endpoints`
-**Prefix:** `/api/granit/background-jobs`
+**Prefix:** `background-jobs`
 
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
@@ -77,7 +88,7 @@ for request/response types — this page focuses on **routes, methods, and permi
 ## Blob Storage
 
 **Module:** `Granit.BlobStorage.Endpoints`
-**Prefix:** `/api/granit/blobs`
+**Prefix:** `blobs`
 
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
@@ -89,7 +100,7 @@ for request/response types — this page focuses on **routes, methods, and permi
 ### Blob Proxy
 
 **Module:** `Granit.BlobStorage.Proxy`
-**Prefix:** `/api/granit/blobs/proxy`
+**Prefix:** `blobs/proxy`
 
 | Method | Route | Operation | Auth |
 |--------|-------|-----------|------|
@@ -101,7 +112,7 @@ for request/response types — this page focuses on **routes, methods, and permi
 ## Cookie Consent
 
 **Module:** `Granit.Http.Cookies.Endpoints`
-**Prefix:** `/api/granit`
+**Prefix:** _(root — mounted directly on the app group)_
 
 | Method | Route | Operation | Auth |
 |--------|-------|-----------|------|
@@ -112,7 +123,7 @@ for request/response types — this page focuses on **routes, methods, and permi
 ## Data Exchange
 
 **Module:** `Granit.DataExchange.Endpoints`
-**Prefix:** `/api/granit/data-exchange`
+**Prefix:** `data-exchange`
 
 ### Import
 
@@ -153,7 +164,7 @@ for request/response types — this page focuses on **routes, methods, and permi
 ## Features
 
 **Module:** `Granit.Features.Endpoints`
-**Prefix:** `/api/granit/features`
+**Prefix:** `features`
 
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
@@ -168,7 +179,7 @@ for request/response types — this page focuses on **routes, methods, and permi
 ## Identity
 
 **Module:** `Granit.Identity.Endpoints`
-**Prefix:** `/api/granit/identity`
+**Prefix:** `identity/users`
 
 ### User Cache
 
@@ -236,7 +247,7 @@ for request/response types — this page focuses on **routes, methods, and permi
 ## Localization
 
 **Module:** `Granit.Localization.Endpoints`
-**Prefix:** `/api/granit`
+**Prefix:** _(root — mounted directly on the app group)_
 
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
@@ -250,7 +261,7 @@ for request/response types — this page focuses on **routes, methods, and permi
 ## Notifications
 
 **Module:** `Granit.Notifications.Endpoints`
-**Prefix:** `/api/granit/notifications`
+**Prefix:** `notifications`
 
 ### Inbox
 
@@ -314,7 +325,7 @@ use the same prefix as the module's CRUD endpoints (e.g., `/localization/overrid
 ## Settings
 
 **Module:** `Granit.Settings.Endpoints`
-**Prefix:** `/api/granit/settings`
+**Prefix:** `settings`
 
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
@@ -332,7 +343,7 @@ use the same prefix as the module's CRUD endpoints (e.g., `/localization/overrid
 ## Templating
 
 **Module:** `Granit.Templating.Endpoints`
-**Prefix:** `/api/granit/templates`
+**Prefix:** `templates`
 
 ### Templates
 
@@ -365,7 +376,7 @@ use the same prefix as the module's CRUD endpoints (e.g., `/localization/overrid
 ## Timeline
 
 **Module:** `Granit.Timeline.Endpoints`
-**Prefix:** `/api/granit/timeline`
+**Prefix:** `timeline`
 
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
@@ -378,7 +389,7 @@ use the same prefix as the module's CRUD endpoints (e.g., `/localization/overrid
 ## Validation
 
 **Module:** `Granit.Validation.Endpoints`
-**Prefix:** `/api/granit/validation`
+**Prefix:** `validation`
 
 | Method | Route | Operation | Auth |
 |--------|-------|-----------|------|
@@ -391,7 +402,7 @@ use the same prefix as the module's CRUD endpoints (e.g., `/localization/overrid
 ## Webhooks
 
 **Module:** `Granit.Webhooks.Endpoints`
-**Prefix:** `/api/granit/webhooks`
+**Prefix:** `webhooks`
 
 ### Event Types
 
@@ -400,32 +411,44 @@ use the same prefix as the module's CRUD endpoints (e.g., `/localization/overrid
 | <Badge text="GET" variant="note" /> | `/event-types` | GetWebhookEventTypes | `Webhooks.Subscriptions.Manage` |
 | <Badge text="POST" variant="success" /> | `/event-types/{eventTypeName}/discover` | DiscoverWebhookEventType | `Webhooks.Subscriptions.Manage` |
 
-### Subscriptions
+### Subscriptions — CRUD
 
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
-| <Badge text="GET" variant="note" /> | `/subscriptions` | ListWebhookSubscriptions | `Webhooks.Subscriptions.Manage` |
 | <Badge text="GET" variant="note" /> | `/subscriptions/{id}` | GetWebhookSubscription | `Webhooks.Subscriptions.Manage` |
 | <Badge text="POST" variant="success" /> | `/subscriptions` | CreateWebhookSubscription | `Webhooks.Subscriptions.Manage` |
 | <Badge text="PUT" variant="caution" /> | `/subscriptions/{id}` | UpdateWebhookSubscription | `Webhooks.Subscriptions.Manage` |
 | <Badge text="DELETE" variant="danger" /> | `/subscriptions/{id}` | DeleteWebhookSubscription | `Webhooks.Subscriptions.Manage` |
-| <Badge text="POST" variant="success" /> | `/subscriptions/{id}/activate` | ActivateWebhookSubscription | `Webhooks.Subscriptions.Manage` |
-| <Badge text="POST" variant="success" /> | `/subscriptions/{id}/deactivate` | DeactivateWebhookSubscription | `Webhooks.Subscriptions.Manage` |
-| <Badge text="POST" variant="success" /> | `/subscriptions/{id}/test` | TestWebhookSubscription | `Webhooks.Subscriptions.Manage` |
 
-### Delivery Attempts
+### Subscriptions — Lifecycle
 
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
+| <Badge text="POST" variant="success" /> | `/subscriptions/{id}/activate` | ActivateWebhookSubscription | `Webhooks.Subscriptions.Manage` |
+| <Badge text="POST" variant="success" /> | `/subscriptions/{id}/suspend` | SuspendWebhookSubscription | `Webhooks.Subscriptions.Manage` |
+| <Badge text="POST" variant="success" /> | `/subscriptions/{id}/deactivate` | DeactivateWebhookSubscription | `Webhooks.Subscriptions.Manage` |
+
+### Subscriptions — Operations
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="POST" variant="success" /> | `/subscriptions/{id}/rotate-secret` | RotateWebhookSecret | `Webhooks.Subscriptions.Manage` |
+| <Badge text="POST" variant="success" /> | `/subscriptions/{id}/test-ping` | TestWebhookPing | `Webhooks.Subscriptions.Manage` |
+
+### Statistics & Deliveries
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/stats` | GetWebhookStats | `Webhooks.Subscriptions.Manage` |
 | <Badge text="GET" variant="note" /> | `/deliveries/query` | QueryWebhookDeliveries | `Webhooks.Subscriptions.Manage` |
-| <Badge text="POST" variant="success" /> | `/subscriptions/{id}/retry` | RetryWebhookDelivery | `Webhooks.Subscriptions.Manage` |
+| <Badge text="POST" variant="success" /> | `/deliveries/{deliveryId}/retry` | RetryWebhookDelivery | `Webhooks.Subscriptions.Manage` |
 
 ---
 
 ## Workflow
 
 **Module:** `Granit.Workflow.Endpoints`
-**Prefix:** `/api/granit/workflow`
+**Prefix:** `workflow`
 
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
@@ -439,7 +462,7 @@ use the same prefix as the module's CRUD endpoints (e.g., `/localization/overrid
 ## AI
 
 **Module:** `Granit.AI.Endpoints`
-**Prefix:** `/api/granit/ai`
+**Prefix:** `ai`
 
 ### Workspaces (Admin)
 
@@ -479,7 +502,7 @@ use the same prefix as the module's CRUD endpoints (e.g., `/localization/overrid
 | Templating | 16 | Permission-based |
 | Timeline | 3 | Permission-based |
 | Validation | 3 | Anonymous |
-| Webhooks | 12 | Permission-based |
+| Webhooks | 15 | Permission-based |
 | Workflow | 4 | Permission-based |
 | AI | 7 | Permission-based |
 | **Total** | **~150+** | |

--- a/docs-site/src/content/docs/dotnet/api/endpoint-registry.mdx
+++ b/docs-site/src/content/docs/dotnet/api/endpoint-registry.mdx
@@ -404,6 +404,12 @@ use the same prefix as the module's CRUD endpoints (e.g., `/localization/overrid
 **Module:** `Granit.Webhooks.Endpoints`
 **Prefix:** `webhooks`
 
+### Module Config
+
+| Method | Route | Operation | Permission |
+|--------|-------|-----------|------------|
+| <Badge text="GET" variant="note" /> | `/config` | GetWebhooksConfig | `Webhooks.Subscriptions.Manage` |
+
 ### Event Types
 
 | Method | Route | Operation | Permission |
@@ -502,7 +508,7 @@ use the same prefix as the module's CRUD endpoints (e.g., `/localization/overrid
 | Templating | 16 | Permission-based |
 | Timeline | 3 | Permission-based |
 | Validation | 3 | Anonymous |
-| Webhooks | 15 | Permission-based |
+| Webhooks | 16 | Permission-based |
 | Workflow | 4 | Permission-based |
 | AI | 7 | Permission-based |
 | **Total** | **~150+** | |

--- a/docs-site/src/content/docs/dotnet/api/endpoint-registry.mdx
+++ b/docs-site/src/content/docs/dotnet/api/endpoint-registry.mdx
@@ -516,17 +516,18 @@ use the same prefix as the module's CRUD endpoints (e.g., `/localization/overrid
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
 | <Badge text="GET" variant="note" /> | `/workspaces` | ListAIWorkspaces | `AI.Workspaces.*` |
+| <Badge text="GET" variant="note" /> | `/workspaces/{name}` | GetAIWorkspace | `AI.Workspaces.*` |
 | <Badge text="POST" variant="success" /> | `/workspaces` | CreateAIWorkspace | `AI.Workspaces.*` |
-| <Badge text="PUT" variant="caution" /> | `/workspaces/{id}` | UpdateAIWorkspace | `AI.Workspaces.*` |
-| <Badge text="DELETE" variant="danger" /> | `/workspaces/{id}` | DeleteAIWorkspace | `AI.Workspaces.*` |
+| <Badge text="PUT" variant="caution" /> | `/workspaces/{name}` | UpdateAIWorkspace | `AI.Workspaces.*` |
+| <Badge text="DELETE" variant="danger" /> | `/workspaces/{name}` | DeleteAIWorkspace | `AI.Workspaces.*` |
 
 ### Chat & Embeddings
 
 | Method | Route | Operation | Permission |
 |--------|-------|-----------|------------|
-| <Badge text="POST" variant="success" /> | `/chat/completions` | CreateChatCompletion | `AI.Chat.Execute` |
-| <Badge text="POST" variant="success" /> | `/chat/stream` | StreamChatCompletion | `AI.Chat.Execute` |
-| <Badge text="POST" variant="success" /> | `/embeddings` | GenerateEmbedding | `AI.Embedding.Generate` |
+| <Badge text="POST" variant="success" /> | `/chat/{workspaceName}` | CreateChatCompletion | `AI.Chat.Execute` |
+| <Badge text="POST" variant="success" /> | `/chat/{workspaceName}/stream` | StreamChatCompletion | `AI.Chat.Execute` |
+| <Badge text="POST" variant="success" /> | `/embeddings/{workspaceName}` | GenerateEmbedding | `AI.Embedding.Generate` |
 
 ---
 
@@ -601,5 +602,5 @@ under the prefix.
 | Validation | 3 | Anonymous |
 | Webhooks | 15 | Permission-based |
 | Workflow | 3 | Permission-based |
-| AI | 7 | Permission-based |
+| AI | 8 | Permission-based |
 | **Total** | **~168+** | |

--- a/docs-site/src/content/docs/dotnet/security/privacy.mdx
+++ b/docs-site/src/content/docs/dotnet/security/privacy.mdx
@@ -6,7 +6,7 @@ sidebar:
   label: Privacy
 ---
 
-import { FileTree } from "@astrojs/starlight/components";
+import { Aside, Badge, FileTree } from "@astrojs/starlight/components";
 
 ## Why a privacy module?
 
@@ -27,11 +27,15 @@ compliance during an audit without building a custom consent system.
 
 <FileTree>
 - Granit.Privacy GDPR data export saga, legal agreements, data provider registry
+  - Granit.Privacy.Endpoints Minimal API endpoints for export, deletion, consent
+  - Granit.Privacy.AI AI-powered PII detection in free-text fields
 </FileTree>
 
 | Package | Role | Depends on |
 | ------- | ---- | ---------- |
 | `Granit.Privacy` | GDPR data export/deletion orchestration, legal agreements | `Granit.Core` |
+| `Granit.Privacy.Endpoints` | HTTP endpoints for GDPR Art. 7/15/17/20 | `Granit.Privacy`, `Granit.Authorization`, `Granit.Validation` |
+| `Granit.Privacy.AI` | LLM-powered PII detection (`IAIPiiDetector`) | `Granit.Privacy`, `Granit.AI` |
 
 ## Setup
 
@@ -121,6 +125,76 @@ privacy.UseLegalAgreementStore<EfCoreLegalAgreementStore>();
 document — useful for middleware that blocks access until consent is renewed after
 a policy update.
 
+## Endpoints
+
+`Granit.Privacy.Endpoints` exposes GDPR operations as a Minimal API surface.
+Mount the endpoints via `MapGranitPrivacy()`:
+
+```csharp
+RouteGroupBuilder api = app.MapGroup("api/v{version:apiVersion}");
+api.MapGranitPrivacy(); // → /api/v1/privacy/...
+```
+
+### Data export (Art. 15/20)
+
+| Method | Route | Operation | Permission |
+| ------ | ----- | --------- | ---------- |
+| <Badge text="POST" variant="success" /> | `/export` | RequestPrivacyExport | `Privacy.Export.Execute` |
+| <Badge text="GET" variant="note" /> | `/export/{requestId}` | GetPrivacyExportStatus | `Privacy.Export.Read` |
+| <Badge text="GET" variant="note" /> | `/export` | ListPrivacyExports | `Privacy.Export.Read` |
+
+The POST endpoint triggers the scatter-gather saga. Each registered data provider
+prepares its fragment asynchronously. Poll the status endpoint or wire a
+`Granit.Notifications` handler on `ExportCompletedEto` to notify the user.
+
+When the export is ready, `ArchiveBlobReferenceId` in the response references the
+archive blob. Use the BlobStorage download endpoint to obtain a pre-signed URL.
+
+<Aside type="tip">
+The application must provide an `IExportRequestTrackerReader` / `IExportRequestTrackerWriter`
+implementation via `builder.UseExportRequestTracker<T>()`. This read model decouples
+the HTTP surface from the internal Wolverine saga state.
+</Aside>
+
+### Data deletion (Art. 17)
+
+| Method | Route | Operation | Permission |
+| ------ | ----- | --------- | ---------- |
+| <Badge text="POST" variant="success" /> | `/deletion` | RequestPrivacyDeletion | `Privacy.Deletion.Execute` |
+
+Publishes `PersonalDataDeletionRequestedEto`. Each module handles its own data:
+physical delete, soft delete, anonymization, or retention with legal justification.
+The operation is asynchronous — modules report completion via `PersonalDataDeletedEto`.
+
+### Legal agreements (Art. 7)
+
+| Method | Route | Operation | Permission |
+| ------ | ----- | --------- | ---------- |
+| <Badge text="GET" variant="note" /> | `/agreements/documents` | ListPrivacyLegalDocuments | `Privacy.Agreements.Read` |
+| <Badge text="GET" variant="note" /> | `/agreements/status` | GetPrivacyConsentStatus | `Privacy.Agreements.Read` |
+| <Badge text="GET" variant="note" /> | `/agreements/history` | ListPrivacyAgreementHistory | `Privacy.Agreements.Read` |
+| <Badge text="POST" variant="success" /> | `/agreements/accept` | AcceptPrivacyAgreement | `Privacy.Agreements.Create` |
+
+The accept endpoint validates that the submitted version matches the current version
+(rejects stale consent with 422), checks for duplicate acceptance (409), captures and
+pseudonymizes the client IP for the GDPR Art. 7 audit trail.
+
+<Aside type="caution">
+The consent endpoint reads `RemoteIpAddress` from `HttpContext.Connection`. When
+running behind a reverse proxy (Aspire, Docker, Nginx), enable
+`ForwardedHeadersMiddleware` to capture the real client IP.
+</Aside>
+
+### Permissions summary
+
+| Permission | Scope |
+| ---------- | ----- |
+| `Privacy.Export.Execute` | Request personal data export |
+| `Privacy.Export.Read` | View export status and history |
+| `Privacy.Deletion.Execute` | Request personal data deletion |
+| `Privacy.Agreements.Read` | View legal documents and consent status |
+| `Privacy.Agreements.Create` | Accept a legal agreement |
+
 ## Configuration reference
 
 ```json
@@ -136,10 +210,12 @@ a policy update.
 
 | Category | Key types | Package |
 | -------- | --------- | ------- |
-| Module | `GranitPrivacyModule` | -- |
+| Module | `GranitPrivacyModule`, `GranitPrivacyEndpointsModule` | -- |
 | Registry | `IDataProviderRegistry`, `ILegalDocumentRegistry`, `ILegalAgreementChecker` | `Granit.Privacy` |
 | Builder | `GranitPrivacyBuilder`, `GranitPrivacyOptions` | `Granit.Privacy` |
+| Export tracker | `IExportRequestTrackerReader`, `IExportRequestTrackerWriter`, `ExportRequestStatus` | `Granit.Privacy` |
 | Events | `PersonalDataRequestedEto`, `PersonalDataDeletionRequestedEto`, `ExportCompletedEto`, `ExportTimedOutEvent` | `Granit.Privacy` |
+| Endpoints | `MapGranitPrivacy()`, `PrivacyEndpointsOptions`, `PrivacyPermissions` | `Granit.Privacy.Endpoints` |
 | Extensions | `AddGranitPrivacy()` | `Granit.Privacy` |
 
 ## See also

--- a/docs-site/src/data/constants.ts
+++ b/docs-site/src/data/constants.ts
@@ -1,5 +1,5 @@
 /** Single source of truth for documentation-wide constants. */
-export const PACKAGE_COUNT = 183;
+export const PACKAGE_COUNT = 184;
 export const FRONTEND_PACKAGE_COUNT = 49;
 export const CULTURE_COUNT = 17;
 export const BASE_LANGUAGE_COUNT = 14;

--- a/src/Granit.AI.AzureOpenAI/packages.lock.json
+++ b/src/Granit.AI.AzureOpenAI/packages.lock.json
@@ -34,10 +34,10 @@
       "Microsoft.Extensions.AI.OpenAI": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "7R1fyxwF8KtQi8k2ih3Y6dHZiUfnnmZIgXY7hQ+dFlPkVZoefgKAzdnnrFZzYOjXPeJxh3gqAQ4psXnp59wwqw==",
+        "resolved": "10.4.1",
+        "contentHash": "C+xo+ds4PxSzTEywLcM0hbJJboEuLT5na/Q49rMNi3Y0hsoBuMXIZCvWXOyvNXunvngOwZYvkicEod/g8Gll6w==",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "10.4.0",
+          "Microsoft.Extensions.AI.Abstractions": "10.4.1",
           "OpenAI": "2.9.1"
         }
       },
@@ -215,8 +215,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/src/Granit.AI.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.AI.EntityFrameworkCore/packages.lock.json
@@ -176,8 +176,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",

--- a/src/Granit.AI.Extraction/packages.lock.json
+++ b/src/Granit.AI.Extraction/packages.lock.json
@@ -102,8 +102,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/src/Granit.AI.Ollama/packages.lock.json
+++ b/src/Granit.AI.Ollama/packages.lock.json
@@ -306,8 +306,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/src/Granit.AI.OpenAI/packages.lock.json
+++ b/src/Granit.AI.OpenAI/packages.lock.json
@@ -11,10 +11,10 @@
       "Microsoft.Extensions.AI.OpenAI": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "7R1fyxwF8KtQi8k2ih3Y6dHZiUfnnmZIgXY7hQ+dFlPkVZoefgKAzdnnrFZzYOjXPeJxh3gqAQ4psXnp59wwqw==",
+        "resolved": "10.4.1",
+        "contentHash": "C+xo+ds4PxSzTEywLcM0hbJJboEuLT5na/Q49rMNi3Y0hsoBuMXIZCvWXOyvNXunvngOwZYvkicEod/g8Gll6w==",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "10.4.0",
+          "Microsoft.Extensions.AI.Abstractions": "10.4.1",
           "OpenAI": "2.9.1"
         }
       },
@@ -150,8 +150,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/src/Granit.AI.VectorData/packages.lock.json
+++ b/src/Granit.AI.VectorData/packages.lock.json
@@ -46,10 +46,10 @@
       "Microsoft.Extensions.VectorData.Abstractions": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.0.1",
-        "contentHash": "1vsHJaRET/Q8aldtGiaAP4BKXBrVA9Y1brgYbpWyQQsr6HN7fN5+Qw74sC8g+JSHiZONJ4134pPQd1mk7fGlQw==",
+        "resolved": "10.1.0",
+        "contentHash": "I2XfmqEOWOq0Esbo0eWQ6WE5MAJkGyIs057F8ncmPCLJFw9b1IB7Jj5WiFlH6C5YXCAG9Z91QMBD/SkcMLhE7w==",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "10.3.0"
+          "Microsoft.Extensions.AI.Abstractions": "10.4.0"
         }
       },
       "Microsoft.Extensions.Configuration": {
@@ -124,8 +124,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/src/Granit.AI/packages.lock.json
+++ b/src/Granit.AI/packages.lock.json
@@ -11,8 +11,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Direct",

--- a/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Internal/EfCoreApiKeyAdminStore.cs
+++ b/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Internal/EfCoreApiKeyAdminStore.cs
@@ -87,14 +87,19 @@ internal sealed class EfCoreApiKeyAdminStore(
         await using ApiKeysDbContext db = await contextFactory.CreateDbContextAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        int updated = await db.ApiKeys
-            .Where(k => k.Id == id && k.RevokedAt == null)
-            .ExecuteUpdateAsync(
-                s => s.SetProperty(k => k.RevokedAt, revokedAt),
-                cancellationToken)
+        ApiKeyEntry? entry = await db.ApiKeys
+            .FirstOrDefaultAsync(k => k.Id == id && k.RevokedAt == null, cancellationToken)
             .ConfigureAwait(false);
 
-        return updated > 0;
+        if (entry is null)
+        {
+            return false;
+        }
+
+        entry.Revoke(revokedAt);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return true;
     }
 
     /// <inheritdoc/>

--- a/src/Granit.Authentication.ApiKeys/Domain/ApiKeyEntry.cs
+++ b/src/Granit.Authentication.ApiKeys/Domain/ApiKeyEntry.cs
@@ -23,7 +23,9 @@ public sealed class ApiKeyEntry : FullAuditedAggregateRoot, IMultiTenant
         string hashedKey,
         string prefix,
         string lastFourChars,
-        Guid? tenantId = null) => new()
+        Guid? tenantId = null)
+    {
+        var entry = new ApiKeyEntry
         {
             Id = id,
             Name = name,
@@ -34,6 +36,10 @@ public sealed class ApiKeyEntry : FullAuditedAggregateRoot, IMultiTenant
             LastFourChars = lastFourChars,
             TenantId = tenantId,
         };
+
+        entry.AddDistributedEvent(new ApiKeyCreatedEto(entry.Id, entry.Name, entry.Type));
+        return entry;
+    }
 
     /// <summary>Display name of the API key (e.g., "Partenaire Labo X").</summary>
     public string Name { get; private set; } = string.Empty;
@@ -83,10 +89,13 @@ public sealed class ApiKeyEntry : FullAuditedAggregateRoot, IMultiTenant
     }
 
     /// <summary>
-    /// Revokes the API key.
+    /// Revokes the API key and emits an <see cref="ApiKeyRevokedEvent"/> domain event.
     /// </summary>
-    public void Revoke(DateTimeOffset revokedAt) =>
+    public void Revoke(DateTimeOffset revokedAt)
+    {
         RevokedAt = revokedAt;
+        AddDomainEvent(new ApiKeyRevokedEvent(Id, HashedKey));
+    }
 
     /// <summary>
     /// Records that this key was used for an API call.
@@ -114,8 +123,11 @@ public sealed class ApiKeyEntry : FullAuditedAggregateRoot, IMultiTenant
     /// <summary>
     /// Updates the permissions granted to this key.
     /// </summary>
-    public void UpdatePermissions(List<string> permissions) =>
+    public void UpdatePermissions(List<string> permissions)
+    {
         Permissions = permissions;
+        AddDistributedEvent(new ApiKeyScopesUpdatedEto(Id, HashedKey));
+    }
 
     /// <summary>
     /// Updates the allowed CIDR ranges for IP whitelisting.

--- a/src/Granit.Authentication.ApiKeys/Events/ApiKeyCreatedEvent.cs
+++ b/src/Granit.Authentication.ApiKeys/Events/ApiKeyCreatedEvent.cs
@@ -1,3 +1,5 @@
+using Granit.Core.Events;
+
 namespace Granit.Authentication.ApiKeys.Events;
 
 /// <summary>
@@ -7,4 +9,4 @@ namespace Granit.Authentication.ApiKeys.Events;
 /// <param name="ApiKeyId">The unique identifier of the new key.</param>
 /// <param name="Name">Display name of the key.</param>
 /// <param name="Type">The key type.</param>
-public sealed record ApiKeyCreatedEvent(Guid ApiKeyId, string Name, ApiKeyType Type);
+public sealed record ApiKeyCreatedEto(Guid ApiKeyId, string Name, ApiKeyType Type) : IIntegrationEvent;

--- a/src/Granit.Authentication.ApiKeys/Events/ApiKeyRevokedEvent.cs
+++ b/src/Granit.Authentication.ApiKeys/Events/ApiKeyRevokedEvent.cs
@@ -1,3 +1,5 @@
+using Granit.Core.Events;
+
 namespace Granit.Authentication.ApiKeys.Events;
 
 /// <summary>
@@ -6,4 +8,4 @@ namespace Granit.Authentication.ApiKeys.Events;
 /// </summary>
 /// <param name="ApiKeyId">The unique identifier of the revoked key.</param>
 /// <param name="HashedKey">The SHA-256 hash of the key for cache eviction.</param>
-public sealed record ApiKeyRevokedEvent(Guid ApiKeyId, string HashedKey);
+public sealed record ApiKeyRevokedEvent(Guid ApiKeyId, string HashedKey) : IDomainEvent;

--- a/src/Granit.Authentication.ApiKeys/Events/ApiKeyRotatedEvent.cs
+++ b/src/Granit.Authentication.ApiKeys/Events/ApiKeyRotatedEvent.cs
@@ -1,3 +1,5 @@
+using Granit.Core.Events;
+
 namespace Granit.Authentication.ApiKeys.Events;
 
 /// <summary>
@@ -7,4 +9,4 @@ namespace Granit.Authentication.ApiKeys.Events;
 /// <param name="OldApiKeyId">The identifier of the key being replaced.</param>
 /// <param name="NewApiKeyId">The identifier of the newly created key.</param>
 /// <param name="OldHashedKey">The hash of the old key for cache eviction after the grace period.</param>
-public sealed record ApiKeyRotatedEvent(Guid OldApiKeyId, Guid NewApiKeyId, string OldHashedKey);
+public sealed record ApiKeyRotatedEto(Guid OldApiKeyId, Guid NewApiKeyId, string OldHashedKey) : IIntegrationEvent;

--- a/src/Granit.Authentication.ApiKeys/Events/ApiKeyScopesUpdatedEvent.cs
+++ b/src/Granit.Authentication.ApiKeys/Events/ApiKeyScopesUpdatedEvent.cs
@@ -1,3 +1,5 @@
+using Granit.Core.Events;
+
 namespace Granit.Authentication.ApiKeys.Events;
 
 /// <summary>
@@ -6,4 +8,4 @@ namespace Granit.Authentication.ApiKeys.Events;
 /// </summary>
 /// <param name="ApiKeyId">The identifier of the updated key.</param>
 /// <param name="HashedKey">The hash of the key for cache eviction.</param>
-public sealed record ApiKeyScopesUpdatedEvent(Guid ApiKeyId, string HashedKey);
+public sealed record ApiKeyScopesUpdatedEto(Guid ApiKeyId, string HashedKey) : IIntegrationEvent;

--- a/src/Granit.BackgroundJobs.EntityFrameworkCore/Internal/EfBackgroundJobStore.cs
+++ b/src/Granit.BackgroundJobs.EntityFrameworkCore/Internal/EfBackgroundJobStore.cs
@@ -70,34 +70,42 @@ internal sealed class EfBackgroundJobStore(
     public async Task RecordExecutionStartAsync(string jobName, DateTimeOffset startedAt, CancellationToken cancellationToken = default)
     {
         await using BackgroundJobsDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        await context.Jobs
-            .Where(j => j.JobName == jobName)
-            .ExecuteUpdateAsync(s => s
-                .SetProperty(j => j.LastExecutedAt, startedAt)
-                .SetProperty(j => j.LastErrorMessage, (string?)null)
-                .SetProperty(j => j.ConsecutiveFailureCount, 0)
-                .SetProperty(j => j.TriggeredBy, (string?)null), cancellationToken).ConfigureAwait(false);
+        BackgroundJobDefinition? job = await context.Jobs.FirstOrDefaultAsync(j => j.JobName == jobName, cancellationToken).ConfigureAwait(false);
+        if (job is null)
+        {
+            return;
+        }
+
+        job.RecordExecutionStart(startedAt);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public async Task RecordNextExecutionAsync(string jobName, DateTimeOffset nextExecution, CancellationToken cancellationToken = default)
     {
         await using BackgroundJobsDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        await context.Jobs
-            .Where(j => j.JobName == jobName)
-            .ExecuteUpdateAsync(s => s
-                .SetProperty(j => j.NextExecutionAt, nextExecution), cancellationToken).ConfigureAwait(false);
+        BackgroundJobDefinition? job = await context.Jobs.FirstOrDefaultAsync(j => j.JobName == jobName, cancellationToken).ConfigureAwait(false);
+        if (job is null)
+        {
+            return;
+        }
+
+        job.ScheduleNext(nextExecution);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public async Task RecordExecutionFailureAsync(string jobName, string errorMessage, CancellationToken cancellationToken = default)
     {
         await using BackgroundJobsDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        await context.Jobs
-            .Where(j => j.JobName == jobName)
-            .ExecuteUpdateAsync(s => s
-                .SetProperty(j => j.ConsecutiveFailureCount, j => j.ConsecutiveFailureCount + 1)
-                .SetProperty(j => j.LastErrorMessage, errorMessage), cancellationToken).ConfigureAwait(false);
+        BackgroundJobDefinition? job = await context.Jobs.FirstOrDefaultAsync(j => j.JobName == jobName, cancellationToken).ConfigureAwait(false);
+        if (job is null)
+        {
+            return;
+        }
+
+        job.RecordFailure(errorMessage);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -125,9 +133,13 @@ internal sealed class EfBackgroundJobStore(
     public async Task SetTriggeredByAsync(string jobName, string? triggeredBy, CancellationToken cancellationToken = default)
     {
         await using BackgroundJobsDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        await context.Jobs
-            .Where(j => j.JobName == jobName)
-            .ExecuteUpdateAsync(s => s
-                .SetProperty(j => j.TriggeredBy, triggeredBy), cancellationToken).ConfigureAwait(false);
+        BackgroundJobDefinition? job = await context.Jobs.FirstOrDefaultAsync(j => j.JobName == jobName, cancellationToken).ConfigureAwait(false);
+        if (job is null)
+        {
+            return;
+        }
+
+        job.SetTriggeredBy(triggeredBy);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Granit.BlobStorage.Proxy/Extensions/BlobStorageProxyEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.Proxy/Extensions/BlobStorageProxyEndpointRouteBuilderExtensions.cs
@@ -42,12 +42,20 @@ public static class BlobStorageProxyEndpointRouteBuilderExtensions
         group.MapPut("/upload/{token}", ProxyEndpoints.HandleUploadAsync)
             .WithName("BlobProxyUpload")
             .WithSummary("Proxied blob upload via ephemeral token.")
+            .WithDescription("Uploads a blob using an ephemeral pre-signed token. The token IS the authorization (no bearer token required), mirroring the S3 pre-signed URL model. Returns 403 if the token is invalid or expired, 413 if the payload exceeds the configured size limit, and 415 if the content type is not allowed.")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status413PayloadTooLarge)
+            .ProducesProblem(StatusCodes.Status415UnsupportedMediaType)
             .AllowAnonymous()
             .DisableAntiforgery();
 
         group.MapGet("/download/{token}", ProxyEndpoints.HandleDownloadAsync)
             .WithName("BlobProxyDownload")
             .WithSummary("Proxied blob download via ephemeral token.")
+            .WithDescription("Downloads a blob using an ephemeral pre-signed token. The token IS the authorization (no bearer token required). Returns the blob content as a binary stream with the appropriate content type. Returns 403 if the token is invalid or expired.")
+            .Produces(StatusCodes.Status200OK, contentType: "application/octet-stream")
+            .ProducesProblem(StatusCodes.Status403Forbidden)
             .AllowAnonymous();
 
         return endpoints;

--- a/src/Granit.DataExchange.Csv/packages.lock.json
+++ b/src/Granit.DataExchange.Csv/packages.lock.json
@@ -11,8 +11,8 @@
       "Sep": {
         "type": "Direct",
         "requested": "[0.*, )",
-        "resolved": "0.12.2",
-        "contentHash": "6zIz3NiZn2VLlzr28BcWMfCrTxeLQvNKHj8C2+7pXe3/QrCczAYLs0yc1c7MemSjkBN7zYOknL5utwWKG+tIyQ==",
+        "resolved": "0.12.3",
+        "contentHash": "xuQjdQ4c7A3yfJz6vzOy8T9KirByt8nmmVouhLDi9JYvoSQg4kOUdw9kQfThPOJ0N2MbTokSqF0Xr20RqeDQFQ==",
         "dependencies": {
           "csFastFloat": "4.1.5"
         }

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Pipeline/EfImportOrchestrator.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Pipeline/EfImportOrchestrator.cs
@@ -60,7 +60,7 @@ internal sealed class EfImportOrchestrator(
 
             metrics.RecordImportCompleted(report, job);
 
-            await eventBus.PublishAsync(new ImportJobCompletedEvent(
+            await eventBus.PublishAsync(new ImportJobCompletedEto(
                 importJobId, job.DefinitionName, report.FinalStatus, job.CreatedBy,
                 report.TotalRows, report.SucceededRows, report.FailedRows,
                 report.InsertedRows, report.UpdatedRows, report.SkippedRows), cancellationToken).ConfigureAwait(false);
@@ -91,7 +91,7 @@ internal sealed class EfImportOrchestrator(
 
             metrics.RecordImportCompleted(errorReport, job);
 
-            await eventBus.PublishAsync(new ImportJobCompletedEvent(
+            await eventBus.PublishAsync(new ImportJobCompletedEto(
                 importJobId, job.DefinitionName, ImportJobStatus.Failed, job.CreatedBy,
                 errorReport.TotalRows, errorReport.SucceededRows, errorReport.FailedRows,
                 errorReport.InsertedRows, errorReport.UpdatedRows, errorReport.SkippedRows), cancellationToken).ConfigureAwait(false);

--- a/src/Granit.DataExchange/Export/Internal/ExportOrchestrator.cs
+++ b/src/Granit.DataExchange/Export/Internal/ExportOrchestrator.cs
@@ -108,7 +108,7 @@ internal sealed partial class ExportOrchestrator(
                 request.DefinitionName, request.Format, rowCount,
                 job.TenantId?.ToString(), stopwatch.Elapsed);
 
-            await eventBus.PublishAsync(new ExportJobCompletedEvent(
+            await eventBus.PublishAsync(new ExportJobCompletedEto(
                 jobId, request.DefinitionName, ExportJobStatus.Completed,
                 job.CreatedBy, rowCount, ErrorMessage: null), cancellationToken).ConfigureAwait(false);
 
@@ -123,7 +123,7 @@ internal sealed partial class ExportOrchestrator(
             metrics.RecordExportFailed(
                 job.DefinitionName, job.Format, job.TenantId?.ToString(), stopwatch.Elapsed);
 
-            await eventBus.PublishAsync(new ExportJobCompletedEvent(
+            await eventBus.PublishAsync(new ExportJobCompletedEto(
                 jobId, job.DefinitionName, ExportJobStatus.Failed,
                 job.CreatedBy, RowCount: null, ex.Message), cancellationToken).ConfigureAwait(false);
 

--- a/src/Granit.DataExchange/Export/Messages/ExportJobCompletedEvent.cs
+++ b/src/Granit.DataExchange/Export/Messages/ExportJobCompletedEvent.cs
@@ -1,3 +1,5 @@
+using Granit.Core.Events;
+
 namespace Granit.DataExchange.Export.Messages;
 
 /// <summary>
@@ -14,10 +16,10 @@ namespace Granit.DataExchange.Export.Messages;
 /// <param name="UserId">Identifier of the user who created the job.</param>
 /// <param name="RowCount">Number of rows exported (null if failed before counting).</param>
 /// <param name="ErrorMessage">Error message if failed (null if completed).</param>
-public sealed record ExportJobCompletedEvent(
+public sealed record ExportJobCompletedEto(
     Guid ExportJobId,
     string DefinitionName,
     ExportJobStatus Status,
     string UserId,
     int? RowCount,
-    string? ErrorMessage);
+    string? ErrorMessage) : IIntegrationEvent;

--- a/src/Granit.DataExchange/Import/Messages/ImportJobCompletedEvent.cs
+++ b/src/Granit.DataExchange/Import/Messages/ImportJobCompletedEvent.cs
@@ -1,3 +1,4 @@
+using Granit.Core.Events;
 using Granit.DataExchange.Import.Domain;
 
 namespace Granit.DataExchange.Import.Messages;
@@ -21,7 +22,7 @@ namespace Granit.DataExchange.Import.Messages;
 /// <param name="InsertedRows">New records inserted.</param>
 /// <param name="UpdatedRows">Existing records updated.</param>
 /// <param name="SkippedRows">Rows skipped (e.g. empty rows).</param>
-public sealed record ImportJobCompletedEvent(
+public sealed record ImportJobCompletedEto(
     Guid ImportJobId,
     string DefinitionName,
     ImportJobStatus Status,
@@ -31,4 +32,4 @@ public sealed record ImportJobCompletedEvent(
     int FailedRows,
     int InsertedRows,
     int UpdatedRows,
-    int SkippedRows);
+    int SkippedRows) : IIntegrationEvent;

--- a/src/Granit.DocumentGeneration.Pdf/packages.lock.json
+++ b/src/Granit.DocumentGeneration.Pdf/packages.lock.json
@@ -53,10 +53,11 @@
       "PuppeteerSharp": {
         "type": "Direct",
         "requested": "[24.*, )",
-        "resolved": "24.39.0",
-        "contentHash": "T0Y6LiBa/c7Yk0O5i1A7FG0rSzgyJjGXtkGMCLwR9L7dZaXOjHj3/nq43KSlyzu98+loSKtVbFAnDpOM/Tc+zQ==",
+        "resolved": "24.40.0",
+        "contentHash": "vVvHFHCRW6772ptQmwzIxmc2CdkEv+F9kTlCncv4VFSGev1ev5mtlL9aVOPdHc6ss5ck6sArP4b2JtNy/7GzGA==",
         "dependencies": {
           "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
           "WebDriverBiDi": "0.0.45"
         }
       },
@@ -163,6 +164,12 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
         }
+      },
+      "Microsoft.IO.RecyclableMemoryStream": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.0.1",
+        "contentHash": "s/s20YTVY9r9TPfTrN5g8zPF1YhwxyqO6PxUkrYTGI2B+OGPe9AdajWZrLhFqXIvqIW23fnUE4+ztrUWNU1+9g=="
       }
     }
   }

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/cs.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/cs.json
@@ -1,0 +1,8 @@
+{
+  "culture": "cs",
+  "texts": {
+    "PermissionGroup:Features": "Funkce",
+    "Permission:Features.Flags.Read": "Zobrazit definice funkcí",
+    "Permission:Features.Flags.Manage": "Spravovat přepsání funkcí (nastavit, smazat)"
+  }
+}

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/de.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/de.json
@@ -1,0 +1,8 @@
+{
+  "culture": "de",
+  "texts": {
+    "PermissionGroup:Features": "Funktionen",
+    "Permission:Features.Flags.Read": "Funktionsdefinitionen anzeigen",
+    "Permission:Features.Flags.Manage": "Funktionsüberschreibungen verwalten (setzen, löschen)"
+  }
+}

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/en-GB.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/en-GB.json
@@ -1,0 +1,4 @@
+{
+  "culture": "en-GB",
+  "texts": {}
+}

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/es.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/es.json
@@ -1,0 +1,8 @@
+{
+  "culture": "es",
+  "texts": {
+    "PermissionGroup:Features": "Funcionalidades",
+    "Permission:Features.Flags.Read": "Ver definiciones de funcionalidades",
+    "Permission:Features.Flags.Manage": "Gestionar anulaciones de funcionalidades (establecer, eliminar)"
+  }
+}

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/fr-CA.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/fr-CA.json
@@ -1,0 +1,4 @@
+{
+  "culture": "fr-CA",
+  "texts": {}
+}

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/fr.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/fr.json
@@ -1,0 +1,8 @@
+{
+  "culture": "fr",
+  "texts": {
+    "PermissionGroup:Features": "Fonctionnalités",
+    "Permission:Features.Flags.Read": "Consulter les définitions de fonctionnalités",
+    "Permission:Features.Flags.Manage": "Gérer les substitutions de fonctionnalités (définir, supprimer)"
+  }
+}

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/it.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/it.json
@@ -1,0 +1,8 @@
+{
+  "culture": "it",
+  "texts": {
+    "PermissionGroup:Features": "Funzionalità",
+    "Permission:Features.Flags.Read": "Visualizzare le definizioni delle funzionalità",
+    "Permission:Features.Flags.Manage": "Gestire le sostituzioni delle funzionalità (impostare, eliminare)"
+  }
+}

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/ja.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/ja.json
@@ -1,0 +1,8 @@
+{
+  "culture": "ja",
+  "texts": {
+    "PermissionGroup:Features": "機能管理",
+    "Permission:Features.Flags.Read": "機能定義を表示する",
+    "Permission:Features.Flags.Manage": "機能オーバーライドを管理する（設定、削除）"
+  }
+}

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/ko.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/ko.json
@@ -1,0 +1,8 @@
+{
+  "culture": "ko",
+  "texts": {
+    "PermissionGroup:Features": "기능 관리",
+    "Permission:Features.Flags.Read": "기능 정의 보기",
+    "Permission:Features.Flags.Manage": "기능 재정의 관리 (설정, 삭제)"
+  }
+}

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/nl.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/nl.json
@@ -1,0 +1,8 @@
+{
+  "culture": "nl",
+  "texts": {
+    "PermissionGroup:Features": "Functionaliteiten",
+    "Permission:Features.Flags.Read": "Functiedefinities bekijken",
+    "Permission:Features.Flags.Manage": "Functie-overschrijvingen beheren (instellen, verwijderen)"
+  }
+}

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/pl.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/pl.json
@@ -1,0 +1,8 @@
+{
+  "culture": "pl",
+  "texts": {
+    "PermissionGroup:Features": "Funkcjonalności",
+    "Permission:Features.Flags.Read": "Przeglądaj definicje funkcjonalności",
+    "Permission:Features.Flags.Manage": "Zarządzaj nadpisaniami funkcjonalności (ustawiaj, usuwaj)"
+  }
+}

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/pt-BR.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/pt-BR.json
@@ -1,0 +1,4 @@
+{
+  "culture": "pt-BR",
+  "texts": {}
+}

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/pt.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/pt.json
@@ -1,0 +1,8 @@
+{
+  "culture": "pt",
+  "texts": {
+    "PermissionGroup:Features": "Funcionalidades",
+    "Permission:Features.Flags.Read": "Consultar definições de funcionalidades",
+    "Permission:Features.Flags.Manage": "Gerir substituições de funcionalidades (definir, eliminar)"
+  }
+}

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/sv.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/sv.json
@@ -1,0 +1,8 @@
+{
+  "culture": "sv",
+  "texts": {
+    "PermissionGroup:Features": "Funktioner",
+    "Permission:Features.Flags.Read": "Visa funktionsdefinitioner",
+    "Permission:Features.Flags.Manage": "Hantera funktionsöverskrivningar (ange, ta bort)"
+  }
+}

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/tr.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/tr.json
@@ -1,0 +1,8 @@
+{
+  "culture": "tr",
+  "texts": {
+    "PermissionGroup:Features": "Özellikler",
+    "Permission:Features.Flags.Read": "Özellik tanımlarını görüntüle",
+    "Permission:Features.Flags.Manage": "Özellik geçersiz kılmalarını yönet (ayarla, sil)"
+  }
+}

--- a/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/zh.json
+++ b/src/Granit.Features.Endpoints/Localization/FeaturesEndpoints/zh.json
@@ -1,0 +1,8 @@
+{
+  "culture": "zh",
+  "texts": {
+    "PermissionGroup:Features": "功能管理",
+    "Permission:Features.Flags.Read": "查看功能定义",
+    "Permission:Features.Flags.Manage": "管理功能覆盖（设置、删除）"
+  }
+}

--- a/src/Granit.Http.ApiDocumentation/packages.lock.json
+++ b/src/Granit.Http.ApiDocumentation/packages.lock.json
@@ -20,8 +20,8 @@
       "Scalar.AspNetCore": {
         "type": "Direct",
         "requested": "[2.*, )",
-        "resolved": "2.13.10",
-        "contentHash": "AHsAdrbjIVvV/l6dwsIpluuWZEjafmxLkoJTzdRruRNB3w5VI5MKM1Gu0gyX6xRI0raEtSy3O111YpBrZMOpSA=="
+        "resolved": "2.13.13",
+        "contentHash": "QS94/CNp2thhykXwBaOHjDe8Zlexs8v0QOrdLfUvxS85uW84IhCf1zGiOnYZNNtVxunJvtsr7yPgEP36TXnJ3w=="
       },
       "Asp.Versioning.Abstractions": {
         "type": "Transitive",

--- a/src/Granit.Http.Cookies.Endpoints/packages.lock.json
+++ b/src/Granit.Http.Cookies.Endpoints/packages.lock.json
@@ -94,8 +94,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.13.10",
-        "contentHash": "AHsAdrbjIVvV/l6dwsIpluuWZEjafmxLkoJTzdRruRNB3w5VI5MKM1Gu0gyX6xRI0raEtSy3O111YpBrZMOpSA=="
+        "resolved": "2.13.13",
+        "contentHash": "QS94/CNp2thhykXwBaOHjDe8Zlexs8v0QOrdLfUvxS85uW84IhCf1zGiOnYZNNtVxunJvtsr7yPgEP36TXnJ3w=="
       }
     }
   }

--- a/src/Granit.Identity.Cognito/Internal/CognitoIdentityProvider.cs
+++ b/src/Granit.Identity.Cognito/Internal/CognitoIdentityProvider.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Amazon.CognitoIdentityProvider;
 using Amazon.CognitoIdentityProvider.Model;
+using Granit.Core.Events;
 using Granit.Identity.Cognito.Diagnostics;
 using Granit.Identity.Cognito.Options;
 using Granit.Identity.Models;
@@ -17,7 +18,7 @@ namespace Granit.Identity.Cognito.Internal;
 internal sealed partial class CognitoIdentityProvider(
     IAmazonCognitoIdentityProvider cognitoClient,
     IOptions<CognitoAdminOptions> options,
-    IIdentityEventPublisher eventPublisher,
+    IDistributedEventBus distributedEventBus,
     ILogger<CognitoIdentityProvider> logger) : IIdentityProvider
 {
     private const string EmailAttribute = "email";
@@ -129,8 +130,8 @@ internal sealed partial class CognitoIdentityProvider(
                 cancellationToken).ConfigureAwait(false);
         }
 
-        await eventPublisher.PublishAsync(
-            new Events.IdentityUserEnabledChangedEvent(userId, enabled),
+        await distributedEventBus.PublishAsync(
+            new Events.IdentityUserEnabledChangedEto(userId, enabled),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -187,8 +188,8 @@ internal sealed partial class CognitoIdentityProvider(
                 .ConfigureAwait(false);
         }
 
-        await eventPublisher.PublishAsync(
-            new Events.IdentityUserProfileUpdatedEvent(userId, update),
+        await distributedEventBus.PublishAsync(
+            new Events.IdentityUserProfileUpdatedEto(userId, update),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -237,8 +238,8 @@ internal sealed partial class CognitoIdentityProvider(
             await SetUserEnabledAsync(createdUser.Id, false, cancellationToken).ConfigureAwait(false);
         }
 
-        await eventPublisher.PublishAsync(
-            new Events.IdentityUserCreatedEvent(createdUser.Id, createdUser.Username ?? user.Username, createdUser.Email),
+        await distributedEventBus.PublishAsync(
+            new Events.IdentityUserCreatedEto(createdUser.Id, createdUser.Username ?? user.Username, createdUser.Email),
             cancellationToken).ConfigureAwait(false);
 
         return createdUser;
@@ -385,8 +386,8 @@ internal sealed partial class CognitoIdentityProvider(
             .AdminAddUserToGroupAsync(request, cancellationToken)
             .ConfigureAwait(false);
 
-        await eventPublisher.PublishAsync(
-            new Events.IdentityGroupMembershipChangedEvent(userId, groupId, true),
+        await distributedEventBus.PublishAsync(
+            new Events.IdentityGroupMembershipChangedEto(userId, groupId, true),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -411,8 +412,8 @@ internal sealed partial class CognitoIdentityProvider(
             .AdminRemoveUserFromGroupAsync(request, cancellationToken)
             .ConfigureAwait(false);
 
-        await eventPublisher.PublishAsync(
-            new Events.IdentityGroupMembershipChangedEvent(userId, groupId, false),
+        await distributedEventBus.PublishAsync(
+            new Events.IdentityGroupMembershipChangedEto(userId, groupId, false),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -465,8 +466,8 @@ internal sealed partial class CognitoIdentityProvider(
             .AdminUserGlobalSignOutAsync(request, cancellationToken)
             .ConfigureAwait(false);
 
-        await eventPublisher.PublishAsync(
-            new Events.IdentitySessionsRevokedEvent(userId),
+        await distributedEventBus.PublishAsync(
+            new Events.IdentitySessionsRevokedEto(userId),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -498,8 +499,8 @@ internal sealed partial class CognitoIdentityProvider(
             .AdminResetUserPasswordAsync(request, cancellationToken)
             .ConfigureAwait(false);
 
-        await eventPublisher.PublishAsync(
-            new Events.IdentityPasswordResetEvent(userId),
+        await distributedEventBus.PublishAsync(
+            new Events.IdentityPasswordResetEto(userId),
             cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/Granit.Identity.Cognito/packages.lock.json
+++ b/src/Granit.Identity.Cognito/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.6.2",
-        "contentHash": "MOhL6nl78bYJh1AmoMNq9nJIM4dFjDO/FsLYMYj8IrWCqmfujGeHe8EnNEOM+Bxc8t5CLkil91awpS0TguzT+g==",
+        "resolved": "4.0.6.3",
+        "contentHash": "jgs58BUUO1v/6thtWUYQbuIZD0LotMsbk8bpZ+qYsfMo3HOO89xEmsojs6BgwIKZe7++mltD7eSB8P7VhLSGeg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.17, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.19, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -32,8 +32,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.17",
-        "contentHash": "Ab24kVquQ8kvuQKNe5MK/SvaXR4uoxPkAlTPALDEImaHcwsBg+UWfRVcNzLEx4dRR2y1mDFFh+zZ9TVMXGY6Jg=="
+        "resolved": "4.0.3.19",
+        "contentHash": "8zIzN59+J6arYSyFuhnSxPepr8ff4p6li+MxKUUnqCgwZqQ+icEGJK/23c1USIEALqZZ5gdiITuH2sOZWQom+Q=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Identity.Endpoints/Endpoints/IdentityWebhookEndpoints.cs
+++ b/src/Granit.Identity.Endpoints/Endpoints/IdentityWebhookEndpoints.cs
@@ -17,7 +17,7 @@ namespace Granit.Identity.Endpoints.Endpoints;
 /// </summary>
 /// <remarks>
 /// For asynchronous processing via Wolverine, the application host can publish
-/// <c>IdentityUserUpdatedEvent</c> / <c>IdentityUserDeletedEvent</c> messages instead
+/// <c>IdentityUserUpdatedEto</c> / <c>IdentityUserDeletedEto</c> messages instead
 /// of using this endpoint.
 /// </remarks>
 internal static class IdentityWebhookEndpoints
@@ -38,7 +38,7 @@ internal static class IdentityWebhookEndpoints
             .WithDescription("Webhook receiver for identity provider event notifications. Validates the HMAC signature (if configured) and processes user_created, user_updated, and user_deleted events by refreshing or removing the corresponding cache entries. No authentication required — security relies on the HMAC signature validation.")
             .WithTags("Identity Webhook")
             .Produces(StatusCodes.Status200OK)
-            .Produces(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status400BadRequest);
 
         return endpoints;

--- a/src/Granit.Identity.EntityFrameworkCore/Events/IdentityUserDeletedEvent.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Events/IdentityUserDeletedEvent.cs
@@ -1,3 +1,5 @@
+using Granit.Core.Events;
+
 namespace Granit.Identity.EntityFrameworkCore.Events;
 
 /// <summary>
@@ -8,4 +10,4 @@ namespace Granit.Identity.EntityFrameworkCore.Events;
 /// </summary>
 /// <param name="UserId">The external user ID in the identity provider.</param>
 /// <param name="TenantId">Optional tenant scope for the deletion. Null deletes across all tenants.</param>
-public sealed record IdentityUserDeletedEvent(string UserId, Guid? TenantId = null);
+public sealed record IdentityUserDeletedEto(string UserId, Guid? TenantId = null) : IIntegrationEvent;

--- a/src/Granit.Identity.EntityFrameworkCore/Events/IdentityUserUpdatedEvent.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Events/IdentityUserUpdatedEvent.cs
@@ -1,3 +1,5 @@
+using Granit.Core.Events;
+
 namespace Granit.Identity.EntityFrameworkCore.Events;
 
 /// <summary>
@@ -6,4 +8,4 @@ namespace Granit.Identity.EntityFrameworkCore.Events;
 /// (Keycloak admin events, Entra ID change notifications, etc.) into this event.
 /// </summary>
 /// <param name="UserId">The external user ID in the identity provider.</param>
-public sealed record IdentityUserUpdatedEvent(string UserId);
+public sealed record IdentityUserUpdatedEto(string UserId) : IIntegrationEvent;

--- a/src/Granit.Identity.EntityFrameworkCore/Handlers/IdentityUserEventHandler.cs
+++ b/src/Granit.Identity.EntityFrameworkCore/Handlers/IdentityUserEventHandler.cs
@@ -23,7 +23,7 @@ internal sealed partial class IdentityUserEventHandler(
     /// Handles a user created/updated event (from webhook) by fetching the user from
     /// the identity provider and upserting the cache entry.
     /// </summary>
-    public async Task HandleAsync(IdentityUserUpdatedEvent @event, CancellationToken cancellationToken)
+    public async Task HandleAsync(IdentityUserUpdatedEto @event, CancellationToken cancellationToken)
     {
         await SyncUserCacheAsync(@event.UserId, cancellationToken).ConfigureAwait(false);
         LogUserCacheUpdated(@event.UserId, "webhook");
@@ -32,7 +32,7 @@ internal sealed partial class IdentityUserEventHandler(
     /// <summary>
     /// Handles a user deleted event by hard-deleting the cache entry (RGPD Art. 17).
     /// </summary>
-    public async Task HandleAsync(IdentityUserDeletedEvent @event, CancellationToken cancellationToken)
+    public async Task HandleAsync(IdentityUserDeletedEto @event, CancellationToken cancellationToken)
     {
         await store.DeleteByExternalIdAsync(@event.UserId, @event.TenantId, cancellationToken)
             .ConfigureAwait(false);
@@ -49,7 +49,7 @@ internal sealed partial class IdentityUserEventHandler(
     /// <summary>
     /// Handles a user created event by syncing the new user into the local cache.
     /// </summary>
-    public async Task HandleAsync(IdentityUserCreatedEvent @event, CancellationToken cancellationToken)
+    public async Task HandleAsync(IdentityUserCreatedEto @event, CancellationToken cancellationToken)
     {
         await SyncUserCacheAsync(@event.UserId, cancellationToken).ConfigureAwait(false);
         LogUserCacheUpdated(@event.UserId, "create");
@@ -58,7 +58,7 @@ internal sealed partial class IdentityUserEventHandler(
     /// <summary>
     /// Handles a user profile updated event by refreshing the cache entry.
     /// </summary>
-    public async Task HandleAsync(IdentityUserProfileUpdatedEvent @event, CancellationToken cancellationToken)
+    public async Task HandleAsync(IdentityUserProfileUpdatedEto @event, CancellationToken cancellationToken)
     {
         await SyncUserCacheAsync(@event.UserId, cancellationToken).ConfigureAwait(false);
         LogUserCacheUpdated(@event.UserId, "profile-update");
@@ -67,7 +67,7 @@ internal sealed partial class IdentityUserEventHandler(
     /// <summary>
     /// Handles a user enabled/disabled event by refreshing the cache entry.
     /// </summary>
-    public async Task HandleAsync(IdentityUserEnabledChangedEvent @event, CancellationToken cancellationToken)
+    public async Task HandleAsync(IdentityUserEnabledChangedEto @event, CancellationToken cancellationToken)
     {
         await SyncUserCacheAsync(@event.UserId, cancellationToken).ConfigureAwait(false);
         LogUserCacheUpdated(@event.UserId, "enabled-change");

--- a/src/Granit.Identity.EntraId/Internal/EntraIdIdentityProvider.cs
+++ b/src/Granit.Identity.EntraId/Internal/EntraIdIdentityProvider.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Security.Cryptography;
+using Granit.Core.Events;
 using Granit.Identity.EntraId.Diagnostics;
 using Granit.Identity.EntraId.Options;
 using Granit.Identity.Events;
@@ -31,7 +32,7 @@ internal sealed partial class EntraIdIdentityProvider(
     IHttpClientFactory httpClientFactory,
     IOptions<EntraIdAdminOptions> options,
     IPasswordResetNotifier passwordResetNotifier,
-    IIdentityEventPublisher eventPublisher,
+    IDistributedEventBus distributedEventBus,
     ILogger<EntraIdIdentityProvider> logger) : IIdentityProvider
 {
     /// <inheritdoc/>
@@ -110,7 +111,7 @@ internal sealed partial class EntraIdIdentityProvider(
 
         response.EnsureSuccessStatusCode();
 
-        await eventPublisher.PublishAsync(new IdentityUserEnabledChangedEvent(userId, enabled), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityUserEnabledChangedEto(userId, enabled), cancellationToken).ConfigureAwait(false);
 
         LogUserEnabledChanged(userId, enabled ? "enabled" : "disabled");
     }
@@ -158,7 +159,7 @@ internal sealed partial class EntraIdIdentityProvider(
 
         response.EnsureSuccessStatusCode();
 
-        await eventPublisher.PublishAsync(new IdentityUserProfileUpdatedEvent(userId, update), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityUserProfileUpdatedEto(userId, update), cancellationToken).ConfigureAwait(false);
 
         LogUserProfileUpdated(userId);
     }
@@ -444,7 +445,7 @@ internal sealed partial class EntraIdIdentityProvider(
 
         response.EnsureSuccessStatusCode();
 
-        await eventPublisher.PublishAsync(new IdentityRoleAssignedEvent(userId, roleName), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityRoleAssignedEto(userId, roleName), cancellationToken).ConfigureAwait(false);
 
         LogRoleAssigned(roleName, userId);
     }
@@ -490,7 +491,7 @@ internal sealed partial class EntraIdIdentityProvider(
 
         response.EnsureSuccessStatusCode();
 
-        await eventPublisher.PublishAsync(new IdentityRoleRemovedEvent(userId, roleName), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityRoleRemovedEto(userId, roleName), cancellationToken).ConfigureAwait(false);
 
         LogRoleRemoved(roleName, userId);
     }
@@ -515,7 +516,7 @@ internal sealed partial class EntraIdIdentityProvider(
 
         await TerminateAllSessionsAsync(userId, cancellationToken).ConfigureAwait(false);
 
-        await eventPublisher.PublishAsync(new IdentitySessionsRevokedEvent(userId), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentitySessionsRevokedEto(userId), cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -537,7 +538,7 @@ internal sealed partial class EntraIdIdentityProvider(
 
         response.EnsureSuccessStatusCode();
 
-        await eventPublisher.PublishAsync(new IdentitySessionsRevokedEvent(userId), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentitySessionsRevokedEto(userId), cancellationToken).ConfigureAwait(false);
 
         LogAllSessionsTerminated(userId);
     }
@@ -561,7 +562,7 @@ internal sealed partial class EntraIdIdentityProvider(
         await SetTemporaryPasswordAsync(userId, temporaryPassword, cancellationToken).ConfigureAwait(false);
         await passwordResetNotifier.NotifyAsync(userId, temporaryPassword, cancellationToken).ConfigureAwait(false);
 
-        await eventPublisher.PublishAsync(new IdentityPasswordResetEvent(userId), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityPasswordResetEto(userId), cancellationToken).ConfigureAwait(false);
 
         LogPasswordResetWithNotifier(userId);
     }
@@ -595,7 +596,7 @@ internal sealed partial class EntraIdIdentityProvider(
 
         response.EnsureSuccessStatusCode();
 
-        await eventPublisher.PublishAsync(new IdentityPasswordResetEvent(userId), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityPasswordResetEto(userId), cancellationToken).ConfigureAwait(false);
 
         LogTemporaryPasswordSet(userId);
     }
@@ -664,7 +665,7 @@ internal sealed partial class EntraIdIdentityProvider(
             user.LastName,
             user.Enabled);
 
-        await eventPublisher.PublishAsync(new IdentityUserCreatedEvent(createdIdentityUser.Id, createdIdentityUser.Username, createdIdentityUser.Email), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityUserCreatedEto(createdIdentityUser.Id, createdIdentityUser.Username, createdIdentityUser.Email), cancellationToken).ConfigureAwait(false);
 
         return createdIdentityUser;
     }
@@ -748,7 +749,7 @@ internal sealed partial class EntraIdIdentityProvider(
 
         response.EnsureSuccessStatusCode();
 
-        await eventPublisher.PublishAsync(new IdentityGroupMembershipChangedEvent(userId, groupId, Added: true), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityGroupMembershipChangedEto(userId, groupId, Added: true), cancellationToken).ConfigureAwait(false);
 
         LogUserAddedToGroup(userId, groupId);
     }
@@ -775,7 +776,7 @@ internal sealed partial class EntraIdIdentityProvider(
 
         response.EnsureSuccessStatusCode();
 
-        await eventPublisher.PublishAsync(new IdentityGroupMembershipChangedEvent(userId, groupId, Added: false), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityGroupMembershipChangedEto(userId, groupId, Added: false), cancellationToken).ConfigureAwait(false);
 
         LogUserRemovedFromGroup(userId, groupId);
     }

--- a/src/Granit.Identity.GoogleCloud/Extensions/IdentityGoogleCloudServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.GoogleCloud/Extensions/IdentityGoogleCloudServiceCollectionExtensions.cs
@@ -41,7 +41,8 @@ public static class IdentityGoogleCloudServiceCollectionExtensions
 
             if (!string.IsNullOrEmpty(opts.CredentialFilePath))
             {
-                appOptions.Credential = GoogleCredential.FromFile(opts.CredentialFilePath);
+                appOptions.Credential = CredentialFactory
+                    .FromFile(opts.CredentialFilePath, JsonCredentialParameters.ServiceAccountCredentialType);
             }
 
             var app = FirebaseApp.Create(appOptions);

--- a/src/Granit.Identity.GoogleCloud/Internal/GoogleCloudIdentityProvider.cs
+++ b/src/Granit.Identity.GoogleCloud/Internal/GoogleCloudIdentityProvider.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using FirebaseAdmin.Auth;
+using Granit.Core.Events;
 using Granit.Identity.Events;
 using Granit.Identity.GoogleCloud.Diagnostics;
 using Granit.Identity.GoogleCloud.Options;
@@ -19,7 +20,7 @@ namespace Granit.Identity.GoogleCloud.Internal;
 internal sealed partial class GoogleCloudIdentityProvider(
     IFirebaseAuthTransport transport,
     IOptions<GoogleCloudIdentityOptions> options,
-    IIdentityEventPublisher eventPublisher,
+    IDistributedEventBus distributedEventBus,
     ILogger<GoogleCloudIdentityProvider> logger) : IIdentityProvider
 {
     private readonly GoogleCloudIdentityOptions _options = options.Value;
@@ -103,7 +104,7 @@ internal sealed partial class GoogleCloudIdentityProvider(
         UserRecordArgs args = new() { Uid = userId, Disabled = !enabled };
         await transport.UpdateUserAsync(args, cancellationToken).ConfigureAwait(false);
 
-        await eventPublisher.PublishAsync(new IdentityUserEnabledChangedEvent(userId, enabled), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityUserEnabledChangedEto(userId, enabled), cancellationToken).ConfigureAwait(false);
     }
 
     public async Task UpdateUserAsync(string userId, IdentityUserUpdate update, CancellationToken cancellationToken = default)
@@ -127,7 +128,7 @@ internal sealed partial class GoogleCloudIdentityProvider(
 
         await transport.UpdateUserAsync(args, cancellationToken).ConfigureAwait(false);
 
-        await eventPublisher.PublishAsync(new IdentityUserProfileUpdatedEvent(userId, update), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityUserProfileUpdatedEto(userId, update), cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IdentityUser> CreateUserAsync(IdentityUserCreate user, CancellationToken cancellationToken = default)
@@ -149,7 +150,7 @@ internal sealed partial class GoogleCloudIdentityProvider(
 
         UserRecord created = await transport.CreateUserAsync(args, cancellationToken).ConfigureAwait(false);
 
-        await eventPublisher.PublishAsync(new IdentityUserCreatedEvent(created.Uid, user.Username, user.Email), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityUserCreatedEto(created.Uid, user.Username, user.Email), cancellationToken).ConfigureAwait(false);
 
         return new IdentityUser(
             Id: created.Uid,
@@ -205,7 +206,7 @@ internal sealed partial class GoogleCloudIdentityProvider(
 
         await transport.SetCustomUserClaimsAsync(userId, claims, cancellationToken).ConfigureAwait(false);
 
-        await eventPublisher.PublishAsync(new IdentityRoleAssignedEvent(userId, roleName), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityRoleAssignedEto(userId, roleName), cancellationToken).ConfigureAwait(false);
     }
 
     public async Task RemoveRoleAsync(string userId, string roleName, CancellationToken cancellationToken = default)
@@ -225,7 +226,7 @@ internal sealed partial class GoogleCloudIdentityProvider(
 
         await transport.SetCustomUserClaimsAsync(userId, claims, cancellationToken).ConfigureAwait(false);
 
-        await eventPublisher.PublishAsync(new IdentityRoleRemovedEvent(userId, roleName), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityRoleRemovedEto(userId, roleName), cancellationToken).ConfigureAwait(false);
     }
 
     // ── Groups (not supported by Firebase Auth) ───────────────────────
@@ -261,7 +262,7 @@ internal sealed partial class GoogleCloudIdentityProvider(
 
         await transport.RevokeRefreshTokensAsync(userId, cancellationToken).ConfigureAwait(false);
 
-        await eventPublisher.PublishAsync(new IdentitySessionsRevokedEvent(userId), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentitySessionsRevokedEto(userId), cancellationToken).ConfigureAwait(false);
     }
 
     // ── Password ──────────────────────────────────────────────────────
@@ -284,7 +285,7 @@ internal sealed partial class GoogleCloudIdentityProvider(
 
         await transport.GeneratePasswordResetLinkAsync(user.Email, cancellationToken).ConfigureAwait(false);
 
-        await eventPublisher.PublishAsync(new IdentityPasswordResetEvent(userId), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityPasswordResetEto(userId), cancellationToken).ConfigureAwait(false);
     }
 
     public async Task SetTemporaryPasswordAsync(string userId, string temporaryPassword, CancellationToken cancellationToken = default)

--- a/src/Granit.Identity.GoogleCloud/packages.lock.json
+++ b/src/Granit.Identity.GoogleCloud/packages.lock.json
@@ -5,11 +5,11 @@
       "FirebaseAdmin": {
         "type": "Direct",
         "requested": "[3.*, )",
-        "resolved": "3.4.0",
-        "contentHash": "sQyVEOYRe4HSSmRCJQhKr33DxZk10lpDE2otdTgNkqPn4BRul2JG7TCQC7N7X0wO9ShnPLbVS4xuSUHlaPBbug==",
+        "resolved": "3.5.0",
+        "contentHash": "NL9dWvrGCbgu3VxumjpHXgHsagQswntJNLtgVIgTF/y2ro6e6UpvFuZrlfjsMTzRXJEXqnse3U5rN/6HC5TlFA==",
         "dependencies": {
-          "Google.Api.Gax.Rest": "4.8.0",
-          "Google.Apis.Auth": "1.68.0"
+          "Google.Api.Gax.Rest": "4.13.1",
+          "Google.Apis.Auth": "1.73.0"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -33,47 +33,47 @@
       },
       "Google.Api.Gax": {
         "type": "Transitive",
-        "resolved": "4.8.0",
-        "contentHash": "xlV8Jq/G5CQAA3PwYAuKGjfzGOP7AvjhREnE6vgZlzxREGYchHudZWa2PWSqFJL+MBtz9YgitLpRogANN3CVvg==",
+        "resolved": "4.13.1",
+        "contentHash": "ujDpZk7O2VqAEIqcSlhH0FKzVpGZWly/qcNjHxpNUrL445Tei9PHnu4V1pwW2WDiMDvo3TpL1Bi4DeU525Afrg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Newtonsoft.Json": "13.0.4"
         }
       },
       "Google.Api.Gax.Rest": {
         "type": "Transitive",
-        "resolved": "4.8.0",
-        "contentHash": "zaA5LZ2VvGj/wwIzRB68swr7khi2kWNgqWvsB0fYtScIAl3kGkGtqiBcx63H1YLeKr5xau1866bFjTeReH6FSQ==",
+        "resolved": "4.13.1",
+        "contentHash": "wDfFZXKoHC6sy+Yfub/4cLQOb5ozBVPqDOrxCUAeTfku4d96ILqgzulJSdkPHbiT3oWB3hlYTdJgUwNSJjyo+A==",
         "dependencies": {
-          "Google.Api.Gax": "4.8.0",
-          "Google.Apis.Auth": "[1.67.0, 2.0.0)",
+          "Google.Api.Gax": "4.13.1",
+          "Google.Apis.Auth": "1.73.0",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0"
         }
       },
       "Google.Apis": {
         "type": "Transitive",
-        "resolved": "1.68.0",
-        "contentHash": "s2MymhdpH+ybZNBeZ2J5uFgFHApBp+QXf9FjZSdM1lk/vx5VqIknJwnaWiuAzXxPrLEkesX0Q+UsiWn39yZ9zw==",
+        "resolved": "1.73.0",
+        "contentHash": "TnCjEyV2aCLQ6Zl40OCbEJULDuEkEWc6C/g81KYw5l1PqGo+G7pFZrV+YH8XgUL0JRUanz+IrUp8SsKF4dzkqg==",
         "dependencies": {
-          "Google.Apis.Core": "1.68.0"
+          "Google.Apis.Core": "1.73.0"
         }
       },
       "Google.Apis.Auth": {
         "type": "Transitive",
-        "resolved": "1.68.0",
-        "contentHash": "hFx8Qz5bZ4w0hpnn4tSmZaaFpjAMsgVElZ+ZgVLUZ2r9i+AKcoVgwiNfv1pruNS5cCvpXqhKECbruBCfRezPHA==",
+        "resolved": "1.73.0",
+        "contentHash": "wEu12uhnRv3zrPBSqv4E2vPH6lYLtc1RPAnU9MJRCMFlBVwZ7Lnq3NfbYXi6VG7EurkYInTaMpeBZkbM/HrAog==",
         "dependencies": {
-          "Google.Apis": "1.68.0",
-          "Google.Apis.Core": "1.68.0",
+          "Google.Apis": "1.73.0",
+          "Google.Apis.Core": "1.73.0",
           "System.Management": "7.0.2"
         }
       },
       "Google.Apis.Core": {
         "type": "Transitive",
-        "resolved": "1.68.0",
-        "contentHash": "pAqwa6pfu53UXCR2b7A/PAPXeuVg6L1OFw38WckN27NU2+mf+KTjoEg2YGv/f0UyKxzz7DxF1urOTKg/6dTP9g==",
+        "resolved": "1.73.0",
+        "contentHash": "vSc7CY4KCP7HE4QTElDx/ExnGLbg9kXb89MS6cdvI+0D4sxvTYb16vGtXmF2jSDMV3iDmykSXdIUPTz8TDS6gg==",
         "dependencies": {
-          "Newtonsoft.Json": "13.0.3"
+          "Newtonsoft.Json": "13.0.4"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
@@ -105,8 +105,8 @@
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+        "resolved": "13.0.4",
+        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
       },
       "System.CodeDom": {
         "type": "Transitive",

--- a/src/Granit.Identity.Keycloak/Internal/KeycloakIdentityProvider.cs
+++ b/src/Granit.Identity.Keycloak/Internal/KeycloakIdentityProvider.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using Granit.Core.Events;
 using Granit.Identity.Diagnostics;
 using Granit.Identity.Events;
 using Granit.Identity.Keycloak.Diagnostics;
@@ -29,7 +30,7 @@ internal sealed partial class KeycloakIdentityProvider(
     KeycloakUserTokenExchangeService tokenExchangeService,
     IHttpClientFactory httpClientFactory,
     IOptions<KeycloakAdminOptions> options,
-    IIdentityEventPublisher eventPublisher,
+    IDistributedEventBus distributedEventBus,
     IdentityMetrics metrics,
     ILogger<KeycloakIdentityProvider> logger) : IIdentityProvider
 {
@@ -119,7 +120,7 @@ internal sealed partial class KeycloakIdentityProvider(
 
         LogUserEnabledChanged(userId, enabled ? "enabled" : "disabled");
 
-        await eventPublisher.PublishAsync(new IdentityUserEnabledChangedEvent(userId, enabled), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityUserEnabledChangedEto(userId, enabled), cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -188,7 +189,7 @@ internal sealed partial class KeycloakIdentityProvider(
 
         metrics.RecordOperationCompleted(null, "update_user", ProviderName, "updated");
 
-        await eventPublisher.PublishAsync(new IdentityUserProfileUpdatedEvent(userId, update), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityUserProfileUpdatedEto(userId, update), cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -391,7 +392,7 @@ internal sealed partial class KeycloakIdentityProvider(
 
         metrics.RecordOperationCompleted(null, "assign_role", ProviderName, "assigned");
 
-        await eventPublisher.PublishAsync(new IdentityRoleAssignedEvent(userId, roleName), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityRoleAssignedEto(userId, roleName), cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -426,7 +427,7 @@ internal sealed partial class KeycloakIdentityProvider(
 
         LogRoleRemoved(roleName, userId);
 
-        await eventPublisher.PublishAsync(new IdentityRoleRemovedEvent(userId, roleName), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityRoleRemovedEto(userId, roleName), cancellationToken).ConfigureAwait(false);
     }
 
     // ──── Feature 2: Session termination ────
@@ -454,7 +455,7 @@ internal sealed partial class KeycloakIdentityProvider(
 
         LogSessionTerminated(sessionId, userId);
 
-        await eventPublisher.PublishAsync(new IdentitySessionsRevokedEvent(userId), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentitySessionsRevokedEto(userId), cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -482,7 +483,7 @@ internal sealed partial class KeycloakIdentityProvider(
         metrics.RecordOperationCompleted(null, "terminate_all_sessions", ProviderName, "terminated");
         metrics.RecordOperationDuration(null, "terminate_all_sessions", ProviderName, Stopwatch.GetElapsedTime(startTimestamp));
 
-        await eventPublisher.PublishAsync(new IdentitySessionsRevokedEvent(userId), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentitySessionsRevokedEto(userId), cancellationToken).ConfigureAwait(false);
     }
 
     // ──── Feature 3: Password reset ────
@@ -508,7 +509,7 @@ internal sealed partial class KeycloakIdentityProvider(
 
         LogPasswordResetEmailSent(userId);
 
-        await eventPublisher.PublishAsync(new IdentityPasswordResetEvent(userId), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityPasswordResetEto(userId), cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -535,7 +536,7 @@ internal sealed partial class KeycloakIdentityProvider(
 
         LogTemporaryPasswordSet(userId);
 
-        await eventPublisher.PublishAsync(new IdentityPasswordResetEvent(userId), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityPasswordResetEto(userId), cancellationToken).ConfigureAwait(false);
     }
 
     // ──── Feature 4: User creation ────
@@ -586,7 +587,7 @@ internal sealed partial class KeycloakIdentityProvider(
         metrics.RecordOperationCompleted(null, "create_user", ProviderName, "created");
         metrics.RecordOperationDuration(null, "create_user", ProviderName, Stopwatch.GetElapsedTime(startTimestamp));
 
-        await eventPublisher.PublishAsync(new IdentityUserCreatedEvent(createdUserId, user.Username, user.Email), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityUserCreatedEto(createdUserId, user.Username, user.Email), cancellationToken).ConfigureAwait(false);
 
         return new IdentityUser(
             createdUserId,
@@ -677,7 +678,7 @@ internal sealed partial class KeycloakIdentityProvider(
 
         LogUserAddedToGroup(userId, groupId);
 
-        await eventPublisher.PublishAsync(new IdentityGroupMembershipChangedEvent(userId, groupId, Added: true), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityGroupMembershipChangedEto(userId, groupId, Added: true), cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -704,7 +705,7 @@ internal sealed partial class KeycloakIdentityProvider(
 
         LogUserRemovedFromGroup(userId, groupId);
 
-        await eventPublisher.PublishAsync(new IdentityGroupMembershipChangedEvent(userId, groupId, Added: false), cancellationToken).ConfigureAwait(false);
+        await distributedEventBus.PublishAsync(new IdentityGroupMembershipChangedEto(userId, groupId, Added: false), cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<IReadOnlyList<IdentityDeviceActivity>> GetDeviceActivityViaAccountApiAsync(

--- a/src/Granit.Identity.OpenIddict/packages.lock.json
+++ b/src/Granit.Identity.OpenIddict/packages.lock.json
@@ -1,0 +1,201 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "32c58Rnm47Qvhimawf67KO9PytgPz3QoWye7Abapt0Yocw/JnzMiSNj/pRoIKyn8Jxypkv86zxKD4Q/zNTc0Ag=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "ipC4u1VojgEfoIZhtbS2Sx5IluJTP/Jf1hz3yGsxGBgSukYY/CquI6rAjxn5H58CZgVn36qcuPPtNMwZ0AUzMg=="
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "V7fHMFpfzvx7twWMV3jrf3OFVmYn3QhUYtvfMRD9yUPs9gxnQSaRMZh5NzCsnW3ZZ80J09EE7yyjM71y9JC6hQ=="
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "IakwNWUTy5RlcDcKwtL5TyfDLZmA8FFnSDhfr+wfGGPMON9GkpkUY8NakIJjdy6mv6C1lM/Jkn3IuaeS9MXesA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.12.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "WCU3wv5sioX5hhp3oHw8sCdygnfZJtRKJGCg+AckP6nbp0QGKK3VohTrxIF0dpuziLAPg57CPfS9X8UERroKxA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "8.12.0"
+        }
+      },
+      "OpenIddict.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "sVhLvY4sZ3UFXudfc8A6gM45uyA9WwL8987ksf8zY4spVoADFH3cblkyj85OYF5fCQxRDxvOCvyeYfs7zTiaig==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.12.0"
+        }
+      },
+      "OpenIddict.Core": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "xAYq7U/j6JZAbVU88Xv6yXeKutJvNuGCH6zJAlP++abKtSfpP2mRLp2UbS0QS37S+SqRMLxp301DPNtkiRkuPA==",
+        "dependencies": {
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.EntityFrameworkCore.Models": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "5nyS+XmjoAA8MeyClHA+0EOHCHIDRV4sxDpDpK0RUqtDB4fxmRbKJCzocGHlE/o5iubd6hrKS9bCGZruTWw9oA=="
+      },
+      "granit.core": {
+        "type": "Project"
+      },
+      "granit.eventbus": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.identity": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )"
+        }
+      },
+      "granit.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.openiddict": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.EventBus": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Identity": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.openiddict.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
+          "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "OpenIddict.EntityFrameworkCore": "[6.*, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )"
+        }
+      },
+      "granit.querying": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.security": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "oo1uauTwgcnhYgituZ2nI3wJ8XN9z76ggu2zkOJu1BCfOOsqr+g08Kr4MOiMuXEhwySkpIV+MVoC25hC1288NA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.5"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "9tNBmK3EpYVGRQLiqP+bqK2m+TD0Gv//4vCzR7ZOgl4FWzCFyOpYdIVka13M4kcBdPdSJcs3wbHr3rmzOqbIMA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.5",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.5"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "uxmFjZEAB/KbsgWFSS4lLqkEHCfXxB2x0UcbiO4e5fCRpFFeTMSx/me6009nYJLu5IKlDwO1POh++P6RilFTDw==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "RtNhAwrnZcUZgi3SUMvaDVF405ZtKVR7l/6OHcqFj6JY5nT7QOdBxxULnby9dUQ6Jhnfl7cdDlMjsexfASNyjg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.5"
+        }
+      },
+      "OpenIddict.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[6.*, )",
+        "resolved": "6.4.0",
+        "contentHash": "glyc+uEaJS9zZxzA/cyF2O4TJudgHLR2Qf2AGq1tNA8mBcQIa2DzKIEuP9rEQD+lofnR/V+cFsybGUyYMsra9Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "9.0.6",
+          "OpenIddict.Core": "6.4.0",
+          "OpenIddict.EntityFrameworkCore.Models": "6.4.0"
+        }
+      }
+    }
+  }
+}

--- a/src/Granit.Identity/Events/IdentityEvents.cs
+++ b/src/Granit.Identity/Events/IdentityEvents.cs
@@ -1,3 +1,4 @@
+using Granit.Core.Events;
 using Granit.Identity.Models;
 
 namespace Granit.Identity.Events;
@@ -8,35 +9,35 @@ namespace Granit.Identity.Events;
 /// <param name="UserId">The provider-assigned user ID.</param>
 /// <param name="Username">The username of the created user (may be null).</param>
 /// <param name="Email">The email of the created user (may be null).</param>
-public sealed record IdentityUserCreatedEvent(string UserId, string? Username, string? Email);
+public sealed record IdentityUserCreatedEto(string UserId, string? Username, string? Email) : IIntegrationEvent;
 
 /// <summary>
 /// Published after a user's profile is updated in the identity provider.
 /// </summary>
 /// <param name="UserId">The user ID in the identity provider.</param>
 /// <param name="Update">The fields that were updated.</param>
-public sealed record IdentityUserProfileUpdatedEvent(string UserId, IdentityUserUpdate Update);
+public sealed record IdentityUserProfileUpdatedEto(string UserId, IdentityUserUpdate Update) : IIntegrationEvent;
 
 /// <summary>
 /// Published after a user account is enabled or disabled.
 /// </summary>
 /// <param name="UserId">The user ID in the identity provider.</param>
 /// <param name="Enabled">The new enabled state.</param>
-public sealed record IdentityUserEnabledChangedEvent(string UserId, bool Enabled);
+public sealed record IdentityUserEnabledChangedEto(string UserId, bool Enabled) : IIntegrationEvent;
 
 /// <summary>
 /// Published after a role is assigned to a user.
 /// </summary>
 /// <param name="UserId">The user ID in the identity provider.</param>
 /// <param name="RoleName">The name of the assigned role.</param>
-public sealed record IdentityRoleAssignedEvent(string UserId, string RoleName);
+public sealed record IdentityRoleAssignedEto(string UserId, string RoleName) : IIntegrationEvent;
 
 /// <summary>
 /// Published after a role is removed from a user.
 /// </summary>
 /// <param name="UserId">The user ID in the identity provider.</param>
 /// <param name="RoleName">The name of the removed role.</param>
-public sealed record IdentityRoleRemovedEvent(string UserId, string RoleName);
+public sealed record IdentityRoleRemovedEto(string UserId, string RoleName) : IIntegrationEvent;
 
 /// <summary>
 /// Published after a user is added to or removed from a group.
@@ -44,16 +45,16 @@ public sealed record IdentityRoleRemovedEvent(string UserId, string RoleName);
 /// <param name="UserId">The user ID in the identity provider.</param>
 /// <param name="GroupId">The group ID.</param>
 /// <param name="Added"><c>true</c> if the user was added; <c>false</c> if removed.</param>
-public sealed record IdentityGroupMembershipChangedEvent(string UserId, string GroupId, bool Added);
+public sealed record IdentityGroupMembershipChangedEto(string UserId, string GroupId, bool Added) : IIntegrationEvent;
 
 /// <summary>
 /// Published after a user's password is reset (temporary password set or reset email sent).
 /// </summary>
 /// <param name="UserId">The user ID in the identity provider.</param>
-public sealed record IdentityPasswordResetEvent(string UserId);
+public sealed record IdentityPasswordResetEto(string UserId) : IIntegrationEvent;
 
 /// <summary>
 /// Published after a user's sessions are revoked.
 /// </summary>
 /// <param name="UserId">The user ID in the identity provider.</param>
-public sealed record IdentitySessionsRevokedEvent(string UserId);
+public sealed record IdentitySessionsRevokedEto(string UserId) : IIntegrationEvent;

--- a/src/Granit.Identity/Extensions/IdentityServiceCollectionExtensions.cs
+++ b/src/Granit.Identity/Extensions/IdentityServiceCollectionExtensions.cs
@@ -24,7 +24,6 @@ public static class IdentityServiceCollectionExtensions
         RegisterFineGrainedInterfaces(services);
 
         services.TryAddScoped<IIdentityProviderCapabilities, NullIdentityProviderCapabilities>();
-        services.TryAddScoped<IIdentityEventPublisher, NullIdentityEventPublisher>();
         services.TryAddScoped<IUserLookupService, NullUserLookupService>();
         services.TryAddScoped<IUserCacheStats, NullUserCacheStats>();
         return services;

--- a/src/Granit.Identity/IIdentityEventPublisher.cs
+++ b/src/Granit.Identity/IIdentityEventPublisher.cs
@@ -1,3 +1,5 @@
+using Granit.Core.Events;
+
 namespace Granit.Identity;
 
 /// <summary>
@@ -5,15 +7,11 @@ namespace Granit.Identity;
 /// </summary>
 /// <remarks>
 /// <para>
-/// A <c>NullIdentityEventPublisher</c> (no-op) is registered by default.
-/// To enable event-driven cache synchronization and audit trail, register an implementation
-/// backed by a message bus (e.g. Wolverine <c>IMessageBus</c>).
-/// </para>
-/// <para>
-/// Events are defined as records in <see cref="Granit.Identity.Events"/> and are published
-/// by identity providers after each successful write operation.
+/// This interface is obsolete. Identity providers now use <see cref="IDistributedEventBus"/>
+/// directly to publish integration events (<c>*Eto</c> records implementing <see cref="IIntegrationEvent"/>).
 /// </para>
 /// </remarks>
+[Obsolete("Use IDistributedEventBus from Granit.Core.Events instead. Identity events are now IIntegrationEvent records (*Eto suffix).")]
 public interface IIdentityEventPublisher
 {
     /// <summary>

--- a/src/Granit.Identity/Internal/NullIdentityEventPublisher.cs
+++ b/src/Granit.Identity/Internal/NullIdentityEventPublisher.cs
@@ -4,7 +4,10 @@ namespace Granit.Identity.Internal;
 /// No-op implementation of <see cref="IIdentityEventPublisher"/>.
 /// Registered by default when no message bus integration is configured.
 /// </summary>
+[Obsolete("Use IDistributedEventBus from Granit.Core.Events instead. Identity events are now IIntegrationEvent records (*Eto suffix).")]
+#pragma warning disable CS0618 // Type or member is obsolete
 internal sealed class NullIdentityEventPublisher : IIdentityEventPublisher
+#pragma warning restore CS0618
 {
     /// <inheritdoc/>
     public Task PublishAsync<TEvent>(TEvent domainEvent, CancellationToken cancellationToken = default)

--- a/src/Granit.Imaging.AI/packages.lock.json
+++ b/src/Granit.Imaging.AI/packages.lock.json
@@ -11,8 +11,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Direct",

--- a/src/Granit.Localization.Endpoints/Extensions/LocalizationEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Localization.Endpoints/Extensions/LocalizationEndpointRouteBuilderExtensions.cs
@@ -67,7 +67,8 @@ public static partial class LocalizationEndpointRouteBuilderExtensions
             .WithTags(options.TagName)
             .WithSummary("Returns all localization resources for the requested culture.")
             .WithDescription("Returns all localization resources (key-value pairs) for the requested culture, grouped by resource name. Accepts an optional cultureName query parameter (BCP 47 format); defaults to the Accept-Language header culture. Also returns the list of supported languages. Response is cached for 1 hour (Cache-Control: public, max-age=3600, Vary: Accept-Language). Anonymous — no authentication required.")
-            .Produces<ApplicationLocalizationResponse>();
+            .Produces<ApplicationLocalizationResponse>()
+            .ProducesProblem(StatusCodes.Status400BadRequest);
 
         return endpoints;
     }
@@ -102,26 +103,32 @@ public static partial class LocalizationEndpointRouteBuilderExtensions
 
         RouteGroupBuilder group = endpoints
             .MapGranitGroup($"{options.RoutePrefix}/overrides")
-            .RequireAuthorization(LocalizationOverridesPermissions.Manage)
+            .RequireAuthorization(LocalizationOverridesPermissions.Overrides.Manage)
             .WithTags(options.TagName);
 
         group.MapGet("", HandleGetOverridesAsync)
              .WithName("GetLocalizationOverrides")
              .WithSummary("Returns all translation overrides for a resource and culture.")
              .WithDescription("Returns all active translation overrides for the specified resource and culture as a key-value dictionary. Both resourceName and cultureName query parameters are required. Returns 501 if no override store is registered.")
-             .Produces<IReadOnlyDictionary<string, string>>();
+             .Produces<IReadOnlyDictionary<string, string>>()
+             .ProducesProblem(StatusCodes.Status400BadRequest)
+             .ProducesProblem(StatusCodes.Status501NotImplemented);
 
         group.MapPut("/{resourceName}/{cultureName}/{key}", HandlePutOverrideAsync)
              .WithName("PutLocalizationOverride")
              .WithSummary("Creates or updates a translation override.")
              .WithDescription("Sets a translation override for a specific resource, culture, and key. If an override already exists, it is replaced. The culture name must be a valid BCP 47 tag. Returns 501 if no override store is registered.")
-             .Produces(StatusCodes.Status204NoContent);
+             .Produces(StatusCodes.Status204NoContent)
+             .ProducesProblem(StatusCodes.Status400BadRequest)
+             .ProducesProblem(StatusCodes.Status501NotImplemented);
 
         group.MapDelete("/{resourceName}/{cultureName}/{key}", HandleDeleteOverrideAsync)
              .WithName("DeleteLocalizationOverride")
              .WithSummary("Removes a translation override.")
              .WithDescription("Removes the translation override for the specified resource, culture, and key. The original value from the resource file becomes effective again. No-op if the override does not exist. Returns 501 if no override store is registered.")
-             .Produces(StatusCodes.Status204NoContent);
+             .Produces(StatusCodes.Status204NoContent)
+             .ProducesProblem(StatusCodes.Status400BadRequest)
+             .ProducesProblem(StatusCodes.Status501NotImplemented);
 
         return group;
     }

--- a/src/Granit.Localization.Endpoints/Permissions/LocalizationOverridesPermissionDefinitionProvider.cs
+++ b/src/Granit.Localization.Endpoints/Permissions/LocalizationOverridesPermissionDefinitionProvider.cs
@@ -37,12 +37,12 @@ internal sealed class LocalizationOverridesPermissionDefinitionProvider : IPermi
                 "PermissionGroup:Localization"));
 
         group.AddPermission(
-            LocalizationOverridesPermissions.Read,
+            LocalizationOverridesPermissions.Overrides.Read,
             LocalizableString.Create<LocalizationEndpointsLocalizationResource>(
                 "Permission:Localization.Overrides.Read"));
 
         group.AddPermission(
-            LocalizationOverridesPermissions.Manage,
+            LocalizationOverridesPermissions.Overrides.Manage,
             LocalizableString.Create<LocalizationEndpointsLocalizationResource>(
                 "Permission:Localization.Overrides.Manage"));
     }

--- a/src/Granit.Localization.Endpoints/Permissions/LocalizationOverridesPermissions.cs
+++ b/src/Granit.Localization.Endpoints/Permissions/LocalizationOverridesPermissions.cs
@@ -10,12 +10,18 @@ public static class LocalizationOverridesPermissions
     /// <summary>Permission group name used in <c>IPermissionDefinitionContext.AddGroup()</c>.</summary>
     public const string GroupName = "Localization";
 
-    /// <summary>Grants read-only access to view translation overrides.</summary>
-    public const string Read = "Localization.Overrides.Read";
+    /// <summary>Permissions for the translation overrides resource.</summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1716:Identifiers should not match keywords",
+        Justification = "Overrides is the correct domain term for this resource; VB keyword conflict is acceptable in this context.")]
+    public static class Overrides
+    {
+        /// <summary>Grants read-only access to view translation overrides.</summary>
+        public const string Read = "Localization.Overrides.Read";
 
-    /// <summary>
-    /// Grants management access to localization override endpoints
-    /// (set override, remove override).
-    /// </summary>
-    public const string Manage = "Localization.Overrides.Manage";
+        /// <summary>
+        /// Grants management access to localization override endpoints
+        /// (set override, remove override).
+        /// </summary>
+        public const string Manage = "Localization.Overrides.Manage";
+    }
 }

--- a/src/Granit.Notifications.AI/packages.lock.json
+++ b/src/Granit.Notifications.AI/packages.lock.json
@@ -11,8 +11,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Direct",

--- a/src/Granit.Notifications.Email.AwsSes/Extensions/SesEmailServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Email.AwsSes/Extensions/SesEmailServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Amazon;
 using Amazon.Runtime;
 using Amazon.SimpleEmailV2;
+using Granit.Core.Diagnostics;
 using Granit.Notifications.Email.AwsSes.Diagnostics;
 using Granit.Notifications.Email.AwsSes.HealthChecks;
 using Granit.Notifications.Email.AwsSes.Internal;
@@ -52,7 +53,7 @@ public static class SesEmailServiceCollectionExtensions
 
         services.AddKeyedSingleton<IEmailSender, AwsSesEmailSender>("AwsSes");
 
-        _ = NotificationsEmailAwsSesActivitySource.Source; // ensure static init
+        GranitActivitySourceRegistry.Register(NotificationsEmailAwsSesActivitySource.Name);
 
         return services;
     }

--- a/src/Granit.Notifications.Email.AwsSes/packages.lock.json
+++ b/src/Granit.Notifications.Email.AwsSes/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.SimpleEmailV2": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.12.2",
-        "contentHash": "1NqLYAT5RkwnUjJMfXqmOD2utuBSXL5THzT/YhaLYLlmhKARL5W0QpzuY93ujUkhGapoZO7mjm5E9gv3C+enLQ==",
+        "resolved": "4.0.12.3",
+        "contentHash": "2OV18QATAase5zArxTLNnrFx1G0pECJg/bK73k9KT66W0g2hNFuNTyY/+ERPZ3E63fBDWe0cty/OdhgsFp3ijQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.17, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.19, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -69,8 +69,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.17",
-        "contentHash": "Ab24kVquQ8kvuQKNe5MK/SvaXR4uoxPkAlTPALDEImaHcwsBg+UWfRVcNzLEx4dRR2y1mDFFh+zZ9TVMXGY6Jg=="
+        "resolved": "4.0.3.19",
+        "contentHash": "8zIzN59+J6arYSyFuhnSxPepr8ff4p6li+MxKUUnqCgwZqQ+icEGJK/23c1USIEALqZZ5gdiITuH2sOZWQom+Q=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Notifications.Email.AzureCommunicationServices/Extensions/AcsEmailServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Email.AzureCommunicationServices/Extensions/AcsEmailServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Azure.Communication.Email;
 using Azure.Identity;
+using Granit.Core.Diagnostics;
 using Granit.Notifications.Email.AzureCommunicationServices.Diagnostics;
 using Granit.Notifications.Email.AzureCommunicationServices.HealthChecks;
 using Granit.Notifications.Email.AzureCommunicationServices.Internal;
@@ -45,7 +46,7 @@ public static class AcsEmailServiceCollectionExtensions
 
         services.AddKeyedSingleton<IEmailSender, AcsEmailSender>("AzureCommunicationServices");
 
-        _ = NotificationsEmailAcsActivitySource.Source; // ensure static init
+        GranitActivitySourceRegistry.Register(NotificationsEmailAcsActivitySource.Name);
 
         return services;
     }

--- a/src/Granit.Notifications.Email.Scaleway/Extensions/ScalewayEmailServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Email.Scaleway/Extensions/ScalewayEmailServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Core.Diagnostics;
 using Granit.Http.Resilience.Extensions;
 using Granit.Notifications.Email.Scaleway.Diagnostics;
 using Granit.Notifications.Email.Scaleway.HealthChecks;
@@ -43,7 +44,7 @@ public static class ScalewayEmailServiceCollectionExtensions
         services.AddKeyedSingleton<IEmailSender>(
             ProviderKey, (sp, _) => sp.GetRequiredService<ScalewayEmailSender>());
 
-        _ = NotificationsEmailScalewayActivitySource.Source; // ensure static init
+        GranitActivitySourceRegistry.Register(NotificationsEmailScalewayActivitySource.Name);
 
         return services;
     }

--- a/src/Granit.Notifications.Email.SendGrid/Extensions/SendGridEmailServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Email.SendGrid/Extensions/SendGridEmailServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Core.Diagnostics;
 using Granit.Http.Resilience.Extensions;
 using Granit.Notifications.Email.SendGrid.Diagnostics;
 using Granit.Notifications.Email.SendGrid.HealthChecks;
@@ -42,7 +43,7 @@ public static class SendGridEmailServiceCollectionExtensions
         services.AddKeyedSingleton<IEmailSender>(
             ProviderKey, (sp, _) => sp.GetRequiredService<SendGridEmailSender>());
 
-        _ = NotificationsEmailSendGridActivitySource.Source; // ensure static init
+        GranitActivitySourceRegistry.Register(NotificationsEmailSendGridActivitySource.Name);
 
         return services;
     }

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreUserNotificationStore.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreUserNotificationStore.cs
@@ -60,22 +60,34 @@ internal sealed class EfCoreUserNotificationStore(IDbContextFactory<Notification
     public async Task MarkAsReadAsync(Guid id, DateTimeOffset readAt, CancellationToken cancellationToken = default)
     {
         await using NotificationDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        await db.UserNotifications
-            .Where(n => n.Id == id)
-            .ExecuteUpdateAsync(s => s
-                .SetProperty(n => n.State, UserNotificationState.Read)
-                .SetProperty(n => n.ReadAt, readAt), cancellationToken).ConfigureAwait(false);
+
+        UserNotification? notification = await db.UserNotifications
+            .FirstOrDefaultAsync(n => n.Id == id, cancellationToken).ConfigureAwait(false);
+
+        if (notification is null)
+        {
+            return;
+        }
+
+        notification.MarkAsRead(readAt);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public async Task MarkAllAsReadAsync(string recipientUserId, Guid? tenantId, DateTimeOffset readAt, CancellationToken cancellationToken = default)
     {
         await using NotificationDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        await db.UserNotifications
+
+        List<UserNotification> unread = await db.UserNotifications
             .Where(n => n.RecipientUserId == recipientUserId && n.TenantId == tenantId && n.State == UserNotificationState.Unread)
-            .ExecuteUpdateAsync(s => s
-                .SetProperty(n => n.State, UserNotificationState.Read)
-                .SetProperty(n => n.ReadAt, readAt), cancellationToken).ConfigureAwait(false);
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        foreach (UserNotification notification in unread)
+        {
+            notification.MarkAsRead(readAt);
+        }
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>

--- a/src/Granit.Notifications.MobilePush.AwsSns/Extensions/AwsSnsMobilePushServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.MobilePush.AwsSns/Extensions/AwsSnsMobilePushServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Amazon;
 using Amazon.Runtime;
 using Amazon.SimpleNotificationService;
+using Granit.Core.Diagnostics;
 using Granit.Notifications.MobilePush.AwsSns.Diagnostics;
 using Granit.Notifications.MobilePush.AwsSns.HealthChecks;
 using Granit.Notifications.MobilePush.AwsSns.Internal;
@@ -45,7 +46,7 @@ public static class AwsSnsMobilePushServiceCollectionExtensions
 
         services.AddKeyedSingleton<IMobilePushSender, AwsSnsMobilePushSender>("AwsSns");
 
-        _ = NotificationsMobilePushAwsSnsActivitySource.Source; // ensure static init
+        GranitActivitySourceRegistry.Register(NotificationsMobilePushAwsSnsActivitySource.Name);
 
         return services;
     }

--- a/src/Granit.Notifications.MobilePush.AwsSns/packages.lock.json
+++ b/src/Granit.Notifications.MobilePush.AwsSns/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.19",
-        "contentHash": "LBjXBRwjRFBzrA3b8CFFc2jzso+oxOZGncxJLpC0DKtAfXlIFg2b8S0ZANNmvcJsO77EFeMdvG0kNoW0X3/dKw==",
+        "resolved": "4.0.2.20",
+        "contentHash": "Ukh0ZudL04FhC88ZTyYq2lugoX/9RCWStWvzOTREnmEaPCC51IWX7LQkIFLuMODV0k0GeuqwgReULEC6bjHuLg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.17, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.19, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -19,8 +19,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.17",
-        "contentHash": "Ab24kVquQ8kvuQKNe5MK/SvaXR4uoxPkAlTPALDEImaHcwsBg+UWfRVcNzLEx4dRR2y1mDFFh+zZ9TVMXGY6Jg=="
+        "resolved": "4.0.3.19",
+        "contentHash": "8zIzN59+J6arYSyFuhnSxPepr8ff4p6li+MxKUUnqCgwZqQ+icEGJK/23c1USIEALqZZ5gdiITuH2sOZWQom+Q=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Notifications.MobilePush.AzureNotificationHubs/Extensions/AzureNotificationHubsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.MobilePush.AzureNotificationHubs/Extensions/AzureNotificationHubsServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Core.Diagnostics;
 using Granit.Notifications.MobilePush.AzureNotificationHubs.Diagnostics;
 using Granit.Notifications.MobilePush.AzureNotificationHubs.HealthChecks;
 using Granit.Notifications.MobilePush.AzureNotificationHubs.Internal;
@@ -33,7 +34,7 @@ public static class AzureNotificationHubsServiceCollectionExtensions
         services.AddSingleton<IAzureNotificationHubsTransport, AzureNotificationHubsTransport>();
         services.AddKeyedSingleton<IMobilePushSender, AzureNotificationHubsPushSender>("AzureNotificationHubs");
 
-        _ = NotificationsMobilePushAnhActivitySource.Source; // ensure static init
+        GranitActivitySourceRegistry.Register(NotificationsMobilePushAnhActivitySource.Name);
 
         return services;
     }

--- a/src/Granit.Notifications.Sms.AwsSns/Extensions/SnsSmsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Sms.AwsSns/Extensions/SnsSmsServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Amazon;
 using Amazon.Runtime;
 using Amazon.SimpleNotificationService;
+using Granit.Core.Diagnostics;
 using Granit.Notifications.Sms.AwsSns.Diagnostics;
 using Granit.Notifications.Sms.AwsSns.HealthChecks;
 using Granit.Notifications.Sms.AwsSns.Internal;
@@ -45,7 +46,7 @@ public static class SnsSmsServiceCollectionExtensions
 
         services.AddKeyedSingleton<ISmsSender, AwsSnsSmsSender>("AwsSns");
 
-        _ = NotificationsSmsAwsSnsActivitySource.Source; // ensure static init
+        GranitActivitySourceRegistry.Register(NotificationsSmsAwsSnsActivitySource.Name);
 
         return services;
     }

--- a/src/Granit.Notifications.Sms.AwsSns/packages.lock.json
+++ b/src/Granit.Notifications.Sms.AwsSns/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.19",
-        "contentHash": "LBjXBRwjRFBzrA3b8CFFc2jzso+oxOZGncxJLpC0DKtAfXlIFg2b8S0ZANNmvcJsO77EFeMdvG0kNoW0X3/dKw==",
+        "resolved": "4.0.2.20",
+        "contentHash": "Ukh0ZudL04FhC88ZTyYq2lugoX/9RCWStWvzOTREnmEaPCC51IWX7LQkIFLuMODV0k0GeuqwgReULEC6bjHuLg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.17, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.19, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -19,8 +19,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.17",
-        "contentHash": "Ab24kVquQ8kvuQKNe5MK/SvaXR4uoxPkAlTPALDEImaHcwsBg+UWfRVcNzLEx4dRR2y1mDFFh+zZ9TVMXGY6Jg=="
+        "resolved": "4.0.3.19",
+        "contentHash": "8zIzN59+J6arYSyFuhnSxPepr8ff4p6li+MxKUUnqCgwZqQ+icEGJK/23c1USIEALqZZ5gdiITuH2sOZWQom+Q=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Notifications.Sms.AzureCommunicationServices/Extensions/AcsSmsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Sms.AzureCommunicationServices/Extensions/AcsSmsServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Azure.Communication.Sms;
 using Azure.Identity;
+using Granit.Core.Diagnostics;
 using Granit.Notifications.Sms.AzureCommunicationServices.Diagnostics;
 using Granit.Notifications.Sms.AzureCommunicationServices.HealthChecks;
 using Granit.Notifications.Sms.AzureCommunicationServices.Internal;
@@ -42,7 +43,7 @@ public static class AcsSmsServiceCollectionExtensions
 
         services.AddKeyedSingleton<ISmsSender, AcsSmsSender>("AzureCommunicationServices");
 
-        _ = NotificationsSmsAcsActivitySource.Source; // ensure static init
+        GranitActivitySourceRegistry.Register(NotificationsSmsAcsActivitySource.Name);
 
         return services;
     }

--- a/src/Granit.Observability.AI/packages.lock.json
+++ b/src/Granit.Observability.AI/packages.lock.json
@@ -11,8 +11,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Direct",

--- a/src/Granit.OpenIddict.BackgroundJobs/packages.lock.json
+++ b/src/Granit.OpenIddict.BackgroundJobs/packages.lock.json
@@ -1,0 +1,585 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "OpenIddict": {
+        "type": "Direct",
+        "requested": "[6.*, )",
+        "resolved": "6.4.0",
+        "contentHash": "wujZGdqHdJlHa9NKfH1ywn5cqKWNCLICmzNbIgOj1ymNJ77aSdSq+bY284mnkUp21hPIYozbHNFcysiCqe21ow==",
+        "dependencies": {
+          "OpenIddict.Abstractions": "6.4.0",
+          "OpenIddict.Client": "6.4.0",
+          "OpenIddict.Client.SystemIntegration": "6.4.0",
+          "OpenIddict.Client.SystemNetHttp": "6.4.0",
+          "OpenIddict.Client.WebIntegration": "6.4.0",
+          "OpenIddict.Core": "6.4.0",
+          "OpenIddict.Server": "6.4.0",
+          "OpenIddict.Validation": "6.4.0",
+          "OpenIddict.Validation.ServerIntegration": "6.4.0",
+          "OpenIddict.Validation.SystemNetHttp": "6.4.0"
+        }
+      },
+      "Microsoft.Extensions.AmbientMetadata.Application": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "voKvEpXEsYtEhSiIVrYrZsMP7zEkBjquhqcvhxOCUen1i9TwdSwBmz7tN93IthTPA1nzXzWnz9huCZyegiYM8A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Hosting.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Compliance.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "EsW9aUhkHYfb75wkx24BuusOQbh2BRTSh052Fki2APn3puH1q9owynut1jWMq0Rm/C4zhyw6LAd+F6PX8HUi4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.ObjectPool": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "vS65HMo5RS10DD543fknsyVDxihMcVxVn3/hNaILgBxWYnOLxWIeCIO9X0QFuCvPRNjClvXe9Aj8KaQNx7vFkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.AutoActivation": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "71KqPTemVxSAYf4iv4lYFrL684MLwcTciLOHfoaWzxHG0U7ASWy/cQG8mNGB5Wy59H7eKTeuiNjvKXTebxlKWA==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "mIqCzZseDK9SqTRy4LxtjLwjlUu6aH5UdA6j0vgVER14yki9oRqLF+SmBiF6OlwsBSeL6dMQ8dmq02JMeE2puQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "cquw9eHjO7sJ+t6hC++Zd+UjelvxfAnmmfwIq7KnGllcxBg24VEsmIq5gODxYhxXN4rWOvmnIwix0ze2p5GbgA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Http.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "FEhMpnH7OANl7ux2wuByvRYqqdRQGC7l2RKOd5FDFXySeWhqJnYWEaQPMqgNk1v108N3fIFmIEnGTOBHDpVP+Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "9.6.0",
+          "Microsoft.Extensions.Http": "9.0.6",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.6",
+          "Microsoft.Extensions.Telemetry": "9.6.0"
+        }
+      },
+      "Microsoft.Extensions.Http.Polly": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "eui0JinN+aOSMt6oeAGhSk+wAw5nJbeHt+JyOltn4+zjA7FhYDDLdsUW+Md3x18p+NxUdTwh7W/4EbB5RJ90Aw==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "9.0.6",
+          "Polly": "7.2.4",
+          "Polly.Extensions.Http": "3.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "XBzjitTFaQhF8EbJ645vblZezV1p52ePTxKHoVkRidHF11Xkjxg94qr0Rvp2qyxK2vBJ4OIZ41NB15YUyxTGMQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "lCgpxE5r6v43SB40/yUVnSWZUUqUZF5iUWizhkx4gqvq0L0rMw5g8adWKGO7sfIaSbCiU0et85sDQWswhLcceg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Configuration.Binder": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "N1lSxMYI6DboY/PqCQwb6Bg74Baip7wWkHeHzuL7+PNsBipDmpBukXwVyVEAHdOdYNtasTdcXDVtbtwenoYU1g=="
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
+      },
+      "Microsoft.Extensions.Resilience": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "JhfQk0u4XYGD21fMUvAxmzzVM3CMN2Xy3yemutEBECoSP5ND/7jEG4daL0NODSPtq6rd9Pk7SumnBfxyV3+zxw==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics": "9.0.6",
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "9.6.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.6",
+          "Microsoft.Extensions.Telemetry.Abstractions": "9.6.0",
+          "Polly.Extensions": "8.4.2",
+          "Polly.RateLimiting": "8.4.2"
+        }
+      },
+      "Microsoft.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "4k56GlByl+4gxwMHDMJ/MglbmjPPddLgd21RHZlSfx4WWLqiES/GJ/sHVCrKVjdIQHdcR5MLWvplfuqgj4H+VQ==",
+        "dependencies": {
+          "Microsoft.Extensions.AmbientMetadata.Application": "9.6.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "9.6.0",
+          "Microsoft.Extensions.Logging.Configuration": "9.0.6",
+          "Microsoft.Extensions.ObjectPool": "9.0.6",
+          "Microsoft.Extensions.Telemetry.Abstractions": "9.6.0"
+        }
+      },
+      "Microsoft.Extensions.Telemetry.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "LKkpXv0KCFC7oPzkqwNMgBfBImd8I57e6W1mtnvw5KCwMZ/1iS5PsWQiSxp17J91crAyKv5KosRF6lNK2j9EBQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Compliance.Abstractions": "9.6.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.ObjectPool": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "V7fHMFpfzvx7twWMV3jrf3OFVmYn3QhUYtvfMRD9yUPs9gxnQSaRMZh5NzCsnW3ZZ80J09EE7yyjM71y9JC6hQ=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "gOup2SmdwaXooLR0POKfrkyrw+R+G8nc8Nk80TL0196kFQK7Bg7Qr4x3jvOCm3TR8QLqU8cVpSVqBLtUaosPEg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.12.0"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "IakwNWUTy5RlcDcKwtL5TyfDLZmA8FFnSDhfr+wfGGPMON9GkpkUY8NakIJjdy6mv6C1lM/Jkn3IuaeS9MXesA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.12.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "WwCV1H3lmo6qLjVjFlzi8jBbYLWKzKM3KldD1te1vD3QZbcZ+aN7MBGnbbJAE8FYqv/zLPtsRliRNOs9YHrtxg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.12.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "WCU3wv5sioX5hhp3oHw8sCdygnfZJtRKJGCg+AckP6nbp0QGKK3VohTrxIF0dpuziLAPg57CPfS9X8UERroKxA==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.IdentityModel.Logging": "8.12.0"
+        }
+      },
+      "Microsoft.Net.Http.Headers": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "YwD5LtA45rgLeJV9+DvRolwue2+s/Y1br5BFL+XdakM8Q859ICkbuH3ymvD+ibnXXkHsDaEvr8Sc+nauisABOg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "OpenIddict.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "sVhLvY4sZ3UFXudfc8A6gM45uyA9WwL8987ksf8zY4spVoADFH3cblkyj85OYF5fCQxRDxvOCvyeYfs7zTiaig==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6",
+          "Microsoft.IdentityModel.Tokens": "8.12.0"
+        }
+      },
+      "OpenIddict.Client": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "SO0zSTRaThna4+n/Hcud8S0EC/S/LXC5Sn8dPCp3cDy+cnXYsHhw4X+4bJGxa8kypZEhH1Qdc49lSOYF0SwJvw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.12.0",
+          "Microsoft.IdentityModel.Protocols": "8.12.0",
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.Client.SystemIntegration": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "W8XbiXN5IxTlBfWZmsdG3LdFLY6tOwsCL/Fiu1ZYbKdkldzPZ2P6DV81cBF7G4wTzJ4rCi3iBaow6XWIE7bF+g==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "9.0.6",
+          "Microsoft.Net.Http.Headers": "9.0.6",
+          "OpenIddict.Client": "6.4.0"
+        }
+      },
+      "OpenIddict.Client.SystemNetHttp": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "9cAFvFQe8yzk+W/zzGq7spcNvL5Ug1Sp0f9lzMhJLV1dxfNRYnW1YUPOb67vS3WFUWBePXw+sr2y/xadSt9gNg==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Polly": "9.0.6",
+          "Microsoft.Extensions.Http.Resilience": "9.6.0",
+          "OpenIddict.Client": "6.4.0"
+        }
+      },
+      "OpenIddict.Client.WebIntegration": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "jKsgqGm/5QLWAj/18/Ac7CvvjeTW9XklRadsQ4FLtrZZA0dBfcQNvjKsGivImzPPs/zS8/zH5/XR48UOQ1Qmjg==",
+        "dependencies": {
+          "OpenIddict.Client": "6.4.0",
+          "OpenIddict.Client.SystemNetHttp": "6.4.0"
+        }
+      },
+      "OpenIddict.Core": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "xAYq7U/j6JZAbVU88Xv6yXeKutJvNuGCH6zJAlP++abKtSfpP2mRLp2UbS0QS37S+SqRMLxp301DPNtkiRkuPA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.Server": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "npMVNR7zjTpgZCa1Kg2QYXx66jxDrvMQGuqD+3BFssIbT0j7N9s40RgUaGD827IsZGwO+IenJMxZV7QCdiTYSA==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.12.0",
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.Validation": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "fEolVRSiAymdCQA8SWCgiTXt1o1bS9aJHqXss7XFEID9d9mk4389i93JEDaNspOGKbazzqXUmeczG0xjHNBvcw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.12.0",
+          "Microsoft.IdentityModel.Protocols": "8.12.0",
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.Validation.ServerIntegration": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "fRrBVz7KM1D5C/Az6JpBvUm6epd+hABR4Gi2LAWMur9ePu6WJLBvvkxinLR+WECvm6veCgw4tZVXLNJ+yfJ4Ew==",
+        "dependencies": {
+          "OpenIddict.Server": "6.4.0",
+          "OpenIddict.Validation": "6.4.0"
+        }
+      },
+      "OpenIddict.Validation.SystemNetHttp": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "H+5RiiUbQBzJJURqZR+Z9XqZfGxTX1vTOWfmCMV/HmivuVxxk3H2hZcAUyox1Ah8RTC+rvRomSHFjskhLAhWjA==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Polly": "9.0.6",
+          "Microsoft.Extensions.Http.Resilience": "9.6.0",
+          "OpenIddict.Validation": "6.4.0"
+        }
+      },
+      "Polly": {
+        "type": "Transitive",
+        "resolved": "7.2.4",
+        "contentHash": "bw00Ck5sh6ekduDE3mnCo1ohzuad946uslCDEENu3091+6UKnBuKLo4e+yaNcCzXxOZCXWY2gV4a35+K1d4LDA=="
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "BpE2I6HBYYA5tF0Vn4eoQOGYTYIK1BlF5EXVgkWGn3mqUUjbXAr13J6fZVbp7Q3epRR8yshacBMlsHMhpOiV3g=="
+      },
+      "Polly.Extensions": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "GZ9vRVmR0jV2JtZavt+pGUsQ1O1cuRKG7R7VOZI6ZDy9y6RNPvRvXK1tuS4ffUrv8L0FTea59oEuQzgS0R7zSA==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Options": "8.0.0",
+          "Polly.Core": "8.4.2"
+        }
+      },
+      "Polly.Extensions.Http": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "drrG+hB3pYFY7w1c3BD+lSGYvH2oIclH8GRSehgfyP5kjnFnHKQuuBhuHLv+PWyFuaTDyk/vfRpnxOzd11+J8g==",
+        "dependencies": {
+          "Polly": "7.1.0"
+        }
+      },
+      "Polly.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "ehTImQ/eUyO07VYW2WvwSmU9rRH200SKJ/3jku9rOkyWE0A2JxNFmAVms8dSn49QLSjmjFRRSgfNyOgr/2PSmA==",
+        "dependencies": {
+          "Polly.Core": "8.4.2",
+          "System.Threading.RateLimiting": "8.0.0"
+        }
+      },
+      "System.Threading.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "7mu9v0QDv66ar3DpGSZHg9NuNcxDaaAcnMULuZlaTpP9+hwXhrxNGsF5GmLkSHxFdb5bBc1TzeujsRgTrPWi+Q=="
+      },
+      "granit.backgroundjobs": {
+        "type": "Project",
+        "dependencies": {
+          "Cronos": "[0.11.*, )",
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.core": {
+        "type": "Project"
+      },
+      "granit.eventbus": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.identity": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )"
+        }
+      },
+      "granit.openiddict": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.EventBus": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Identity": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.querying": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.security": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Cronos": {
+        "type": "CentralTransitive",
+        "requested": "[0.11.*, )",
+        "resolved": "0.11.1",
+        "contentHash": "5Ug+giPQITSAdTp/METAsofRSSUi3I5p7t4dlcXnzUgUzwZb4HkOBcYfpHuPwAHrnKJjmyW8amVzLD6mfLpaBg=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "9.0.6",
+        "contentHash": "bL/xQsVNrdVkzjP5yjX4ndkQ03H3+Bk3qPpl+AMCEJR2RkfgAYmoQ/xXffPV7is64+QHShnhA12YAaFmNbfM+A==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "9.0.6",
+        "contentHash": "qPW2d798tBPZcRmrlaBJqyChf2+0odDdE+0Lxvrr0ywkSNl1oNMK8AKrOfDwyXyjuLCv0ua7p6nrUExCeXhCcg==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Http": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "9.0.6",
+        "contentHash": "YoCEkjHHeeKsOzaJaGKuwsi1Ijckkm/+bv5RXmsKA0/qW4veY0eh5lVtkOXxkqQbVRuK3sObhxRM0UeuF6yAgA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Diagnostics": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "9.6.0",
+        "contentHash": "Np2a8u0ttPzqSrfVlVNRavKNzrzrbLAEsd0gR0KX5jIVOp7SVlPQdAHBTBh8/Hd7Amni9STSBWE2hoxq2pu3XA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Binder": "9.0.6",
+          "Microsoft.Extensions.Http.Diagnostics": "9.6.0",
+          "Microsoft.Extensions.ObjectPool": "9.0.6",
+          "Microsoft.Extensions.Resilience": "9.6.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      }
+    }
+  }
+}

--- a/src/Granit.OpenIddict.Client/packages.lock.json
+++ b/src/Granit.OpenIddict.Client/packages.lock.json
@@ -1,0 +1,322 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "OpenIddict": {
+        "type": "Direct",
+        "requested": "[6.*, )",
+        "resolved": "6.4.0",
+        "contentHash": "wujZGdqHdJlHa9NKfH1ywn5cqKWNCLICmzNbIgOj1ymNJ77aSdSq+bY284mnkUp21hPIYozbHNFcysiCqe21ow==",
+        "dependencies": {
+          "OpenIddict.Abstractions": "6.4.0",
+          "OpenIddict.Client": "6.4.0",
+          "OpenIddict.Client.SystemIntegration": "6.4.0",
+          "OpenIddict.Client.SystemNetHttp": "6.4.0",
+          "OpenIddict.Client.WebIntegration": "6.4.0",
+          "OpenIddict.Core": "6.4.0",
+          "OpenIddict.Server": "6.4.0",
+          "OpenIddict.Validation": "6.4.0",
+          "OpenIddict.Validation.ServerIntegration": "6.4.0",
+          "OpenIddict.Validation.SystemNetHttp": "6.4.0"
+        }
+      },
+      "Microsoft.Extensions.AmbientMetadata.Application": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "voKvEpXEsYtEhSiIVrYrZsMP7zEkBjquhqcvhxOCUen1i9TwdSwBmz7tN93IthTPA1nzXzWnz9huCZyegiYM8A=="
+      },
+      "Microsoft.Extensions.Compliance.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "EsW9aUhkHYfb75wkx24BuusOQbh2BRTSh052Fki2APn3puH1q9owynut1jWMq0Rm/C4zhyw6LAd+F6PX8HUi4Q=="
+      },
+      "Microsoft.Extensions.DependencyInjection.AutoActivation": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "71KqPTemVxSAYf4iv4lYFrL684MLwcTciLOHfoaWzxHG0U7ASWy/cQG8mNGB5Wy59H7eKTeuiNjvKXTebxlKWA=="
+      },
+      "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "cquw9eHjO7sJ+t6hC++Zd+UjelvxfAnmmfwIq7KnGllcxBg24VEsmIq5gODxYhxXN4rWOvmnIwix0ze2p5GbgA=="
+      },
+      "Microsoft.Extensions.Http.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "FEhMpnH7OANl7ux2wuByvRYqqdRQGC7l2RKOd5FDFXySeWhqJnYWEaQPMqgNk1v108N3fIFmIEnGTOBHDpVP+Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "9.6.0",
+          "Microsoft.Extensions.Telemetry": "9.6.0"
+        }
+      },
+      "Microsoft.Extensions.Http.Polly": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "eui0JinN+aOSMt6oeAGhSk+wAw5nJbeHt+JyOltn4+zjA7FhYDDLdsUW+Md3x18p+NxUdTwh7W/4EbB5RJ90Aw==",
+        "dependencies": {
+          "Polly": "7.2.4",
+          "Polly.Extensions.Http": "3.0.0"
+        }
+      },
+      "Microsoft.Extensions.Resilience": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "JhfQk0u4XYGD21fMUvAxmzzVM3CMN2Xy3yemutEBECoSP5ND/7jEG4daL0NODSPtq6rd9Pk7SumnBfxyV3+zxw==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "9.6.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "9.6.0",
+          "Polly.Extensions": "8.4.2",
+          "Polly.RateLimiting": "8.4.2"
+        }
+      },
+      "Microsoft.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "4k56GlByl+4gxwMHDMJ/MglbmjPPddLgd21RHZlSfx4WWLqiES/GJ/sHVCrKVjdIQHdcR5MLWvplfuqgj4H+VQ==",
+        "dependencies": {
+          "Microsoft.Extensions.AmbientMetadata.Application": "9.6.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "9.6.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "9.6.0"
+        }
+      },
+      "Microsoft.Extensions.Telemetry.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "LKkpXv0KCFC7oPzkqwNMgBfBImd8I57e6W1mtnvw5KCwMZ/1iS5PsWQiSxp17J91crAyKv5KosRF6lNK2j9EBQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Compliance.Abstractions": "9.6.0"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "V7fHMFpfzvx7twWMV3jrf3OFVmYn3QhUYtvfMRD9yUPs9gxnQSaRMZh5NzCsnW3ZZ80J09EE7yyjM71y9JC6hQ=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "gOup2SmdwaXooLR0POKfrkyrw+R+G8nc8Nk80TL0196kFQK7Bg7Qr4x3jvOCm3TR8QLqU8cVpSVqBLtUaosPEg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.12.0"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "IakwNWUTy5RlcDcKwtL5TyfDLZmA8FFnSDhfr+wfGGPMON9GkpkUY8NakIJjdy6mv6C1lM/Jkn3IuaeS9MXesA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.12.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "WwCV1H3lmo6qLjVjFlzi8jBbYLWKzKM3KldD1te1vD3QZbcZ+aN7MBGnbbJAE8FYqv/zLPtsRliRNOs9YHrtxg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.12.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "WCU3wv5sioX5hhp3oHw8sCdygnfZJtRKJGCg+AckP6nbp0QGKK3VohTrxIF0dpuziLAPg57CPfS9X8UERroKxA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "8.12.0"
+        }
+      },
+      "OpenIddict.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "sVhLvY4sZ3UFXudfc8A6gM45uyA9WwL8987ksf8zY4spVoADFH3cblkyj85OYF5fCQxRDxvOCvyeYfs7zTiaig==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.12.0"
+        }
+      },
+      "OpenIddict.Client": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "SO0zSTRaThna4+n/Hcud8S0EC/S/LXC5Sn8dPCp3cDy+cnXYsHhw4X+4bJGxa8kypZEhH1Qdc49lSOYF0SwJvw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.12.0",
+          "Microsoft.IdentityModel.Protocols": "8.12.0",
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.Client.SystemIntegration": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "W8XbiXN5IxTlBfWZmsdG3LdFLY6tOwsCL/Fiu1ZYbKdkldzPZ2P6DV81cBF7G4wTzJ4rCi3iBaow6XWIE7bF+g==",
+        "dependencies": {
+          "OpenIddict.Client": "6.4.0"
+        }
+      },
+      "OpenIddict.Client.SystemNetHttp": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "9cAFvFQe8yzk+W/zzGq7spcNvL5Ug1Sp0f9lzMhJLV1dxfNRYnW1YUPOb67vS3WFUWBePXw+sr2y/xadSt9gNg==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Polly": "9.0.6",
+          "Microsoft.Extensions.Http.Resilience": "9.6.0",
+          "OpenIddict.Client": "6.4.0"
+        }
+      },
+      "OpenIddict.Client.WebIntegration": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "jKsgqGm/5QLWAj/18/Ac7CvvjeTW9XklRadsQ4FLtrZZA0dBfcQNvjKsGivImzPPs/zS8/zH5/XR48UOQ1Qmjg==",
+        "dependencies": {
+          "OpenIddict.Client": "6.4.0",
+          "OpenIddict.Client.SystemNetHttp": "6.4.0"
+        }
+      },
+      "OpenIddict.Core": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "xAYq7U/j6JZAbVU88Xv6yXeKutJvNuGCH6zJAlP++abKtSfpP2mRLp2UbS0QS37S+SqRMLxp301DPNtkiRkuPA==",
+        "dependencies": {
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.Server": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "npMVNR7zjTpgZCa1Kg2QYXx66jxDrvMQGuqD+3BFssIbT0j7N9s40RgUaGD827IsZGwO+IenJMxZV7QCdiTYSA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.12.0",
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.Validation": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "fEolVRSiAymdCQA8SWCgiTXt1o1bS9aJHqXss7XFEID9d9mk4389i93JEDaNspOGKbazzqXUmeczG0xjHNBvcw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.12.0",
+          "Microsoft.IdentityModel.Protocols": "8.12.0",
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.Validation.ServerIntegration": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "fRrBVz7KM1D5C/Az6JpBvUm6epd+hABR4Gi2LAWMur9ePu6WJLBvvkxinLR+WECvm6veCgw4tZVXLNJ+yfJ4Ew==",
+        "dependencies": {
+          "OpenIddict.Server": "6.4.0",
+          "OpenIddict.Validation": "6.4.0"
+        }
+      },
+      "OpenIddict.Validation.SystemNetHttp": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "H+5RiiUbQBzJJURqZR+Z9XqZfGxTX1vTOWfmCMV/HmivuVxxk3H2hZcAUyox1Ah8RTC+rvRomSHFjskhLAhWjA==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Polly": "9.0.6",
+          "Microsoft.Extensions.Http.Resilience": "9.6.0",
+          "OpenIddict.Validation": "6.4.0"
+        }
+      },
+      "Polly": {
+        "type": "Transitive",
+        "resolved": "7.2.4",
+        "contentHash": "bw00Ck5sh6ekduDE3mnCo1ohzuad946uslCDEENu3091+6UKnBuKLo4e+yaNcCzXxOZCXWY2gV4a35+K1d4LDA=="
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "BpE2I6HBYYA5tF0Vn4eoQOGYTYIK1BlF5EXVgkWGn3mqUUjbXAr13J6fZVbp7Q3epRR8yshacBMlsHMhpOiV3g=="
+      },
+      "Polly.Extensions": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "GZ9vRVmR0jV2JtZavt+pGUsQ1O1cuRKG7R7VOZI6ZDy9y6RNPvRvXK1tuS4ffUrv8L0FTea59oEuQzgS0R7zSA==",
+        "dependencies": {
+          "Polly.Core": "8.4.2"
+        }
+      },
+      "Polly.Extensions.Http": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "drrG+hB3pYFY7w1c3BD+lSGYvH2oIclH8GRSehgfyP5kjnFnHKQuuBhuHLv+PWyFuaTDyk/vfRpnxOzd11+J8g==",
+        "dependencies": {
+          "Polly": "7.1.0"
+        }
+      },
+      "Polly.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "ehTImQ/eUyO07VYW2WvwSmU9rRH200SKJ/3jku9rOkyWE0A2JxNFmAVms8dSn49QLSjmjFRRSgfNyOgr/2PSmA==",
+        "dependencies": {
+          "Polly.Core": "8.4.2"
+        }
+      },
+      "granit.core": {
+        "type": "Project"
+      },
+      "granit.eventbus": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.identity": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )"
+        }
+      },
+      "granit.openiddict": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.EventBus": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Identity": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.querying": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.security": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "9.6.0",
+        "contentHash": "Np2a8u0ttPzqSrfVlVNRavKNzrzrbLAEsd0gR0KX5jIVOp7SVlPQdAHBTBh8/Hd7Amni9STSBWE2hoxq2pu3XA==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Diagnostics": "9.6.0",
+          "Microsoft.Extensions.Resilience": "9.6.0"
+        }
+      }
+    }
+  }
+}

--- a/src/Granit.OpenIddict.Endpoints/packages.lock.json
+++ b/src/Granit.OpenIddict.Endpoints/packages.lock.json
@@ -1,0 +1,234 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Asp.Versioning.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "I4CuGwl0nO98j6Ft6XlGBgzj1+goE/TSVlnHKgtRkuMZ0K4gy9I+Wyrtto8dyt0hWcFMDFAZ4lYNr58DSemH1g=="
+      },
+      "Asp.Versioning.Http": {
+        "type": "Transitive",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "4/QzujOrkGn9sMch3eHhR5LpVJ4Xo5T2BNg7U1/r4YwEa8JywzkoGQHjW7Nk0W8ljETnpoJaO5mrTsfEOnJK3A==",
+        "dependencies": {
+          "Asp.Versioning.Abstractions": "10.0.0-preview.2"
+        }
+      },
+      "Microsoft.OpenApi": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
+      },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.core": {
+        "type": "Project"
+      },
+      "granit.eventbus": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.apidocumentation": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Http.ApiVersioning": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )",
+          "Scalar.AspNetCore": "[2.*, )"
+        }
+      },
+      "granit.http.apiversioning": {
+        "type": "Project",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "[10.0.0-preview.*, )",
+          "Asp.Versioning.Mvc.ApiExplorer": "[10.0.0-preview.*, )",
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.identity": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Core": "[0.1.0-dev, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.openiddict": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.EventBus": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Identity": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.querying": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.security": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.validation": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.*, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.*, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )"
+        }
+      },
+      "Asp.Versioning.Mvc": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0-preview.*, )",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "AyrcDwLzJp8yRJaFjZMJXkR1Rx2UaJkwGrGlX8sxIt2F5ZGiZwn/puXkB/oEaq55TxLkpiXWAOHHFsiVptp0fA==",
+        "dependencies": {
+          "Asp.Versioning.Http": "10.0.0-preview.2"
+        }
+      },
+      "Asp.Versioning.Mvc.ApiExplorer": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0-preview.*, )",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "G/LhAaLQj+gsB8UXRNm65fxjsI7fe87itZExb+MvJOQdrXYalZKbwuzMntO95xM5cKDrDgLnCH64fl6w173aGg==",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "10.0.0-preview.2"
+        }
+      },
+      "FluentValidation": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1"
+        }
+      },
+      "Microsoft.AspNetCore.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "vTcxIfOPyfFbYk1g8YcXJfkMnlEWVkSnnjxcZLy60zgwiHMRf2SnZR+9E4HlpwKxgE3yfKMOti8J6WfKuKsw6w==",
+        "dependencies": {
+          "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.14.0",
+        "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "Scalar.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.13.13",
+        "contentHash": "QS94/CNp2thhykXwBaOHjDe8Zlexs8v0QOrdLfUvxS85uW84IhCf1zGiOnYZNNtVxunJvtsr7yPgEP36TXnJ3w=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog=="
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      }
+    }
+  }
+}

--- a/src/Granit.OpenIddict.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/packages.lock.json
@@ -1,0 +1,189 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "oo1uauTwgcnhYgituZ2nI3wJ8XN9z76ggu2zkOJu1BCfOOsqr+g08Kr4MOiMuXEhwySkpIV+MVoC25hC1288NA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.5"
+        }
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "9tNBmK3EpYVGRQLiqP+bqK2m+TD0Gv//4vCzR7ZOgl4FWzCFyOpYdIVka13M4kcBdPdSJcs3wbHr3rmzOqbIMA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.5",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.5"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "uxmFjZEAB/KbsgWFSS4lLqkEHCfXxB2x0UcbiO4e5fCRpFFeTMSx/me6009nYJLu5IKlDwO1POh++P6RilFTDw==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.5"
+        }
+      },
+      "OpenIddict.EntityFrameworkCore": {
+        "type": "Direct",
+        "requested": "[6.*, )",
+        "resolved": "6.4.0",
+        "contentHash": "glyc+uEaJS9zZxzA/cyF2O4TJudgHLR2Qf2AGq1tNA8mBcQIa2DzKIEuP9rEQD+lofnR/V+cFsybGUyYMsra9Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "9.0.6",
+          "OpenIddict.Core": "6.4.0",
+          "OpenIddict.EntityFrameworkCore.Models": "6.4.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "32c58Rnm47Qvhimawf67KO9PytgPz3QoWye7Abapt0Yocw/JnzMiSNj/pRoIKyn8Jxypkv86zxKD4Q/zNTc0Ag=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "ipC4u1VojgEfoIZhtbS2Sx5IluJTP/Jf1hz3yGsxGBgSukYY/CquI6rAjxn5H58CZgVn36qcuPPtNMwZ0AUzMg=="
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "V7fHMFpfzvx7twWMV3jrf3OFVmYn3QhUYtvfMRD9yUPs9gxnQSaRMZh5NzCsnW3ZZ80J09EE7yyjM71y9JC6hQ=="
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "IakwNWUTy5RlcDcKwtL5TyfDLZmA8FFnSDhfr+wfGGPMON9GkpkUY8NakIJjdy6mv6C1lM/Jkn3IuaeS9MXesA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.12.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "WCU3wv5sioX5hhp3oHw8sCdygnfZJtRKJGCg+AckP6nbp0QGKK3VohTrxIF0dpuziLAPg57CPfS9X8UERroKxA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "8.12.0"
+        }
+      },
+      "OpenIddict.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "sVhLvY4sZ3UFXudfc8A6gM45uyA9WwL8987ksf8zY4spVoADFH3cblkyj85OYF5fCQxRDxvOCvyeYfs7zTiaig==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.12.0"
+        }
+      },
+      "OpenIddict.Core": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "xAYq7U/j6JZAbVU88Xv6yXeKutJvNuGCH6zJAlP++abKtSfpP2mRLp2UbS0QS37S+SqRMLxp301DPNtkiRkuPA==",
+        "dependencies": {
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.EntityFrameworkCore.Models": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "5nyS+XmjoAA8MeyClHA+0EOHCHIDRV4sxDpDpK0RUqtDB4fxmRbKJCzocGHlE/o5iubd6hrKS9bCGZruTWw9oA=="
+      },
+      "granit.core": {
+        "type": "Project"
+      },
+      "granit.eventbus": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.identity": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )"
+        }
+      },
+      "granit.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.openiddict": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.EventBus": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Identity": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )"
+        }
+      },
+      "granit.querying": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.security": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "RtNhAwrnZcUZgi3SUMvaDVF405ZtKVR7l/6OHcqFj6JY5nT7QOdBxxULnby9dUQ6Jhnfl7cdDlMjsexfASNyjg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.5"
+        }
+      }
+    }
+  }
+}

--- a/src/Granit.OpenIddict.Passkeys/packages.lock.json
+++ b/src/Granit.OpenIddict.Passkeys/packages.lock.json
@@ -1,0 +1,421 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "OpenIddict": {
+        "type": "Direct",
+        "requested": "[6.*, )",
+        "resolved": "6.4.0",
+        "contentHash": "wujZGdqHdJlHa9NKfH1ywn5cqKWNCLICmzNbIgOj1ymNJ77aSdSq+bY284mnkUp21hPIYozbHNFcysiCqe21ow==",
+        "dependencies": {
+          "OpenIddict.Abstractions": "6.4.0",
+          "OpenIddict.Client": "6.4.0",
+          "OpenIddict.Client.SystemIntegration": "6.4.0",
+          "OpenIddict.Client.SystemNetHttp": "6.4.0",
+          "OpenIddict.Client.WebIntegration": "6.4.0",
+          "OpenIddict.Core": "6.4.0",
+          "OpenIddict.Server": "6.4.0",
+          "OpenIddict.Validation": "6.4.0",
+          "OpenIddict.Validation.ServerIntegration": "6.4.0",
+          "OpenIddict.Validation.SystemNetHttp": "6.4.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "32c58Rnm47Qvhimawf67KO9PytgPz3QoWye7Abapt0Yocw/JnzMiSNj/pRoIKyn8Jxypkv86zxKD4Q/zNTc0Ag=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "ipC4u1VojgEfoIZhtbS2Sx5IluJTP/Jf1hz3yGsxGBgSukYY/CquI6rAjxn5H58CZgVn36qcuPPtNMwZ0AUzMg=="
+      },
+      "Microsoft.Extensions.AmbientMetadata.Application": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "voKvEpXEsYtEhSiIVrYrZsMP7zEkBjquhqcvhxOCUen1i9TwdSwBmz7tN93IthTPA1nzXzWnz9huCZyegiYM8A=="
+      },
+      "Microsoft.Extensions.Compliance.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "EsW9aUhkHYfb75wkx24BuusOQbh2BRTSh052Fki2APn3puH1q9owynut1jWMq0Rm/C4zhyw6LAd+F6PX8HUi4Q=="
+      },
+      "Microsoft.Extensions.DependencyInjection.AutoActivation": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "71KqPTemVxSAYf4iv4lYFrL684MLwcTciLOHfoaWzxHG0U7ASWy/cQG8mNGB5Wy59H7eKTeuiNjvKXTebxlKWA=="
+      },
+      "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "cquw9eHjO7sJ+t6hC++Zd+UjelvxfAnmmfwIq7KnGllcxBg24VEsmIq5gODxYhxXN4rWOvmnIwix0ze2p5GbgA=="
+      },
+      "Microsoft.Extensions.Http.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "FEhMpnH7OANl7ux2wuByvRYqqdRQGC7l2RKOd5FDFXySeWhqJnYWEaQPMqgNk1v108N3fIFmIEnGTOBHDpVP+Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "9.6.0",
+          "Microsoft.Extensions.Telemetry": "9.6.0"
+        }
+      },
+      "Microsoft.Extensions.Http.Polly": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "eui0JinN+aOSMt6oeAGhSk+wAw5nJbeHt+JyOltn4+zjA7FhYDDLdsUW+Md3x18p+NxUdTwh7W/4EbB5RJ90Aw==",
+        "dependencies": {
+          "Polly": "7.2.4",
+          "Polly.Extensions.Http": "3.0.0"
+        }
+      },
+      "Microsoft.Extensions.Resilience": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "JhfQk0u4XYGD21fMUvAxmzzVM3CMN2Xy3yemutEBECoSP5ND/7jEG4daL0NODSPtq6rd9Pk7SumnBfxyV3+zxw==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "9.6.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "9.6.0",
+          "Polly.Extensions": "8.4.2",
+          "Polly.RateLimiting": "8.4.2"
+        }
+      },
+      "Microsoft.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "4k56GlByl+4gxwMHDMJ/MglbmjPPddLgd21RHZlSfx4WWLqiES/GJ/sHVCrKVjdIQHdcR5MLWvplfuqgj4H+VQ==",
+        "dependencies": {
+          "Microsoft.Extensions.AmbientMetadata.Application": "9.6.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "9.6.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "9.6.0"
+        }
+      },
+      "Microsoft.Extensions.Telemetry.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "LKkpXv0KCFC7oPzkqwNMgBfBImd8I57e6W1mtnvw5KCwMZ/1iS5PsWQiSxp17J91crAyKv5KosRF6lNK2j9EBQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Compliance.Abstractions": "9.6.0"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "V7fHMFpfzvx7twWMV3jrf3OFVmYn3QhUYtvfMRD9yUPs9gxnQSaRMZh5NzCsnW3ZZ80J09EE7yyjM71y9JC6hQ=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "gOup2SmdwaXooLR0POKfrkyrw+R+G8nc8Nk80TL0196kFQK7Bg7Qr4x3jvOCm3TR8QLqU8cVpSVqBLtUaosPEg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.12.0"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "IakwNWUTy5RlcDcKwtL5TyfDLZmA8FFnSDhfr+wfGGPMON9GkpkUY8NakIJjdy6mv6C1lM/Jkn3IuaeS9MXesA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.12.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "WwCV1H3lmo6qLjVjFlzi8jBbYLWKzKM3KldD1te1vD3QZbcZ+aN7MBGnbbJAE8FYqv/zLPtsRliRNOs9YHrtxg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.12.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "WCU3wv5sioX5hhp3oHw8sCdygnfZJtRKJGCg+AckP6nbp0QGKK3VohTrxIF0dpuziLAPg57CPfS9X8UERroKxA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "8.12.0"
+        }
+      },
+      "OpenIddict.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "sVhLvY4sZ3UFXudfc8A6gM45uyA9WwL8987ksf8zY4spVoADFH3cblkyj85OYF5fCQxRDxvOCvyeYfs7zTiaig==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.12.0"
+        }
+      },
+      "OpenIddict.Client": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "SO0zSTRaThna4+n/Hcud8S0EC/S/LXC5Sn8dPCp3cDy+cnXYsHhw4X+4bJGxa8kypZEhH1Qdc49lSOYF0SwJvw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.12.0",
+          "Microsoft.IdentityModel.Protocols": "8.12.0",
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.Client.SystemIntegration": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "W8XbiXN5IxTlBfWZmsdG3LdFLY6tOwsCL/Fiu1ZYbKdkldzPZ2P6DV81cBF7G4wTzJ4rCi3iBaow6XWIE7bF+g==",
+        "dependencies": {
+          "OpenIddict.Client": "6.4.0"
+        }
+      },
+      "OpenIddict.Client.SystemNetHttp": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "9cAFvFQe8yzk+W/zzGq7spcNvL5Ug1Sp0f9lzMhJLV1dxfNRYnW1YUPOb67vS3WFUWBePXw+sr2y/xadSt9gNg==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Polly": "9.0.6",
+          "Microsoft.Extensions.Http.Resilience": "9.6.0",
+          "OpenIddict.Client": "6.4.0"
+        }
+      },
+      "OpenIddict.Client.WebIntegration": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "jKsgqGm/5QLWAj/18/Ac7CvvjeTW9XklRadsQ4FLtrZZA0dBfcQNvjKsGivImzPPs/zS8/zH5/XR48UOQ1Qmjg==",
+        "dependencies": {
+          "OpenIddict.Client": "6.4.0",
+          "OpenIddict.Client.SystemNetHttp": "6.4.0"
+        }
+      },
+      "OpenIddict.Core": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "xAYq7U/j6JZAbVU88Xv6yXeKutJvNuGCH6zJAlP++abKtSfpP2mRLp2UbS0QS37S+SqRMLxp301DPNtkiRkuPA==",
+        "dependencies": {
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.EntityFrameworkCore.Models": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "5nyS+XmjoAA8MeyClHA+0EOHCHIDRV4sxDpDpK0RUqtDB4fxmRbKJCzocGHlE/o5iubd6hrKS9bCGZruTWw9oA=="
+      },
+      "OpenIddict.Server": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "npMVNR7zjTpgZCa1Kg2QYXx66jxDrvMQGuqD+3BFssIbT0j7N9s40RgUaGD827IsZGwO+IenJMxZV7QCdiTYSA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.12.0",
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.Validation": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "fEolVRSiAymdCQA8SWCgiTXt1o1bS9aJHqXss7XFEID9d9mk4389i93JEDaNspOGKbazzqXUmeczG0xjHNBvcw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.12.0",
+          "Microsoft.IdentityModel.Protocols": "8.12.0",
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.Validation.ServerIntegration": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "fRrBVz7KM1D5C/Az6JpBvUm6epd+hABR4Gi2LAWMur9ePu6WJLBvvkxinLR+WECvm6veCgw4tZVXLNJ+yfJ4Ew==",
+        "dependencies": {
+          "OpenIddict.Server": "6.4.0",
+          "OpenIddict.Validation": "6.4.0"
+        }
+      },
+      "OpenIddict.Validation.SystemNetHttp": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "H+5RiiUbQBzJJURqZR+Z9XqZfGxTX1vTOWfmCMV/HmivuVxxk3H2hZcAUyox1Ah8RTC+rvRomSHFjskhLAhWjA==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Polly": "9.0.6",
+          "Microsoft.Extensions.Http.Resilience": "9.6.0",
+          "OpenIddict.Validation": "6.4.0"
+        }
+      },
+      "Polly": {
+        "type": "Transitive",
+        "resolved": "7.2.4",
+        "contentHash": "bw00Ck5sh6ekduDE3mnCo1ohzuad946uslCDEENu3091+6UKnBuKLo4e+yaNcCzXxOZCXWY2gV4a35+K1d4LDA=="
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "BpE2I6HBYYA5tF0Vn4eoQOGYTYIK1BlF5EXVgkWGn3mqUUjbXAr13J6fZVbp7Q3epRR8yshacBMlsHMhpOiV3g=="
+      },
+      "Polly.Extensions": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "GZ9vRVmR0jV2JtZavt+pGUsQ1O1cuRKG7R7VOZI6ZDy9y6RNPvRvXK1tuS4ffUrv8L0FTea59oEuQzgS0R7zSA==",
+        "dependencies": {
+          "Polly.Core": "8.4.2"
+        }
+      },
+      "Polly.Extensions.Http": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "drrG+hB3pYFY7w1c3BD+lSGYvH2oIclH8GRSehgfyP5kjnFnHKQuuBhuHLv+PWyFuaTDyk/vfRpnxOzd11+J8g==",
+        "dependencies": {
+          "Polly": "7.1.0"
+        }
+      },
+      "Polly.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "ehTImQ/eUyO07VYW2WvwSmU9rRH200SKJ/3jku9rOkyWE0A2JxNFmAVms8dSn49QLSjmjFRRSgfNyOgr/2PSmA==",
+        "dependencies": {
+          "Polly.Core": "8.4.2"
+        }
+      },
+      "granit.core": {
+        "type": "Project"
+      },
+      "granit.eventbus": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.identity": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )"
+        }
+      },
+      "granit.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.openiddict": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.EventBus": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Identity": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.openiddict.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
+          "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "OpenIddict.EntityFrameworkCore": "[6.*, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )"
+        }
+      },
+      "granit.querying": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.security": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "oo1uauTwgcnhYgituZ2nI3wJ8XN9z76ggu2zkOJu1BCfOOsqr+g08Kr4MOiMuXEhwySkpIV+MVoC25hC1288NA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.5"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "9tNBmK3EpYVGRQLiqP+bqK2m+TD0Gv//4vCzR7ZOgl4FWzCFyOpYdIVka13M4kcBdPdSJcs3wbHr3rmzOqbIMA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.5",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.5"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "uxmFjZEAB/KbsgWFSS4lLqkEHCfXxB2x0UcbiO4e5fCRpFFeTMSx/me6009nYJLu5IKlDwO1POh++P6RilFTDw==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "RtNhAwrnZcUZgi3SUMvaDVF405ZtKVR7l/6OHcqFj6JY5nT7QOdBxxULnby9dUQ6Jhnfl7cdDlMjsexfASNyjg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "9.6.0",
+        "contentHash": "Np2a8u0ttPzqSrfVlVNRavKNzrzrbLAEsd0gR0KX5jIVOp7SVlPQdAHBTBh8/Hd7Amni9STSBWE2hoxq2pu3XA==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Diagnostics": "9.6.0",
+          "Microsoft.Extensions.Resilience": "9.6.0"
+        }
+      },
+      "OpenIddict.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[6.*, )",
+        "resolved": "6.4.0",
+        "contentHash": "glyc+uEaJS9zZxzA/cyF2O4TJudgHLR2Qf2AGq1tNA8mBcQIa2DzKIEuP9rEQD+lofnR/V+cFsybGUyYMsra9Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "9.0.6",
+          "OpenIddict.Core": "6.4.0",
+          "OpenIddict.EntityFrameworkCore.Models": "6.4.0"
+        }
+      }
+    }
+  }
+}

--- a/src/Granit.OpenIddict.Seeding/packages.lock.json
+++ b/src/Granit.OpenIddict.Seeding/packages.lock.json
@@ -1,0 +1,647 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "OpenIddict": {
+        "type": "Direct",
+        "requested": "[6.*, )",
+        "resolved": "6.4.0",
+        "contentHash": "wujZGdqHdJlHa9NKfH1ywn5cqKWNCLICmzNbIgOj1ymNJ77aSdSq+bY284mnkUp21hPIYozbHNFcysiCqe21ow==",
+        "dependencies": {
+          "OpenIddict.Abstractions": "6.4.0",
+          "OpenIddict.Client": "6.4.0",
+          "OpenIddict.Client.SystemIntegration": "6.4.0",
+          "OpenIddict.Client.SystemNetHttp": "6.4.0",
+          "OpenIddict.Client.WebIntegration": "6.4.0",
+          "OpenIddict.Core": "6.4.0",
+          "OpenIddict.Server": "6.4.0",
+          "OpenIddict.Validation": "6.4.0",
+          "OpenIddict.Validation.ServerIntegration": "6.4.0",
+          "OpenIddict.Validation.SystemNetHttp": "6.4.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "32c58Rnm47Qvhimawf67KO9PytgPz3QoWye7Abapt0Yocw/JnzMiSNj/pRoIKyn8Jxypkv86zxKD4Q/zNTc0Ag=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "ipC4u1VojgEfoIZhtbS2Sx5IluJTP/Jf1hz3yGsxGBgSukYY/CquI6rAjxn5H58CZgVn36qcuPPtNMwZ0AUzMg=="
+      },
+      "Microsoft.Extensions.AmbientMetadata.Application": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "voKvEpXEsYtEhSiIVrYrZsMP7zEkBjquhqcvhxOCUen1i9TwdSwBmz7tN93IthTPA1nzXzWnz9huCZyegiYM8A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Hosting.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Compliance.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "EsW9aUhkHYfb75wkx24BuusOQbh2BRTSh052Fki2APn3puH1q9owynut1jWMq0Rm/C4zhyw6LAd+F6PX8HUi4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.ObjectPool": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "VWB5jdkxHsRiuoniTqwOL32R4OWyp5If/bAucLjRJczRVNcwb8iCXKLjn3Inv8fv+jHMVMnvQLg7xhSys+y5PA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "v1SVsowG6YE1YnHVGmLWz57YTRCQRx9pH5ebIESXfm5isI9gA3QaMyg/oMTzPpXYZwSAVDzYItGJKfmV+pqXkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.AutoActivation": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "71KqPTemVxSAYf4iv4lYFrL684MLwcTciLOHfoaWzxHG0U7ASWy/cQG8mNGB5Wy59H7eKTeuiNjvKXTebxlKWA==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "mIqCzZseDK9SqTRy4LxtjLwjlUu6aH5UdA6j0vgVER14yki9oRqLF+SmBiF6OlwsBSeL6dMQ8dmq02JMeE2puQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "cquw9eHjO7sJ+t6hC++Zd+UjelvxfAnmmfwIq7KnGllcxBg24VEsmIq5gODxYhxXN4rWOvmnIwix0ze2p5GbgA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "NrIMTy7dpqxAvA6kHAYH8cXID/YgeNOy0OqFKpLtkPu5X4WS/basX91UszANzVrMNRAICJ2GOnGiRxJtsRyEQw=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Http.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "FEhMpnH7OANl7ux2wuByvRYqqdRQGC7l2RKOd5FDFXySeWhqJnYWEaQPMqgNk1v108N3fIFmIEnGTOBHDpVP+Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "9.6.0",
+          "Microsoft.Extensions.Http": "9.0.6",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.6",
+          "Microsoft.Extensions.Telemetry": "9.6.0"
+        }
+      },
+      "Microsoft.Extensions.Http.Polly": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "eui0JinN+aOSMt6oeAGhSk+wAw5nJbeHt+JyOltn4+zjA7FhYDDLdsUW+Md3x18p+NxUdTwh7W/4EbB5RJ90Aw==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "9.0.6",
+          "Polly": "7.2.4",
+          "Polly.Extensions.Http": "3.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "+XTMKQyDWg4ODoNHU/BN3BaI1jhGO7VCS+BnzT/4IauiG6y2iPAte7MyD7rHKS+hNP0TkFkjrae8DFjDUxtcxg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "lCgpxE5r6v43SB40/yUVnSWZUUqUZF5iUWizhkx4gqvq0L0rMw5g8adWKGO7sfIaSbCiU0et85sDQWswhLcceg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Configuration.Binder": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "N1lSxMYI6DboY/PqCQwb6Bg74Baip7wWkHeHzuL7+PNsBipDmpBukXwVyVEAHdOdYNtasTdcXDVtbtwenoYU1g=="
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
+      },
+      "Microsoft.Extensions.Resilience": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "JhfQk0u4XYGD21fMUvAxmzzVM3CMN2Xy3yemutEBECoSP5ND/7jEG4daL0NODSPtq6rd9Pk7SumnBfxyV3+zxw==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics": "9.0.6",
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "9.6.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.6",
+          "Microsoft.Extensions.Telemetry.Abstractions": "9.6.0",
+          "Polly.Extensions": "8.4.2",
+          "Polly.RateLimiting": "8.4.2"
+        }
+      },
+      "Microsoft.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "4k56GlByl+4gxwMHDMJ/MglbmjPPddLgd21RHZlSfx4WWLqiES/GJ/sHVCrKVjdIQHdcR5MLWvplfuqgj4H+VQ==",
+        "dependencies": {
+          "Microsoft.Extensions.AmbientMetadata.Application": "9.6.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "9.6.0",
+          "Microsoft.Extensions.Logging.Configuration": "9.0.6",
+          "Microsoft.Extensions.ObjectPool": "9.0.6",
+          "Microsoft.Extensions.Telemetry.Abstractions": "9.6.0"
+        }
+      },
+      "Microsoft.Extensions.Telemetry.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "LKkpXv0KCFC7oPzkqwNMgBfBImd8I57e6W1mtnvw5KCwMZ/1iS5PsWQiSxp17J91crAyKv5KosRF6lNK2j9EBQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Compliance.Abstractions": "9.6.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.ObjectPool": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "V7fHMFpfzvx7twWMV3jrf3OFVmYn3QhUYtvfMRD9yUPs9gxnQSaRMZh5NzCsnW3ZZ80J09EE7yyjM71y9JC6hQ=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "gOup2SmdwaXooLR0POKfrkyrw+R+G8nc8Nk80TL0196kFQK7Bg7Qr4x3jvOCm3TR8QLqU8cVpSVqBLtUaosPEg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.12.0"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "IakwNWUTy5RlcDcKwtL5TyfDLZmA8FFnSDhfr+wfGGPMON9GkpkUY8NakIJjdy6mv6C1lM/Jkn3IuaeS9MXesA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.12.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "WwCV1H3lmo6qLjVjFlzi8jBbYLWKzKM3KldD1te1vD3QZbcZ+aN7MBGnbbJAE8FYqv/zLPtsRliRNOs9YHrtxg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.12.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "WCU3wv5sioX5hhp3oHw8sCdygnfZJtRKJGCg+AckP6nbp0QGKK3VohTrxIF0dpuziLAPg57CPfS9X8UERroKxA==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.IdentityModel.Logging": "8.12.0"
+        }
+      },
+      "Microsoft.Net.Http.Headers": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "YwD5LtA45rgLeJV9+DvRolwue2+s/Y1br5BFL+XdakM8Q859ICkbuH3ymvD+ibnXXkHsDaEvr8Sc+nauisABOg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "OpenIddict.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "sVhLvY4sZ3UFXudfc8A6gM45uyA9WwL8987ksf8zY4spVoADFH3cblkyj85OYF5fCQxRDxvOCvyeYfs7zTiaig==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6",
+          "Microsoft.IdentityModel.Tokens": "8.12.0"
+        }
+      },
+      "OpenIddict.Client": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "SO0zSTRaThna4+n/Hcud8S0EC/S/LXC5Sn8dPCp3cDy+cnXYsHhw4X+4bJGxa8kypZEhH1Qdc49lSOYF0SwJvw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.12.0",
+          "Microsoft.IdentityModel.Protocols": "8.12.0",
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.Client.SystemIntegration": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "W8XbiXN5IxTlBfWZmsdG3LdFLY6tOwsCL/Fiu1ZYbKdkldzPZ2P6DV81cBF7G4wTzJ4rCi3iBaow6XWIE7bF+g==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "9.0.6",
+          "Microsoft.Net.Http.Headers": "9.0.6",
+          "OpenIddict.Client": "6.4.0"
+        }
+      },
+      "OpenIddict.Client.SystemNetHttp": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "9cAFvFQe8yzk+W/zzGq7spcNvL5Ug1Sp0f9lzMhJLV1dxfNRYnW1YUPOb67vS3WFUWBePXw+sr2y/xadSt9gNg==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Polly": "9.0.6",
+          "Microsoft.Extensions.Http.Resilience": "9.6.0",
+          "OpenIddict.Client": "6.4.0"
+        }
+      },
+      "OpenIddict.Client.WebIntegration": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "jKsgqGm/5QLWAj/18/Ac7CvvjeTW9XklRadsQ4FLtrZZA0dBfcQNvjKsGivImzPPs/zS8/zH5/XR48UOQ1Qmjg==",
+        "dependencies": {
+          "OpenIddict.Client": "6.4.0",
+          "OpenIddict.Client.SystemNetHttp": "6.4.0"
+        }
+      },
+      "OpenIddict.Core": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "xAYq7U/j6JZAbVU88Xv6yXeKutJvNuGCH6zJAlP++abKtSfpP2mRLp2UbS0QS37S+SqRMLxp301DPNtkiRkuPA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.Server": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "npMVNR7zjTpgZCa1Kg2QYXx66jxDrvMQGuqD+3BFssIbT0j7N9s40RgUaGD827IsZGwO+IenJMxZV7QCdiTYSA==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.12.0",
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.Validation": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "fEolVRSiAymdCQA8SWCgiTXt1o1bS9aJHqXss7XFEID9d9mk4389i93JEDaNspOGKbazzqXUmeczG0xjHNBvcw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.12.0",
+          "Microsoft.IdentityModel.Protocols": "8.12.0",
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.Validation.ServerIntegration": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "fRrBVz7KM1D5C/Az6JpBvUm6epd+hABR4Gi2LAWMur9ePu6WJLBvvkxinLR+WECvm6veCgw4tZVXLNJ+yfJ4Ew==",
+        "dependencies": {
+          "OpenIddict.Server": "6.4.0",
+          "OpenIddict.Validation": "6.4.0"
+        }
+      },
+      "OpenIddict.Validation.SystemNetHttp": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "H+5RiiUbQBzJJURqZR+Z9XqZfGxTX1vTOWfmCMV/HmivuVxxk3H2hZcAUyox1Ah8RTC+rvRomSHFjskhLAhWjA==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Polly": "9.0.6",
+          "Microsoft.Extensions.Http.Resilience": "9.6.0",
+          "OpenIddict.Validation": "6.4.0"
+        }
+      },
+      "Polly": {
+        "type": "Transitive",
+        "resolved": "7.2.4",
+        "contentHash": "bw00Ck5sh6ekduDE3mnCo1ohzuad946uslCDEENu3091+6UKnBuKLo4e+yaNcCzXxOZCXWY2gV4a35+K1d4LDA=="
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "BpE2I6HBYYA5tF0Vn4eoQOGYTYIK1BlF5EXVgkWGn3mqUUjbXAr13J6fZVbp7Q3epRR8yshacBMlsHMhpOiV3g=="
+      },
+      "Polly.Extensions": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "GZ9vRVmR0jV2JtZavt+pGUsQ1O1cuRKG7R7VOZI6ZDy9y6RNPvRvXK1tuS4ffUrv8L0FTea59oEuQzgS0R7zSA==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Options": "8.0.0",
+          "Polly.Core": "8.4.2"
+        }
+      },
+      "Polly.Extensions.Http": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "drrG+hB3pYFY7w1c3BD+lSGYvH2oIclH8GRSehgfyP5kjnFnHKQuuBhuHLv+PWyFuaTDyk/vfRpnxOzd11+J8g==",
+        "dependencies": {
+          "Polly": "7.1.0"
+        }
+      },
+      "Polly.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "ehTImQ/eUyO07VYW2WvwSmU9rRH200SKJ/3jku9rOkyWE0A2JxNFmAVms8dSn49QLSjmjFRRSgfNyOgr/2PSmA==",
+        "dependencies": {
+          "Polly.Core": "8.4.2",
+          "System.Threading.RateLimiting": "8.0.0"
+        }
+      },
+      "System.Threading.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "7mu9v0QDv66ar3DpGSZHg9NuNcxDaaAcnMULuZlaTpP9+hwXhrxNGsF5GmLkSHxFdb5bBc1TzeujsRgTrPWi+Q=="
+      },
+      "granit.core": {
+        "type": "Project"
+      },
+      "granit.eventbus": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.identity": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )"
+        }
+      },
+      "granit.openiddict": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.EventBus": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Identity": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.querying": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.security": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "9tNBmK3EpYVGRQLiqP+bqK2m+TD0Gv//4vCzR7ZOgl4FWzCFyOpYdIVka13M4kcBdPdSJcs3wbHr3rmzOqbIMA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.5",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.5",
+          "Microsoft.Extensions.Caching.Memory": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "uxmFjZEAB/KbsgWFSS4lLqkEHCfXxB2x0UcbiO4e5fCRpFFeTMSx/me6009nYJLu5IKlDwO1POh++P6RilFTDw==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.5",
+          "Microsoft.Extensions.Caching.Memory": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "k/QDdQ94/0Shi0KfU+e12m73jfQo+3JpErTtgpZfsCIqkvdEEO0XIx6R+iTbN55rNPaNhOqNY4/sB+jZ8XxVPw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "jUEXmkBUPdOS/MP9areK/sbKhdklq9+tEhvwfxGalZVnmyLUO5rrheNNutUBtvbZ7J8ECkG7/r2KXi/IFC06cA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "9.0.6",
+        "contentHash": "Opl/7SIrwDy9WjHn/vU2thQ8CUtrIWHLr+89I7/0VYNEJQvpL24zvqYrh83cH38RzNKHji0WGVkCVP6HJChVVw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "REdt95QXHscGdtw/UUgyCW2lF9DJcAOJxmebKW2IkgUjuCAdMODIi2HNOWg5utW98nm8ekgV0Gjqs/sljwwqMw==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "RtNhAwrnZcUZgi3SUMvaDVF405ZtKVR7l/6OHcqFj6JY5nT7QOdBxxULnby9dUQ6Jhnfl7cdDlMjsexfASNyjg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Http": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "9.0.6",
+        "contentHash": "YoCEkjHHeeKsOzaJaGKuwsi1Ijckkm/+bv5RXmsKA0/qW4veY0eh5lVtkOXxkqQbVRuK3sObhxRM0UeuF6yAgA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Diagnostics": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "9.6.0",
+        "contentHash": "Np2a8u0ttPzqSrfVlVNRavKNzrzrbLAEsd0gR0KX5jIVOp7SVlPQdAHBTBh8/Hd7Amni9STSBWE2hoxq2pu3XA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Binder": "9.0.6",
+          "Microsoft.Extensions.Http.Diagnostics": "9.6.0",
+          "Microsoft.Extensions.ObjectPool": "9.0.6",
+          "Microsoft.Extensions.Resilience": "9.6.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "9.0.6",
+        "contentHash": "2lnp8nrvfzyp+5zvfeULm/hkZsDsKkl2ziBt5T8EZKoON5q+XRpRLoWcSPo8mP7GNZXpxKMBVjFNIZNbBIcnRw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Configuration.Binder": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      }
+    }
+  }
+}

--- a/src/Granit.OpenIddict/packages.lock.json
+++ b/src/Granit.OpenIddict/packages.lock.json
@@ -1,0 +1,53 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "granit.core": {
+        "type": "Project"
+      },
+      "granit.eventbus": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.identity": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )"
+        }
+      },
+      "granit.querying": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.security": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      }
+    }
+  }
+}

--- a/src/Granit.Privacy.Endpoints/Dtos/PrivacyAcceptAgreementRequest.cs
+++ b/src/Granit.Privacy.Endpoints/Dtos/PrivacyAcceptAgreementRequest.cs
@@ -1,0 +1,8 @@
+namespace Granit.Privacy.Endpoints.Dtos;
+
+/// <summary>
+/// Request to accept a legal agreement (GDPR Art. 7 — proof of consent).
+/// </summary>
+/// <param name="DocumentId">Identifier of the legal document (e.g., "privacy-policy").</param>
+/// <param name="Version">Version of the document being accepted (e.g., "2.1.0"). Must match the current version.</param>
+public sealed record PrivacyAcceptAgreementRequest(string DocumentId, string Version);

--- a/src/Granit.Privacy.Endpoints/Dtos/PrivacyConsentStatusResponse.cs
+++ b/src/Granit.Privacy.Endpoints/Dtos/PrivacyConsentStatusResponse.cs
@@ -1,0 +1,14 @@
+namespace Granit.Privacy.Endpoints.Dtos;
+
+/// <summary>
+/// Consent status for a single legal document (GDPR Art. 7).
+/// </summary>
+/// <param name="DocumentId">Legal document identifier.</param>
+/// <param name="CurrentVersion">Current version of the document.</param>
+/// <param name="HasAcceptedLatest">Whether the user has accepted the latest version.</param>
+/// <param name="LastAcceptedAt">Timestamp of the most recent acceptance, or <c>null</c> if never accepted.</param>
+public sealed record PrivacyConsentStatusResponse(
+    string DocumentId,
+    string CurrentVersion,
+    bool HasAcceptedLatest,
+    DateTimeOffset? LastAcceptedAt);

--- a/src/Granit.Privacy.Endpoints/Dtos/PrivacyDeletionRequest.cs
+++ b/src/Granit.Privacy.Endpoints/Dtos/PrivacyDeletionRequest.cs
@@ -1,0 +1,7 @@
+namespace Granit.Privacy.Endpoints.Dtos;
+
+/// <summary>
+/// Request to initiate personal data deletion (GDPR Art. 17 — right to erasure).
+/// </summary>
+/// <param name="Reason">Reason for the deletion request (e.g., "Account closure", "Withdrawal of consent").</param>
+public sealed record PrivacyDeletionRequest(string Reason);

--- a/src/Granit.Privacy.Endpoints/Dtos/PrivacyExportRequestResponse.cs
+++ b/src/Granit.Privacy.Endpoints/Dtos/PrivacyExportRequestResponse.cs
@@ -1,0 +1,8 @@
+namespace Granit.Privacy.Endpoints.Dtos;
+
+/// <summary>
+/// Response returned when a personal data export is requested (GDPR Art. 15/20).
+/// </summary>
+/// <param name="RequestId">Correlation ID for tracking the export saga.</param>
+/// <param name="RequestedAt">Timestamp when the export was requested (UTC).</param>
+public sealed record PrivacyExportRequestResponse(Guid RequestId, DateTimeOffset RequestedAt);

--- a/src/Granit.Privacy.Endpoints/Dtos/PrivacyExportStatusResponse.cs
+++ b/src/Granit.Privacy.Endpoints/Dtos/PrivacyExportStatusResponse.cs
@@ -1,0 +1,21 @@
+namespace Granit.Privacy.Endpoints.Dtos;
+
+/// <summary>
+/// Status of a personal data export request (GDPR Art. 15/20).
+/// </summary>
+/// <param name="RequestId">Correlation ID of the export saga.</param>
+/// <param name="State">Current state: Pending, Completed, PartiallyCompleted, or TimedOut.</param>
+/// <param name="RequestedAt">Timestamp when the export was requested (UTC).</param>
+/// <param name="CompletedAt">Timestamp when the export completed (UTC), or <c>null</c> if still pending.</param>
+/// <param name="ArchiveBlobReferenceId">
+/// Blob reference ID of the export archive. Use the BlobStorage download endpoint
+/// (<c>POST /api/v1/blobs/.../download-url</c>) to obtain a pre-signed URL.
+/// </param>
+/// <param name="MissingProviders">Data providers that did not respond before timeout (empty if fully completed).</param>
+public sealed record PrivacyExportStatusResponse(
+    Guid RequestId,
+    string State,
+    DateTimeOffset RequestedAt,
+    DateTimeOffset? CompletedAt,
+    string? ArchiveBlobReferenceId,
+    IReadOnlyList<string> MissingProviders);

--- a/src/Granit.Privacy.Endpoints/Dtos/PrivacyLegalDocumentResponse.cs
+++ b/src/Granit.Privacy.Endpoints/Dtos/PrivacyLegalDocumentResponse.cs
@@ -1,0 +1,9 @@
+namespace Granit.Privacy.Endpoints.Dtos;
+
+/// <summary>
+/// A legal document registered in the consent registry (GDPR Art. 7).
+/// </summary>
+/// <param name="DocumentId">Unique identifier (e.g., "privacy-policy", "terms-of-service").</param>
+/// <param name="CurrentVersion">Current version of the document (e.g., "2.1.0").</param>
+/// <param name="DisplayName">Human-readable display name (for audit reports).</param>
+public sealed record PrivacyLegalDocumentResponse(string DocumentId, string CurrentVersion, string DisplayName);

--- a/src/Granit.Privacy.Endpoints/Dtos/PrivacyUserAgreementResponse.cs
+++ b/src/Granit.Privacy.Endpoints/Dtos/PrivacyUserAgreementResponse.cs
@@ -1,0 +1,16 @@
+namespace Granit.Privacy.Endpoints.Dtos;
+
+/// <summary>
+/// A single consent record from the user's agreement history (GDPR Art. 7).
+/// </summary>
+/// <param name="Id">Unique identifier of the consent record.</param>
+/// <param name="DocumentId">Legal document identifier.</param>
+/// <param name="Version">Version of the document that was accepted.</param>
+/// <param name="AcceptedAt">Timestamp of acceptance (UTC).</param>
+/// <param name="IsLatest">Whether this acceptance matches the current document version.</param>
+public sealed record PrivacyUserAgreementResponse(
+    Guid Id,
+    string DocumentId,
+    string Version,
+    DateTimeOffset AcceptedAt,
+    bool IsLatest);

--- a/src/Granit.Privacy.Endpoints/Extensions/PrivacyEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Privacy.Endpoints/Extensions/PrivacyEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,475 @@
+using Granit.Core.Events;
+using Granit.Core.MultiTenancy;
+using Granit.Privacy.DataDeletion.Events;
+using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Events;
+using Granit.Privacy.Diagnostics;
+using Granit.Privacy.Endpoints.Dtos;
+using Granit.Privacy.Endpoints.Options;
+using Granit.Privacy.Endpoints.Permissions;
+using Granit.Privacy.LegalAgreements;
+using Granit.Privacy.LegalAgreements.Events;
+using Granit.Security;
+using Granit.Validation.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Privacy.Endpoints.Extensions;
+
+/// <summary>
+/// Extension methods for mapping GDPR privacy endpoints.
+/// </summary>
+public static class PrivacyEndpointRouteBuilderExtensions
+{
+    /// <summary>
+    /// Maps GDPR privacy endpoints under <c>/{prefix}/privacy</c>: data export (Art. 15/20),
+    /// data deletion (Art. 17), and legal agreement consent (Art. 7).
+    /// </summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="configure">Optional delegate to customize <see cref="PrivacyEndpointsOptions"/>.</param>
+    /// <returns>The route group builder for further chaining.</returns>
+    public static RouteGroupBuilder MapGranitPrivacy(
+        this IEndpointRouteBuilder endpoints,
+        Action<PrivacyEndpointsOptions>? configure = null)
+    {
+        PrivacyEndpointsOptions options = new();
+        configure?.Invoke(options);
+
+        RouteGroupBuilder group = endpoints
+            .MapGranitGroup(options.RoutePrefix)
+            .RequireAuthorization()
+            .WithTags(options.TagName);
+
+        MapExportEndpoints(group);
+        MapDeletionEndpoints(group);
+        MapAgreementEndpoints(group);
+
+        return group;
+    }
+
+    // -------------------------------------------------------------------------
+    // Export (GDPR Art. 15/20)
+    // -------------------------------------------------------------------------
+
+    private static void MapExportEndpoints(RouteGroupBuilder group)
+    {
+        group.MapPost("/export", HandleRequestExportAsync)
+             .RequireAuthorization(PrivacyPermissions.Export.Execute)
+             .WithName("RequestPrivacyExport")
+             .WithSummary("Requests a personal data export for the current user.")
+             .WithDescription(
+                 "Triggers the scatter-gather export saga (GDPR Art. 15/20). Each registered data provider "
+                 + "prepares its fragment asynchronously. The saga assembles fragments into a downloadable archive. "
+                 + "Poll GET /export/{requestId} for status, or wire a Granit.Notifications handler on "
+                 + "ExportCompletedEto to notify the user when the archive is ready. "
+                 + "Use the ArchiveBlobReferenceId with the BlobStorage download endpoint to obtain a pre-signed URL.")
+             .Produces<PrivacyExportRequestResponse>(StatusCodes.Status202Accepted);
+
+        group.MapGet("/export/{requestId:guid}", HandleGetExportStatusAsync)
+             .RequireAuthorization(PrivacyPermissions.Export.Read)
+             .WithName("GetPrivacyExportStatus")
+             .WithSummary("Returns the status of a personal data export request.")
+             .WithDescription(
+                 "Queries the export request tracker for the specified request ID. "
+                 + "Returns the current state (Pending, Completed, PartiallyCompleted, TimedOut), "
+                 + "the archive blob reference when available, and any missing providers. "
+                 + "Returns 404 if the request ID is not found.")
+             .Produces<PrivacyExportStatusResponse>()
+             .ProducesProblem(StatusCodes.Status404NotFound);
+
+        group.MapGet("/export", HandleGetMyExportsAsync)
+             .RequireAuthorization(PrivacyPermissions.Export.Read)
+             .WithName("ListPrivacyExports")
+             .WithSummary("Lists all export requests for the current user.")
+             .WithDescription(
+                 "Returns all export requests submitted by the current user, ordered by most recent first. "
+                 + "Each entry includes the request state, timestamps, and archive reference when available.")
+             .Produces<IReadOnlyList<PrivacyExportStatusResponse>>();
+    }
+
+    // -------------------------------------------------------------------------
+    // Deletion (GDPR Art. 17)
+    // -------------------------------------------------------------------------
+
+    private static void MapDeletionEndpoints(RouteGroupBuilder group)
+    {
+        group.MapPost("/deletion", HandleRequestDeletionAsync)
+             .RequireAuthorization(PrivacyPermissions.Deletion.Execute)
+             .WithName("RequestPrivacyDeletion")
+             .WithSummary("Requests personal data deletion for the current user.")
+             .WithDescription(
+                 "Publishes a distributed deletion event (GDPR Art. 17 — right to erasure). "
+                 + "Each module handles its own data: physical delete, soft delete, anonymization, "
+                 + "or retention with legal justification. The operation is asynchronous — "
+                 + "modules report completion via PersonalDataDeletedEto events.")
+             .Produces(StatusCodes.Status202Accepted)
+             .ProducesValidationProblem();
+    }
+
+    // -------------------------------------------------------------------------
+    // Legal Agreements (GDPR Art. 7)
+    // -------------------------------------------------------------------------
+
+    private static void MapAgreementEndpoints(RouteGroupBuilder group)
+    {
+        group.MapGet("/agreements/documents", HandleGetDocumentsAsync)
+             .RequireAuthorization(PrivacyPermissions.Agreements.Read)
+             .WithName("ListPrivacyLegalDocuments")
+             .WithSummary("Returns all registered legal documents.")
+             .WithDescription(
+                 "Returns all legal documents registered in the consent registry (GDPR Art. 7). "
+                 + "Each document includes its identifier, current version, and display name. "
+                 + "Use GET /agreements/status to check the user's consent per document.")
+             .Produces<IReadOnlyList<PrivacyLegalDocumentResponse>>();
+
+        group.MapGet("/agreements/status", HandleGetConsentStatusAsync)
+             .RequireAuthorization(PrivacyPermissions.Agreements.Read)
+             .WithName("GetPrivacyConsentStatus")
+             .WithSummary("Returns the consent status for all legal documents.")
+             .WithDescription(
+                 "For each registered legal document, returns whether the current user has accepted "
+                 + "the latest version and when the last acceptance occurred. "
+                 + "Documents where HasAcceptedLatest is false require re-consent.")
+             .Produces<IReadOnlyList<PrivacyConsentStatusResponse>>();
+
+        group.MapGet("/agreements/history", HandleGetAgreementHistoryAsync)
+             .RequireAuthorization(PrivacyPermissions.Agreements.Read)
+             .WithName("ListPrivacyAgreementHistory")
+             .WithSummary("Returns the consent history for the current user.")
+             .WithDescription(
+                 "Returns all consent records for the current user, ordered by most recent first. "
+                 + "Each record includes the document ID, accepted version, timestamp, and whether "
+                 + "it matches the current document version.")
+             .Produces<IReadOnlyList<PrivacyUserAgreementResponse>>();
+
+        group.MapPost("/agreements/accept", HandleAcceptAgreementAsync)
+             .RequireAuthorization(PrivacyPermissions.Agreements.Create)
+             .WithName("AcceptPrivacyAgreement")
+             .WithSummary("Records acceptance of a legal agreement.")
+             .WithDescription(
+                 "Records the user's consent for a specific legal document version (GDPR Art. 7). "
+                 + "The version must match the current version — stale consent is rejected (422). "
+                 + "If the user has already accepted the latest version, returns 409. "
+                 + "The client IP address is captured and pseudonymized for the audit trail. "
+                 + "Ensure ForwardedHeadersMiddleware is enabled when running behind a reverse proxy.")
+             .Produces(StatusCodes.Status201Created)
+             .ProducesProblem(StatusCodes.Status404NotFound)
+             .ProducesProblem(StatusCodes.Status409Conflict)
+             .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+             .ProducesValidationProblem();
+    }
+
+    // -------------------------------------------------------------------------
+    // Export handlers
+    // -------------------------------------------------------------------------
+
+    private static async Task<Results<Accepted<PrivacyExportRequestResponse>, ProblemHttpResult>> HandleRequestExportAsync(
+        [FromServices] ICurrentUserService currentUser,
+        [FromServices] IDistributedEventBus eventBus,
+        [FromServices] IExportRequestTrackerWriter tracker,
+        [FromServices] PrivacyMetrics metrics,
+        [FromServices] TimeProvider timeProvider,
+        [FromServices] ICurrentTenant currentTenant,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetUserId(currentUser, out Guid userId))
+        {
+            return UserNotAuthenticated();
+        }
+
+        var requestId = Guid.CreateVersion7();
+        DateTimeOffset now = timeProvider.GetUtcNow();
+        string? tenantId = ResolveTenantId(currentTenant);
+
+        await tracker
+            .RecordRequestAsync(requestId, userId, now, cancellationToken)
+            .ConfigureAwait(false);
+
+        await eventBus
+            .PublishAsync(new PersonalDataRequestedEto(requestId, userId, now), cancellationToken)
+            .ConfigureAwait(false);
+
+        metrics.RecordExportRequested(tenantId);
+
+        return TypedResults.Accepted(
+            $"/privacy/export/{requestId}",
+            new PrivacyExportRequestResponse(requestId, now));
+    }
+
+    private static async Task<Results<Ok<PrivacyExportStatusResponse>, ProblemHttpResult>> HandleGetExportStatusAsync(
+        Guid requestId,
+        [FromServices] IExportRequestTrackerReader tracker,
+        CancellationToken cancellationToken)
+    {
+        ExportRequestStatus? status = await tracker
+            .GetStatusAsync(requestId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (status is null)
+        {
+            return TypedResults.Problem(
+                detail: $"Export request '{requestId}' not found.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        return TypedResults.Ok(MapExportStatus(status));
+    }
+
+    private static async Task<Results<Ok<IReadOnlyList<PrivacyExportStatusResponse>>, ProblemHttpResult>> HandleGetMyExportsAsync(
+        [FromServices] ICurrentUserService currentUser,
+        [FromServices] IExportRequestTrackerReader tracker,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetUserId(currentUser, out Guid userId))
+        {
+            return UserNotAuthenticated();
+        }
+
+        IReadOnlyList<ExportRequestStatus> statuses = await tracker
+            .GetByUserAsync(userId, cancellationToken)
+            .ConfigureAwait(false);
+
+        IReadOnlyList<PrivacyExportStatusResponse> result = statuses
+            .Select(MapExportStatus)
+            .ToList();
+
+        return TypedResults.Ok(result);
+    }
+
+    // -------------------------------------------------------------------------
+    // Deletion handlers
+    // -------------------------------------------------------------------------
+
+    private static async Task<Results<Accepted, ProblemHttpResult>> HandleRequestDeletionAsync(
+        PrivacyDeletionRequest body,
+        [FromServices] ICurrentUserService currentUser,
+        [FromServices] IDistributedEventBus eventBus,
+        [FromServices] PrivacyMetrics metrics,
+        [FromServices] TimeProvider timeProvider,
+        [FromServices] ICurrentTenant currentTenant,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetUserId(currentUser, out Guid userId))
+        {
+            return UserNotAuthenticated();
+        }
+
+        var requestId = Guid.CreateVersion7();
+        DateTimeOffset now = timeProvider.GetUtcNow();
+        string? tenantId = ResolveTenantId(currentTenant);
+
+        await eventBus
+            .PublishAsync(
+                new PersonalDataDeletionRequestedEto(
+                    requestId,
+                    userId,
+                    currentUser.Email ?? "unknown",
+                    now,
+                    body.Reason),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        metrics.RecordDeletionRequested(tenantId);
+
+        return TypedResults.Accepted((string?)null);
+    }
+
+    // -------------------------------------------------------------------------
+    // Agreement handlers
+    // -------------------------------------------------------------------------
+
+    private static Ok<IReadOnlyList<PrivacyLegalDocumentResponse>> HandleGetDocumentsAsync(
+        [FromServices] ILegalDocumentRegistry registry)
+    {
+        IReadOnlyList<PrivacyLegalDocumentResponse> result = registry
+            .GetAll()
+            .Select(d => new PrivacyLegalDocumentResponse(d.DocumentId, d.CurrentVersion, d.DisplayName))
+            .ToList();
+
+        return TypedResults.Ok(result);
+    }
+
+    private static async Task<Results<Ok<IReadOnlyList<PrivacyConsentStatusResponse>>, ProblemHttpResult>> HandleGetConsentStatusAsync(
+        [FromServices] ICurrentUserService currentUser,
+        [FromServices] ILegalDocumentRegistry registry,
+        [FromServices] ILegalAgreementChecker checker,
+        [FromServices] ILegalAgreementStoreReader storeReader,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetUserId(currentUser, out Guid userId))
+        {
+            return UserNotAuthenticated();
+        }
+
+        IReadOnlyList<LegalDocumentDefinition> documents = registry.GetAll();
+        List<PrivacyConsentStatusResponse> result = new(documents.Count);
+
+        foreach (LegalDocumentDefinition doc in documents)
+        {
+            bool hasAccepted = await checker
+                .HasAcceptedLatestAsync(userId, doc.DocumentId, cancellationToken)
+                .ConfigureAwait(false);
+
+            LegalAgreements.Domain.LegalAgreementBase? latest = await storeReader
+                .FindLatestAsync(userId, doc.DocumentId, cancellationToken)
+                .ConfigureAwait(false);
+
+            result.Add(new PrivacyConsentStatusResponse(
+                doc.DocumentId,
+                doc.CurrentVersion,
+                hasAccepted,
+                latest?.AcceptedAt));
+        }
+
+        return TypedResults.Ok<IReadOnlyList<PrivacyConsentStatusResponse>>(result);
+    }
+
+    private static async Task<Results<Ok<IReadOnlyList<PrivacyUserAgreementResponse>>, ProblemHttpResult>> HandleGetAgreementHistoryAsync(
+        [FromServices] ICurrentUserService currentUser,
+        [FromServices] ILegalAgreementChecker checker,
+        [FromServices] ILegalDocumentRegistry registry,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetUserId(currentUser, out Guid userId))
+        {
+            return UserNotAuthenticated();
+        }
+
+        IReadOnlyList<LegalAgreements.Domain.LegalAgreementBase> agreements = await checker
+            .GetUserAgreementsAsync(userId, cancellationToken)
+            .ConfigureAwait(false);
+
+        IReadOnlyList<PrivacyUserAgreementResponse> result = agreements
+            .Select(a => new PrivacyUserAgreementResponse(
+                a.Id,
+                a.DocumentId,
+                a.Version,
+                a.AcceptedAt,
+                registry.GetDefinition(a.DocumentId)?.CurrentVersion == a.Version))
+            .ToList();
+
+        return TypedResults.Ok(result);
+    }
+
+    private static async Task<Results<Created, ProblemHttpResult>> HandleAcceptAgreementAsync(
+        PrivacyAcceptAgreementRequest body,
+        HttpContext httpContext,
+        [FromServices] ICurrentUserService currentUser,
+        [FromServices] ILegalDocumentRegistry registry,
+        [FromServices] ILegalAgreementChecker checker,
+        [FromServices] ILegalAgreementStoreWriter storeWriter,
+        [FromServices] IDistributedEventBus eventBus,
+        [FromServices] TimeProvider timeProvider,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetUserId(currentUser, out Guid userId))
+        {
+            return UserNotAuthenticated();
+        }
+
+        LegalDocumentDefinition? document = registry.GetDefinition(body.DocumentId);
+        if (document is null)
+        {
+            return TypedResults.Problem(
+                detail: $"Legal document '{body.DocumentId}' is not registered.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        if (!string.Equals(body.Version, document.CurrentVersion, StringComparison.Ordinal))
+        {
+            return TypedResults.Problem(
+                detail: $"Version mismatch: expected '{document.CurrentVersion}', got '{body.Version}'. The user must accept the latest version.",
+                statusCode: StatusCodes.Status422UnprocessableEntity);
+        }
+
+        bool alreadyAccepted = await checker
+            .HasAcceptedLatestAsync(userId, body.DocumentId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (alreadyAccepted)
+        {
+            return TypedResults.Problem(
+                detail: $"User has already accepted version '{body.Version}' of document '{body.DocumentId}'.",
+                statusCode: StatusCodes.Status409Conflict);
+        }
+
+        DateTimeOffset now = timeProvider.GetUtcNow();
+        string? ipAddress = PseudonymizeIpAddress(httpContext.Connection.RemoteIpAddress?.ToString());
+
+        await storeWriter
+            .RecordConsentAsync(userId, body.DocumentId, body.Version, ipAddress, now, cancellationToken)
+            .ConfigureAwait(false);
+
+        await eventBus
+            .PublishAsync(
+                new LegalAgreementAcceptedEto(userId, body.DocumentId, body.Version, now),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return TypedResults.Created((string?)null);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static bool TryGetUserId(ICurrentUserService currentUser, out Guid userId)
+    {
+        userId = default;
+
+        if (!currentUser.IsAuthenticated || currentUser.UserId is null)
+        {
+            return false;
+        }
+
+        return Guid.TryParse(currentUser.UserId, out userId);
+    }
+
+    private static ProblemHttpResult UserNotAuthenticated() =>
+        TypedResults.Problem(
+            detail: "User is not authenticated or has no valid user ID.",
+            statusCode: StatusCodes.Status401Unauthorized);
+
+    private static string? ResolveTenantId(ICurrentTenant currentTenant) =>
+        currentTenant.IsAvailable ? currentTenant.Id?.ToString() : null;
+
+    private static PrivacyExportStatusResponse MapExportStatus(ExportRequestStatus status) =>
+        new(
+            status.RequestId,
+            status.State.ToString(),
+            status.RequestedAt,
+            status.CompletedAt,
+            status.ArchiveBlobReferenceId,
+            status.MissingProviders);
+
+    /// <summary>
+    /// Pseudonymizes an IP address by masking the last octet (IPv4) or last group (IPv6).
+    /// GDPR requires data minimization — the full IP is not stored.
+    /// </summary>
+    internal static string? PseudonymizeIpAddress(string? ipAddress)
+    {
+        if (string.IsNullOrEmpty(ipAddress))
+        {
+            return null;
+        }
+
+        // IPv4: replace last octet with 0
+        int lastDot = ipAddress.LastIndexOf('.');
+        if (lastDot > 0)
+        {
+            return $"{ipAddress[..lastDot]}.0";
+        }
+
+        // IPv6: replace last group with 0
+        int lastColon = ipAddress.LastIndexOf(':');
+        if (lastColon > 0)
+        {
+            return $"{ipAddress[..lastColon]}:0";
+        }
+
+        return null;
+    }
+}

--- a/src/Granit.Privacy.Endpoints/Granit.Privacy.Endpoints.csproj
+++ b/src/Granit.Privacy.Endpoints/Granit.Privacy.Endpoints.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Granit.Privacy.Endpoints</PackageId>
+    <Description>Minimal API endpoints for GDPR data subject rights: personal data export (Art. 15/20), data deletion (Art. 17), and legal agreement consent management (Art. 7). Backed by Granit.Privacy scatter-gather saga, deletion orchestration, and consent versioning.</Description>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Granit.Privacy.Endpoints.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
+    <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
+    <ProjectReference Include="..\Granit.Privacy\Granit.Privacy.csproj" />
+    <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Localization\**\*.json" />
+  </ItemGroup>
+
+</Project>

--- a/src/Granit.Privacy.Endpoints/GranitPrivacyEndpointsModule.cs
+++ b/src/Granit.Privacy.Endpoints/GranitPrivacyEndpointsModule.cs
@@ -1,0 +1,30 @@
+using Granit.Authorization;
+using Granit.Core.Modularity;
+using Granit.Http.ApiDocumentation;
+using Granit.Validation;
+
+namespace Granit.Privacy.Endpoints;
+
+/// <summary>
+/// Granit module for GDPR privacy endpoints: personal data export (Art. 15/20),
+/// data deletion (Art. 17), and legal agreement consent management (Art. 7).
+/// </summary>
+/// <remarks>
+/// <para>Exposes three endpoint groups via <see cref="Extensions.PrivacyEndpointRouteBuilderExtensions.MapGranitPrivacy"/>:</para>
+/// <list type="bullet">
+/// <item>Export — triggers the scatter-gather saga and reports export status.</item>
+/// <item>Deletion — publishes the distributed deletion event.</item>
+/// <item>Agreements — lists legal documents, records consent, checks user status.</item>
+/// </list>
+/// <para>
+/// <b>Reverse proxy note:</b> The consent acceptance endpoint reads the client IP address
+/// from <c>HttpContext.Connection.RemoteIpAddress</c> for the GDPR Art. 7 audit trail.
+/// Ensure <c>ForwardedHeadersMiddleware</c> is enabled when running behind a reverse proxy.
+/// </para>
+/// </remarks>
+[DependsOn(
+    typeof(GranitAuthorizationModule),
+    typeof(GranitHttpApiDocumentationModule),
+    typeof(GranitPrivacyModule),
+    typeof(GranitValidationModule))]
+public sealed class GranitPrivacyEndpointsModule : GranitModule;

--- a/src/Granit.Privacy.Endpoints/Internal/PrivacyEndpointsLocalizationResource.cs
+++ b/src/Granit.Privacy.Endpoints/Internal/PrivacyEndpointsLocalizationResource.cs
@@ -1,0 +1,11 @@
+using Granit.Core.Localization;
+
+namespace Granit.Privacy.Endpoints.Internal;
+
+/// <summary>
+/// Marker class for the <c>PrivacyEndpoints</c> localization resource.
+/// JSON files: <c>Localization/PrivacyEndpoints/{culture}.json</c>, embedded in this assembly.
+/// Auto-discovered by <see cref="LocalizationResourceNameAttribute"/>.
+/// </summary>
+[LocalizationResourceName("PrivacyEndpoints")]
+internal sealed class PrivacyEndpointsLocalizationResource;

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/cs.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/cs.json
@@ -1,0 +1,11 @@
+{
+  "culture": "cs",
+  "texts": {
+    "PermissionGroup:Privacy": "Soukromí (GDPR)",
+    "Permission:Privacy.Export.Execute": "Požádat o export osobních údajů",
+    "Permission:Privacy.Export.Read": "Zobrazit stav exportu osobních údajů",
+    "Permission:Privacy.Deletion.Execute": "Požádat o smazání osobních údajů",
+    "Permission:Privacy.Agreements.Read": "Zobrazit právní dokumenty a stav souhlasu",
+    "Permission:Privacy.Agreements.Create": "Přijmout právní smlouvu"
+  }
+}

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/de.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/de.json
@@ -1,0 +1,11 @@
+{
+  "culture": "de",
+  "texts": {
+    "PermissionGroup:Privacy": "Datenschutz (DSGVO)",
+    "Permission:Privacy.Export.Execute": "Export personenbezogener Daten anfordern",
+    "Permission:Privacy.Export.Read": "Status des Datenexports anzeigen",
+    "Permission:Privacy.Deletion.Execute": "Löschung personenbezogener Daten anfordern",
+    "Permission:Privacy.Agreements.Read": "Rechtliche Dokumente und Einwilligungsstatus anzeigen",
+    "Permission:Privacy.Agreements.Create": "Einer rechtlichen Vereinbarung zustimmen"
+  }
+}

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/en-GB.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/en-GB.json
@@ -1,0 +1,4 @@
+{
+  "culture": "en-GB",
+  "texts": {}
+}

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/en.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/en.json
@@ -1,0 +1,11 @@
+{
+  "culture": "en",
+  "texts": {
+    "PermissionGroup:Privacy": "Privacy (GDPR)",
+    "Permission:Privacy.Export.Execute": "Request personal data export",
+    "Permission:Privacy.Export.Read": "View personal data export status",
+    "Permission:Privacy.Deletion.Execute": "Request personal data deletion",
+    "Permission:Privacy.Agreements.Read": "View legal documents and consent status",
+    "Permission:Privacy.Agreements.Create": "Accept a legal agreement"
+  }
+}

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/es.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/es.json
@@ -1,0 +1,11 @@
+{
+  "culture": "es",
+  "texts": {
+    "PermissionGroup:Privacy": "Privacidad (RGPD)",
+    "Permission:Privacy.Export.Execute": "Solicitar exportación de datos personales",
+    "Permission:Privacy.Export.Read": "Ver estado de exportación de datos personales",
+    "Permission:Privacy.Deletion.Execute": "Solicitar eliminación de datos personales",
+    "Permission:Privacy.Agreements.Read": "Ver documentos legales y estado de consentimiento",
+    "Permission:Privacy.Agreements.Create": "Aceptar un acuerdo legal"
+  }
+}

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/fr-CA.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/fr-CA.json
@@ -1,0 +1,4 @@
+{
+  "culture": "fr-CA",
+  "texts": {}
+}

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/fr.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/fr.json
@@ -1,0 +1,11 @@
+{
+  "culture": "fr",
+  "texts": {
+    "PermissionGroup:Privacy": "Confidentialité (RGPD)",
+    "Permission:Privacy.Export.Execute": "Demander l'export des données personnelles",
+    "Permission:Privacy.Export.Read": "Consulter le statut des exports de données",
+    "Permission:Privacy.Deletion.Execute": "Demander la suppression des données personnelles",
+    "Permission:Privacy.Agreements.Read": "Consulter les documents légaux et le statut de consentement",
+    "Permission:Privacy.Agreements.Create": "Accepter un accord légal"
+  }
+}

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/it.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/it.json
@@ -1,0 +1,11 @@
+{
+  "culture": "it",
+  "texts": {
+    "PermissionGroup:Privacy": "Privacy (GDPR)",
+    "Permission:Privacy.Export.Execute": "Richiedere l'esportazione dei dati personali",
+    "Permission:Privacy.Export.Read": "Visualizzare lo stato dell'esportazione dei dati",
+    "Permission:Privacy.Deletion.Execute": "Richiedere la cancellazione dei dati personali",
+    "Permission:Privacy.Agreements.Read": "Visualizzare documenti legali e stato del consenso",
+    "Permission:Privacy.Agreements.Create": "Accettare un accordo legale"
+  }
+}

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/ja.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/ja.json
@@ -1,0 +1,11 @@
+{
+  "culture": "ja",
+  "texts": {
+    "PermissionGroup:Privacy": "プライバシー (GDPR)",
+    "Permission:Privacy.Export.Execute": "個人データのエクスポートを要求",
+    "Permission:Privacy.Export.Read": "個人データエクスポートのステータスを表示",
+    "Permission:Privacy.Deletion.Execute": "個人データの削除を要求",
+    "Permission:Privacy.Agreements.Read": "法的文書と同意ステータスを表示",
+    "Permission:Privacy.Agreements.Create": "法的合意に同意"
+  }
+}

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/ko.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/ko.json
@@ -1,0 +1,11 @@
+{
+  "culture": "ko",
+  "texts": {
+    "PermissionGroup:Privacy": "개인정보 (GDPR)",
+    "Permission:Privacy.Export.Execute": "개인 데이터 내보내기 요청",
+    "Permission:Privacy.Export.Read": "개인 데이터 내보내기 상태 조회",
+    "Permission:Privacy.Deletion.Execute": "개인 데이터 삭제 요청",
+    "Permission:Privacy.Agreements.Read": "법적 문서 및 동의 상태 조회",
+    "Permission:Privacy.Agreements.Create": "법적 계약 수락"
+  }
+}

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/nl.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/nl.json
@@ -1,0 +1,11 @@
+{
+  "culture": "nl",
+  "texts": {
+    "PermissionGroup:Privacy": "Privacy (AVG)",
+    "Permission:Privacy.Export.Execute": "Export van persoonsgegevens aanvragen",
+    "Permission:Privacy.Export.Read": "Status van persoonsgegevensexport bekijken",
+    "Permission:Privacy.Deletion.Execute": "Verwijdering van persoonsgegevens aanvragen",
+    "Permission:Privacy.Agreements.Read": "Juridische documenten en toestemmingsstatus bekijken",
+    "Permission:Privacy.Agreements.Create": "Een juridische overeenkomst accepteren"
+  }
+}

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pl.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pl.json
@@ -1,0 +1,11 @@
+{
+  "culture": "pl",
+  "texts": {
+    "PermissionGroup:Privacy": "Prywatność (RODO)",
+    "Permission:Privacy.Export.Execute": "Żądanie eksportu danych osobowych",
+    "Permission:Privacy.Export.Read": "Wyświetlanie statusu eksportu danych osobowych",
+    "Permission:Privacy.Deletion.Execute": "Żądanie usunięcia danych osobowych",
+    "Permission:Privacy.Agreements.Read": "Wyświetlanie dokumentów prawnych i statusu zgody",
+    "Permission:Privacy.Agreements.Create": "Zaakceptowanie umowy prawnej"
+  }
+}

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pt-BR.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pt-BR.json
@@ -1,0 +1,4 @@
+{
+  "culture": "pt-BR",
+  "texts": {}
+}

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pt.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/pt.json
@@ -1,0 +1,11 @@
+{
+  "culture": "pt",
+  "texts": {
+    "PermissionGroup:Privacy": "Privacidade (RGPD)",
+    "Permission:Privacy.Export.Execute": "Solicitar exportação de dados pessoais",
+    "Permission:Privacy.Export.Read": "Ver estado da exportação de dados pessoais",
+    "Permission:Privacy.Deletion.Execute": "Solicitar eliminação de dados pessoais",
+    "Permission:Privacy.Agreements.Read": "Ver documentos legais e estado de consentimento",
+    "Permission:Privacy.Agreements.Create": "Aceitar um acordo legal"
+  }
+}

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/sv.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/sv.json
@@ -1,0 +1,11 @@
+{
+  "culture": "sv",
+  "texts": {
+    "PermissionGroup:Privacy": "Integritet (GDPR)",
+    "Permission:Privacy.Export.Execute": "Begär export av personuppgifter",
+    "Permission:Privacy.Export.Read": "Visa status för export av personuppgifter",
+    "Permission:Privacy.Deletion.Execute": "Begär radering av personuppgifter",
+    "Permission:Privacy.Agreements.Read": "Visa juridiska dokument och samtycksstatus",
+    "Permission:Privacy.Agreements.Create": "Acceptera ett juridiskt avtal"
+  }
+}

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/tr.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/tr.json
@@ -1,0 +1,11 @@
+{
+  "culture": "tr",
+  "texts": {
+    "PermissionGroup:Privacy": "Gizlilik (KVKK)",
+    "Permission:Privacy.Export.Execute": "Kişisel veri dışa aktarımı talep et",
+    "Permission:Privacy.Export.Read": "Kişisel veri dışa aktarım durumunu görüntüle",
+    "Permission:Privacy.Deletion.Execute": "Kişisel veri silme talep et",
+    "Permission:Privacy.Agreements.Read": "Yasal belgeleri ve onay durumunu görüntüle",
+    "Permission:Privacy.Agreements.Create": "Yasal sözleşmeyi kabul et"
+  }
+}

--- a/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/zh.json
+++ b/src/Granit.Privacy.Endpoints/Localization/PrivacyEndpoints/zh.json
@@ -1,0 +1,11 @@
+{
+  "culture": "zh",
+  "texts": {
+    "PermissionGroup:Privacy": "隐私 (GDPR)",
+    "Permission:Privacy.Export.Execute": "请求导出个人数据",
+    "Permission:Privacy.Export.Read": "查看个人数据导出状态",
+    "Permission:Privacy.Deletion.Execute": "请求删除个人数据",
+    "Permission:Privacy.Agreements.Read": "查看法律文件和同意状态",
+    "Permission:Privacy.Agreements.Create": "接受法律协议"
+  }
+}

--- a/src/Granit.Privacy.Endpoints/Options/PrivacyEndpointsOptions.cs
+++ b/src/Granit.Privacy.Endpoints/Options/PrivacyEndpointsOptions.cs
@@ -1,0 +1,19 @@
+namespace Granit.Privacy.Endpoints.Options;
+
+/// <summary>
+/// Configuration options for the privacy GDPR endpoints.
+/// </summary>
+public sealed class PrivacyEndpointsOptions
+{
+    /// <summary>
+    /// Route prefix for all privacy endpoints.
+    /// Default: <c>"privacy"</c>.
+    /// </summary>
+    public string RoutePrefix { get; set; } = "privacy";
+
+    /// <summary>
+    /// OpenAPI tag name for grouping privacy endpoints.
+    /// Default: <c>"Privacy"</c>.
+    /// </summary>
+    public string TagName { get; set; } = "Privacy";
+}

--- a/src/Granit.Privacy.Endpoints/Permissions/PrivacyPermissionDefinitionProvider.cs
+++ b/src/Granit.Privacy.Endpoints/Permissions/PrivacyPermissionDefinitionProvider.cs
@@ -1,0 +1,46 @@
+using Granit.Authorization.Abstractions;
+using Granit.Core.Localization;
+using Granit.Privacy.Endpoints.Internal;
+
+namespace Granit.Privacy.Endpoints.Permissions;
+
+/// <summary>
+/// Declares the <c>Privacy.*.*</c> permissions in the Granit RBAC system.
+/// Auto-discovered by <c>GranitAuthorizationModule</c> — no manual registration needed.
+/// </summary>
+internal sealed class PrivacyPermissionDefinitionProvider : IPermissionDefinitionProvider
+{
+    /// <inheritdoc />
+    public void DefinePermissions(IPermissionDefinitionContext context)
+    {
+        PermissionGroup group = context.AddGroup(
+            PrivacyPermissions.GroupName,
+            LocalizableString.Create<PrivacyEndpointsLocalizationResource>(
+                "PermissionGroup:Privacy"));
+
+        group.AddPermission(
+            PrivacyPermissions.Export.Execute,
+            LocalizableString.Create<PrivacyEndpointsLocalizationResource>(
+                "Permission:Privacy.Export.Execute"));
+
+        group.AddPermission(
+            PrivacyPermissions.Export.Read,
+            LocalizableString.Create<PrivacyEndpointsLocalizationResource>(
+                "Permission:Privacy.Export.Read"));
+
+        group.AddPermission(
+            PrivacyPermissions.Deletion.Execute,
+            LocalizableString.Create<PrivacyEndpointsLocalizationResource>(
+                "Permission:Privacy.Deletion.Execute"));
+
+        group.AddPermission(
+            PrivacyPermissions.Agreements.Read,
+            LocalizableString.Create<PrivacyEndpointsLocalizationResource>(
+                "Permission:Privacy.Agreements.Read"));
+
+        group.AddPermission(
+            PrivacyPermissions.Agreements.Create,
+            LocalizableString.Create<PrivacyEndpointsLocalizationResource>(
+                "Permission:Privacy.Agreements.Create"));
+    }
+}

--- a/src/Granit.Privacy.Endpoints/Permissions/PrivacyPermissions.cs
+++ b/src/Granit.Privacy.Endpoints/Permissions/PrivacyPermissions.cs
@@ -1,0 +1,38 @@
+namespace Granit.Privacy.Endpoints.Permissions;
+
+/// <summary>
+/// Permission constants for GDPR privacy endpoints.
+/// Format: <c>{Group}.{Resource}.{Action}</c> (three dot-separated segments).
+/// </summary>
+public static class PrivacyPermissions
+{
+    /// <summary>Permission group name.</summary>
+    public const string GroupName = "Privacy";
+
+    /// <summary>Permissions for personal data export (GDPR Art. 15/20).</summary>
+    public static class Export
+    {
+        /// <summary>Request a personal data export.</summary>
+        public const string Execute = "Privacy.Export.Execute";
+
+        /// <summary>View export request status and history.</summary>
+        public const string Read = "Privacy.Export.Read";
+    }
+
+    /// <summary>Permissions for personal data deletion (GDPR Art. 17).</summary>
+    public static class Deletion
+    {
+        /// <summary>Request personal data erasure.</summary>
+        public const string Execute = "Privacy.Deletion.Execute";
+    }
+
+    /// <summary>Permissions for legal agreement consent management (GDPR Art. 7).</summary>
+    public static class Agreements
+    {
+        /// <summary>View legal documents and consent status.</summary>
+        public const string Read = "Privacy.Agreements.Read";
+
+        /// <summary>Accept a legal agreement.</summary>
+        public const string Create = "Privacy.Agreements.Create";
+    }
+}

--- a/src/Granit.Privacy.Endpoints/README.md
+++ b/src/Granit.Privacy.Endpoints/README.md
@@ -1,0 +1,22 @@
+# Granit.Privacy.Endpoints
+
+Minimal API endpoints for GDPR data subject rights: personal data export (Art. 15/20), data deletion (Art. 17), and legal agreement consent management (Art. 7). Backed by Granit.Privacy scatter-gather saga, deletion orchestration, and consent versioning.
+
+Part of the [granit](https://granit-fx.dev) framework.
+
+## Installation
+
+```bash
+dotnet add package Granit.Privacy.Endpoints
+```
+
+## Dependencies
+
+- `Granit.Authorization`
+- `Granit.Http.ApiDocumentation`
+- `Granit.Privacy`
+- `Granit.Validation`
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev).

--- a/src/Granit.Privacy.Endpoints/Validators/PrivacyAcceptAgreementRequestValidator.cs
+++ b/src/Granit.Privacy.Endpoints/Validators/PrivacyAcceptAgreementRequestValidator.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+using Granit.Privacy.Endpoints.Dtos;
+
+namespace Granit.Privacy.Endpoints.Validators;
+
+/// <summary>
+/// Validator for <see cref="PrivacyAcceptAgreementRequest"/>.
+/// </summary>
+internal sealed class PrivacyAcceptAgreementRequestValidator : AbstractValidator<PrivacyAcceptAgreementRequest>
+{
+    public PrivacyAcceptAgreementRequestValidator()
+    {
+        RuleFor(x => x.DocumentId)
+            .NotEmpty()
+            .MaximumLength(200);
+
+        RuleFor(x => x.Version)
+            .NotEmpty()
+            .MaximumLength(50);
+    }
+}

--- a/src/Granit.Privacy.Endpoints/Validators/PrivacyDeletionRequestValidator.cs
+++ b/src/Granit.Privacy.Endpoints/Validators/PrivacyDeletionRequestValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using Granit.Privacy.Endpoints.Dtos;
+
+namespace Granit.Privacy.Endpoints.Validators;
+
+/// <summary>
+/// Validator for <see cref="PrivacyDeletionRequest"/>.
+/// </summary>
+internal sealed class PrivacyDeletionRequestValidator : AbstractValidator<PrivacyDeletionRequest>
+{
+    public PrivacyDeletionRequestValidator()
+    {
+        RuleFor(x => x.Reason)
+            .NotEmpty()
+            .MaximumLength(2000);
+    }
+}

--- a/src/Granit.Privacy.Endpoints/packages.lock.json
+++ b/src/Granit.Privacy.Endpoints/packages.lock.json
@@ -1,0 +1,455 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Asp.Versioning.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "I4CuGwl0nO98j6Ft6XlGBgzj1+goE/TSVlnHKgtRkuMZ0K4gy9I+Wyrtto8dyt0hWcFMDFAZ4lYNr58DSemH1g=="
+      },
+      "Asp.Versioning.Http": {
+        "type": "Transitive",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "4/QzujOrkGn9sMch3eHhR5LpVJ4Xo5T2BNg7U1/r4YwEa8JywzkoGQHjW7Nk0W8ljETnpoJaO5mrTsfEOnJK3A==",
+        "dependencies": {
+          "Asp.Versioning.Abstractions": "10.0.0-preview.2"
+        }
+      },
+      "FastExpressionCompiler": {
+        "type": "Transitive",
+        "resolved": "5.3.0",
+        "contentHash": "XRmGW48Gdm7B70WUtTJJUnmuc8jRDmOhhjG/a3rix/nXChnrkETaSvA0j2VrcsH4MNeYLe60LA5o5JABmbneag=="
+      },
+      "Humanizer.Core": {
+        "type": "Transitive",
+        "resolved": "2.14.1",
+        "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
+      },
+      "ImTools": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "dms0JfLKC9AQbQX/EdpRjn59EjEvaCxIgv1z9YxbEQb5SiOVoo7vlIKdEySeEwUkWhN05rZnNpUpG+aw5VqPVQ=="
+      },
+      "JasperFx": {
+        "type": "Transitive",
+        "resolved": "1.21.1",
+        "contentHash": "oEswL6IWlSsSw+3vylT1fh+aZhiG1LVv/fJxC+E7dtxw80M8jW1cbSh2QaXDMyvYsxWrlwkA8TvCYPuvN5NMVA==",
+        "dependencies": {
+          "FastExpressionCompiler": "5.3.0",
+          "ImTools": "4.0.0",
+          "Microsoft.Bcl.TimeProvider": "10.0.0",
+          "Polly.Core": "8.6.5",
+          "Spectre.Console": "0.53.0"
+        }
+      },
+      "JasperFx.Events": {
+        "type": "Transitive",
+        "resolved": "1.24.0",
+        "contentHash": "vDkYMarrBqHSqoLBlpQfePz5FdVK/3LyFoBVRCzaWKeS/jxwUQG4fckHu30ozwZId1DulkHKcNjYziO5oyG08Q==",
+        "dependencies": {
+          "JasperFx": "1.21.1"
+        }
+      },
+      "JasperFx.RuntimeCompiler": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "n5dOtQlytGsCfpRyOGDw/qHaqPDd2GcR7pgO53bQto1T82/VZjQdzkfuLQt8vUMY6D+m1TgqUjqedNFDT1+rEQ==",
+        "dependencies": {
+          "JasperFx": "1.18.0",
+          "Microsoft.CodeAnalysis": "5.0.0",
+          "Microsoft.CodeAnalysis.CSharp": "5.0.0",
+          "Microsoft.CodeAnalysis.Scripting": "5.0.0"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "bUubrBD6tRJE3V1kvRloYc6NymH3R5oFKjAS9e0ELNx6u0ZR+zjps9dDQyjgqN/rArzl7f+21KGszj3YRN7F2Q=="
+      },
+      "Microsoft.CodeAnalysis": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "X7vItpZDkGm4NS2wp4P1S07Z1e61LaBWDW5tPXE1c6z5/x9KbF2RymhAPoYg7Qoiyk7odEZ6EjBEJ47p3dBpYQ==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[5.0.0]",
+          "Microsoft.CodeAnalysis.VisualBasic.Workspaces": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Scripting": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "1sGloRYbG3743ut/+vuXy9/WaRQTm7mDtp71rBaVSmKpFntvo5Hcro1ubg6/3SeeLtiFYJl7V3Dk0Fo3CGlnHA==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Scripting.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.Scripting": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "/KgZdm6kRTrR/O2jqXxU5GWREYhtVmqcNWczyPt8hsQkFGFK/C6CrLWfG44FCUn0aPHGDRBHYjXlGosQ/H8oXw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp.Scripting": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.Scripting.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "XTulByMNxqXGCgMeODUoG2h4oK4/nLv1BcawRVcjv+UZHMpoaymtdaq3cJqlNrEvYEcbU48g5swJ3RhY1m3fBg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "sUBWvHs2HgHGA+b716dgjS7JiXGen5ntyohAurPLR1ZiZzFp3FlnVA7GrMTqVGdVJTVqiC3c4K8k1bk0gj6IPg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic.Workspaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Nom4UuZVEZGaV6Qa+joJR/BawXZMtflvQJFKc0SaUc3LrZr/8LmRY5cn8mbvLOWIVfwWkQz+cVE6eQKu9qa65g==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.VisualBasic": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZbUmIvT6lqTNKiv06Jl5wf0MTMi1vQ1oH7ou4CLcs2C/no/L7EhP3T8y3XXvn9VbqMcJaJnEsNA1jwYUMgc5jg==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.OpenApi": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
+      },
+      "NewId": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "jegBasNndmG21G3BmT51suFDCIz/sLN81j+IxmkZ4iWoaDi8LygeHiyNnYbXz5OQh9nCRJFIx1+PJrlYi1Gc9Q=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.6.5",
+        "contentHash": "t+sUVrIwvo7UmsgHGgOG9F0GDZSRIm47u2ylH17Gvcv1q5hNEwgD5GoBlFyc0kh/pebmPyrAgvGsR/65ZBaXlg=="
+      },
+      "Spectre.Console": {
+        "type": "Transitive",
+        "resolved": "0.53.0",
+        "contentHash": "m2iv8Egfywp7FaNLKCmCFHbSf36D4ctzZKvlAK9NXMyGLh6L+CnrZWK8o+LOYsoAS1jtoHn0W1BT0W8vuq/FUw=="
+      },
+      "System.Composition": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "3Djj70fFTraOarSKmRnmRy/zm4YurICm+kiCtI0dYRqGJnLX6nJ+G3WYuFJ173cAPax/gh96REcbNiVqcrypFQ==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Convention": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0",
+          "System.Composition.TypedParts": "9.0.0"
+        }
+      },
+      "System.Composition.Convention": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "+vuqVP6xpi582XIjJi6OCsIxuoTZfR0M7WWufk3uGDeCl3wGW6KnpylUJ3iiXdPByPE0vR5TjJgR6hDLez4FQg==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0"
+        }
+      },
+      "System.Composition.Hosting": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "OFqSeFeJYr7kHxDfaViGM1ymk7d4JxK//VSoNF9Ux0gpqkLsauDZpu89kTHHNdCWfSljbFcvAafGyBoY094btQ==",
+        "dependencies": {
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Composition.Runtime": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "w1HOlQY1zsOWYussjFGZCEYF2UZXgvoYnS94NIu2CBnAGMbXFAX8PY8c92KwUItPmowal68jnVLBCzdrWLeEKA=="
+      },
+      "System.Composition.TypedParts": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "aRZlojCCGEHDKqh43jaDgaVpYETsgd7Nx4g1zwLKMtv4iTo0627715ajEFNpEEBTgLmvZuv8K0EVxc3sM4NWJA==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.core": {
+        "type": "Project"
+      },
+      "granit.http.apidocumentation": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Http.ApiVersioning": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )",
+          "Scalar.AspNetCore": "[2.*, )"
+        }
+      },
+      "granit.http.apiversioning": {
+        "type": "Project",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "[10.0.0-preview.*, )",
+          "Asp.Versioning.Mvc.ApiExplorer": "[10.0.0-preview.*, )",
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Core": "[0.1.0-dev, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.privacy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "WolverineFx": "[5.21.*, )"
+        }
+      },
+      "granit.security": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.validation": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.*, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.*, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )"
+        }
+      },
+      "Asp.Versioning.Mvc": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0-preview.*, )",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "AyrcDwLzJp8yRJaFjZMJXkR1Rx2UaJkwGrGlX8sxIt2F5ZGiZwn/puXkB/oEaq55TxLkpiXWAOHHFsiVptp0fA==",
+        "dependencies": {
+          "Asp.Versioning.Http": "10.0.0-preview.2"
+        }
+      },
+      "Asp.Versioning.Mvc.ApiExplorer": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0-preview.*, )",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "G/LhAaLQj+gsB8UXRNm65fxjsI7fe87itZExb+MvJOQdrXYalZKbwuzMntO95xM5cKDrDgLnCH64fl6w173aGg==",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "10.0.0-preview.2"
+        }
+      },
+      "FluentValidation": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1"
+        }
+      },
+      "Microsoft.AspNetCore.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "vTcxIfOPyfFbYk1g8YcXJfkMnlEWVkSnnjxcZLy60zgwiHMRf2SnZR+9E4HlpwKxgE3yfKMOti8J6WfKuKsw6w==",
+        "dependencies": {
+          "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "CentralTransitive",
+        "requested": "[5.0.*, )",
+        "resolved": "5.0.0",
+        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+        "type": "CentralTransitive",
+        "requested": "[5.0.*, )",
+        "resolved": "5.0.0",
+        "contentHash": "Al/Q8B+yO8odSqGVpSvrShMFDvlQdIBU//F3E6Rb0YdiLSALE9wh/pvozPNnfmh5HDnvU+mkmSjpz4hQO++jaA==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.14.0",
+        "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "Scalar.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.13.13",
+        "contentHash": "QS94/CNp2thhykXwBaOHjDe8Zlexs8v0QOrdLfUvxS85uW84IhCf1zGiOnYZNNtVxunJvtsr7yPgEP36TXnJ3w=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "System.Composition.AttributedModel": {
+        "type": "CentralTransitive",
+        "requested": "[9.*, )",
+        "resolved": "9.0.0",
+        "contentHash": "iri00l/zIX9g4lHMY+Nz0qV1n40+jFYAmgsaiNn16xvt2RDwlqByNG4wgblagnDYxm3YSQQ0jLlC/7Xlk9CzyA=="
+      },
+      "WolverineFx": {
+        "type": "CentralTransitive",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
+        "dependencies": {
+          "JasperFx": "1.21.1",
+          "JasperFx.Events": "1.24.0",
+          "JasperFx.RuntimeCompiler": "4.4.0",
+          "NewId": "4.0.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog=="
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      }
+    }
+  }
+}

--- a/src/Granit.Privacy/DataExport/ExportRequestState.cs
+++ b/src/Granit.Privacy/DataExport/ExportRequestState.cs
@@ -1,0 +1,19 @@
+namespace Granit.Privacy.DataExport;
+
+/// <summary>
+/// State of a GDPR personal data export request (Art. 15/20).
+/// </summary>
+public enum ExportRequestState
+{
+    /// <summary>Request submitted, scatter-gather saga in progress.</summary>
+    Pending = 0,
+
+    /// <summary>All data providers responded — archive is ready for download.</summary>
+    Completed = 1,
+
+    /// <summary>Saga timed out but some providers responded — partial archive available.</summary>
+    PartiallyCompleted = 2,
+
+    /// <summary>Saga timed out with no provider responses.</summary>
+    TimedOut = 3,
+}

--- a/src/Granit.Privacy/DataExport/ExportRequestStatus.cs
+++ b/src/Granit.Privacy/DataExport/ExportRequestStatus.cs
@@ -1,0 +1,23 @@
+namespace Granit.Privacy.DataExport;
+
+/// <summary>
+/// Read model for a GDPR export request, used by endpoints to report progress.
+/// </summary>
+/// <param name="RequestId">Correlation ID of the export saga.</param>
+/// <param name="UserId">Identifier of the data subject.</param>
+/// <param name="State">Current state of the export request.</param>
+/// <param name="RequestedAt">Timestamp when the export was requested (UTC).</param>
+/// <param name="CompletedAt">Timestamp when the saga completed (UTC), or <c>null</c> if still pending.</param>
+/// <param name="ArchiveBlobReferenceId">
+/// Blob reference ID of the completed archive (convention: <c>gdpr-export/{RequestId}</c>).
+/// Use the BlobStorage download endpoint to obtain a pre-signed URL.
+/// </param>
+/// <param name="MissingProviders">Providers that did not respond before timeout (empty if fully completed).</param>
+public sealed record ExportRequestStatus(
+    Guid RequestId,
+    Guid UserId,
+    ExportRequestState State,
+    DateTimeOffset RequestedAt,
+    DateTimeOffset? CompletedAt,
+    string? ArchiveBlobReferenceId,
+    IReadOnlyList<string> MissingProviders);

--- a/src/Granit.Privacy/DataExport/IExportRequestTrackerReader.cs
+++ b/src/Granit.Privacy/DataExport/IExportRequestTrackerReader.cs
@@ -1,0 +1,18 @@
+namespace Granit.Privacy.DataExport;
+
+/// <summary>
+/// Read-only abstraction for querying GDPR export request status.
+/// Implemented by the application's persistence layer (EF Core, etc.).
+/// </summary>
+/// <remarks>
+/// The Wolverine export saga state is internal; this interface provides the read model
+/// that endpoints use to report export progress to the frontend.
+/// </remarks>
+public interface IExportRequestTrackerReader
+{
+    /// <summary>Returns the status of a single export request, or <c>null</c> if not found.</summary>
+    Task<ExportRequestStatus?> GetStatusAsync(Guid requestId, CancellationToken cancellationToken = default);
+
+    /// <summary>Returns all export requests for a given user, ordered by most recent first.</summary>
+    Task<IReadOnlyList<ExportRequestStatus>> GetByUserAsync(Guid userId, CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Privacy/DataExport/IExportRequestTrackerWriter.cs
+++ b/src/Granit.Privacy/DataExport/IExportRequestTrackerWriter.cs
@@ -1,0 +1,32 @@
+namespace Granit.Privacy.DataExport;
+
+/// <summary>
+/// Write abstraction for tracking GDPR export requests.
+/// Implemented by the application's persistence layer (EF Core, etc.).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Called in two places:
+/// <list type="bullet">
+/// <item>By the <c>POST /privacy/export</c> endpoint to record the initial request.</item>
+/// <item>By an application-side <see cref="Events.ExportCompletedEto"/> handler to mark completion.</item>
+/// </list>
+/// </para>
+/// </remarks>
+public interface IExportRequestTrackerWriter
+{
+    /// <summary>Records a new export request in <see cref="ExportRequestState.Pending"/> state.</summary>
+    Task RecordRequestAsync(
+        Guid requestId,
+        Guid userId,
+        DateTimeOffset requestedAt,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Marks an existing export request as completed (fully, partially, or timed out).</summary>
+    Task MarkCompletedAsync(
+        Guid requestId,
+        ExportRequestState state,
+        string? archiveBlobReferenceId,
+        IReadOnlyList<string>? missingProviders,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Privacy/GranitPrivacyBuilder.cs
+++ b/src/Granit.Privacy/GranitPrivacyBuilder.cs
@@ -53,4 +53,24 @@ public sealed class GranitPrivacyBuilder(IServiceCollection services)
         Services.AddScoped<ILegalAgreementStoreWriter>(sp => sp.GetRequiredService<TStore>());
         return this;
     }
+
+    /// <summary>
+    /// Registers the export request tracker implementation (provided by the application).
+    /// The concrete type is registered once, then forwarded to both
+    /// <see cref="IExportRequestTrackerReader"/> and <see cref="IExportRequestTrackerWriter"/>.
+    /// </summary>
+    /// <remarks>
+    /// Required for the <c>GET /privacy/export</c> endpoints to query export status.
+    /// The application must also wire an <see cref="Events.ExportCompletedEto"/> handler
+    /// that calls <see cref="IExportRequestTrackerWriter.MarkCompletedAsync"/> to update
+    /// the read model when the scatter-gather saga finishes.
+    /// </remarks>
+    public GranitPrivacyBuilder UseExportRequestTracker<TStore>()
+        where TStore : class, IExportRequestTrackerReader, IExportRequestTrackerWriter
+    {
+        Services.AddScoped<TStore>();
+        Services.AddScoped<IExportRequestTrackerReader>(sp => sp.GetRequiredService<TStore>());
+        Services.AddScoped<IExportRequestTrackerWriter>(sp => sp.GetRequiredService<TStore>());
+        return this;
+    }
 }

--- a/src/Granit.Privacy/LegalAgreements/ILegalAgreementStoreWriter.cs
+++ b/src/Granit.Privacy/LegalAgreements/ILegalAgreementStoreWriter.cs
@@ -9,4 +9,22 @@ public interface ILegalAgreementStoreWriter
 {
     /// <summary>Records a new legal agreement (append-only).</summary>
     Task RecordAsync(LegalAgreementBase agreement, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Records consent from primitive values, without requiring a concrete <see cref="LegalAgreementBase"/> subclass.
+    /// Used by <c>Granit.Privacy.Endpoints</c> to record consent without depending on the application's entity type.
+    /// </summary>
+    /// <param name="userId">Identifier of the consenting user.</param>
+    /// <param name="documentId">Legal document identifier (e.g., "privacy-policy").</param>
+    /// <param name="version">Version of the document accepted (e.g., "2.1.0").</param>
+    /// <param name="ipAddress">Pseudonymized IP address (last octet masked), or <c>null</c>.</param>
+    /// <param name="acceptedAt">Timestamp of acceptance (UTC).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task RecordConsentAsync(
+        Guid userId,
+        string documentId,
+        string version,
+        string? ipAddress,
+        DateTimeOffset acceptedAt,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Querying.AI/packages.lock.json
+++ b/src/Granit.Querying.AI/packages.lock.json
@@ -108,8 +108,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/src/Granit.Querying.Endpoints/Extensions/QueryEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Querying.Endpoints/Extensions/QueryEndpointRouteBuilderExtensions.cs
@@ -90,7 +90,8 @@ public static class QueryEndpointRouteBuilderExtensions
 #pragma warning restore GRAPI001
         .WithName($"Query{entityName}")
         .WithSummary($"Returns a filtered, sorted, and paginated list of {entityName} entries.")
-        .WithDescription($"Executes a dynamic query against {entityName} using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. The response includes paginated results and total count.");
+        .WithDescription($"Executes a dynamic query against {entityName} using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).")
+        .Produces<PagedResult<TEntity>>();
 
         // GET /meta — query metadata
         if (options.IncludeMetaEndpoint)
@@ -109,7 +110,8 @@ public static class QueryEndpointRouteBuilderExtensions
             })
             .WithName($"Get{entityName}Meta")
             .WithSummary($"Returns query metadata for {entityName} (columns, filters, sorts, presets).")
-            .WithDescription($"Returns the query definition metadata for {entityName}: available columns with display labels and data types, supported filter operators, default sort order, and the current user's saved views. Use this to dynamically build query UIs without hardcoding column definitions.");
+            .WithDescription($"Returns the query definition metadata for {entityName}: available columns with display labels and data types, supported filter operators, default sort order, and the current user's saved views. Use this to dynamically build query UIs without hardcoding column definitions.")
+            .Produces<QueryMetadata>();
         }
 
         // Saved views CRUD

--- a/src/Granit.Querying.EntityFrameworkCore/GranitQueryingEntityFrameworkCoreModule.cs
+++ b/src/Granit.Querying.EntityFrameworkCore/GranitQueryingEntityFrameworkCoreModule.cs
@@ -1,3 +1,4 @@
+using Granit.Core.Diagnostics;
 using Granit.Core.Modularity;
 using Granit.Persistence;
 using Granit.Querying.EntityFrameworkCore.Diagnostics;
@@ -17,6 +18,9 @@ namespace Granit.Querying.EntityFrameworkCore;
 public sealed class GranitQueryingEntityFrameworkCoreModule : GranitModule
 {
     /// <inheritdoc/>
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
         context.Services.TryAddSingleton<QueryingEfCoreMetrics>();
+        GranitActivitySourceRegistry.Register(QueryingEfCoreActivitySource.Name);
+    }
 }

--- a/src/Granit.Settings.Endpoints/Extensions/AdminSettingsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Settings.Endpoints/Extensions/AdminSettingsEndpointRouteBuilderExtensions.cs
@@ -37,14 +37,14 @@ public static class AdminSettingsEndpointRouteBuilderExtensions
             .WithTags(options.TagName);
 
         group.MapGet("", HandleGetAllGlobalSettingsAsync)
-             .RequireAuthorization(SettingsPermissions.GlobalRead)
+             .RequireAuthorization(SettingsPermissions.Global.Read)
              .WithName("GetAllGlobalSettings")
              .WithSummary("Returns all settings at the global scope.")
              .WithDescription("Returns all settings defined at the global (application-wide) scope as a key-value dictionary. Global settings serve as the base layer in the cascading resolution chain (User → Tenant → Global). Requires the Settings.Global.Read permission.")
              .Produces<IReadOnlyDictionary<string, string?>>();
 
         group.MapPut("/{name}", HandlePutGlobalSettingAsync)
-             .RequireAuthorization(SettingsPermissions.GlobalManage)
+             .RequireAuthorization(SettingsPermissions.Global.Manage)
              .WithName("UpdateGlobalSetting")
              .WithSummary("Sets a global-level setting value.")
              .WithDescription("Sets or clears a global-level setting value. Pass null to remove the override and revert to the definition's default. The setting name must match a registered setting definition (returns 404 otherwise). Requires the Settings.Global.Manage permission.")
@@ -72,7 +72,7 @@ public static class AdminSettingsEndpointRouteBuilderExtensions
             .WithTags(options.TagName);
 
         group.MapGet("", HandleGetAllTenantSettingsAsync)
-             .RequireAuthorization(SettingsPermissions.TenantRead)
+             .RequireAuthorization(SettingsPermissions.Tenant.Read)
              .WithName("GetAllTenantSettings")
              .WithSummary("Returns all settings at the current tenant scope.")
              .WithDescription("Returns all settings defined at the tenant scope for the current tenant. Tenant settings override global values in the cascading resolution chain. Requires the Settings.Tenant.Read permission. Returns 400 if no tenant context is available.")
@@ -80,7 +80,7 @@ public static class AdminSettingsEndpointRouteBuilderExtensions
              .ProducesProblem(StatusCodes.Status400BadRequest);
 
         group.MapPut("/{name}", HandlePutTenantSettingAsync)
-             .RequireAuthorization(SettingsPermissions.TenantManage)
+             .RequireAuthorization(SettingsPermissions.Tenant.Manage)
              .WithName("UpdateTenantSetting")
              .WithSummary("Sets a tenant-level setting value.")
              .WithDescription("Sets or clears a tenant-level setting value for the current tenant. Pass null to remove the tenant override and fall back to the global value. The setting name must match a registered setting definition (returns 404 otherwise). Requires the Settings.Tenant.Manage permission.")

--- a/src/Granit.Settings.Endpoints/Permissions/SettingsPermissionDefinitionProvider.cs
+++ b/src/Granit.Settings.Endpoints/Permissions/SettingsPermissionDefinitionProvider.cs
@@ -18,22 +18,22 @@ internal sealed class SettingsPermissionDefinitionProvider : IPermissionDefiniti
                 "PermissionGroup:Settings"));
 
         group.AddPermission(
-            SettingsPermissions.GlobalRead,
+            SettingsPermissions.Global.Read,
             LocalizableString.Create<SettingsEndpointsLocalizationResource>(
                 "Permission:Settings.Global.Read"));
 
         group.AddPermission(
-            SettingsPermissions.GlobalManage,
+            SettingsPermissions.Global.Manage,
             LocalizableString.Create<SettingsEndpointsLocalizationResource>(
                 "Permission:Settings.Global.Manage"));
 
         group.AddPermission(
-            SettingsPermissions.TenantRead,
+            SettingsPermissions.Tenant.Read,
             LocalizableString.Create<SettingsEndpointsLocalizationResource>(
                 "Permission:Settings.Tenant.Read"));
 
         group.AddPermission(
-            SettingsPermissions.TenantManage,
+            SettingsPermissions.Tenant.Manage,
             LocalizableString.Create<SettingsEndpointsLocalizationResource>(
                 "Permission:Settings.Tenant.Manage"));
     }

--- a/src/Granit.Settings.Endpoints/Permissions/SettingsPermissions.cs
+++ b/src/Granit.Settings.Endpoints/Permissions/SettingsPermissions.cs
@@ -8,23 +8,25 @@ public static class SettingsPermissions
     /// <summary>Permission group name used in <c>IPermissionDefinitionContext.AddGroup()</c>.</summary>
     public const string GroupName = "Settings";
 
-    /// <summary>
-    /// Grants read access to global settings.
-    /// </summary>
-    public const string GlobalRead = "Settings.Global.Read";
+    /// <summary>Permissions for the global settings resource.</summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1716:Identifiers should not match keywords",
+        Justification = "Global is the correct domain term for application-wide settings; VB keyword conflict is acceptable in this context.")]
+    public static class Global
+    {
+        /// <summary>Grants read access to global settings.</summary>
+        public const string Read = "Settings.Global.Read";
 
-    /// <summary>
-    /// Grants write access to global settings.
-    /// </summary>
-    public const string GlobalManage = "Settings.Global.Manage";
+        /// <summary>Grants write access to global settings.</summary>
+        public const string Manage = "Settings.Global.Manage";
+    }
 
-    /// <summary>
-    /// Grants read access to tenant settings.
-    /// </summary>
-    public const string TenantRead = "Settings.Tenant.Read";
+    /// <summary>Permissions for the tenant settings resource.</summary>
+    public static class Tenant
+    {
+        /// <summary>Grants read access to tenant settings.</summary>
+        public const string Read = "Settings.Tenant.Read";
 
-    /// <summary>
-    /// Grants write access to tenant settings.
-    /// </summary>
-    public const string TenantManage = "Settings.Tenant.Manage";
+        /// <summary>Grants write access to tenant settings.</summary>
+        public const string Manage = "Settings.Tenant.Manage";
+    }
 }

--- a/src/Granit.Templating.AI/packages.lock.json
+++ b/src/Granit.Templating.AI/packages.lock.json
@@ -108,8 +108,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/src/Granit.Timeline.AI/packages.lock.json
+++ b/src/Granit.Timeline.AI/packages.lock.json
@@ -11,8 +11,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Direct",

--- a/src/Granit.Validation/packages.lock.json
+++ b/src/Granit.Validation/packages.lock.json
@@ -66,8 +66,7 @@
         "dependencies": {
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Core": "[0.1.0-dev, )",
-          "SmartFormat": "[3.*, )",
-          "ZiggyCreatures.FusionCache": "[2.*, )"
+          "SmartFormat": "[3.*, )"
         }
       },
       "granit.timing": {

--- a/src/Granit.Vault.Aws/Extensions/AwsVaultServiceCollectionExtensions.cs
+++ b/src/Granit.Vault.Aws/Extensions/AwsVaultServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Amazon;
 using Amazon.KeyManagementService;
 using Amazon.Runtime;
 using Amazon.SecretsManager;
+using Granit.Core.Diagnostics;
 using Granit.Encryption;
 using Granit.Vault.Aws.Diagnostics;
 using Granit.Vault.Aws.HealthChecks;
@@ -71,7 +72,7 @@ public static class AwsVaultServiceCollectionExtensions
             sp.GetRequiredService<AwsSecretsCredentialProvider>());
         services.AddHostedService(sp => sp.GetRequiredService<AwsSecretsCredentialProvider>());
 
-        _ = VaultAwsActivitySource.Source; // ensure static init
+        GranitActivitySourceRegistry.Register(VaultAwsActivitySource.Name);
 
         return services;
     }

--- a/src/Granit.Vault.Aws/packages.lock.json
+++ b/src/Granit.Vault.Aws/packages.lock.json
@@ -5,19 +5,19 @@
       "AWSSDK.KeyManagementService": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.9.3",
-        "contentHash": "pjFEtLCARMDpU6vGeGfCWAWPqfyr5hx2rir8bWc00h2lg/a8f9DMNDsmxefqKKl2oSlHwkvDSOK/7cox8ewTRg==",
+        "resolved": "4.0.9.4",
+        "contentHash": "/k/kif+Iu8pzZZN2mNCJMC4bI/+3YLetPFE/bcZdtSxZPvbTdymiXOdjGwVfD6m8x6TX56xm/8GcjfvE0Rur9w==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.17, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.19, 5.0.0)"
         }
       },
       "AWSSDK.SecretsManager": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.4.9",
-        "contentHash": "7ymzCUjCuKKk7eQJVr33WMi2AcF5wThlta8NKnINZra6qIHmn/VclOLabvNSysiWDS8m+4Sx9ZHWYRYGJRDFZQ==",
+        "resolved": "4.0.4.10",
+        "contentHash": "5DKe0U1KVCZqlHUef/rAJm72twJMSVtsDa4+aubskqpIEffvUWWzXVgWI1MzZpvms2VKMw9DDmjUYLOXfXx88w==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.17, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.19, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -91,8 +91,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.17",
-        "contentHash": "Ab24kVquQ8kvuQKNe5MK/SvaXR4uoxPkAlTPALDEImaHcwsBg+UWfRVcNzLEx4dRR2y1mDFFh+zZ9TVMXGY6Jg=="
+        "resolved": "4.0.3.19",
+        "contentHash": "8zIzN59+J6arYSyFuhnSxPepr8ff4p6li+MxKUUnqCgwZqQ+icEGJK/23c1USIEALqZZ5gdiITuH2sOZWQom+Q=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Vault.Azure/Extensions/AzureKeyVaultServiceCollectionExtensions.cs
+++ b/src/Granit.Vault.Azure/Extensions/AzureKeyVaultServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Azure.Identity;
 using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Keys.Cryptography;
 using Azure.Security.KeyVault.Secrets;
+using Granit.Core.Diagnostics;
 using Granit.Encryption;
 using Granit.Vault.Azure.Diagnostics;
 using Granit.Vault.Azure.HealthChecks;
@@ -61,7 +62,7 @@ public static class AzureKeyVaultServiceCollectionExtensions
             sp.GetRequiredService<AzureSecretsCredentialProvider>());
         services.AddHostedService(sp => sp.GetRequiredService<AzureSecretsCredentialProvider>());
 
-        _ = VaultAzureActivitySource.Source; // ensure static init
+        GranitActivitySourceRegistry.Register(VaultAzureActivitySource.Name);
 
         return services;
     }

--- a/src/Granit.Vault.GoogleCloud/Extensions/GoogleCloudVaultServiceCollectionExtensions.cs
+++ b/src/Granit.Vault.GoogleCloud/Extensions/GoogleCloudVaultServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Cloud.Kms.V1;
 using Google.Cloud.SecretManager.V1;
+using Granit.Core.Diagnostics;
 using Granit.Encryption;
 using Granit.Vault.GoogleCloud.Diagnostics;
 using Granit.Vault.GoogleCloud.HealthChecks;
@@ -74,7 +75,7 @@ public static class GoogleCloudVaultServiceCollectionExtensions
             sp.GetRequiredService<SecretManagerCredentialProvider>());
         services.AddHostedService(sp => sp.GetRequiredService<SecretManagerCredentialProvider>());
 
-        _ = VaultGoogleCloudActivitySource.Source; // ensure static init
+        GranitActivitySourceRegistry.Register(VaultGoogleCloudActivitySource.Name);
 
         return services;
     }

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/WebhooksDbContext.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/WebhooksDbContext.cs
@@ -27,8 +27,10 @@ internal sealed class WebhooksDbContext(
     public DbSet<WebhookDeliveryAttempt> WebhookDeliveryAttempts => Set<WebhookDeliveryAttempt>();
 
     /// <inheritdoc/>
+    /// <inheritdoc/>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+        base.OnModelCreating(modelBuilder);
         modelBuilder.ConfigureWebhooksModule();
         modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
     }

--- a/src/Granit.Webhooks/Endpoints/WebhookRedeliveryEndpoint.cs
+++ b/src/Granit.Webhooks/Endpoints/WebhookRedeliveryEndpoint.cs
@@ -24,6 +24,7 @@ public static class WebhookRedeliveryEndpoint
             .WithName("RetryWebhookDelivery")
             .WithTags("Webhooks")
             .WithSummary("Retries a previously failed webhook delivery attempt.")
+            .WithDescription("Enqueues a manual redelivery for a previously failed webhook delivery attempt. Returns 404 if the delivery does not exist, 409 if the delivery is not in a retryable state (e.g., already succeeded or retry in progress), and 400 for other validation errors.")
             .Produces(StatusCodes.Status202Accepted)
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)

--- a/src/Granit.Workflow.AI/packages.lock.json
+++ b/src/Granit.Workflow.AI/packages.lock.json
@@ -116,8 +116,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/src/bundles/Granit.Bundle.Documents/packages.lock.json
+++ b/src/bundles/Granit.Bundle.Documents/packages.lock.json
@@ -376,13 +376,20 @@
           "Microsoft.Extensions.Primitives": "10.0.5"
         }
       },
+      "Microsoft.IO.RecyclableMemoryStream": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.0.1",
+        "contentHash": "s/s20YTVY9r9TPfTrN5g8zPF1YhwxyqO6PxUkrYTGI2B+OGPe9AdajWZrLhFqXIvqIW23fnUE4+ztrUWNU1+9g=="
+      },
       "PuppeteerSharp": {
         "type": "CentralTransitive",
         "requested": "[24.*, )",
-        "resolved": "24.39.1",
-        "contentHash": "RCKyk1wqutXytk3Cb//XxrK7ouaBoN5UvEaOQRQ3TRPqVLimDgBpumZlVLyg4XMeI7FkoPh/2QQ865mFINCFDQ==",
+        "resolved": "24.40.0",
+        "contentHash": "vVvHFHCRW6772ptQmwzIxmc2CdkEv+F9kTlCncv4VFSGev1ev5mtlL9aVOPdHc6ss5ck6sArP4b2JtNy/7GzGA==",
         "dependencies": {
           "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
           "WebDriverBiDi": "0.0.45"
         }
       },

--- a/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
+++ b/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
@@ -1,0 +1,988 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Asp.Versioning.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "I4CuGwl0nO98j6Ft6XlGBgzj1+goE/TSVlnHKgtRkuMZ0K4gy9I+Wyrtto8dyt0hWcFMDFAZ4lYNr58DSemH1g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Asp.Versioning.Http": {
+        "type": "Transitive",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "4/QzujOrkGn9sMch3eHhR5LpVJ4Xo5T2BNg7U1/r4YwEa8JywzkoGQHjW7Nk0W8ljETnpoJaO5mrTsfEOnJK3A==",
+        "dependencies": {
+          "Asp.Versioning.Abstractions": "10.0.0-preview.2"
+        }
+      },
+      "Microsoft.AspNetCore.Cryptography.Internal": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "kFUpNRYySfqNLuQKGMKZ2mK8b86R1zizlc9QB6R/Ess0rSkrA8pRNCMSFm+DqUnNfm5G3FWjsYIJOKYyhkHeig=="
+      },
+      "Microsoft.AspNetCore.Cryptography.KeyDerivation": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "NkWUZYkL6wavYY2wMZgnODzsyTOZhcRxP/DJvZlBbWEJViukdyuIqtdTzltODyjsc3MjEvxmbPDDk2KgGv6tMA==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Cryptography.Internal": "10.0.5"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "32c58Rnm47Qvhimawf67KO9PytgPz3QoWye7Abapt0Yocw/JnzMiSNj/pRoIKyn8Jxypkv86zxKD4Q/zNTc0Ag=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "ipC4u1VojgEfoIZhtbS2Sx5IluJTP/Jf1hz3yGsxGBgSukYY/CquI6rAjxn5H58CZgVn36qcuPPtNMwZ0AUzMg=="
+      },
+      "Microsoft.Extensions.AmbientMetadata.Application": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "voKvEpXEsYtEhSiIVrYrZsMP7zEkBjquhqcvhxOCUen1i9TwdSwBmz7tN93IthTPA1nzXzWnz9huCZyegiYM8A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Hosting.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Compliance.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "EsW9aUhkHYfb75wkx24BuusOQbh2BRTSh052Fki2APn3puH1q9owynut1jWMq0Rm/C4zhyw6LAd+F6PX8HUi4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.ObjectPool": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "v1SVsowG6YE1YnHVGmLWz57YTRCQRx9pH5ebIESXfm5isI9gA3QaMyg/oMTzPpXYZwSAVDzYItGJKfmV+pqXkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.AutoActivation": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "71KqPTemVxSAYf4iv4lYFrL684MLwcTciLOHfoaWzxHG0U7ASWy/cQG8mNGB5Wy59H7eKTeuiNjvKXTebxlKWA==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "vAJHd4yOpmKoK+jBuYV7a3y+Ab9U4ARCc29b6qvMy276RgJFw9LFs0DdsPqOL3ahwzyrX7tM+i4cCxU/RX0qAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "cquw9eHjO7sJ+t6hC++Zd+UjelvxfAnmmfwIq7KnGllcxBg24VEsmIq5gODxYhxXN4rWOvmnIwix0ze2p5GbgA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "NrIMTy7dpqxAvA6kHAYH8cXID/YgeNOy0OqFKpLtkPu5X4WS/basX91UszANzVrMNRAICJ2GOnGiRxJtsRyEQw=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Http.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "FEhMpnH7OANl7ux2wuByvRYqqdRQGC7l2RKOd5FDFXySeWhqJnYWEaQPMqgNk1v108N3fIFmIEnGTOBHDpVP+Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "9.6.0",
+          "Microsoft.Extensions.Http": "9.0.6",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.6",
+          "Microsoft.Extensions.Telemetry": "9.6.0"
+        }
+      },
+      "Microsoft.Extensions.Http.Polly": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "eui0JinN+aOSMt6oeAGhSk+wAw5nJbeHt+JyOltn4+zjA7FhYDDLdsUW+Md3x18p+NxUdTwh7W/4EbB5RJ90Aw==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "9.0.6",
+          "Polly": "7.2.4",
+          "Polly.Extensions.Http": "3.0.0"
+        }
+      },
+      "Microsoft.Extensions.Identity.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "ew2Xob+HFvJvM7BelIrUIbGeVMO2q1A6gsZEsI8N/v0ddSv7qbvvY68mH16XzvlsqydqD3ct5ioQHsiEUDSNkg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Cryptography.KeyDerivation": "10.0.5",
+          "Microsoft.Extensions.Diagnostics": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Identity.Stores": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "St8g+4xGLUhfSzTlHSLtCv7kh/tppvFab5x0kFIOsWryf1ffK2Ux+JIg01v5Yf27g2iQLCFEmW5hG5DDZL1HLA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Identity.Core": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "xKobiPRPVkK/bD/oLUTF1OnilG3N+4o0u/T8YWqHq+E97zWgCRr8Zhk9N6OZeLBSNHC7imT53QkH/yv9MaXkew=="
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "+XTMKQyDWg4ODoNHU/BN3BaI1jhGO7VCS+BnzT/4IauiG6y2iPAte7MyD7rHKS+hNP0TkFkjrae8DFjDUxtcxg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "lCgpxE5r6v43SB40/yUVnSWZUUqUZF5iUWizhkx4gqvq0L0rMw5g8adWKGO7sfIaSbCiU0et85sDQWswhLcceg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Configuration.Binder": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "N1lSxMYI6DboY/PqCQwb6Bg74Baip7wWkHeHzuL7+PNsBipDmpBukXwVyVEAHdOdYNtasTdcXDVtbtwenoYU1g=="
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
+      },
+      "Microsoft.Extensions.Resilience": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "JhfQk0u4XYGD21fMUvAxmzzVM3CMN2Xy3yemutEBECoSP5ND/7jEG4daL0NODSPtq6rd9Pk7SumnBfxyV3+zxw==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics": "9.0.6",
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "9.6.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.6",
+          "Microsoft.Extensions.Telemetry.Abstractions": "9.6.0",
+          "Polly.Extensions": "8.4.2",
+          "Polly.RateLimiting": "8.4.2"
+        }
+      },
+      "Microsoft.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "4k56GlByl+4gxwMHDMJ/MglbmjPPddLgd21RHZlSfx4WWLqiES/GJ/sHVCrKVjdIQHdcR5MLWvplfuqgj4H+VQ==",
+        "dependencies": {
+          "Microsoft.Extensions.AmbientMetadata.Application": "9.6.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "9.6.0",
+          "Microsoft.Extensions.Logging.Configuration": "9.0.6",
+          "Microsoft.Extensions.ObjectPool": "9.0.6",
+          "Microsoft.Extensions.Telemetry.Abstractions": "9.6.0"
+        }
+      },
+      "Microsoft.Extensions.Telemetry.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.6.0",
+        "contentHash": "LKkpXv0KCFC7oPzkqwNMgBfBImd8I57e6W1mtnvw5KCwMZ/1iS5PsWQiSxp17J91crAyKv5KosRF6lNK2j9EBQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Compliance.Abstractions": "9.6.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.ObjectPool": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "V7fHMFpfzvx7twWMV3jrf3OFVmYn3QhUYtvfMRD9yUPs9gxnQSaRMZh5NzCsnW3ZZ80J09EE7yyjM71y9JC6hQ=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "gOup2SmdwaXooLR0POKfrkyrw+R+G8nc8Nk80TL0196kFQK7Bg7Qr4x3jvOCm3TR8QLqU8cVpSVqBLtUaosPEg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.12.0"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "IakwNWUTy5RlcDcKwtL5TyfDLZmA8FFnSDhfr+wfGGPMON9GkpkUY8NakIJjdy6mv6C1lM/Jkn3IuaeS9MXesA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.12.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "WwCV1H3lmo6qLjVjFlzi8jBbYLWKzKM3KldD1te1vD3QZbcZ+aN7MBGnbbJAE8FYqv/zLPtsRliRNOs9YHrtxg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.12.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "WCU3wv5sioX5hhp3oHw8sCdygnfZJtRKJGCg+AckP6nbp0QGKK3VohTrxIF0dpuziLAPg57CPfS9X8UERroKxA==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.IdentityModel.Logging": "8.12.0"
+        }
+      },
+      "Microsoft.Net.Http.Headers": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "YwD5LtA45rgLeJV9+DvRolwue2+s/Y1br5BFL+XdakM8Q859ICkbuH3ymvD+ibnXXkHsDaEvr8Sc+nauisABOg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "9.0.6"
+        }
+      },
+      "Microsoft.OpenApi": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
+      },
+      "OpenIddict.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "sVhLvY4sZ3UFXudfc8A6gM45uyA9WwL8987ksf8zY4spVoADFH3cblkyj85OYF5fCQxRDxvOCvyeYfs7zTiaig==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Primitives": "9.0.6",
+          "Microsoft.IdentityModel.Tokens": "8.12.0"
+        }
+      },
+      "OpenIddict.Client": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "SO0zSTRaThna4+n/Hcud8S0EC/S/LXC5Sn8dPCp3cDy+cnXYsHhw4X+4bJGxa8kypZEhH1Qdc49lSOYF0SwJvw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.12.0",
+          "Microsoft.IdentityModel.Protocols": "8.12.0",
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.Client.SystemIntegration": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "W8XbiXN5IxTlBfWZmsdG3LdFLY6tOwsCL/Fiu1ZYbKdkldzPZ2P6DV81cBF7G4wTzJ4rCi3iBaow6XWIE7bF+g==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "9.0.6",
+          "Microsoft.Net.Http.Headers": "9.0.6",
+          "OpenIddict.Client": "6.4.0"
+        }
+      },
+      "OpenIddict.Client.SystemNetHttp": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "9cAFvFQe8yzk+W/zzGq7spcNvL5Ug1Sp0f9lzMhJLV1dxfNRYnW1YUPOb67vS3WFUWBePXw+sr2y/xadSt9gNg==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Polly": "9.0.6",
+          "Microsoft.Extensions.Http.Resilience": "9.6.0",
+          "OpenIddict.Client": "6.4.0"
+        }
+      },
+      "OpenIddict.Client.WebIntegration": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "jKsgqGm/5QLWAj/18/Ac7CvvjeTW9XklRadsQ4FLtrZZA0dBfcQNvjKsGivImzPPs/zS8/zH5/XR48UOQ1Qmjg==",
+        "dependencies": {
+          "OpenIddict.Client": "6.4.0",
+          "OpenIddict.Client.SystemNetHttp": "6.4.0"
+        }
+      },
+      "OpenIddict.Core": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "xAYq7U/j6JZAbVU88Xv6yXeKutJvNuGCH6zJAlP++abKtSfpP2mRLp2UbS0QS37S+SqRMLxp301DPNtkiRkuPA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6",
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.EntityFrameworkCore.Models": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "5nyS+XmjoAA8MeyClHA+0EOHCHIDRV4sxDpDpK0RUqtDB4fxmRbKJCzocGHlE/o5iubd6hrKS9bCGZruTWw9oA=="
+      },
+      "OpenIddict.Server": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "npMVNR7zjTpgZCa1Kg2QYXx66jxDrvMQGuqD+3BFssIbT0j7N9s40RgUaGD827IsZGwO+IenJMxZV7QCdiTYSA==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.12.0",
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.Validation": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "fEolVRSiAymdCQA8SWCgiTXt1o1bS9aJHqXss7XFEID9d9mk4389i93JEDaNspOGKbazzqXUmeczG0xjHNBvcw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.12.0",
+          "Microsoft.IdentityModel.Protocols": "8.12.0",
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.Validation.ServerIntegration": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "fRrBVz7KM1D5C/Az6JpBvUm6epd+hABR4Gi2LAWMur9ePu6WJLBvvkxinLR+WECvm6veCgw4tZVXLNJ+yfJ4Ew==",
+        "dependencies": {
+          "OpenIddict.Server": "6.4.0",
+          "OpenIddict.Validation": "6.4.0"
+        }
+      },
+      "OpenIddict.Validation.SystemNetHttp": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "H+5RiiUbQBzJJURqZR+Z9XqZfGxTX1vTOWfmCMV/HmivuVxxk3H2hZcAUyox1Ah8RTC+rvRomSHFjskhLAhWjA==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Polly": "9.0.6",
+          "Microsoft.Extensions.Http.Resilience": "9.6.0",
+          "OpenIddict.Validation": "6.4.0"
+        }
+      },
+      "Polly": {
+        "type": "Transitive",
+        "resolved": "7.2.4",
+        "contentHash": "bw00Ck5sh6ekduDE3mnCo1ohzuad946uslCDEENu3091+6UKnBuKLo4e+yaNcCzXxOZCXWY2gV4a35+K1d4LDA=="
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "BpE2I6HBYYA5tF0Vn4eoQOGYTYIK1BlF5EXVgkWGn3mqUUjbXAr13J6fZVbp7Q3epRR8yshacBMlsHMhpOiV3g=="
+      },
+      "Polly.Extensions": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "GZ9vRVmR0jV2JtZavt+pGUsQ1O1cuRKG7R7VOZI6ZDy9y6RNPvRvXK1tuS4ffUrv8L0FTea59oEuQzgS0R7zSA==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Options": "8.0.0",
+          "Polly.Core": "8.4.2"
+        }
+      },
+      "Polly.Extensions.Http": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "drrG+hB3pYFY7w1c3BD+lSGYvH2oIclH8GRSehgfyP5kjnFnHKQuuBhuHLv+PWyFuaTDyk/vfRpnxOzd11+J8g==",
+        "dependencies": {
+          "Polly": "7.1.0"
+        }
+      },
+      "Polly.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "ehTImQ/eUyO07VYW2WvwSmU9rRH200SKJ/3jku9rOkyWE0A2JxNFmAVms8dSn49QLSjmjFRRSgfNyOgr/2PSmA==",
+        "dependencies": {
+          "Polly.Core": "8.4.2",
+          "System.Threading.RateLimiting": "8.0.0"
+        }
+      },
+      "System.Threading.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "7mu9v0QDv66ar3DpGSZHg9NuNcxDaaAcnMULuZlaTpP9+hwXhrxNGsF5GmLkSHxFdb5bBc1TzeujsRgTrPWi+Q=="
+      },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )"
+        }
+      },
+      "granit.backgroundjobs": {
+        "type": "Project",
+        "dependencies": {
+          "Cronos": "[0.11.*, )",
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.core": {
+        "type": "Project"
+      },
+      "granit.eventbus": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.http.apidocumentation": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Http.ApiVersioning": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )",
+          "Scalar.AspNetCore": "[2.*, )"
+        }
+      },
+      "granit.http.apiversioning": {
+        "type": "Project",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "[10.0.0-preview.*, )",
+          "Asp.Versioning.Mvc.ApiExplorer": "[10.0.0-preview.*, )",
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.identity": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )"
+        }
+      },
+      "granit.identity.openiddict": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Identity": "[0.1.0-dev, )",
+          "Granit.OpenIddict.EntityFrameworkCore": "[0.1.0-dev, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.openiddict": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.EventBus": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Identity": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.openiddict.backgroundjobs": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.BackgroundJobs": "[0.1.0-dev, )",
+          "Granit.OpenIddict": "[0.1.0-dev, )",
+          "OpenIddict": "[6.*, )"
+        }
+      },
+      "granit.openiddict.client": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.OpenIddict": "[0.1.0-dev, )",
+          "OpenIddict": "[6.*, )"
+        }
+      },
+      "granit.openiddict.endpoints": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.openiddict.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
+          "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "OpenIddict.EntityFrameworkCore": "[6.*, )"
+        }
+      },
+      "granit.openiddict.passkeys": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.OpenIddict.EntityFrameworkCore": "[0.1.0-dev, )",
+          "OpenIddict": "[6.*, )"
+        }
+      },
+      "granit.openiddict.seeding": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "OpenIddict": "[6.*, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.querying": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.security": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.validation": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.*, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.*, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )"
+        }
+      },
+      "Asp.Versioning.Mvc": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0-preview.*, )",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "AyrcDwLzJp8yRJaFjZMJXkR1Rx2UaJkwGrGlX8sxIt2F5ZGiZwn/puXkB/oEaq55TxLkpiXWAOHHFsiVptp0fA==",
+        "dependencies": {
+          "Asp.Versioning.Http": "10.0.0-preview.2"
+        }
+      },
+      "Asp.Versioning.Mvc.ApiExplorer": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0-preview.*, )",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "G/LhAaLQj+gsB8UXRNm65fxjsI7fe87itZExb+MvJOQdrXYalZKbwuzMntO95xM5cKDrDgLnCH64fl6w173aGg==",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "10.0.0-preview.2"
+        }
+      },
+      "Cronos": {
+        "type": "CentralTransitive",
+        "requested": "[0.11.*, )",
+        "resolved": "0.11.1",
+        "contentHash": "5Ug+giPQITSAdTp/METAsofRSSUi3I5p7t4dlcXnzUgUzwZb4HkOBcYfpHuPwAHrnKJjmyW8amVzLD6mfLpaBg=="
+      },
+      "FluentValidation": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+        }
+      },
+      "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "oo1uauTwgcnhYgituZ2nI3wJ8XN9z76ggu2zkOJu1BCfOOsqr+g08Kr4MOiMuXEhwySkpIV+MVoC25hC1288NA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.5",
+          "Microsoft.Extensions.Identity.Stores": "10.0.5"
+        }
+      },
+      "Microsoft.AspNetCore.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "vTcxIfOPyfFbYk1g8YcXJfkMnlEWVkSnnjxcZLy60zgwiHMRf2SnZR+9E4HlpwKxgE3yfKMOti8J6WfKuKsw6w==",
+        "dependencies": {
+          "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "9tNBmK3EpYVGRQLiqP+bqK2m+TD0Gv//4vCzR7ZOgl4FWzCFyOpYdIVka13M4kcBdPdSJcs3wbHr3rmzOqbIMA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.5",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.5",
+          "Microsoft.Extensions.Caching.Memory": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "uxmFjZEAB/KbsgWFSS4lLqkEHCfXxB2x0UcbiO4e5fCRpFFeTMSx/me6009nYJLu5IKlDwO1POh++P6RilFTDw==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.5",
+          "Microsoft.Extensions.Caching.Memory": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "k/QDdQ94/0Shi0KfU+e12m73jfQo+3JpErTtgpZfsCIqkvdEEO0XIx6R+iTbN55rNPaNhOqNY4/sB+jZ8XxVPw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "jUEXmkBUPdOS/MP9areK/sbKhdklq9+tEhvwfxGalZVnmyLUO5rrheNNutUBtvbZ7J8ECkG7/r2KXi/IFC06cA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "REdt95QXHscGdtw/UUgyCW2lF9DJcAOJxmebKW2IkgUjuCAdMODIi2HNOWg5utW98nm8ekgV0Gjqs/sljwwqMw==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "RtNhAwrnZcUZgi3SUMvaDVF405ZtKVR7l/6OHcqFj6JY5nT7QOdBxxULnby9dUQ6Jhnfl7cdDlMjsexfASNyjg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Http": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "9.0.6",
+        "contentHash": "YoCEkjHHeeKsOzaJaGKuwsi1Ijckkm/+bv5RXmsKA0/qW4veY0eh5lVtkOXxkqQbVRuK3sObhxRM0UeuF6yAgA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Diagnostics": "9.0.6",
+          "Microsoft.Extensions.Logging": "9.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "9.6.0",
+        "contentHash": "Np2a8u0ttPzqSrfVlVNRavKNzrzrbLAEsd0gR0KX5jIVOp7SVlPQdAHBTBh8/Hd7Amni9STSBWE2hoxq2pu3XA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Binder": "9.0.6",
+          "Microsoft.Extensions.Http.Diagnostics": "9.6.0",
+          "Microsoft.Extensions.ObjectPool": "9.0.6",
+          "Microsoft.Extensions.Resilience": "9.6.0"
+        }
+      },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "Co/URpVB1P1WbvswTumphjYZcvqTA2piSTLVOVtN6qLNrK6pg0OjZ/9SzigI+7NYGS2UpxVMydk/n45VvWZvOg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "OpenIddict": {
+        "type": "CentralTransitive",
+        "requested": "[6.*, )",
+        "resolved": "6.4.0",
+        "contentHash": "wujZGdqHdJlHa9NKfH1ywn5cqKWNCLICmzNbIgOj1ymNJ77aSdSq+bY284mnkUp21hPIYozbHNFcysiCqe21ow==",
+        "dependencies": {
+          "OpenIddict.Abstractions": "6.4.0",
+          "OpenIddict.Client": "6.4.0",
+          "OpenIddict.Client.SystemIntegration": "6.4.0",
+          "OpenIddict.Client.SystemNetHttp": "6.4.0",
+          "OpenIddict.Client.WebIntegration": "6.4.0",
+          "OpenIddict.Core": "6.4.0",
+          "OpenIddict.Server": "6.4.0",
+          "OpenIddict.Validation": "6.4.0",
+          "OpenIddict.Validation.ServerIntegration": "6.4.0",
+          "OpenIddict.Validation.SystemNetHttp": "6.4.0"
+        }
+      },
+      "OpenIddict.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[6.*, )",
+        "resolved": "6.4.0",
+        "contentHash": "glyc+uEaJS9zZxzA/cyF2O4TJudgHLR2Qf2AGq1tNA8mBcQIa2DzKIEuP9rEQD+lofnR/V+cFsybGUyYMsra9Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "9.0.6",
+          "OpenIddict.Core": "6.4.0",
+          "OpenIddict.EntityFrameworkCore.Models": "6.4.0"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.14.0",
+        "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "Scalar.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.13.13",
+        "contentHash": "QS94/CNp2thhykXwBaOHjDe8Zlexs8v0QOrdLfUvxS85uW84IhCf1zGiOnYZNNtVxunJvtsr7yPgEP36TXnJ3w=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      }
+    }
+  }
+}

--- a/tests/Granit.AI.AzureOpenAI.Tests/packages.lock.json
+++ b/tests/Granit.AI.AzureOpenAI.Tests/packages.lock.json
@@ -408,16 +408,16 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.AI.OpenAI": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "7R1fyxwF8KtQi8k2ih3Y6dHZiUfnnmZIgXY7hQ+dFlPkVZoefgKAzdnnrFZzYOjXPeJxh3gqAQ4psXnp59wwqw==",
+        "resolved": "10.4.1",
+        "contentHash": "C+xo+ds4PxSzTEywLcM0hbJJboEuLT5na/Q49rMNi3Y0hsoBuMXIZCvWXOyvNXunvngOwZYvkicEod/g8Gll6w==",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "10.4.0",
+          "Microsoft.Extensions.AI.Abstractions": "10.4.1",
           "OpenAI": "2.9.1"
         }
       },

--- a/tests/Granit.AI.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.AI.EntityFrameworkCore.Tests/packages.lock.json
@@ -415,8 +415,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",

--- a/tests/Granit.AI.Extraction.Tests/packages.lock.json
+++ b/tests/Granit.AI.Extraction.Tests/packages.lock.json
@@ -320,8 +320,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/tests/Granit.AI.Ollama.Tests/packages.lock.json
+++ b/tests/Granit.AI.Ollama.Tests/packages.lock.json
@@ -499,8 +499,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/tests/Granit.AI.OpenAI.Tests/packages.lock.json
+++ b/tests/Granit.AI.OpenAI.Tests/packages.lock.json
@@ -352,16 +352,16 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.AI.OpenAI": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "7R1fyxwF8KtQi8k2ih3Y6dHZiUfnnmZIgXY7hQ+dFlPkVZoefgKAzdnnrFZzYOjXPeJxh3gqAQ4psXnp59wwqw==",
+        "resolved": "10.4.1",
+        "contentHash": "C+xo+ds4PxSzTEywLcM0hbJJboEuLT5na/Q49rMNi3Y0hsoBuMXIZCvWXOyvNXunvngOwZYvkicEod/g8Gll6w==",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "10.4.0",
+          "Microsoft.Extensions.AI.Abstractions": "10.4.1",
           "OpenAI": "2.9.1"
         }
       },

--- a/tests/Granit.AI.VectorData.Tests/packages.lock.json
+++ b/tests/Granit.AI.VectorData.Tests/packages.lock.json
@@ -322,8 +322,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",
@@ -389,10 +389,10 @@
       "Microsoft.Extensions.VectorData.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.1",
-        "contentHash": "1vsHJaRET/Q8aldtGiaAP4BKXBrVA9Y1brgYbpWyQQsr6HN7fN5+Qw74sC8g+JSHiZONJ4134pPQd1mk7fGlQw==",
+        "resolved": "10.1.0",
+        "contentHash": "I2XfmqEOWOq0Esbo0eWQ6WE5MAJkGyIs057F8ncmPCLJFw9b1IB7Jj5WiFlH6C5YXCAG9Z91QMBD/SkcMLhE7w==",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "10.3.0"
+          "Microsoft.Extensions.AI.Abstractions": "10.4.0"
         }
       }
     }

--- a/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
+++ b/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
@@ -153,6 +153,7 @@
     <ProjectReference Include="..\..\src\Granit.Persistence.Migrations.Wolverine\Granit.Persistence.Migrations.Wolverine.csproj" />
     <ProjectReference Include="..\..\src\Granit.Privacy\Granit.Privacy.csproj" />
     <ProjectReference Include="..\..\src\Granit.Privacy.AI\Granit.Privacy.AI.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Privacy.Endpoints\Granit.Privacy.Endpoints.csproj" />
     <ProjectReference Include="..\..\src\Granit.Querying\Granit.Querying.csproj" />
     <ProjectReference Include="..\..\src\Granit.RateLimiting\Granit.RateLimiting.csproj" />
     <ProjectReference Include="..\..\src\Granit.Querying.AI\Granit.Querying.AI.csproj" />

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2193,6 +2193,15 @@
           "Granit.Privacy": "[0.1.0-dev, )"
         }
       },
+      "granit.privacy.endpoints": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.Privacy": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
       "granit.querying": {
         "type": "Project",
         "dependencies": {
@@ -3157,8 +3166,8 @@
       "Sep": {
         "type": "CentralTransitive",
         "requested": "[0.*, )",
-        "resolved": "0.12.2",
-        "contentHash": "6zIz3NiZn2VLlzr28BcWMfCrTxeLQvNKHj8C2+7pXe3/QrCczAYLs0yc1c7MemSjkBN7zYOknL5utwWKG+tIyQ==",
+        "resolved": "0.12.3",
+        "contentHash": "xuQjdQ4c7A3yfJz6vzOy8T9KirByt8nmmVouhLDi9JYvoSQg4kOUdw9kQfThPOJ0N2MbTokSqF0Xr20RqeDQFQ==",
         "dependencies": {
           "csFastFloat": "4.1.5"
         }

--- a/tests/Granit.Authentication.ApiKeys.Tests/EventTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.Tests/EventTests.cs
@@ -6,13 +6,13 @@ using Xunit;
 
 namespace Granit.Authentication.ApiKeys.Tests;
 
-public sealed class ApiKeyCreatedEventTests
+public sealed class ApiKeyCreatedEtoTests
 {
     [Fact]
     public void Properties_AreSetFromConstructor()
     {
         var id = Guid.NewGuid();
-        var evt = new ApiKeyCreatedEvent(id, "Partner Key", ApiKeyType.Secret);
+        var evt = new ApiKeyCreatedEto(id, "Partner Key", ApiKeyType.Secret);
 
         evt.ApiKeyId.ShouldBe(id);
         evt.Name.ShouldBe("Partner Key");
@@ -23,8 +23,8 @@ public sealed class ApiKeyCreatedEventTests
     public void RecordEquality_WorksCorrectly()
     {
         var id = Guid.NewGuid();
-        var evt1 = new ApiKeyCreatedEvent(id, "Key A", ApiKeyType.Publishable);
-        var evt2 = new ApiKeyCreatedEvent(id, "Key A", ApiKeyType.Publishable);
+        var evt1 = new ApiKeyCreatedEto(id, "Key A", ApiKeyType.Publishable);
+        var evt2 = new ApiKeyCreatedEto(id, "Key A", ApiKeyType.Publishable);
 
         evt1.ShouldBe(evt2);
     }
@@ -33,8 +33,8 @@ public sealed class ApiKeyCreatedEventTests
     public void RecordInequality_DifferentType()
     {
         var id = Guid.NewGuid();
-        var evt1 = new ApiKeyCreatedEvent(id, "Key A", ApiKeyType.Secret);
-        var evt2 = new ApiKeyCreatedEvent(id, "Key A", ApiKeyType.Publishable);
+        var evt1 = new ApiKeyCreatedEto(id, "Key A", ApiKeyType.Secret);
+        var evt2 = new ApiKeyCreatedEto(id, "Key A", ApiKeyType.Publishable);
 
         evt1.ShouldNotBe(evt2);
     }
@@ -63,14 +63,14 @@ public sealed class ApiKeyRevokedEventTests
     }
 }
 
-public sealed class ApiKeyRotatedEventTests
+public sealed class ApiKeyRotatedEtoTests
 {
     [Fact]
     public void Properties_AreSetFromConstructor()
     {
         var oldId = Guid.NewGuid();
         var newId = Guid.NewGuid();
-        var evt = new ApiKeyRotatedEvent(oldId, newId, "oldhash");
+        var evt = new ApiKeyRotatedEto(oldId, newId, "oldhash");
 
         evt.OldApiKeyId.ShouldBe(oldId);
         evt.NewApiKeyId.ShouldBe(newId);
@@ -82,20 +82,20 @@ public sealed class ApiKeyRotatedEventTests
     {
         var oldId = Guid.NewGuid();
         var newId = Guid.NewGuid();
-        var evt1 = new ApiKeyRotatedEvent(oldId, newId, "hash");
-        var evt2 = new ApiKeyRotatedEvent(oldId, newId, "hash");
+        var evt1 = new ApiKeyRotatedEto(oldId, newId, "hash");
+        var evt2 = new ApiKeyRotatedEto(oldId, newId, "hash");
 
         evt1.ShouldBe(evt2);
     }
 }
 
-public sealed class ApiKeyScopesUpdatedEventTests
+public sealed class ApiKeyScopesUpdatedEtoTests
 {
     [Fact]
     public void Properties_AreSetFromConstructor()
     {
         var id = Guid.NewGuid();
-        var evt = new ApiKeyScopesUpdatedEvent(id, "scopehash");
+        var evt = new ApiKeyScopesUpdatedEto(id, "scopehash");
 
         evt.ApiKeyId.ShouldBe(id);
         evt.HashedKey.ShouldBe("scopehash");
@@ -105,8 +105,8 @@ public sealed class ApiKeyScopesUpdatedEventTests
     public void RecordEquality_WorksCorrectly()
     {
         var id = Guid.NewGuid();
-        var evt1 = new ApiKeyScopesUpdatedEvent(id, "hash");
-        var evt2 = new ApiKeyScopesUpdatedEvent(id, "hash");
+        var evt1 = new ApiKeyScopesUpdatedEto(id, "hash");
+        var evt2 = new ApiKeyScopesUpdatedEto(id, "hash");
 
         evt1.ShouldBe(evt2);
     }
@@ -129,8 +129,8 @@ public sealed class ApiKeyUsedEtoTests
 
         entry.RecordUsage(usedAt);
 
-        IIntegrationEvent integrationEvent = entry.IntegrationEvents.ShouldHaveSingleItem();
-        ApiKeyUsedEto eto = integrationEvent.ShouldBeOfType<ApiKeyUsedEto>();
+        entry.IntegrationEvents.Count.ShouldBe(2); // ApiKeyCreatedEto + ApiKeyUsedEto
+        ApiKeyUsedEto eto = entry.IntegrationEvents.OfType<ApiKeyUsedEto>().ShouldHaveSingleItem();
         eto.ApiKeyId.ShouldBe(entry.Id);
         eto.Prefix.ShouldBe("gk_live_sk_");
         eto.UsedAt.ShouldBe(usedAt);

--- a/tests/Granit.Authentication.ApiKeys.Tests/Events/ApiKeyEventsTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.Tests/Events/ApiKeyEventsTests.cs
@@ -7,10 +7,10 @@ namespace Granit.Authentication.ApiKeys.Tests.Events;
 public sealed class ApiKeyEventsTests
 {
     [Fact]
-    public void ApiKeyCreatedEvent_HasCorrectProperties()
+    public void ApiKeyCreatedEto_HasCorrectProperties()
     {
         var id = Guid.NewGuid();
-        ApiKeyCreatedEvent evt = new(id, "My Key", ApiKeyType.Secret);
+        ApiKeyCreatedEto evt = new(id, "My Key", ApiKeyType.Secret);
 
         evt.ApiKeyId.ShouldBe(id);
         evt.Name.ShouldBe("My Key");
@@ -18,11 +18,11 @@ public sealed class ApiKeyEventsTests
     }
 
     [Fact]
-    public void ApiKeyCreatedEvent_Equality_Works()
+    public void ApiKeyCreatedEto_Equality_Works()
     {
         var id = Guid.NewGuid();
-        ApiKeyCreatedEvent a = new(id, "Key", ApiKeyType.Secret);
-        ApiKeyCreatedEvent b = new(id, "Key", ApiKeyType.Secret);
+        ApiKeyCreatedEto a = new(id, "Key", ApiKeyType.Secret);
+        ApiKeyCreatedEto b = new(id, "Key", ApiKeyType.Secret);
 
         a.ShouldBe(b);
     }
@@ -38,21 +38,21 @@ public sealed class ApiKeyEventsTests
     }
 
     [Fact]
-    public void ApiKeyScopesUpdatedEvent_HasCorrectProperties()
+    public void ApiKeyScopesUpdatedEto_HasCorrectProperties()
     {
         var id = Guid.NewGuid();
-        ApiKeyScopesUpdatedEvent evt = new(id, "hash-xyz");
+        ApiKeyScopesUpdatedEto evt = new(id, "hash-xyz");
 
         evt.ApiKeyId.ShouldBe(id);
         evt.HashedKey.ShouldBe("hash-xyz");
     }
 
     [Fact]
-    public void ApiKeyRotatedEvent_HasCorrectProperties()
+    public void ApiKeyRotatedEto_HasCorrectProperties()
     {
         var oldId = Guid.NewGuid();
         var newId = Guid.NewGuid();
-        ApiKeyRotatedEvent evt = new(oldId, newId, "old-hash");
+        ApiKeyRotatedEto evt = new(oldId, newId, "old-hash");
 
         evt.OldApiKeyId.ShouldBe(oldId);
         evt.NewApiKeyId.ShouldBe(newId);
@@ -60,10 +60,10 @@ public sealed class ApiKeyEventsTests
     }
 
     [Fact]
-    public void ApiKeyRotatedEvent_Equality_DifferentIds_AreNotEqual()
+    public void ApiKeyRotatedEto_Equality_DifferentIds_AreNotEqual()
     {
-        ApiKeyRotatedEvent a = new(Guid.NewGuid(), Guid.NewGuid(), "hash");
-        ApiKeyRotatedEvent b = new(Guid.NewGuid(), Guid.NewGuid(), "hash");
+        ApiKeyRotatedEto a = new(Guid.NewGuid(), Guid.NewGuid(), "hash");
+        ApiKeyRotatedEto b = new(Guid.NewGuid(), Guid.NewGuid(), "hash");
 
         a.ShouldNotBe(b);
     }

--- a/tests/Granit.DataExchange.Csv.Tests/packages.lock.json
+++ b/tests/Granit.DataExchange.Csv.Tests/packages.lock.json
@@ -490,8 +490,8 @@
       "Sep": {
         "type": "CentralTransitive",
         "requested": "[0.*, )",
-        "resolved": "0.12.2",
-        "contentHash": "6zIz3NiZn2VLlzr28BcWMfCrTxeLQvNKHj8C2+7pXe3/QrCczAYLs0yc1c7MemSjkBN7zYOknL5utwWKG+tIyQ==",
+        "resolved": "0.12.3",
+        "contentHash": "xuQjdQ4c7A3yfJz6vzOy8T9KirByt8nmmVouhLDi9JYvoSQg4kOUdw9kQfThPOJ0N2MbTokSqF0Xr20RqeDQFQ==",
         "dependencies": {
           "csFastFloat": "4.1.5"
         }

--- a/tests/Granit.DataExchange.Tests/Export/ExportOrchestratorTests.cs
+++ b/tests/Granit.DataExchange.Tests/Export/ExportOrchestratorTests.cs
@@ -402,7 +402,7 @@ public sealed class ExportOrchestratorTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_completed_publishes_ExportJobCompletedEvent()
+    public async Task ExecuteAsync_completed_publishes_ExportJobCompletedEto()
     {
         // Arrange
         ExportOrchestrator sut = CreateOrchestrator();
@@ -416,7 +416,7 @@ public sealed class ExportOrchestratorTests
 
         // Assert
         await _eventBus.Received(1).PublishAsync(
-            Arg.Is<ExportJobCompletedEvent>(e =>
+            Arg.Is<ExportJobCompletedEto>(e =>
                 e.ExportJobId == jobId &&
                 e.DefinitionName == "Test.Export" &&
                 e.Status == ExportJobStatus.Completed &&
@@ -427,7 +427,7 @@ public sealed class ExportOrchestratorTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_failed_publishes_ExportJobCompletedEvent_with_error()
+    public async Task ExecuteAsync_failed_publishes_ExportJobCompletedEto_with_error()
     {
         // Arrange
         var jobId = Guid.NewGuid();
@@ -454,7 +454,7 @@ public sealed class ExportOrchestratorTests
             () => sut.ExecuteAsync(jobId, TestContext.Current.CancellationToken));
 
         await _eventBus.Received(1).PublishAsync(
-            Arg.Is<ExportJobCompletedEvent>(e =>
+            Arg.Is<ExportJobCompletedEto>(e =>
                 e.ExportJobId == jobId &&
                 e.Status == ExportJobStatus.Failed &&
                 e.UserId == "user-99" &&

--- a/tests/Granit.DataExchange.Tests/Export/ExportRecordTests.cs
+++ b/tests/Granit.DataExchange.Tests/Export/ExportRecordTests.cs
@@ -132,14 +132,14 @@ public sealed class ExportRecordTests
         a.ShouldBe(b);
     }
 
-    // ── ExportJobCompletedEvent ──────────────────────────────────
+    // ── ExportJobCompletedEto ──────────────────────────────────
 
     [Fact]
-    public void ExportJobCompletedEvent_Constructor_SetsAllProperties()
+    public void ExportJobCompletedEto_Constructor_SetsAllProperties()
     {
         var jobId = Guid.NewGuid();
 
-        ExportJobCompletedEvent evt = new(
+        ExportJobCompletedEto evt = new(
             jobId, "Acme.Export", ExportJobStatus.Completed, "user-123", 500, null);
 
         evt.ExportJobId.ShouldBe(jobId);
@@ -151,9 +151,9 @@ public sealed class ExportRecordTests
     }
 
     [Fact]
-    public void ExportJobCompletedEvent_FailedWithError()
+    public void ExportJobCompletedEto_FailedWithError()
     {
-        ExportJobCompletedEvent evt = new(
+        ExportJobCompletedEto evt = new(
             Guid.NewGuid(), "def", ExportJobStatus.Failed, "user", null, "Connection refused");
 
         evt.Status.ShouldBe(ExportJobStatus.Failed);

--- a/tests/Granit.DataExchange.Tests/Import/Messages/ImportJobCompletedEventTests.cs
+++ b/tests/Granit.DataExchange.Tests/Import/Messages/ImportJobCompletedEventTests.cs
@@ -5,14 +5,14 @@ using Xunit;
 
 namespace Granit.DataExchange.Tests.Import.Messages;
 
-public sealed class ImportJobCompletedEventTests
+public sealed class ImportJobCompletedEtoTests
 {
     [Fact]
     public void Constructor_SetsAllProperties()
     {
         var jobId = Guid.NewGuid();
 
-        var sut = new ImportJobCompletedEvent(
+        var sut = new ImportJobCompletedEto(
             jobId,
             "CustomerImport",
             ImportJobStatus.Completed,
@@ -43,7 +43,7 @@ public sealed class ImportJobCompletedEventTests
     [InlineData(ImportJobStatus.Cancelled)]
     public void Constructor_AcceptsTerminalStatuses(ImportJobStatus status)
     {
-        var sut = new ImportJobCompletedEvent(
+        var sut = new ImportJobCompletedEto(
             Guid.NewGuid(), "def", status, "user", 10, 5, 5, 3, 2, 0);
 
         sut.Status.ShouldBe(status);
@@ -54,8 +54,8 @@ public sealed class ImportJobCompletedEventTests
     {
         var jobId = Guid.NewGuid();
 
-        var a = new ImportJobCompletedEvent(jobId, "d", ImportJobStatus.Completed, "u", 1, 1, 0, 1, 0, 0);
-        var b = new ImportJobCompletedEvent(jobId, "d", ImportJobStatus.Completed, "u", 1, 1, 0, 1, 0, 0);
+        var a = new ImportJobCompletedEto(jobId, "d", ImportJobStatus.Completed, "u", 1, 1, 0, 1, 0, 0);
+        var b = new ImportJobCompletedEto(jobId, "d", ImportJobStatus.Completed, "u", 1, 1, 0, 1, 0, 0);
 
         a.ShouldBe(b);
     }

--- a/tests/Granit.DocumentGeneration.Pdf.Tests/packages.lock.json
+++ b/tests/Granit.DocumentGeneration.Pdf.Tests/packages.lock.json
@@ -397,13 +397,20 @@
           "Microsoft.Extensions.Primitives": "10.0.5"
         }
       },
+      "Microsoft.IO.RecyclableMemoryStream": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.0.1",
+        "contentHash": "s/s20YTVY9r9TPfTrN5g8zPF1YhwxyqO6PxUkrYTGI2B+OGPe9AdajWZrLhFqXIvqIW23fnUE4+ztrUWNU1+9g=="
+      },
       "PuppeteerSharp": {
         "type": "CentralTransitive",
         "requested": "[24.*, )",
-        "resolved": "24.39.0",
-        "contentHash": "T0Y6LiBa/c7Yk0O5i1A7FG0rSzgyJjGXtkGMCLwR9L7dZaXOjHj3/nq43KSlyzu98+loSKtVbFAnDpOM/Tc+zQ==",
+        "resolved": "24.40.0",
+        "contentHash": "vVvHFHCRW6772ptQmwzIxmc2CdkEv+F9kTlCncv4VFSGev1ev5mtlL9aVOPdHc6ss5ck6sArP4b2JtNy/7GzGA==",
         "dependencies": {
           "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.1",
           "WebDriverBiDi": "0.0.45"
         }
       }

--- a/tests/Granit.Http.ApiDocumentation.Tests/packages.lock.json
+++ b/tests/Granit.Http.ApiDocumentation.Tests/packages.lock.json
@@ -623,8 +623,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.13.10",
-        "contentHash": "AHsAdrbjIVvV/l6dwsIpluuWZEjafmxLkoJTzdRruRNB3w5VI5MKM1Gu0gyX6xRI0raEtSy3O111YpBrZMOpSA=="
+        "resolved": "2.13.13",
+        "contentHash": "QS94/CNp2thhykXwBaOHjDe8Zlexs8v0QOrdLfUvxS85uW84IhCf1zGiOnYZNNtVxunJvtsr7yPgEP36TXnJ3w=="
       }
     }
   }

--- a/tests/Granit.Http.Cookies.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Http.Cookies.Endpoints.Tests/packages.lock.json
@@ -645,8 +645,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.13.10",
-        "contentHash": "AHsAdrbjIVvV/l6dwsIpluuWZEjafmxLkoJTzdRruRNB3w5VI5MKM1Gu0gyX6xRI0raEtSy3O111YpBrZMOpSA=="
+        "resolved": "2.13.13",
+        "contentHash": "QS94/CNp2thhykXwBaOHjDe8Zlexs8v0QOrdLfUvxS85uW84IhCf1zGiOnYZNNtVxunJvtsr7yPgEP36TXnJ3w=="
       }
     }
   }

--- a/tests/Granit.Identity.Cognito.Tests/CognitoIdentityProviderTests.cs
+++ b/tests/Granit.Identity.Cognito.Tests/CognitoIdentityProviderTests.cs
@@ -1,6 +1,7 @@
 using Amazon.CognitoIdentityProvider;
 using Amazon.CognitoIdentityProvider.Model;
 using Amazon.Runtime;
+using Granit.Core.Events;
 using Granit.Identity.Cognito.Internal;
 using Granit.Identity.Cognito.Options;
 using Granit.Identity.Models;
@@ -15,7 +16,7 @@ namespace Granit.Identity.Cognito.Tests;
 public sealed class CognitoIdentityProviderTests
 {
     private readonly IAmazonCognitoIdentityProvider _cognitoClient = Substitute.For<IAmazonCognitoIdentityProvider>();
-    private readonly IIdentityEventPublisher _eventPublisher = Substitute.For<IIdentityEventPublisher>();
+    private readonly IDistributedEventBus _distributedEventBus = Substitute.For<IDistributedEventBus>();
     private readonly CognitoIdentityProvider _sut;
 
     public CognitoIdentityProviderTests()
@@ -30,7 +31,7 @@ public sealed class CognitoIdentityProviderTests
         _sut = new CognitoIdentityProvider(
             _cognitoClient,
             Microsoft.Extensions.Options.Options.Create(options),
-            _eventPublisher,
+            _distributedEventBus,
             NullLogger<CognitoIdentityProvider>.Instance);
     }
 
@@ -179,8 +180,8 @@ public sealed class CognitoIdentityProviderTests
             Arg.Is<AdminAddUserToGroupRequest>(r => r.Username == "user1" && r.GroupName == "admin"),
             Arg.Any<CancellationToken>());
 
-        await _eventPublisher.Received(1).PublishAsync(
-            Arg.Any<Events.IdentityGroupMembershipChangedEvent>(),
+        await _distributedEventBus.Received(1).PublishAsync(
+            Arg.Any<Events.IdentityGroupMembershipChangedEto>(),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/Granit.Identity.Cognito.Tests/IdentityCognitoServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Identity.Cognito.Tests/IdentityCognitoServiceCollectionExtensionsTests.cs
@@ -1,4 +1,5 @@
 using Amazon.CognitoIdentityProvider;
+using Granit.Core.Events;
 using Granit.Identity.Cognito.Extensions;
 using Granit.Identity.Cognito.Internal;
 using Granit.Identity.Cognito.Options;
@@ -6,6 +7,7 @@ using Granit.Identity.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -28,6 +30,7 @@ public sealed class IdentityCognitoServiceCollectionExtensionsTests
         ServiceCollection services = new();
         services.AddSingleton(configuration);
         services.AddLogging();
+        services.AddSingleton(Substitute.For<IDistributedEventBus>());
         services.AddGranitIdentity();
         services.AddGranitIdentityCognito();
         return services.BuildServiceProvider();

--- a/tests/Granit.Identity.Cognito.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Cognito.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.17",
-        "contentHash": "Ab24kVquQ8kvuQKNe5MK/SvaXR4uoxPkAlTPALDEImaHcwsBg+UWfRVcNzLEx4dRR2y1mDFFh+zZ9TVMXGY6Jg=="
+        "resolved": "4.0.3.19",
+        "contentHash": "8zIzN59+J6arYSyFuhnSxPepr8ff4p6li+MxKUUnqCgwZqQ+icEGJK/23c1USIEALqZZ5gdiITuH2sOZWQom+Q=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -294,10 +294,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.6.2",
-        "contentHash": "MOhL6nl78bYJh1AmoMNq9nJIM4dFjDO/FsLYMYj8IrWCqmfujGeHe8EnNEOM+Bxc8t5CLkil91awpS0TguzT+g==",
+        "resolved": "4.0.6.3",
+        "contentHash": "jgs58BUUO1v/6thtWUYQbuIZD0LotMsbk8bpZ+qYsfMo3HOO89xEmsojs6BgwIKZe7++mltD7eSB8P7VhLSGeg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.17, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.19, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {

--- a/tests/Granit.Identity.EntityFrameworkCore.Tests/Events/EfCoreIdentityEventsTests.cs
+++ b/tests/Granit.Identity.EntityFrameworkCore.Tests/Events/EfCoreIdentityEventsTests.cs
@@ -7,58 +7,58 @@ namespace Granit.Identity.EntityFrameworkCore.Tests.Events;
 
 public sealed class EfCoreIdentityEventsTests
 {
-    // ──── IdentityUserUpdatedEvent ────
+    // ──── IdentityUserUpdatedEto ────
 
     [Fact]
-    public void IdentityUserUpdatedEvent_SetsUserId()
+    public void IdentityUserUpdatedEto_SetsUserId()
     {
-        var evt = new IdentityUserUpdatedEvent("user-1");
+        var evt = new IdentityUserUpdatedEto("user-1");
 
         evt.UserId.ShouldBe("user-1");
     }
 
     [Fact]
-    public void IdentityUserUpdatedEvent_SupportsRecordEquality()
+    public void IdentityUserUpdatedEto_SupportsRecordEquality()
     {
-        var evt1 = new IdentityUserUpdatedEvent("user-1");
-        var evt2 = new IdentityUserUpdatedEvent("user-1");
+        var evt1 = new IdentityUserUpdatedEto("user-1");
+        var evt2 = new IdentityUserUpdatedEto("user-1");
 
         evt1.ShouldBe(evt2);
     }
 
-    // ──── IdentityUserDeletedEvent ────
+    // ──── IdentityUserDeletedEto ────
 
     [Fact]
-    public void IdentityUserDeletedEvent_SetsUserId()
+    public void IdentityUserDeletedEto_SetsUserId()
     {
-        var evt = new IdentityUserDeletedEvent("user-1");
+        var evt = new IdentityUserDeletedEto("user-1");
 
         evt.UserId.ShouldBe("user-1");
     }
 
     [Fact]
-    public void IdentityUserDeletedEvent_TenantIdDefaultsToNull()
+    public void IdentityUserDeletedEto_TenantIdDefaultsToNull()
     {
-        var evt = new IdentityUserDeletedEvent("user-1");
+        var evt = new IdentityUserDeletedEto("user-1");
 
         evt.TenantId.ShouldBeNull();
     }
 
     [Fact]
-    public void IdentityUserDeletedEvent_AcceptsTenantId()
+    public void IdentityUserDeletedEto_AcceptsTenantId()
     {
         var tenantId = Guid.NewGuid();
-        var evt = new IdentityUserDeletedEvent("user-1", tenantId);
+        var evt = new IdentityUserDeletedEto("user-1", tenantId);
 
         evt.TenantId.ShouldBe(tenantId);
     }
 
     [Fact]
-    public void IdentityUserDeletedEvent_SupportsRecordEquality()
+    public void IdentityUserDeletedEto_SupportsRecordEquality()
     {
         var tenantId = Guid.NewGuid();
-        var evt1 = new IdentityUserDeletedEvent("user-1", tenantId);
-        var evt2 = new IdentityUserDeletedEvent("user-1", tenantId);
+        var evt1 = new IdentityUserDeletedEto("user-1", tenantId);
+        var evt2 = new IdentityUserDeletedEto("user-1", tenantId);
 
         evt1.ShouldBe(evt2);
     }

--- a/tests/Granit.Identity.EntityFrameworkCore.Tests/IdentityUserEventHandlerTests.cs
+++ b/tests/Granit.Identity.EntityFrameworkCore.Tests/IdentityUserEventHandlerTests.cs
@@ -37,7 +37,7 @@ public sealed class IdentityUserEventHandlerTests
 
         IdentityUserEventHandler handler = CreateHandler();
         await handler.HandleAsync(
-            new IdentityUserUpdatedEvent("user-1"), TestContext.Current.CancellationToken);
+            new IdentityUserUpdatedEto("user-1"), TestContext.Current.CancellationToken);
 
         await _store.Received(1).UpsertAsync(
             Arg.Is<UserCacheEntry>(e => e.ExternalUserId == "user-1" && e.Username == "jdoe"),
@@ -52,7 +52,7 @@ public sealed class IdentityUserEventHandlerTests
 
         IdentityUserEventHandler handler = CreateHandler();
         await handler.HandleAsync(
-            new IdentityUserUpdatedEvent("user-1"), TestContext.Current.CancellationToken);
+            new IdentityUserUpdatedEto("user-1"), TestContext.Current.CancellationToken);
 
         await _store.DidNotReceive().UpsertAsync(
             Arg.Any<UserCacheEntry>(), Arg.Any<CancellationToken>());
@@ -65,7 +65,7 @@ public sealed class IdentityUserEventHandlerTests
         IdentityUserEventHandler handler = CreateHandler();
 
         await handler.HandleAsync(
-            new IdentityUserDeletedEvent("user-1", tenantId), TestContext.Current.CancellationToken);
+            new IdentityUserDeletedEto("user-1", tenantId), TestContext.Current.CancellationToken);
 
         await _store.Received(1).DeleteByExternalIdAsync("user-1", tenantId, Arg.Any<CancellationToken>());
     }

--- a/tests/Granit.Identity.EntraId.Tests/EntraIdIdentityProviderAdditionalTests.cs
+++ b/tests/Granit.Identity.EntraId.Tests/EntraIdIdentityProviderAdditionalTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Net;
+using Granit.Core.Events;
 using Granit.Identity;
 using Granit.Identity.EntraId.Internal;
 using Granit.Identity.EntraId.Options;
@@ -28,7 +29,7 @@ public sealed class EntraIdIdentityProviderAdditionalTests : IDisposable
 
     private readonly EntraIdAdminTokenService _tokenService;
     private readonly IPasswordResetNotifier _passwordResetNotifier = Substitute.For<IPasswordResetNotifier>();
-    private readonly IIdentityEventPublisher _eventPublisher = Substitute.For<IIdentityEventPublisher>();
+    private readonly IDistributedEventBus _distributedEventBus = Substitute.For<IDistributedEventBus>();
     private readonly EntraIdIdentityProvider _provider;
     private readonly ActivityListener _activityListener;
 
@@ -66,7 +67,7 @@ public sealed class EntraIdIdentityProviderAdditionalTests : IDisposable
             _httpClientFactory,
             Microsoft.Extensions.Options.Options.Create(_options),
             _passwordResetNotifier,
-            _eventPublisher,
+            _distributedEventBus,
             NullLogger<EntraIdIdentityProvider>.Instance);
     }
 
@@ -124,8 +125,8 @@ public sealed class EntraIdIdentityProviderAdditionalTests : IDisposable
 
         await _provider.UpdateUserAsync("user-1", update, TestContext.Current.CancellationToken);
 
-        await _eventPublisher.Received(1).PublishAsync(
-            Arg.Is<IdentityUserProfileUpdatedEvent>(e =>
+        await _distributedEventBus.Received(1).PublishAsync(
+            Arg.Is<IdentityUserProfileUpdatedEto>(e =>
                 e.UserId == "user-1" && e.Update == update),
             Arg.Any<CancellationToken>());
     }
@@ -319,7 +320,7 @@ public sealed class EntraIdIdentityProviderAdditionalTests : IDisposable
             sequenceFactory,
             Microsoft.Extensions.Options.Options.Create(_options),
             _passwordResetNotifier,
-            _eventPublisher,
+            _distributedEventBus,
             NullLogger<EntraIdIdentityProvider>.Instance);
 
         IReadOnlyList<IdentityRole> result = await provider.GetUserRolesAsync(
@@ -354,8 +355,8 @@ public sealed class EntraIdIdentityProviderAdditionalTests : IDisposable
 
         await _provider.TerminateAllSessionsAsync("user-1", TestContext.Current.CancellationToken);
 
-        await _eventPublisher.Received(1).PublishAsync(
-            Arg.Is<IdentitySessionsRevokedEvent>(e => e.UserId == "user-1"),
+        await _distributedEventBus.Received(1).PublishAsync(
+            Arg.Is<IdentitySessionsRevokedEto>(e => e.UserId == "user-1"),
             Arg.Any<CancellationToken>());
     }
 
@@ -387,8 +388,8 @@ public sealed class EntraIdIdentityProviderAdditionalTests : IDisposable
         await _provider.SetTemporaryPasswordAsync(
             "user-1", "TempPass123!", TestContext.Current.CancellationToken);
 
-        await _eventPublisher.Received(1).PublishAsync(
-            Arg.Is<IdentityPasswordResetEvent>(e => e.UserId == "user-1"),
+        await _distributedEventBus.Received(1).PublishAsync(
+            Arg.Is<IdentityPasswordResetEto>(e => e.UserId == "user-1"),
             Arg.Any<CancellationToken>());
     }
 
@@ -420,8 +421,8 @@ public sealed class EntraIdIdentityProviderAdditionalTests : IDisposable
 
         await _provider.SendPasswordResetEmailAsync("user-1", TestContext.Current.CancellationToken);
 
-        await _eventPublisher.Received().PublishAsync(
-            Arg.Is<IdentityPasswordResetEvent>(e => e.UserId == "user-1"),
+        await _distributedEventBus.Received().PublishAsync(
+            Arg.Is<IdentityPasswordResetEto>(e => e.UserId == "user-1"),
             Arg.Any<CancellationToken>());
     }
 
@@ -476,8 +477,8 @@ public sealed class EntraIdIdentityProviderAdditionalTests : IDisposable
 
         await _provider.AddUserToGroupAsync("user-1", "grp-1", TestContext.Current.CancellationToken);
 
-        await _eventPublisher.Received(1).PublishAsync(
-            Arg.Is<IdentityGroupMembershipChangedEvent>(e =>
+        await _distributedEventBus.Received(1).PublishAsync(
+            Arg.Is<IdentityGroupMembershipChangedEto>(e =>
                 e.UserId == "user-1" && e.GroupId == "grp-1" && e.Added),
             Arg.Any<CancellationToken>());
     }
@@ -505,8 +506,8 @@ public sealed class EntraIdIdentityProviderAdditionalTests : IDisposable
 
         await _provider.RemoveUserFromGroupAsync("user-1", "grp-1", TestContext.Current.CancellationToken);
 
-        await _eventPublisher.Received(1).PublishAsync(
-            Arg.Is<IdentityGroupMembershipChangedEvent>(e =>
+        await _distributedEventBus.Received(1).PublishAsync(
+            Arg.Is<IdentityGroupMembershipChangedEto>(e =>
                 e.UserId == "user-1" && e.GroupId == "grp-1" && !e.Added),
             Arg.Any<CancellationToken>());
     }

--- a/tests/Granit.Identity.EntraId.Tests/EntraIdIdentityProviderTests.cs
+++ b/tests/Granit.Identity.EntraId.Tests/EntraIdIdentityProviderTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Net;
+using Granit.Core.Events;
 using Granit.Identity;
 using Granit.Identity.EntraId.Internal;
 using Granit.Identity.EntraId.Options;
@@ -29,7 +30,7 @@ public sealed class EntraIdIdentityProviderTests : IDisposable
 
     private readonly EntraIdAdminTokenService _tokenService;
     private readonly IPasswordResetNotifier _passwordResetNotifier = Substitute.For<IPasswordResetNotifier>();
-    private readonly IIdentityEventPublisher _eventPublisher = Substitute.For<IIdentityEventPublisher>();
+    private readonly IDistributedEventBus _distributedEventBus = Substitute.For<IDistributedEventBus>();
     private readonly EntraIdIdentityProvider _provider;
     private readonly ActivityListener _activityListener;
 
@@ -68,7 +69,7 @@ public sealed class EntraIdIdentityProviderTests : IDisposable
             _httpClientFactory,
             Microsoft.Extensions.Options.Options.Create(_options),
             _passwordResetNotifier,
-            _eventPublisher,
+            _distributedEventBus,
             NullLogger<EntraIdIdentityProvider>.Instance);
     }
 
@@ -226,7 +227,7 @@ public sealed class EntraIdIdentityProviderTests : IDisposable
             factory,
             Microsoft.Extensions.Options.Options.Create(optionsWithRopc),
             _passwordResetNotifier,
-            _eventPublisher,
+            _distributedEventBus,
             NullLogger<EntraIdIdentityProvider>.Instance);
 
         bool result = await provider.VerifyUserCredentialsAsync("admin", "password123",
@@ -267,7 +268,7 @@ public sealed class EntraIdIdentityProviderTests : IDisposable
             factory,
             Microsoft.Extensions.Options.Options.Create(optionsWithRopc),
             _passwordResetNotifier,
-            _eventPublisher,
+            _distributedEventBus,
             NullLogger<EntraIdIdentityProvider>.Instance);
 
         bool result = await provider.VerifyUserCredentialsAsync("admin", "wrong-password",
@@ -294,8 +295,8 @@ public sealed class EntraIdIdentityProviderTests : IDisposable
 
         await _provider.SetUserEnabledAsync("u1", true, TestContext.Current.CancellationToken);
 
-        await _eventPublisher.Received(1).PublishAsync(
-            Arg.Is<IdentityUserEnabledChangedEvent>(e => e.UserId == "u1" && e.Enabled),
+        await _distributedEventBus.Received(1).PublishAsync(
+            Arg.Is<IdentityUserEnabledChangedEto>(e => e.UserId == "u1" && e.Enabled),
             Arg.Any<CancellationToken>());
     }
 
@@ -320,22 +321,22 @@ public sealed class EntraIdIdentityProviderTests : IDisposable
         IHttpClientFactory factory = Substitute.For<IHttpClientFactory>();
         factory.CreateClient("MicrosoftGraph").Returns(client);
 
-        IIdentityEventPublisher eventPublisher = Substitute.For<IIdentityEventPublisher>();
+        IDistributedEventBus distributedEventBus = Substitute.For<IDistributedEventBus>();
 
         EntraIdIdentityProvider provider = new(
             _tokenService,
             factory,
             Microsoft.Extensions.Options.Options.Create(optionsWithDomain),
             _passwordResetNotifier,
-            eventPublisher,
+            distributedEventBus,
             NullLogger<EntraIdIdentityProvider>.Instance);
 
         IdentityUserCreate newUser = new("alice", "alice@test.com", "Alice", "Doe");
 
         await provider.CreateUserAsync(newUser, TestContext.Current.CancellationToken);
 
-        await eventPublisher.Received(1).PublishAsync(
-            Arg.Is<IdentityUserCreatedEvent>(e =>
+        await distributedEventBus.Received(1).PublishAsync(
+            Arg.Is<IdentityUserCreatedEto>(e =>
                 e.UserId == "new-user-id" &&
                 e.Username == "alice" &&
                 e.Email == "alice@test.com"),

--- a/tests/Granit.Identity.EntraId.Tests/IdentityEntraIdActivitySourceTests.cs
+++ b/tests/Granit.Identity.EntraId.Tests/IdentityEntraIdActivitySourceTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Net;
+using Granit.Core.Events;
 using Granit.Identity;
 using Granit.Identity.EntraId.Diagnostics;
 using Granit.Identity.EntraId.Internal;
@@ -23,7 +24,7 @@ public sealed class IdentityEntraIdActivitySourceTests : IDisposable
     private readonly IHttpClientFactory _httpClientFactory = Substitute.For<IHttpClientFactory>();
     private readonly EntraIdAdminTokenService _tokenService;
     private readonly IPasswordResetNotifier _passwordResetNotifier = Substitute.For<IPasswordResetNotifier>();
-    private readonly IIdentityEventPublisher _eventPublisher = Substitute.For<IIdentityEventPublisher>();
+    private readonly IDistributedEventBus _distributedEventBus = Substitute.For<IDistributedEventBus>();
     private readonly EntraIdIdentityProvider _provider;
 
     public IdentityEntraIdActivitySourceTests()
@@ -71,7 +72,7 @@ public sealed class IdentityEntraIdActivitySourceTests : IDisposable
             _httpClientFactory,
             MsOptions.Create(options),
             _passwordResetNotifier,
-            _eventPublisher,
+            _distributedEventBus,
             NullLogger<EntraIdIdentityProvider>.Instance);
     }
 

--- a/tests/Granit.Identity.EntraId.Tests/IdentityEntraIdActivitySourceTests.cs
+++ b/tests/Granit.Identity.EntraId.Tests/IdentityEntraIdActivitySourceTests.cs
@@ -107,9 +107,11 @@ public sealed class IdentityEntraIdActivitySourceTests : IDisposable
 
         await _provider.GetUsersAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        Activity? activity = _activities.Find(a => a.OperationName == IdentityEntraIdActivitySource.GetUsers);
-        activity.ShouldNotBeNull();
-        activity.Status.ShouldBe(ActivityStatusCode.Error);
+        // Filter by both operation name AND status to avoid cross-contamination from parallel test classes
+        // (EntraIdIdentityProviderTests also calls GetUsersAsync with success, producing Unset activities).
+        _activities.ShouldContain(a =>
+            a.OperationName == IdentityEntraIdActivitySource.GetUsers
+            && a.Status == ActivityStatusCode.Error);
     }
 
     [Fact]
@@ -174,9 +176,11 @@ public sealed class IdentityEntraIdActivitySourceTests : IDisposable
 
         await _provider.GetRolesAsync(TestContext.Current.CancellationToken);
 
-        Activity? activity = _activities.Find(a => a.OperationName == IdentityEntraIdActivitySource.GetRoles);
-        activity.ShouldNotBeNull();
-        activity.Status.ShouldBe(ActivityStatusCode.Error);
+        // Filter by both operation name AND status to avoid cross-contamination from parallel test classes
+        // (EntraIdIdentityProviderAdditionalTests also calls GetRolesAsync with success, producing Unset activities).
+        _activities.ShouldContain(a =>
+            a.OperationName == IdentityEntraIdActivitySource.GetRoles
+            && a.Status == ActivityStatusCode.Error);
     }
 
     [Fact]

--- a/tests/Granit.Identity.GoogleCloud.Tests/GoogleCloudIdentityProviderTests.cs
+++ b/tests/Granit.Identity.GoogleCloud.Tests/GoogleCloudIdentityProviderTests.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using FirebaseAdmin.Auth;
+using Granit.Core.Events;
 using Granit.Identity.Events;
 using Granit.Identity.GoogleCloud.Internal;
 using Granit.Identity.GoogleCloud.Options;
@@ -15,7 +16,7 @@ namespace Granit.Identity.GoogleCloud.Tests;
 public sealed class GoogleCloudIdentityProviderTests
 {
     private readonly IFirebaseAuthTransport _transport = Substitute.For<IFirebaseAuthTransport>();
-    private readonly IIdentityEventPublisher _eventPublisher = Substitute.For<IIdentityEventPublisher>();
+    private readonly IDistributedEventBus _distributedEventBus = Substitute.For<IDistributedEventBus>();
     private readonly GoogleCloudIdentityOptions _options = new() { ProjectId = "test-project", RolesClaimKey = "roles" };
     private readonly GoogleCloudIdentityProvider _sut;
 
@@ -24,7 +25,7 @@ public sealed class GoogleCloudIdentityProviderTests
         _sut = new GoogleCloudIdentityProvider(
             _transport,
             Microsoft.Extensions.Options.Options.Create(_options),
-            _eventPublisher,
+            _distributedEventBus,
             NullLogger<GoogleCloudIdentityProvider>.Instance);
     }
 
@@ -68,8 +69,8 @@ public sealed class GoogleCloudIdentityProviderTests
         await _transport.Received(1).UpdateUserAsync(
             Arg.Is<UserRecordArgs>(a => a.Uid == "uid-1" && a.Disabled == !enabled),
             Arg.Any<CancellationToken>());
-        await _eventPublisher.Received(1).PublishAsync(
-            Arg.Is<IdentityUserEnabledChangedEvent>(e => e.UserId == "uid-1" && e.Enabled == enabled),
+        await _distributedEventBus.Received(1).PublishAsync(
+            Arg.Is<IdentityUserEnabledChangedEto>(e => e.UserId == "uid-1" && e.Enabled == enabled),
             Arg.Any<CancellationToken>());
     }
 
@@ -85,8 +86,8 @@ public sealed class GoogleCloudIdentityProviderTests
         await _transport.Received(1).UpdateUserAsync(
             Arg.Is<UserRecordArgs>(a => a.Uid == "uid-1" && a.Email == "new@example.com" && a.DisplayName == "Jane Smith"),
             Arg.Any<CancellationToken>());
-        await _eventPublisher.Received(1).PublishAsync(
-            Arg.Is<IdentityUserProfileUpdatedEvent>(e => e.UserId == "uid-1"),
+        await _distributedEventBus.Received(1).PublishAsync(
+            Arg.Is<IdentityUserProfileUpdatedEto>(e => e.UserId == "uid-1"),
             Arg.Any<CancellationToken>());
     }
 
@@ -117,8 +118,8 @@ public sealed class GoogleCloudIdentityProviderTests
                 a.Disabled == false &&
                 a.Password == "TempPass123!"),
             Arg.Any<CancellationToken>());
-        await _eventPublisher.Received(1).PublishAsync(
-            Arg.Is<IdentityUserCreatedEvent>(e => e.UserId == "new-uid"),
+        await _distributedEventBus.Received(1).PublishAsync(
+            Arg.Is<IdentityUserCreatedEto>(e => e.UserId == "new-uid"),
             Arg.Any<CancellationToken>());
     }
 
@@ -180,8 +181,8 @@ public sealed class GoogleCloudIdentityProviderTests
             "uid-1",
             Arg.Any<IReadOnlyDictionary<string, object>>(),
             Arg.Any<CancellationToken>());
-        await _eventPublisher.Received(1).PublishAsync(
-            Arg.Is<IdentityRoleAssignedEvent>(e => e.UserId == "uid-1" && e.RoleName == "admin"),
+        await _distributedEventBus.Received(1).PublishAsync(
+            Arg.Is<IdentityRoleAssignedEto>(e => e.UserId == "uid-1" && e.RoleName == "admin"),
             Arg.Any<CancellationToken>());
     }
 
@@ -198,8 +199,8 @@ public sealed class GoogleCloudIdentityProviderTests
             "uid-1",
             Arg.Any<IReadOnlyDictionary<string, object>>(),
             Arg.Any<CancellationToken>());
-        await _eventPublisher.Received(1).PublishAsync(
-            Arg.Is<IdentityRoleRemovedEvent>(e => e.UserId == "uid-1" && e.RoleName == "admin"),
+        await _distributedEventBus.Received(1).PublishAsync(
+            Arg.Is<IdentityRoleRemovedEto>(e => e.UserId == "uid-1" && e.RoleName == "admin"),
             Arg.Any<CancellationToken>());
     }
 
@@ -242,8 +243,8 @@ public sealed class GoogleCloudIdentityProviderTests
         await _sut.TerminateAllSessionsAsync("uid-1", TestContext.Current.CancellationToken);
 
         await _transport.Received(1).RevokeRefreshTokensAsync("uid-1", Arg.Any<CancellationToken>());
-        await _eventPublisher.Received(1).PublishAsync(
-            Arg.Is<IdentitySessionsRevokedEvent>(e => e.UserId == "uid-1"),
+        await _distributedEventBus.Received(1).PublishAsync(
+            Arg.Is<IdentitySessionsRevokedEto>(e => e.UserId == "uid-1"),
             Arg.Any<CancellationToken>());
     }
 
@@ -260,8 +261,8 @@ public sealed class GoogleCloudIdentityProviderTests
         await _sut.SendPasswordResetEmailAsync("uid-1", TestContext.Current.CancellationToken);
 
         await _transport.Received(1).GeneratePasswordResetLinkAsync("john@example.com", Arg.Any<CancellationToken>());
-        await _eventPublisher.Received(1).PublishAsync(
-            Arg.Is<IdentityPasswordResetEvent>(e => e.UserId == "uid-1"),
+        await _distributedEventBus.Received(1).PublishAsync(
+            Arg.Is<IdentityPasswordResetEto>(e => e.UserId == "uid-1"),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/Granit.Identity.GoogleCloud.Tests/IdentityGoogleCloudServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Identity.GoogleCloud.Tests/IdentityGoogleCloudServiceCollectionExtensionsTests.cs
@@ -1,3 +1,4 @@
+using Granit.Core.Events;
 using Granit.Identity.GoogleCloud.Extensions;
 using Granit.Identity.GoogleCloud.Internal;
 using Granit.Identity.GoogleCloud.Options;
@@ -24,7 +25,7 @@ public sealed class IdentityGoogleCloudServiceCollectionExtensionsTests
         services.AddLogging();
 
         // Register identity abstractions that AddGranitIdentityGoogleCloud expects
-        services.AddSingleton(NSubstitute.Substitute.For<IIdentityEventPublisher>());
+        services.AddSingleton(NSubstitute.Substitute.For<IDistributedEventBus>());
 
         return services;
     }

--- a/tests/Granit.Identity.GoogleCloud.Tests/packages.lock.json
+++ b/tests/Granit.Identity.GoogleCloud.Tests/packages.lock.json
@@ -88,47 +88,47 @@
       },
       "Google.Api.Gax": {
         "type": "Transitive",
-        "resolved": "4.8.0",
-        "contentHash": "xlV8Jq/G5CQAA3PwYAuKGjfzGOP7AvjhREnE6vgZlzxREGYchHudZWa2PWSqFJL+MBtz9YgitLpRogANN3CVvg==",
+        "resolved": "4.13.1",
+        "contentHash": "ujDpZk7O2VqAEIqcSlhH0FKzVpGZWly/qcNjHxpNUrL445Tei9PHnu4V1pwW2WDiMDvo3TpL1Bi4DeU525Afrg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Newtonsoft.Json": "13.0.4"
         }
       },
       "Google.Api.Gax.Rest": {
         "type": "Transitive",
-        "resolved": "4.8.0",
-        "contentHash": "zaA5LZ2VvGj/wwIzRB68swr7khi2kWNgqWvsB0fYtScIAl3kGkGtqiBcx63H1YLeKr5xau1866bFjTeReH6FSQ==",
+        "resolved": "4.13.1",
+        "contentHash": "wDfFZXKoHC6sy+Yfub/4cLQOb5ozBVPqDOrxCUAeTfku4d96ILqgzulJSdkPHbiT3oWB3hlYTdJgUwNSJjyo+A==",
         "dependencies": {
-          "Google.Api.Gax": "4.8.0",
-          "Google.Apis.Auth": "[1.67.0, 2.0.0)",
+          "Google.Api.Gax": "4.13.1",
+          "Google.Apis.Auth": "1.73.0",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0"
         }
       },
       "Google.Apis": {
         "type": "Transitive",
-        "resolved": "1.68.0",
-        "contentHash": "s2MymhdpH+ybZNBeZ2J5uFgFHApBp+QXf9FjZSdM1lk/vx5VqIknJwnaWiuAzXxPrLEkesX0Q+UsiWn39yZ9zw==",
+        "resolved": "1.73.0",
+        "contentHash": "TnCjEyV2aCLQ6Zl40OCbEJULDuEkEWc6C/g81KYw5l1PqGo+G7pFZrV+YH8XgUL0JRUanz+IrUp8SsKF4dzkqg==",
         "dependencies": {
-          "Google.Apis.Core": "1.68.0"
+          "Google.Apis.Core": "1.73.0"
         }
       },
       "Google.Apis.Auth": {
         "type": "Transitive",
-        "resolved": "1.68.0",
-        "contentHash": "hFx8Qz5bZ4w0hpnn4tSmZaaFpjAMsgVElZ+ZgVLUZ2r9i+AKcoVgwiNfv1pruNS5cCvpXqhKECbruBCfRezPHA==",
+        "resolved": "1.73.0",
+        "contentHash": "wEu12uhnRv3zrPBSqv4E2vPH6lYLtc1RPAnU9MJRCMFlBVwZ7Lnq3NfbYXi6VG7EurkYInTaMpeBZkbM/HrAog==",
         "dependencies": {
-          "Google.Apis": "1.68.0",
-          "Google.Apis.Core": "1.68.0",
+          "Google.Apis": "1.73.0",
+          "Google.Apis.Core": "1.73.0",
           "System.Management": "7.0.2"
         }
       },
       "Google.Apis.Core": {
         "type": "Transitive",
-        "resolved": "1.68.0",
-        "contentHash": "pAqwa6pfu53UXCR2b7A/PAPXeuVg6L1OFw38WckN27NU2+mf+KTjoEg2YGv/f0UyKxzz7DxF1urOTKg/6dTP9g==",
+        "resolved": "1.73.0",
+        "contentHash": "vSc7CY4KCP7HE4QTElDx/ExnGLbg9kXb89MS6cdvI+0D4sxvTYb16vGtXmF2jSDMV3iDmykSXdIUPTz8TDS6gg==",
         "dependencies": {
-          "Newtonsoft.Json": "13.0.3"
+          "Newtonsoft.Json": "13.0.4"
         }
       },
       "Microsoft.ApplicationInsights": {
@@ -219,8 +219,8 @@
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+        "resolved": "13.0.4",
+        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
       },
       "System.CodeDom": {
         "type": "Transitive",
@@ -334,11 +334,11 @@
       "FirebaseAdmin": {
         "type": "CentralTransitive",
         "requested": "[3.*, )",
-        "resolved": "3.4.0",
-        "contentHash": "sQyVEOYRe4HSSmRCJQhKr33DxZk10lpDE2otdTgNkqPn4BRul2JG7TCQC7N7X0wO9ShnPLbVS4xuSUHlaPBbug==",
+        "resolved": "3.5.0",
+        "contentHash": "NL9dWvrGCbgu3VxumjpHXgHsagQswntJNLtgVIgTF/y2ro6e6UpvFuZrlfjsMTzRXJEXqnse3U5rN/6HC5TlFA==",
         "dependencies": {
-          "Google.Api.Gax.Rest": "4.8.0",
-          "Google.Apis.Auth": "1.68.0"
+          "Google.Api.Gax.Rest": "4.13.1",
+          "Google.Apis.Auth": "1.73.0"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {

--- a/tests/Granit.Identity.Keycloak.Tests/KeycloakIdentityProviderTests.cs
+++ b/tests/Granit.Identity.Keycloak.Tests/KeycloakIdentityProviderTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Net;
+using Granit.Core.Events;
 using Granit.Identity;
 using Granit.Identity.Diagnostics;
 using Granit.Identity.Events;
@@ -32,7 +33,7 @@ public sealed class KeycloakIdentityProviderTests : IDisposable
 
     private readonly KeycloakAdminTokenService _tokenService;
     private readonly KeycloakUserTokenExchangeService _tokenExchangeService;
-    private readonly IIdentityEventPublisher _eventPublisher = Substitute.For<IIdentityEventPublisher>();
+    private readonly IDistributedEventBus _distributedEventBus = Substitute.For<IDistributedEventBus>();
     private readonly IdentityMetrics _metrics;
     private readonly ServiceProvider _metricsServiceProvider;
     private readonly KeycloakIdentityProvider _provider;
@@ -95,7 +96,7 @@ public sealed class KeycloakIdentityProviderTests : IDisposable
             _tokenExchangeService,
             _httpClientFactory,
             Microsoft.Extensions.Options.Options.Create(_options),
-            _eventPublisher,
+            _distributedEventBus,
             _metrics,
             NullLogger<KeycloakIdentityProvider>.Instance);
     }
@@ -563,7 +564,7 @@ public sealed class KeycloakIdentityProviderTests : IDisposable
             exchangeSvc,
             seqFactory,
             Microsoft.Extensions.Options.Options.Create(opts),
-            Substitute.For<IIdentityEventPublisher>(),
+            Substitute.For<IDistributedEventBus>(),
             _metrics,
             NullLogger<KeycloakIdentityProvider>.Instance);
 
@@ -962,7 +963,7 @@ public sealed class KeycloakIdentityProviderTests : IDisposable
             _tokenExchangeService,
             locationFactory,
             Microsoft.Extensions.Options.Options.Create(_options),
-            Substitute.For<IIdentityEventPublisher>(),
+            Substitute.For<IDistributedEventBus>(),
             _metrics,
             NullLogger<KeycloakIdentityProvider>.Instance);
 
@@ -1137,7 +1138,7 @@ public sealed class KeycloakIdentityProviderTests : IDisposable
             _tokenExchangeService,
             seqFactory,
             Microsoft.Extensions.Options.Options.Create(_options),
-            Substitute.For<IIdentityEventPublisher>(),
+            Substitute.For<IDistributedEventBus>(),
             _metrics,
             NullLogger<KeycloakIdentityProvider>.Instance);
 
@@ -1205,7 +1206,7 @@ public sealed class KeycloakIdentityProviderTests : IDisposable
             _tokenExchangeService,
             factory,
             Microsoft.Extensions.Options.Options.Create(optionsWithDirect),
-            Substitute.For<IIdentityEventPublisher>(),
+            Substitute.For<IDistributedEventBus>(),
             _metrics,
             NullLogger<KeycloakIdentityProvider>.Instance);
 
@@ -1247,7 +1248,7 @@ public sealed class KeycloakIdentityProviderTests : IDisposable
             _tokenExchangeService,
             factory,
             Microsoft.Extensions.Options.Options.Create(optionsWithDirect),
-            Substitute.For<IIdentityEventPublisher>(),
+            Substitute.For<IDistributedEventBus>(),
             _metrics,
             NullLogger<KeycloakIdentityProvider>.Instance);
 
@@ -1291,8 +1292,8 @@ public sealed class KeycloakIdentityProviderTests : IDisposable
 
         await _provider.SetUserEnabledAsync("u1", true, TestContext.Current.CancellationToken);
 
-        await _eventPublisher.Received(1).PublishAsync(
-            Arg.Is<IdentityUserEnabledChangedEvent>(e => e.UserId == "u1" && e.Enabled),
+        await _distributedEventBus.Received(1).PublishAsync(
+            Arg.Is<IdentityUserEnabledChangedEto>(e => e.UserId == "u1" && e.Enabled),
             Arg.Any<CancellationToken>());
     }
 
@@ -1303,8 +1304,8 @@ public sealed class KeycloakIdentityProviderTests : IDisposable
 
         await _provider.AssignRoleAsync("u1", "editor", TestContext.Current.CancellationToken);
 
-        await _eventPublisher.Received(1).PublishAsync(
-            Arg.Is<IdentityRoleAssignedEvent>(e => e.UserId == "u1" && e.RoleName == "editor"),
+        await _distributedEventBus.Received(1).PublishAsync(
+            Arg.Is<IdentityRoleAssignedEto>(e => e.UserId == "u1" && e.RoleName == "editor"),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/Granit.Identity.OpenIddict.Tests/packages.lock.json
+++ b/tests/Granit.Identity.OpenIddict.Tests/packages.lock.json
@@ -20,12 +20,6 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
-      "Microsoft.Extensions.TimeProvider.Testing": {
-        "type": "Direct",
-        "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "uJ8n9WUEzux9I2CjZh7imGBgZadfwhAKlxuBq7GsNGL8FJF81aHXAYaRMnwW+9EvRFQNytu7xo1ffeuuTncAzg=="
-      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
@@ -73,10 +67,7 @@
       "Castle.Core": {
         "type": "Transitive",
         "resolved": "5.1.1",
-        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
-        "dependencies": {
-          "System.Diagnostics.EventLog": "6.0.0"
-        }
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g=="
       },
       "DiffEngine": {
         "type": "Transitive",
@@ -107,44 +98,36 @@
         "resolved": "18.3.0",
         "contentHash": "23BNy/vziREC20Wwhb50K7+kZe0m07KlLWDQv4qjJ9tt3QjpDpDIqJFrhYHmMEo9xDkuSp55U/8h4bMF7MiB+g=="
       },
-      "Microsoft.Extensions.Configuration": {
+      "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.5",
-        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
+        "contentHash": "32c58Rnm47Qvhimawf67KO9PytgPz3QoWye7Abapt0Yocw/JnzMiSNj/pRoIKyn8Jxypkv86zxKD4Q/zNTc0Ag=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "ipC4u1VojgEfoIZhtbS2Sx5IluJTP/Jf1hz3yGsxGBgSukYY/CquI6rAjxn5H58CZgVn36qcuPPtNMwZ0AUzMg=="
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "V7fHMFpfzvx7twWMV3jrf3OFVmYn3QhUYtvfMRD9yUPs9gxnQSaRMZh5NzCsnW3ZZ80J09EE7yyjM71y9JC6hQ=="
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.12.0",
+        "contentHash": "IakwNWUTy5RlcDcKwtL5TyfDLZmA8FFnSDhfr+wfGGPMON9GkpkUY8NakIJjdy6mv6C1lM/Jkn3IuaeS9MXesA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
+          "Microsoft.IdentityModel.Abstractions": "8.12.0"
         }
       },
-      "Microsoft.Extensions.Configuration.Abstractions": {
+      "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "resolved": "8.12.0",
+        "contentHash": "WCU3wv5sioX5hhp3oHw8sCdygnfZJtRKJGCg+AckP6nbp0QGKK3VohTrxIF0dpuziLAPg57CPfS9X8UERroKxA==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.5"
+          "Microsoft.IdentityModel.Logging": "8.12.0"
         }
-      },
-      "Microsoft.Extensions.Diagnostics.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.FileProviders.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Primitives": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -200,15 +183,31 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "OpenIddict.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "sVhLvY4sZ3UFXudfc8A6gM45uyA9WwL8987ksf8zY4spVoADFH3cblkyj85OYF5fCQxRDxvOCvyeYfs7zTiaig==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.12.0"
+        }
+      },
+      "OpenIddict.Core": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "xAYq7U/j6JZAbVU88Xv6yXeKutJvNuGCH6zJAlP++abKtSfpP2mRLp2UbS0QS37S+SqRMLxp301DPNtkiRkuPA==",
+        "dependencies": {
+          "OpenIddict.Abstractions": "6.4.0"
+        }
+      },
+      "OpenIddict.EntityFrameworkCore.Models": {
+        "type": "Transitive",
+        "resolved": "6.4.0",
+        "contentHash": "5nyS+XmjoAA8MeyClHA+0EOHCHIDRV4sxDpDpK0RUqtDB4fxmRbKJCzocGHlE/o5iubd6hrKS9bCGZruTWw9oA=="
+      },
       "System.CodeDom": {
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
-      },
-      "System.Diagnostics.EventLog": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -285,120 +284,147 @@
           "xunit.v3.runner.common": "[3.2.2]"
         }
       },
-      "granit.ai": {
-        "type": "Project",
-        "dependencies": {
-          "Granit.Core": "[0.1.0-dev, )",
-          "Granit.Guids": "[0.1.0-dev, )",
-          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
       "granit.core": {
         "type": "Project"
+      },
+      "granit.eventbus": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
       },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
-          "Granit.Timing": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )"
+          "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "granit.imaging": {
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.identity": {
         "type": "Project",
         "dependencies": {
           "Granit.Core": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+          "Granit.Querying": "[0.1.0-dev, )"
         }
       },
-      "granit.imaging.ai": {
+      "granit.identity.openiddict": {
         "type": "Project",
         "dependencies": {
-          "Granit.AI": "[0.1.0-dev, )",
-          "Granit.Imaging": "[0.1.0-dev, )",
-          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+          "Granit.Identity": "[0.1.0-dev, )",
+          "Granit.OpenIddict.EntityFrameworkCore": "[0.1.0-dev, )"
+        }
+      },
+      "granit.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.openiddict": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.EventBus": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Identity": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.openiddict.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
+          "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "OpenIddict.EntityFrameworkCore": "[6.*, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )"
+        }
+      },
+      "granit.querying": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.security": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {
         "type": "Project",
         "dependencies": {
-          "Granit.Core": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )"
+          "Granit.Core": "[0.1.0-dev, )"
         }
       },
-      "Microsoft.Extensions.AI.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.4.1",
-        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
-      },
-      "Microsoft.Extensions.Configuration.Binder": {
+      "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
         "resolved": "10.0.5",
-        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
+        "contentHash": "oo1uauTwgcnhYgituZ2nI3wJ8XN9z76ggu2zkOJu1BCfOOsqr+g08Kr4MOiMuXEhwySkpIV+MVoC25hC1288NA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.5",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.5"
         }
       },
-      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+      "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
         "resolved": "10.0.5",
-        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
-      },
-      "Microsoft.Extensions.Hosting.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "contentHash": "9tNBmK3EpYVGRQLiqP+bqK2m+TD0Gv//4vCzR7ZOgl4FWzCFyOpYdIVka13M4kcBdPdSJcs3wbHr3rmzOqbIMA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.5",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.5"
         }
       },
-      "Microsoft.Extensions.Logging.Abstractions": {
+      "Microsoft.EntityFrameworkCore.Relational": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
         "resolved": "10.0.5",
-        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "contentHash": "uxmFjZEAB/KbsgWFSS4lLqkEHCfXxB2x0UcbiO4e5fCRpFFeTMSx/me6009nYJLu5IKlDwO1POh++P6RilFTDw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+          "Microsoft.EntityFrameworkCore": "10.0.5"
         }
       },
-      "Microsoft.Extensions.Options": {
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
         "resolved": "10.0.5",
-        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "contentHash": "RtNhAwrnZcUZgi3SUMvaDVF405ZtKVR7l/6OHcqFj6JY5nT7QOdBxxULnby9dUQ6Jhnfl7cdDlMjsexfASNyjg==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.5"
         }
       },
-      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+      "OpenIddict.EntityFrameworkCore": {
         "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "requested": "[6.*, )",
+        "resolved": "6.4.0",
+        "contentHash": "glyc+uEaJS9zZxzA/cyF2O4TJudgHLR2Qf2AGq1tNA8mBcQIa2DzKIEuP9rEQD+lofnR/V+cFsybGUyYMsra9Q==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
+          "Microsoft.EntityFrameworkCore.Relational": "9.0.6",
+          "OpenIddict.Core": "6.4.0",
+          "OpenIddict.EntityFrameworkCore.Models": "6.4.0"
         }
       }
     }

--- a/tests/Granit.Identity.Tests/Events/IdentityEventsTests.cs
+++ b/tests/Granit.Identity.Tests/Events/IdentityEventsTests.cs
@@ -8,9 +8,9 @@ namespace Granit.Identity.Tests.Events;
 public sealed class IdentityEventsTests
 {
     [Fact]
-    public void IdentityUserCreatedEvent_SetsAllProperties()
+    public void IdentityUserCreatedEto_SetsAllProperties()
     {
-        var evt = new IdentityUserCreatedEvent("u1", "alice", "alice@test.com");
+        var evt = new IdentityUserCreatedEto("u1", "alice", "alice@test.com");
 
         evt.UserId.ShouldBe("u1");
         evt.Username.ShouldBe("alice");
@@ -18,63 +18,63 @@ public sealed class IdentityEventsTests
     }
 
     [Fact]
-    public void IdentityUserCreatedEvent_AllowsNullOptionalFields()
+    public void IdentityUserCreatedEto_AllowsNullOptionalFields()
     {
-        var evt = new IdentityUserCreatedEvent("u1", null, null);
+        var evt = new IdentityUserCreatedEto("u1", null, null);
 
         evt.Username.ShouldBeNull();
         evt.Email.ShouldBeNull();
     }
 
     [Fact]
-    public void IdentityUserProfileUpdatedEvent_SetsAllProperties()
+    public void IdentityUserProfileUpdatedEto_SetsAllProperties()
     {
         IdentityUserUpdate update = new("new@test.com", "Alice", "Doe");
-        var evt = new IdentityUserProfileUpdatedEvent("u1", update);
+        var evt = new IdentityUserProfileUpdatedEto("u1", update);
 
         evt.UserId.ShouldBe("u1");
         evt.Update.ShouldBe(update);
     }
 
     [Fact]
-    public void IdentityUserEnabledChangedEvent_SetsAllProperties()
+    public void IdentityUserEnabledChangedEto_SetsAllProperties()
     {
-        var evt = new IdentityUserEnabledChangedEvent("u1", true);
+        var evt = new IdentityUserEnabledChangedEto("u1", true);
 
         evt.UserId.ShouldBe("u1");
         evt.Enabled.ShouldBeTrue();
     }
 
     [Fact]
-    public void IdentityUserEnabledChangedEvent_DisabledState()
+    public void IdentityUserEnabledChangedEto_DisabledState()
     {
-        var evt = new IdentityUserEnabledChangedEvent("u1", false);
+        var evt = new IdentityUserEnabledChangedEto("u1", false);
 
         evt.Enabled.ShouldBeFalse();
     }
 
     [Fact]
-    public void IdentityRoleAssignedEvent_SetsAllProperties()
+    public void IdentityRoleAssignedEto_SetsAllProperties()
     {
-        var evt = new IdentityRoleAssignedEvent("u1", "admin");
+        var evt = new IdentityRoleAssignedEto("u1", "admin");
 
         evt.UserId.ShouldBe("u1");
         evt.RoleName.ShouldBe("admin");
     }
 
     [Fact]
-    public void IdentityRoleRemovedEvent_SetsAllProperties()
+    public void IdentityRoleRemovedEto_SetsAllProperties()
     {
-        var evt = new IdentityRoleRemovedEvent("u1", "editor");
+        var evt = new IdentityRoleRemovedEto("u1", "editor");
 
         evt.UserId.ShouldBe("u1");
         evt.RoleName.ShouldBe("editor");
     }
 
     [Fact]
-    public void IdentityGroupMembershipChangedEvent_Added()
+    public void IdentityGroupMembershipChangedEto_Added()
     {
-        var evt = new IdentityGroupMembershipChangedEvent("u1", "group-1", true);
+        var evt = new IdentityGroupMembershipChangedEto("u1", "group-1", true);
 
         evt.UserId.ShouldBe("u1");
         evt.GroupId.ShouldBe("group-1");
@@ -82,25 +82,25 @@ public sealed class IdentityEventsTests
     }
 
     [Fact]
-    public void IdentityGroupMembershipChangedEvent_Removed()
+    public void IdentityGroupMembershipChangedEto_Removed()
     {
-        var evt = new IdentityGroupMembershipChangedEvent("u1", "group-1", false);
+        var evt = new IdentityGroupMembershipChangedEto("u1", "group-1", false);
 
         evt.Added.ShouldBeFalse();
     }
 
     [Fact]
-    public void IdentityPasswordResetEvent_SetsUserId()
+    public void IdentityPasswordResetEto_SetsUserId()
     {
-        var evt = new IdentityPasswordResetEvent("u1");
+        var evt = new IdentityPasswordResetEto("u1");
 
         evt.UserId.ShouldBe("u1");
     }
 
     [Fact]
-    public void IdentitySessionsRevokedEvent_SetsUserId()
+    public void IdentitySessionsRevokedEto_SetsUserId()
     {
-        var evt = new IdentitySessionsRevokedEvent("u1");
+        var evt = new IdentitySessionsRevokedEto("u1");
 
         evt.UserId.ShouldBe("u1");
     }
@@ -108,8 +108,8 @@ public sealed class IdentityEventsTests
     [Fact]
     public void AllEvents_SupportRecordEquality()
     {
-        var evt1 = new IdentityRoleAssignedEvent("u1", "admin");
-        var evt2 = new IdentityRoleAssignedEvent("u1", "admin");
+        var evt1 = new IdentityRoleAssignedEto("u1", "admin");
+        var evt2 = new IdentityRoleAssignedEto("u1", "admin");
 
         evt1.ShouldBe(evt2);
     }
@@ -117,8 +117,8 @@ public sealed class IdentityEventsTests
     [Fact]
     public void AllEvents_SupportRecordInequality()
     {
-        var evt1 = new IdentityRoleAssignedEvent("u1", "admin");
-        var evt2 = new IdentityRoleAssignedEvent("u1", "editor");
+        var evt1 = new IdentityRoleAssignedEto("u1", "admin");
+        var evt2 = new IdentityRoleAssignedEto("u1", "editor");
 
         evt1.ShouldNotBe(evt2);
     }

--- a/tests/Granit.Identity.Tests/IdentityEventPublisherTests.cs
+++ b/tests/Granit.Identity.Tests/IdentityEventPublisherTests.cs
@@ -1,3 +1,5 @@
+#pragma warning disable CS0618
+
 using Granit.Identity.Events;
 using Granit.Identity.Extensions;
 using Granit.Identity.Internal;
@@ -18,7 +20,7 @@ public sealed class IdentityEventPublisherTests
     [Fact]
     public async Task PublishAsync_CompletesWithoutError()
     {
-        var evt = new IdentityUserCreatedEvent("u1", "alice", "alice@test.com");
+        var evt = new IdentityUserCreatedEto("u1", "alice", "alice@test.com");
 
         await Should.NotThrowAsync(
             () => _publisher.PublishAsync(evt, TestContext.Current.CancellationToken));
@@ -27,7 +29,7 @@ public sealed class IdentityEventPublisherTests
     [Fact]
     public async Task PublishAsync_WithEnabledChangedEvent_CompletesWithoutError()
     {
-        var evt = new IdentityUserEnabledChangedEvent("u1", true);
+        var evt = new IdentityUserEnabledChangedEto("u1", true);
 
         await Should.NotThrowAsync(
             () => _publisher.PublishAsync(evt, TestContext.Current.CancellationToken));
@@ -36,48 +38,10 @@ public sealed class IdentityEventPublisherTests
     [Fact]
     public async Task PublishAsync_WithRoleAssignedEvent_CompletesWithoutError()
     {
-        var evt = new IdentityRoleAssignedEvent("u1", "admin");
+        var evt = new IdentityRoleAssignedEto("u1", "admin");
 
         await Should.NotThrowAsync(
             () => _publisher.PublishAsync(evt, TestContext.Current.CancellationToken));
     }
 
-    [Fact]
-    public void AddGranitIdentity_RegistersNullIdentityEventPublisherByDefault()
-    {
-        ServiceCollection services = new();
-
-        services.AddGranitIdentity();
-
-        ServiceProvider provider = services.BuildServiceProvider();
-        using IServiceScope scope = provider.CreateScope();
-        IIdentityEventPublisher eventPublisher = scope.ServiceProvider
-            .GetRequiredService<IIdentityEventPublisher>();
-
-        eventPublisher.ShouldBeOfType<NullIdentityEventPublisher>();
-    }
-
-    [Fact]
-    public void AddGranitIdentity_RegistersEventPublisherAsScoped()
-    {
-        ServiceCollection services = new();
-
-        services.AddGranitIdentity();
-
-        ServiceDescriptor descriptor = services.Single(
-            d => d.ServiceType == typeof(IIdentityEventPublisher));
-        descriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
-    }
-
-    [Fact]
-    public void AddGranitIdentity_DoesNotOverrideExistingEventPublisher()
-    {
-        ServiceCollection services = new();
-        services.AddScoped<IIdentityEventPublisher, NullIdentityEventPublisher>();
-
-        services.AddGranitIdentity();
-
-        // TryAddScoped should not replace the already-registered publisher.
-        services.Count(d => d.ServiceType == typeof(IIdentityEventPublisher)).ShouldBe(1);
-    }
 }

--- a/tests/Granit.Localization.Endpoints.Tests/LocalizationOverridesEndpointTests.cs
+++ b/tests/Granit.Localization.Endpoints.Tests/LocalizationOverridesEndpointTests.cs
@@ -44,7 +44,7 @@ public sealed class LocalizationOverridesEndpointTests : IAsyncDisposable
 
         // Register a role-based policy for the permission name so the TestAuthHandler can resolve it.
         builder.Services.AddAuthorizationBuilder()
-            .AddPolicy(LocalizationOverridesPermissions.Manage,
+            .AddPolicy(LocalizationOverridesPermissions.Overrides.Manage,
                 policy => policy.RequireRole(ManageRole));
 
         builder.Services.AddSingleton(_storeReader);
@@ -418,7 +418,7 @@ public sealed class LocalizationOverridesEndpointTests : IAsyncDisposable
             .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
                 TestAuthHandler.SchemeName, _ => { });
         builder.Services.AddAuthorizationBuilder()
-            .AddPolicy(LocalizationOverridesPermissions.Manage,
+            .AddPolicy(LocalizationOverridesPermissions.Overrides.Manage,
                 policy => policy.RequireRole(ManageRole));
         builder.Services.AddSingleton(_storeReader);
         builder.Services.AddSingleton(_storeWriter);
@@ -466,7 +466,7 @@ public sealed class LocalizationOverridesEndpointTests : IAsyncDisposable
                 TestAuthHandler.SchemeName, _ => { });
 
         builder.Services.AddAuthorizationBuilder()
-            .AddPolicy(LocalizationOverridesPermissions.Manage,
+            .AddPolicy(LocalizationOverridesPermissions.Overrides.Manage,
                 policy => policy.RequireRole(ManageRole));
 
         WebApplication app = builder.Build();

--- a/tests/Granit.Localization.Endpoints.Tests/LocalizationOverridesPermissionDefinitionProviderTests.cs
+++ b/tests/Granit.Localization.Endpoints.Tests/LocalizationOverridesPermissionDefinitionProviderTests.cs
@@ -44,7 +44,7 @@ public sealed class LocalizationOverridesPermissionDefinitionProviderTests
         provider.DefinePermissions(context);
 
         // Assert
-        group.Permissions.ShouldContain(p => p.Name == LocalizationOverridesPermissions.Read);
+        group.Permissions.ShouldContain(p => p.Name == LocalizationOverridesPermissions.Overrides.Read);
     }
 
     [Fact]
@@ -61,7 +61,7 @@ public sealed class LocalizationOverridesPermissionDefinitionProviderTests
         provider.DefinePermissions(context);
 
         // Assert
-        group.Permissions.ShouldContain(p => p.Name == LocalizationOverridesPermissions.Manage);
+        group.Permissions.ShouldContain(p => p.Name == LocalizationOverridesPermissions.Overrides.Manage);
     }
 
     [Fact]

--- a/tests/Granit.Localization.Endpoints.Tests/LocalizationOverridesPermissionsTests.cs
+++ b/tests/Granit.Localization.Endpoints.Tests/LocalizationOverridesPermissionsTests.cs
@@ -12,34 +12,34 @@ public sealed class LocalizationOverridesPermissionsTests
     [Fact]
     public void Read_FollowsThreeSegmentConvention()
     {
-        string[] segments = LocalizationOverridesPermissions.Read.Split('.');
+        string[] segments = LocalizationOverridesPermissions.Overrides.Read.Split('.');
         segments.Length.ShouldBe(3);
     }
 
     [Fact]
     public void Read_StartsWithGroupName()
     {
-        LocalizationOverridesPermissions.Read.ShouldStartWith(
+        LocalizationOverridesPermissions.Overrides.Read.ShouldStartWith(
             LocalizationOverridesPermissions.GroupName + ".");
     }
 
     [Fact]
-    public void Read_HasCorrectValue() => LocalizationOverridesPermissions.Read.ShouldBe("Localization.Overrides.Read");
+    public void Read_HasCorrectValue() => LocalizationOverridesPermissions.Overrides.Read.ShouldBe("Localization.Overrides.Read");
 
     [Fact]
     public void Manage_FollowsThreeSegmentConvention()
     {
-        string[] segments = LocalizationOverridesPermissions.Manage.Split('.');
+        string[] segments = LocalizationOverridesPermissions.Overrides.Manage.Split('.');
         segments.Length.ShouldBe(3);
     }
 
     [Fact]
     public void Manage_StartsWithGroupName()
     {
-        LocalizationOverridesPermissions.Manage.ShouldStartWith(
+        LocalizationOverridesPermissions.Overrides.Manage.ShouldStartWith(
             LocalizationOverridesPermissions.GroupName + ".");
     }
 
     [Fact]
-    public void Manage_HasCorrectValue() => LocalizationOverridesPermissions.Manage.ShouldBe("Localization.Overrides.Manage");
+    public void Manage_HasCorrectValue() => LocalizationOverridesPermissions.Overrides.Manage.ShouldBe("Localization.Overrides.Manage");
 }

--- a/tests/Granit.Notifications.AI.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.AI.Tests/packages.lock.json
@@ -347,8 +347,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/tests/Granit.Notifications.Email.AwsSes.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Email.AwsSes.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.17",
-        "contentHash": "Ab24kVquQ8kvuQKNe5MK/SvaXR4uoxPkAlTPALDEImaHcwsBg+UWfRVcNzLEx4dRR2y1mDFFh+zZ9TVMXGY6Jg=="
+        "resolved": "4.0.3.19",
+        "contentHash": "8zIzN59+J6arYSyFuhnSxPepr8ff4p6li+MxKUUnqCgwZqQ+icEGJK/23c1USIEALqZZ5gdiITuH2sOZWQom+Q=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -350,10 +350,10 @@
       "AWSSDK.SimpleEmailV2": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.12.2",
-        "contentHash": "1NqLYAT5RkwnUjJMfXqmOD2utuBSXL5THzT/YhaLYLlmhKARL5W0QpzuY93ujUkhGapoZO7mjm5E9gv3C+enLQ==",
+        "resolved": "4.0.12.3",
+        "contentHash": "2OV18QATAase5zArxTLNnrFx1G0pECJg/bK73k9KT66W0g2hNFuNTyY/+ERPZ3E63fBDWe0cty/OdhgsFp3ijQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.17, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.19, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {

--- a/tests/Granit.Notifications.MobilePush.AwsSns.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.MobilePush.AwsSns.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.17",
-        "contentHash": "Ab24kVquQ8kvuQKNe5MK/SvaXR4uoxPkAlTPALDEImaHcwsBg+UWfRVcNzLEx4dRR2y1mDFFh+zZ9TVMXGY6Jg=="
+        "resolved": "4.0.3.19",
+        "contentHash": "8zIzN59+J6arYSyFuhnSxPepr8ff4p6li+MxKUUnqCgwZqQ+icEGJK/23c1USIEALqZZ5gdiITuH2sOZWQom+Q=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -341,10 +341,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.19",
-        "contentHash": "LBjXBRwjRFBzrA3b8CFFc2jzso+oxOZGncxJLpC0DKtAfXlIFg2b8S0ZANNmvcJsO77EFeMdvG0kNoW0X3/dKw==",
+        "resolved": "4.0.2.20",
+        "contentHash": "Ukh0ZudL04FhC88ZTyYq2lugoX/9RCWStWvzOTREnmEaPCC51IWX7LQkIFLuMODV0k0GeuqwgReULEC6bjHuLg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.17, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.19, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {

--- a/tests/Granit.Notifications.Sms.AwsSns.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Sms.AwsSns.Tests/packages.lock.json
@@ -66,8 +66,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.17",
-        "contentHash": "Ab24kVquQ8kvuQKNe5MK/SvaXR4uoxPkAlTPALDEImaHcwsBg+UWfRVcNzLEx4dRR2y1mDFFh+zZ9TVMXGY6Jg=="
+        "resolved": "4.0.3.19",
+        "contentHash": "8zIzN59+J6arYSyFuhnSxPepr8ff4p6li+MxKUUnqCgwZqQ+icEGJK/23c1USIEALqZZ5gdiITuH2sOZWQom+Q=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -340,10 +340,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.19",
-        "contentHash": "LBjXBRwjRFBzrA3b8CFFc2jzso+oxOZGncxJLpC0DKtAfXlIFg2b8S0ZANNmvcJsO77EFeMdvG0kNoW0X3/dKw==",
+        "resolved": "4.0.2.20",
+        "contentHash": "Ukh0ZudL04FhC88ZTyYq2lugoX/9RCWStWvzOTREnmEaPCC51IWX7LQkIFLuMODV0k0GeuqwgReULEC6bjHuLg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.17, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.19, 5.0.0)"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {

--- a/tests/Granit.Observability.AI.Tests/packages.lock.json
+++ b/tests/Granit.Observability.AI.Tests/packages.lock.json
@@ -486,8 +486,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
@@ -20,12 +20,6 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
-      "Microsoft.Extensions.TimeProvider.Testing": {
-        "type": "Direct",
-        "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "uJ8n9WUEzux9I2CjZh7imGBgZadfwhAKlxuBq7GsNGL8FJF81aHXAYaRMnwW+9EvRFQNytu7xo1ffeuuTncAzg=="
-      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
@@ -70,13 +64,23 @@
           "xunit.v3.mtp-v1": "[3.2.2]"
         }
       },
+      "Asp.Versioning.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "I4CuGwl0nO98j6Ft6XlGBgzj1+goE/TSVlnHKgtRkuMZ0K4gy9I+Wyrtto8dyt0hWcFMDFAZ4lYNr58DSemH1g=="
+      },
+      "Asp.Versioning.Http": {
+        "type": "Transitive",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "4/QzujOrkGn9sMch3eHhR5LpVJ4Xo5T2BNg7U1/r4YwEa8JywzkoGQHjW7Nk0W8ljETnpoJaO5mrTsfEOnJK3A==",
+        "dependencies": {
+          "Asp.Versioning.Abstractions": "10.0.0-preview.2"
+        }
+      },
       "Castle.Core": {
         "type": "Transitive",
         "resolved": "5.1.1",
-        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
-        "dependencies": {
-          "System.Diagnostics.EventLog": "6.0.0"
-        }
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g=="
       },
       "DiffEngine": {
         "type": "Transitive",
@@ -107,44 +111,10 @@
         "resolved": "18.3.0",
         "contentHash": "23BNy/vziREC20Wwhb50K7+kZe0m07KlLWDQv4qjJ9tt3QjpDpDIqJFrhYHmMEo9xDkuSp55U/8h4bMF7MiB+g=="
       },
-      "Microsoft.Extensions.Configuration": {
+      "Microsoft.OpenApi": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Configuration.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.FileProviders.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Primitives": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
+        "resolved": "2.0.0",
+        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -204,11 +174,6 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
-      },
-      "System.Diagnostics.EventLog": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -285,120 +250,217 @@
           "xunit.v3.runner.common": "[3.2.2]"
         }
       },
-      "granit.ai": {
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
         "type": "Project",
         "dependencies": {
           "Granit.Core": "[0.1.0-dev, )",
-          "Granit.Guids": "[0.1.0-dev, )",
-          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+          "Granit.Timing": "[0.1.0-dev, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
       "granit.core": {
         "type": "Project"
       },
+      "granit.eventbus": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
-          "Granit.Timing": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )"
+          "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "granit.imaging": {
+      "granit.http.apidocumentation": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Http.ApiVersioning": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )",
+          "Scalar.AspNetCore": "[2.*, )"
+        }
+      },
+      "granit.http.apiversioning": {
+        "type": "Project",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "[10.0.0-preview.*, )",
+          "Asp.Versioning.Mvc.ApiExplorer": "[10.0.0-preview.*, )",
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.identity": {
         "type": "Project",
         "dependencies": {
           "Granit.Core": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+          "Granit.Querying": "[0.1.0-dev, )"
         }
       },
-      "granit.imaging.ai": {
+      "granit.localization": {
         "type": "Project",
         "dependencies": {
-          "Granit.AI": "[0.1.0-dev, )",
-          "Granit.Imaging": "[0.1.0-dev, )",
-          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Core": "[0.1.0-dev, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.openiddict": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.EventBus": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Identity": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.openiddict.endpoints": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.querying": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.security": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {
         "type": "Project",
         "dependencies": {
-          "Granit.Core": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )"
+          "Granit.Core": "[0.1.0-dev, )"
         }
       },
-      "Microsoft.Extensions.AI.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.4.1",
-        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
-      },
-      "Microsoft.Extensions.Configuration.Binder": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
+      "granit.validation": {
+        "type": "Project",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.5",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+          "FluentValidation": "[12.*, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.*, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )"
         }
       },
-      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+      "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
-      },
-      "Microsoft.Extensions.Hosting.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "requested": "[10.0.0-preview.*, )",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "AyrcDwLzJp8yRJaFjZMJXkR1Rx2UaJkwGrGlX8sxIt2F5ZGiZwn/puXkB/oEaq55TxLkpiXWAOHHFsiVptp0fA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+          "Asp.Versioning.Http": "10.0.0-preview.2"
         }
       },
-      "Microsoft.Extensions.Logging.Abstractions": {
+      "Asp.Versioning.Mvc.ApiExplorer": {
         "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "requested": "[10.0.0-preview.*, )",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "G/LhAaLQj+gsB8UXRNm65fxjsI7fe87itZExb+MvJOQdrXYalZKbwuzMntO95xM5cKDrDgLnCH64fl6w173aGg==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+          "Asp.Versioning.Mvc": "10.0.0-preview.2"
         }
       },
-      "Microsoft.Extensions.Options": {
+      "FluentValidation": {
         "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
+          "FluentValidation": "12.1.1"
         }
       },
-      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+      "Microsoft.AspNetCore.OpenApi": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
         "resolved": "10.0.5",
-        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "contentHash": "vTcxIfOPyfFbYk1g8YcXJfkMnlEWVkSnnjxcZLy60zgwiHMRf2SnZR+9E4HlpwKxgE3yfKMOti8J6WfKuKsw6w==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
+          "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.14.0",
+        "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "Scalar.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.13.13",
+        "contentHash": "QS94/CNp2thhykXwBaOHjDe8Zlexs8v0QOrdLfUvxS85uW84IhCf1zGiOnYZNNtVxunJvtsr7yPgEP36TXnJ3w=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog=="
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
         }
       }
     }

--- a/tests/Granit.OpenIddict.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests/packages.lock.json
@@ -20,12 +20,6 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
-      "Microsoft.Extensions.TimeProvider.Testing": {
-        "type": "Direct",
-        "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "uJ8n9WUEzux9I2CjZh7imGBgZadfwhAKlxuBq7GsNGL8FJF81aHXAYaRMnwW+9EvRFQNytu7xo1ffeuuTncAzg=="
-      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
@@ -73,10 +67,7 @@
       "Castle.Core": {
         "type": "Transitive",
         "resolved": "5.1.1",
-        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
-        "dependencies": {
-          "System.Diagnostics.EventLog": "6.0.0"
-        }
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g=="
       },
       "DiffEngine": {
         "type": "Transitive",
@@ -106,45 +97,6 @@
         "type": "Transitive",
         "resolved": "18.3.0",
         "contentHash": "23BNy/vziREC20Wwhb50K7+kZe0m07KlLWDQv4qjJ9tt3QjpDpDIqJFrhYHmMEo9xDkuSp55U/8h4bMF7MiB+g=="
-      },
-      "Microsoft.Extensions.Configuration": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Configuration.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Diagnostics.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.FileProviders.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
-        "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Primitives": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -204,11 +156,6 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
-      },
-      "System.Diagnostics.EventLog": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -285,120 +232,56 @@
           "xunit.v3.runner.common": "[3.2.2]"
         }
       },
-      "granit.ai": {
-        "type": "Project",
-        "dependencies": {
-          "Granit.Core": "[0.1.0-dev, )",
-          "Granit.Guids": "[0.1.0-dev, )",
-          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
-        }
-      },
       "granit.core": {
         "type": "Project"
+      },
+      "granit.eventbus": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
       },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
-          "Granit.Timing": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )"
+          "Granit.Timing": "[0.1.0-dev, )"
         }
       },
-      "granit.imaging": {
+      "granit.identity": {
         "type": "Project",
         "dependencies": {
           "Granit.Core": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+          "Granit.Querying": "[0.1.0-dev, )"
         }
       },
-      "granit.imaging.ai": {
+      "granit.openiddict": {
         "type": "Project",
         "dependencies": {
-          "Granit.AI": "[0.1.0-dev, )",
-          "Granit.Imaging": "[0.1.0-dev, )",
-          "Microsoft.Extensions.AI.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.EventBus": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Identity": "[0.1.0-dev, )",
+          "Granit.Querying": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.querying": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.security": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {
         "type": "Project",
         "dependencies": {
-          "Granit.Core": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )"
-        }
-      },
-      "Microsoft.Extensions.AI.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.4.1",
-        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
-      },
-      "Microsoft.Extensions.Configuration.Binder": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.5",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
-      },
-      "Microsoft.Extensions.Hosting.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Logging.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Options": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Microsoft.Extensions.Options.ConfigurationExtensions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
+          "Granit.Core": "[0.1.0-dev, )"
         }
       }
     }

--- a/tests/Granit.Persistence.Hosting.Tests/packages.lock.json
+++ b/tests/Granit.Persistence.Hosting.Tests/packages.lock.json
@@ -235,14 +235,6 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
-      "Npgsql": {
-        "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg==",
-        "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
-        }
-      },
       "System.CodeDom": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -363,8 +355,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Persistence": "[0.1.0-dev, )",
-          "Granit.Persistence.Migrations": "[0.1.0-dev, )",
-          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.*, )"
+          "Granit.Persistence.Migrations": "[0.1.0-dev, )"
         }
       },
       "granit.persistence.migrations": {
@@ -495,17 +486,6 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
           "Microsoft.Extensions.Primitives": "10.0.5"
-        }
-      },
-      "Npgsql.EntityFrameworkCore.PostgreSQL": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.1",
-        "contentHash": "P6EwH0Q4xkaA264iNZDqCPhWt8pscfUGxXazDQg4noBfqjoOlk4hKWfvBjF9ZX3R/9JybRmmJfmxr2iBMj0EpA==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
-          "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
-          "Npgsql": "10.0.2"
         }
       }
     }

--- a/tests/Granit.Privacy.Endpoints.Tests/Dtos/PrivacyDtoTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Dtos/PrivacyDtoTests.cs
@@ -1,0 +1,93 @@
+using Granit.Privacy.Endpoints.Dtos;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Endpoints.Tests.Dtos;
+
+public sealed class PrivacyDtoTests
+{
+    [Fact]
+    public void PrivacyExportRequestResponse_HoldsProperties()
+    {
+        var requestId = Guid.NewGuid();
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        PrivacyExportRequestResponse response = new(requestId, now);
+
+        response.RequestId.ShouldBe(requestId);
+        response.RequestedAt.ShouldBe(now);
+    }
+
+    [Fact]
+    public void PrivacyExportStatusResponse_HoldsAllProperties()
+    {
+        var requestId = Guid.NewGuid();
+        DateTimeOffset requested = DateTimeOffset.UtcNow;
+        DateTimeOffset completed = requested.AddMinutes(3);
+        List<string> missing = ["provider-a"];
+
+        PrivacyExportStatusResponse response = new(
+            requestId, "Completed", requested, completed, "gdpr-export/123", missing);
+
+        response.RequestId.ShouldBe(requestId);
+        response.State.ShouldBe("Completed");
+        response.RequestedAt.ShouldBe(requested);
+        response.CompletedAt.ShouldBe(completed);
+        response.ArchiveBlobReferenceId.ShouldBe("gdpr-export/123");
+        response.MissingProviders.ShouldContain("provider-a");
+    }
+
+    [Fact]
+    public void PrivacyLegalDocumentResponse_HoldsProperties()
+    {
+        PrivacyLegalDocumentResponse response = new("privacy-policy", "2.1.0", "Privacy Policy");
+
+        response.DocumentId.ShouldBe("privacy-policy");
+        response.CurrentVersion.ShouldBe("2.1.0");
+        response.DisplayName.ShouldBe("Privacy Policy");
+    }
+
+    [Fact]
+    public void PrivacyConsentStatusResponse_HoldsProperties()
+    {
+        DateTimeOffset accepted = DateTimeOffset.UtcNow;
+
+        PrivacyConsentStatusResponse response = new("privacy-policy", "2.1.0", true, accepted);
+
+        response.DocumentId.ShouldBe("privacy-policy");
+        response.HasAcceptedLatest.ShouldBeTrue();
+        response.LastAcceptedAt.ShouldBe(accepted);
+    }
+
+    [Fact]
+    public void PrivacyUserAgreementResponse_HoldsProperties()
+    {
+        var id = Guid.NewGuid();
+        DateTimeOffset accepted = DateTimeOffset.UtcNow;
+
+        PrivacyUserAgreementResponse response = new(id, "terms", "1.0", accepted, false);
+
+        response.Id.ShouldBe(id);
+        response.DocumentId.ShouldBe("terms");
+        response.Version.ShouldBe("1.0");
+        response.AcceptedAt.ShouldBe(accepted);
+        response.IsLatest.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void PrivacyDeletionRequest_HoldsReason()
+    {
+        PrivacyDeletionRequest request = new("Account closure");
+
+        request.Reason.ShouldBe("Account closure");
+    }
+
+    [Fact]
+    public void PrivacyAcceptAgreementRequest_HoldsProperties()
+    {
+        PrivacyAcceptAgreementRequest request = new("privacy-policy", "2.1.0");
+
+        request.DocumentId.ShouldBe("privacy-policy");
+        request.Version.ShouldBe("2.1.0");
+    }
+}

--- a/tests/Granit.Privacy.Endpoints.Tests/Extensions/PseudonymizeIpAddressTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Extensions/PseudonymizeIpAddressTests.cs
@@ -1,0 +1,27 @@
+using Granit.Privacy.Endpoints.Extensions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Endpoints.Tests.Extensions;
+
+public sealed class PseudonymizeIpAddressTests
+{
+    [Theory]
+    [InlineData("192.168.1.42", "192.168.1.0")]
+    [InlineData("10.0.0.1", "10.0.0.0")]
+    [InlineData("172.16.254.255", "172.16.254.0")]
+    public void IPv4_MasksLastOctet(string input, string expected) =>
+        PrivacyEndpointRouteBuilderExtensions.PseudonymizeIpAddress(input).ShouldBe(expected);
+
+    [Theory]
+    [InlineData("2001:db8::1", "2001:db8::0")]
+    [InlineData("::1", "::0")]
+    public void IPv6_MasksLastGroup(string input, string expected) =>
+        PrivacyEndpointRouteBuilderExtensions.PseudonymizeIpAddress(input).ShouldBe(expected);
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void NullOrEmpty_ReturnsNull(string? input) =>
+        PrivacyEndpointRouteBuilderExtensions.PseudonymizeIpAddress(input).ShouldBeNull();
+}

--- a/tests/Granit.Privacy.Endpoints.Tests/Granit.Privacy.Endpoints.Tests.csproj
+++ b/tests/Granit.Privacy.Endpoints.Tests/Granit.Privacy.Endpoints.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Privacy.Endpoints\Granit.Privacy.Endpoints.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.Privacy.Endpoints.Tests/GranitPrivacyEndpointsModuleTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/GranitPrivacyEndpointsModuleTests.cs
@@ -1,0 +1,63 @@
+using Granit.Authorization;
+using Granit.Core.Modularity;
+using Granit.Http.ApiDocumentation;
+using Granit.Validation;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Endpoints.Tests;
+
+public sealed class GranitPrivacyEndpointsModuleTests
+{
+    [Fact]
+    public void Module_IsSealed() =>
+        typeof(GranitPrivacyEndpointsModule).IsSealed.ShouldBeTrue();
+
+    [Fact]
+    public void Module_InheritsFromGranitModule() =>
+        typeof(GranitPrivacyEndpointsModule)
+            .IsSubclassOf(typeof(GranitModule))
+            .ShouldBeTrue();
+
+    [Fact]
+    public void Module_DependsOn_GranitAuthorizationModule()
+    {
+        DependsOnAttribute[] attrs = GetDependsOnAttributes();
+
+        attrs.SelectMany(a => a.DependedTypes)
+             .ShouldContain(typeof(GranitAuthorizationModule));
+    }
+
+    [Fact]
+    public void Module_DependsOn_GranitHttpApiDocumentationModule()
+    {
+        DependsOnAttribute[] attrs = GetDependsOnAttributes();
+
+        attrs.SelectMany(a => a.DependedTypes)
+             .ShouldContain(typeof(GranitHttpApiDocumentationModule));
+    }
+
+    [Fact]
+    public void Module_DependsOn_GranitPrivacyModule()
+    {
+        DependsOnAttribute[] attrs = GetDependsOnAttributes();
+
+        attrs.SelectMany(a => a.DependedTypes)
+             .ShouldContain(typeof(GranitPrivacyModule));
+    }
+
+    [Fact]
+    public void Module_DependsOn_GranitValidationModule()
+    {
+        DependsOnAttribute[] attrs = GetDependsOnAttributes();
+
+        attrs.SelectMany(a => a.DependedTypes)
+             .ShouldContain(typeof(GranitValidationModule));
+    }
+
+    private static DependsOnAttribute[] GetDependsOnAttributes() =>
+        typeof(GranitPrivacyEndpointsModule)
+            .GetCustomAttributes(typeof(DependsOnAttribute), false)
+            .Cast<DependsOnAttribute>()
+            .ToArray();
+}

--- a/tests/Granit.Privacy.Endpoints.Tests/Options/PrivacyEndpointsOptionsTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Options/PrivacyEndpointsOptionsTests.cs
@@ -1,0 +1,44 @@
+using Granit.Privacy.Endpoints.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Endpoints.Tests.Options;
+
+public sealed class PrivacyEndpointsOptionsTests
+{
+    [Fact]
+    public void Defaults_RoutePrefix_IsPrivacy()
+    {
+        PrivacyEndpointsOptions options = new();
+
+        options.RoutePrefix.ShouldBe("privacy");
+    }
+
+    [Fact]
+    public void Defaults_TagName_IsPrivacy()
+    {
+        PrivacyEndpointsOptions options = new();
+
+        options.TagName.ShouldBe("Privacy");
+    }
+
+    [Fact]
+    public void RoutePrefix_CanBeOverridden()
+    {
+        PrivacyEndpointsOptions options = new() { RoutePrefix = "api/privacy" };
+
+        options.RoutePrefix.ShouldBe("api/privacy");
+    }
+
+    [Fact]
+    public void TagName_CanBeOverridden()
+    {
+        PrivacyEndpointsOptions options = new() { TagName = "GDPR" };
+
+        options.TagName.ShouldBe("GDPR");
+    }
+
+    [Fact]
+    public void Class_IsSealed() =>
+        typeof(PrivacyEndpointsOptions).IsSealed.ShouldBeTrue();
+}

--- a/tests/Granit.Privacy.Endpoints.Tests/Permissions/PrivacyPermissionDefinitionProviderTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Permissions/PrivacyPermissionDefinitionProviderTests.cs
@@ -1,0 +1,55 @@
+using Granit.Authorization.Abstractions;
+using Granit.Core.Localization;
+using Granit.Privacy.Endpoints.Permissions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Endpoints.Tests.Permissions;
+
+public sealed class PrivacyPermissionDefinitionProviderTests
+{
+    [Fact]
+    public void DefinePermissions_CreatesPrivacyGroup()
+    {
+        IPermissionDefinitionContext context = Substitute.For<IPermissionDefinitionContext>();
+        PermissionGroup group = new(PrivacyPermissions.GroupName);
+        context.AddGroup(PrivacyPermissions.GroupName, Arg.Any<LocalizableString>()).Returns(group);
+
+        PrivacyPermissionDefinitionProvider provider = new();
+        provider.DefinePermissions(context);
+
+        context.Received(1).AddGroup(PrivacyPermissions.GroupName, Arg.Any<LocalizableString>());
+    }
+
+    [Theory]
+    [InlineData("Privacy.Export.Execute")]
+    [InlineData("Privacy.Export.Read")]
+    [InlineData("Privacy.Deletion.Execute")]
+    [InlineData("Privacy.Agreements.Read")]
+    [InlineData("Privacy.Agreements.Create")]
+    public void DefinePermissions_RegistersPermission(string permissionName)
+    {
+        IPermissionDefinitionContext context = Substitute.For<IPermissionDefinitionContext>();
+        PermissionGroup group = new(PrivacyPermissions.GroupName);
+        context.AddGroup(PrivacyPermissions.GroupName, Arg.Any<LocalizableString>()).Returns(group);
+
+        PrivacyPermissionDefinitionProvider provider = new();
+        provider.DefinePermissions(context);
+
+        group.Permissions.ShouldContain(p => p.Name == permissionName);
+    }
+
+    [Fact]
+    public void DefinePermissions_RegistersExactlyFivePermissions()
+    {
+        IPermissionDefinitionContext context = Substitute.For<IPermissionDefinitionContext>();
+        PermissionGroup group = new(PrivacyPermissions.GroupName);
+        context.AddGroup(PrivacyPermissions.GroupName, Arg.Any<LocalizableString>()).Returns(group);
+
+        PrivacyPermissionDefinitionProvider provider = new();
+        provider.DefinePermissions(context);
+
+        group.Permissions.Count.ShouldBe(5);
+    }
+}

--- a/tests/Granit.Privacy.Endpoints.Tests/Permissions/PrivacyPermissionsTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Permissions/PrivacyPermissionsTests.cs
@@ -1,0 +1,52 @@
+using Granit.Privacy.Endpoints.Permissions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Endpoints.Tests.Permissions;
+
+public sealed class PrivacyPermissionsTests
+{
+    [Fact]
+    public void GroupName_IsPrivacy() => PrivacyPermissions.GroupName.ShouldBe("Privacy");
+
+    [Fact]
+    public void Export_Execute_FollowsThreeSegmentConvention() =>
+        PrivacyPermissions.Export.Execute.ShouldBe("Privacy.Export.Execute");
+
+    [Fact]
+    public void Export_Read_FollowsThreeSegmentConvention() =>
+        PrivacyPermissions.Export.Read.ShouldBe("Privacy.Export.Read");
+
+    [Fact]
+    public void Deletion_Execute_FollowsThreeSegmentConvention() =>
+        PrivacyPermissions.Deletion.Execute.ShouldBe("Privacy.Deletion.Execute");
+
+    [Fact]
+    public void Agreements_Read_FollowsThreeSegmentConvention() =>
+        PrivacyPermissions.Agreements.Read.ShouldBe("Privacy.Agreements.Read");
+
+    [Fact]
+    public void Agreements_Create_FollowsThreeSegmentConvention() =>
+        PrivacyPermissions.Agreements.Create.ShouldBe("Privacy.Agreements.Create");
+
+    [Theory]
+    [InlineData("Privacy.Export.Execute")]
+    [InlineData("Privacy.Export.Read")]
+    [InlineData("Privacy.Deletion.Execute")]
+    [InlineData("Privacy.Agreements.Read")]
+    [InlineData("Privacy.Agreements.Create")]
+    public void AllPermissions_HaveThreeDotSeparatedSegments(string permission)
+    {
+        string[] segments = permission.Split('.');
+        segments.Length.ShouldBe(3);
+    }
+
+    [Theory]
+    [InlineData("Privacy.Export.Execute")]
+    [InlineData("Privacy.Export.Read")]
+    [InlineData("Privacy.Deletion.Execute")]
+    [InlineData("Privacy.Agreements.Read")]
+    [InlineData("Privacy.Agreements.Create")]
+    public void AllPermissions_StartWithGroupName(string permission) =>
+        permission.ShouldStartWith(PrivacyPermissions.GroupName + ".");
+}

--- a/tests/Granit.Privacy.Endpoints.Tests/Validators/PrivacyAcceptAgreementRequestValidatorTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Validators/PrivacyAcceptAgreementRequestValidatorTests.cs
@@ -1,0 +1,70 @@
+using FluentValidation.Results;
+using Granit.Privacy.Endpoints.Dtos;
+using Granit.Privacy.Endpoints.Validators;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Endpoints.Tests.Validators;
+
+public sealed class PrivacyAcceptAgreementRequestValidatorTests
+{
+    private readonly PrivacyAcceptAgreementRequestValidator _validator = new();
+
+    [Fact]
+    public void Valid_Request_Passes()
+    {
+        PrivacyAcceptAgreementRequest request = new("privacy-policy", "2.1.0");
+
+        ValidationResult result = _validator.Validate(request);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("", "2.1.0")]
+    [InlineData(null, "2.1.0")]
+    public void Empty_DocumentId_Fails(string? documentId, string version)
+    {
+        PrivacyAcceptAgreementRequest request = new(documentId!, version);
+
+        ValidationResult result = _validator.Validate(request);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.PropertyName == "DocumentId");
+    }
+
+    [Theory]
+    [InlineData("privacy-policy", "")]
+    [InlineData("privacy-policy", null)]
+    public void Empty_Version_Fails(string documentId, string? version)
+    {
+        PrivacyAcceptAgreementRequest request = new(documentId, version!);
+
+        ValidationResult result = _validator.Validate(request);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.PropertyName == "Version");
+    }
+
+    [Fact]
+    public void DocumentId_ExceedingMaxLength_Fails()
+    {
+        PrivacyAcceptAgreementRequest request = new(new string('x', 201), "1.0");
+
+        ValidationResult result = _validator.Validate(request);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.PropertyName == "DocumentId");
+    }
+
+    [Fact]
+    public void Version_ExceedingMaxLength_Fails()
+    {
+        PrivacyAcceptAgreementRequest request = new("privacy-policy", new string('x', 51));
+
+        ValidationResult result = _validator.Validate(request);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.PropertyName == "Version");
+    }
+}

--- a/tests/Granit.Privacy.Endpoints.Tests/Validators/PrivacyDeletionRequestValidatorTests.cs
+++ b/tests/Granit.Privacy.Endpoints.Tests/Validators/PrivacyDeletionRequestValidatorTests.cs
@@ -1,0 +1,56 @@
+using FluentValidation.Results;
+using Granit.Privacy.Endpoints.Dtos;
+using Granit.Privacy.Endpoints.Validators;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Privacy.Endpoints.Tests.Validators;
+
+public sealed class PrivacyDeletionRequestValidatorTests
+{
+    private readonly PrivacyDeletionRequestValidator _validator = new();
+
+    [Fact]
+    public void Valid_Reason_Passes()
+    {
+        PrivacyDeletionRequest request = new("Account closure");
+
+        ValidationResult result = _validator.Validate(request);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Empty_Reason_Fails(string? reason)
+    {
+        PrivacyDeletionRequest request = new(reason!);
+
+        ValidationResult result = _validator.Validate(request);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.PropertyName == "Reason");
+    }
+
+    [Fact]
+    public void Reason_ExceedingMaxLength_Fails()
+    {
+        PrivacyDeletionRequest request = new(new string('x', 2001));
+
+        ValidationResult result = _validator.Validate(request);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.PropertyName == "Reason");
+    }
+
+    [Fact]
+    public void Reason_AtMaxLength_Passes()
+    {
+        PrivacyDeletionRequest request = new(new string('x', 2000));
+
+        ValidationResult result = _validator.Validate(request);
+
+        result.IsValid.ShouldBeTrue();
+    }
+}

--- a/tests/Granit.Privacy.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Privacy.Endpoints.Tests/packages.lock.json
@@ -1,0 +1,1065 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[8.*, )",
+        "resolved": "8.0.1",
+        "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "MfacYQ7jNzj6073YobyoFfXpNmGqrV1UCywTM339DOcYpfalcM4K4heFjV5k3dDkKkWOGWO/DV3hdmVRqFkIxA==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.5",
+          "Microsoft.Extensions.DependencyModel": "10.0.5",
+          "Microsoft.Extensions.Hosting": "10.0.5"
+        }
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.*, )",
+        "resolved": "18.3.0",
+        "contentHash": "xW3kXuWRQtgoxJp4J+gdhHSQyK+6Wb/AZDSd7lMvuMRYlZ1tnpkojyfZlWilB5G4dmZ0Y0ZxU/M23TlubndNkw==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.3.0",
+          "Microsoft.TestPlatform.TestHost": "18.3.0"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.*, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "Asp.Versioning.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "I4CuGwl0nO98j6Ft6XlGBgzj1+goE/TSVlnHKgtRkuMZ0K4gy9I+Wyrtto8dyt0hWcFMDFAZ4lYNr58DSemH1g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Asp.Versioning.Http": {
+        "type": "Transitive",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "4/QzujOrkGn9sMch3eHhR5LpVJ4Xo5T2BNg7U1/r4YwEa8JywzkoGQHjW7Nk0W8ljETnpoJaO5mrTsfEOnJK3A==",
+        "dependencies": {
+          "Asp.Versioning.Abstractions": "10.0.0-preview.2"
+        }
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "FastExpressionCompiler": {
+        "type": "Transitive",
+        "resolved": "5.3.0",
+        "contentHash": "XRmGW48Gdm7B70WUtTJJUnmuc8jRDmOhhjG/a3rix/nXChnrkETaSvA0j2VrcsH4MNeYLe60LA5o5JABmbneag=="
+      },
+      "Humanizer.Core": {
+        "type": "Transitive",
+        "resolved": "2.14.1",
+        "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
+      },
+      "ImTools": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "dms0JfLKC9AQbQX/EdpRjn59EjEvaCxIgv1z9YxbEQb5SiOVoo7vlIKdEySeEwUkWhN05rZnNpUpG+aw5VqPVQ=="
+      },
+      "JasperFx": {
+        "type": "Transitive",
+        "resolved": "1.21.1",
+        "contentHash": "oEswL6IWlSsSw+3vylT1fh+aZhiG1LVv/fJxC+E7dtxw80M8jW1cbSh2QaXDMyvYsxWrlwkA8TvCYPuvN5NMVA==",
+        "dependencies": {
+          "FastExpressionCompiler": "5.3.0",
+          "ImTools": "4.0.0",
+          "Microsoft.Bcl.TimeProvider": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.0",
+          "Polly.Core": "8.6.5",
+          "Spectre.Console": "0.53.0"
+        }
+      },
+      "JasperFx.Events": {
+        "type": "Transitive",
+        "resolved": "1.24.0",
+        "contentHash": "vDkYMarrBqHSqoLBlpQfePz5FdVK/3LyFoBVRCzaWKeS/jxwUQG4fckHu30ozwZId1DulkHKcNjYziO5oyG08Q==",
+        "dependencies": {
+          "JasperFx": "1.21.1"
+        }
+      },
+      "JasperFx.RuntimeCompiler": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "n5dOtQlytGsCfpRyOGDw/qHaqPDd2GcR7pgO53bQto1T82/VZjQdzkfuLQt8vUMY6D+m1TgqUjqedNFDT1+rEQ==",
+        "dependencies": {
+          "JasperFx": "1.18.0",
+          "Microsoft.CodeAnalysis": "5.0.0",
+          "Microsoft.CodeAnalysis.CSharp": "5.0.0",
+          "Microsoft.CodeAnalysis.Scripting": "5.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "PJEdrZnnhvxIEXzDdvdZ38GvpdaiUfKkZ99kudS8riJwhowFb/Qh26Wjk9smrCWcYdMFQmpN5epGiL4o1s8LYA=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "bUubrBD6tRJE3V1kvRloYc6NymH3R5oFKjAS9e0ELNx6u0ZR+zjps9dDQyjgqN/rArzl7f+21KGszj3YRN7F2Q=="
+      },
+      "Microsoft.CodeAnalysis": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "X7vItpZDkGm4NS2wp4P1S07Z1e61LaBWDW5tPXE1c6z5/x9KbF2RymhAPoYg7Qoiyk7odEZ6EjBEJ47p3dBpYQ==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[5.0.0]",
+          "Microsoft.CodeAnalysis.VisualBasic.Workspaces": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Scripting": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "1sGloRYbG3743ut/+vuXy9/WaRQTm7mDtp71rBaVSmKpFntvo5Hcro1ubg6/3SeeLtiFYJl7V3Dk0Fo3CGlnHA==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Scripting.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.Scripting": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "/KgZdm6kRTrR/O2jqXxU5GWREYhtVmqcNWczyPt8hsQkFGFK/C6CrLWfG44FCUn0aPHGDRBHYjXlGosQ/H8oXw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp.Scripting": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.Scripting.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "XTulByMNxqXGCgMeODUoG2h4oK4/nLv1BcawRVcjv+UZHMpoaymtdaq3cJqlNrEvYEcbU48g5swJ3RhY1m3fBg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "sUBWvHs2HgHGA+b716dgjS7JiXGen5ntyohAurPLR1ZiZzFp3FlnVA7GrMTqVGdVJTVqiC3c4K8k1bk0gj6IPg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic.Workspaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Nom4UuZVEZGaV6Qa+joJR/BawXZMtflvQJFKc0SaUc3LrZr/8LmRY5cn8mbvLOWIVfwWkQz+cVE6eQKu9qa65g==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.VisualBasic": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZbUmIvT6lqTNKiv06Jl5wf0MTMi1vQ1oH7ou4CLcs2C/no/L7EhP3T8y3XXvn9VbqMcJaJnEsNA1jwYUMgc5jg==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "23BNy/vziREC20Wwhb50K7+kZe0m07KlLWDQv4qjJ9tt3QjpDpDIqJFrhYHmMEo9xDkuSp55U/8h4bMF7MiB+g=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "or9fOLopMUTJOQVJ3bou4aD6PwvsiKf4kZC4EE5sRRKSkmh+wfk/LekJXRjAX88X+1JA9zHjDo+5fiQ7z3MY/A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "tchMGQ+zVTO40np/Zzg2Li/TIR8bksQgg4UVXZa0OzeFCKWnIYtxE2FVs+eSmjPGCjMS2voZbwN/mUcYfpSTuA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "OhTr0O79dP49734lLTqVveivVX9sDXxbI/8vjELAZTHXqoN90mdpgTAgwicJED42iaHMCcZcK6Bj+8wNyBikaw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "brBM/WP0YAUYh2+QqSYVdK8eQHYQTtTEUJXJ+84Zkdo2buGLja9VSrMIhgoeBUU7JBmcskAib8Lb/N83bvxgYQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "fhdG6UV9lIp70QhNkVyaHciUVq25IPFkczheVJL9bIFvmnJ+Zghaie6dWkDbbVmxZlHl9gj3zTDxMxJs5zNhIA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Json": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "v1SVsowG6YE1YnHVGmLWz57YTRCQRx9pH5ebIESXfm5isI9gA3QaMyg/oMTzPpXYZwSAVDzYItGJKfmV+pqXkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "xA4kkL+QS6KCAOKz/O0oquHs44Ob8J7zpBCNt3wjkBWDg5aCqfwG8rWWLsg5V86AM0sB849g9JjPjIdksTCIKg=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "vAJHd4yOpmKoK+jBuYV7a3y+Ab9U4ARCc29b6qvMy276RgJFw9LFs0DdsPqOL3ahwzyrX7tM+i4cCxU/RX0qAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "dMu5kUPSfol1Rqhmr6nWPSmbFjDe9w6bkoKithG17bWTZA0UyKirTatM5mqYUN3mGpNA0MorlusIoVTh6J7o5g==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "mOE3ARusNQR0a5x8YOcnUbfyyXGqoAWQtEc7qFOfNJgruDWQLo39Re+3/Lzj5pLPFuFYj8hN4dgKzaSQDKiOCw=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "8i7e5IBdiKLNqt/+ciWrS8U95Rv5DClaaj7ulkZbimnCi4uREWd+lXzkp3joofFuIPOlAzV4AckxLTIELv2jdg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.5",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.5",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Json": "10.0.5",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Diagnostics": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.5",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.5",
+          "Microsoft.Extensions.Logging.Console": "10.0.5",
+          "Microsoft.Extensions.Logging.Debug": "10.0.5",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.5",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "xKobiPRPVkK/bD/oLUTF1OnilG3N+4o0u/T8YWqHq+E97zWgCRr8Zhk9N6OZeLBSNHC7imT53QkH/yv9MaXkew=="
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "+XTMKQyDWg4ODoNHU/BN3BaI1jhGO7VCS+BnzT/4IauiG6y2iPAte7MyD7rHKS+hNP0TkFkjrae8DFjDUxtcxg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "cSgxsDgfP0+gmVRPVoNHI/KIDavIZxh+CxE6tSLPlYTogqccDnjBFI9CgEsiNuMP6+fiuXUwhhlTz36uUEpwbQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "PMs2gha2v24hvH5o5KQem5aNK4mN0BhhCWlMqsg9tzifWKzjeQi2tyPOP/RaWMVvalOhVLcrmoMYPqbnia/epg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/VacEkBQ02A8PBXSa6YpbIXCuisYy6JJr62/+ANJDZE+RMBfZMcXJXLfr/LpyLE6pgdp17Wxlt7e7R9zvkwZ3Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "0ezhWYJS4/6KrqQel9JL+Tr4n+4EX2TF5EYiaysBWNNEM2c3Gtj1moD39esfgk8OHblSX+UFjtZ3z0c4i9tRvw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "System.Diagnostics.EventLog": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "vN+aq1hBFXyYvY5Ow9WyeR66drKQxRZmas4lAjh6QWfryPkjTn1uLtX5AFIxyDaZj78v5TG2sELUyvrXpAPQQw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "kpCp4m7nwJVBcRKWXYHdVK/W0dkKyyFOjCmKVdO+zKThWvUxP1V+jVEP9FGpqRu4GPl9041SEXu2f+U/l825nQ=="
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
+      },
+      "Microsoft.OpenApi": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "AEIEX2aWdPO9XbtR96eBaJxmXRD9vaI9uQ1T/JbPEKlTAZwYx0ZrMzKyULMdh/HH9Sg03kXCoN7LszQ90o6nPQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.3.0",
+        "contentHash": "twmsoelXnp1uWMU3VGip9f0Jr1mZ0PZqgJdF35CIrdYgYrkHIJMV1m8uKyhcdjLdsQDESHAgkR7KhS9i1qpJag==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.3.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "NewId": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "jegBasNndmG21G3BmT51suFDCIz/sLN81j+IxmkZ4iWoaDi8LygeHiyNnYbXz5OQh9nCRJFIx1+PJrlYi1Gc9Q=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.6.5",
+        "contentHash": "t+sUVrIwvo7UmsgHGgOG9F0GDZSRIm47u2ylH17Gvcv1q5hNEwgD5GoBlFyc0kh/pebmPyrAgvGsR/65ZBaXlg=="
+      },
+      "Spectre.Console": {
+        "type": "Transitive",
+        "resolved": "0.53.0",
+        "contentHash": "m2iv8Egfywp7FaNLKCmCFHbSf36D4ctzZKvlAK9NXMyGLh6L+CnrZWK8o+LOYsoAS1jtoHn0W1BT0W8vuq/FUw=="
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Composition": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "3Djj70fFTraOarSKmRnmRy/zm4YurICm+kiCtI0dYRqGJnLX6nJ+G3WYuFJ173cAPax/gh96REcbNiVqcrypFQ==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Convention": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0",
+          "System.Composition.TypedParts": "9.0.0"
+        }
+      },
+      "System.Composition.Convention": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "+vuqVP6xpi582XIjJi6OCsIxuoTZfR0M7WWufk3uGDeCl3wGW6KnpylUJ3iiXdPByPE0vR5TjJgR6hDLez4FQg==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0"
+        }
+      },
+      "System.Composition.Hosting": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "OFqSeFeJYr7kHxDfaViGM1ymk7d4JxK//VSoNF9Ux0gpqkLsauDZpu89kTHHNdCWfSljbFcvAafGyBoY094btQ==",
+        "dependencies": {
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Composition.Runtime": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "w1HOlQY1zsOWYussjFGZCEYF2UZXgvoYnS94NIu2CBnAGMbXFAX8PY8c92KwUItPmowal68jnVLBCzdrWLeEKA=="
+      },
+      "System.Composition.TypedParts": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "aRZlojCCGEHDKqh43jaDgaVpYETsgd7Nx4g1zwLKMtv4iTo0627715ajEFNpEEBTgLmvZuv8K0EVxc3sM4NWJA==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "wugvy+pBVzjQEnRs9wMTWwoaeNFX3hsaHeVHFDIvJSWXp7wfmNWu3mxAwBIE6pyW+g6+rHa1Of5fTzb0QVqUTA=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.core": {
+        "type": "Project"
+      },
+      "granit.http.apidocumentation": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Http.ApiVersioning": "[0.1.0-dev, )",
+          "Granit.Security": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )",
+          "Scalar.AspNetCore": "[2.*, )"
+        }
+      },
+      "granit.http.apiversioning": {
+        "type": "Project",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "[10.0.0-preview.*, )",
+          "Asp.Versioning.Mvc.ApiExplorer": "[10.0.0-preview.*, )",
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
+      "granit.privacy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "WolverineFx": "[5.21.*, )"
+        }
+      },
+      "granit.privacy.endpoints": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.Privacy": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.security": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Core": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.validation": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.*, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.*, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )"
+        }
+      },
+      "Asp.Versioning.Mvc": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0-preview.*, )",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "AyrcDwLzJp8yRJaFjZMJXkR1Rx2UaJkwGrGlX8sxIt2F5ZGiZwn/puXkB/oEaq55TxLkpiXWAOHHFsiVptp0fA==",
+        "dependencies": {
+          "Asp.Versioning.Http": "10.0.0-preview.2"
+        }
+      },
+      "Asp.Versioning.Mvc.ApiExplorer": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0-preview.*, )",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "G/LhAaLQj+gsB8UXRNm65fxjsI7fe87itZExb+MvJOQdrXYalZKbwuzMntO95xM5cKDrDgLnCH64fl6w173aGg==",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "10.0.0-preview.2"
+        }
+      },
+      "FluentValidation": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+        }
+      },
+      "Microsoft.AspNetCore.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "vTcxIfOPyfFbYk1g8YcXJfkMnlEWVkSnnjxcZLy60zgwiHMRf2SnZR+9E4HlpwKxgE3yfKMOti8J6WfKuKsw6w==",
+        "dependencies": {
+          "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "CentralTransitive",
+        "requested": "[5.0.*, )",
+        "resolved": "5.0.0",
+        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+        "type": "CentralTransitive",
+        "requested": "[5.0.*, )",
+        "resolved": "5.0.0",
+        "contentHash": "Al/Q8B+yO8odSqGVpSvrShMFDvlQdIBU//F3E6Rb0YdiLSALE9wh/pvozPNnfmh5HDnvU+mkmSjpz4hQO++jaA==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "k/QDdQ94/0Shi0KfU+e12m73jfQo+3JpErTtgpZfsCIqkvdEEO0XIx6R+iTbN55rNPaNhOqNY4/sB+jZ8XxVPw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "jUEXmkBUPdOS/MP9areK/sbKhdklq9+tEhvwfxGalZVnmyLUO5rrheNNutUBtvbZ7J8ECkG7/r2KXi/IFC06cA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "Co/URpVB1P1WbvswTumphjYZcvqTA2piSTLVOVtN6qLNrK6pg0OjZ/9SzigI+7NYGS2UpxVMydk/n45VvWZvOg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.14.0",
+        "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "Scalar.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.13.13",
+        "contentHash": "QS94/CNp2thhykXwBaOHjDe8Zlexs8v0QOrdLfUvxS85uW84IhCf1zGiOnYZNNtVxunJvtsr7yPgEP36TXnJ3w=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "System.Composition.AttributedModel": {
+        "type": "CentralTransitive",
+        "requested": "[9.*, )",
+        "resolved": "9.0.0",
+        "contentHash": "iri00l/zIX9g4lHMY+Nz0qV1n40+jFYAmgsaiNn16xvt2RDwlqByNG4wgblagnDYxm3YSQQ0jLlC/7Xlk9CzyA=="
+      },
+      "WolverineFx": {
+        "type": "CentralTransitive",
+        "requested": "[5.21.*, )",
+        "resolved": "5.21.0",
+        "contentHash": "2FxtZ4o/STJnEz8DVPFkzvIchRJUvINKpIvDJXNlAikAR5p15Jtn+THknOXiKyEKdDHsJQ//Z4TFAZfn2UBOvQ==",
+        "dependencies": {
+          "JasperFx": "1.21.1",
+          "JasperFx.Events": "1.24.0",
+          "JasperFx.RuntimeCompiler": "4.4.0",
+          "Microsoft.Extensions.Caching.Memory": "10.0.0",
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.2",
+          "NewId": "4.0.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      }
+    }
+  }
+}

--- a/tests/Granit.Privacy.Tests/GranitPrivacyBuilderTests.cs
+++ b/tests/Granit.Privacy.Tests/GranitPrivacyBuilderTests.cs
@@ -157,5 +157,8 @@ public sealed class GranitPrivacyBuilderTests
 
         public Task RecordAsync(LegalAgreementBase agreement, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
+
+        public Task RecordConsentAsync(Guid userId, string documentId, string version, string? ipAddress, DateTimeOffset acceptedAt, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
     }
 }

--- a/tests/Granit.Querying.AI.Tests/packages.lock.json
+++ b/tests/Granit.Querying.AI.Tests/packages.lock.json
@@ -328,8 +328,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/tests/Granit.Settings.Endpoints.Tests/AdminSettingsEndpointTests.cs
+++ b/tests/Granit.Settings.Endpoints.Tests/AdminSettingsEndpointTests.cs
@@ -55,13 +55,13 @@ public sealed class AdminSettingsEndpointTests : IAsyncDisposable
                 TestAuthHandler.SchemeName, _ => { });
 
         builder.Services.AddAuthorizationBuilder()
-            .AddPolicy(SettingsPermissions.GlobalRead,
+            .AddPolicy(SettingsPermissions.Global.Read,
                 policy => policy.RequireRole(GlobalReadRole))
-            .AddPolicy(SettingsPermissions.GlobalManage,
+            .AddPolicy(SettingsPermissions.Global.Manage,
                 policy => policy.RequireRole(GlobalManageRole))
-            .AddPolicy(SettingsPermissions.TenantRead,
+            .AddPolicy(SettingsPermissions.Tenant.Read,
                 policy => policy.RequireRole(TenantReadRole))
-            .AddPolicy(SettingsPermissions.TenantManage,
+            .AddPolicy(SettingsPermissions.Tenant.Manage,
                 policy => policy.RequireRole(TenantManageRole));
 
         builder.Services.AddSingleton(_settingProvider);

--- a/tests/Granit.Settings.Endpoints.Tests/SettingsPermissionDefinitionProviderTests.cs
+++ b/tests/Granit.Settings.Endpoints.Tests/SettingsPermissionDefinitionProviderTests.cs
@@ -47,7 +47,7 @@ public sealed class SettingsPermissionDefinitionProviderTests
 
         provider.DefinePermissions(context);
 
-        group.Permissions.ShouldContain(p => p.Name == SettingsPermissions.GlobalRead);
+        group.Permissions.ShouldContain(p => p.Name == SettingsPermissions.Global.Read);
     }
 
     [Fact]
@@ -60,7 +60,7 @@ public sealed class SettingsPermissionDefinitionProviderTests
 
         provider.DefinePermissions(context);
 
-        group.Permissions.ShouldContain(p => p.Name == SettingsPermissions.GlobalManage);
+        group.Permissions.ShouldContain(p => p.Name == SettingsPermissions.Global.Manage);
     }
 
     [Fact]
@@ -73,7 +73,7 @@ public sealed class SettingsPermissionDefinitionProviderTests
 
         provider.DefinePermissions(context);
 
-        group.Permissions.ShouldContain(p => p.Name == SettingsPermissions.TenantRead);
+        group.Permissions.ShouldContain(p => p.Name == SettingsPermissions.Tenant.Read);
     }
 
     [Fact]
@@ -86,6 +86,6 @@ public sealed class SettingsPermissionDefinitionProviderTests
 
         provider.DefinePermissions(context);
 
-        group.Permissions.ShouldContain(p => p.Name == SettingsPermissions.TenantManage);
+        group.Permissions.ShouldContain(p => p.Name == SettingsPermissions.Tenant.Manage);
     }
 }

--- a/tests/Granit.Settings.Endpoints.Tests/SettingsPermissionsTests.cs
+++ b/tests/Granit.Settings.Endpoints.Tests/SettingsPermissionsTests.cs
@@ -12,37 +12,37 @@ public sealed class SettingsPermissionsTests
     [Fact]
     public void GlobalRead_FollowsThreeSegmentFormat()
     {
-        SettingsPermissions.GlobalRead.ShouldBe("Settings.Global.Read");
-        SettingsPermissions.GlobalRead.Split('.').Length.ShouldBe(3);
+        SettingsPermissions.Global.Read.ShouldBe("Settings.Global.Read");
+        SettingsPermissions.Global.Read.Split('.').Length.ShouldBe(3);
     }
 
     [Fact]
     public void GlobalManage_FollowsThreeSegmentFormat()
     {
-        SettingsPermissions.GlobalManage.ShouldBe("Settings.Global.Manage");
-        SettingsPermissions.GlobalManage.Split('.').Length.ShouldBe(3);
+        SettingsPermissions.Global.Manage.ShouldBe("Settings.Global.Manage");
+        SettingsPermissions.Global.Manage.Split('.').Length.ShouldBe(3);
     }
 
     [Fact]
     public void TenantRead_FollowsThreeSegmentFormat()
     {
-        SettingsPermissions.TenantRead.ShouldBe("Settings.Tenant.Read");
-        SettingsPermissions.TenantRead.Split('.').Length.ShouldBe(3);
+        SettingsPermissions.Tenant.Read.ShouldBe("Settings.Tenant.Read");
+        SettingsPermissions.Tenant.Read.Split('.').Length.ShouldBe(3);
     }
 
     [Fact]
     public void TenantManage_FollowsThreeSegmentFormat()
     {
-        SettingsPermissions.TenantManage.ShouldBe("Settings.Tenant.Manage");
-        SettingsPermissions.TenantManage.Split('.').Length.ShouldBe(3);
+        SettingsPermissions.Tenant.Manage.ShouldBe("Settings.Tenant.Manage");
+        SettingsPermissions.Tenant.Manage.Split('.').Length.ShouldBe(3);
     }
 
     [Fact]
     public void AllPermissions_StartWithGroupName()
     {
-        SettingsPermissions.GlobalRead.ShouldStartWith(SettingsPermissions.GroupName + ".");
-        SettingsPermissions.GlobalManage.ShouldStartWith(SettingsPermissions.GroupName + ".");
-        SettingsPermissions.TenantRead.ShouldStartWith(SettingsPermissions.GroupName + ".");
-        SettingsPermissions.TenantManage.ShouldStartWith(SettingsPermissions.GroupName + ".");
+        SettingsPermissions.Global.Read.ShouldStartWith(SettingsPermissions.GroupName + ".");
+        SettingsPermissions.Global.Manage.ShouldStartWith(SettingsPermissions.GroupName + ".");
+        SettingsPermissions.Tenant.Read.ShouldStartWith(SettingsPermissions.GroupName + ".");
+        SettingsPermissions.Tenant.Manage.ShouldStartWith(SettingsPermissions.GroupName + ".");
     }
 }

--- a/tests/Granit.Templating.AI.Tests/packages.lock.json
+++ b/tests/Granit.Templating.AI.Tests/packages.lock.json
@@ -327,8 +327,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/tests/Granit.Timeline.AI.Tests/packages.lock.json
+++ b/tests/Granit.Timeline.AI.Tests/packages.lock.json
@@ -352,8 +352,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",

--- a/tests/Granit.Workflow.AI.Tests/packages.lock.json
+++ b/tests/Granit.Workflow.AI.Tests/packages.lock.json
@@ -335,8 +335,8 @@
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.4.0",
-        "contentHash": "t3S2H4do4YeNheIfE3GEl3MnKIrnxpbLu7a88spfApYR3in9ddhIq/GMtxgMaFjn/PUMTCFv5YH7Y6Q91dsDXQ=="
+        "resolved": "10.4.1",
+        "contentHash": "ZxhU/wg9BOc3ohibhLl18toPLWm96ysQoE+3OhCgrZ0TUPZd7bsUmGteeatz08yweyuPIEhtyUzEZTF+3bMWEQ=="
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Summary

- **feat(privacy):** Add `Granit.Privacy.Endpoints` — 8 GDPR endpoints (Art. 15/17/20) with export saga, deletion, legal agreements
- **fix(conventions):** Enforce framework audit compliance across 25 modules (OpenAPI metadata, permissions naming, endpoint documentation)
- **docs(api):** Add comprehensive endpoint registry (150+ framework routes) with corrections
- **fix(tests):** Harden EntraId activity error-status tests against parallel contamination
- **chore:** Regenerate packages.lock.json, upgrade actions/checkout to v6

## Test plan

- [ ] `dotnet build` — 0 errors
- [ ] `dotnet format --verify-no-changes` — clean
- [ ] `dotnet test` — all architecture tests pass (Privacy.Endpoints included)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
