### PR TITLE
feat(openiddict): add Pushed Authorization Requests support (RFC 9126) (#600)

### DIFF
--- a/docs-site/src/content/docs/blog/crypto-shredding-gdpr-erasure-without-deleting-rows.md
+++ b/docs-site/src/content/docs/blog/crypto-shredding-gdpr-erasure-without-deleting-rows.md
@@ -1,0 +1,186 @@
+---
+title: "Crypto-Shredding: GDPR Erasure Without Deleting a Single Row"
+date: 2026-03-24
+sidebar:
+  order: 12
+authors:
+  - jfmeyers
+tags:
+  - security
+  - compliance
+  - deep-dive
+description: "Destroy the encryption key, not the data. How Granit implements GDPR Art. 17 crypto-shredding with per-entity key isolation — one API call, permanent erasure, zero rows deleted."
+excerpt: >
+  Physical deletion breaks audit trails, conflicts with legal holds, and fails on
+  append-only systems. Crypto-shredding solves all three: destroy the key, and the
+  ciphertext becomes random noise. Here is how Granit implements it.
+---
+
+Your DPO sends you a ticket: "Patient #4821 exercised their right to erasure. All personal data must be irreversibly deleted within 30 days." You open your ORM, write a `DELETE`, and ship it.
+
+Six months later, during an ISO 27001 audit, someone asks: "Where is the audit trail for patient #4821?" You stare at the screen. The row is gone. The foreign keys cascaded. The timeline entries that referenced this patient now point to nothing. The auditor writes a finding.
+
+**You satisfied one regulation by violating another.**
+
+This is not a hypothetical edge case. It is the default outcome when you treat GDPR erasure as a SQL `DELETE`. In this post, I will explain why physical deletion is architecturally hostile to compliance, and how **crypto-shredding** — destroying encryption keys instead of data — resolves the contradiction.
+
+## The impossible triangle
+
+GDPR Article 17 demands **erasure**. ISO 27001 demands **immutable audit trails**. Your legal team demands **data retention** during active litigation. You cannot satisfy all three with a `DELETE` statement.
+
+| Obligation | What it requires | What `DELETE` does |
+| ---------- | ---------------- | ------------------ |
+| GDPR Art. 17 | Irreversible erasure of personal data | Satisfies (row gone) |
+| ISO 27001 A.8.15 | Immutable, traceable audit trail | **Violates** (evidence destroyed) |
+| Legal hold | Retain data until litigation ends | **Violates** (data gone) |
+| Backup consistency | Erasure must cover all copies | **Fails** (backup still has it) |
+
+Soft delete (`IsDeleted = true`) is not erasure — an admin can still read the data, and regulators know it. Anonymization (replacing PII with "REDACTED") works in some cases but fails when backups retain the original values, and the replacement quality is hard to verify.
+
+**Crypto-shredding** breaks the triangle by redefining what "erasure" means. If data is encrypted with a unique key and you permanently destroy that key, the ciphertext is mathematically equivalent to random noise. The row stays. The audit trail stays. The foreign keys stay. But the personal data is gone — permanently, provably, irreversibly.
+
+The **European Data Protection Board** (Guidelines 5/2019), the **UK ICO**, and the **French CNIL** all recognize this as valid erasure, provided the encryption is strong (AES-256), the key destruction is irreversible, and the destruction is auditable.
+
+## The key insight: one key per entity
+
+Standard field-level encryption uses a **shared key ring** — the same key encrypts every patient's SSN. Destroying that key would make every patient's data unreadable. That is not targeted erasure. That is a catastrophe.
+
+Crypto-shredding requires **per-entity key isolation**: each entity instance gets its own encryption key. When patient #4821 exercises their right to erasure, you destroy only their key. Every other patient's data remains perfectly readable.
+
+In Granit, this is a single attribute:
+
+```csharp title="Patient.cs"
+public sealed class Patient : AuditedAggregateRoot
+{
+    public string LastName { get; private set; } = string.Empty;
+
+    [Encrypted]
+    public string NationalId { get; private set; } = string.Empty;       // shared key
+
+    [Encrypted(KeyIsolation = true)]
+    public string MedicalNotes { get; private set; } = string.Empty;     // per-entity key
+
+    [Encrypted(KeyIsolation = true)]
+    public string? DiagnosisCode { get; private set; }                   // per-entity key
+}
+```
+
+`NationalId` uses shared encryption — fast, simple, supports key rotation via `IReEncryptionJob`. `MedicalNotes` and `DiagnosisCode` use isolated keys — each patient has their own AES-256 key stored in HashiCorp Vault KV v2. When you shred patient #4821, only their medical notes and diagnosis become unreadable. Their `NationalId` (shared key) and `LastName` (plaintext) are unaffected.
+
+**Use key isolation only for properties that need individual erasure.** It is heavier than shared encryption — one Vault KV secret per entity instance. Choose deliberately.
+
+## How it works under the hood
+
+The technical challenge is subtle. EF Core value converters receive a scalar value — they have no access to the entity type or ID. But per-entity key isolation needs `{EntityType}:{EntityId}` to look up the right key.
+
+Granit solves this with **two EF Core interceptors**, not a value converter:
+
+**On write** (`EncryptionIsolationSaveChangesInterceptor`): iterates the change tracker, finds entities with `[Encrypted(KeyIsolation = true)]` properties, calls `IEntityEncryptionKeyStore.GetOrCreateKeyAsync(entityType, entityId)` to get (or generate) the per-entity AES-256 key, encrypts in-place, and saves.
+
+**On read** (`EncryptionIsolationMaterializationInterceptor`): after EF Core materializes an entity, checks for isolated properties, retrieves the key from the store, and decrypts in-place. If the key is gone (shredded), the property is set to `null`.
+
+The interceptors must run **after** `AuditedEntityInterceptor` (which assigns entity IDs). One line in your `DbContext` setup ensures correct ordering:
+
+```csharp title="AppDbContext setup"
+options.UseGranitInterceptors(sp);              // audit, versioning, soft delete
+options.UseGranitEncryptionInterceptors(sp);    // encryption isolation (must be after)
+```
+
+## Shredding in practice
+
+When the Privacy module's deletion saga reaches its deadline, it publishes `PersonalDataDeletionRequestedEto`. Your data provider handler catches it and calls `ICryptoShredder`:
+
+```csharp title="PatientDeletionHandler.cs"
+public sealed class PatientDeletionHandler(ICryptoShredder shredder)
+{
+    public async Task<PersonalDataDeletedEto> HandleAsync(
+        PersonalDataDeletionRequestedEto request,
+        AppDbContext db,
+        CancellationToken cancellationToken)
+    {
+        List<string> patientIds = await db.Patients
+            .Where(p => p.CreatedBy == request.UserId.ToString())
+            .Select(p => p.Id.ToString())
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        await shredder.ShredBatchAsync("Patient", patientIds, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new PersonalDataDeletedEto(
+            request.RequestId, "PatientModule",
+            DeletionAction.CryptoShredding, patientIds.Count,
+            DateTimeOffset.UtcNow);
+    }
+}
+```
+
+`ShredBatchAsync` calls `IEntityEncryptionKeyStore.DeleteKeyAsync` for each entity, which permanently destroys the Vault KV secret (metadata delete — all versions gone, no recovery). Then it notifies all registered `ICryptoShreddingAuditRecorder` implementations to write an immutable `SystemLog` entry in the Timeline.
+
+After shredding, reading patient #4821 returns:
+
+```csharp
+var patient = await db.Patients.FindAsync([patientId], cancellationToken);
+
+patient.MedicalNotes;   // null — key destroyed
+patient.DiagnosisCode;  // null — key destroyed
+patient.NationalId;     // still readable — shared key, not shredded
+patient.LastName;       // still readable — not encrypted
+```
+
+The row is intact. The audit trail is intact. The compliance officer is satisfied. And the PII is mathematically gone.
+
+## The audit trail closes the loop
+
+ISO 27001 A.10.1.2 requires traceability of key destruction. `DefaultCryptoShredder` automatically calls all registered `ICryptoShreddingAuditRecorder` implementations after each key deletion. Granit's Timeline module provides the natural storage for these records:
+
+```csharp title="TimelineCryptoShreddingRecorder.cs"
+public sealed class TimelineCryptoShreddingRecorder(
+    ITimelineWriter writer) : ICryptoShreddingAuditRecorder
+{
+    public async Task RecordAsync(
+        string entityType, string entityId,
+        DateTimeOffset shreddedAt,
+        CancellationToken cancellationToken = default)
+    {
+        await writer.PostEntryAsync(
+            entityType, entityId,
+            TimelineEntryType.SystemLog,
+            $"Encryption key destroyed at {shreddedAt:O}",
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+}
+```
+
+`TimelineEntryType.SystemLog` entries are **immutable** — the Timeline module rejects deletion attempts. Even a database administrator cannot erase the evidence that key destruction occurred. The auditor finds a clean, timestamped trail.
+
+## When to use it — and when not to
+
+Crypto-shredding is the right choice when:
+
+- You have **immutable storage** (event sourcing, WORM, Kafka) where physical deletion is impossible
+- You need to satisfy **both erasure and retention** simultaneously (GDPR + legal hold)
+- You need **granular erasure** — one patient, not the entire table
+- **Backups are a concern** — ciphertext in backups is useless without the key
+
+Skip it when:
+
+- **Physical deletion is sufficient** for your compliance requirements — it is simpler
+- The data is **not PII** — key isolation adds Vault overhead per entity
+- **Anonymization** is acceptable and cheaper for your use case
+- You have **very high read throughput** on encrypted fields — the materialization interceptor adds per-entity lookups (mitigated by caching, but still more than shared encryption)
+
+## Key takeaways
+
+- **Physical deletion satisfies GDPR but violates ISO 27001.** You need both.
+- **Crypto-shredding** destroys the encryption key, not the data. The row stays, the PII is gone.
+- **Per-entity key isolation** (`[Encrypted(KeyIsolation = true)]`) gives each entity its own AES-256 key in Vault KV.
+- **`ICryptoShredder.ShredAsync`** destroys the key in one API call. The ciphertext becomes random noise.
+- **The audit trail is automatic.** `ICryptoShreddingAuditRecorder` writes immutable `SystemLog` entries.
+
+## Further reading
+
+- [Crypto-Shredding module reference](/dotnet/security/crypto-shredding/) — setup, API reference, Vault KV structure
+- [Field-level Encryption](/dotnet/security/encryption/) — shared key encryption, `[Encrypted]` attribute, key rotation
+- [Privacy module](/dotnet/security/privacy/) — GDPR deletion saga, cooling-off period, `DeletionAction`
+- [GDPR by Design](/blog/gdpr-by-design/) — broader privacy patterns in Granit

--- a/docs-site/src/content/docs/blog/from-zero-to-crud.md
+++ b/docs-site/src/content/docs/blog/from-zero-to-crud.md
@@ -1,6 +1,8 @@
 ---
 title: "From Zero to CRUD in 10 Minutes with Granit"
 date: 2026-03-07
+sidebar:
+  order: 8
 authors:
   - jfmeyers
 tags:

--- a/docs-site/src/content/docs/blog/gdpr-by-design.md
+++ b/docs-site/src/content/docs/blog/gdpr-by-design.md
@@ -1,6 +1,8 @@
 ---
 title: "GDPR by Design: Privacy Patterns in a .NET Framework"
 date: 2026-02-25
+sidebar:
+  order: 5
 authors:
   - jfmeyers
 tags:

--- a/docs-site/src/content/docs/blog/generated-regex-is-not-optional.md
+++ b/docs-site/src/content/docs/blog/generated-regex-is-not-optional.md
@@ -1,6 +1,8 @@
 ---
 title: "[GeneratedRegex] Is Not Optional — Compiled Regex Is Dead"
 date: 2026-02-21
+sidebar:
+  order: 4
 authors:
   - jfmeyers
 tags:

--- a/docs-site/src/content/docs/blog/guard-clauses-done-right.md
+++ b/docs-site/src/content/docs/blog/guard-clauses-done-right.md
@@ -1,6 +1,8 @@
 ---
 title: "Guard Clauses Done Right"
 date: 2026-02-28
+sidebar:
+  order: 6
 authors:
   - jfmeyers
 tags:

--- a/docs-site/src/content/docs/blog/introducing-granit.mdx
+++ b/docs-site/src/content/docs/blog/introducing-granit.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Introducing Granit: A Modular Framework for .NET 10"
 date: 2026-03-04
+sidebar:
+  order: 7
 authors:
   - jfmeyers
 tags:

--- a/docs-site/src/content/docs/blog/isolated-dbcontext-per-module.md
+++ b/docs-site/src/content/docs/blog/isolated-dbcontext-per-module.md
@@ -1,6 +1,8 @@
 ---
 title: "Isolated DbContext Per Module: Why and How"
 date: 2026-02-18
+sidebar:
+  order: 3
 authors:
   - jfmeyers
 tags:

--- a/docs-site/src/content/docs/blog/never-return-ef-entities.md
+++ b/docs-site/src/content/docs/blog/never-return-ef-entities.md
@@ -1,6 +1,8 @@
 ---
 title: "Never Return Your EF Entities From an API"
 date: 2026-03-14
+sidebar:
+  order: 10
 authors:
   - jfmeyers
 tags:

--- a/docs-site/src/content/docs/blog/stop-using-datetime-now.md
+++ b/docs-site/src/content/docs/blog/stop-using-datetime-now.md
@@ -1,6 +1,8 @@
 ---
 title: "Stop Using DateTime.Now — Inject TimeProvider Instead"
 date: 2026-02-14
+sidebar:
+  order: 2
 authors:
   - jfmeyers
 tags:

--- a/docs-site/src/content/docs/blog/why-modular-monolith.mdx
+++ b/docs-site/src/content/docs/blog/why-modular-monolith.mdx
@@ -1,6 +1,8 @@
 ---
 title: Why We Chose Modular Monolith Over Microservices
 date: 2026-02-11
+sidebar:
+  order: 1
 authors:
   - jfmeyers
 tags:

--- a/docs-site/src/content/docs/blog/why-your-react-app-should-never-touch-an-access-token.mdx
+++ b/docs-site/src/content/docs/blog/why-your-react-app-should-never-touch-an-access-token.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Why Your React App Should Never Touch an Access Token"
 date: 2026-03-22
+sidebar:
+  order: 11
 authors:
   - jfmeyers
 tags:

--- a/docs-site/src/content/docs/blog/zero-circular-dependencies.mdx
+++ b/docs-site/src/content/docs/blog/zero-circular-dependencies.mdx
@@ -1,6 +1,8 @@
 ---
 title: "100+ Packages, Zero Circular Dependencies — How We Enforce a Strict DAG"
 date: 2026-03-11
+sidebar:
+  order: 9
 authors:
   - jfmeyers
 tags:

--- a/docs-site/src/content/docs/dotnet/security/bff/architecture.mdx
+++ b/docs-site/src/content/docs/dotnet/security/bff/architecture.mdx
@@ -293,7 +293,7 @@ A clear picture of where each piece of sensitive data resides:
 <Aside type="caution" title="Encryption at rest">
 The default `DistributedCacheBffTokenStore` uses `IDistributedCache` directly.
 For production deployments, enable Redis TLS and consider integrating
-[`Granit.Caching`](/dotnet/infrastructure/caching/) with `ICacheValueEncryptor`
+[`Granit.Caching`](/dotnet/data/caching/) with `ICacheValueEncryptor`
 (AES-256-CBC) for encryption at rest. See the
 [Security](/dotnet/security/bff/security/) page for details.
 </Aside>

--- a/docs-site/src/content/docs/dotnet/security/bff/configuration.mdx
+++ b/docs-site/src/content/docs/dotnet/security/bff/configuration.mdx
@@ -82,6 +82,7 @@ Bind from the `Bff` configuration section. Section name constant: `GranitBffOpti
 | `RefreshGracePeriod` | `TimeSpan` | `00:01:00` (1 minute) | Access token is refreshed this long before expiry. |
 | `PostLoginRedirectPath` | `string` | `"/"` | Path to redirect to after successful login. |
 | `PostLogoutRedirectPath` | `string` | `"/"` | Path to redirect to after logout. |
+| `UsePushedAuthorizationRequests` | `bool` | `false` | Use Pushed Authorization Requests (RFC 9126). When `true`, the BFF posts authorization parameters to `/connect/par` and redirects with only the `request_uri`. Requires the OIDC server to support PAR. |
 
 ### Configuration binding
 

--- a/docs-site/src/content/docs/dotnet/security/openiddict/configuration.mdx
+++ b/docs-site/src/content/docs/dotnet/security/openiddict/configuration.mdx
@@ -16,6 +16,7 @@ import { Tabs, TabItem, Badge } from "@astrojs/starlight/components";
     "Issuer": "https://auth.example.com",
     "UseReferenceTokens": false,
     "EnableEntityCaching": false,
+    "RequirePar": false,
 
     "Client": {
       "AutoRegisterExternalUsers": true,
@@ -101,6 +102,7 @@ environment variables. Never commit secrets to source control.
 | `Issuer` | `Uri?` | `null` | Explicit OIDC issuer URI. When `null`, the issuer is inferred from the incoming request URL. Set explicitly for multi-node deployments behind a load balancer. |
 | `UseReferenceTokens` | `bool` | `false` | Issue opaque reference tokens instead of self-contained JWTs. Reference tokens are validated against the database on every API request, enabling instant revocation. Required for SOC2 / ISO 27001 strict compliance. Trade-off: +1 DB round-trip per API call. |
 | `EnableEntityCaching` | `bool` | `false` | Enable OpenIddict's built-in entity caching. **Disable in multi-tenant deployments** -- the cache uses `ClientId` as the sole key, which causes cross-tenant pollution when two tenants have the same `ClientId`. |
+| `RequirePar` | `bool` | `false` | Require Pushed Authorization Requests (RFC 9126) for all authorization code flows. The `/connect/par` endpoint is always available; when `true`, direct authorization requests without a `request_uri` are rejected. Required for FAPI 2.0 compliance. |
 
 **Example:**
 
@@ -109,7 +111,8 @@ environment variables. Never commit secrets to source control.
   "OpenIddict": {
     "Issuer": "https://auth.example.com",
     "UseReferenceTokens": false,
-    "EnableEntityCaching": false
+    "EnableEntityCaching": false,
+    "RequirePar": false
   }
 }
 ```

--- a/docs-site/src/content/docs/dotnet/security/openiddict/oidc-server.mdx
+++ b/docs-site/src/content/docs/dotnet/security/openiddict/oidc-server.mdx
@@ -14,13 +14,14 @@ the supported flows, endpoints, token formats, and signing key management.
 
 ## Endpoints
 
-The server exposes 8 standard endpoints, registered automatically by
+The server exposes 9 standard endpoints, registered automatically by
 `AddGranitOpenIddictEntityFrameworkCore()`:
 
 | Endpoint | Path | Specification | Passthrough |
 |----------|------|---------------|-------------|
 | Authorization | `/connect/authorize` | RFC 6749 S3.1 | Yes |
 | Token | `/connect/token` | RFC 6749 S3.2 | Yes |
+| Pushed Authorization | `/connect/par` | RFC 9126 | No |
 | UserInfo | `/connect/userinfo` | OIDC Core S5.3 | Yes |
 | Introspection | `/connect/introspect` | RFC 7662 | No |
 | Revocation | `/connect/revoke` | RFC 7009 | No |
@@ -86,6 +87,49 @@ Two custom grant types are registered for advanced authentication scenarios:
 
 These grants are processed by custom handlers in the host application and follow
 the standard OAuth 2.0 token endpoint pattern.
+
+### Pushed Authorization Requests (PAR)
+
+The server supports Pushed Authorization Requests (RFC 9126). PAR moves
+authorization parameters from the browser URL to a back-channel POST request,
+preventing parameter tampering and PII leakage in URLs.
+
+```text
+Client --> POST /connect/par (client_id, client_secret, all auth params)
+  <-- 201 Created { request_uri, expires_in }
+Client --> GET /connect/authorize?client_id=...&request_uri=...
+  --> Standard authorization code flow continues
+```
+
+The `/connect/par` endpoint is **always available** — clients can use it without
+any additional configuration. To **require** PAR for all authorization requests
+(rejecting direct requests without a `request_uri`), set `RequirePar`:
+
+```json
+{
+  "OpenIddict": {
+    "RequirePar": true
+  }
+}
+```
+
+When using the BFF module, enable PAR on the frontend configuration:
+
+```json
+{
+  "Bff": {
+    "Frontends": [
+      {
+        "Name": "main",
+        "UsePushedAuthorizationRequests": true
+      }
+    ]
+  }
+}
+```
+
+PAR is required by the **FAPI 2.0 Security Profile** for open banking,
+healthcare, and other high-security industries.
 
 ## Scopes
 

--- a/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
@@ -31,8 +31,9 @@ internal static partial class BffLoginEndpoints
                 [FromServices] IOptions<GranitBffOptions> options,
                 [FromServices] IDistributedCache cache,
                 [FromServices] IClock clock,
+                [FromServices] IHttpClientFactory httpClientFactory,
                 [FromServices] ILoggerFactory loggerFactory) =>
