### PR TITLE
refactor(tests): replace FederatedIdentityUser with FakeIdentityUser

### DIFF
--- a/.github/shard-filters/business.slnf
+++ b/.github/shard-filters/business.slnf
@@ -21,6 +21,7 @@
       "src/Granit.Http.ApiDocumentation/Granit.Http.ApiDocumentation.csproj",
       "src/Granit.Http.ApiVersioning/Granit.Http.ApiVersioning.csproj",
       "src/Granit.Http.ExceptionHandling/Granit.Http.ExceptionHandling.csproj",
+      "src/Granit.Identity.Federated/Granit.Identity.Federated.csproj",
       "src/Granit.Identity/Granit.Identity.csproj",
       "src/Granit.Localization/Granit.Localization.csproj",
       "src/Granit.Notifications/Granit.Notifications.csproj",

--- a/.github/shard-filters/business.slnf
+++ b/.github/shard-filters/business.slnf
@@ -21,7 +21,6 @@
       "src/Granit.Http.ApiDocumentation/Granit.Http.ApiDocumentation.csproj",
       "src/Granit.Http.ApiVersioning/Granit.Http.ApiVersioning.csproj",
       "src/Granit.Http.ExceptionHandling/Granit.Http.ExceptionHandling.csproj",
-      "src/Granit.Identity.Federated/Granit.Identity.Federated.csproj",
       "src/Granit.Identity/Granit.Identity.csproj",
       "src/Granit.Localization/Granit.Localization.csproj",
       "src/Granit.Notifications/Granit.Notifications.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-22T14:47:03.653418+00:00",
