### PR TITLE
fix: regenerate packages.lock.json for Http.Cookies and Bff.Endpoints

### DIFF
--- a/src/Granit.Bff.Endpoints/packages.lock.json
+++ b/src/Granit.Bff.Endpoints/packages.lock.json
@@ -68,6 +68,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.http.cookies": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.http.exceptionhandling": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.Http.Cookies.Endpoints/packages.lock.json
+++ b/src/Granit.Http.Cookies.Endpoints/packages.lock.json
@@ -48,12 +48,6 @@
       "granit.http.cookies": {
         "type": "Project",
         "dependencies": {
-          "Granit.Timing": "[0.1.0-dev, )"
-        }
-      },
-      "granit.timing": {
-        "type": "Project",
-        "dependencies": {
           "Granit": "[0.1.0-dev, )"
         }
       },

--- a/src/Granit.Http.Cookies.Klaro/packages.lock.json
+++ b/src/Granit.Http.Cookies.Klaro/packages.lock.json
@@ -14,12 +14,6 @@
       "granit.http.cookies": {
         "type": "Project",
         "dependencies": {
-          "Granit.Timing": "[0.1.0-dev, )"
-        }
-      },
-      "granit.timing": {
-        "type": "Project",
-        "dependencies": {
           "Granit": "[0.1.0-dev, )"
         }
       }

--- a/src/Granit.Http.Cookies/packages.lock.json
+++ b/src/Granit.Http.Cookies/packages.lock.json
@@ -10,12 +10,6 @@
       },
       "granit": {
         "type": "Project"
-      },
-      "granit.timing": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )"
-        }
       }
     }
   }

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1618,6 +1618,7 @@
         "dependencies": {
           "Granit.Bff": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Oidc": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
@@ -1926,7 +1927,7 @@
       "granit.http.cookies": {
         "type": "Project",
         "dependencies": {
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.http.cookies.endpoints": {

--- a/tests/Granit.Bff.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Bff.Endpoints.Tests/packages.lock.json
@@ -299,6 +299,7 @@
         "dependencies": {
           "Granit.Bff": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Oidc": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
@@ -326,6 +327,12 @@
         "dependencies": {
           "Asp.Versioning.Mvc": "[10.0.0-preview.*, )",
           "Asp.Versioning.Mvc.ApiExplorer": "[10.0.0-preview.*, )",
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.cookies": {
+        "type": "Project",
+        "dependencies": {
           "Granit": "[0.1.0-dev, )"
         }
       },

--- a/tests/Granit.Http.Cookies.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Http.Cookies.Endpoints.Tests/packages.lock.json
@@ -528,7 +528,7 @@
       "granit.http.cookies": {
         "type": "Project",
         "dependencies": {
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.http.cookies.endpoints": {
@@ -537,14 +537,6 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Http.Cookies": "[0.1.0-dev, )"
-        }
-      },
-      "granit.timing": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
       "Asp.Versioning.Mvc": {

--- a/tests/Granit.Http.Cookies.Klaro.Tests/packages.lock.json
+++ b/tests/Granit.Http.Cookies.Klaro.Tests/packages.lock.json
@@ -101,11 +101,6 @@
         "resolved": "18.3.0",
         "contentHash": "23BNy/vziREC20Wwhb50K7+kZe0m07KlLWDQv4qjJ9tt3QjpDpDIqJFrhYHmMEo9xDkuSp55U/8h4bMF7MiB+g=="
       },
-      "Microsoft.Extensions.Primitives": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
-      },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
         "resolved": "1.9.1",
@@ -251,37 +246,13 @@
       "granit.http.cookies": {
         "type": "Project",
         "dependencies": {
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.http.cookies.klaro": {
         "type": "Project",
         "dependencies": {
           "Granit.Http.Cookies": "[0.1.0-dev, )"
-        }
-      },
-      "granit.timing": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
-      },
-      "Microsoft.Extensions.Options": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
         }
       }
     }

--- a/tests/Granit.Http.Cookies.Tests/packages.lock.json
+++ b/tests/Granit.Http.Cookies.Tests/packages.lock.json
@@ -107,11 +107,6 @@
         "resolved": "18.3.0",
         "contentHash": "23BNy/vziREC20Wwhb50K7+kZe0m07KlLWDQv4qjJ9tt3QjpDpDIqJFrhYHmMEo9xDkuSp55U/8h4bMF7MiB+g=="
       },
-      "Microsoft.Extensions.Primitives": {
-        "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
-      },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
         "resolved": "1.9.1",
@@ -257,31 +252,7 @@
       "granit.http.cookies": {
         "type": "Project",
         "dependencies": {
-          "Granit.Timing": "[0.1.0-dev, )"
-        }
-      },
-      "granit.timing": {
-        "type": "Project",
-        "dependencies": {
-          "Granit": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
-          "Microsoft.Extensions.Options": "[10.*, )"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection.Abstractions": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
-      },
-      "Microsoft.Extensions.Options": {
-        "type": "CentralTransitive",
-        "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
+          "Granit": "[0.1.0-dev, )"
         }
       }
     }


### PR DESCRIPTION
## Summary

- Regenerate lockfiles for `Http.Cookies`, `Http.Cookies.Klaro`, `Http.Cookies.Endpoints`, and `Bff.Endpoints` after dependency changes in `Granit.Http.Cookies`
- Fixes CI build failure: `NU1004: The packages lock file is inconsistent with the project dependencies`

## Test plan

- [x] `dotnet restore` succeeds in locked mode
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)