-                HandleLoginAsync(httpContext, frontend, options, cache, clock, loggerFactory))
+                HandleLoginAsync(httpContext, frontend, options, cache, clock, httpClientFactory, loggerFactory))
             .WithName($"BffLogin_{frontend.Name}")
             .WithSummary("Initiates OIDC login with PKCE and redirects to the authority.")
             .WithDescription(
@@ -77,6 +78,7 @@ internal static partial class BffLoginEndpoints
         [FromServices] IOptions<GranitBffOptions> options,
         [FromServices] IDistributedCache cache,
         [FromServices] IClock clock,
+        [FromServices] IHttpClientFactory httpClientFactory,
         [FromServices] ILoggerFactory loggerFactory)
     {
         ILogger logger = loggerFactory.CreateLogger("Granit.Bff.Endpoints.BffLoginEndpoints");
@@ -108,14 +110,36 @@ internal static partial class BffLoginEndpoints
         string scopes = string.Join(" ", frontend.Scopes);
         string pathPrefix = string.IsNullOrEmpty(frontend.PathPrefix) ? "" : frontend.PathPrefix;
         string callbackUrl = $"{httpContext.Request.Scheme}://{httpContext.Request.Host}{pathPrefix}/bff/callback";
-        string authorizeUrl = $"{bffOptions.Authority.ToString().TrimEnd('/')}/connect/authorize"
-            + $"?client_id={Uri.EscapeDataString(frontend.ClientId)}"
-            + $"&response_type=code"
-            + $"&redirect_uri={Uri.EscapeDataString(callbackUrl)}"
-            + $"&scope={Uri.EscapeDataString(scopes)}"
-            + $"&state={Uri.EscapeDataString(state)}"
-            + $"&code_challenge={Uri.EscapeDataString(codeChallenge)}"
-            + $"&code_challenge_method=S256";
+        string authorityBase = bffOptions.Authority.ToString().TrimEnd('/');
+
+        string authorizeUrl;
+
+        if (frontend.UsePushedAuthorizationRequests)
+        {
+            // PAR: push parameters to /connect/par, then redirect with request_uri only
+            string? requestUri = await PushAuthorizationRequestAsync(
+                httpClientFactory, authorityBase, frontend, callbackUrl, scopes, state,
+                codeChallenge, logger).ConfigureAwait(false);
+
+            if (requestUri is not null)
+            {
+                authorizeUrl = $"{authorityBase}/connect/authorize"
+                    + $"?client_id={Uri.EscapeDataString(frontend.ClientId)}"
+                    + $"&request_uri={Uri.EscapeDataString(requestUri)}";
+            }
+            else
+            {
+                // PAR failed — fall back to direct parameters
+                LogParFallback(logger, frontend.Name);
+                authorizeUrl = BuildDirectAuthorizeUrl(
+                    authorityBase, frontend.ClientId, callbackUrl, scopes, state, codeChallenge);
+            }
+        }
+        else
+        {
+            authorizeUrl = BuildDirectAuthorizeUrl(
+                authorityBase, frontend.ClientId, callbackUrl, scopes, state, codeChallenge);
+        }
 #pragma warning restore GRSEC003
 
         LogLoginRedirect(logger, bffOptions.Authority.ToString(), frontend.Name);
@@ -271,6 +295,87 @@ internal static partial class BffLoginEndpoints
     }
 #pragma warning restore GRSEC003
 
