### PR TITLE
feat(encryption): GDPR crypto-shredding — per-entity key isolation and erasure (#146)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -10708,12 +10708,50 @@
       ]
     },
     {
+      "name": "ICryptoShreddingAuditRecorder",
+      "fqn": "Granit.Encryption.CryptoShredding.ICryptoShreddingAuditRecorder",
+      "kind": "interface",
+      "project": "Granit.Encryption",
+      "file": "src/Granit.Encryption/CryptoShredding/ICryptoShreddingAuditRecorder.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "RecordAsync",
+          "kind": "method",
+          "signature": "RecordAsync(string entityType, string entityId, DateTimeOffset shreddedAt, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "EncryptionMetrics",
+      "fqn": "Granit.Encryption.Diagnostics.EncryptionMetrics",
+      "kind": "class",
+      "project": "Granit.Encryption",
+      "file": "src/Granit.Encryption/Diagnostics/EncryptionMetrics.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RecordKeyShredded",
+          "kind": "method",
+          "signature": "RecordKeyShredded(string? tenantId, string entityType)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordShreddingError",
+          "kind": "method",
+          "signature": "RecordShreddingError(string? tenantId, string entityType)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
       "name": "EncryptedAttribute",
       "fqn": "Granit.Encryption.EntityFrameworkCore.EncryptedAttribute",
       "kind": "class",
       "project": "Granit.Encryption.EntityFrameworkCore",
       "file": "src/Granit.Encryption.EntityFrameworkCore/EncryptedAttribute.cs",
-      "line": 25,
+      "line": 30,
       "members": []
     },
     {
@@ -10724,6 +10762,22 @@
       "file": "src/Granit.Encryption.EntityFrameworkCore/EncryptedStringConverter.cs",
       "line": 15,
       "members": []
+    },
+    {
+      "name": "EncryptionDbContextOptionsBuilderExtensions",
+      "fqn": "Granit.Encryption.EntityFrameworkCore.Extensions.EncryptionDbContextOptionsBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Encryption.EntityFrameworkCore",
+      "file": "src/Granit.Encryption.EntityFrameworkCore/Extensions/EncryptionDbContextOptionsBuilderExtensions.cs",
+      "line": 29,
+      "members": [
+        {
+          "name": "UseGranitEncryptionInterceptors",
+          "kind": "method",
+          "signature": "UseGranitEncryptionInterceptors(this DbContextOptionsBuilder options, IServiceProvider serviceProvider)",
+          "returnType": "DbContextOptionsBuilder"
+        }
+      ]
     },
     {
       "name": "ModelBuilderEncryptionExtensions",
@@ -10747,7 +10801,55 @@
       "kind": "class",
       "project": "Granit.Encryption.EntityFrameworkCore",
       "file": "src/Granit.Encryption.EntityFrameworkCore/GranitEncryptionEntityFrameworkCoreModule.cs",
-      "line": 14,
+      "line": 22,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "EncryptionIsolationMaterializationInterceptor",
+      "fqn": "Granit.Encryption.EntityFrameworkCore.Interceptors.EncryptionIsolationMaterializationInterceptor",
+      "kind": "class",
+      "project": "Granit.Encryption.EntityFrameworkCore",
+      "file": "src/Granit.Encryption.EntityFrameworkCore/Interceptors/EncryptionIsolationMaterializationInterceptor.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "InitializedInstance",
+          "kind": "method",
+          "signature": "InitializedInstance(MaterializationInterceptionData materializationData, object entity)",
+          "returnType": "object"
+        }
+      ]
+    },
+    {
+      "name": "EncryptionIsolationSaveChangesInterceptor",
+      "fqn": "Granit.Encryption.EntityFrameworkCore.Interceptors.EncryptionIsolationSaveChangesInterceptor",
+      "kind": "class",
+      "project": "Granit.Encryption.EntityFrameworkCore",
+      "file": "src/Granit.Encryption.EntityFrameworkCore/Interceptors/EncryptionIsolationSaveChangesInterceptor.cs",
+      "line": 28,
+      "members": [
+        {
+          "name": "SavingChanges",
+          "kind": "method",
+          "signature": "SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)",
+          "returnType": "InterceptionResult<int>"
+        }
+      ]
+    },
+    {
+      "name": "CryptoShreddedEvent",
+      "fqn": "Granit.Encryption.Events.CryptoShreddedEvent",
+      "kind": "record",
+      "project": "Granit.Encryption",
+      "file": "src/Granit.Encryption/Events/CryptoShreddedEvent.cs",
+      "line": 13,
       "members": []
     },
     {
@@ -10756,7 +10858,7 @@
       "kind": "class",
       "project": "Granit.Encryption",
       "file": "src/Granit.Encryption/Extensions/EncryptionServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 14,
       "members": [
         {
           "name": "AddGranitEncryption",
@@ -10779,6 +10881,62 @@
           "kind": "method",
           "signature": "ConfigureServices(ServiceConfigurationContext context)",
           "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ICryptoShredder",
+      "fqn": "Granit.Encryption.ICryptoShredder",
+      "kind": "interface",
+      "project": "Granit.Encryption",
+      "file": "src/Granit.Encryption/ICryptoShredder.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "ShredAsync",
+          "kind": "method",
+          "signature": "ShredAsync(string entityType, string entityId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "ShredBatchAsync",
+          "kind": "method",
+          "signature": "ShredBatchAsync(string entityType, IEnumerable<string> entityIds, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IEntityEncryptionKeyStore",
+      "fqn": "Granit.Encryption.IEntityEncryptionKeyStore",
+      "kind": "interface",
+      "project": "Granit.Encryption",
+      "file": "src/Granit.Encryption/IEntityEncryptionKeyStore.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "GetOrCreateKeyAsync",
+          "kind": "method",
+          "signature": "GetOrCreateKeyAsync(string entityType, string entityId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<byte[]>"
+        },
+        {
+          "name": "GetKeyAsync",
+          "kind": "method",
+          "signature": "GetKeyAsync(string entityType, string entityId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<byte[]?>"
+        },
+        {
+          "name": "DeleteKeyAsync",
+          "kind": "method",
+          "signature": "DeleteKeyAsync(string entityType, string entityId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "KeyExistsAsync",
+          "kind": "method",
+          "signature": "KeyExistsAsync(string entityType, string entityId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
         }
       ]
     },
@@ -10911,6 +11069,22 @@
       "file": "src/Granit.Encryption.ReEncryption/IReEncryptionJob.cs",
       "line": 12,
       "members": []
+    },
+    {
+      "name": "DefaultCryptoShredder",
+      "fqn": "Granit.Encryption.Services.DefaultCryptoShredder",
+      "kind": "class",
+      "project": "Granit.Encryption",
+      "file": "src/Granit.Encryption/Services/DefaultCryptoShredder.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "ShredAsync",
+          "kind": "method",
+          "signature": "ShredAsync(string entityType, string entityId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
     },
     {
       "name": "DefaultStringEncryptionService",
@@ -26891,7 +27065,7 @@
       "kind": "class",
       "project": "Granit.Vault.HashiCorp",
       "file": "src/Granit.Vault.HashiCorp/Extensions/HashiCorpVaultServiceCollectionExtensions.cs",
-      "line": 13,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitVaultHashiCorp",
@@ -26974,6 +27148,12 @@
           "returnType": "string"
         },
         {
+          "name": "KvMountPoint",
+          "kind": "property",
+          "signature": "string KvMountPoint",
+          "returnType": "string"
+        },
+        {
           "name": "LeaseRenewalThreshold",
           "kind": "property",
           "signature": "double LeaseRenewalThreshold",
@@ -27006,6 +27186,22 @@
           "kind": "method",
           "signature": "Decrypt(string cipherText)",
           "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "HashiCorpEntityEncryptionKeyStore",
+      "fqn": "Granit.Vault.HashiCorp.Services.HashiCorpEntityEncryptionKeyStore",
+      "kind": "class",
+      "project": "Granit.Vault.HashiCorp",
+      "file": "src/Granit.Vault.HashiCorp/Services/HashiCorpEntityEncryptionKeyStore.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "GetOrCreateKeyAsync",
+          "kind": "method",
+          "signature": "GetOrCreateKeyAsync(string entityType, string entityId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<byte[]>"
         }
       ]
     },

