### PR TITLE
fix(cookies): route BFF session cookies through IGranitCookieManager

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -280,9 +280,10 @@
     {
       "name": "Granit.Bff.Endpoints",
       "deps": [
-        "Granit.Oidc",
         "Granit.Bff",
         "Granit.Http.ApiDocumentation",
+        "Granit.Http.Cookies",
+        "Granit.Oidc",
         "Granit.Validation"
       ],
       "framework": "net10.0"
@@ -600,7 +601,7 @@
     {
       "name": "Granit.Http.Cookies",
       "deps": [
-        "Granit.Timing"
+        "Granit"
       ],
       "framework": "net10.0"
     },
@@ -5953,7 +5954,7 @@
       "kind": "class",
       "project": "Granit.Bff.Endpoints",
       "file": "src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs",
-      "line": 18,
+      "line": 19,
       "members": [
         {
           "name": "MapGranitBffEndpoints",
@@ -5969,7 +5970,7 @@
       "kind": "class",
       "project": "Granit.Bff.Endpoints",
       "file": "src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs",
-      "line": 142,
+      "line": 163,
       "members": [
         {
           "name": "InvokeAsync",
@@ -5985,8 +5986,15 @@
       "kind": "class",
       "project": "Granit.Bff.Endpoints",
       "file": "src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs",
-      "line": 14,
-      "members": []
+      "line": 17,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "GranitBffEntityFrameworkCoreModule",
@@ -12412,8 +12420,21 @@
       "kind": "record",
       "project": "Granit.Http.Cookies",
       "file": "src/Granit.Http.Cookies/CookieDefinition.cs",
-      "line": 12,
-      "members": []
+      "line": 14,
+      "members": [
+        {
+          "name": "SameSite",
+          "kind": "property",
+          "signature": "SameSiteMode SameSite",
+          "returnType": "SameSiteMode"
+        },
+        {
+          "name": "Path",
+          "kind": "property",
+          "signature": "string Path",
+          "returnType": "string"
+        }
+      ]
     },
     {
       "name": "CookiesLocalizationResource",
@@ -12552,7 +12573,7 @@
       "kind": "class",
       "project": "Granit.Http.Cookies",
       "file": "src/Granit.Http.Cookies/GranitHttpCookiesModule.cs",
-      "line": 14,
+      "line": 10,
       "members": []
     },
     {
@@ -13641,25 +13662,16 @@
       "fqn": "Granit.Identity.Endpoints.Permissions.Groups",
       "kind": "class",
       "project": "Granit.Identity.Endpoints",
-      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityProviderPermissions.cs",
-      "line": 36,
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityPermissions.cs",
+      "line": 49,
       "members": []
     },
     {
-      "name": "IdentityProviderPermissions",
-      "fqn": "Granit.Identity.Endpoints.Permissions.IdentityProviderPermissions",
+      "name": "IdentityPermissions",
+      "fqn": "Granit.Identity.Endpoints.Permissions.IdentityPermissions",
       "kind": "class",
       "project": "Granit.Identity.Endpoints",
-      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityProviderPermissions.cs",
-      "line": 10,
-      "members": []
-    },
-    {
-      "name": "IdentityUserCachePermissions",
-      "fqn": "Granit.Identity.Endpoints.Permissions.IdentityUserCachePermissions",
-      "kind": "class",
-      "project": "Granit.Identity.Endpoints",
-      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityUserCachePermissions.cs",
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityPermissions.cs",
       "line": 10,
       "members": []
     },
@@ -13668,8 +13680,8 @@
       "fqn": "Granit.Identity.Endpoints.Permissions.Passwords",
       "kind": "class",
       "project": "Granit.Identity.Endpoints",
-      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityProviderPermissions.cs",
-      "line": 56,
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityPermissions.cs",
+      "line": 69,
       "members": []
     },
     {
@@ -13677,8 +13689,8 @@
       "fqn": "Granit.Identity.Endpoints.Permissions.Roles",
       "kind": "class",
       "project": "Granit.Identity.Endpoints",
-      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityProviderPermissions.cs",
-      "line": 26,
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityPermissions.cs",
+      "line": 39,
       "members": []
     },
     {
@@ -13686,8 +13698,8 @@
       "fqn": "Granit.Identity.Endpoints.Permissions.Sessions",
       "kind": "class",
       "project": "Granit.Identity.Endpoints",
-      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityProviderPermissions.cs",
-      "line": 46,
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityPermissions.cs",
+      "line": 59,
       "members": []
     },
     {
@@ -13695,7 +13707,7 @@
       "fqn": "Granit.Identity.Endpoints.Permissions.UserCache",
       "kind": "class",
       "project": "Granit.Identity.Endpoints",
-      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityUserCachePermissions.cs",
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityPermissions.cs",
       "line": 16,
       "members": []
     },
@@ -13704,8 +13716,8 @@
       "fqn": "Granit.Identity.Endpoints.Permissions.Users",
       "kind": "class",
       "project": "Granit.Identity.Endpoints",
-      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityProviderPermissions.cs",
-      "line": 16,
+      "file": "src/Granit.Identity.Endpoints/Permissions/IdentityPermissions.cs",
+      "line": 29,
       "members": []
     },
     {

--- a/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 using Granit.Bff.Diagnostics;
 using Granit.Bff.Options;
+using Granit.Http.Cookies;
 using Granit.Oidc.ClientAuthentication;
 using Granit.Oidc.ClientAuthentication.Internal;
 using Granit.Oidc.DPoP;
@@ -156,7 +157,6 @@ internal static partial class BffLoginEndpoints
         IDistributedCache cache = services.GetRequiredService<IDistributedCache>();
         IBffTokenStore tokenStore = services.GetRequiredService<IBffTokenStore>();
         BffMetrics metrics = services.GetRequiredService<BffMetrics>();
-        IClock clock = services.GetRequiredService<IClock>();
         ILogger logger = services.GetRequiredService<ILoggerFactory>()
             .CreateLogger("Granit.Bff.Endpoints.BffLoginEndpoints");
 
@@ -251,16 +251,10 @@ internal static partial class BffLoginEndpoints
 #pragma warning restore GRSEC002
         await tokenStore.StoreAsync(frontend.Name, sessionId, tokens, cancellationToken).ConfigureAwait(false);
 
-        // Set frontend-specific session cookie
-        httpContext.Response.Cookies.Append(frontend.SessionCookieName, sessionId, new CookieOptions
-        {
-            HttpOnly = true,
-            Secure = true,
-            SameSite = SameSiteMode.Strict,
-            Path = "/",
-            MaxAge = bffOptions.SessionDuration,
-            IsEssential = true,
-        });
+        // Set frontend-specific session cookie via managed cookie system (GRSEC004)
+        IGranitCookieManager cookieManager = services.GetRequiredService<IGranitCookieManager>();
+        await cookieManager.SetCookieAsync(httpContext, frontend.SessionCookieName, sessionId)
+            .ConfigureAwait(false);
 
         metrics.RecordLogin(null);
         LogLoginSuccess(logger, sessionId, frontend.Name);

--- a/src/Granit.Bff.Endpoints/Endpoints/BffLogoutEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffLogoutEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Granit.Bff.Diagnostics;
 using Granit.Bff.Options;
+using Granit.Http.Cookies;
 using Granit.Oidc.ClientAuthentication;
 using Granit.Oidc.ClientAuthentication.Internal;
 using Granit.Oidc.DPoP;
@@ -10,6 +11,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -89,14 +91,9 @@ internal static partial class BffLogoutEndpoints
             LogLogout(logger, sessionId, frontend.Name);
         }
 
-        // Clear frontend-specific session cookie
-        httpContext.Response.Cookies.Delete(frontend.SessionCookieName, new CookieOptions
-        {
-            HttpOnly = true,
-            Secure = true,
-            SameSite = SameSiteMode.Strict,
-            Path = "/",
-        });
+        // Clear frontend-specific session cookie via managed cookie system (GRSEC004)
+        IGranitCookieManager cookieManager = httpContext.RequestServices.GetRequiredService<IGranitCookieManager>();
+        cookieManager.DeleteCookie(httpContext, frontend.SessionCookieName);
 
         // Build end_session URL
 #pragma warning disable GRSEC003 // Building OIDC end_session URL with client credentials

--- a/src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Granit.Bff.Endpoints.Endpoints;
 using Granit.Bff.Options;
+using Granit.Http.Cookies;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -29,14 +30,34 @@ public static class BffEndpointRouteBuilderExtensions
     {
         GranitBffOptions options = endpoints.ServiceProvider
             .GetRequiredService<IOptions<GranitBffOptions>>().Value;
+        ICookieRegistry cookieRegistry = endpoints.ServiceProvider
+            .GetRequiredService<ICookieRegistry>();
 
         foreach (BffFrontendOptions frontend in options.Frontends)
         {
+            RegisterBffSessionCookie(cookieRegistry, frontend, options);
             MapFrontendEndpoints(endpoints, frontend);
             MapFrontendStaticFiles(endpoints, frontend);
         }
 
         return endpoints;
+    }
+
+    private static void RegisterBffSessionCookie(
+        ICookieRegistry cookieRegistry, BffFrontendOptions frontend, GranitBffOptions bffOptions)
+    {
+        cookieRegistry.Register(new CookieDefinition(
+            Name: frontend.SessionCookieName,
+            Category: CookieCategory.StrictlyNecessary,
+            RetentionDays: (int)Math.Ceiling(bffOptions.SessionDuration.TotalDays),
+            IsHttpOnly: true,
+            Purpose: $"BFF session identifier for the '{frontend.Name}' frontend. "
+                + "Stores a server-side session ID to associate the browser with stored OIDC tokens.")
+        {
+            SameSite = SameSiteMode.Strict,
+            Path = "/",
+            IsEssential = true,
+        });
     }
 
     private static void MapFrontendEndpoints(IEndpointRouteBuilder endpoints, BffFrontendOptions frontend)

--- a/src/Granit.Bff.Endpoints/Granit.Bff.Endpoints.csproj
+++ b/src/Granit.Bff.Endpoints/Granit.Bff.Endpoints.csproj
@@ -16,9 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Granit.Oidc\Granit.Oidc.csproj" />
     <ProjectReference Include="..\Granit.Bff\Granit.Bff.csproj" />
     <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
+    <ProjectReference Include="..\Granit.Http.Cookies\Granit.Http.Cookies.csproj" />
+    <ProjectReference Include="..\Granit.Oidc\Granit.Oidc.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
   </ItemGroup>
 

--- a/src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs
+++ b/src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs
@@ -1,4 +1,6 @@
 using Granit.Http.ApiDocumentation;
+using Granit.Http.Cookies;
+using Granit.Http.Cookies.Extensions;
 using Granit.Modularity;
 using Granit.Validation;
 
@@ -10,5 +12,14 @@ namespace Granit.Bff.Endpoints;
 [DependsOn(
     typeof(GranitBffModule),
     typeof(GranitHttpApiDocumentationModule),
+    typeof(GranitHttpCookiesModule),
     typeof(GranitValidationModule))]
-public sealed class GranitBffEndpointsModule : GranitModule;
+public sealed class GranitBffEndpointsModule : GranitModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        // Ensure IGranitCookieManager + ICookieRegistry are available for BFF session cookies.
+        // No-op if AddGranitCookies() was already called by the hosting application.
+        context.Services.AddGranitCookies(_ => { });
+    }
+}