+    private static string BuildDirectAuthorizeUrl(
+        string authorityBase, string clientId, string callbackUrl,
+        string scopes, string state, string codeChallenge) =>
+        $"{authorityBase}/connect/authorize"
+            + $"?client_id={Uri.EscapeDataString(clientId)}"
+            + $"&response_type=code"
+            + $"&redirect_uri={Uri.EscapeDataString(callbackUrl)}"
+            + $"&scope={Uri.EscapeDataString(scopes)}"
+            + $"&state={Uri.EscapeDataString(state)}"
+            + $"&code_challenge={Uri.EscapeDataString(codeChallenge)}"
+            + $"&code_challenge_method=S256";
+
+#pragma warning disable GRSEC003 // Method handles client credentials for PAR — server-side only
+    private static async Task<string?> PushAuthorizationRequestAsync(
+        IHttpClientFactory httpClientFactory,
+        string authorityBase,
+        BffFrontendOptions frontend,
+        string callbackUrl,
+        string scopes,
+        string state,
+        string codeChallenge,
+        ILogger logger)
+    {
+        try
+        {
+            using HttpClient httpClient = httpClientFactory.CreateClient("Granit.Bff");
+            string parEndpoint = $"{authorityBase}/connect/par";
+
+            Dictionary<string, string> parameters = new()
+            {
+                ["client_id"] = frontend.ClientId,
+                ["client_secret"] = frontend.ClientSecret,
+                ["response_type"] = "code",
+                ["redirect_uri"] = callbackUrl,
+                ["scope"] = scopes,
+                ["state"] = state,
+                ["code_challenge"] = codeChallenge,
+                ["code_challenge_method"] = "S256",
+            };
+
+            using FormUrlEncodedContent content = new(parameters);
+            using HttpResponseMessage response = await httpClient
+                .PostAsync(parEndpoint, content)
+                .ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                LogParRequestFailed(logger, (int)response.StatusCode, frontend.Name);
+                return null;
+            }
+
+            using Stream stream = await response.Content.ReadAsStreamAsync()
+                .ConfigureAwait(false);
+
+            JsonElement parResponse = await JsonSerializer.DeserializeAsync<JsonElement>(stream)
+                .ConfigureAwait(false);
+
+            string? requestUri = parResponse.TryGetProperty("request_uri", out JsonElement ru)
+                ? ru.GetString() : null;
+
+            if (string.IsNullOrEmpty(requestUri))
+            {
+                LogParMissingRequestUri(logger, frontend.Name);
+                return null;
+            }
+
+            LogParSuccess(logger, frontend.Name);
+            return requestUri;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogParException(logger, ex, frontend.Name);
+            return null;
+        }
+    }
+#pragma warning restore GRSEC003
+
     private static string GenerateCodeVerifier()
     {
         byte[] bytes = RandomNumberGenerator.GetBytes(CodeVerifierLength);
@@ -304,4 +409,19 @@ internal static partial class BffLoginEndpoints
 
     [LoggerMessage(Level = LogLevel.Information, Message = "BFF login successful, session {SessionId} created for frontend {FrontendName}")]
     private static partial void LogLoginSuccess(ILogger logger, string sessionId, string frontendName);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "BFF PAR: pushed authorization request accepted for frontend {FrontendName}")]