--- a/docs-site/src/content/docs/dotnet/security/crypto-shredding.mdx
+++ b/docs-site/src/content/docs/dotnet/security/crypto-shredding.mdx
@@ -1,0 +1,662 @@
+---
+title: "Crypto-Shredding — GDPR Erasure Without Deleting Rows"
+description: Per-entity key isolation and cryptographic data destruction — permanently erase sensitive data by destroying encryption keys while preserving database rows for audit trails and legal holds.
+sidebar:
+  order: 9
+  label: Crypto-Shredding
+  badge:
+    text: New
+    variant: tip
+---
+
+import { Tabs, TabItem, FileTree, Steps, Badge } from "@astrojs/starlight/components";
+
+## The problem: GDPR says delete, but you can't
+
+GDPR Article 17 grants every data subject the **right to erasure** — their personal
+data must be irreversibly deleted upon request. Failure to comply costs up to
+**€20 million or 4% of global annual turnover**, whichever is higher (Art. 83(5)(b)).
+Under the Belgian DPA, fines apply even for *delayed* compliance with an erasure
+request.
+
+In theory, deletion is simple: `DELETE FROM patients WHERE id = @id`. In practice,
+it is anything but.
+
+### Three reasons physical deletion fails
+
+```mermaid
+flowchart LR
+    Request["🗑️ Erasure request<br/>GDPR Art. 17"] --> Problem1
+    Request --> Problem2
+    Request --> Problem3
+
+    Problem1["❌ Audit trail<br/>ISO 27001 requires<br/>immutable records"]
+    Problem2["❌ Legal hold<br/>Active litigation or<br/>regulatory investigation"]
+    Problem3["❌ Append-only<br/>Event sourcing, WORM,<br/>backups"]
+
+    Problem1 --> Conflict["Conflicting<br/>obligations"]
+    Problem2 --> Conflict
+    Problem3 --> Conflict
+```
+
+1. **Audit trails break.** ISO 27001 (A.8.15) requires an immutable audit trail. The
+   moment you `DELETE` a row, you destroy evidence of *what* happened, *when*, and
+   *to whom*. A regulator auditing your data processing activities will find gaps
+   where records used to be — which looks worse than the original data retention.
+
+2. **Legal holds conflict.** Active litigation, tax audits, or regulatory
+   investigations may *legally require* you to retain data — even when a GDPR
+   erasure request arrives. Deleting data under legal hold is spoliation of evidence
+   in most EU jurisdictions.
+
+3. **Append-only architectures resist deletion.** Event sourcing, WORM (Write Once
+   Read Many) storage, Kafka topics, and database backups cannot physically erase
+   individual records. You would need to rewrite entire log segments or restore-and-filter
+   backups — a multi-day, error-prone operation with no guarantee of completeness.
+
+The core tension: **GDPR demands erasure, but other regulations and architectures
+demand retention.** You need to satisfy both at the same time.
+
+### The solution: destroy the key, not the data
+
+Crypto-shredding resolves this tension with a simple insight: if data is encrypted
+and you permanently destroy the encryption key, the ciphertext is mathematically
+equivalent to random noise. The data is *still there* structurally — row counts,
+join relationships, audit timestamps all remain intact — but the personal information
+is **irreversibly unreadable**. No key, no data.
+
+This is not a creative interpretation of the law. The **European Data Protection
+Board** (Guidelines 5/2019), the **UK ICO**, and the **French CNIL** all explicitly
+recognize cryptographic erasure as a valid implementation of the right to be forgotten,
+provided that:
+
+- The encryption algorithm is strong (AES-256 qualifies)
+- The key destruction is **irreversible** (no backup key, no recovery path)
+- The destruction is **auditable** (you can prove *when* the key was destroyed)
+
+### Erasure strategies compared
+
+| Strategy | Data gone? | Audit trail intact? | Works with backups? | Reversible? |
+|----------|-----------|--------------------|--------------------|------------|
+| Physical deletion (`DELETE`) | Yes | No — row is gone | No — backup still has it | No |
+| Soft delete (`IsDeleted = true`) | No — still readable by admin | Yes | Yes | Yes — that's the problem |
+| Anonymization (replace PII) | Depends on quality | Yes | No — backup has original | No |
+| **Crypto-shredding** | **Yes — mathematically** | **Yes — row stays** | **Yes — backup ciphertext is useless** | **No — key is gone** |
+
+Crypto-shredding is the only strategy that satisfies all four requirements
+simultaneously. It is particularly valuable when you need **granular erasure** — erase
+one patient's data without touching any other row in the same table.
+
+## How Granit implements it
+
+The Granit crypto-shredding feature builds on the existing
+[field-level encryption](/dotnet/security/encryption/) infrastructure. Properties
+marked with `[Encrypted(KeyIsolation = true)]` get their own encryption key per
+entity instance, stored in HashiCorp Vault KV v2. When the DPO triggers erasure,
+`ICryptoShredder.ShredAsync()` deletes the key from Vault — one API call, and the
+data is gone forever.
+
+The key insight: standard `[Encrypted]` properties share a single key ring across all
+entities. Destroying that shared key would make *every* record unreadable — that is
+catastrophic data loss, not controlled erasure. **Per-entity key isolation** is what
+makes selective crypto-shredding possible.
+
+## Package structure
+
+<FileTree>
+
+- Granit.Encryption/ IEntityEncryptionKeyStore, ICryptoShredder, ICryptoShreddingAuditRecorder
+  - Granit.Encryption.EntityFrameworkCore/ [Encrypted(KeyIsolation = true)], isolation interceptors
+- Granit.Vault.HashiCorp/ HashiCorpEntityEncryptionKeyStore (Vault KV v2)
+- Granit.Privacy/ DeletionAction.CryptoShredding (integration point)
+
+</FileTree>
+
+| Package | Role | Depends on |
+|---------|------|------------|
+| `Granit.Encryption` | `IEntityEncryptionKeyStore`, `ICryptoShredder`, `DefaultCryptoShredder`, `ICryptoShreddingAuditRecorder` | `Granit.Core` |
+| `Granit.Encryption.EntityFrameworkCore` | `[Encrypted(KeyIsolation = true)]`, `EncryptionIsolationSaveChangesInterceptor`, `EncryptionIsolationMaterializationInterceptor` | `Granit.Encryption`, `Granit.Persistence` |
+| `Granit.Vault.HashiCorp` | `HashiCorpEntityEncryptionKeyStore` — Vault KV v2 implementation with in-memory cache | `Granit.Vault` |
+| `Granit.Privacy` | `DeletionAction.CryptoShredding` — integration with GDPR erasure workflow | `Granit.Core` |
+
+## Encryption and shredding lifecycle
+
+Each entity instance gets its own 32-byte AES-256 key, stored in Vault KV v2. The
+lifecycle has three phases: key creation (first write), normal operation (reads and
+updates), and shredding (key destruction).
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant EF as EF Core Interceptor
+    participant Store as IEntityEncryptionKeyStore
+    participant Vault as Vault KV v2
+    participant DB as Database
+
+    Note over App,DB: Write path — new entity with isolated encryption
+
+    App->>EF: SaveChangesAsync (Patient with SSN)
+    EF->>Store: GetOrCreateKeyAsync("Patient", "a1b2c3")
+    Store->>Vault: PUT secret/granit/encryption/isolated/Patient/a1b2c3
+    Vault-->>Store: 32-byte AES-256 key
+    Store-->>EF: Key bytes
+    EF->>EF: AES-256-CBC + HMAC-SHA256 encrypt SSN
+    EF->>DB: INSERT (ciphertext)
+
+    Note over App,DB: Crypto-shredding — destroy the key
+
+    App->>App: ICryptoShredder.ShredAsync("Patient", "a1b2c3")
+    App->>Store: DeleteKeyAsync("Patient", "a1b2c3")
+    Store->>Vault: DELETE secret/granit/encryption/isolated/Patient/a1b2c3
+    Vault-->>Store: 204 No Content
+    Note over DB: Row intact — ciphertext permanently unreadable
+```
+
+After shredding, reading the entity returns `null` for isolated encrypted properties.
+The row stays in the database — audit queries, join counts, and aggregations continue
+to work. Only the PII is gone.
+
+## Setup
+
+<Steps>
+
+1. **Add the NuGet packages**
+
+   ```bash
+   dotnet add package Granit.Encryption.EntityFrameworkCore
+   dotnet add package Granit.Vault.HashiCorp
+   ```
+
+2. **Register the modules**
+
+   ```csharp
+   [DependsOn(
+       typeof(GranitEncryptionEntityFrameworkCoreModule),
+       typeof(GranitVaultHashiCorpModule))]
+   public sealed class AppModule : GranitModule { }
+   ```
+
+   `GranitVaultHashiCorpModule` automatically registers `HashiCorpEntityEncryptionKeyStore`
+   as `IEntityEncryptionKeyStore`. `GranitEncryptionEntityFrameworkCoreModule` registers
+   the isolation interceptors.
+
+3. **Configure Vault KV**
+
+   ```json
+   {
+     "Vault": {
+       "Address": "https://vault.example.com",
+       "AuthMethod": "Kubernetes",
+       "KvMountPoint": "secret",
+       "TransitMountPoint": "transit"
+     }
+   }
+   ```
+
+   The `KvMountPoint` setting controls which Vault KV v2 engine stores per-entity keys.
+   Default: `"secret"`.
+
+4. **Wire interceptors in your DbContext**
+
+   The encryption isolation interceptors must run **after** `UseGranitInterceptors`
+   (which assigns entity IDs via `AuditedEntityInterceptor`):
+
+   ```csharp
+   using Granit.Encryption.EntityFrameworkCore.Extensions;
+   using Granit.Persistence.Extensions;
+
+   builder.Services.AddDbContextFactory<AppDbContext>((sp, options) =>
+   {
+       options.UseNpgsql(connectionString);
+       options.UseGranitInterceptors(sp);
+       options.UseGranitEncryptionInterceptors(sp); // must be after UseGranitInterceptors
+   }, ServiceLifetime.Scoped);
+   ```
+
+</Steps>
+
+## Marking properties for key isolation
+
+Add `[Encrypted(KeyIsolation = true)]` to properties that must support crypto-shredding.
+Non-isolated `[Encrypted]` properties continue to use the shared key ring:
+
+```csharp
+using Granit.Encryption.EntityFrameworkCore;
+
+namespace MyApp.Domain;
+
+public sealed class Patient : AuditedAggregateRoot
+{
+    public string LastName { get; private set; } = string.Empty;
+
+    [Encrypted]
+    public string NationalId { get; private set; } = string.Empty;       // shared key ring
+
+    [Encrypted(KeyIsolation = true)]
+    public string MedicalNotes { get; private set; } = string.Empty;     // per-entity key
+
+    [Encrypted(KeyIsolation = true)]
+    public string? DiagnosisCode { get; private set; }                   // per-entity key
+}
+```
+
+In this example, `NationalId` uses shared encryption (the same key encrypts all
+patients' national IDs). `MedicalNotes` and `DiagnosisCode` use isolated keys — when
+patient "abc-123" is shredded, only *their* medical notes and diagnosis code become
+unreadable. Other patients are unaffected.
+
+:::tip
+Use key isolation only for properties that require **individual erasure**. Shared
+encryption is simpler, faster, and supports key rotation via `IReEncryptionJob`.
+Key isolation is heavier — one Vault KV secret per entity instance.
+:::
+
+## Wiring ApplyEncryptionConventions
+
+The `ApplyEncryptionConventions` method handles both encryption modes automatically:
+
+```csharp
+protected override void OnModelCreating(ModelBuilder modelBuilder)
+{
+    base.OnModelCreating(modelBuilder);
+    modelBuilder.ApplyGranitConventions(currentTenant, dataFilter);
+    modelBuilder.ApplyEncryptionConventions(encryptionService);
+}
+```
+
+Internally, `ApplyEncryptionConventions`:
+
+- Applies `EncryptedStringConverter` to `[Encrypted]` properties (shared key)
+- **Skips** the converter for `[Encrypted(KeyIsolation = true)]` properties and annotates
+  them with `"Granit:EncryptionIsolated"` — these are handled by the interceptors instead
+
+No code changes in `OnModelCreating` are needed to support key isolation.
+
+## Performing crypto-shredding
+
+### Single entity
+
+Inject `ICryptoShredder` and call `ShredAsync`:
+
+```csharp
+public sealed class PatientDeletionHandler(ICryptoShredder shredder)
+{
+    public async Task HandleAsync(
+        PersonalDataDeletionRequestedEto request,
+        AppDbContext db,
+        CancellationToken cancellationToken)
+    {
+        // Find all patient records for this user
+        List<Guid> patientIds = await db.Patients
+            .Where(p => p.CreatedBy == request.UserId.ToString())
+            .Select(p => p.Id)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Shred each patient's encryption keys
+        foreach (var id in patientIds)
+        {
+            await shredder.ShredAsync("Patient", id.ToString(), cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+}
+```
+
+### Batch shredding
+
+For bulk operations, use `ShredBatchAsync`:
+
+```csharp
+await shredder.ShredBatchAsync(
+    "Patient",
+    patientIds.Select(id => id.ToString()),
+    cancellationToken).ConfigureAwait(false);
+```
+
+### What happens after shredding
+
+When you read a shredded entity, the materialization interceptor detects that the key
+is gone and clears the isolated properties:
+
+```csharp
+var patient = await db.Patients.FindAsync([id], cancellationToken);
+
+patient.MedicalNotes;   // null (was non-nullable string — now cleared)
+patient.DiagnosisCode;  // null (nullable string)
+patient.NationalId;     // still readable — uses shared key, not shredded
+patient.LastName;       // still readable — not encrypted at all
+```
+
+:::caution
+Crypto-shredding is **irreversible**. There is no key recovery path. Once
+`ICryptoShredder.ShredAsync` completes, the data is permanently gone. Make sure
+your GDPR deletion workflow includes a cooling-off period before calling the shredder.
+See [Privacy module — deletion saga](/dotnet/security/privacy/#gdpr-deletion).
+:::
+
+## Integration with Granit.Privacy
+
+The Privacy module supports two erasure flows: **immediate** (the application calls
+`ICryptoShredder` directly) and **deferred** (a cooling-off saga delays destruction
+to give the user time to cancel). Both flows end the same way — per-entity keys are
+destroyed and `DeletionAction.CryptoShredding` is reported.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Choice: Erasure request (GDPR Art. 17)
+
+    state Choice <<choice>>
+    Choice --> Direct: No cooling-off
+    Choice --> Waiting: With cooling-off (recommended)
+
+    Direct --> Shredding: ICryptoShredder.ShredAsync
+
+    state "Deferred flow (GdprDeletionSaga)" as DeferredFlow {
+        Waiting --> Reminder: T minus 3 days
+        Reminder --> Deadline: T (30 days)
+        Waiting --> Cancelled: User cancels
+    }
+
+    Deadline --> Shredding: PersonalDataDeletionRequestedEto
+    Cancelled --> DataRetained: Data intact
+
+    Shredding --> AuditTrail: ICryptoShreddingAuditRecorder
+    AuditTrail --> DataUnreadable: Keys destroyed, ciphertext remains
+```
+
+**Immediate flow** — the application calls `ICryptoShredder` directly, for example
+from an admin endpoint or a background job. Use this when no cooling-off period is
+required (e.g., internal data cleanup, test data, or when the DPO has already
+validated the request).
+
+**Deferred flow** — the recommended approach for end-user erasure requests.
+`GdprDeletionSaga` enforces a configurable cooling-off period (default: 30 days,
+max: 90 days per CNIL guidance). The user can cancel during this period. When the
+deadline expires, the saga publishes `PersonalDataDeletionRequestedEto` — your data
+provider handler catches it and calls `ICryptoShredder`.
+
+Report the action back using `DeletionAction.CryptoShredding`:
+
+```csharp
+public sealed class PatientDataProvider(ICryptoShredder shredder)
+{
+    // Wolverine handler for PersonalDataDeletionRequestedEto
+    public async Task<PersonalDataDeletedEto> HandleAsync(
+        PersonalDataDeletionRequestedEto request,
+        AppDbContext db,
+        CancellationToken cancellationToken)
+    {
+        List<string> entityIds = await db.Patients
+            .Where(p => p.CreatedBy == request.UserId.ToString())
+            .Select(p => p.Id.ToString())
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        await shredder.ShredBatchAsync("Patient", entityIds, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new PersonalDataDeletedEto(
+            request.RequestId,
+            "PatientModule",
+            DeletionAction.CryptoShredding,
+            entityIds.Count,
+            DateTimeOffset.UtcNow);
+    }
+}
+```
+
+## Audit trail (ISO 27001)
+
+Every crypto-shredding operation should be recorded in an immutable audit trail
+(ISO 27001 A.10.1.2 — key destruction traceability). `DefaultCryptoShredder`
+automatically calls all registered `ICryptoShreddingAuditRecorder` implementations
+after each successful key deletion.
+
+To record shredding events in the Timeline module:
+
+```csharp
+using Granit.Encryption.CryptoShredding;
+using Granit.Timeline.Abstractions;
+using Granit.Timeline.Domain;
+
+public sealed class TimelineCryptoShreddingRecorder(
+    ITimelineWriter writer) : ICryptoShreddingAuditRecorder
+{
+    public async Task RecordAsync(
+        string entityType,
+        string entityId,
+        DateTimeOffset shreddedAt,
+        CancellationToken cancellationToken = default)
+    {
+        string body = $"""
+            **Encryption key destroyed** (crypto-shredding)
+            - Entity: `{entityType}/{entityId}`
+            - Timestamp: {shreddedAt:O}
+            - Action: Per-entity AES-256 key permanently deleted from Vault KV
+            - Effect: All `[Encrypted(KeyIsolation = true)]` fields are permanently unreadable
+            """;
+
+        await writer.PostEntryAsync(
+            entityType,
+            entityId,
+            TimelineEntryType.SystemLog,  // immutable — cannot be deleted
+            body,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+}
+```
+
+Register it in DI:
+
+```csharp
+builder.Services.AddScoped<ICryptoShreddingAuditRecorder, TimelineCryptoShreddingRecorder>();
+```
+
+:::note
+`TimelineEntryType.SystemLog` entries are **immutable** — the Timeline module rejects
+deletion attempts on system log entries. This guarantees the audit trail survives even
+if an administrator tries to cover tracks (ISO 27001 compliance).
+:::
+
+## Observability
+
+### Metrics
+
+`EncryptionMetrics` (meter: `Granit.Encryption`) exposes three counters:
+
+| Metric | Description |
+|--------|-------------|
+| `granit.encryption.key.created` | Per-entity key generated in Vault KV |
+| `granit.encryption.key.shredded` | Per-entity key permanently destroyed |
+| `granit.encryption.shredding.errors` | Shredding operations that failed |
+
+All metrics include `tenant_id` and `entity_type` tags.
+
+### Tracing
+
+`EncryptionActivitySource` (source: `Granit.Encryption`) records spans for:
+`encryption.key-create`, `encryption.key-retrieve`, `encryption.key-delete`,
+`encryption.shred`, `encryption.shred-batch`.
+
+## API reference
+
+### `[Encrypted(KeyIsolation = true)]`
+
+```csharp
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class EncryptedAttribute : Attribute
+{
+    public bool KeyIsolation { get; set; }
+}
+```
+
+When `KeyIsolation` is `true`, each entity instance gets its own AES-256 key stored
+in Vault KV. Default: `false` (shared key ring).
+
+### `IEntityEncryptionKeyStore`
+
+```csharp
+public interface IEntityEncryptionKeyStore
+{
+    Task<byte[]> GetOrCreateKeyAsync(string entityType, string entityId, CancellationToken ct = default);
+    Task<byte[]?> GetKeyAsync(string entityType, string entityId, CancellationToken ct = default);
+    Task DeleteKeyAsync(string entityType, string entityId, CancellationToken ct = default);
+    Task<bool> KeyExistsAsync(string entityType, string entityId, CancellationToken ct = default);
+}
+```
+
+Provider-agnostic abstraction. Implemented by `HashiCorpEntityEncryptionKeyStore`
+(Vault KV v2, path: `granit/encryption/isolated/{entityType}/{entityId}`).
+
+### `ICryptoShredder`
+
+```csharp
+public interface ICryptoShredder
+{
+    Task ShredAsync(string entityType, string entityId, CancellationToken ct = default);
+    Task ShredBatchAsync(string entityType, IEnumerable<string> entityIds, CancellationToken ct = default);
+}
+```
+
+Permanently destroys per-entity encryption keys. `DefaultCryptoShredder` delegates
+to `IEntityEncryptionKeyStore.DeleteKeyAsync` and calls all registered
+`ICryptoShreddingAuditRecorder` instances.
+
+### `ICryptoShreddingAuditRecorder`
+
+```csharp
+public interface ICryptoShreddingAuditRecorder
+{
+    Task RecordAsync(string entityType, string entityId, DateTimeOffset shreddedAt, CancellationToken ct = default);
+}
+```
+
+Extension point for recording shredding events. Register implementations via DI.
+`DefaultCryptoShredder` iterates all registered recorders after each successful
+key deletion.
+
+### `UseGranitEncryptionInterceptors`
+
+```csharp
+public static DbContextOptionsBuilder UseGranitEncryptionInterceptors(
+    this DbContextOptionsBuilder options,
+    IServiceProvider serviceProvider);
+```
+
+Adds `EncryptionIsolationSaveChangesInterceptor` and
+`EncryptionIsolationMaterializationInterceptor` if `IEntityEncryptionKeyStore` is
+registered. Must be called **after** `UseGranitInterceptors`.
+
+## Vault KV structure
+
+Per-entity keys are stored in Vault KV v2 with this path layout:
+
+```text
+secret/
+  granit/
+    encryption/
+      isolated/
+        Patient/
+          a1b2c3d4-e5f6-...    → { "key": "base64-encoded-aes-256-key" }
+          f7g8h9i0-j1k2-...    → { "key": "base64-encoded-aes-256-key" }
+        Invoice/
+          x9y8z7w6-v5u4-...    → { "key": "base64-encoded-aes-256-key" }
+```
+
+`DeleteKeyAsync` calls `DeleteMetadataAsync` — permanently destroying all versions
+of the secret with no recovery path. The in-memory cache is evicted on deletion to
+prevent stale reads.
+
+## Compliance
+
+| Regulation | Requirement | Coverage |
+|------------|-------------|---------|
+| GDPR Art. 17 | Right to erasure | Key destruction makes ciphertext permanently unreadable |
+| GDPR Art. 5(1)(e) | Storage limitation | Data is cryptographically erased without physical deletion |
+| ISO 27001 A.10.1.2 | Key destruction | Audit trail via `ICryptoShreddingAuditRecorder` + `TimelineEntryType.SystemLog` |
+| ISO 27001 A.8.10 | Media sanitization | Ciphertext remains but is mathematically equivalent to random noise |
+
+## When to use — and when not to
+
+Use crypto-shredding when:
+
+- You have **append-only or immutable storage** (event sourcing, WORM, immutable backups) where physical deletion is impossible
+- You need to satisfy **concurrent obligations**: erasure *and* audit trail retention
+- **Legal holds** may prevent row deletion, but GDPR requires data to be unreadable
+- You need **granular erasure** — destroy one patient's data without affecting others in the same table
+
+Skip it when:
+
+- **Physical deletion** is acceptable and sufficient for your compliance requirements — it is simpler
+- The data is **not PII** — crypto-shredding adds Vault KV overhead per entity instance
+- You can use **anonymization** instead — replacing PII with pseudonymized values is cheaper and reversible
+- Your application has **very high read throughput** on encrypted fields — the materialization interceptor adds per-entity Vault lookups (mitigated by caching, but still more overhead than shared encryption)
+
+## Common pitfalls
+
+:::caution[Interceptor ordering]
+`UseGranitEncryptionInterceptors(sp)` **must** be called after `UseGranitInterceptors(sp)`.
+`AuditedEntityInterceptor` assigns `Entity.Id` on `Added` state. If the encryption
+interceptor runs first, the entity ID is `Guid.Empty` and the Vault KV path is wrong.
+:::
+
+:::caution[Shared key vs isolated key]
+`[Encrypted]` (without `KeyIsolation`) uses the shared key ring. Destroying the shared
+key makes **all** records of **all** entity types unreadable — that is not crypto-shredding,
+that is catastrophic data loss. Only `[Encrypted(KeyIsolation = true)]` properties can
+be individually shredded.
+:::
+
+:::caution[EF InMemory provider]
+`UseInMemoryDatabase()` does not invoke `SaveChangesInterceptor` or
+`IMaterializationInterceptor`. Use **SQLite** or **Testcontainers PostgreSQL** for
+integration tests that verify encryption isolation behaviour.
+:::
+
+:::caution[Cache invalidation]
+`HashiCorpEntityEncryptionKeyStore` caches keys in-memory for performance. After
+`DeleteKeyAsync`, the cache entry is evicted. However, if multiple application instances
+share the same Vault backend, other instances may still serve cached keys until they
+restart or the cache entry expires. Design your shredding workflow to account for
+this propagation delay.
+:::
+
+## Testing crypto-shredding
+
+```csharp
+[Fact]
+public async Task Shredded_entity_returns_null_for_isolated_properties()
+{
+    // Arrange
+    var keyStore = Substitute.For<IEntityEncryptionKeyStore>();
+    var key = RandomNumberGenerator.GetBytes(32);
+    keyStore.GetOrCreateKeyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        .Returns(key);
+    keyStore.GetKeyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        .Returns(key);
+
+    await using var context = CreateSqliteContext(keyStore);
+    var patientId = Guid.NewGuid();
+
+    // Act — save with encryption
+    context.Patients.Add(new Patient { Id = patientId, MedicalNotes = "Confidential diagnosis" });
+    await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+    // Act — simulate crypto-shredding (key store returns null)
+    keyStore.GetKeyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        .Returns((byte[]?)null);
+
+    // Assert — isolated property is cleared
+    var loaded = await context.Patients.FindAsync([patientId], TestContext.Current.CancellationToken);
+    loaded!.MedicalNotes.ShouldBeNull();
+}
+```
+
+## See also
+
+- [Field-level Encryption](/dotnet/security/encryption/) — shared key ring, `[Encrypted]` attribute, key rotation
+- [Vault & Encryption](/dotnet/security/vault-encryption/) — Vault Transit, KV configuration, provider setup
+- [Privacy module](/dotnet/security/privacy/) — GDPR erasure saga, cooling-off period, `DeletionAction`
+- [Audit Log](/dotnet/security/audit-log/) — tamper-proof activity tracking, ISO 27001
+- [Persistence](/dotnet/data/persistence/) — isolated DbContext, `UseGranitInterceptors`

--- a/docs-site/src/content/docs/dotnet/security/encryption.mdx
+++ b/docs-site/src/content/docs/dotnet/security/encryption.mdx
@@ -413,6 +413,7 @@ public async Task Encrypted_field_is_not_stored_as_plaintext()
 
 ## See also
 
+- [Crypto-Shredding](/dotnet/security/crypto-shredding/) — per-entity key isolation, GDPR erasure by key destruction
 - [Encrypt sensitive data guide](/dotnet/guides/encrypt-sensitive-data/) — step-by-step walkthrough
 - [Vault & Encryption](/dotnet/security/vault-encryption/) — provider configuration, key rotation, `ITransitEncryptionService`
 - [Privacy module](/dotnet/security/privacy/) — GDPR erasure patterns

--- a/src/Granit.Encryption.EntityFrameworkCore/EncryptedAttribute.cs
+++ b/src/Granit.Encryption.EntityFrameworkCore/EncryptedAttribute.cs
@@ -8,6 +8,11 @@ namespace Granit.Encryption.EntityFrameworkCore;
 /// <c>OnModelCreating</c>, transparently calling <see cref="IStringEncryptionService"/>
 /// on every read and write.
 /// </para>
+/// <para>
+/// When <see cref="KeyIsolation"/> is <c>true</c>, each entity instance gets its own
+/// encryption key (stored in Vault KV), enabling crypto-shredding (GDPR Art. 17)
+/// by deleting the per-entity key via <see cref="ICryptoShredder"/>.
+/// </para>
 /// </summary>
 /// <example>
 /// <code>
@@ -16,10 +21,18 @@ namespace Granit.Encryption.EntityFrameworkCore;
 ///     [Encrypted]
 ///     public string Ssn { get; set; } = string.Empty;
 ///
-///     [Encrypted]
+///     [Encrypted(KeyIsolation = true)]
 ///     public string? MedicalNotes { get; set; }
 /// }
 /// </code>
 /// </example>
 [AttributeUsage(AttributeTargets.Property)]
-public sealed class EncryptedAttribute : Attribute;
+public sealed class EncryptedAttribute : Attribute
+{
+    /// <summary>
+    /// When <c>true</c>, each entity instance gets its own encryption key,
+    /// enabling crypto-shredding (GDPR Art. 17) by deleting the per-entity key.
+    /// Default: <c>false</c> (shared key ring via <see cref="IStringEncryptionService"/>).
+    /// </summary>
+    public bool KeyIsolation { get; set; }
+}

--- a/src/Granit.Encryption.EntityFrameworkCore/Extensions/EncryptionDbContextOptionsBuilderExtensions.cs
+++ b/src/Granit.Encryption.EntityFrameworkCore/Extensions/EncryptionDbContextOptionsBuilderExtensions.cs
@@ -1,0 +1,58 @@
+using Granit.Encryption.EntityFrameworkCore.Interceptors;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.Encryption.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="DbContextOptionsBuilder"/> to wire
+/// Granit encryption interceptors for per-entity key isolation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Must be called AFTER <c>UseGranitInterceptors(sp)</c> to ensure correct
+/// interceptor ordering: <c>AuditedEntityInterceptor</c> assigns entity IDs
+/// before <see cref="EncryptionIsolationSaveChangesInterceptor"/> encrypts.
+/// </para>
+/// <para>
+/// Usage:
+/// <code>
+/// services.AddDbContextFactory&lt;MyDbContext&gt;((sp, options) =&gt;
+/// {
+///     options.UseNpgsql(connectionString);
+///     options.UseGranitInterceptors(sp);
+///     options.UseGranitEncryptionInterceptors(sp);
+/// }, ServiceLifetime.Scoped);
+/// </code>
+/// </para>
+/// </remarks>
+public static class EncryptionDbContextOptionsBuilderExtensions
+{
+    /// <summary>
+    /// Adds encryption isolation interceptors if <see cref="IEntityEncryptionKeyStore"/>
+    /// is registered. Silently skips if not registered (encryption isolation is opt-in).
+    /// </summary>
+    public static DbContextOptionsBuilder UseGranitEncryptionInterceptors(
+        this DbContextOptionsBuilder options,
+        IServiceProvider serviceProvider)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+
+        EncryptionIsolationSaveChangesInterceptor? saveInterceptor =
+            serviceProvider.GetService<EncryptionIsolationSaveChangesInterceptor>();
+        if (saveInterceptor is not null)
+        {
+            options.AddInterceptors(saveInterceptor);
+        }
+
+        EncryptionIsolationMaterializationInterceptor? materializationInterceptor =
+            serviceProvider.GetService<EncryptionIsolationMaterializationInterceptor>();
+        if (materializationInterceptor is not null)
+        {
+            options.AddInterceptors(materializationInterceptor);
+        }
+
+        return options;
+    }
+}

--- a/src/Granit.Encryption.EntityFrameworkCore/Extensions/ModelBuilderEncryptionExtensions.cs
+++ b/src/Granit.Encryption.EntityFrameworkCore/Extensions/ModelBuilderEncryptionExtensions.cs
@@ -9,9 +9,21 @@ namespace Granit.Encryption.EntityFrameworkCore.Extensions;
 public static class ModelBuilderEncryptionExtensions
 {
     /// <summary>
+    /// Annotation key applied to properties with <c>[Encrypted(KeyIsolation = true)]</c>.
+    /// Used by interceptors to quickly identify isolated properties without re-reflecting.
+    /// </summary>
+    internal const string IsolatedAnnotation = "Granit:EncryptionIsolated";
+
+    /// <summary>
     /// Scans all entity types registered in the model and applies
     /// <see cref="EncryptedStringConverter"/> to every <c>string</c> property
     /// annotated with <see cref="EncryptedAttribute"/>.
+    /// <para>
+    /// Properties with <see cref="EncryptedAttribute.KeyIsolation"/> set to <c>true</c>
+    /// are skipped (no converter applied) — they are handled by
+    /// <c>EncryptionIsolationSaveChangesInterceptor</c> and
+    /// <c>EncryptionIsolationMaterializationInterceptor</c> instead.
+    /// </para>
     /// <para>
     /// Call this method at the end of <c>OnModelCreating</c>, after
     /// <c>modelBuilder.ApplyGranitConventions()</c>:
@@ -45,8 +57,17 @@ public static class ModelBuilderEncryptionExtensions
                     continue;
                 }
 
-                if (property.PropertyInfo?.GetCustomAttribute<EncryptedAttribute>() is null)
+                EncryptedAttribute? attr = property.PropertyInfo?.GetCustomAttribute<EncryptedAttribute>();
+                if (attr is null)
                 {
+                    continue;
+                }
+
+                if (attr.KeyIsolation)
+                {
+                    // Per-entity key isolation: handled by interceptors, not converter.
+                    // Annotate so interceptors can identify these properties from metadata.
+                    property.SetAnnotation(IsolatedAnnotation, true);
                     continue;
                 }
 

--- a/src/Granit.Encryption.EntityFrameworkCore/Granit.Encryption.EntityFrameworkCore.csproj
+++ b/src/Granit.Encryption.EntityFrameworkCore/Granit.Encryption.EntityFrameworkCore.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Granit.Encryption.EntityFrameworkCore.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
   </ItemGroup>
 

--- a/src/Granit.Encryption.EntityFrameworkCore/GranitEncryptionEntityFrameworkCoreModule.cs
+++ b/src/Granit.Encryption.EntityFrameworkCore/GranitEncryptionEntityFrameworkCoreModule.cs
@@ -1,5 +1,8 @@
 using Granit.Core.Modularity;
+using Granit.Encryption.EntityFrameworkCore.Interceptors;
 using Granit.Persistence;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Granit.Encryption.EntityFrameworkCore;
 
@@ -8,7 +11,21 @@ namespace Granit.Encryption.EntityFrameworkCore;
 /// Provides <see cref="EncryptedAttribute"/> and <see cref="EncryptedStringConverter"/>
 /// backed by <see cref="IStringEncryptionService"/>.
 /// </summary>
+/// <remarks>
+/// When <see cref="IEntityEncryptionKeyStore"/> is registered (by a Vault provider),
+/// also registers the <see cref="EncryptionIsolationSaveChangesInterceptor"/> and
+/// <see cref="EncryptionIsolationMaterializationInterceptor"/> for per-entity key isolation.
+/// </remarks>
 [DependsOn(
     typeof(GranitEncryptionModule),
     typeof(GranitPersistenceModule))]
-public sealed class GranitEncryptionEntityFrameworkCoreModule : GranitModule;
+public sealed class GranitEncryptionEntityFrameworkCoreModule : GranitModule
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        // Interceptors for per-entity key isolation (require IEntityEncryptionKeyStore)
+        context.Services.TryAddScoped<EncryptionIsolationSaveChangesInterceptor>();
+        context.Services.TryAddScoped<EncryptionIsolationMaterializationInterceptor>();
+    }
+}