--- a/src/Granit.Http.Cookies/CookieDefinition.cs
+++ b/src/Granit.Http.Cookies/CookieDefinition.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Http;
+
 namespace Granit.Http.Cookies;
 
 /// <summary>
@@ -14,4 +16,23 @@ public sealed record CookieDefinition(
     CookieCategory Category,
     int RetentionDays,
     bool IsHttpOnly,
-    string Purpose);
+    string Purpose)
+{
+    /// <summary>
+    /// Gets the <c>SameSite</c> attribute for the cookie. Default: <see cref="SameSiteMode.Lax"/>.
+    /// Security-sensitive cookies (e.g., BFF session) should use <see cref="SameSiteMode.Strict"/>.
+    /// </summary>
+    public SameSiteMode SameSite { get; init; } = SameSiteMode.Lax;
+
+    /// <summary>
+    /// Gets the <c>Path</c> attribute for the cookie. Default: <c>"/"</c>.
+    /// Required to be <c>"/"</c> for <c>__Host-</c> prefixed cookies (RFC 6265bis §4.1.3.2).
+    /// </summary>
+    public string Path { get; init; } = "/";
+
+    /// <summary>
+    /// Gets whether the cookie is marked as essential (bypasses GDPR consent banner suppression).
+    /// Only <see cref="CookieCategory.StrictlyNecessary"/> cookies should set this to <see langword="true"/>.
+    /// </summary>
+    public bool IsEssential { get; init; }
+}