+    private static partial void LogParSuccess(ILogger logger, string frontendName);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "BFF PAR: request failed with status {StatusCode} for frontend {FrontendName}, falling back to direct parameters")]
+    private static partial void LogParRequestFailed(ILogger logger, int statusCode, string frontendName);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "BFF PAR: response missing request_uri for frontend {FrontendName}")]
+    private static partial void LogParMissingRequestUri(ILogger logger, string frontendName);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "BFF PAR: falling back to direct parameters for frontend {FrontendName}")]
+    private static partial void LogParFallback(ILogger logger, string frontendName);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "BFF PAR: exception during pushed authorization request for frontend {FrontendName}")]
+    private static partial void LogParException(ILogger logger, Exception exception, string frontendName);
 }

--- a/src/Granit.Bff/Options/GranitBffOptions.cs
+++ b/src/Granit.Bff/Options/GranitBffOptions.cs
@@ -88,5 +88,17 @@ public sealed class BffFrontendOptions
     /// </summary>
     public string EffectivePostLogoutRedirectPath =>
         PostLogoutRedirectPath ?? (string.IsNullOrEmpty(PathPrefix) ? "/" : $"{PathPrefix}/");
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the BFF should use Pushed Authorization
+    /// Requests (RFC 9126) when initiating the OIDC login flow.
+    /// </summary>
+    /// <remarks>
+    /// When <see langword="true"/>, the BFF posts authorization parameters to the
+    /// <c>/connect/par</c> endpoint and redirects the user with only the
+    /// <c>request_uri</c>. Requires the OIDC server to support PAR.
+    /// Default: <see langword="false"/>.
+    /// </remarks>
+    public bool UsePushedAuthorizationRequests { get; set; }
 }
 #pragma warning restore GRSEC003