--- a/src/Granit.Encryption.EntityFrameworkCore/Interceptors/EncryptionIsolationMaterializationInterceptor.cs
+++ b/src/Granit.Encryption.EntityFrameworkCore/Interceptors/EncryptionIsolationMaterializationInterceptor.cs
@@ -1,0 +1,121 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Granit.Encryption.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Encryption.EntityFrameworkCore.Interceptors;
+
+/// <summary>
+/// EF Core <see cref="IMaterializationInterceptor"/> that decrypts properties
+/// marked with <c>[Encrypted(KeyIsolation = true)]</c> after entity materialization,
+/// using a per-entity key from <see cref="IEntityEncryptionKeyStore"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// When the per-entity key has been destroyed (crypto-shredding), the property value
+/// is set to <c>null</c> for nullable strings or <c>string.Empty</c> for non-nullable strings.
+/// The raw ciphertext is not exposed.
+/// </para>
+/// <para>
+/// Uses <see cref="Task.GetAwaiter()"/> + <see cref="System.Runtime.CompilerServices.TaskAwaiter.GetResult()"/>
+/// because <see cref="IMaterializationInterceptor.InitializedInstance"/> is synchronous.
+/// The <see cref="IEntityEncryptionKeyStore"/> implementation should use an in-memory
+/// cache to minimize blocking calls.
+/// </para>
+/// </remarks>
+public sealed partial class EncryptionIsolationMaterializationInterceptor(
+    IEntityEncryptionKeyStore keyStore,
+    ILogger<EncryptionIsolationMaterializationInterceptor> logger) : IMaterializationInterceptor
+{
+    private static readonly ConcurrentDictionary<Type, PropertyInfo[]> IsolatedPropertiesCache = new();
+
+    public object InitializedInstance(MaterializationInterceptionData materializationData, object entity)
+    {
+        Type entityType = entity.GetType();
+        PropertyInfo[] isolatedProperties = GetIsolatedProperties(entityType);
+
+        if (isolatedProperties.Length == 0)
+        {
+            return entity;
+        }
+
+        string entityTypeName = entityType.Name;
+        string entityId = GetEntityId(entity, entityType);
+
+        if (string.IsNullOrEmpty(entityId))
+        {
+            return entity;
+        }
+
+        // Synchronous call — IEntityEncryptionKeyStore implementations should cache keys
+        byte[]? key = keyStore.GetKeyAsync(entityTypeName, entityId, CancellationToken.None)
+            .GetAwaiter().GetResult();
+
+        if (key is null)
+        {
+            // Key was shredded — clear all isolated properties
+            foreach (PropertyInfo property in isolatedProperties)
+            {
+                NullableContextInfoProvider info = new(property);
+                property.SetValue(entity, info.IsNullable ? null : string.Empty);
+            }
+
+            LogShreddedEntity(logger, entityTypeName, entityId);
+            return entity;
+        }
+
+        foreach (PropertyInfo property in isolatedProperties)
+        {
+            string? cipherText = property.GetValue(entity) as string;
+            if (cipherText is null)
+            {
+                continue;
+            }
+
+            string? plainText = IsolatedFieldEncryptor.Decrypt(key, cipherText);
+            property.SetValue(entity, plainText);
+        }
+
+        return entity;
+    }
+
+    private static PropertyInfo[] GetIsolatedProperties(Type entityType) =>
+        IsolatedPropertiesCache.GetOrAdd(entityType, static type =>
+            type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(static p =>
+                    p.PropertyType == typeof(string) &&
+                    p.GetCustomAttribute<EncryptedAttribute>() is { KeyIsolation: true })
+                .ToArray());
+
+    private static string GetEntityId(object entity, Type entityType)
+    {
+        // Convention: entities have an 'Id' property
+        PropertyInfo? idProperty = entityType.GetProperty("Id");
+        object? idValue = idProperty?.GetValue(entity);
+
+        if (idValue is Guid guid && guid != Guid.Empty)
+        {
+            return guid.ToString();
+        }
+
+        return idValue?.ToString() ?? string.Empty;
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "Entity {EntityType}/{EntityId} has been crypto-shredded — isolated properties cleared")]
+    private static partial void LogShreddedEntity(ILogger logger, string entityType, string entityId);
+
+    /// <summary>Helper to check property nullability via NullableContextAttribute.</summary>
+    private readonly struct NullableContextInfoProvider
+    {
+        public bool IsNullable { get; }
+
+        public NullableContextInfoProvider(PropertyInfo property)
+        {
+            NullabilityInfoContext context = new();
+            NullabilityInfo info = context.Create(property);
+            IsNullable = info.ReadState is NullabilityState.Nullable;
+        }
+    }
+}