--- a/src/Granit.Http.Cookies/Extensions/CookiesServiceCollectionExtensions.cs
+++ b/src/Granit.Http.Cookies/Extensions/CookiesServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ public static class CookiesServiceCollectionExtensions
         }
 
         services.TryAddSingleton<ICookieRegistry>(registry);
+        services.TryAddScoped<IConsentResolver, NullConsentResolver>();
         services.TryAddScoped<IGranitCookieManager, GranitCookieManager>();
 
         // Third-party service registry — populated from configuration

--- a/src/Granit.Http.Cookies/Granit.Http.Cookies.csproj
+++ b/src/Granit.Http.Cookies/Granit.Http.Cookies.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />
+    <ProjectReference Include="..\Granit\Granit.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.Http.Cookies/GranitHttpCookiesModule.cs
+++ b/src/Granit.Http.Cookies/GranitHttpCookiesModule.cs
@@ -1,5 +1,4 @@
 using Granit.Modularity;
-using Granit.Timing;
 
 namespace Granit.Http.Cookies;
 
@@ -7,8 +6,5 @@ namespace Granit.Http.Cookies;
 /// Granit module for RGPD-compliant cookie management.
 /// Registration is done via <c>AddGranitCookies()</c> because it requires
 /// an <see cref="System.Action{GranitCookiesBuilder}"/> for cookie declarations.
