### PR TITLE
fix(wolverine,encryption): Wolverine 5.24 compat and AES dev fallback

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -10882,7 +10882,7 @@
       "kind": "class",
       "project": "Granit.Encryption",
       "file": "src/Granit.Encryption/Providers/AesStringEncryptionProvider.cs",
-      "line": 20,
+      "line": 21,
       "members": [
         {
           "name": "ProviderName",

--- a/src/Granit.Encryption/Providers/AesStringEncryptionProvider.cs
+++ b/src/Granit.Encryption/Providers/AesStringEncryptionProvider.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using System.Text;
 using Granit.Encryption;
 using Granit.Encryption.Options;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Granit.Encryption.Providers;
@@ -17,7 +18,7 @@ namespace Granit.Encryption.Providers;
 /// </para>
 /// Designed for frequent operations (&lt; 1 ms after startup).
 /// </summary>
-public sealed class AesStringEncryptionProvider : IStringEncryptionProvider
+public sealed partial class AesStringEncryptionProvider : IStringEncryptionProvider
 {
     /// <remarks>
     /// SECURITY: Fixed internal salt for PBKDF2 key derivation.
@@ -42,20 +43,22 @@ public sealed class AesStringEncryptionProvider : IStringEncryptionProvider
     /// <inheritdoc/>
     public string ProviderName => StringEncryptionOptions.AesProviderName;
 
-    public AesStringEncryptionProvider(IOptions<StringEncryptionOptions> options)
+    public AesStringEncryptionProvider(
+        IOptions<StringEncryptionOptions> options,
+        ILogger<AesStringEncryptionProvider> logger)
     {
         StringEncryptionOptions opts = options.Value;
+        string passPhrase = opts.PassPhrase;
 
-        if (string.IsNullOrEmpty(opts.PassPhrase))
+        if (string.IsNullOrEmpty(passPhrase))
         {
-            throw new InvalidOperationException(
-                "Encryption:PassPhrase is required for AesStringEncryptionProvider. " +
-                "Configure via Vault config provider (never in plain text in appsettings).");
+            passPhrase = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+            LogEphemeralPassPhrase(logger);
         }
 
         int aesKeySize = opts.KeySize / 8;
         byte[] derivedKey = Rfc2898DeriveBytes.Pbkdf2(
-            opts.PassPhrase,
+            passPhrase,
             KeyDerivationSalt,
             KeyDerivationIterations,
             HashAlgorithmName.SHA256,
@@ -146,4 +149,10 @@ public sealed class AesStringEncryptionProvider : IStringEncryptionProvider
             return null;
         }
     }
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Encryption:PassPhrase is not configured — using an ephemeral random passphrase. " +
+                  "Encrypted data will NOT survive application restarts. " +
+                  "Configure a stable passphrase via Vault for production use")]
+    private static partial void LogEphemeralPassPhrase(ILogger logger);
 }

--- a/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
@@ -121,7 +121,11 @@ public static class WolverinePostgresqlHostApplicationBuilderExtensions
 
         string connectionString = ResolveConnectionString(builder.Configuration, options);
 
-        builder.Services.ConfigureWolverine(opts =>
+        // UseWolverine (not ConfigureWolverine): PersistMessagesWithPostgresql registers
+        // services internally. Since Wolverine 3.0/5.24, DI-registered IWolverineExtension
+        // instances run after the container is built (read-only). UseWolverine accumulates
+        // configuration delegates that run while the service collection is still writable.
+        builder.UseWolverine(opts =>
         {
             opts.PersistMessagesWithPostgresql(connectionString);
             opts.UseEntityFrameworkCoreTransactions(options.TransactionMode);

--- a/tests/Granit.Encryption.Tests/AesStringEncryptionProviderTests.cs
+++ b/tests/Granit.Encryption.Tests/AesStringEncryptionProviderTests.cs
@@ -5,6 +5,7 @@
 using Granit.Encryption;
 using Granit.Encryption.Options;
 using Granit.Encryption.Providers;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Shouldly;
 using Xunit;
@@ -22,7 +23,7 @@ public sealed class AesStringEncryptionProviderTests
             ProviderName = StringEncryptionOptions.AesProviderName
         });
 
-        return new AesStringEncryptionProvider(options);
+        return new AesStringEncryptionProvider(options, NullLogger<AesStringEncryptionProvider>.Instance);
     }
 
     [Fact]
