### PR TITLE
fix(bff): remove unused clock variable in login callback

### DIFF
--- a/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
@@ -72,7 +72,6 @@ internal static partial class BffLoginEndpoints
         IServiceProvider services = httpContext.RequestServices;
         GranitBffOptions bffOptions = services.GetRequiredService<IOptions<GranitBffOptions>>().Value;
         IFusionCache cache = services.GetRequiredService<IFusionCache>();
-        IClock clock = services.GetRequiredService<IClock>();
         IDPoPProofService dpopService = services.GetRequiredService<IDPoPProofService>();
         ILogger logger = services.GetRequiredService<ILoggerFactory>()
             .CreateLogger("Granit.Bff.Endpoints.BffLoginEndpoints");


### PR DESCRIPTION
## Summary

- Remove unused `IClock clock` local variable in `BffLoginEndpoints.HandleLoginAsync` (SonarQube code smell)

## Test plan

- [x] `dotnet build Granit.Bff.Endpoints` — compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)