+  "generatedAt": "2026-03-22T14:56:32.280124+00:00",
   "repo": "granit-dotnet",
   "projectGraph": [
     {

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-22T14:33:35.750677+00:00",
+  "generatedAt": "2026-03-22T14:47:03.653418+00:00",
   "repo": "granit-dotnet",
   "projectGraph": [
     {
@@ -13638,6 +13638,15 @@
       ]
     },
     {
+      "name": "FederatedIdentityUser",
+      "fqn": "Granit.Identity.Federated.FederatedIdentityUser",
+      "kind": "record",
+      "project": "Granit.Identity.Federated",
+      "file": "src/Granit.Identity.Federated/FederatedIdentityUser.cs",
+      "line": 23,
+      "members": []
+    },
+    {
       "name": "IdentityGoogleCloudServiceCollectionExtensions",
       "fqn": "Granit.Identity.Federated.GoogleCloud.Extensions.IdentityGoogleCloudServiceCollectionExtensions",
       "kind": "class",
@@ -14133,15 +14142,6 @@
           "returnType": "void"
         }
       ]
-    },
-    {
-      "name": "FederatedIdentityUser",
-      "fqn": "Granit.Identity.Models.FederatedIdentityUser",
-      "kind": "record",
-      "project": "Granit.Identity",
-      "file": "src/Granit.Identity/Models/FederatedIdentityUser.cs",
-      "line": 23,
-      "members": []
     },
     {
       "name": "IdentityDeviceActivity",

--- a/src/Granit.Identity.Federated.Cognito/Internal/CognitoIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.Cognito/Internal/CognitoIdentityProvider.cs
@@ -2,12 +2,12 @@ using System.Diagnostics;
 using Amazon.CognitoIdentityProvider;
 using Amazon.CognitoIdentityProvider.Model;
 using Granit.Core.Events;
+using Granit.Identity.Federated;
 using Granit.Identity.Federated.Cognito.Diagnostics;
 using Granit.Identity.Federated.Cognito.Options;
 using Granit.Identity.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Granit.Identity.Federated.Cognito.Internal;

--- a/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProvider.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using System.Security.Cryptography;
 using Granit.Core.Events;
 using Granit.Identity.Events;
+using Granit.Identity.Federated;
 using Granit.Identity.Federated.EntraId.Diagnostics;
 using Granit.Identity.Federated.EntraId.Options;
 using Granit.Identity.Models;

--- a/src/Granit.Identity.Federated.GoogleCloud/Internal/GoogleCloudIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.GoogleCloud/Internal/GoogleCloudIdentityProvider.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using FirebaseAdmin.Auth;
 using Granit.Core.Events;
 using Granit.Identity.Events;
+using Granit.Identity.Federated;
 using Granit.Identity.Federated.GoogleCloud.Diagnostics;
 using Granit.Identity.Federated.GoogleCloud.Options;
 using Granit.Identity.Models;

--- a/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using Granit.Core.Events;
 using Granit.Identity.Diagnostics;
 using Granit.Identity.Events;
+using Granit.Identity.Federated;
 using Granit.Identity.Federated.Keycloak.Diagnostics;
 using Granit.Identity.Federated.Keycloak.Options;
 using Granit.Identity.Models;

--- a/src/Granit.Identity.Federated/FederatedIdentityUser.cs
+++ b/src/Granit.Identity.Federated/FederatedIdentityUser.cs
@@ -1,6 +1,6 @@
 using System.Collections.ObjectModel;
 
-namespace Granit.Identity.Models;
+namespace Granit.Identity.Federated;
 
 /// <summary>
 /// Immutable snapshot of user data returned by federated identity providers

--- a/src/Granit.Identity/Internal/NullIdentityProvider.cs
+++ b/src/Granit.Identity/Internal/NullIdentityProvider.cs
@@ -93,7 +93,7 @@ internal sealed class NullIdentityProvider : IIdentityProvider
     /// <inheritdoc/>
     public Task<IIdentityUser> CreateUserAsync(
         IdentityUserCreate user, CancellationToken cancellationToken = default) =>
-        Task.FromResult<IIdentityUser>(new FederatedIdentityUser(string.Empty, user.Username, user.Email,
+        Task.FromResult<IIdentityUser>(new NullIdentityUser(string.Empty, user.Username, user.Email,
             user.FirstName, user.LastName, user.Enabled));
 
     /// <inheritdoc/>
@@ -120,4 +120,15 @@ internal sealed class NullIdentityProvider : IIdentityProvider
     public Task<bool> VerifyUserCredentialsAsync(
         string username, string password, CancellationToken cancellationToken = default) =>
         Task.FromResult(false);
+
+    /// <summary>
+    /// Minimal <see cref="IIdentityUser"/> for the null provider.
+    /// </summary>
+    private sealed record NullIdentityUser(
+        string UserId, string? Username, string? Email,
+        string? FirstName, string? LastName, bool Enabled) : IIdentityUser
+    {
+        public IReadOnlyDictionary<string, string> ExtraProperties { get; } =
+            System.Collections.ObjectModel.ReadOnlyDictionary<string, string>.Empty;
+    }
 }

--- a/src/Granit.OpenIddict/README.md
+++ b/src/Granit.OpenIddict/README.md
@@ -29,7 +29,7 @@ dotnet add package Granit.OpenIddict
 | --- | --- |
 | `Granit.OpenIddict.Server` | OIDC server configuration |
 | `Granit.OpenIddict.EntityFrameworkCore` | Entities, DbContext, tenant-isolated stores |
-| `Granit.Identity.OpenIddict` | `IIdentityProvider` bridge over ASP.NET Core Identity |
+| `Granit.Identity.Local.AspNetCore` | `IIdentityProvider` bridge over ASP.NET Core Identity |
 | `Granit.Authentication.OpenIddict` | Authentication handler configuration |
 | `Granit.OpenIddict.Endpoints` | Account self-service and admin API |
 | `Granit.OpenIddict.BackgroundJobs` | Token cleanup + idle session enforcement |

--- a/src/bundles/Granit.Bundle.OpenIddict/README.md
+++ b/src/bundles/Granit.Bundle.OpenIddict/README.md
@@ -12,7 +12,7 @@ Part of the [granit](https://granit-fx.dev) framework.
 | `Granit.OpenIddict` | Abstractions, interfaces, options |
 | `Granit.OpenIddict.Server` | OIDC server configuration |
 | `Granit.OpenIddict.EntityFrameworkCore` | Entities, DbContext, tenant-isolated stores |
-| `Granit.Identity.OpenIddict` | `IIdentityProvider` bridge |
+| `Granit.Identity.Local.AspNetCore` | `IIdentityProvider` bridge |
 | `Granit.Authentication.OpenIddict` | Authentication handler configuration |
 | `Granit.OpenIddict.Endpoints` | Account and admin REST API |
 | `Granit.OpenIddict.BackgroundJobs` | Token cleanup, idle session enforcement |

--- a/tests/Granit.Identity.Endpoints.Tests/Granit.Identity.Endpoints.Tests.csproj
+++ b/tests/Granit.Identity.Endpoints.Tests/Granit.Identity.Endpoints.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Granit.Identity.Endpoints\Granit.Identity.Endpoints.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Identity.Federated\Granit.Identity.Federated.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.Identity.Endpoints.Tests/Granit.Identity.Endpoints.Tests.csproj
+++ b/tests/Granit.Identity.Endpoints.Tests/Granit.Identity.Endpoints.Tests.csproj
@@ -17,7 +17,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Granit.Identity.Endpoints\Granit.Identity.Endpoints.csproj" />
-    <ProjectReference Include="..\..\src\Granit.Identity.Federated\Granit.Identity.Federated.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\FakeIdentityUser.cs" Link="Shared\FakeIdentityUser.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityProviderRoleEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityProviderRoleEndpointsTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using Granit.Identity.Endpoints.Extensions;
+using Granit.Identity.Federated;
 using Granit.Identity.Models;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityProviderRoleEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityProviderRoleEndpointsTests.cs
@@ -1,8 +1,8 @@
 using System.Net;
 using System.Net.Http.Json;
 using Granit.Identity.Endpoints.Extensions;
-using Granit.Identity.Federated;
 using Granit.Identity.Models;
+using Granit.Tests.Shared;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
@@ -42,7 +42,7 @@ public sealed class IdentityProviderRoleEndpointsTests : IAsyncDisposable
             .Returns([new IdentityRole("role-1", "admin", null)]);
 
         _roleManager.GetRoleMembersAsync("admin", Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<IIdentityUser>)[new FederatedIdentityUser("user-1", "jdoe", "jdoe@test.com", "John", "Doe", true)]);
+            .Returns((IReadOnlyList<IIdentityUser>)[new FakeIdentityUser("user-1", "jdoe", "jdoe@test.com", "John", "Doe", true)]);
 
         _roleManager.GetUserRolesAsync("user-1", Arg.Any<CancellationToken>())
             .Returns([new IdentityRole("role-1", "admin", null)]);
@@ -104,8 +104,8 @@ public sealed class IdentityProviderRoleEndpointsTests : IAsyncDisposable
             $"{Prefix}/roles/admin/members", TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        List<FederatedIdentityUser>? members = await response.Content
-            .ReadFromJsonAsync<List<FederatedIdentityUser>>(TestContext.Current.CancellationToken);
+        List<FakeIdentityUser>? members = await response.Content
+            .ReadFromJsonAsync<List<FakeIdentityUser>>(TestContext.Current.CancellationToken);
         members.ShouldNotBeNull();
         members.Count.ShouldBe(1);
         members[0].Username.ShouldBe("jdoe");

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityProviderUserEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityProviderUserEndpointsTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using Granit.Identity.Endpoints.Extensions;
+using Granit.Identity.Federated;
 using Granit.Identity.Models;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityProviderUserEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityProviderUserEndpointsTests.cs
@@ -1,8 +1,8 @@
 using System.Net;
 using System.Net.Http.Json;
 using Granit.Identity.Endpoints.Extensions;
-using Granit.Identity.Federated;
 using Granit.Identity.Models;
+using Granit.Tests.Shared;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
@@ -41,7 +41,7 @@ public sealed class IdentityProviderUserEndpointsTests : IAsyncDisposable
         _capabilities.MaxCustomAttributes.Returns(50);
 
         _userWriter.CreateUserAsync(Arg.Any<IdentityUserCreate>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IIdentityUser>(new FederatedIdentityUser("new-id", "newuser", "new@test.com", "New", "User", true)));
+            .Returns(Task.FromResult<IIdentityUser>(new FakeIdentityUser("new-id", "newuser", "new@test.com", "New", "User", true)));
 
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
@@ -74,14 +74,14 @@ public sealed class IdentityProviderUserEndpointsTests : IAsyncDisposable
     public async Task GetUsers_returns_200_with_list()
     {
         _userReader.GetUsersAsync(null, null, null, Arg.Any<CancellationToken>())
-            .Returns((IReadOnlyList<IIdentityUser>)[new FederatedIdentityUser("user-1", "jdoe", "jdoe@test.com", "John", "Doe", true)]);
+            .Returns((IReadOnlyList<IIdentityUser>)[new FakeIdentityUser("user-1", "jdoe", "jdoe@test.com", "John", "Doe", true)]);
 
         HttpResponseMessage response = await _adminClient.GetAsync(
             $"{Prefix}/users", TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        List<FederatedIdentityUser>? users = await response.Content
-            .ReadFromJsonAsync<List<FederatedIdentityUser>>(TestContext.Current.CancellationToken);
+        List<FakeIdentityUser>? users = await response.Content
+            .ReadFromJsonAsync<List<FakeIdentityUser>>(TestContext.Current.CancellationToken);
         users.ShouldNotBeNull();
         users.Count.ShouldBe(1);
         users[0].Username.ShouldBe("jdoe");
@@ -102,14 +102,14 @@ public sealed class IdentityProviderUserEndpointsTests : IAsyncDisposable
     public async Task GetUser_existing_returns_200()
     {
         _userReader.GetUserAsync("user-1", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IIdentityUser?>(new FederatedIdentityUser("user-1", "jdoe", "jdoe@test.com", "John", "Doe", true)));
+            .Returns(Task.FromResult<IIdentityUser?>(new FakeIdentityUser("user-1", "jdoe", "jdoe@test.com", "John", "Doe", true)));
 
         HttpResponseMessage response = await _adminClient.GetAsync(
             $"{Prefix}/users/user-1", TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        FederatedIdentityUser? user = await response.Content
-            .ReadFromJsonAsync<FederatedIdentityUser>(TestContext.Current.CancellationToken);
+        FakeIdentityUser? user = await response.Content
+            .ReadFromJsonAsync<FakeIdentityUser>(TestContext.Current.CancellationToken);
         user.ShouldNotBeNull();
         user.UserId.ShouldBe("user-1");
     }
@@ -137,8 +137,8 @@ public sealed class IdentityProviderUserEndpointsTests : IAsyncDisposable
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.Created);
-        FederatedIdentityUser? created = await response.Content
-            .ReadFromJsonAsync<FederatedIdentityUser>(TestContext.Current.CancellationToken);
+        FakeIdentityUser? created = await response.Content
+            .ReadFromJsonAsync<FakeIdentityUser>(TestContext.Current.CancellationToken);
         created.ShouldNotBeNull();
         created.UserId.ShouldBe("new-id");
     }

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityUserCacheReadEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityUserCacheReadEndpointsTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using Granit.Identity.Endpoints.Extensions;
 using Granit.Identity.Endpoints.Internal;
+using Granit.Identity.Federated;
 using Granit.Identity.Models;
 using Granit.Querying;
 using Microsoft.AspNetCore.Authentication;

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityUserCacheReadEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityUserCacheReadEndpointsTests.cs
@@ -2,9 +2,9 @@ using System.Net;
 using System.Net.Http.Json;
 using Granit.Identity.Endpoints.Extensions;
 using Granit.Identity.Endpoints.Internal;
-using Granit.Identity.Federated;
 using Granit.Identity.Models;
 using Granit.Querying;
+using Granit.Tests.Shared;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
@@ -61,14 +61,14 @@ public sealed class IdentityUserCacheReadEndpointsTests : IAsyncDisposable
     {
         _lookupService.SearchAsync("john", 1, 20, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(new PagedResult<IIdentityUser>(
-                [new FederatedIdentityUser("user-1", "jdoe", "jdoe@test.com", "John", "Doe", true)], 1, HasMore: false)));
+                [new FakeIdentityUser("user-1", "jdoe", "jdoe@test.com", "John", "Doe", true)], 1, HasMore: false)));
 
         HttpResponseMessage response = await _adminClient.GetAsync(
             $"{Prefix}?search=john", TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        PagedResult<FederatedIdentityUser>? result = await response.Content
-            .ReadFromJsonAsync<PagedResult<FederatedIdentityUser>>(TestContext.Current.CancellationToken);
+        PagedResult<FakeIdentityUser>? result = await response.Content
+            .ReadFromJsonAsync<PagedResult<FakeIdentityUser>>(TestContext.Current.CancellationToken);
         result.ShouldNotBeNull();
         result.Items.Count.ShouldBe(1);
         result.TotalCount.ShouldBe(1);
@@ -90,14 +90,14 @@ public sealed class IdentityUserCacheReadEndpointsTests : IAsyncDisposable
     public async Task GetById_existing_user_returns_200()
     {
         _lookupService.FindByIdAsync("user-1", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IIdentityUser?>(new FederatedIdentityUser("user-1", "jdoe", "jdoe@test.com", "John", "Doe", true)));
+            .Returns(Task.FromResult<IIdentityUser?>(new FakeIdentityUser("user-1", "jdoe", "jdoe@test.com", "John", "Doe", true)));
 
         HttpResponseMessage response = await _adminClient.GetAsync(
             $"{Prefix}/user-1", TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        FederatedIdentityUser? user = await response.Content
-            .ReadFromJsonAsync<FederatedIdentityUser>(TestContext.Current.CancellationToken);
+        FakeIdentityUser? user = await response.Content
+            .ReadFromJsonAsync<FakeIdentityUser>(TestContext.Current.CancellationToken);
         user.ShouldNotBeNull();
         user.UserId.ShouldBe("user-1");
     }
@@ -121,8 +121,8 @@ public sealed class IdentityUserCacheReadEndpointsTests : IAsyncDisposable
     {
         _lookupService.FindByIdsAsync(Arg.Any<IReadOnlyCollection<string>>(), Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<IIdentityUser>)[
-                new FederatedIdentityUser("user-1", "jdoe", "jdoe@test.com", "John", "Doe", true),
-                new FederatedIdentityUser("user-2", "jane", "jane@test.com", "Jane", "Smith", true),
+                new FakeIdentityUser("user-1", "jdoe", "jdoe@test.com", "John", "Doe", true),
+                new FakeIdentityUser("user-2", "jane", "jane@test.com", "Jane", "Smith", true),
             ]);
 
         HttpResponseMessage response = await _adminClient.PostAsJsonAsync(
@@ -131,8 +131,8 @@ public sealed class IdentityUserCacheReadEndpointsTests : IAsyncDisposable
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        List<FederatedIdentityUser>? users = await response.Content
-            .ReadFromJsonAsync<List<FederatedIdentityUser>>(TestContext.Current.CancellationToken);
+        List<FakeIdentityUser>? users = await response.Content
+            .ReadFromJsonAsync<List<FakeIdentityUser>>(TestContext.Current.CancellationToken);
         users.ShouldNotBeNull();
         users.Count.ShouldBe(2);
     }

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityUserCacheSyncEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityUserCacheSyncEndpointsTests.cs
@@ -2,8 +2,8 @@ using System.Net;
 using System.Net.Http.Json;
 using Granit.Identity.Endpoints.Extensions;
 using Granit.Identity.Endpoints.Internal;
-using Granit.Identity.Federated;
 using Granit.Identity.Models;
+using Granit.Tests.Shared;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
@@ -59,7 +59,7 @@ public sealed class IdentityUserCacheSyncEndpointsTests : IAsyncDisposable
     public async Task Sync_returns_200_with_refreshed_users()
     {
         _lookupService.RefreshByIdAsync("user-1", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IIdentityUser?>(new FederatedIdentityUser("user-1", "jdoe", "jdoe@test.com", "John", "Doe", true)));
+            .Returns(Task.FromResult<IIdentityUser?>(new FakeIdentityUser("user-1", "jdoe", "jdoe@test.com", "John", "Doe", true)));
         _lookupService.RefreshByIdAsync("user-2", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IIdentityUser?>(null));
 
@@ -69,8 +69,8 @@ public sealed class IdentityUserCacheSyncEndpointsTests : IAsyncDisposable
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        List<FederatedIdentityUser>? users = await response.Content
-            .ReadFromJsonAsync<List<FederatedIdentityUser>>(TestContext.Current.CancellationToken);
+        List<FakeIdentityUser>? users = await response.Content
+            .ReadFromJsonAsync<List<FakeIdentityUser>>(TestContext.Current.CancellationToken);
         users.ShouldNotBeNull();
         users.Count.ShouldBe(1);
     }

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityUserCacheSyncEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityUserCacheSyncEndpointsTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using Granit.Identity.Endpoints.Extensions;
 using Granit.Identity.Endpoints.Internal;
+using Granit.Identity.Federated;
 using Granit.Identity.Models;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;

--- a/tests/Granit.Identity.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Endpoints.Tests/packages.lock.json
@@ -591,6 +591,12 @@
           "Granit.Validation": "[0.1.0-dev, )"
         }
       },
+      "granit.identity.federated": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Identity": "[0.1.0-dev, )"
+        }
+      },
       "granit.localization": {
         "type": "Project",
         "dependencies": {

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/CachedUserLookupServiceTests.cs
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/CachedUserLookupServiceTests.cs
@@ -1,4 +1,5 @@
 using Granit.Core.MultiTenancy;
+using Granit.Identity.Federated;
 using Granit.Identity.Federated.EntityFrameworkCore.Entities;
 using Granit.Identity.Federated.EntityFrameworkCore.Internal;
 using Granit.Identity.Federated.EntityFrameworkCore.Options;

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/IdentityUserEventHandlerTests.cs
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/IdentityUserEventHandlerTests.cs
@@ -1,4 +1,5 @@
 using Granit.Core.Events;
+using Granit.Identity.Federated;
 using Granit.Identity.Federated.EntityFrameworkCore.Entities;
 using Granit.Identity.Federated.EntityFrameworkCore.Events;
 using Granit.Identity.Federated.EntityFrameworkCore.Handlers;

--- a/tests/Granit.Identity.Federated.Tests/FederatedIdentityUserTests.cs
+++ b/tests/Granit.Identity.Federated.Tests/FederatedIdentityUserTests.cs
@@ -1,8 +1,9 @@
+using Granit.Identity.Federated;
 using Granit.Identity.Models;
 using Shouldly;
 using Xunit;
 
-namespace Granit.Identity.Tests;
+namespace Granit.Identity.Federated.Tests;
 
 public sealed class FederatedIdentityUserTests
 {

--- a/tests/Granit.Identity.Local.AspNetCore.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.AspNetCore.Tests/packages.lock.json
@@ -351,16 +351,6 @@
           "OpenIddict.Validation": "7.4.0"
         }
       },
-      "OpenIddict.Validation.SystemNetHttp": {
-        "type": "Transitive",
-        "resolved": "7.4.0",
-        "contentHash": "zBkL9kx6Z5PDnZjFUrkUnT/9jt2kjNVPoh9zw41BBkP8NKRPGjZk3y7av0qR51IgN1V+ZRQqmc1fQoK4qeOtjg==",
-        "dependencies": {
-          "Microsoft.Extensions.Http.Polly": "10.0.3",
-          "Microsoft.Extensions.Http.Resilience": "10.3.0",
-          "OpenIddict.Validation": "7.4.0"
-        }
-      },
       "Polly": {
         "type": "Transitive",
         "resolved": "7.2.4",
@@ -540,13 +530,20 @@
         "dependencies": {
           "Granit.Encryption": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
-          "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.OpenIddict.Server": "[0.1.0-dev, )",
           "Granit.Persistence": "[0.1.0-dev, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.*, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
           "OpenIddict": "[7.*, )",
-          "OpenIddict.EntityFrameworkCore": "[7.*, )",
+          "OpenIddict.EntityFrameworkCore": "[7.*, )"
+        }
+      },
+      "granit.openiddict.server": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.OpenIddict": "[0.1.0-dev, )",
+          "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",
           "OpenIddict.Validation.AspNetCore": "[7.*, )"
         }