--- a/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
@@ -44,7 +44,8 @@ public static class OpenIddictServerHostApplicationBuilderExtensions
                 .SetRevocationEndpointUris("/connect/revoke")
                 .SetEndSessionEndpointUris("/connect/logout")
                 .SetDeviceAuthorizationEndpointUris("/connect/device")
-                .SetEndUserVerificationEndpointUris("/connect/verify");
+                .SetEndUserVerificationEndpointUris("/connect/verify")
+                .SetPushedAuthorizationEndpointUris("/connect/par");
 
             // ──── Flows ────
             options
@@ -55,6 +56,12 @@ public static class OpenIddictServerHostApplicationBuilderExtensions
 
             // PKCE required by default (can be relaxed per-application)
             options.RequireProofKeyForCodeExchange();
+
+            // PAR enforcement (optional — endpoint is always available via SetPushedAuthorizationEndpointUris)
+            if (granitOptions.RequirePar)
+            {
+                options.RequirePushedAuthorizationRequests();
+            }
 
             // ──── Signing & encryption ────
             // Development keys — host application MUST replace with production keys

--- a/src/Granit.OpenIddict/OpenIddictFeatureNames.cs
+++ b/src/Granit.OpenIddict/OpenIddictFeatureNames.cs
@@ -33,4 +33,10 @@ public static class OpenIddictFeatureNames
     /// Enables passwordless authentication via WebAuthn/FIDO2 passkeys. Default: <see langword="false"/>.
     /// </summary>
     public const string Passkeys = "OpenIddict.Passkeys";