--- a/src/Granit.Encryption.EntityFrameworkCore/Interceptors/EncryptionIsolationSaveChangesInterceptor.cs
+++ b/src/Granit.Encryption.EntityFrameworkCore/Interceptors/EncryptionIsolationSaveChangesInterceptor.cs
@@ -1,0 +1,142 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Granit.Encryption.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Encryption.EntityFrameworkCore.Interceptors;
+
+/// <summary>
+/// EF Core interceptor that encrypts properties marked with
+/// <c>[Encrypted(KeyIsolation = true)]</c> before <c>SaveChanges</c>,
+/// using a per-entity key from <see cref="IEntityEncryptionKeyStore"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Must be registered AFTER <c>AuditedEntityInterceptor</c> to ensure entity IDs
+/// are assigned before encryption runs. Use <c>UseGranitEncryptionInterceptors(sp)</c>
+/// after <c>UseGranitInterceptors(sp)</c>.
+/// </para>
+/// <para>
+/// Properties without <c>KeyIsolation = true</c> are handled by
+/// <see cref="EncryptedStringConverter"/> (shared key ring) — this interceptor
+/// skips them.
+/// </para>
+/// </remarks>
+public sealed partial class EncryptionIsolationSaveChangesInterceptor(
+    IEntityEncryptionKeyStore keyStore,
+    ILogger<EncryptionIsolationSaveChangesInterceptor> logger) : SaveChangesInterceptor
+{
+    private static readonly ConcurrentDictionary<Type, PropertyInfo[]> IsolatedPropertiesCache = new();
+
+    public override InterceptionResult<int> SavingChanges(
+        DbContextEventData eventData,
+        InterceptionResult<int> result)
+    {
+        EncryptIsolatedPropertiesAsync(eventData.Context, CancellationToken.None)
+            .GetAwaiter().GetResult();
+        return base.SavingChanges(eventData, result);
+    }
+
+    public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        await EncryptIsolatedPropertiesAsync(eventData.Context, cancellationToken)
+            .ConfigureAwait(false);
+        return await base.SavingChangesAsync(eventData, result, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task EncryptIsolatedPropertiesAsync(DbContext? context, CancellationToken cancellationToken)
+    {
+        if (context is null)
+        {
+            return;
+        }
+
+        foreach (EntityEntry entry in context.ChangeTracker.Entries())
+        {
+            if (entry.State is not (EntityState.Added or EntityState.Modified))
+            {
+                continue;
+            }
+
+            PropertyInfo[] isolatedProperties = GetIsolatedProperties(entry.Entity.GetType());
+            if (isolatedProperties.Length == 0)
+            {
+                continue;
+            }
+
+            string entityType = entry.Entity.GetType().Name;
+            string entityId = GetEntityId(entry);
+
+            if (string.IsNullOrEmpty(entityId))
+            {
+                LogSkippedNoId(logger, entityType);
+                continue;
+            }
+
+            byte[] key = await keyStore.GetOrCreateKeyAsync(entityType, entityId, cancellationToken)
+                .ConfigureAwait(false);
+
+            foreach (PropertyInfo property in isolatedProperties)
+            {
+                string? plainText = property.GetValue(entry.Entity) as string;
+                if (plainText is null)
+                {
+                    continue;
+                }
+
+                string cipherText = IsolatedFieldEncryptor.Encrypt(key, plainText);
+                property.SetValue(entry.Entity, cipherText);
+
+                // Ensure EF Core tracks the change
+                if (entry.State is EntityState.Modified)
+                {
+                    entry.Property(property.Name).IsModified = true;
+                }
+            }
+
+            LogEncryptedProperties(logger, entityType, entityId, isolatedProperties.Length);
+        }
+    }
+
+    private static PropertyInfo[] GetIsolatedProperties(Type entityType) =>
+        IsolatedPropertiesCache.GetOrAdd(entityType, static type =>
+            type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(static p =>
+                    p.PropertyType == typeof(string) &&
+                    p.GetCustomAttribute<EncryptedAttribute>() is { KeyIsolation: true })
+                .ToArray());
+
+    private static string GetEntityId(EntityEntry entry)
+    {
+        // Use the primary key value — handles both Guid and composite keys
+        object?[] keyValues = entry.Properties
+            .Where(p => p.Metadata.IsPrimaryKey())
+            .Select(p => p.CurrentValue)
+            .ToArray();
+
+        if (keyValues.Length == 1 && keyValues[0] is Guid guid && guid != Guid.Empty)
+        {
+            return guid.ToString();
+        }
+
+        return keyValues.Length == 1
+            ? keyValues[0]?.ToString() ?? string.Empty
+            : string.Join(":", keyValues.Select(v => v?.ToString() ?? string.Empty));
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "Encrypted {Count} isolated properties for {EntityType}/{EntityId}")]
+    private static partial void LogEncryptedProperties(
+        ILogger logger, string entityType, string entityId, int count);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Skipped encryption isolation for {EntityType}: entity ID is empty")]
+    private static partial void LogSkippedNoId(ILogger logger, string entityType);
+}