@@ -672,6 +669,17 @@
         "resolved": "7.4.0",
         "contentHash": "KQkDiHFUrTkCt6+kB51sVkTAlpia3Mz04lFFPvUL3nunro0aqysk4I5DhI7qjRyKIVrQGafjSVQcf+0V77t6ww==",
         "dependencies": {
+          "OpenIddict.Validation": "7.4.0"
+        }
+      },
+      "OpenIddict.Validation.SystemNetHttp": {
+        "type": "CentralTransitive",
+        "requested": "[7.*, )",
+        "resolved": "7.4.0",
+        "contentHash": "zBkL9kx6Z5PDnZjFUrkUnT/9jt2kjNVPoh9zw41BBkP8NKRPGjZk3y7av0qR51IgN1V+ZRQqmc1fQoK4qeOtjg==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Polly": "10.0.3",
+          "Microsoft.Extensions.Http.Resilience": "10.3.0",
           "OpenIddict.Validation": "7.4.0"
         }
       }

--- a/tests/Granit.Identity.Tests/FakeIdentityProvider.cs
+++ b/tests/Granit.Identity.Tests/FakeIdentityProvider.cs
@@ -1,5 +1,5 @@
-using Granit.Identity.Federated;
 using Granit.Identity.Models;
+using Granit.Tests.Shared;
 
 namespace Granit.Identity.Tests;
 