+
+    /// <summary>
+    /// Requires Pushed Authorization Requests (RFC 9126) for authorization code flows.
+    /// Default: <see langword="false"/>.
+    /// </summary>
+    public const string ParRequired = "OpenIddict.ParRequired";
 }

--- a/src/Granit.OpenIddict/Options/GranitOpenIddictOptions.cs
+++ b/src/Granit.OpenIddict/Options/GranitOpenIddictOptions.cs
@@ -52,4 +52,21 @@ public sealed class GranitOpenIddictOptions
     /// </para>
     /// </remarks>
     public bool UseReferenceTokens { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the server requires Pushed Authorization Requests
+    /// (RFC 9126) for all authorization code flows.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The PAR endpoint (<c>/connect/par</c>) is always registered. When this option is
+    /// <see langword="true"/>, the server rejects direct authorization requests that do not
+    /// include a <c>request_uri</c> obtained from the PAR endpoint.
+    /// </para>
+    /// <para>
+    /// Required for FAPI 2.0 Security Profile compliance.
+    /// Default: <see langword="false"/> (PAR available but not enforced).
+    /// </para>
+    /// </remarks>
+    public bool RequirePar { get; set; }
 }

--- a/tests/Granit.OpenIddict.Tests.Integration/Fixtures/OpenIddictTestApplication.cs
+++ b/tests/Granit.OpenIddict.Tests.Integration/Fixtures/OpenIddictTestApplication.cs
@@ -185,12 +185,18 @@ public sealed class OpenIddictTestApplication : IAsyncLifetime
             };
 
             descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Token);
