### PR TITLE
fix(wolverine): update tests for UseWolverine migration

### DIFF
--- a/tests/Granit.Wolverine.Postgresql.Tests/AddGranitWolverineWithPostgresqlTests.cs
+++ b/tests/Granit.Wolverine.Postgresql.Tests/AddGranitWolverineWithPostgresqlTests.cs
@@ -12,8 +12,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Shouldly;
-using Wolverine;
-using Wolverine.Runtime;
 using Xunit;
 
 namespace Granit.Wolverine.Postgresql.Tests;
@@ -39,20 +37,20 @@ public sealed class AddGranitWolverineWithPostgresqlTests
     }
 
     // -----------------------------------------------------------------------
-    // Configure callback — ConfigureWolverine defers invocation until
-    // WolverineOptions is resolved. We verify the IConfigureOptions<>
-    // registration exists and that the callback runs when resolved.
+    // Configure callback — UseWolverine registers Wolverine core services
+    // directly (no IWolverineExtension in DI since Wolverine 3.0/5.24).
+    // We verify the hosted service is registered, proving UseWolverine ran.
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void AddGranitWolverineWithPostgresql_WithConfigureCallback_RegistersWolverineExtension()
+    public void AddGranitWolverineWithPostgresql_WithConfigureCallback_RegistersWolverine()
     {
         HostApplicationBuilder builder = CreateBuilder();
 
         builder.AddGranitWolverineWithPostgresql(opts => { });
 
         builder.Services.ShouldContain(d =>
-            d.ServiceType == typeof(IWolverineExtension));
+            d.ServiceType == typeof(IHostedService));
     }
 
     // -----------------------------------------------------------------------
@@ -121,18 +119,18 @@ public sealed class AddGranitWolverineWithPostgresqlTests
     }
 
     // -----------------------------------------------------------------------
-    // PerTenant — configure callback (deferred by ConfigureWolverine)
+    // PerTenant — configure callback (applied via UseWolverine)
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void AddGranitWolverineWithPostgresqlPerTenant_WithConfigureCallback_RegistersWolverineExtension()
+    public void AddGranitWolverineWithPostgresqlPerTenant_WithConfigureCallback_RegistersWolverine()
     {
         HostApplicationBuilder builder = CreateBuilder();
 
         builder.AddGranitWolverineWithPostgresqlPerTenant<StubTenantDbContext>(opts => { });
 
         builder.Services.ShouldContain(d =>
-            d.ServiceType == typeof(IWolverineExtension));
+            d.ServiceType == typeof(IHostedService));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Update 2 failing tests in `Granit.Wolverine.Postgresql.Tests` that asserted `IWolverineExtension` was registered in DI — this was the old `ConfigureWolverine` behavior removed in PR #680
- Assert `IHostedService` registration instead, which proves `UseWolverine` configured Wolverine core services

## Test plan

- [x] `Granit.Wolverine.Postgresql.Tests` — 35/35 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)