@@ -75,7 +75,7 @@ internal sealed class FakeIdentityProvider : IIdentityProvider
 
     public Task<IIdentityUser> CreateUserAsync(
         IdentityUserCreate user, CancellationToken cancellationToken = default) =>
-        Task.FromResult<IIdentityUser>(new FederatedIdentityUser(string.Empty, user.Username, user.Email,
+        Task.FromResult<IIdentityUser>(new FakeIdentityUser(string.Empty, user.Username, user.Email,
             user.FirstName, user.LastName, user.Enabled));
 
     public Task<IReadOnlyList<IdentityGroup>> GetGroupsAsync(

--- a/tests/Granit.Identity.Tests/FakeIdentityProvider.cs
+++ b/tests/Granit.Identity.Tests/FakeIdentityProvider.cs
@@ -1,3 +1,4 @@
+using Granit.Identity.Federated;
 using Granit.Identity.Models;
 
 namespace Granit.Identity.Tests;

--- a/tests/Granit.Identity.Tests/Granit.Identity.Tests.csproj
+++ b/tests/Granit.Identity.Tests/Granit.Identity.Tests.csproj
@@ -17,7 +17,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Granit.Identity\Granit.Identity.csproj" />
-    <ProjectReference Include="..\..\src\Granit.Identity.Federated\Granit.Identity.Federated.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\FakeIdentityUser.cs" Link="Shared\FakeIdentityUser.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.Identity.Tests/Granit.Identity.Tests.csproj
+++ b/tests/Granit.Identity.Tests/Granit.Identity.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Granit.Identity\Granit.Identity.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Identity.Federated\Granit.Identity.Federated.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.Identity.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Tests/packages.lock.json
@@ -326,6 +326,12 @@
           "Granit.Querying": "[0.1.0-dev, )"
         }
       },
+      "granit.identity.federated": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Identity": "[0.1.0-dev, )"
+        }
+      },
       "granit.querying": {
         "type": "Project",
         "dependencies": {

--- a/tests/Granit.OpenIddict.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.BackgroundJobs.Tests/packages.lock.json
@@ -351,16 +351,6 @@
           "OpenIddict.Validation": "7.4.0"
         }
       },