+            descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Authorization);
             descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Introspection);
             descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Revocation);
+            descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.PushedAuthorization);
+            descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode);
             descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.ClientCredentials);
             descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.RefreshToken);
+            descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.Code);
             descriptor.Permissions.Add(OpenIddictConstants.Permissions.Scopes.Profile);
             descriptor.Permissions.Add(OpenIddictConstants.Permissions.Prefixes.Scope + "openid");
+
+            descriptor.RedirectUris.Add(new Uri("http://localhost/callback"));
 
             await appManager.CreateAsync(descriptor);
         }

--- a/tests/Granit.OpenIddict.Tests.Integration/Flows/DiscoveryEndpointTests.cs
+++ b/tests/Granit.OpenIddict.Tests.Integration/Flows/DiscoveryEndpointTests.cs
@@ -51,6 +51,20 @@ public sealed class DiscoveryEndpointTests(OpenIddictTestApplication app)
     }
 
     [Fact]
+    public async Task Should_expose_pushed_authorization_request_endpoint()
+    {
+        OidcTestClient client = app.CreateOidcClient();
+
+        JsonDocument discovery = await client.GetDiscoveryDocumentAsync();
+
+        string? parEndpoint = discovery.RootElement
+            .GetProperty("pushed_authorization_request_endpoint").GetString();
+
+        parEndpoint.ShouldNotBeNullOrEmpty();
+        parEndpoint.ShouldEndWith("/connect/par");
+    }
+
+    [Fact]
     public async Task Should_advertise_supported_grant_types()
     {
         OidcTestClient client = app.CreateOidcClient();

--- a/tests/Granit.OpenIddict.Tests.Integration/Flows/PushedAuthorizationRequestTests.cs
+++ b/tests/Granit.OpenIddict.Tests.Integration/Flows/PushedAuthorizationRequestTests.cs
@@ -1,0 +1,69 @@
+using System.Net;
+using System.Text.Json;
+using Granit.OpenIddict.Tests.Integration.Fixtures;
+using Granit.OpenIddict.Tests.Integration.Helpers;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.Tests.Integration.Flows;
+
+[Collection("openiddict-integration")]
+public sealed class PushedAuthorizationRequestTests(OpenIddictTestApplication app)
+{
+    [Fact]
+    public async Task Should_accept_par_and_return_request_uri()
+    {
+        OidcTestClient client = app.CreateOidcClient();
+
+        HttpResponseMessage response = await client.RawPushedAuthorizationRequestAsync(
+            OpenIddictTestApplication.TestClientId,
+            OpenIddictTestApplication.TestClientSecret,
+            "http://localhost/callback");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        using var doc = JsonDocument.Parse(json);
+
+        string? requestUri = doc.RootElement.GetProperty("request_uri").GetString();
+        requestUri.ShouldNotBeNullOrEmpty("PAR response must include a request_uri");
+
+        doc.RootElement.TryGetProperty("expires_in", out JsonElement expiresIn).ShouldBeTrue();
+        expiresIn.GetInt32().ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task Should_reject_par_without_client_authentication()
+    {
+        OidcTestClient client = app.CreateOidcClient();
+        HttpClient httpClient = app.CreateHttpClient();
+
+        using var content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["response_type"] = "code",
+            ["redirect_uri"] = "http://localhost/callback",
+            ["scope"] = "openid",
+            ["code_challenge"] = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+            ["code_challenge_method"] = "S256",
+        });
+
+        HttpResponseMessage response = await httpClient.PostAsync(
+            "/connect/par", content, TestContext.Current.CancellationToken);
+
+        // OpenIddict returns 400 for missing client authentication on the PAR endpoint
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Should_reject_par_with_invalid_client()
+    {
+        OidcTestClient client = app.CreateOidcClient();
+
+        HttpResponseMessage response = await client.RawPushedAuthorizationRequestAsync(
+            "nonexistent-client",
+            "wrong-secret",
+            "http://localhost/callback");
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+}

--- a/tests/Granit.OpenIddict.Tests.Integration/Helpers/OidcTestClient.cs
+++ b/tests/Granit.OpenIddict.Tests.Integration/Helpers/OidcTestClient.cs
@@ -100,6 +100,25 @@ public sealed class OidcTestClient(HttpClient client)
         return await client.SendAsync(request);
     }
 
+    // ──── Pushed Authorization Requests ────
+
+    public async Task<HttpResponseMessage> RawPushedAuthorizationRequestAsync(
+        string clientId, string clientSecret, string redirectUri, string? scope = null)
+    {
+        using var content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["client_id"] = clientId,
+            ["client_secret"] = clientSecret,
+            ["response_type"] = "code",
+            ["redirect_uri"] = redirectUri,
+            ["scope"] = scope ?? "openid",
+            ["code_challenge"] = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+            ["code_challenge_method"] = "S256",
+        });
+
+        return await client.PostAsync("/connect/par", content);
+    }
+
     // ──── Discovery ────
 
     public async Task<JsonDocument> GetDiscoveryDocumentAsync()


### PR DESCRIPTION
## Summary

- Enable the PAR endpoint (`/connect/par`) on the OpenIddict server (RFC 9126)
- Add `RequirePar` build-time option to enforce PAR for all authorization code flows (FAPI 2.0)
- BFF login flow uses PAR when `UsePushedAuthorizationRequests` is enabled, with automatic fallback to direct parameters on failure
- 4 new integration tests (PAR flow + discovery endpoint)
- Fix broken link in BFF architecture docs (`/infrastructure/caching` → `/data/caching`)

## Test plan

- [x] `dotnet build` — zero errors, zero warnings
- [x] `dotnet test tests/Granit.OpenIddict.Tests.Integration` — 22/22 passing (3 new PAR + 1 discovery)
- [x] `dotnet format --verify-no-changes` — clean
- [x] `gitleaks detect` — no new leaks
- [x] `npx astro build` — docs build clean, all links valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)