@@ -132,16 +133,17 @@ public sealed class AesStringEncryptionProviderTests
     }
 
     [Fact]
-    public void Constructor_EmptyPassPhrase_Throws_InvalidOperationException()
+    public void Constructor_EmptyPassPhrase_Uses_Ephemeral_Key_And_Still_Works()
     {
         IOptions<StringEncryptionOptions> options = Microsoft.Extensions.Options.Options.Create(new StringEncryptionOptions
         {
             PassPhrase = string.Empty
         });
 
-        Action act = () => _ = new AesStringEncryptionProvider(options);
+        AesStringEncryptionProvider provider = new(options, NullLogger<AesStringEncryptionProvider>.Instance);
 
-        Should.Throw<InvalidOperationException>(act).Message.ShouldContain("PassPhrase");
+        string cipherText = provider.Encrypt("ephemeral empty test");
+        provider.Decrypt(cipherText).ShouldBe("ephemeral empty test");
     }
 
     [Fact]
@@ -157,16 +159,17 @@ public sealed class AesStringEncryptionProviderTests
     }
 
     [Fact]
-    public void Constructor_NullPassPhrase_Throws_InvalidOperationException()
+    public void Constructor_NullPassPhrase_Uses_Ephemeral_Key_And_Still_Works()
     {
         IOptions<StringEncryptionOptions> options = Microsoft.Extensions.Options.Options.Create(new StringEncryptionOptions
         {
             PassPhrase = null!
         });
 
-        Action act = () => _ = new AesStringEncryptionProvider(options);
+        AesStringEncryptionProvider provider = new(options, NullLogger<AesStringEncryptionProvider>.Instance);
 
-        Should.Throw<InvalidOperationException>(act).Message.ShouldContain("PassPhrase");
+        string cipherText = provider.Encrypt("ephemeral test");
+        provider.Decrypt(cipherText).ShouldBe("ephemeral test");
     }
 
     [Fact]
@@ -235,7 +238,7 @@ public sealed class AesStringEncryptionProviderTests
             KeySize = 128,
             ProviderName = StringEncryptionOptions.AesProviderName
         });
-        AesStringEncryptionProvider provider = new(options);
+        AesStringEncryptionProvider provider = new(options, NullLogger<AesStringEncryptionProvider>.Instance);
 
         string cipherText = provider.Encrypt("hello 128-bit");
         string? decrypted = provider.Decrypt(cipherText);
@@ -252,7 +255,7 @@ public sealed class AesStringEncryptionProviderTests
             KeySize = 192,
             ProviderName = StringEncryptionOptions.AesProviderName
         });
-        AesStringEncryptionProvider provider = new(options);
+        AesStringEncryptionProvider provider = new(options, NullLogger<AesStringEncryptionProvider>.Instance);
 
         string cipherText = provider.Encrypt("hello 192-bit");
         string? decrypted = provider.Decrypt(cipherText);
@@ -274,8 +277,8 @@ public sealed class AesStringEncryptionProviderTests
             KeySize = 128
         });
 
-        AesStringEncryptionProvider provider256 = new(options256);
-        AesStringEncryptionProvider provider128 = new(options128);
+        AesStringEncryptionProvider provider256 = new(options256, NullLogger<AesStringEncryptionProvider>.Instance);
+        AesStringEncryptionProvider provider128 = new(options128, NullLogger<AesStringEncryptionProvider>.Instance);
 
         string cipherText = provider256.Encrypt("cross-key test");
         string? result = provider128.Decrypt(cipherText);


### PR DESCRIPTION
## Summary

- **Wolverine.Postgresql**: replace `ConfigureWolverine` with `UseWolverine` — since WolverineFx 5.24, DI-registered `IWolverineExtension` instances run after the container is built (read-only). `PersistMessagesWithPostgresql` registers services internally, so it must run during the `UseWolverine` phase while the service collection is still writable.
- **AesStringEncryptionProvider**: generate an ephemeral random passphrase with a warning log when `Encryption:PassPhrase` is not configured (dev without Vault), instead of throwing `InvalidOperationException`. Tests updated accordingly.

> These changes were part of PR #678 but were committed after the squash merge.

## Test plan

- [x] `Granit.Encryption.Tests` — 50/50 pass (incl. ephemeral passphrase tests)
- [x] `Granit.Wolverine.Tests` — 164/164 pass
- [ ] Start a showcase app in Development (no Vault) — verify no DI crash at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