-      "OpenIddict.Validation.SystemNetHttp": {
-        "type": "Transitive",
-        "resolved": "7.4.0",
-        "contentHash": "zBkL9kx6Z5PDnZjFUrkUnT/9jt2kjNVPoh9zw41BBkP8NKRPGjZk3y7av0qR51IgN1V+ZRQqmc1fQoK4qeOtjg==",
-        "dependencies": {
-          "Microsoft.Extensions.Http.Polly": "10.0.3",
-          "Microsoft.Extensions.Http.Resilience": "10.3.0",
-          "OpenIddict.Validation": "7.4.0"
-        }
-      },
       "Polly": {
         "type": "Transitive",
         "resolved": "7.2.4",
@@ -634,6 +624,17 @@
           "Microsoft.EntityFrameworkCore.Relational": "10.0.3",
           "OpenIddict.Core": "7.4.0",
           "OpenIddict.EntityFrameworkCore.Models": "7.4.0"
+        }
+      },
+      "OpenIddict.Validation.SystemNetHttp": {
+        "type": "CentralTransitive",
+        "requested": "[7.*, )",
+        "resolved": "7.4.0",
+        "contentHash": "zBkL9kx6Z5PDnZjFUrkUnT/9jt2kjNVPoh9zw41BBkP8NKRPGjZk3y7av0qR51IgN1V+ZRQqmc1fQoK4qeOtjg==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Polly": "10.0.3",
+          "Microsoft.Extensions.Http.Resilience": "10.3.0",
+          "OpenIddict.Validation": "7.4.0"
         }
       },
       "OpenTelemetry.Api": {

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
@@ -351,16 +351,6 @@
           "OpenIddict.Validation": "7.4.0"
         }
       },
