### PR TITLE
fix(di): dev-safe fallbacks for Encryption, OpenIddict, and Wolverine 5.24 compat

### DIFF
--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -149,12 +149,22 @@ const programHtml = hl(`var builder = WebApplication.CreateBuilder(args);\n\nbui
       color: var(--sl-color-white);
     }
 
-    /* Hero visual */
+
+    /* Hero visual — hidden on mobile */
     .lp-hero-visual {
-      display: flex; align-items: center; justify-content: center;
+      display: none; align-items: center; justify-content: center;
+      position: relative;
+    }
+    @media (min-width: 960px) {
+      .lp-hero-visual { display: flex; }
     }
     .lp-hero-visual img {
       width: 100%; max-width: 520px; height: auto;
+    }
+    .lp-alpha {
+      background: var(--sl-color-accent);
+      color: var(--sl-color-accent-text-over);
+      border-color: transparent;
     }
     /* ── Accent banner ── */
     .lp-banner {
@@ -365,10 +375,13 @@ const programHtml = hl(`var builder = WebApplication.CreateBuilder(args);\n\nbui
       color: var(--sl-color-gray-3); white-space: nowrap;
     }
     .lp-ai-caps {
-      display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.625rem;
+      display: grid; grid-template-columns: 1fr; gap: 0.625rem;
     }