--- a/src/Granit.Encryption.EntityFrameworkCore/Internal/IsolatedFieldEncryptor.cs
+++ b/src/Granit.Encryption.EntityFrameworkCore/Internal/IsolatedFieldEncryptor.cs
@@ -1,0 +1,129 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Granit.Encryption.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// AES-256-CBC + HMAC-SHA256 encrypt/decrypt using a per-entity key.
+/// Format: <c>Base64(IV[16] || CipherText || HMAC-SHA256(IV || CipherText)[32])</c>.
+/// </summary>
+/// <remarks>
+/// Same encrypt-then-MAC scheme as <c>AesStringEncryptionProvider</c>, but uses
+/// a raw 32-byte key instead of PBKDF2-derived key material. The key is split:
+/// first 32 bytes for AES-256, HMAC key derived via HKDF from the same key material.
+/// </remarks>
+internal static class IsolatedFieldEncryptor
+{
+    private const int IvSize = 16;
+    private const int HmacSize = 32;
+    private const int AesKeySize = 32;
+    private static readonly byte[] HkdfInfo = "granit-isolated-hmac"u8.ToArray();
+
+    /// <summary>Encrypts plaintext with the given per-entity key.</summary>
+    internal static string Encrypt(byte[] key, string plainText)
+    {
+        ValidateKey(key);
+
+        byte[] hmacKey = DeriveHmacKey(key);
+        byte[] iv = RandomNumberGenerator.GetBytes(IvSize);
+        byte[] plainBytes = Encoding.UTF8.GetBytes(plainText);
+
+        using var aes = Aes.Create();
+        aes.Key = key;
+        aes.IV = iv;
+        aes.Mode = CipherMode.CBC;
+        aes.Padding = PaddingMode.PKCS7;
+
+        using ICryptoTransform encryptor = aes.CreateEncryptor();
+        byte[] cipherBytes = encryptor.TransformFinalBlock(plainBytes, 0, plainBytes.Length);
+
+        // Encrypt-then-MAC: HMAC-SHA256(IV || CipherText)
+        int dataLength = IvSize + cipherBytes.Length;
+        byte[] dataToMac = new byte[dataLength];
+        Buffer.BlockCopy(iv, 0, dataToMac, 0, IvSize);
+        Buffer.BlockCopy(cipherBytes, 0, dataToMac, IvSize, cipherBytes.Length);
+        byte[] hmac = HMACSHA256.HashData(hmacKey, dataToMac);
+
+        // Format: IV[16] || CipherText || HMAC[32]
+        byte[] output = new byte[dataLength + HmacSize];
+        Buffer.BlockCopy(dataToMac, 0, output, 0, dataLength);
+        Buffer.BlockCopy(hmac, 0, output, dataLength, HmacSize);
+
+        return Convert.ToBase64String(output);
+    }
+
+    /// <summary>
+    /// Decrypts ciphertext with the given per-entity key.
+    /// Returns <c>null</c> if the ciphertext is invalid, tampered, or the key is wrong.
+    /// </summary>
+    internal static string? Decrypt(byte[] key, string cipherText)
+    {
+        ValidateKey(key);
+
+        if (string.IsNullOrEmpty(cipherText))
+        {
+            return null;
+        }
+
+        byte[] input;
+        try
+        {
+            input = Convert.FromBase64String(cipherText);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+
+        // Minimum: IV[16] + one AES block[16] + HMAC[32] = 64 bytes
+        if (input.Length < IvSize + 16 + HmacSize)
+        {
+            return null;
+        }
+
+        byte[] hmacKey = DeriveHmacKey(key);
+
+        // Verify HMAC before decryption (encrypt-then-MAC: always verify first)
+        byte[] receivedHmac = input[^HmacSize..];
+        byte[] dataToMac = input[..^HmacSize];
+        byte[] computedHmac = HMACSHA256.HashData(hmacKey, dataToMac);
+
+        if (!CryptographicOperations.FixedTimeEquals(computedHmac, receivedHmac))
+        {
+            return null;
+        }
+
+        byte[] iv = input[..IvSize];
+        byte[] cipherBytes = input[IvSize..^HmacSize];
+
+        using var aes = Aes.Create();
+        aes.Key = key;
+        aes.IV = iv;
+        aes.Mode = CipherMode.CBC;
+        aes.Padding = PaddingMode.PKCS7;
+
+        try
+        {
+            using ICryptoTransform decryptor = aes.CreateDecryptor();
+            byte[] plainBytes = decryptor.TransformFinalBlock(cipherBytes, 0, cipherBytes.Length);
+            return Encoding.UTF8.GetString(plainBytes);
+        }
+        catch (CryptographicException)
+        {
+            return null;
+        }
+    }
+
+    private static byte[] DeriveHmacKey(byte[] key) =>
+        HKDF.DeriveKey(HashAlgorithmName.SHA256, key, HmacSize, info: HkdfInfo);
+
+    private static void ValidateKey(byte[] key)
+    {
+        if (key.Length != AesKeySize)
+        {
+            throw new ArgumentException(
+                $"Per-entity encryption key must be {AesKeySize} bytes (AES-256), got {key.Length}.",
+                nameof(key));
+        }
+    }
+}

--- a/src/Granit.Encryption/CryptoShredding/ICryptoShreddingAuditRecorder.cs
+++ b/src/Granit.Encryption/CryptoShredding/ICryptoShreddingAuditRecorder.cs
@@ -1,0 +1,34 @@
+namespace Granit.Encryption.CryptoShredding;
+
+/// <summary>
+/// Records crypto-shredding events for audit trail compliance (ISO 27001 A.10.1.2).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations typically write to <c>ITimelineWriter</c> with
+/// <c>TimelineEntryType.SystemLog</c> for immutable audit trail entries.
+/// The interface lives in <c>Granit.Encryption</c> to avoid coupling
+/// the encryption module to <c>Granit.Timeline</c>.
+/// </para>
+/// <para>
+/// Register implementations via DI:
+/// <code>
+/// services.AddScoped&lt;ICryptoShreddingAuditRecorder, TimelineCryptoShreddingRecorder&gt;();
+/// </code>
+/// </para>
+/// </remarks>
+public interface ICryptoShreddingAuditRecorder
+{
+    /// <summary>
+    /// Records that a per-entity encryption key was permanently destroyed.
+    /// </summary>
+    /// <param name="entityType">Logical entity type name.</param>
+    /// <param name="entityId">Entity identifier.</param>
+    /// <param name="shreddedAt">Timestamp of the shredding operation.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task RecordAsync(
+        string entityType,
+        string entityId,
+        DateTimeOffset shreddedAt,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Encryption/Diagnostics/EncryptionActivitySource.cs
+++ b/src/Granit.Encryption/Diagnostics/EncryptionActivitySource.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics;
+
+namespace Granit.Encryption.Diagnostics;
+
+/// <summary>
+/// Central <see cref="ActivitySource"/> for Granit.Encryption distributed tracing.
+/// </summary>
+/// <remarks>
+/// <c>Granit.Observability</c> adds this source automatically via
+/// <c>GranitActivitySourceRegistry</c> when both packages are used.
+/// </remarks>
+internal static class EncryptionActivitySource
+{
+    /// <summary>The name of the Granit.Encryption <see cref="ActivitySource"/>.</summary>
+    internal const string Name = "Granit.Encryption";
+
+    /// <summary>The singleton <see cref="ActivitySource"/> instance.</summary>
+    internal static readonly ActivitySource Source = new(Name);
+
+    // ──── Operation names ────
+
+    internal const string KeyCreate = "encryption.key-create";
+    internal const string KeyRetrieve = "encryption.key-retrieve";
+    internal const string KeyDelete = "encryption.key-delete";
+    internal const string Shred = "encryption.shred";
+    internal const string ShredBatch = "encryption.shred-batch";
+}

--- a/src/Granit.Encryption/Diagnostics/EncryptionMetrics.cs
+++ b/src/Granit.Encryption/Diagnostics/EncryptionMetrics.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Granit.Encryption.Diagnostics;
+
+/// <summary>
+/// OpenTelemetry metrics for the encryption module.
+/// Meter: <c>Granit.Encryption</c>.
+/// </summary>
+public sealed class EncryptionMetrics
+{
+    public const string MeterName = "Granit.Encryption";
+
+    private readonly Counter<long> _keysCreated;
+    private readonly Counter<long> _keysShredded;
+    private readonly Counter<long> _shreddingErrors;
+
+    public EncryptionMetrics(IMeterFactory meterFactory)
+    {
+        Meter meter = meterFactory.Create(MeterName);
+
+        _keysCreated = meter.CreateCounter<long>(
+            "granit.encryption.key.created",
+            description: "Number of per-entity encryption keys created.");
+
+        _keysShredded = meter.CreateCounter<long>(
+            "granit.encryption.key.shredded",
+            description: "Number of per-entity encryption keys permanently destroyed (crypto-shredding).");
+
+        _shreddingErrors = meter.CreateCounter<long>(
+            "granit.encryption.shredding.errors",
+            description: "Number of crypto-shredding operations that failed.");
+    }
+
+    public void RecordKeyCreated(string? tenantId, string entityType) =>
+        _keysCreated.Add(1, new TagList
+        {
+            { "tenant_id", tenantId ?? "global" },
+            { "entity_type", entityType },
+        });
+
+    public void RecordKeyShredded(string? tenantId, string entityType) =>
+        _keysShredded.Add(1, new TagList
+        {
+            { "tenant_id", tenantId ?? "global" },
+            { "entity_type", entityType },
+        });
+
+    public void RecordShreddingError(string? tenantId, string entityType) =>
+        _shreddingErrors.Add(1, new TagList
+        {
+            { "tenant_id", tenantId ?? "global" },
+            { "entity_type", entityType },
+        });
+}

--- a/src/Granit.Encryption/Events/CryptoShreddedEvent.cs
+++ b/src/Granit.Encryption/Events/CryptoShreddedEvent.cs
@@ -1,0 +1,16 @@
+using Granit.Core.Events;
+
+namespace Granit.Encryption.Events;
+
+/// <summary>
+/// Domain event raised after a per-entity encryption key is permanently destroyed.
+/// </summary>
+/// <remarks>
+/// In-process, transactional event. Handlers run within the same execution context.
+/// Used by <see cref="CryptoShredding.ICryptoShreddingAuditRecorder"/> implementations
+/// and metrics recording.
+/// </remarks>
+public sealed record CryptoShreddedEvent(
+    string EntityType,
+    string EntityId,
+    DateTimeOffset ShreddedAt) : IDomainEvent;

--- a/src/Granit.Encryption/Extensions/EncryptionServiceCollectionExtensions.cs
+++ b/src/Granit.Encryption/Extensions/EncryptionServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using Granit.Core.Diagnostics;
+using Granit.Encryption.Diagnostics;
 using Granit.Encryption.Options;
 using Granit.Encryption.Providers;
 using Granit.Encryption.Services;
@@ -26,6 +28,13 @@ public static class EncryptionServiceCollectionExtensions
         services.AddSingleton<IStringEncryptionProvider, AesStringEncryptionProvider>();
 
         services.TryAddSingleton<IStringEncryptionService, DefaultStringEncryptionService>();
+
+        // Crypto-shredding (requires IEntityEncryptionKeyStore to be registered by a Vault provider)
+        services.TryAddScoped<ICryptoShredder, DefaultCryptoShredder>();
+
+        // Diagnostics
+        services.TryAddSingleton<EncryptionMetrics>();
+        GranitActivitySourceRegistry.Register(EncryptionActivitySource.Name);
 
         return services;
     }

--- a/src/Granit.Encryption/ICryptoShredder.cs
+++ b/src/Granit.Encryption/ICryptoShredder.cs
@@ -1,0 +1,36 @@
+namespace Granit.Encryption;
+
+/// <summary>
+/// Permanently destroys per-entity encryption keys, making all ciphertext
+/// encrypted with those keys permanently unreadable (GDPR Art. 17 compliance).
+/// </summary>
+/// <remarks>
+/// Crypto-shredding is irreversible — there is no key recovery path.
+/// Database rows are preserved (audit trail / legal hold compatibility),
+/// but the encrypted fields become unreadable garbage.
+/// </remarks>
+public interface ICryptoShredder
+{
+    /// <summary>
+    /// Permanently destroys the per-entity encryption key for a single entity.
+    /// </summary>
+    /// <param name="entityType">Logical entity type name (e.g., <c>"Patient"</c>).</param>
+    /// <param name="entityId">Entity identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task ShredAsync(
+        string entityType,
+        string entityId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Permanently destroys per-entity encryption keys for multiple entities
+    /// of the same type. Used for bulk GDPR erasure.
+    /// </summary>
+    /// <param name="entityType">Logical entity type name.</param>
+    /// <param name="entityIds">Entity identifiers to shred.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task ShredBatchAsync(
+        string entityType,
+        IEnumerable<string> entityIds,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Encryption/IEntityEncryptionKeyStore.cs
+++ b/src/Granit.Encryption/IEntityEncryptionKeyStore.cs
@@ -1,0 +1,52 @@
+namespace Granit.Encryption;
+
+/// <summary>
+/// Provider-agnostic store for per-entity encryption keys.
+/// Each entity instance gets its own AES-256 key, enabling crypto-shredding
+/// (GDPR Art. 17) by deleting the key without touching database rows.
+/// </summary>
+/// <remarks>
+/// Implementations must ensure key material is stored securely (e.g., Vault KV v2)
+/// and that <see cref="DeleteKeyAsync"/> permanently destroys the key with no
+/// recovery path (ISO 27001 A.10.1.2).
+/// </remarks>
+public interface IEntityEncryptionKeyStore
+{
+    /// <summary>
+    /// Returns the AES-256 key for the given entity, creating one if it does not exist.
+    /// </summary>
+    /// <param name="entityType">Logical entity type name (e.g., <c>"Patient"</c>).</param>
+    /// <param name="entityId">Entity identifier (typically <c>Guid.ToString()</c>).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>32-byte AES-256 key.</returns>
+    Task<byte[]> GetOrCreateKeyAsync(
+        string entityType,
+        string entityId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the AES-256 key for the given entity, or <c>null</c> if the key
+    /// does not exist (e.g., after crypto-shredding).
+    /// </summary>
+    Task<byte[]?> GetKeyAsync(
+        string entityType,
+        string entityId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Permanently destroys the per-entity key. This is the crypto-shredding operation:
+    /// all ciphertext encrypted with this key becomes permanently unreadable.
+    /// </summary>
+    Task DeleteKeyAsync(
+        string entityType,
+        string entityId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks whether a per-entity key exists without retrieving the key material.
+    /// </summary>
+    Task<bool> KeyExistsAsync(
+        string entityType,
+        string entityId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Encryption/Services/DefaultCryptoShredder.cs
+++ b/src/Granit.Encryption/Services/DefaultCryptoShredder.cs
@@ -1,0 +1,94 @@
+using System.Diagnostics;
+using Granit.Encryption.CryptoShredding;
+using Granit.Encryption.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Encryption.Services;
+
+/// <summary>
+/// Default implementation of <see cref="ICryptoShredder"/> that delegates key
+/// destruction to <see cref="IEntityEncryptionKeyStore"/> and notifies all
+/// registered <see cref="ICryptoShreddingAuditRecorder"/> instances.
+/// </summary>
+public sealed partial class DefaultCryptoShredder(
+    IEntityEncryptionKeyStore keyStore,
+    TimeProvider timeProvider,
+    EncryptionMetrics metrics,
+    ILogger<DefaultCryptoShredder> logger,
+    IEnumerable<ICryptoShreddingAuditRecorder> auditRecorders) : ICryptoShredder
+{
+    public async Task ShredAsync(
+        string entityType,
+        string entityId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entityType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entityId);
+
+        using Activity? activity = EncryptionActivitySource.Source.StartActivity(
+            EncryptionActivitySource.Shred);
+        activity?.SetTag("entity_type", entityType);
+        activity?.SetTag("entity_id", entityId);
+
+        await keyStore.DeleteKeyAsync(entityType, entityId, cancellationToken).ConfigureAwait(false);
+
+        DateTimeOffset shreddedAt = timeProvider.GetUtcNow();
+        metrics.RecordKeyShredded(null, entityType);
+        LogKeyShredded(logger, entityType, entityId);
+
+        await NotifyAuditRecordersAsync(entityType, entityId, shreddedAt, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task ShredBatchAsync(
+        string entityType,
+        IEnumerable<string> entityIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entityType);
+        ArgumentNullException.ThrowIfNull(entityIds);
+
+        using Activity? activity = EncryptionActivitySource.Source.StartActivity(
+            EncryptionActivitySource.ShredBatch);
+        activity?.SetTag("entity_type", entityType);
+
+        DateTimeOffset shreddedAt = timeProvider.GetUtcNow();
+        int count = 0;
+
+        foreach (string entityId in entityIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await keyStore.DeleteKeyAsync(entityType, entityId, cancellationToken).ConfigureAwait(false);
+            metrics.RecordKeyShredded(null, entityType);
+
+            await NotifyAuditRecordersAsync(entityType, entityId, shreddedAt, cancellationToken)
+                .ConfigureAwait(false);
+
+            count++;
+        }
+
+        LogBatchShredded(logger, entityType, count);
+    }
+
+    private async Task NotifyAuditRecordersAsync(
+        string entityType,
+        string entityId,
+        DateTimeOffset shreddedAt,
+        CancellationToken cancellationToken)
+    {
+        foreach (ICryptoShreddingAuditRecorder recorder in auditRecorders)
+        {
+            await recorder.RecordAsync(entityType, entityId, shreddedAt, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Per-entity encryption key destroyed for {EntityType}/{EntityId} — data is permanently unreadable")]
+    private static partial void LogKeyShredded(ILogger logger, string entityType, string entityId);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Batch crypto-shredding completed for {EntityType}: {Count} keys destroyed")]
+    private static partial void LogBatchShredded(ILogger logger, string entityType, int count);
+}

--- a/src/Granit.Privacy/DataDeletion/DeletionAction.cs
+++ b/src/Granit.Privacy/DataDeletion/DeletionAction.cs
@@ -19,5 +19,8 @@ public enum DeletionAction
     Retained = 3,
 
     /// <summary>Combination of multiple actions (e.g., PII anonymized + medical data retained).</summary>
-    Mixed = 4
+    Mixed = 4,
+
+    /// <summary>Per-entity encryption key was permanently destroyed — ciphertext is mathematically unreadable (GDPR Art. 17 crypto-shredding).</summary>
+    CryptoShredding = 5
 }

--- a/src/Granit.Vault.HashiCorp/Extensions/HashiCorpVaultServiceCollectionExtensions.cs
+++ b/src/Granit.Vault.HashiCorp/Extensions/HashiCorpVaultServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
+using Granit.Encryption;
 using Granit.Vault.HashiCorp.HealthChecks;
 using Granit.Vault.HashiCorp.Options;
 using Granit.Vault.HashiCorp.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using VaultSharp;
 
@@ -34,6 +36,9 @@ public static class HashiCorpVaultServiceCollectionExtensions
         services.AddHostedService(sp => sp.GetRequiredService<VaultCredentialLeaseManager>());
 
         services.AddScoped<ITransitEncryptionService, HashiCorpTransitEncryptionService>();
+
+        // Per-entity key isolation for crypto-shredding (GDPR Art. 17)
+        services.TryAddScoped<IEntityEncryptionKeyStore, HashiCorpEntityEncryptionKeyStore>();
 
         return services;
     }

--- a/src/Granit.Vault.HashiCorp/Options/HashiCorpVaultOptions.cs
+++ b/src/Granit.Vault.HashiCorp/Options/HashiCorpVaultOptions.cs
@@ -34,6 +34,9 @@ public sealed class HashiCorpVaultOptions
     /// <summary>Mount point for the Transit engine. Default: "transit".</summary>
     public string TransitMountPoint { get; set; } = "transit";
 
+    /// <summary>Mount point for the KV v2 secrets engine used by per-entity key isolation. Default: "secret".</summary>
+    public string KvMountPoint { get; set; } = "secret";
+
     /// <summary>Lease renewal interval (percentage of TTL). Default: 0.75 (75%).</summary>
     public double LeaseRenewalThreshold { get; set; } = 0.75;
 }

--- a/src/Granit.Vault.HashiCorp/Services/HashiCorpEntityEncryptionKeyStore.cs
+++ b/src/Granit.Vault.HashiCorp/Services/HashiCorpEntityEncryptionKeyStore.cs
@@ -1,0 +1,168 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using Granit.Encryption;
+using Granit.Vault.HashiCorp.Options;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using VaultSharp;
+using VaultSharp.V1.Commons;
+
+namespace Granit.Vault.HashiCorp.Services;
+
+/// <summary>
+/// Implementation of <see cref="IEntityEncryptionKeyStore"/> backed by HashiCorp Vault KV v2.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Key path format: <c>{kvMountPoint}/data/granit/encryption/isolated/{entityType}/{entityId}</c>.
+/// The secret value is a 32-byte AES-256 key stored as Base64 in the <c>"key"</c> field.
+/// </para>
+/// <para>
+/// Includes an in-memory cache to avoid round-trips to Vault on every entity materialization.
+/// Cache entries are evicted on <see cref="DeleteKeyAsync"/> (crypto-shredding).
+/// </para>
+/// </remarks>
+public sealed partial class HashiCorpEntityEncryptionKeyStore(
+    IVaultClient vaultClient,
+    IOptions<HashiCorpVaultOptions> options,
+    ILogger<HashiCorpEntityEncryptionKeyStore> logger) : IEntityEncryptionKeyStore
+{
+    private const int KeySizeBytes = 32; // AES-256
+    private const string SecretKeyField = "key";
+    private const string PathPrefix = "granit/encryption/isolated";
+
+    private readonly string _kvMountPoint = options.Value.KvMountPoint;
+    private readonly ConcurrentDictionary<string, byte[]> _cache = new(StringComparer.Ordinal);
+
+    public async Task<byte[]> GetOrCreateKeyAsync(
+        string entityType,
+        string entityId,
+        CancellationToken cancellationToken = default)
+    {
+        string cacheKey = BuildCacheKey(entityType, entityId);
+
+        if (_cache.TryGetValue(cacheKey, out byte[]? cached))
+        {
+            return cached;
+        }
+
+        string path = BuildPath(entityType, entityId);
+
+        // Try to read existing key
+        try
+        {
+            Secret<SecretData> secret = await vaultClient.V1.Secrets.KeyValue.V2
+                .ReadSecretAsync(path, mountPoint: _kvMountPoint)
+                .WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            if (secret.Data.Data.TryGetValue(SecretKeyField, out object? value) &&
+                value is string base64Key)
+            {
+                byte[] existingKey = Convert.FromBase64String(base64Key);
+                _cache.TryAdd(cacheKey, existingKey);
+                return existingKey;
+            }
+        }
+        catch (VaultSharp.Core.VaultApiException ex) when (ex.HttpStatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            // Key doesn't exist yet — create below
+        }
+
+        // Generate new key
+        byte[] newKey = RandomNumberGenerator.GetBytes(KeySizeBytes);
+        string newKeyBase64 = Convert.ToBase64String(newKey);
+
+        await vaultClient.V1.Secrets.KeyValue.V2.WriteSecretAsync(
+            path,
+            new Dictionary<string, object> { [SecretKeyField] = newKeyBase64 },
+            mountPoint: _kvMountPoint)
+            .WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        _cache.TryAdd(cacheKey, newKey);
+        LogKeyCreated(logger, entityType, entityId);
+        return newKey;
+    }
+
+    public async Task<byte[]?> GetKeyAsync(
+        string entityType,
+        string entityId,
+        CancellationToken cancellationToken = default)
+    {
+        string cacheKey = BuildCacheKey(entityType, entityId);
+
+        if (_cache.TryGetValue(cacheKey, out byte[]? cached))
+        {
+            return cached;
+        }
+
+        string path = BuildPath(entityType, entityId);
+
+        try
+        {
+            Secret<SecretData> secret = await vaultClient.V1.Secrets.KeyValue.V2
+                .ReadSecretAsync(path, mountPoint: _kvMountPoint)
+                .WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            if (secret.Data.Data.TryGetValue(SecretKeyField, out object? value) &&
+                value is string base64Key)
+            {
+                byte[] key = Convert.FromBase64String(base64Key);
+                _cache.TryAdd(cacheKey, key);
+                return key;
+            }
+        }
+        catch (VaultSharp.Core.VaultApiException ex) when (ex.HttpStatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            // Key doesn't exist (possibly shredded)
+        }
+
+        return null;
+    }
+
+    public async Task DeleteKeyAsync(
+        string entityType,
+        string entityId,
+        CancellationToken cancellationToken = default)
+    {
+        string path = BuildPath(entityType, entityId);
+        string cacheKey = BuildCacheKey(entityType, entityId);
+
+        // Permanently destroy all versions — irreversible crypto-shredding
+        await vaultClient.V1.Secrets.KeyValue.V2
+            .DeleteMetadataAsync(path, mountPoint: _kvMountPoint)
+            .WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        _cache.TryRemove(cacheKey, out _);
+        LogKeyDeleted(logger, entityType, entityId);
+    }
+
+    public async Task<bool> KeyExistsAsync(
+        string entityType,
+        string entityId,
+        CancellationToken cancellationToken = default)
+    {
+        string cacheKey = BuildCacheKey(entityType, entityId);
+
+        if (_cache.ContainsKey(cacheKey))
+        {
+            return true;
+        }
+
+        byte[]? key = await GetKeyAsync(entityType, entityId, cancellationToken).ConfigureAwait(false);
+        return key is not null;
+    }
+
+    private static string BuildPath(string entityType, string entityId) =>
+        $"{PathPrefix}/{entityType}/{entityId}";
+
+    private static string BuildCacheKey(string entityType, string entityId) =>
+        $"{entityType}:{entityId}";
+
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "Per-entity encryption key created in Vault KV for {EntityType}/{EntityId}")]
+    private static partial void LogKeyCreated(ILogger logger, string entityType, string entityId);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Per-entity encryption key permanently destroyed in Vault KV for {EntityType}/{EntityId}")]
+    private static partial void LogKeyDeleted(ILogger logger, string entityType, string entityId);
+}

--- a/tests/Granit.Encryption.EntityFrameworkCore.Tests/EncryptedAttributeTests.cs
+++ b/tests/Granit.Encryption.EntityFrameworkCore.Tests/EncryptedAttributeTests.cs
@@ -39,10 +39,37 @@ public sealed class EncryptedAttributeTests
         attr.ShouldBeNull();
     }
 
+    [Fact]
+    public void EncryptedAttribute_KeyIsolation_DefaultsFalse()
+    {
+        PropertyInfo? property = typeof(TestEntity)
+            .GetProperty(nameof(TestEntity.SecretValue));
+
+        EncryptedAttribute? attr = property?.GetCustomAttribute<EncryptedAttribute>();
+
+        attr.ShouldNotBeNull();
+        attr.KeyIsolation.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void EncryptedAttribute_KeyIsolation_CanBeSetToTrue()
+    {
+        PropertyInfo? property = typeof(TestEntity)
+            .GetProperty(nameof(TestEntity.IsolatedValue));
+
+        EncryptedAttribute? attr = property?.GetCustomAttribute<EncryptedAttribute>();
+
+        attr.ShouldNotBeNull();
+        attr.KeyIsolation.ShouldBeTrue();
+    }
+
     private sealed class TestEntity
     {
         [Encrypted]
         public string SecretValue { get; set; } = string.Empty;
+
+        [Encrypted(KeyIsolation = true)]
+        public string IsolatedValue { get; set; } = string.Empty;
 
         public string PlainValue { get; set; } = string.Empty;
     }

--- a/tests/Granit.Encryption.EntityFrameworkCore.Tests/EncryptionIsolationMaterializationInterceptorTests.cs
+++ b/tests/Granit.Encryption.EntityFrameworkCore.Tests/EncryptionIsolationMaterializationInterceptorTests.cs
@@ -1,0 +1,168 @@
+using System.Security.Cryptography;
+using Granit.Encryption.EntityFrameworkCore.Interceptors;
+using Granit.Encryption.EntityFrameworkCore.Internal;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Encryption.EntityFrameworkCore.Tests;
+
+public sealed class EncryptionIsolationMaterializationInterceptorTests : IDisposable
+{
+    private readonly IEntityEncryptionKeyStore _keyStore = Substitute.For<IEntityEncryptionKeyStore>();
+    private readonly EncryptionIsolationSaveChangesInterceptor _saveInterceptor;
+    private readonly EncryptionIsolationMaterializationInterceptor _readInterceptor;
+    private readonly SqliteConnection _connection;
+    private readonly byte[] _testKey;
+
+    public EncryptionIsolationMaterializationInterceptorTests()
+    {
+        _testKey = RandomNumberGenerator.GetBytes(32);
+
+        _saveInterceptor = new EncryptionIsolationSaveChangesInterceptor(
+            _keyStore,
+            NullLogger<EncryptionIsolationSaveChangesInterceptor>.Instance);
+
+        _readInterceptor = new EncryptionIsolationMaterializationInterceptor(
+            _keyStore,
+            NullLogger<EncryptionIsolationMaterializationInterceptor>.Instance);
+
+        _keyStore.GetOrCreateKeyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_testKey);
+
+        _keyStore.GetKeyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_testKey);
+
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+    }
+
+    [Fact]
+    public async Task RoundTrip_SaveAndRead_ReturnsOriginalPlaintext()
+    {
+        var entityId = Guid.NewGuid();
+
+        // Save with encryption
+        await using (TestDbContext writeCtx = CreateContext())
+        {
+            await writeCtx.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+            writeCtx.Patients.Add(new PatientEntity
+            {
+                Id = entityId,
+                Name = "Alice",
+                Ssn = "123-45-6789"
+            });
+            await writeCtx.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // Read with decryption
+        await using (TestDbContext readCtx = CreateContext())
+        {
+            PatientEntity? patient = await readCtx.Patients.FindAsync([entityId], TestContext.Current.CancellationToken);
+
+            patient.ShouldNotBeNull();
+            patient.Ssn.ShouldBe("123-45-6789");
+            patient.Name.ShouldBe("Alice");
+        }
+    }
+
+    [Fact]
+    public async Task Read_AfterKeyShredded_ReturnsNullForNullableProperty()
+    {
+        var entityId = Guid.NewGuid();
+
+        // Save with encryption
+        await using (TestDbContext writeCtx = CreateContext())
+        {
+            await writeCtx.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+            writeCtx.Patients.Add(new PatientEntity
+            {
+                Id = entityId,
+                Name = "Bob",
+                Ssn = "987-65-4321"
+            });
+            await writeCtx.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // Simulate crypto-shredding: key store returns null
+        _keyStore.GetKeyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((byte[]?)null);
+
+        // Read after shredding
+        await using (TestDbContext readCtx = CreateContext())
+        {
+            PatientEntity? patient = await readCtx.Patients.FindAsync([entityId], TestContext.Current.CancellationToken);
+
+            patient.ShouldNotBeNull();
+            patient.Ssn.ShouldBeNull("Shredded entity should have null isolated properties");
+            patient.Name.ShouldBe("Bob", "Non-isolated properties should be unaffected");
+        }
+    }
+
+    [Fact]
+    public async Task Read_WithNullStoredValue_ReturnsNull()
+    {
+        var entityId = Guid.NewGuid();
+
+        // Insert directly with NULL Ssn
+        await using (TestDbContext writeCtx = CreateContext())
+        {
+            await writeCtx.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+            writeCtx.Patients.Add(new PatientEntity
+            {
+                Id = entityId,
+                Name = "Charlie",
+                Ssn = null
+            });
+            await writeCtx.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        // Read — null should stay null (no decryption attempt)
+        await using (TestDbContext readCtx = CreateContext())
+        {
+            PatientEntity? patient = await readCtx.Patients.FindAsync([entityId], TestContext.Current.CancellationToken);
+
+            patient.ShouldNotBeNull();
+            patient.Ssn.ShouldBeNull();
+        }
+    }
+
+    private TestDbContext CreateContext()
+    {
+        DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseSqlite(_connection)
+            .AddInterceptors(_saveInterceptor, _readInterceptor)
+            .Options;
+
+        return new TestDbContext(options);
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options)
+    {
+        public DbSet<PatientEntity> Patients => Set<PatientEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<PatientEntity>(b =>
+            {
+                b.ToTable("Patients");
+                b.HasKey(e => e.Id);
+            });
+        }
+    }
+
+    private sealed class PatientEntity
+    {
+        public Guid Id { get; set; }
+
+        public string Name { get; set; } = string.Empty;
+
+        [Encrypted(KeyIsolation = true)]
+        public string? Ssn { get; set; }
+    }
+}

--- a/tests/Granit.Encryption.EntityFrameworkCore.Tests/EncryptionIsolationSaveChangesInterceptorTests.cs
+++ b/tests/Granit.Encryption.EntityFrameworkCore.Tests/EncryptionIsolationSaveChangesInterceptorTests.cs
@@ -1,0 +1,141 @@
+using Granit.Encryption.EntityFrameworkCore.Interceptors;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Encryption.EntityFrameworkCore.Tests;
+
+public sealed class EncryptionIsolationSaveChangesInterceptorTests : IDisposable
+{
+    private readonly IEntityEncryptionKeyStore _keyStore = Substitute.For<IEntityEncryptionKeyStore>();
+    private readonly EncryptionIsolationSaveChangesInterceptor _interceptor;
+    private readonly SqliteConnection _connection;
+    private readonly byte[] _testKey = new byte[32];
+
+    public EncryptionIsolationSaveChangesInterceptorTests()
+    {
+        _interceptor = new EncryptionIsolationSaveChangesInterceptor(
+            _keyStore,
+            NullLogger<EncryptionIsolationSaveChangesInterceptor>.Instance);
+
+        Random.Shared.NextBytes(_testKey);
+
+        _keyStore.GetOrCreateKeyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_testKey);
+
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+    }
+
+    [Fact]
+    public async Task SavingChanges_EncryptsIsolatedProperties()
+    {
+        await using TestDbContext ctx = CreateContext();
+        await ctx.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        ctx.Patients.Add(new PatientEntity
+        {
+            Id = Guid.NewGuid(),
+            Name = "Alice",
+            Ssn = "123-45-6789"
+        });
+
+        await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Verify the key store was called
+        await _keyStore.Received(1).GetOrCreateKeyAsync(
+            "PatientEntity", Arg.Any<string>(), Arg.Any<CancellationToken>());
+
+        // Verify raw DB value is encrypted (not plaintext)
+        using SqliteCommand cmd = _connection.CreateCommand();
+        cmd.CommandText = "SELECT Ssn FROM Patients WHERE Name = 'Alice'";
+        string? rawValue = cmd.ExecuteScalar() as string;
+
+        rawValue.ShouldNotBeNull();
+        rawValue.ShouldNotBe("123-45-6789", "Isolated property should be encrypted in DB");
+    }
+
+    [Fact]
+    public async Task SavingChanges_SkipsNonIsolatedProperties()
+    {
+        await using TestDbContext ctx = CreateContext();
+        await ctx.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        ctx.Patients.Add(new PatientEntity
+        {
+            Id = Guid.NewGuid(),
+            Name = "Bob",
+            Ssn = "987-65-4321"
+        });
+
+        await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Name is not annotated with [Encrypted] — should be stored as-is
+        using SqliteCommand cmd = _connection.CreateCommand();
+        cmd.CommandText = "SELECT Name FROM Patients WHERE Name = 'Bob'";
+        string? rawName = cmd.ExecuteScalar() as string;
+
+        rawName.ShouldBe("Bob");
+    }
+
+    [Fact]
+    public async Task SavingChanges_HandlesNullPropertyValue()
+    {
+        await using TestDbContext ctx = CreateContext();
+        await ctx.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        ctx.Patients.Add(new PatientEntity
+        {
+            Id = Guid.NewGuid(),
+            Name = "Charlie",
+            Ssn = null
+        });
+
+        await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        using SqliteCommand cmd = _connection.CreateCommand();
+        cmd.CommandText = "SELECT Ssn FROM Patients WHERE Name = 'Charlie'";
+        object? rawValue = cmd.ExecuteScalar();
+
+        rawValue.ShouldBe(DBNull.Value);
+    }
+
+    private TestDbContext CreateContext()
+    {
+        DbContextOptions<TestDbContext> options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseSqlite(_connection)
+            .AddInterceptors(_interceptor)
+            .Options;
+
+        return new TestDbContext(options);
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    private sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options)
+    {
+        public DbSet<PatientEntity> Patients => Set<PatientEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<PatientEntity>(b =>
+            {
+                b.ToTable("Patients");
+                b.HasKey(e => e.Id);
+            });
+        }
+    }
+
+    private sealed class PatientEntity
+    {
+        public Guid Id { get; set; }
+
+        public string Name { get; set; } = string.Empty;
+
+        [Encrypted(KeyIsolation = true)]
+        public string? Ssn { get; set; }
+    }
+}

--- a/tests/Granit.Encryption.EntityFrameworkCore.Tests/IsolatedFieldEncryptorTests.cs
+++ b/tests/Granit.Encryption.EntityFrameworkCore.Tests/IsolatedFieldEncryptorTests.cs
@@ -1,0 +1,131 @@
+using System.Security.Cryptography;
+using Granit.Encryption.EntityFrameworkCore.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Encryption.EntityFrameworkCore.Tests;
+
+#pragma warning disable EF1001 // IsolatedFieldEncryptor is Granit-internal, not EF Core-internal
+public sealed class IsolatedFieldEncryptorTests
+{
+    private static byte[] GenerateKey() => RandomNumberGenerator.GetBytes(32);
+
+    [Fact]
+    public void Encrypt_Decrypt_RoundTrip_ReturnsOriginalPlaintext()
+    {
+        byte[] key = GenerateKey();
+        const string plainText = "SSN-123-45-6789";
+
+        string cipherText = IsolatedFieldEncryptor.Encrypt(key, plainText);
+        string? decrypted = IsolatedFieldEncryptor.Decrypt(key, cipherText);
+
+        decrypted.ShouldBe(plainText);
+    }
+
+    [Fact]
+    public void Encrypt_ProducesDifferentCiphertext_ForSamePlaintext()
+    {
+        byte[] key = GenerateKey();
+        const string plainText = "same-value";
+
+        string cipher1 = IsolatedFieldEncryptor.Encrypt(key, plainText);
+        string cipher2 = IsolatedFieldEncryptor.Encrypt(key, plainText);
+
+        cipher1.ShouldNotBe(cipher2, "Random IV should produce different ciphertext each time");
+    }
+
+    [Fact]
+    public void Decrypt_WithWrongKey_ReturnsNull()
+    {
+        byte[] key1 = GenerateKey();
+        byte[] key2 = GenerateKey();
+        const string plainText = "secret-data";
+
+        string cipherText = IsolatedFieldEncryptor.Encrypt(key1, plainText);
+        string? result = IsolatedFieldEncryptor.Decrypt(key2, cipherText);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Decrypt_WithTamperedCiphertext_ReturnsNull()
+    {
+        byte[] key = GenerateKey();
+        string cipherText = IsolatedFieldEncryptor.Encrypt(key, "sensitive-data");
+
+        // Tamper with the ciphertext
+        byte[] raw = Convert.FromBase64String(cipherText);
+        raw[20] ^= 0xFF;
+        string tampered = Convert.ToBase64String(raw);
+
+        string? result = IsolatedFieldEncryptor.Decrypt(key, tampered);
+
+        result.ShouldBeNull("HMAC verification should fail on tampered ciphertext");
+    }
+
+    [Fact]
+    public void Decrypt_WithEmptyString_ReturnsNull()
+    {
+        byte[] key = GenerateKey();
+
+        IsolatedFieldEncryptor.Decrypt(key, string.Empty).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Decrypt_WithInvalidBase64_ReturnsNull()
+    {
+        byte[] key = GenerateKey();
+
+        IsolatedFieldEncryptor.Decrypt(key, "not-base64!!!").ShouldBeNull();
+    }
+
+    [Fact]
+    public void Decrypt_WithTooShortInput_ReturnsNull()
+    {
+        byte[] key = GenerateKey();
+
+        IsolatedFieldEncryptor.Decrypt(key, Convert.ToBase64String(new byte[10])).ShouldBeNull();
+    }
+
+    [Fact]
+    public void Encrypt_WithInvalidKeySize_ThrowsArgumentException()
+    {
+        byte[] shortKey = new byte[16]; // AES-128, not AES-256
+
+        Should.Throw<ArgumentException>(() =>
+            IsolatedFieldEncryptor.Encrypt(shortKey, "test"));
+    }
+
+    [Fact]
+    public void Decrypt_WithInvalidKeySize_ThrowsArgumentException()
+    {
+        byte[] shortKey = new byte[16];
+
+        Should.Throw<ArgumentException>(() =>
+            IsolatedFieldEncryptor.Decrypt(shortKey, "dGVzdA=="));
+    }
+
+    [Fact]
+    public void Encrypt_Decrypt_HandlesUnicodeContent()
+    {
+        byte[] key = GenerateKey();
+        const string plainText = "Données personnelles: médécin traitant — GDPR Art. 17 🔐";
+
+        string cipherText = IsolatedFieldEncryptor.Encrypt(key, plainText);
+        string? decrypted = IsolatedFieldEncryptor.Decrypt(key, cipherText);
+
+        decrypted.ShouldBe(plainText);
+    }
+
+    [Fact]
+    public void Encrypt_Decrypt_HandlesLargeContent()
+    {
+        byte[] key = GenerateKey();
+        string plainText = new('A', 100_000);
+
+        string cipherText = IsolatedFieldEncryptor.Encrypt(key, plainText);
+        string? decrypted = IsolatedFieldEncryptor.Decrypt(key, cipherText);
+
+        decrypted.ShouldBe(plainText);
+    }
+}

--- a/tests/Granit.Encryption.Tests/DefaultCryptoShredderTests.cs
+++ b/tests/Granit.Encryption.Tests/DefaultCryptoShredderTests.cs
@@ -1,0 +1,130 @@
+using Granit.Encryption.CryptoShredding;
+using Granit.Encryption.Diagnostics;
+using Granit.Encryption.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Encryption.Tests;
+
+public sealed class DefaultCryptoShredderTests
+{
+    private readonly IEntityEncryptionKeyStore _keyStore = Substitute.For<IEntityEncryptionKeyStore>();
+    private readonly ICryptoShreddingAuditRecorder _auditRecorder = Substitute.For<ICryptoShreddingAuditRecorder>();
+    private readonly EncryptionMetrics _metrics;
+    private readonly DefaultCryptoShredder _sut;
+
+    public DefaultCryptoShredderTests()
+    {
+        _metrics = new EncryptionMetrics(new TestMeterFactory());
+        _sut = new DefaultCryptoShredder(
+            _keyStore,
+            TimeProvider.System,
+            _metrics,
+            NullLogger<DefaultCryptoShredder>.Instance,
+            [_auditRecorder]);
+    }
+
+    [Fact]
+    public async Task ShredAsync_CallsDeleteKeyAsync()
+    {
+        await _sut.ShredAsync("Patient", "abc-123", TestContext.Current.CancellationToken);
+
+        await _keyStore.Received(1).DeleteKeyAsync("Patient", "abc-123", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ShredAsync_CallsAuditRecorder()
+    {
+        await _sut.ShredAsync("Patient", "abc-123", TestContext.Current.CancellationToken);
+
+        await _auditRecorder.Received(1).RecordAsync(
+            "Patient",
+            "abc-123",
+            Arg.Any<DateTimeOffset>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ShredAsync_WithNoAuditRecorders_DoesNotThrow()
+    {
+        DefaultCryptoShredder shredder = new(
+            _keyStore,
+            TimeProvider.System,
+            _metrics,
+            NullLogger<DefaultCryptoShredder>.Instance,
+            []);
+
+        await Should.NotThrowAsync(() => shredder.ShredAsync("Patient", "abc-123", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ShredAsync_WithNullEntityType_ThrowsArgumentException()
+    {
+        await Should.ThrowAsync<ArgumentException>(() => _sut.ShredAsync(null!, "abc-123", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ShredAsync_WithEmptyEntityId_ThrowsArgumentException()
+    {
+        await Should.ThrowAsync<ArgumentException>(() => _sut.ShredAsync("Patient", "", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ShredBatchAsync_CallsDeleteKeyAsync_ForEachEntityId()
+    {
+        string[] entityIds = ["id-1", "id-2", "id-3"];
+
+        await _sut.ShredBatchAsync("Patient", entityIds, TestContext.Current.CancellationToken);
+
+        await _keyStore.Received(3).DeleteKeyAsync("Patient", Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _keyStore.Received(1).DeleteKeyAsync("Patient", "id-1", Arg.Any<CancellationToken>());
+        await _keyStore.Received(1).DeleteKeyAsync("Patient", "id-2", Arg.Any<CancellationToken>());
+        await _keyStore.Received(1).DeleteKeyAsync("Patient", "id-3", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ShredBatchAsync_CallsAuditRecorder_ForEachEntityId()
+    {
+        string[] entityIds = ["id-1", "id-2"];
+
+        await _sut.ShredBatchAsync("Patient", entityIds, TestContext.Current.CancellationToken);
+
+        await _auditRecorder.Received(2).RecordAsync(
+            "Patient",
+            Arg.Any<string>(),
+            Arg.Any<DateTimeOffset>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ShredBatchAsync_WithEmptyEnumerable_DoesNotCallStore()
+    {
+        await _sut.ShredBatchAsync("Patient", [], TestContext.Current.CancellationToken);
+
+        await _keyStore.DidNotReceive().DeleteKeyAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>Minimal IMeterFactory for testing.</summary>
+    private sealed class TestMeterFactory : System.Diagnostics.Metrics.IMeterFactory
+    {
+        private readonly List<System.Diagnostics.Metrics.Meter> _meters = [];
+
+        public System.Diagnostics.Metrics.Meter Create(System.Diagnostics.Metrics.MeterOptions options)
+        {
+            System.Diagnostics.Metrics.Meter meter = new(options);
+            _meters.Add(meter);
+            return meter;
+        }
+
+        public void Dispose()
+        {
+            foreach (System.Diagnostics.Metrics.Meter meter in _meters)
+            {
+                meter.Dispose();
+            }
+        }
+    }
+}

--- a/tests/Granit.Privacy.Tests/DataDeletion/DeletionActionTests.cs
+++ b/tests/Granit.Privacy.Tests/DataDeletion/DeletionActionTests.cs
@@ -22,10 +22,13 @@ public sealed class DeletionActionTests
     public void Mixed_HasValue_Four() => ((int)DeletionAction.Mixed).ShouldBe(4);
 
     [Fact]
+    public void CryptoShredding_HasValue_Five() => ((int)DeletionAction.CryptoShredding).ShouldBe(5);
+
+    [Fact]
     public void AllValues_AreDefined()
     {
         DeletionAction[] values = Enum.GetValues<DeletionAction>();
 
-        values.Length.ShouldBe(5);
+        values.Length.ShouldBe(6);
     }
 }

--- a/tests/Granit.Vault.HashiCorp.Tests/HashiCorpEntityEncryptionKeyStoreTests.cs
+++ b/tests/Granit.Vault.HashiCorp.Tests/HashiCorpEntityEncryptionKeyStoreTests.cs
@@ -1,0 +1,204 @@
+using System.Net;
+using Granit.Vault.HashiCorp.Options;
+using Granit.Vault.HashiCorp.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+using VaultSharp;
+using VaultSharp.Core;
+using VaultSharp.V1;
+using VaultSharp.V1.Commons;
+using VaultSharp.V1.SecretsEngines;
+using VaultSharp.V1.SecretsEngines.KeyValue;
+using VaultSharp.V1.SecretsEngines.KeyValue.V2;
+using Xunit;
+
+namespace Granit.Vault.HashiCorp.Tests;
+
+public sealed class HashiCorpEntityEncryptionKeyStoreTests
+{
+    private readonly IVaultClient _vaultClient;
+    private readonly IKeyValueSecretsEngineV2 _kvV2;
+    private readonly HashiCorpEntityEncryptionKeyStore _sut;
+
+    public HashiCorpEntityEncryptionKeyStoreTests()
+    {
+        _vaultClient = Substitute.For<IVaultClient>();
+        _kvV2 = Substitute.For<IKeyValueSecretsEngineV2>();
+
+        IVaultClientV1 v1 = Substitute.For<IVaultClientV1>();
+        ISecretsEngine secrets = Substitute.For<ISecretsEngine>();
+        IKeyValueSecretsEngine kv = Substitute.For<IKeyValueSecretsEngine>();
+
+        _vaultClient.V1.Returns(v1);
+        v1.Secrets.Returns(secrets);
+        secrets.KeyValue.Returns(kv);
+        kv.V2.Returns(_kvV2);
+
+        IOptions<HashiCorpVaultOptions> options = Microsoft.Extensions.Options.Options.Create(new HashiCorpVaultOptions
+        {
+            KvMountPoint = "secret"
+        });
+
+        _sut = new HashiCorpEntityEncryptionKeyStore(
+            _vaultClient,
+            options,
+            NullLogger<HashiCorpEntityEncryptionKeyStore>.Instance);
+    }
+
+    [Fact]
+    public async Task GetOrCreateKeyAsync_WhenKeyDoesNotExist_CreatesNewKey()
+    {
+        _kvV2.ReadSecretAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>())
+            .ThrowsAsync(new VaultApiException(HttpStatusCode.NotFound, "not found"));
+
+        byte[] key = await _sut.GetOrCreateKeyAsync("Patient", "abc-123", TestContext.Current.CancellationToken);
+
+        key.ShouldNotBeNull();
+        key.Length.ShouldBe(32, "Should generate a 32-byte AES-256 key");
+
+        await _kvV2.Received(1).WriteSecretAsync(
+            "granit/encryption/isolated/Patient/abc-123",
+            Arg.Any<IDictionary<string, object>>(),
+            Arg.Any<int?>(),
+            Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task GetOrCreateKeyAsync_WhenKeyExists_ReturnsExistingKey()
+    {
+        byte[] existingKey = new byte[32];
+        Random.Shared.NextBytes(existingKey);
+        string base64Key = Convert.ToBase64String(existingKey);
+
+        Secret<SecretData> secret = CreateSecretData(new Dictionary<string, object>
+        {
+            ["key"] = base64Key
+        });
+
+        _kvV2.ReadSecretAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>())
+            .Returns(Task.FromResult(secret));
+
+        byte[] key = await _sut.GetOrCreateKeyAsync("Patient", "abc-123", TestContext.Current.CancellationToken);
+
+        key.ShouldBe(existingKey);
+
+        await _kvV2.DidNotReceive().WriteSecretAsync(
+            Arg.Any<string>(), Arg.Any<IDictionary<string, object>>(),
+            Arg.Any<int?>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task GetKeyAsync_WhenKeyDoesNotExist_ReturnsNull()
+    {
+        _kvV2.ReadSecretAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>())
+            .ThrowsAsync(new VaultApiException(HttpStatusCode.NotFound, "not found"));
+
+        byte[]? key = await _sut.GetKeyAsync("Patient", "abc-123", TestContext.Current.CancellationToken);
+
+        key.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetKeyAsync_WhenKeyExists_ReturnsCachedOnSecondCall()
+    {
+        byte[] existingKey = new byte[32];
+        Random.Shared.NextBytes(existingKey);
+
+        Secret<SecretData> secret = CreateSecretData(new Dictionary<string, object>
+        {
+            ["key"] = Convert.ToBase64String(existingKey)
+        });
+
+        _kvV2.ReadSecretAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>())
+            .Returns(Task.FromResult(secret));
+
+        // First call — reads from Vault
+        byte[]? key1 = await _sut.GetKeyAsync("Patient", "abc-123", TestContext.Current.CancellationToken);
+        // Second call — should be cached
+        byte[]? key2 = await _sut.GetKeyAsync("Patient", "abc-123", TestContext.Current.CancellationToken);
+
+        key1.ShouldBe(existingKey);
+        key2.ShouldBe(existingKey);
+
+        // Only one Vault read
+        await _kvV2.Received(1).ReadSecretAsync(
+            Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task DeleteKeyAsync_CallsDeleteMetadataAsync()
+    {
+        await _sut.DeleteKeyAsync("Patient", "abc-123", TestContext.Current.CancellationToken);
+
+        await _kvV2.Received(1).DeleteMetadataAsync(
+            "granit/encryption/isolated/Patient/abc-123",
+            Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task DeleteKeyAsync_EvictsCacheEntry()
+    {
+        byte[] existingKey = new byte[32];
+        Random.Shared.NextBytes(existingKey);
+
+        Secret<SecretData> secret = CreateSecretData(new Dictionary<string, object>
+        {
+            ["key"] = Convert.ToBase64String(existingKey)
+        });
+
+        _kvV2.ReadSecretAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>())
+            .Returns(Task.FromResult(secret));
+
+        // Populate cache
+        await _sut.GetKeyAsync("Patient", "abc-123", TestContext.Current.CancellationToken);
+
+        // Delete — should evict cache
+        await _sut.DeleteKeyAsync("Patient", "abc-123", TestContext.Current.CancellationToken);
+
+        // After delete, reading from Vault again (returns 404)
+        _kvV2.ReadSecretAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>())
+            .ThrowsAsync(new VaultApiException(HttpStatusCode.NotFound, "not found"));
+
+        byte[]? key = await _sut.GetKeyAsync("Patient", "abc-123", TestContext.Current.CancellationToken);
+        key.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task KeyExistsAsync_ReturnsTrue_WhenKeyExists()
+    {
+        Secret<SecretData> secret = CreateSecretData(new Dictionary<string, object>
+        {
+            ["key"] = Convert.ToBase64String(new byte[32])
+        });
+
+        _kvV2.ReadSecretAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>())
+            .Returns(Task.FromResult(secret));
+
+        bool exists = await _sut.KeyExistsAsync("Patient", "abc-123", TestContext.Current.CancellationToken);
+
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task KeyExistsAsync_ReturnsFalse_WhenKeyDoesNotExist()
+    {
+        _kvV2.ReadSecretAsync(Arg.Any<string>(), Arg.Any<int?>(), Arg.Any<string>())
+            .ThrowsAsync(new VaultApiException(HttpStatusCode.NotFound, "not found"));
+
+        bool exists = await _sut.KeyExistsAsync("Patient", "abc-123", TestContext.Current.CancellationToken);
+
+        exists.ShouldBeFalse();
+    }
+
+    private static Secret<SecretData> CreateSecretData(Dictionary<string, object> data) =>
+        new()
+        {
+            Data = new SecretData
+            {
+                Data = data
+            }
+        };
+}


### PR DESCRIPTION
## Summary

- **GDPR Art. 17 crypto-shredding**: permanently erase sensitive data by destroying per-entity encryption keys in Vault KV v2, while preserving database rows for audit trails and legal holds
- **Per-entity key isolation** via `[Encrypted(KeyIsolation = true)]` — each entity instance gets its own AES-256 key, enabling selective erasure without affecting other records
- **Privacy module integration**: new `DeletionAction.CryptoShredding` enum value for the GDPR deletion workflow
- **ISO 27001 audit trail**: `ICryptoShreddingAuditRecorder` extension point for immutable key destruction records
- **Comprehensive Starlight documentation** (660 lines, 3 Mermaid diagrams) covering the regulatory context, architecture, setup, and integration patterns

### New abstractions (`Granit.Encryption`)

| Type | Purpose |
|------|---------|
| `IEntityEncryptionKeyStore` | Per-entity key CRUD (GetOrCreate / Get / Delete / KeyExists) |
| `ICryptoShredder` | `ShredAsync` + `ShredBatchAsync` for GDPR Art. 17 |
| `ICryptoShreddingAuditRecorder` | Extension point for ISO 27001 audit trail |
| `DefaultCryptoShredder` | Delegates to key store + notifies audit recorders |
| `EncryptionMetrics` / `EncryptionActivitySource` | Observability (counters + tracing) |

### EF Core integration (`Granit.Encryption.EntityFrameworkCore`)

| Type | Purpose |
|------|---------|
| `EncryptionIsolationSaveChangesInterceptor` | Encrypts isolated properties on save |
| `EncryptionIsolationMaterializationInterceptor` | Decrypts on read; returns null for shredded entities |
| `IsolatedFieldEncryptor` | AES-256-CBC + HMAC-SHA256 with per-entity key |
| `UseGranitEncryptionInterceptors(sp)` | DbContext options extension |

### Vault provider (`Granit.Vault.HashiCorp`)

- `HashiCorpEntityEncryptionKeyStore` — Vault KV v2 with in-memory cache
- `KvMountPoint` option added to `HashiCorpVaultOptions`

Closes #146, #148, #149, #151, #153

## Test plan

- [x] 31 new unit tests across 4 projects — all passing
- [x] `dotnet build` — full solution, 0 errors, 0 warnings
- [x] `dotnet format --verify-no-changes` — clean
- [x] `npx astro build` — docs site builds (only pre-existing BFF link error)
- [x] Architecture tests pass (73/73)
- [ ] CI pipeline validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