-      "OpenIddict.Validation.SystemNetHttp": {
-        "type": "Transitive",
-        "resolved": "7.4.0",
-        "contentHash": "zBkL9kx6Z5PDnZjFUrkUnT/9jt2kjNVPoh9zw41BBkP8NKRPGjZk3y7av0qR51IgN1V+ZRQqmc1fQoK4qeOtjg==",
-        "dependencies": {
-          "Microsoft.Extensions.Http.Polly": "10.0.3",
-          "Microsoft.Extensions.Http.Resilience": "10.3.0",
-          "OpenIddict.Validation": "7.4.0"
-        }
-      },
       "Polly": {
         "type": "Transitive",
         "resolved": "7.2.4",
@@ -533,13 +523,20 @@
         "dependencies": {
           "Granit.Encryption": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
-          "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.OpenIddict.Server": "[0.1.0-dev, )",
           "Granit.Persistence": "[0.1.0-dev, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.*, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
           "OpenIddict": "[7.*, )",
-          "OpenIddict.EntityFrameworkCore": "[7.*, )",
+          "OpenIddict.EntityFrameworkCore": "[7.*, )"
+        }
+      },
+      "granit.openiddict.server": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.OpenIddict": "[0.1.0-dev, )",
+          "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",
           "OpenIddict.Validation.AspNetCore": "[7.*, )"
         }