-/// The dependency on <see cref="GranitTimingModule"/> guarantees that
-/// <see cref="IClock"/> is available for cookie expiration calculation.
 /// </summary>
-[DependsOn(typeof(GranitTimingModule))]
 public sealed class GranitHttpCookiesModule : GranitModule;

--- a/src/Granit.Http.Cookies/Internal/GranitCookieManager.cs
+++ b/src/Granit.Http.Cookies/Internal/GranitCookieManager.cs
@@ -1,5 +1,4 @@
 using Granit.Http.Cookies.Exceptions;
-using Granit.Timing;
 using Microsoft.AspNetCore.Http;
 
 #pragma warning disable GRSEC004 // This IS the IGranitCookieManager implementation
@@ -11,8 +10,7 @@ namespace Granit.Http.Cookies.Internal;
 /// </summary>
 internal sealed class GranitCookieManager(
     ICookieRegistry registry,
-    IConsentResolver consentResolver,
-    IClock clock) : IGranitCookieManager
+    IConsentResolver consentResolver) : IGranitCookieManager
 {
     /// <inheritdoc/>
     public async Task SetCookieAsync(HttpContext httpContext, string cookieName, string value)
@@ -31,10 +29,12 @@ internal sealed class GranitCookieManager(
 
         CookieOptions options = new()
         {
-            Expires = clock.Now.AddDays(definition.RetentionDays),
+            MaxAge = TimeSpan.FromDays(definition.RetentionDays),
             HttpOnly = definition.IsHttpOnly, // NOSONAR S3330 - intentional: HttpOnly is configurable per cookie (analytics cookies like _ga require JS access)
             Secure = true,
-            SameSite = SameSiteMode.Lax
+            SameSite = definition.SameSite,
+            Path = definition.Path,
+            IsEssential = definition.IsEssential,
         };
 
         httpContext.Response.Cookies.Append(cookieName, value, options);
@@ -56,11 +56,15 @@ internal sealed class GranitCookieManager(
     /// <inheritdoc/>
     public void DeleteCookie(HttpContext httpContext, string cookieName)
     {
-        if (!registry.IsRegistered(cookieName))
-        {
-            throw new UnregisteredCookieException(cookieName);
-        }
+        CookieDefinition definition = registry.GetDefinition(cookieName)
+            ?? throw new UnregisteredCookieException(cookieName);
 
-        httpContext.Response.Cookies.Delete(cookieName);
+        httpContext.Response.Cookies.Delete(cookieName, new CookieOptions
+        {
+            HttpOnly = definition.IsHttpOnly,
+            Secure = true,
+            SameSite = definition.SameSite,
+            Path = definition.Path,
+        });
     }
 }

--- a/src/Granit.Http.Cookies/Internal/NullConsentResolver.cs
+++ b/src/Granit.Http.Cookies/Internal/NullConsentResolver.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Granit.Http.Cookies.Internal;
+
+/// <summary>
+/// Default consent resolver that denies consent for all non-essential categories.
+/// Applications must register a real <see cref="IConsentResolver"/> (Klaro, Axeptio, etc.)
+/// to allow non-<see cref="CookieCategory.StrictlyNecessary"/> cookies.
+/// </summary>
+internal sealed class NullConsentResolver : IConsentResolver
+{
+    /// <inheritdoc/>
+    public Task<bool> ResolveAsync(HttpContext httpContext, CookieCategory category) =>
+        Task.FromResult(false);
+}

--- a/tests/Granit.ArchitectureTests/SourceCodeAntiPatternTests.cs
+++ b/tests/Granit.ArchitectureTests/SourceCodeAntiPatternTests.cs
@@ -208,6 +208,59 @@ public sealed partial class SourceCodeAntiPatternTests
             $"Violators: {string.Join("; ", violations)}");
     }
 