-    @media (max-width: 480px) {
+    @media (min-width: 480px) {
       .lp-ai-caps { grid-template-columns: repeat(2, 1fr); }
+    }
+    @media (min-width: 768px) {
+      .lp-ai-caps { grid-template-columns: repeat(3, 1fr); }
     }
     .lp-ai-cap {
       background: var(--sl-color-bg);
@@ -381,9 +394,12 @@ const programHtml = hl(`var builder = WebApplication.CreateBuilder(args);\n\nbui
     .lp-ai-cap:hover {
       border-color: var(--sl-color-accent); transform: translateY(-1px);
     }
+    .lp-ai-cap-header {
+      display: flex; align-items: center; gap: 0.375rem;
+    }
     .lp-ai-cap-icon {
       width: 1.125rem; height: 1.125rem;
-      color: var(--sl-color-accent); flex-shrink: 0; margin-bottom: 0.25rem;
+      color: var(--sl-color-accent); flex-shrink: 0;
     }
     .lp-ai-cap-icon svg { width: 100%; height: 100%; }
     .lp-ai-cap-title {
@@ -412,8 +428,11 @@ const programHtml = hl(`var builder = WebApplication.CreateBuilder(args);\n\nbui
       color: var(--sl-color-gray-2); line-height: 1.6; margin: 0;
     }
     .lp-badges {
-      display: grid; grid-template-columns: 1fr 1fr 1fr;
+      display: grid; grid-template-columns: 1fr;
       gap: 1rem; text-align: center;
+    }
+    @media (min-width: 600px) {
+      .lp-badges { grid-template-columns: 1fr 1fr 1fr; }
     }
     .lp-badge {
       border-radius: 0.5rem; border: 1px solid var(--sl-color-gray-5);
@@ -464,7 +483,7 @@ const programHtml = hl(`var builder = WebApplication.CreateBuilder(args);\n\nbui
   <!-- ════════ Hero ════════ -->
   <section class="lp lp-hero">
     <div class="lp-hero-text">
-      <div class="lp-eyebrow">Granit <span class="lp-eyebrow-badge">.NET 10</span></div>
+      <div class="lp-eyebrow">Granit <span class="lp-eyebrow-badge">.NET 10</span> <span class="lp-eyebrow-badge lp-alpha">Alpha</span></div>
       <h1 class="lp-h1">Solid by design,<br />modular by nature.</h1>
       <p class="lp-sub">
         A modular <span style="color:var(--sl-color-accent);font-weight:600">.NET 10</span> framework — orchestrate auth, persistence, CQRS, messaging, and {PACKAGE_COUNT - 5}+ more modules
@@ -472,7 +491,7 @@ const programHtml = hl(`var builder = WebApplication.CreateBuilder(args);\n\nbui
       </p>
       <div class="lp-actions">
         <a href="/dotnet/getting-started/" class="lp-btn lp-btn-primary">Getting Started</a>
-        <a href="/dotnet/" class="lp-btn lp-btn-outline">Explore Docs</a>
+        <a href="/contributing/" class="lp-btn lp-btn-outline">Join our Community</a>
       </div>
     </div>
     <div class="lp-hero-visual">
@@ -600,38 +619,50 @@ const programHtml = hl(`var builder = WebApplication.CreateBuilder(args);\n\nbui
         <div class="lp-ai-caps">
 
           <a href="/dotnet/ai/natural-language-query/" class="lp-ai-cap">
-            <div class="lp-ai-cap-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" /></svg></div>
-            <div class="lp-ai-cap-title">Natural Language Query</div>
+            <div class="lp-ai-cap-header">
+              <div class="lp-ai-cap-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" /></svg></div>
+              <div class="lp-ai-cap-title">Natural Language Query</div>
+            </div>
             <div class="lp-ai-cap-desc">Type a question, get a typed QueryRequest.</div>
           </a>
 
           <a href="/dotnet/ai/workflow-ai/" class="lp-ai-cap">
-            <div class="lp-ai-cap-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" /></svg></div>
-            <div class="lp-ai-cap-title">Workflow decisions</div>
+            <div class="lp-ai-cap-header">
+              <div class="lp-ai-cap-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" /></svg></div>
+              <div class="lp-ai-cap-title">Workflow decisions</div>
+            </div>
             <div class="lp-ai-cap-desc">Score risk. Let safe transitions approve themselves.</div>
           </a>
 
           <a href="/dotnet/ai/timeline-ai/" class="lp-ai-cap">
-            <div class="lp-ai-cap-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" /></svg></div>
-            <div class="lp-ai-cap-title">Audit summaries</div>
+            <div class="lp-ai-cap-header">
+              <div class="lp-ai-cap-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" /></svg></div>
+              <div class="lp-ai-cap-title">Audit summaries</div>
+            </div>
             <div class="lp-ai-cap-desc">300 log entries → one readable paragraph.</div>
           </a>
 
           <a href="/dotnet/ai/notifications-ai/" class="lp-ai-cap">
-            <div class="lp-ai-cap-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" /></svg></div>
-            <div class="lp-ai-cap-title">Smart notifications</div>
+            <div class="lp-ai-cap-header">
+              <div class="lp-ai-cap-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" /></svg></div>
+              <div class="lp-ai-cap-title">Smart notifications</div>
+            </div>
             <div class="lp-ai-cap-desc">LLM writes content in the recipient's language.</div>
           </a>
 
           <a href="/dotnet/ai/import-mapping/" class="lp-ai-cap">
-            <div class="lp-ai-cap-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" /></svg></div>
-            <div class="lp-ai-cap-title">Intelligent import</div>
+            <div class="lp-ai-cap-header">
+              <div class="lp-ai-cap-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" /></svg></div>
+              <div class="lp-ai-cap-title">Intelligent import</div>
+            </div>
             <div class="lp-ai-cap-desc">AI maps CSV headers to your entity properties.</div>
           </a>
 
           <a href="/dotnet/ai/privacy-ai/" class="lp-ai-cap">
-            <div class="lp-ai-cap-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 11c0 3.517-1.009 6.799-2.753 9.571m-3.44-2.04l.054-.09A13.916 13.916 0 008 11a4 4 0 118 0c0 1.017-.07 2.019-.203 3m-2.118 6.844A21.88 21.88 0 0015.171 17m3.839 1.132c.645-2.266.99-4.659.99-7.132A8 8 0 008 4.07M3 15.364c.64-1.319 1-2.8 1-4.364 0-1.457.39-2.823 1.07-4" /></svg></div>
-            <div class="lp-ai-cap-title">PII detection</div>
+            <div class="lp-ai-cap-header">
+              <div class="lp-ai-cap-icon"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 11c0 3.517-1.009 6.799-2.753 9.571m-3.44-2.04l.054-.09A13.916 13.916 0 008 11a4 4 0 118 0c0 1.017-.07 2.019-.203 3m-2.118 6.844A21.88 21.88 0 0015.171 17m3.839 1.132c.645-2.266.99-4.659.99-7.132A8 8 0 008 4.07M3 15.364c.64-1.319 1-2.8 1-4.364 0-1.457.39-2.823 1.07-4" /></svg></div>
+              <div class="lp-ai-cap-title">PII detection</div>
+            </div>
             <div class="lp-ai-cap-desc">Scan free text for personal data before storage.</div>
           </a>
 

--- a/docs-site/src/styles/tailwind.css
+++ b/docs-site/src/styles/tailwind.css
@@ -62,9 +62,15 @@ a.site-title {
   font-weight: 500 !important;
 }
 
-/* Hide Starlight's default hero on splash pages (we render our own) */
-.hero {
+/* Hide Starlight's default hero only on the homepage (custom hero in .lp) */
+main:has(.lp) .hero {
   display: none !important;
+}
+
+/* starlight-blog hides .content-panel:first-of-type globally — restore it
+   on pages that have a single content-panel with a hero (e.g. 404 page) */
+main:has(.hero) > .content-panel:only-of-type {
+  display: block !important;
 }
 
 /* ── Print styles ── */

--- a/src/Granit.Encryption/Extensions/EncryptionServiceCollectionExtensions.cs
+++ b/src/Granit.Encryption/Extensions/EncryptionServiceCollectionExtensions.cs
@@ -29,7 +29,10 @@ public static class EncryptionServiceCollectionExtensions
 
         services.TryAddSingleton<IStringEncryptionService, DefaultStringEncryptionService>();
 
-        // Crypto-shredding (requires IEntityEncryptionKeyStore to be registered by a Vault provider)
+        // In-memory fallback for dev/test — replaced by a Vault provider in production
+        services.TryAddScoped<IEntityEncryptionKeyStore, InMemoryEntityEncryptionKeyStore>();
+
+        // Crypto-shredding
         services.TryAddScoped<ICryptoShredder, DefaultCryptoShredder>();
 
         // Diagnostics

--- a/src/Granit.Encryption/Services/InMemoryEntityEncryptionKeyStore.cs
+++ b/src/Granit.Encryption/Services/InMemoryEntityEncryptionKeyStore.cs
@@ -1,0 +1,66 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+
+namespace Granit.Encryption.Services;
+
+/// <summary>
+/// In-memory implementation of <see cref="IEntityEncryptionKeyStore"/> for development
+/// and testing environments where a Vault provider is not available.
+/// </summary>
+/// <remarks>
+/// Keys are stored in a <see cref="ConcurrentDictionary{TKey,TValue}"/> and are lost
+/// when the process restarts. This implementation MUST NOT be used in production —
+/// a secure provider (e.g., HashiCorp Vault) should override this registration.
+/// </remarks>
+internal sealed class InMemoryEntityEncryptionKeyStore : IEntityEncryptionKeyStore
+{
+    private const int KeySizeBytes = 32; // AES-256
+
+    private readonly ConcurrentDictionary<string, byte[]> _keys = new(StringComparer.Ordinal);
+
+    /// <inheritdoc/>
+    public Task<byte[]> GetOrCreateKeyAsync(
+        string entityType,
+        string entityId,
+        CancellationToken cancellationToken = default)
+    {
+        string cacheKey = BuildKey(entityType, entityId);
+        byte[] key = _keys.GetOrAdd(cacheKey, _ => RandomNumberGenerator.GetBytes(KeySizeBytes));
+        return Task.FromResult(key);
+    }
+
+    /// <inheritdoc/>
+    public Task<byte[]?> GetKeyAsync(
+        string entityType,
+        string entityId,
+        CancellationToken cancellationToken = default)
+    {
+        string cacheKey = BuildKey(entityType, entityId);
+        byte[]? result = _keys.TryGetValue(cacheKey, out byte[]? key) ? key : null;
+        return Task.FromResult(result);
+    }
+
+    /// <inheritdoc/>
+    public Task DeleteKeyAsync(
+        string entityType,
+        string entityId,
+        CancellationToken cancellationToken = default)
+    {
+        string cacheKey = BuildKey(entityType, entityId);
+        _keys.TryRemove(cacheKey, out _);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task<bool> KeyExistsAsync(
+        string entityType,
+        string entityId,
+        CancellationToken cancellationToken = default)
+    {
+        string cacheKey = BuildKey(entityType, entityId);
+        return Task.FromResult(_keys.ContainsKey(cacheKey));
+    }
+
+    private static string BuildKey(string entityType, string entityId) =>
+        $"{entityType}:{entityId}";
+}

--- a/src/Granit.OpenIddict/GranitOpenIddictModule.cs
+++ b/src/Granit.OpenIddict/GranitOpenIddictModule.cs
@@ -49,5 +49,6 @@ public sealed class GranitOpenIddictModule : GranitModule
             .BindConfiguration(GranitOpenIddictSeedingOptions.SectionName);
 
         context.Services.TryAddScoped<IClaimsDestinationProvider, DefaultClaimsDestinationProvider>();
+        context.Services.TryAddScoped<ITotpService, DefaultTotpService>();
     }
 }

--- a/src/Granit.OpenIddict/Services/DefaultTotpService.cs
+++ b/src/Granit.OpenIddict/Services/DefaultTotpService.cs
@@ -1,0 +1,151 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+using Granit.Timing;
+
+namespace Granit.OpenIddict.Services;
+
+/// <summary>
+/// Default RFC 6238 TOTP implementation using <see cref="HMACSHA1"/> for two-factor authentication.
+/// </summary>
+/// <remarks>
+/// Provides a lightweight fallback when the EF Core persistence layer (which ships a richer
+/// implementation reading the issuer from <c>IdentityOptions</c>) is not loaded.
+/// Uses a +/-1 time-step window to tolerate clock drift between the server and authenticator apps.
+/// </remarks>
+internal sealed class DefaultTotpService(IClock clock) : ITotpService
+{
+    private const int KeyLength = 20; // 160-bit per RFC 4226 §4
+    private const int TimeStepSeconds = 30;
+    private const int CodeDigits = 6;
+    private const int CodeModulus = 1_000_000; // 10^6
+    private const string DefaultIssuer = "Granit";
+    private const string Base32Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+    /// <inheritdoc/>
+    public string GenerateSharedKey()
+    {
+        byte[] key = RandomNumberGenerator.GetBytes(KeyLength);
+        return Base32Encode(key);
+    }
+
+    /// <inheritdoc/>
+    public string GetQrCodeUri(string email, string sharedKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(email);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sharedKey);
+
+        string encodedIssuer = Uri.EscapeDataString(DefaultIssuer);
+        string encodedEmail = Uri.EscapeDataString(email);
+
+        return $"otpauth://totp/{encodedIssuer}:{encodedEmail}?secret={sharedKey}&issuer={encodedIssuer}&digits={CodeDigits}&period={TimeStepSeconds}";
+    }
+
+    /// <inheritdoc/>
+    public bool ValidateCode(string sharedKey, string code)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sharedKey);
+
+        if (string.IsNullOrEmpty(code) || code.Length != CodeDigits)
+        {
+            return false;
+        }
+
+        byte[] key = Base32Decode(sharedKey);
+        long currentStep = clock.Now.ToUnixTimeSeconds() / TimeStepSeconds;
+
+        // Allow +/-1 step for clock drift (RFC 6238 §5.2)
+        for (long offset = -1; offset <= 1; offset++)
+        {
+            string computed = ComputeTotp(key, currentStep + offset);
+
+            if (CryptographicOperations.FixedTimeEquals(
+                Encoding.UTF8.GetBytes(computed),
+                Encoding.UTF8.GetBytes(code)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // HMAC-SHA1 is mandated by RFC 6238 §5.1 / RFC 4226 §5 for interoperability
+    // with authenticator apps (Google Authenticator, Microsoft Authenticator, etc.).
+#pragma warning disable CA5350 // Do not use weak cryptographic algorithms
+    private static string ComputeTotp(byte[] key, long timeStep)
+    {
+        Span<byte> timeBytes = stackalloc byte[8];
+        BinaryPrimitives.WriteInt64BigEndian(timeBytes, timeStep);
+
+        Span<byte> hash = stackalloc byte[HMACSHA1.HashSizeInBytes];
+        HMACSHA1.HashData(key, timeBytes, hash);
+
+        int offset = hash[^1] & 0x0F;
+        int binaryCode = ((hash[offset] & 0x7F) << 24)
+                       | ((hash[offset + 1] & 0xFF) << 16)
+                       | ((hash[offset + 2] & 0xFF) << 8)
+                       | (hash[offset + 3] & 0xFF);
+
+        int otp = binaryCode % CodeModulus;
+        return otp.ToString().PadLeft(CodeDigits, '0');
+    }
+#pragma warning restore CA5350
+
+    private static string Base32Encode(ReadOnlySpan<byte> data)
+    {
+        var result = new StringBuilder((data.Length * 8 + 4) / 5);
+        int buffer = 0;
+        int bitsLeft = 0;
+
+        foreach (byte b in data)
+        {
+            buffer = (buffer << 8) | b;
+            bitsLeft += 8;
+
+            while (bitsLeft >= 5)
+            {
+                bitsLeft -= 5;
+                result.Append(Base32Alphabet[(buffer >> bitsLeft) & 0x1F]);
+            }
+        }
+
+        if (bitsLeft > 0)
+        {
+            result.Append(Base32Alphabet[(buffer << (5 - bitsLeft)) & 0x1F]);
+        }
+
+        return result.ToString();
+    }
+
+    private static byte[] Base32Decode(string base32)
+    {
+        ReadOnlySpan<char> trimmed = base32.AsSpan().TrimEnd('=');
+        byte[] result = new byte[trimmed.Length * 5 / 8];
+        int buffer = 0;
+        int bitsLeft = 0;
+        int index = 0;
+
+        foreach (char c in trimmed)
+        {
+            char upper = char.ToUpperInvariant(c);
+            int value = upper switch
+            {
+                >= 'A' and <= 'Z' => upper - 'A',
+                >= '2' and <= '7' => upper - '2' + 26,
+                _ => throw new FormatException($"Invalid Base32 character: '{c}'.")
+            };
+
+            buffer = (buffer << 5) | value;
+            bitsLeft += 5;
+
+            if (bitsLeft >= 8)
+            {
+                bitsLeft -= 8;
+                result[index++] = (byte)(buffer >> bitsLeft);
+            }
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary

- **`IEntityEncryptionKeyStore`**: add `InMemoryEntityEncryptionKeyStore` (ConcurrentDictionary-backed) in `Granit.Encryption` as a dev/test fallback — the Vault module's `HashiCorpEntityEncryptionKeyStore` overrides it in production via `TryAddScoped`
- **`ITotpService`**: add `DefaultTotpService` (RFC 6238, pure `System.Security.Cryptography`) in `Granit.OpenIddict` — the EF Core layer's richer `TotpService` (with `IdentityOptions` issuer) overrides it when loaded
- **`AesStringEncryptionProvider`**: generate an ephemeral random passphrase with a warning log when `Encryption:PassPhrase` is not configured (dev without Vault), instead of throwing `InvalidOperationException`
- **`Wolverine.Postgresql`**: replace `ConfigureWolverine` with `UseWolverine` — since WolverineFx 5.24, DI-registered extensions can no longer modify the service collection, and `PersistMessagesWithPostgresql` registers services internally
- **docs-site**: responsive layout fixes (mobile-first grids, hero visibility, Alpha badge)

## Test plan

- [x] `dotnet build` — all modified projects compile clean
- [x] `Granit.Encryption.Tests` — 50/50 pass (incl. ephemeral passphrase tests)
- [x] `Granit.OpenIddict.Tests` — 155/155 pass
- [x] `Granit.Wolverine.Tests` — 164/164 pass
- [ ] Start a showcase app in Development (no Vault) — verify no DI crash at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