@@ -665,6 +662,17 @@
         "resolved": "7.4.0",
         "contentHash": "KQkDiHFUrTkCt6+kB51sVkTAlpia3Mz04lFFPvUL3nunro0aqysk4I5DhI7qjRyKIVrQGafjSVQcf+0V77t6ww==",
         "dependencies": {
+          "OpenIddict.Validation": "7.4.0"
+        }
+      },
+      "OpenIddict.Validation.SystemNetHttp": {
+        "type": "CentralTransitive",
+        "requested": "[7.*, )",
+        "resolved": "7.4.0",
+        "contentHash": "zBkL9kx6Z5PDnZjFUrkUnT/9jt2kjNVPoh9zw41BBkP8NKRPGjZk3y7av0qR51IgN1V+ZRQqmc1fQoK4qeOtjg==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Polly": "10.0.3",
+          "Microsoft.Extensions.Http.Resilience": "10.3.0",
           "OpenIddict.Validation": "7.4.0"
         }
       }

--- a/tests/Granit.Workflow.Notifications.Tests/Granit.Workflow.Notifications.Tests.csproj
+++ b/tests/Granit.Workflow.Notifications.Tests/Granit.Workflow.Notifications.Tests.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Granit.Workflow.Notifications\Granit.Workflow.Notifications.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Identity.Federated\Granit.Identity.Federated.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.Workflow.Notifications.Tests/Granit.Workflow.Notifications.Tests.csproj
+++ b/tests/Granit.Workflow.Notifications.Tests/Granit.Workflow.Notifications.Tests.csproj
@@ -16,7 +16,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Granit.Workflow.Notifications\Granit.Workflow.Notifications.csproj" />
-    <ProjectReference Include="..\..\src\Granit.Identity.Federated\Granit.Identity.Federated.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\FakeIdentityUser.cs" Link="Shared\FakeIdentityUser.cs" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.Workflow.Notifications.Tests/IdentityApproverResolverTests.cs
+++ b/tests/Granit.Workflow.Notifications.Tests/IdentityApproverResolverTests.cs
@@ -1,8 +1,7 @@
 using Granit.Authorization.Abstractions;
 using Granit.Core.MultiTenancy;
 using Granit.Identity;