+    /// <summary>
+    /// Direct calls to <c>IResponseCookies.Append()</c> or <c>IResponseCookies.Delete()</c>
+    /// bypass the Strict Registry Pattern and RGPD consent checks enforced by
+    /// <c>IGranitCookieManager</c>. Only <c>GranitCookieManager</c> (the manager implementation
+    /// itself) is allowed to call these methods directly.
+    /// Complements the <c>GRSEC004</c> Roslyn analyzer which is opt-in per project.
+    /// </summary>
+    [Fact]
+    public void Direct_IResponseCookies_access_should_only_be_in_GranitCookieManager()
+    {
+        string srcDir = Path.Combine(RepoRoot, "src");
+
+        List<string> violations = [];
+
+        foreach (string csFile in Directory.GetFiles(srcDir, "*.cs", SearchOption.AllDirectories))
+        {
+            if (csFile.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar)
+                || csFile.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar))
+            {
+                continue;
+            }
+
+            // Only GranitCookieManager.cs is allowed to call Response.Cookies directly
+            if (Path.GetFileName(csFile) == "GranitCookieManager.cs")
+            {
+                continue;
+            }
+
+            string content = File.ReadAllText(csFile);
+
+            foreach (Match match in DirectCookieAccess().Matches(content))
+            {
+                // Skip matches inside pragma disable GRSEC004 blocks (already suppressed intentionally)
+                string precedingText = content[..match.Index];
+                if (precedingText.Contains("#pragma warning disable GRSEC004", StringComparison.Ordinal)
+                    && !precedingText.Contains("#pragma warning restore GRSEC004", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                string relativePath = Path.GetRelativePath(RepoRoot, csFile);
+                int lineNumber = content[..match.Index].Count(c => c == '\n') + 1;
+                violations.Add($"{relativePath}:{lineNumber}");
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Direct calls to Response.Cookies.Append() / Delete() bypass the Strict Registry Pattern "
+            + "and RGPD consent checks. Use IGranitCookieManager.SetCookieAsync() or DeleteCookie() instead. "
+            + "If this is the cookie manager implementation itself, name the file GranitCookieManager.cs. "
+            + $"Violators: {string.Join(", ", violations)}");
+    }
+
     private static string FindRepoRoot()
     {
         string? dir = Path.GetDirectoryName(typeof(SourceCodeAntiPatternTests).Assembly.Location);
@@ -244,4 +297,12 @@ public sealed partial class SourceCodeAntiPatternTests
     /// </summary>
     [GeneratedRegex(@"^namespace\s+([\w.]+)\s*[;{]", RegexOptions.Multiline)]
     private static partial Regex NamespaceDeclaration();
+
+    /// <summary>
+    /// Matches direct calls to <c>.Cookies.Append(</c> or <c>.Cookies.Delete(</c>
+    /// on response objects. Captures both <c>Response.Cookies.*</c> and variables
+    /// holding <c>IResponseCookies</c>.
+    /// </summary>
+    [GeneratedRegex(@"\.Cookies\.(Append|Delete)\s*\(")]
+    private static partial Regex DirectCookieAccess();
 }

--- a/tests/Granit.Http.Cookies.Tests/CookieDefinitionTests.cs
+++ b/tests/Granit.Http.Cookies.Tests/CookieDefinitionTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Shouldly;
 using Xunit;
 
@@ -15,6 +16,31 @@ public sealed class CookieDefinitionTests
         definition.RetentionDays.ShouldBe(1);
         definition.IsHttpOnly.ShouldBeTrue();
         definition.Purpose.ShouldBe("Session management");
+    }
+
+    [Fact]
+    public void InitProperties_HaveSensibleDefaults()
+    {
+        CookieDefinition definition = new("test", CookieCategory.Analytics, 365, false, "Test");
+
+        definition.SameSite.ShouldBe(SameSiteMode.Lax);
+        definition.Path.ShouldBe("/");
+        definition.IsEssential.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void InitProperties_CanBeOverridden()
+    {
+        CookieDefinition definition = new("__Host-bff", CookieCategory.StrictlyNecessary, 1, true, "BFF")
+        {
+            SameSite = SameSiteMode.Strict,
+            Path = "/",
+            IsEssential = true,
+        };
+
+        definition.SameSite.ShouldBe(SameSiteMode.Strict);
+        definition.Path.ShouldBe("/");
+        definition.IsEssential.ShouldBeTrue();
     }
 
     [Fact]

--- a/tests/Granit.Http.Cookies.Tests/CookiesServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Http.Cookies.Tests/CookiesServiceCollectionExtensionsTests.cs
@@ -1,7 +1,5 @@
 using Granit.Http.Cookies.Extensions;
-using Granit.Timing.Extensions;
 using Microsoft.Extensions.DependencyInjection;
-using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -13,7 +11,6 @@ public sealed class CookiesServiceCollectionExtensionsTests
     public void AddGranitCookies_RegistersServices()
     {
         ServiceCollection services = new();
-        services.AddGranitTiming();
         services.AddGranitCookies(cookies =>
         {
             cookies.UseConsentResolver<FakeConsentResolver>();
@@ -59,6 +56,18 @@ public sealed class CookiesServiceCollectionExtensionsTests
 
         resolver.ShouldNotBeNull();
         resolver.ShouldBeOfType<FakeConsentResolver>();
+    }
+
+    [Fact]
+    public void AddGranitCookies_WithoutConsentResolver_RegistersNullConsentResolver()
+    {
+        ServiceCollection services = new();
+        services.AddGranitCookies(_ => { });
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        IConsentResolver? resolver = provider.GetService<IConsentResolver>();
+
+        resolver.ShouldNotBeNull();
     }
 
     [Fact]

--- a/tests/Granit.Http.Cookies.Tests/GranitCookieManagerTests.cs
+++ b/tests/Granit.Http.Cookies.Tests/GranitCookieManagerTests.cs
@@ -1,6 +1,5 @@
 using Granit.Http.Cookies.Exceptions;
 using Granit.Http.Cookies.Internal;
-using Granit.Timing;
 using Microsoft.AspNetCore.Http;
 using NSubstitute;
 using Shouldly;
@@ -12,13 +11,11 @@ public sealed class GranitCookieManagerTests
 {
     private readonly CookieRegistry _registry = new();
     private readonly IConsentResolver _consentResolver = Substitute.For<IConsentResolver>();
-    private readonly IClock _clock = Substitute.For<IClock>();
     private readonly GranitCookieManager _sut;
 
     public GranitCookieManagerTests()
     {
-        _clock.Now.Returns(new DateTimeOffset(2026, 1, 15, 10, 0, 0, TimeSpan.Zero));
-        _sut = new GranitCookieManager(_registry, _consentResolver, _clock);
+        _sut = new GranitCookieManager(_registry, _consentResolver);
     }
 
     private static DefaultHttpContext CreateHttpContext() => new();
@@ -77,7 +74,7 @@ public sealed class GranitCookieManagerTests
     }
 
     [Fact]
-    public async Task SetCookieAsync_UsesClockForExpiration()
+    public async Task SetCookieAsync_SetsMaxAgeFromRetentionDays()
     {
         CookieDefinition definition = new("pref_cookie", CookieCategory.Preferences, 30, true, "Preferences");
         _registry.Register(definition);
@@ -88,7 +85,7 @@ public sealed class GranitCookieManagerTests
 
         string? setCookieHeader = httpContext.Response.Headers.SetCookie.ToString();
         setCookieHeader.ShouldContain("pref_cookie=value");
-        setCookieHeader.ShouldContain("expires=");
+        setCookieHeader.ShouldContain("max-age=2592000"); // 30 days in seconds
         setCookieHeader.ShouldContain("secure");
         setCookieHeader.ShouldContain("httponly");
     }
@@ -105,6 +102,44 @@ public sealed class GranitCookieManagerTests
         string? setCookieHeader = httpContext.Response.Headers.SetCookie.ToString();
         setCookieHeader.ShouldContain("secure");
         setCookieHeader.ShouldContain("samesite=lax");
+    }
+
+    [Fact]
+    public async Task SetCookieAsync_UsesDefinitionSameSiteAndPath()
+    {
+        CookieDefinition definition = new("__Host-bff-admin", CookieCategory.StrictlyNecessary, 1, true, "BFF session")
+        {
+            SameSite = SameSiteMode.Strict,
+            Path = "/",
+            IsEssential = true,
+        };
+        _registry.Register(definition);
+        DefaultHttpContext httpContext = CreateHttpContext();
+
+        await _sut.SetCookieAsync(httpContext, "__Host-bff-admin", "sess_123");
+
+        string? setCookieHeader = httpContext.Response.Headers.SetCookie.ToString();
+        setCookieHeader.ShouldContain("samesite=strict");
+        setCookieHeader.ShouldContain("path=/");
+    }
+
+    [Fact]
+    public void DeleteCookie_UsesSameSiteAndPathFromDefinition()
+    {
+        CookieDefinition definition = new("__Host-bff-admin", CookieCategory.StrictlyNecessary, 1, true, "BFF session")
+        {
+            SameSite = SameSiteMode.Strict,
+            Path = "/",
+        };
+        _registry.Register(definition);
+        DefaultHttpContext httpContext = CreateHttpContext();
+
+        _sut.DeleteCookie(httpContext, "__Host-bff-admin");
+
+        string? setCookieHeader = httpContext.Response.Headers.SetCookie.ToString();
+        setCookieHeader.ShouldContain("__Host-bff-admin");
+        setCookieHeader.ShouldContain("samesite=strict");
+        setCookieHeader.ShouldContain("path=/");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- **BFF → IGranitCookieManager**: Replace direct `httpContext.Response.Cookies.Append/Delete` in BFF login/logout endpoints with `IGranitCookieManager.SetCookieAsync/DeleteCookie`, enforcing the Strict Registry Pattern and RGPD compliance
- **CookieDefinition extensions**: Add `SameSite`, `Path`, `IsEssential` init properties (backward-compatible defaults: `Lax`, `"/"`, `false`) so security-sensitive cookies like BFF `__Host-` sessions can use `SameSiteMode.Strict`
- **GranitCookieManager**: Switch from `Expires` to `MaxAge` (no clock dependency, no clock-skew issues), use definition's `SameSite`/`Path`/`IsEssential`, pass `CookieOptions` on delete for `__Host-` cookie compliance
- **NullConsentResolver**: Safe default registered by `AddGranitCookies()` when no CMP is configured — denies non-essential cookies, allows `StrictlyNecessary` without requiring explicit consent resolver
- **Architecture test**: `Direct_IResponseCookies_access_should_only_be_in_GranitCookieManager()` scans all `src/*.cs` files in CI, complementing the opt-in `GRSEC004` Roslyn analyzer

## Test plan

- [x] `dotnet test tests/Granit.Http.Cookies.Tests` — 56 tests pass (includes new `SameSite`/`Path`, `MaxAge`, `NullConsentResolver` tests)
- [x] `dotnet test tests/Granit.Bff.Endpoints.Tests` — 2 tests pass
- [x] `dotnet test tests/Granit.Bff.Yarp.Tests` — 13 tests pass
- [x] `dotnet test tests/Granit.ArchitectureTests --filter SourceCodeAntiPattern` — 5 tests pass (includes new cookie access test)
- [x] `dotnet format --verify-no-changes` on both modified projects
- [ ] Full CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