-using Granit.Identity.Federated;
-using Granit.Identity.Models;
+using Granit.Tests.Shared;
 using Granit.Workflow.Notifications.Internal;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -38,8 +37,8 @@ public sealed class IdentityApproverResolverTests
         _identityProvider.GetRoleMembersAsync("editor", Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<IIdentityUser>)
             [
-                new FederatedIdentityUser("user-1", "alice", "alice@test.com", "Alice", "Doe", true),
-                new FederatedIdentityUser("user-2", "bob", null, null, null, true),
+                new FakeIdentityUser("user-1", "alice", "alice@test.com", "Alice", "Doe", true),
+                new FakeIdentityUser("user-2", "bob", null, null, null, true),
             ]);
 
         IReadOnlyList<string> result = await _resolver.ResolveApproversAsync(
@@ -86,15 +85,15 @@ public sealed class IdentityApproverResolverTests
         _identityProvider.GetRoleMembersAsync("editor", Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<IIdentityUser>)
             [
-                new FederatedIdentityUser("shared-user", "shared", null, null, null, true),
-                new FederatedIdentityUser("editor-user", "editor", null, null, null, true),
+                new FakeIdentityUser("shared-user", "shared", null, null, null, true),
+                new FakeIdentityUser("editor-user", "editor", null, null, null, true),
             ]);
 
         _identityProvider.GetRoleMembersAsync("admin", Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<IIdentityUser>)
             [
-                new FederatedIdentityUser("shared-user", "shared", null, null, null, true),
-                new FederatedIdentityUser("admin-user", "admin", null, null, null, true),
+                new FakeIdentityUser("shared-user", "shared", null, null, null, true),
+                new FakeIdentityUser("admin-user", "admin", null, null, null, true),
             ]);
 
         IReadOnlyList<string> result = await _resolver.ResolveApproversAsync(
@@ -119,7 +118,7 @@ public sealed class IdentityApproverResolverTests
         _identityProvider.GetRoleMembersAsync("editor", Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<IIdentityUser>)
             [
-                new FederatedIdentityUser("user-1", "alice", null, null, null, true),
+                new FakeIdentityUser("user-1", "alice", null, null, null, true),
             ]);
 
         IReadOnlyList<string> result = await _resolver.ResolveApproversAsync(

--- a/tests/Granit.Workflow.Notifications.Tests/IdentityApproverResolverTests.cs
+++ b/tests/Granit.Workflow.Notifications.Tests/IdentityApproverResolverTests.cs
@@ -1,6 +1,7 @@
 using Granit.Authorization.Abstractions;
 using Granit.Core.MultiTenancy;
 using Granit.Identity;
+using Granit.Identity.Federated;
 using Granit.Identity.Models;
 using Granit.Workflow.Notifications.Internal;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tests/Granit.Workflow.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Workflow.Notifications.Tests/packages.lock.json
@@ -320,6 +320,12 @@
           "Granit.Querying": "[0.1.0-dev, )"
         }
       },
+      "granit.identity.federated": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Identity": "[0.1.0-dev, )"
+        }
+      },
       "granit.notifications": {
         "type": "Project",
         "dependencies": {

--- a/tests/Shared/FakeIdentityUser.cs
+++ b/tests/Shared/FakeIdentityUser.cs
@@ -1,0 +1,20 @@
+using System.Collections.ObjectModel;
+using Granit.Identity;
+
+namespace Granit.Tests.Shared;
+
+/// <summary>
+/// Lightweight <see cref="IIdentityUser"/> for unit tests.
+/// Avoids depending on <c>Granit.Identity.Federated</c> in non-federated test projects.
+/// </summary>
+internal sealed record FakeIdentityUser(
+    string UserId,
+    string? Username,
+    string? Email,
+    string? FirstName,
+    string? LastName,
+    bool Enabled) : IIdentityUser
+{
+    public IReadOnlyDictionary<string, string> ExtraProperties { get; init; } =
+        ReadOnlyDictionary<string, string>.Empty;
+}


### PR DESCRIPTION
Removes Granit.Identity.Federated dependency from 3 non-federated test projects. Uses a shared FakeIdentityUser record instead.