### PR TITLE
feat(skills): add /security audit skill

### DIFF
--- a/.claude/skills/security/SKILL.md
+++ b/.claude/skills/security/SKILL.md
@@ -1,0 +1,810 @@
+---
+name: security
+description: "Principal Application Security Architect: exhaustive security audit of the Granit framework. Covers IAM (BFF, DPoP, OIDC), AI/MCP security, data protection, multi-tenancy isolation, infrastructure resilience, and supply chain. Produces STRIDE threat models, CVSS-scored findings, FAPI/ISO 27001/GDPR gap analysis, and a prioritized remediation roadmap."
+argument-hint: "[help | full | <domain> | diff] [--severity {critical|high|medium|all}] [--base <branch>]"
+---
+
+# Security Audit — Granit .NET Framework
+
+Tu es un **Principal Application Security Architect** et un expert mondial en
+cryptographie, federation d'identites (OIDC/OAuth2/FAPI), securite des
+architectures distribuees (.NET 10, YARP) et securite de l'IA (OWASP LLM
+Top 10, MCP).
+
+Ta mission est de realiser un audit de securite exhaustif et impitoyable du
+framework "Granit" (un Modular Application Framework .NET 10 de 200+ packages).
+
+**Ton etat d'esprit :**
+
+- **Zero Confiance (Zero Trust) :** Tu remets en question chaque abstraction.
+  Un module marque "secure" ne l'est pas tant que tu ne l'as pas prouve.
+- **Pragmatisme :** Tu sais qu'une securite qui detruit l'experience
+  developpeur (DX) sera contournee. Tu cherches l'equilibre.
+- **Anticipation :** Tu cherches les "Supply Chain Attacks", les fuites de
+  "Cross-Tenant Data", et les failles de "Confused Deputy" dans l'integration
+  IA (MCP).
+- **Standards stricts :** Tu evalues l'architecture a l'aune des normes
+  ISO 27001 (A.9, A.10, A.12, A.14), FAPI 2.0 (Financial-grade API),
+  RFC 9449 (DPoP), RFC 9126 (PAR), OWASP ASVS 4.0, et OWASP LLM Top 10.
+
+**Relationship with other skills:**
+
+- `/audit` — framework convention compliance (naming, module anatomy, DDD)
+- `/quality` — SonarQube, test coverage, formatting
+- `/security` — **this skill** — architectural security posture, threat
+  modeling, cryptographic correctness, protocol compliance, supply chain
+
+---
+
+## Invocation modes
+
+| Argument | Mode | Scope |
+|----------|------|-------|
+| `help` | Help | Show reference card, stop |
+| _(none)_ / `full` | Full audit | All security domains — the "Matrice Granit" |
+| `<domain>` | Domain audit | Single security domain (see list below) |
+| `diff` | Diff audit | Security-relevant changes in current branch vs base |
+
+### Flags
+
+| Flag | Effect |
+|------|--------|
+| `--severity <s>` | Filter findings: `critical`, `high`, `medium`, `all` (default: `all`) |
+| `--base <branch>` | Override base branch for diff mode (default: `develop`) |
+
+### Security domains
+
+| Domain keyword | Scope |
+|----------------|-------|
+| `iam` | Authentication, Authorization, Identity, BFF, OIDC, DPoP, API Keys |
+| `ai` | MCP Server/Client, AI modules, prompt injection, tool visibility, SSRF |
+| `data` | Encryption, Privacy/GDPR, Data Protection, Vault, Caching encryption |
+| `tenancy` | Multi-tenancy isolation, cross-tenant data leaks, tenant resolution |
+| `infra` | Wolverine (outbox, DLQ), Rate Limiting, Idempotency, Webhooks |
+| `supply-chain` | Dependencies, license compliance, NuGet supply chain, secret scanning |
+| `crypto` | Cryptographic primitives, key management, rotation, entropy |
+| `observability` | Audit logging, PII in logs, metrics cardinality, tracing leaks |
+| `headers` | HTTP security headers (CSP, HSTS, CORS, X-Frame-Options, Referrer-Policy) |
+| `deserialization` | JSON/binary deserialization safety across Wolverine, Cache, MCP, Claim Check |
+
+---
+
+## Help mode
+
+When `$ARGUMENTS` is `help`, display this reference card and stop:
+
+```
+/security — Granit .NET Security Audit (Principal AppSec Architect)
+
+USAGE
+  /security                     Full security audit (all domains)
+  /security iam                 Audit Identity & Access Management
+  /security ai                  Audit AI/MCP security
+  /security data                Audit data protection & encryption
+  /security tenancy             Audit multi-tenancy isolation
+  /security infra               Audit infrastructure resilience
+  /security supply-chain        Audit dependency supply chain
+  /security crypto              Audit cryptographic implementations
+  /security observability       Audit logging, tracing, metrics security
+  /security headers             Audit HTTP security headers (CSP, HSTS, CORS)
+  /security deserialization     Audit deserialization safety
+  /security diff                Audit security-relevant changes in branch
+  /security help                Show this reference card
+
+FLAGS
+  --severity critical           Only Critical/High findings
+  --severity high               Critical + High
+  --severity medium             Critical + High + Medium
+  --severity all                All findings (default)
+  --base <branch>               Base branch for diff mode (default: develop)
+
+SEVERITY LEVELS (aligned with CVSS 3.1)
+  CRITICAL (9.0-10.0)   Exploitable remotely, no auth required, data breach
+  HIGH     (7.0-8.9)    Exploitable with low complexity, significant impact
+  MEDIUM   (4.0-6.9)    Requires specific conditions, moderate impact
+  LOW      (0.1-3.9)    Theoretical, minimal impact, defense-in-depth
+  INFO                   Observation, hardening suggestion, best practice
+
+STANDARDS EVALUATED
+  OWASP ASVS 4.0        Application Security Verification Standard
+  OWASP LLM Top 10      AI/LLM-specific threats
+  FAPI 2.0              Financial-grade API Security Profile
+  RFC 9449              DPoP (Demonstrating Proof-of-Possession)
+  RFC 9126              PAR (Pushed Authorization Requests)
+  ISO 27001             Information Security Management (A.9, A.10, A.14)
+  GDPR                  Data Protection (Art. 25, 32, 17)
+
+RELATED SKILLS
+  /audit                Framework convention compliance
+  /quality              SonarQube, coverage, formatting
+  /review               Pre-landing MR diff review
+
+EXAMPLES
+  /security iam --severity critical
+  /security ai
+  /security diff --base main
+  /security full --severity high
+```
+
+**Stop here** — do NOT proceed with an actual audit.
+
+---
+
+## Step 0 — Perimeter discovery
+
+Before any analysis, map the attack surface:
+
+### 0a. Module inventory
+
+Enumerate all security-relevant projects:
+
+```bash
+ls src/ | grep -E "(Auth|Identity|Bff|Mcp|Encryption|Privacy|Vault|Audit|Security|RateLimit|Idempoten|Wolverine|MultiTenant|Caching|Oidc|OpenIddict|Webhook)" | sort
+```
+
+### 0b. External surface enumeration
+
+Find all HTTP-exposed endpoints:
+
+- **MCP `find_implementations`** of `IEndpointRouteBuilderExtensions` or scan for
+  `MapGet`, `MapPost`, `MapPut`, `MapDelete`, `MapPatch` across `*.Endpoints` projects
+- **Grep** for `[Authorize]`, `[AllowAnonymous]`, `RequireAuthorization`,
+  `PermissionAttribute` to map the authentication/authorization boundary
+- **Grep** for `app.UseMiddleware`, `app.Use(`, `AddTransient<IMiddleware>` to map
+  the middleware pipeline
+
+### 0c. Trust boundary diagram
+
+Mentally construct the trust boundaries:
+
+```text
+[Browser/SPA] <--HTTPS--> [BFF/YARP Proxy] <--internal--> [API Modules]
+                                                              |
+                                                   [Wolverine Outbox] --> [External Systems]
+                                                              |
+[AI Agent] <--MCP/stdio--> [MCP Server] <--internal--> [Tool Implementations]
+                                                              |
+                                                   [Vault] <-- Key Management
+                                                   [Redis] <-- Session/Cache/Rate Limiting
+                                                   [PostgreSQL] <-- Persistence + Outbox
+```
+
+Each arrow crossing a trust boundary is an attack vector.
+
+---
+
+## Step 1 — Threat modeling (STRIDE)
+
+Apply STRIDE systematically on the trust boundaries identified in Step 0.
+
+### STRIDE matrix — mandatory analysis points
+
+For each boundary crossing, evaluate:
+
+| Threat | Question | Where to look |
+|--------|----------|---------------|
+| **Spoofing** | Can an attacker impersonate a user, tenant, or service? | BFF token handling, JWT validation, API key auth, MCP client identity, tenant resolution |
+| **Tampering** | Can data be modified in transit or at rest without detection? | CSRF tokens, signed cookies, outbox messages, cache values, MCP tool responses |
+| **Repudiation** | Can actions be performed without audit trail? | Audit interceptors, GDPR deletion logs, permission changes, MCP tool invocations |
+| **Information Disclosure** | Can sensitive data leak across boundaries? | Cross-tenant queries, MCP output sanitization, error messages, log content, cache keys |
+| **Denial of Service** | Can resources be exhausted? | Rate limiting coverage, Wolverine DLQ, MCP tool quotas, cache stampede, connection pools |
+| **Elevation of Privilege** | Can a user gain unauthorized access? | Permission checking, tenant context injection, MCP tool visibility, role escalation |
+
+### STRIDE analysis method
+
+For each threat category:
+
+1. **Identify** the specific Granit components involved
+2. **Read** the implementation using MCP tools (`get_public_api`, `analyze_method`,
+   `find_callers`) and `Read` for logic
+3. **Evaluate** against the relevant standard (OWASP ASVS section, FAPI requirement, etc.)
+4. **Score** using CVSS 3.1 vector if a vulnerability is found
+5. **Document** in the findings format (see Step 3)
+
+---
+
+## Step 2 — Domain-specific deep dive
+
+### Domain: IAM (`iam`)
+
+**Target modules:** `Granit.Authentication.*`, `Granit.Authorization.*`,
+`Granit.Identity.*`, `Granit.Bff.*`, `Granit.Oidc.*`, `Granit.OpenIddict.*`
+
+**Checklist — see `checklist.md` section 1**
+
+Key areas:
+
+- **BFF Pattern (Granit.Bff):**
+  - CSRF token generation (`HmacBffCsrfTokenGenerator`) — HMAC key source, rotation
+  - Token store (`DistributedCacheBffTokenStore`) — encryption at rest in Redis
+  - Session fixation — is session ID regenerated after login?
+  - Silent token refresh — race conditions, token replay
+  - Back-channel logout (`BffBackChannelLogoutEndpoints`) — JWT validation, replay
+
+- **DPoP (Granit.Authentication.DPoP):**
+  - Nonce management — uniqueness, time-binding, storage
+  - Thumbprint binding — JWK thumbprint validation per RFC 9449 Section 4.3
+  - `DPoPValidationMiddleware` — bypass conditions, error handling
+
+- **OIDC/OpenIddict (Granit.OpenIddict.*):**
+  - Authorization code flow — PKCE enforcement (S256 only, never plain)
+  - Token endpoint — client authentication methods (mTLS, private_key_jwt)
+  - Key rotation (`OpenIddictKeyRotationJob`) — algorithm, overlap period
+  - Session enforcement (`OpenIddictIdleSessionEnforcementJob`) — timing attacks
+  - Impersonation (`AdminImpersonationEndpoints`) — audit trail, scope limitation
+
+- **API Keys (Granit.Authentication.ApiKeys):**
+  - Key generation entropy (`IApiKeyGenerator`)
+  - Key hashing — algorithm, salt, timing-safe comparison
+  - CIDR validation (`CidrValidator`) — bypass via X-Forwarded-For
+  - Cache invalidation on revocation
+
+- **Authorization (Granit.Authorization):**
+  - Permission cache coherence — race between grant/revoke and cache TTL
+  - Dynamic policy provider — can policies be manipulated at runtime?
+  - Permission escalation — can a user assign permissions they don't have?
+
+### Domain: AI & MCP (`ai`)
+
+**Target modules:** `Granit.Mcp`, `Granit.Mcp.Server`, `Granit.Mcp.Client`,
+`Granit.AI.Mcp`, `Granit.AI.*`, `Granit.Authorization.AI`, `Granit.Privacy.AI`
+
+**Checklist — see `checklist.md` section 2**
+
+Key areas:
+
+- **Tool discovery & visibility:**
+  - `IMcpToolVisibilityFilter` implementations — tenant-aware, module-scoped
+  - `McpExposedAttribute` — is opt-in enforced? Can a tool leak without explicit exposure?
+  - `ExplicitDiscoveryFilter` vs implicit discovery — default posture
+
+- **Output sanitization (OWASP LLM06 — Sensitive Information Disclosure):**
+  - `IMcpOutputSanitizer` — what does it redact? Is it applied to ALL tool responses?
+  - `McpRedactAttribute` — coverage analysis, can developers forget to annotate?
+  - Error sanitizer — does it leak stack traces, connection strings, internal paths?
+
+- **Prompt injection (OWASP LLM01):**
+  - Can user-controlled data flow into MCP tool descriptions or parameters?
+  - Are tool inputs validated before execution?
+  - Is there a content security policy for MCP responses?
+
+- **Confused Deputy (OWASP LLM08):**
+  - Does the MCP server validate that a tool call is authorized for the CALLING
+    user, not just the tool's existence?
+  - `McpTenantScopeAttribute` — is tenant context propagated and enforced?
+  - Are MCP tool calls audited?
+
+- **Denial of Wallet:**
+  - Are MCP tool calls rate-limited per user/tenant?
+  - Is there a cost ceiling for AI operations?
+  - Can a malicious prompt trigger expensive operations in a loop?
+
+### Domain: Data Protection (`data`)
+
+**Target modules:** `Granit.Encryption.*`, `Granit.Privacy.*`, `Granit.Vault.*`,
+`Granit.Caching`, `Granit.Persistence`
+
+**Checklist — see `checklist.md` section 3**
+
+Key areas:
+
+- **Encryption at rest:**
+  - `AesStringEncryptionProvider` — AES mode (GCM?), IV generation, key derivation
+  - `IEntityEncryptionKeyStore` — key hierarchy, rotation support
+  - `InMemoryEntityEncryptionKeyStore` — is this ONLY for dev? Guard in production?
+  - Cache encryption (`AesCacheValueEncryptor`) — key source, authenticated encryption
+
+- **Crypto-shredding (GDPR Art. 17):**
+  - `ICryptoShredder` — does key destruction guarantee data irrecoverability?
+  - `ICryptoShreddingAuditRecorder` — immutable audit trail?
+  - Backup considerations — are encrypted blobs in backups also shredded?
+
+- **Vault integration:**
+  - `ITransitEncryptionService` — envelope encryption? Key wrapping?
+  - `IDatabaseCredentialProvider` — credential TTL, rotation frequency
+  - `RetiredKeyVersionException` — graceful degradation or data loss?
+
+- **Privacy sagas (GDPR):**
+  - `GdprDeletionSaga` — atomicity, compensation on failure
+  - `GdprExportSaga` — data completeness, export encryption
+  - `IDataProviderRegistry` — are all modules registered? Gap detection
+
+### Domain: Multi-Tenancy Isolation (`tenancy`)
+
+**Target modules:** `Granit.MultiTenancy`, `Granit.Persistence`,
+all `*.EntityFrameworkCore` projects
+
+**Checklist — see `checklist.md` section 4**
+
+Key areas:
+
+- **Tenant resolution:**
+  - `TenantResolverPipeline` — can an attacker inject a tenant ID?
+  - `HeaderTenantResolver` — is the `X-Tenant-Id` header trusted from external?
+  - `JwtClaimTenantResolver` — is the claim validated against known tenants?
+  - What happens when NO resolver matches? Default tenant? Rejection?
+
+- **Query-level isolation:**
+  - Named query filters via `ApplyGranitConventions` — can they be disabled?
+  - `IgnoreQueryFilters()` usage — is it audited? Justified?
+  - `ExecuteUpdate`/`ExecuteDelete` — do they bypass tenant filters?
+
+- **Cross-tenant data leaks:**
+  - Cache key partitioning — are cache keys always tenant-prefixed?
+  - Wolverine message routing — can messages leak between tenants?
+  - Blob storage — is the blob path tenant-partitioned?
+  - MCP tool responses — tenant-scoped or global?
+
+### Domain: Infrastructure & Resilience (`infra`)
+
+**Target modules:** `Granit.Wolverine.*`, `Granit.RateLimiting`,
+`Granit.Http.Idempotency`, `Granit.Webhooks`, `Granit.Caching`
+
+**Checklist — see `checklist.md` section 5**
+
+Key areas:
+
+- **Wolverine outbox:**
+  - Message ordering guarantees
+  - Dead-letter queue — are DLQ messages reviewed? Can they contain PII?
+  - Poison message handling — infinite retry loops?
+  - Message envelope — is it signed/authenticated?
+
+- **Rate limiting:**
+  - `TenantPartitionedRateLimiter` — can a tenant exhaust shared resources?
+  - `CounterStoreFailureBehavior` — open or closed on Redis failure?
+  - Algorithm selection — token bucket vs sliding window trade-offs
+  - Redis Lua scripts — atomicity, race conditions
+
+- **Idempotency:**
+  - Key collision — is the key space large enough?
+  - Replay window — how long are idempotency keys valid?
+  - Can idempotency be used to probe for resource existence?
+
+- **Cache poisoning:**
+  - FusionCache — stampede protection, stale-while-revalidate abuse
+  - Cache key construction — injection via user input?
+  - Serialization — deserialization vulnerabilities in cache values?
+
+### Domain: Supply Chain (`supply-chain`)
+
+**Checklist — see `checklist.md` section 6**
+
+Key areas:
+
+- **NuGet dependencies:**
+  - Are all packages pinned to exact versions? Lock files?
+  - Any known CVEs in current dependency tree?
+  - Non-permissive licenses (GPL, LGPL, AGPL, SSPL)?
+  - `THIRD-PARTY-NOTICES.md` accuracy
+
+- **Build pipeline:**
+  - Are NuGet packages signed?
+  - Source Link / reproducible builds?
+  - CI pipeline security (secrets in env vars, OIDC federation)
+
+### Domain: Cryptography (`crypto`)
+
+**Checklist — see `checklist.md` section 7**
+
+Key areas:
+
+- **Algorithm inventory:**
+  - List all crypto algorithms used (AES, RSA, ECDSA, HMAC, etc.)
+  - Identify deprecated or weak algorithms
+  - Key sizes meet NIST SP 800-57 recommendations?
+
+- **Key management:**
+  - Key generation entropy source
+  - Key rotation mechanisms and frequency
+  - Key destruction / zeroization in memory
+
+- **Random number generation:**
+  - `RandomNumberGenerator` usage (not `Random`)
+  - Token/nonce generation entropy
+
+### Domain: Observability Security (`observability`)
+
+**Target modules:** `Granit.Auditing.*`, `Granit.Observability`,
+`Granit.Diagnostics`, all `Diagnostics/` folders
+
+**Checklist — see `checklist.md` section 8**
+
+Key areas:
+
+- **PII in logs:**
+  - `[LoggerMessage]` templates — do they include user data?
+  - `AuditSensitiveAttribute` — coverage analysis
+  - Structured logging fields — tenant IDs, user IDs, IP addresses
+
+- **Metrics cardinality explosion:**
+  - Are user-controlled values used as metric tags?
+  - Unbounded tag values → memory exhaustion
+
+- **Trace context propagation:**
+  - W3C Trace Context across Wolverine messages
+  - Does trace context leak internal topology to external systems?
+
+---
+
+## Step 3 — Findings format
+
+For each finding, use this strict format:
+
+```markdown
+### [SEV: CRITICAL|HIGH|MEDIUM|LOW|INFO] VULN-{nnn}: {Title}
+
+**Component:** `Granit.{Module}` — `{ClassName}` / `{MethodName}`
+**File:** [{file}:{line}]({relative-path}#L{line})
+**CVSS 3.1:** {score} ({vector-string}) *(omit for INFO)*
+**Standard:** {OWASP ASVS x.y.z | FAPI 2.0 §x | ISO 27001 A.x.y | RFC xxxx §y | OWASP LLM-xx}
+
+**Description:**
+{What the vulnerability is, in precise technical terms.}
+
+**Attack vector:**
+{Step-by-step exploitation scenario. Be specific to Granit's architecture.}
+
+**Evidence:**
+```csharp
+// Relevant code snippet showing the vulnerability
+```
+
+**Recommendation:**
+{Precise .NET 10 / C# 14 fix. Show code when possible.}
+
+**Compensating controls:**
+{Existing mitigations that reduce the risk, if any.}
+```
+
+### Finding numbering
+
+- `VULN-001` to `VULN-099`: Critical
+- `VULN-100` to `VULN-199`: High
+- `VULN-200` to `VULN-299`: Medium
+- `VULN-300` to `VULN-399`: Low
+- `VULN-400+`: Informational
+
+---
+
+## Step 4 — Analysis method
+
+### 4a. Code analysis strategy
+
+Use MCP tools for efficient analysis — **never read entire files blindly**:
+
+| Goal | Tool | Why |
+|------|------|-----|
+| Understand a module's API surface | `get_public_api` / `get_public_api_batch` | Token-efficient overview |
+| Inspect a specific type | `get_type_overview` | Members + hierarchy |
+| Analyze a security-critical method | `analyze_method` | Complexity + data flow + control flow |
+| Find who calls a method | `find_callers` | Attack surface mapping |
+| Find interface implementations | `find_implementations` | Discover all providers |
+| Check for anti-patterns | `detect_antipatterns` | Automated smell detection |
+| Read implementation logic | `Read` | When you need method bodies |
+| Search for patterns | `Grep` | Cross-cutting concerns (e.g., `AllowAnonymous`) |
+
+### 4b. Analysis sequence per module
+
+1. **API surface** — `get_public_api` to understand what's exposed
+2. **Implementation scan** — `detect_antipatterns` for low-hanging fruit
+3. **Critical paths** — `analyze_method` on authentication/authorization entry points
+4. **Data flow** — `analyze_data_flow` on sensitive data handlers (tokens, keys, PII)
+5. **Caller analysis** — `find_callers` to verify all consumers of security APIs
+6. **Configuration review** — `Read` options classes for insecure defaults
+7. **Test coverage** — `Grep` for security-relevant test assertions
+
+### 4c. Historical context — MANDATORY
+
+Before flagging ANY finding:
+
+```bash
+git log --oneline -10 -- <file>
+```
+
+Code that looks insecure may have a documented reason (regulatory constraint,
+backward compatibility, compensating control). Check before reporting.
+
+---
+
+## Step 5 — Compliance gap analysis
+
+Evaluate against these standards and produce a matrix:
+
+### FAPI 2.0 Security Profile
+
+| Requirement | Status | Evidence |
+|-------------|--------|----------|
+| PKCE with S256 (mandatory) | | |
+| mTLS or DPoP for token binding | | |
+| PAR (RFC 9126) support | | |
+| Signed request objects (JAR) | | |
+| Response mode `jwt` | | |
+| Sender-constrained access tokens | | |
+
+### OWASP ASVS 4.0 (relevant sections)
+
+| Section | Area | Status | Gap |
+|---------|------|--------|-----|
+| V2 | Authentication | | |
+| V3 | Session Management | | |
+| V4 | Access Control | | |
+| V6 | Cryptography | | |
+| V8 | Data Protection | | |
+| V9 | Communications | | |
+| V11 | Business Logic | | |
+| V13 | API Security | | |
+
+### ISO 27001:2022 (Annex A controls)
+
+| Control | Description | Status | Gap |
+|---------|-------------|--------|-----|
+| A.5.15 | Access control | | |
+| A.5.17 | Authentication information | | |
+| A.5.34 | Privacy and PII protection | | |
+| A.8.1 | User endpoint devices | | |
+| A.8.5 | Secure authentication | | |
+| A.8.9 | Configuration management | | |
+| A.8.24 | Use of cryptography | | |
+| A.8.25 | Secure development lifecycle | | |
+
+### OWASP LLM Top 10 (2025)
+
+| Risk | Description | Status | Gap |
+|------|-------------|--------|-----|
+| LLM01 | Prompt Injection | | |
+| LLM02 | Insecure Output Handling | | |
+| LLM03 | Training Data Poisoning | | |
+| LLM05 | Improper Output Handling | | |
+| LLM06 | Sensitive Information Disclosure | | |
+| LLM07 | Insecure Plugin/Tool Design | | |
+| LLM08 | Excessive Agency | | |
+| LLM09 | Overreliance | | |
+| LLM10 | Model Theft | | |
+
+---
+
+## Step 6 — Report generation
+
+### Full report structure
+
+```markdown
+# Security Audit Report: Granit Framework
+
+**Auditor:** Principal Application Security Architect (AI-assisted)
+**Date:** {YYYY-MM-DD}
+**Scope:** {full | domain | diff}
+**Framework version:** {git describe --tags --always}
+**Modules audited:** {count}
+**Standards evaluated:** OWASP ASVS 4.0, FAPI 2.0, ISO 27001:2022,
+  OWASP LLM Top 10, RFC 9449, RFC 9126
+
+---
+
+## 1. Executive Summary
+
+**Overall security posture:** {STRONG | ADEQUATE | NEEDS IMPROVEMENT | CRITICAL}
+
+**Key strengths:**
+1. {strength}
+2. {strength}
+3. {strength}
+
+**Top 3 systemic risks:**
+1. {risk — one sentence with impact}
+2. {risk}
+3. {risk}
+
+**Finding summary:**
+| Severity | Count | Remediated | Remaining |
+|----------|-------|------------|-----------|
+| Critical | | | |
+| High | | | |
+| Medium | | | |
+| Low | | | |
+| Info | | | |
+
+---
+
+## 2. STRIDE Threat Model
+
+### 2.1 Trust boundaries
+{Diagram and description from Step 0c}
+
+### 2.2 Threat matrix
+{STRIDE analysis from Step 1, organized by boundary}
+
+### 2.3 Attack trees
+{For the top 3 most impactful threats, draw attack trees showing
+exploitation paths and required preconditions}
+
+---
+
+## 3. Detailed Findings
+
+### 3.1 Identity & Access Management
+{Findings VULN-xxx using the format from Step 3}
+
+### 3.2 AI & MCP Security
+{Findings}
+
+### 3.3 Data Protection & Encryption
+{Findings}
+
+### 3.4 Multi-Tenancy Isolation
+{Findings}
+
+### 3.5 Infrastructure & Resilience
+{Findings}
+
+### 3.6 Supply Chain
+{Findings}
+
+### 3.7 Cryptographic Correctness
+{Findings}
+
+### 3.8 Observability Security
+{Findings}
+
+---
+
+## 4. Compliance Gap Analysis
+
+### 4.1 FAPI 2.0
+{Matrix from Step 5}
+
+### 4.2 OWASP ASVS 4.0
+{Matrix from Step 5}
+
+### 4.3 ISO 27001:2022
+{Matrix from Step 5}
+
+### 4.4 OWASP LLM Top 10
+{Matrix from Step 5}
+
+### 4.5 GDPR — Privacy by Design (Art. 25)
+| Principle | Implementation | Gap |
+|-----------|---------------|-----|
+| Data minimization | | |
+| Purpose limitation | | |
+| Storage limitation | | |
+| Integrity & confidentiality | | |
+| Right to erasure (Art. 17) | | |
+| Right to portability (Art. 20) | | |
+| Data Protection Impact Assessment | | |
+
+---
+
+## 5. Residual Risk Register
+
+{For each finding, after considering compensating controls and planned
+remediations, assess the residual risk. This is the CISO's primary deliverable.}
+
+| # | Risk description | Inherent risk (P x I) | Compensating controls | Residual risk | Risk owner | Accept / Mitigate / Transfer |
+|---|-----------------|----------------------|----------------------|---------------|------------|------------------------------|
+| | | | | | | |
+
+**Probability scale:** Rare (1) — Unlikely (2) — Possible (3) — Likely (4) — Almost certain (5)
+**Impact scale:** Negligible (1) — Minor (2) — Moderate (3) — Major (4) — Catastrophic (5)
+**Risk = Probability x Impact** → Low (1-5), Medium (6-12), High (13-19), Critical (20-25)
+
+{Group by risk level: Critical first, then High, Medium, Low.
+For each "Accept" decision, document the justification and review date.}
+
+---
+
+## 6. Remediation Roadmap
+
+### Quick Wins (Immediate — 0-2 weeks)
+{Low effort, high impact fixes. Configuration changes, missing attributes,
+default hardening.}
+
+| # | Finding | Effort | Impact | Owner |
+|---|---------|--------|--------|-------|
+| | | | | |
+
+### Tactical (1-3 months)
+{Medium effort fixes requiring code changes but no architecture redesign.}
+
+| # | Finding | Effort | Impact | Owner |
+|---|---------|--------|--------|-------|
+| | | | | |
+
+### Strategic (3-6 months — architecture evolution)
+{Major changes requiring design, implementation, and migration.}
+
+| # | Finding | Effort | Impact | Owner |
+|---|---------|--------|--------|-------|
+| | | | | |
+
+---
+
+## Appendices
+
+### A. Modules audited
+{Full list with version/commit}
+
+### B. Tools and methods used
+{MCP queries, grep patterns, manual review areas}
+
+### C. Out of scope
+{What was NOT audited and why}
+
+### D. Glossary
+{Security terms used in this report}
+```
+
+---
+
+## Diff mode (`diff`)
+
+Security-focused review of changes in the current branch.
+
+### 1. Identify security-relevant changes
+
+```bash
+git fetch origin develop 2>/dev/null || true
+git diff origin/develop...HEAD --name-only -- 'src/**/*.cs' 'src/**/*.csproj'
+```
+
+Filter to security-relevant modules (Authentication, Authorization, Identity,
+Bff, Mcp, Encryption, Privacy, Vault, Audit, Security, RateLimiting,
+MultiTenancy, Idempotency, Oidc, OpenIddict).
+
+If on the base branch, abort: "Already on base branch — use `/security full`
+or `/security <domain>` instead."
+
+### 2. Diff-specific checks
+
+For each changed file in security-relevant modules:
+
+- **New endpoints** — authentication/authorization applied?
+- **New `[AllowAnonymous]`** — justified? Audited?
+- **Changed crypto code** — algorithm, key size, mode preserved?
+- **Changed auth logic** — token validation, permission checks intact?
+- **New dependencies** — known CVEs? License?
+- **Removed security checks** — was it intentional? Git blame.
+- **New MCP tools** — visibility filter applied? Output sanitized?
+- **Changed tenant resolution** — isolation preserved?
+
+### 3. Diff report
+
+```markdown
+## Security Diff Review — {branch} — {date}
+
+### Security-relevant files changed
+| File | Module | Change type | Risk |
+|------|--------|-------------|------|
+
+### Findings
+{Using standard finding format, VULN-xxx}
+
+### Verdict
+SAFE TO MERGE | SECURITY REVIEW REQUIRED — {reasons}
+```
+
+---
+
+## Rules — STRICT
+
+1. **Read before judging** — always read the full implementation and git history
+   before flagging. Security code often has non-obvious reasons.
+2. **Evidence-based** — every finding MUST include a code reference or
+   configuration evidence. No speculative findings.
+3. **CVSS scoring** — use CVSS 3.1 vector strings for Critical/High/Medium
+   findings. Be precise about Attack Vector, Complexity, Privileges Required.
+4. **No false positives** — a false positive in a security audit destroys
+   credibility. When uncertain, classify as INFO with a note to investigate.
+5. **Compensating controls** — always check for existing mitigations before
+   raising severity. A vulnerability with a compensating control may be Medium
+   instead of Critical.
+6. **Framework-aware** — `ApplyGranitConventions`, architecture tests, and
+   Roslyn analyzers already enforce many rules. Acknowledge them as controls.
+7. **DX balance** — if a recommendation would make the framework unusable,
+   propose a pragmatic alternative with the security trade-off documented.
+8. **MCP first** — use Roslyn MCP tools for code analysis. Fall back to `Read`
+   only for implementation logic and non-C# files.
+9. **Context window discipline** — for full audits, process one domain at a
+   time. Produce per-domain findings, then aggregate.
+10. **No invented standards** — only evaluate against standards listed in this
+    skill. Do not fabricate requirements.

--- a/.claude/skills/security/checklist.md
+++ b/.claude/skills/security/checklist.md
@@ -1,0 +1,477 @@
+# Security Audit Checklist — Granit .NET
+
+Detailed verification matrix used by the `/security` skill. Each section maps
+to a `<domain>` keyword. Apply methodically — check each item, note evidence.
+
+Standards referenced:
+
+- **ASVS** — OWASP Application Security Verification Standard 4.0
+- **FAPI** — Financial-grade API Security Profile 2.0
+- **ISO** — ISO 27001:2022 Annex A
+- **LLM** — OWASP LLM Top 10 (2025)
+- **RFC** — IETF RFCs (9449, 9126, 7519, 6749, 7636, etc.)
+- **CWE** — Common Weakness Enumeration
+
+---
+
+## 1. Identity & Access Management (`iam`)
+
+### 1a. BFF Pattern — Granit.Bff
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 1.1 | CSRF token uses HMAC-SHA256 with cryptographically random key | ASVS 4.2.2 | HIGH |
+| 1.2 | CSRF key is rotated periodically (not hardcoded) | ISO A.8.24 | CRITICAL |
+| 1.3 | CSRF token is bound to user session (not global) | ASVS 4.2.2 | HIGH |
+| 1.4 | BFF token store encrypts tokens at rest in Redis | ASVS 6.4.2 | CRITICAL |
+| 1.5 | Session ID regenerated after authentication | ASVS 3.2.1 | HIGH |
+| 1.6 | Silent token refresh uses `lock` to prevent concurrent refreshes | CWE-362 | MEDIUM |
+| 1.7 | Refresh token rotation invalidates previous token | ASVS 3.5.2 | HIGH |
+| 1.8 | Back-channel logout validates `logout_token` JWT signature | RFC 7519 | CRITICAL |
+| 1.9 | Back-channel logout checks `iss`, `aud`, `iat`, `events` claims | ASVS 3.6.1 | HIGH |
+| 1.10 | `Set-Cookie` flags: `Secure`, `HttpOnly`, `SameSite=Strict/Lax` | ASVS 3.4.1 | HIGH |
+| 1.11 | Token injection in YARP uses secure header (not query string) | ASVS 3.1.1 | MEDIUM |
+| 1.12 | BFF endpoints reject requests without valid session | ASVS 3.3.1 | HIGH |
+| 1.13 | Login endpoint validates `redirect_uri` against allowlist | CWE-601 | CRITICAL |
+| 1.14 | Logout revokes tokens at the IdP (not just local session) | ASVS 3.3.3 | HIGH |
+
+### 1b. DPoP — Granit.Authentication.DPoP
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 1.15 | DPoP proof JWT validated: `typ`, `alg`, `jwk`, `htm`, `htu`, `iat` | RFC 9449 §4.3 | CRITICAL |
+| 1.16 | `ath` claim validated (access token hash) | RFC 9449 §4.3 | HIGH |
+| 1.17 | JWK thumbprint (S256) matches token `cnf.jkt` claim | RFC 9449 §6 | CRITICAL |
+| 1.18 | Nonce is server-generated, single-use, time-bound | RFC 9449 §8 | HIGH |
+| 1.19 | DPoP proof replay detection (nonce or `jti` tracking) | RFC 9449 §11.1 | HIGH |
+| 1.20 | Clock skew tolerance is bounded (max 60s recommended) | RFC 9449 §4.3 | MEDIUM |
+| 1.21 | Only asymmetric algorithms accepted (no `HS256`) | RFC 9449 §4.3 | CRITICAL |
+| 1.22 | Middleware cannot be bypassed via route configuration | CWE-284 | HIGH |
+
+### 1c. OIDC / OpenIddict
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 1.23 | PKCE mandatory with `S256` method (never `plain`) | RFC 7636, FAPI §5.2.2 | CRITICAL |
+| 1.24 | Authorization code is single-use | RFC 6749 §4.1.2 | HIGH |
+| 1.25 | Token endpoint requires client authentication | FAPI §5.2.2 | HIGH |
+| 1.26 | `private_key_jwt` or mTLS preferred over `client_secret_post` | FAPI §5.2.2 | MEDIUM |
+| 1.27 | ID token `nonce` validated against session-stored value | ASVS 3.5.1 | HIGH |
+| 1.28 | ID token `at_hash` validated for implicit/hybrid flows | RFC 9207 | MEDIUM |
+| 1.29 | Token lifetime is bounded (access: 5-15min, refresh: 24h max) | ASVS 3.5.3 | MEDIUM |
+| 1.30 | Signing keys use RS256 or ES256 (never HS256 for public clients) | FAPI §5.2.2 | CRITICAL |
+| 1.31 | Key rotation job overlaps old and new keys (grace period) | ISO A.8.24 | HIGH |
+| 1.32 | PAR (Pushed Authorization Requests) supported | RFC 9126, FAPI §5.2.2 | MEDIUM |
+| 1.33 | `redirect_uri` exact match (no wildcard, no path traversal) | CWE-601 | CRITICAL |
+| 1.34 | Impersonation requires elevated privilege AND audit logging | ASVS 4.1.3 | CRITICAL |
+| 1.35 | Impersonation scope is limited (no admin-over-admin) | CWE-269 | HIGH |
+| 1.36 | Token cleanup job removes expired tokens within SLA | ISO A.8.10 | LOW |
+
+### 1d. API Key Authentication
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 1.37 | API key generated with >= 256 bits of entropy | ASVS 2.4.1 | CRITICAL |
+| 1.38 | API key stored hashed (SHA-256 or better), never plaintext | ASVS 2.4.1 | CRITICAL |
+| 1.39 | Key comparison is timing-safe (`CryptographicOperations.FixedTimeEquals`) | CWE-208 | HIGH |
+| 1.40 | CIDR validation cannot be bypassed via `X-Forwarded-For` spoofing | CWE-290 | HIGH |
+| 1.41 | Revoked keys are immediately removed from cache | ASVS 2.10.2 | HIGH |
+| 1.42 | Key type (service/user/readonly) enforced at authorization layer | ASVS 4.1.1 | MEDIUM |
+| 1.43 | API key transmission only via header (never URL query parameter) | ASVS 3.1.1 | MEDIUM |
+
+### 1e. Authorization
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 1.44 | Default-deny: endpoints require explicit authorization | ASVS 4.1.1 | CRITICAL |
+| 1.45 | `[AllowAnonymous]` endpoints are inventoried and justified | ASVS 4.1.1 | HIGH |
+| 1.46 | Permission cache TTL is short enough to reflect revocation | ASVS 4.1.3 | MEDIUM |
+| 1.47 | Permission assignment requires the assigner to hold the permission | CWE-269 | HIGH |
+| 1.48 | `DynamicPermissionPolicyProvider` rejects unknown permission names | CWE-284 | MEDIUM |
+| 1.49 | Permission changes emit integration events for downstream sync | ASVS 4.1.3 | LOW |
+| 1.50 | Horizontal privilege escalation: user cannot access other users' resources | CWE-639 | CRITICAL |
+
+### 1f. Identity & Password Management
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 1.51 | Password hashing uses Argon2id, bcrypt, or PBKDF2 (>= 600K iterations) | ASVS 2.4.1 | CRITICAL |
+| 1.52 | Password complexity enforced (min 8 chars, no max limit < 128) | ASVS 2.1.1 | MEDIUM |
+| 1.53 | Account lockout after N failed attempts (with exponential backoff) | ASVS 2.2.1 | HIGH |
+| 1.54 | Password reset tokens are single-use, time-bound (< 1h) | ASVS 2.5.2 | HIGH |
+| 1.55 | User enumeration prevented (identical responses for existing/non-existing) | CWE-204 | MEDIUM |
+| 1.56 | Session revocation on password change | ASVS 3.3.4 | HIGH |
+| 1.57 | MFA/TOTP implementation uses time-based tokens (RFC 6238) | ASVS 2.8.1 | MEDIUM |
+| 1.58 | Passkey/WebAuthn support validates attestation | ASVS 2.7.1 | LOW |
+
+---
+
+## 2. AI & MCP Security (`ai`)
+
+### 2a. MCP Tool Discovery & Visibility
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 2.1 | Default discovery mode is explicit (opt-in, not opt-out) | LLM07 | CRITICAL |
+| 2.2 | `McpExposedAttribute` required for tool exposure | LLM07 | HIGH |
+| 2.3 | `TenantAwareVisibilityFilter` enforces tenant isolation | LLM06 | CRITICAL |
+| 2.4 | `ModuleScopeVisibilityFilter` restricts tools to loaded modules | LLM08 | HIGH |
+| 2.5 | Tool descriptions do not leak internal architecture details | LLM06 | MEDIUM |
+| 2.6 | Tool parameter schemas validate input types and ranges | LLM01 | HIGH |
+| 2.7 | MCP transport (stdio/SSE/HTTP) uses authenticated channel | LLM07 | HIGH |
+
+### 2b. Output Sanitization
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 2.8 | `IMcpOutputSanitizer` applied to ALL tool responses (not opt-in) | LLM02 | CRITICAL |
+| 2.9 | `McpRedactAttribute` coverage: all PII/secret fields annotated | LLM06 | HIGH |
+| 2.10 | `RedactionStrategy` includes full redaction (not just masking) for secrets | LLM06 | HIGH |
+| 2.11 | Error responses sanitized (no stack traces, connection strings, paths) | LLM06 | HIGH |
+| 2.12 | SQL query results sanitized for cross-tenant data | LLM06 | CRITICAL |
+| 2.13 | File system paths in responses are relative (no absolute paths) | LLM06 | MEDIUM |
+
+### 2c. Prompt Injection & Confused Deputy
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 2.14 | MCP tool inputs validated against schema before execution | LLM01 | CRITICAL |
+| 2.15 | User-controlled strings not interpolated into tool descriptions | LLM01 | CRITICAL |
+| 2.16 | Tool execution checks CALLING user's permissions (not tool owner) | LLM08 | CRITICAL |
+| 2.17 | `McpTenantScopeAttribute` enforced — tools respect tenant context | LLM08 | CRITICAL |
+| 2.18 | MCP tool calls are audited (who, what, when, result summary) | LLM07 | HIGH |
+| 2.19 | Tool chaining cannot escalate privileges across calls | LLM08 | HIGH |
+| 2.20 | Content returned by tools is treated as untrusted by the LLM layer | LLM01 | HIGH |
+
+### 2d. Resource Exhaustion & Denial of Wallet
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 2.21 | MCP tool calls are rate-limited per user/tenant | LLM08 | HIGH |
+| 2.22 | Expensive operations (DB queries, file I/O) have timeouts | LLM08 | HIGH |
+| 2.23 | Token/cost budget per session or per user | LLM08 | MEDIUM |
+| 2.24 | Recursive tool calls are bounded (max depth) | LLM08 | HIGH |
+| 2.25 | Large result sets are paginated or truncated | LLM06 | MEDIUM |
+
+### 2e. MCP Client-Side Risks (SSRF)
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 2.26 | `McpConnectionOptions` URL validated against allowlist (no internal IPs) | CWE-918 | CRITICAL |
+| 2.27 | `IMcpClientFactory` rejects connections to `localhost`, `127.0.0.1`, `::1`, `169.254.*` (link-local), RFC 1918 ranges | CWE-918 | CRITICAL |
+| 2.28 | MCP client does not follow redirects to internal endpoints | CWE-918 | HIGH |
+| 2.29 | DNS rebinding protection: re-validate resolved IP before connecting | CWE-918 | HIGH |
+| 2.30 | MCP client connection timeout bounded (prevent slowloris against internal) | CWE-400 | MEDIUM |
+| 2.31 | MCP client credentials (API key, token) not sent to untrusted servers | CWE-522 | CRITICAL |
+
+---
+
+## 3. Data Protection & Encryption (`data`)
+
+### 3a. Encryption at Rest
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 3.1 | AES encryption uses GCM mode (authenticated encryption) | ASVS 6.2.1 | CRITICAL |
+| 3.2 | IV/nonce is unique per encryption operation (never reused) | CWE-329 | CRITICAL |
+| 3.3 | Key derivation uses a KDF (HKDF, PBKDF2) — not raw key | ASVS 6.2.2 | HIGH |
+| 3.4 | Encryption keys >= 256 bits | NIST SP 800-57 | HIGH |
+| 3.5 | `InMemoryEntityEncryptionKeyStore` guarded: dev/test only | ASVS 6.4.1 | CRITICAL |
+| 3.6 | Cache values encrypted with `AesCacheValueEncryptor` use unique IVs | CWE-329 | HIGH |
+| 3.7 | Encrypted fields in database use a separate column for IV/tag | ASVS 6.2.1 | HIGH |
+
+### 3b. Key Management
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 3.8 | Encryption keys stored in Vault (never in config/env vars) | ISO A.8.24 | CRITICAL |
+| 3.9 | Key rotation supported without data re-encryption downtime | ISO A.8.24 | HIGH |
+| 3.10 | `RetiredKeyVersionException` handled gracefully (re-encrypt, not fail) | ISO A.8.24 | HIGH |
+| 3.11 | Envelope encryption: data key encrypted by master key | ASVS 6.4.1 | MEDIUM |
+| 3.12 | Key destruction zeroizes memory (`CryptographicOperations.ZeroMemory`) | CWE-244 | HIGH |
+| 3.13 | `IDatabaseCredentialProvider` rotates credentials before TTL expiry | ISO A.8.24 | HIGH |
+| 3.14 | Transit encryption (`ITransitEncryptionService`) uses Vault's transit backend | ISO A.8.24 | MEDIUM |
+
+### 3c. Crypto-Shredding (GDPR Art. 17)
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 3.15 | `ICryptoShredder` destroys ALL copies of the entity encryption key | GDPR Art. 17 | CRITICAL |
+| 3.16 | Crypto-shredding audit trail (`ICryptoShreddingAuditRecorder`) is immutable | ISO A.8.15 | HIGH |
+| 3.17 | Shredding covers backup keys (or backups are themselves encrypted) | GDPR Art. 17 | HIGH |
+| 3.18 | Shredding is atomic (key destruction + audit entry in one transaction) | ASVS 8.3.7 | HIGH |
+
+### 3d. Privacy / GDPR
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 3.19 | `GdprDeletionSaga` has compensation on failure (no partial deletion) | GDPR Art. 17 | CRITICAL |
+| 3.20 | `GdprExportSaga` encrypts exported data before transmission | GDPR Art. 20 | HIGH |
+| 3.21 | `IDataProviderRegistry` covers ALL modules with personal data | GDPR Art. 17 | HIGH |
+| 3.22 | Data export format is machine-readable (JSON/CSV) | GDPR Art. 20 | LOW |
+| 3.23 | Deletion request processing completes within 30 days (SLA) | GDPR Art. 12 | MEDIUM |
+| 3.24 | Consent records (`LegalAgreements`) are tamper-proof | GDPR Art. 7 | HIGH |
+| 3.25 | Consent revocation triggers downstream data processing stop | GDPR Art. 7.3 | HIGH |
+
+---
+
+## 4. Multi-Tenancy Isolation (`tenancy`)
+
+### 4a. Tenant Resolution
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 4.1 | `HeaderTenantResolver` only trusted on internal network (not public) | CWE-290 | CRITICAL |
+| 4.2 | `JwtClaimTenantResolver` validates tenant against known tenant list | CWE-284 | HIGH |
+| 4.3 | Default behavior when no resolver matches: REJECT (not default tenant) | CWE-284 | CRITICAL |
+| 4.4 | Tenant context is immutable once set for the request | CWE-284 | HIGH |
+| 4.5 | Tenant resolution logged for audit trail | ISO A.5.15 | MEDIUM |
+
+### 4b. Data Isolation
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 4.6 | Named query filters (`ApplyGranitConventions`) applied to ALL entities | CWE-639 | CRITICAL |
+| 4.7 | `IgnoreQueryFilters()` usage audited — grep and justify each occurrence | CWE-639 | HIGH |
+| 4.8 | `ExecuteUpdate`/`ExecuteDelete` manually adds tenant WHERE clause | CWE-639 | CRITICAL |
+| 4.9 | Database migrations do not alter tenant filter indexes | CWE-639 | MEDIUM |
+| 4.10 | Bulk operations verify tenant context before execution | CWE-639 | HIGH |
+
+### 4c. Cross-Service Isolation
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 4.11 | Cache keys include tenant ID prefix (`{tenantId}:{module}:{key}`) | CWE-639 | CRITICAL |
+| 4.12 | Wolverine messages propagate tenant context (`TenantContextBehavior`) | CWE-639 | CRITICAL |
+| 4.13 | Blob storage paths include tenant partition | CWE-639 | HIGH |
+| 4.14 | Rate limiting is tenant-partitioned (`TenantPartitionedRateLimiter`) | CWE-639 | HIGH |
+| 4.15 | MCP tool responses scoped to calling tenant | CWE-639 | CRITICAL |
+| 4.16 | Background jobs restore tenant context before execution | CWE-639 | HIGH |
+| 4.17 | Integration events include `TenantId` for cross-module routing | CWE-639 | HIGH |
+
+---
+
+## 5. Infrastructure & Resilience (`infra`)
+
+### 5a. Wolverine Messaging
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 5.1 | Outbox messages encrypted at rest if containing PII | GDPR Art. 32 | HIGH |
+| 5.2 | Dead-letter queue messages reviewed for PII before manual replay | GDPR Art. 32 | MEDIUM |
+| 5.3 | Poison message detection: max retry count with exponential backoff | CWE-400 | HIGH |
+| 5.4 | Message handlers are idempotent (at-least-once delivery) | CWE-400 | HIGH |
+| 5.5 | W3C Trace Context propagated (`TraceContextBehavior`) | ISO A.8.15 | MEDIUM |
+| 5.6 | User context restored in async handlers (`UserContextBehavior`) | CWE-284 | HIGH |
+| 5.7 | Claim Check pattern validates payload integrity on retrieval | CWE-345 | MEDIUM |
+| 5.8 | Large messages stored via `IClaimCheckStore`, not inline | CWE-400 | MEDIUM |
+
+### 5b. Rate Limiting
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 5.9 | Rate limiting applied BEFORE authentication (to protect auth endpoint) | CWE-307 | HIGH |
+| 5.10 | `CounterStoreFailureBehavior` is CLOSED (deny on Redis failure) | CWE-636 | HIGH |
+| 5.11 | Redis Lua scripts are atomic (no TOCTOU race conditions) | CWE-362 | HIGH |
+| 5.12 | Rate limit headers returned (`Retry-After`, `X-RateLimit-*`) | ASVS 13.1.5 | LOW |
+| 5.13 | Per-IP rate limiting for unauthenticated endpoints | CWE-307 | HIGH |
+| 5.14 | Rate limit policies are not bypassable via header manipulation | CWE-290 | MEDIUM |
+
+### 5c. Idempotency
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 5.15 | Idempotency key has sufficient entropy (UUID v4 or better) | CWE-330 | MEDIUM |
+| 5.16 | Idempotency window is bounded (TTL prevents indefinite storage) | CWE-400 | MEDIUM |
+| 5.17 | Stored responses do not leak data to different users with same key | CWE-639 | HIGH |
+| 5.18 | Idempotency store is tenant-partitioned | CWE-639 | HIGH |
+
+### 5d. Caching Security
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 5.19 | Cache keys are not constructable from user input (injection) | CWE-74 | HIGH |
+| 5.20 | Serialized cache values use safe deserializer (no type resolution) | CWE-502 | CRITICAL |
+| 5.21 | FusionCache stampede protection enabled | CWE-400 | MEDIUM |
+| 5.22 | Stale-while-revalidate does not serve expired security decisions | CWE-613 | HIGH |
+| 5.23 | Encrypted cache (`CacheEncryptedAttribute`) uses authenticated encryption | ASVS 6.2.1 | HIGH |
+
+### 5e. Webhooks
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 5.24 | Outbound webhooks sign payload (HMAC-SHA256 with shared secret) | CWE-345 | HIGH |
+| 5.25 | Inbound webhooks validate signature before processing | CWE-345 | CRITICAL |
+| 5.26 | Webhook URLs validated (no SSRF: reject internal IPs, localhost) | CWE-918 | CRITICAL |
+| 5.27 | Webhook retry does not replay sensitive data indefinitely | GDPR Art. 32 | MEDIUM |
+
+---
+
+## 6. Supply Chain (`supply-chain`)
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 6.1 | All NuGet packages have lock files (`packages.lock.json`) | CWE-1357 | HIGH |
+| 6.2 | No known CVEs in dependency tree (`dotnet list package --vulnerable`) | CWE-1357 | CRITICAL |
+| 6.3 | No deprecated packages (`dotnet list package --deprecated`) | CWE-1357 | MEDIUM |
+| 6.4 | Non-permissive licenses flagged (GPL, LGPL, AGPL, SSPL) | Legal | HIGH |
+| 6.5 | `THIRD-PARTY-NOTICES.md` matches actual dependency tree | Legal | MEDIUM |
+| 6.6 | NuGet packages are from trusted sources (nuget.org, verified publishers) | CWE-1357 | HIGH |
+| 6.7 | No `<PackageReference>` to prerelease packages in Release config | CWE-1357 | MEDIUM |
+| 6.8 | Source generators are pinned to exact versions | CWE-1357 | HIGH |
+| 6.9 | CI pipeline uses OIDC federation (no long-lived secrets) | ISO A.5.17 | MEDIUM |
+| 6.10 | Build is reproducible (deterministic compilation) | CWE-1357 | LOW |
+| 6.11 | Pre-commit secret scanning enabled (`gitleaks` or `trufflehog`) | CWE-798 | HIGH |
+| 6.12 | CI pipeline runs secret scanning on every push | CWE-798 | HIGH |
+| 6.13 | Historical secrets in git history identified and rotated | CWE-798 | MEDIUM |
+| 6.14 | `.gitleaksignore` or baseline file reviewed (no blanket suppressions) | CWE-798 | MEDIUM |
+
+---
+
+## 7. Cryptographic Correctness (`crypto`)
+
+### 7a. Algorithm Inventory
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 7.1 | No MD5 or SHA-1 for security purposes (only checksums) | ASVS 6.2.5 | CRITICAL |
+| 7.2 | AES uses GCM or CCM mode (never ECB, never CBC without HMAC) | ASVS 6.2.1 | CRITICAL |
+| 7.3 | RSA key size >= 2048 bits (4096 preferred) | NIST SP 800-57 | HIGH |
+| 7.4 | ECDSA uses P-256 or P-384 curves (not P-192) | NIST SP 800-57 | HIGH |
+| 7.5 | HMAC uses SHA-256 or SHA-512 (not SHA-1) | ASVS 6.2.5 | HIGH |
+
+### 7b. Random Number Generation
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 7.6 | `RandomNumberGenerator` used (never `System.Random` for security) | CWE-330 | CRITICAL |
+| 7.7 | Token generation uses >= 128 bits of entropy | ASVS 2.4.1 | HIGH |
+| 7.8 | Nonce generation is non-repeating (counter or random) | CWE-330 | HIGH |
+
+### 7c. Key Lifecycle
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 7.9 | Keys never logged, never in error messages | CWE-532 | CRITICAL |
+| 7.10 | Key material zeroized after use (Span, ArrayPool return) | CWE-244 | HIGH |
+| 7.11 | Key rotation is automated (background job or Vault) | ISO A.8.24 | HIGH |
+| 7.12 | Retired keys support decryption (re-encrypt on read) | ISO A.8.24 | MEDIUM |
+| 7.13 | Key hierarchy: master key > data encryption key > field key | ISO A.8.24 | MEDIUM |
+
+---
+
+## 8. Observability Security (`observability`)
+
+### 8a. Logging
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 8.1 | No PII in log messages (names, emails, phone numbers) | GDPR Art. 5 | CRITICAL |
+| 8.2 | No secrets in log messages (tokens, keys, passwords) | CWE-532 | CRITICAL |
+| 8.3 | `AuditSensitiveAttribute` applied to all sensitive entity properties | GDPR Art. 5 | HIGH |
+| 8.4 | Structured logging does not include raw request bodies | GDPR Art. 5 | HIGH |
+| 8.5 | Exception details redacted in production (no stack traces to client) | CWE-209 | HIGH |
+| 8.6 | Log injection prevented (user input not directly in log templates) | CWE-117 | MEDIUM |
+
+### 8b. Metrics
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 8.7 | No user-controlled values as metric tag VALUES (cardinality explosion) | CWE-400 | HIGH |
+| 8.8 | Metric names do not reveal internal architecture | CWE-200 | LOW |
+| 8.9 | Health check endpoints do not expose sensitive system info | CWE-200 | MEDIUM |
+| 8.10 | Health checks have timeout (10s) to prevent hung probes | CWE-400 | MEDIUM |
+
+### 8c. Distributed Tracing
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 8.11 | Trace context does not propagate to untrusted external systems | CWE-200 | MEDIUM |
+| 8.12 | Span attributes do not contain PII or secrets | GDPR Art. 5 | HIGH |
+| 8.13 | Audit entries include trace ID for correlation | ISO A.8.15 | LOW |
+
+### 8d. Audit Trail
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 8.14 | Audit log is append-only (no update/delete) | ISO A.8.15 | CRITICAL |
+| 8.15 | Audit log captures: who, what, when, where, result | ISO A.8.15 | HIGH |
+| 8.16 | Security events (login, logout, permission change) are audited | ASVS 7.1.1 | HIGH |
+| 8.17 | Failed authentication attempts are logged with rate limiting context | ASVS 7.2.1 | HIGH |
+| 8.18 | Audit log retention meets regulatory requirements (>= 1 year) | ISO A.8.15 | MEDIUM |
+| 8.19 | `AuditEntityChange` captures before/after values for accountability | ISO A.8.15 | MEDIUM |
+
+---
+
+## 9. HTTP Security Headers & Transport (`headers`)
+
+### 9a. Response Headers
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 9.1 | `Strict-Transport-Security` with `max-age >= 31536000; includeSubDomains` | ASVS 9.1.1 | HIGH |
+| 9.2 | `Content-Security-Policy` restricts `script-src`, `style-src`, `frame-ancestors` | ASVS 14.4.3 | HIGH |
+| 9.3 | `X-Content-Type-Options: nosniff` on all responses | ASVS 14.4.4 | MEDIUM |
+| 9.4 | `X-Frame-Options: DENY` (or `SAMEORIGIN` if iframes needed) | ASVS 14.4.7 | MEDIUM |
+| 9.5 | `Referrer-Policy: strict-origin-when-cross-origin` (or `no-referrer`) | ASVS 14.4.5 | MEDIUM |
+| 9.6 | `Permissions-Policy` restricts camera, microphone, geolocation, etc. | ASVS 14.4.6 | LOW |
+| 9.7 | `Cache-Control: no-store` on authenticated API responses | ASVS 14.4.2 | HIGH |
+| 9.8 | No `Server` or `X-Powered-By` headers leaking technology stack | CWE-200 | LOW |
+| 9.9 | YARP proxy strips sensitive upstream headers before returning to client | CWE-200 | MEDIUM |
+
+### 9b. CORS
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 9.10 | No wildcard `*` origin for authenticated endpoints | CWE-942 | HIGH |
+| 9.11 | `Access-Control-Allow-Credentials` only with explicit origin list | CWE-942 | HIGH |
+| 9.12 | Preflight `Access-Control-Max-Age` bounded (< 7200s) | CWE-942 | LOW |
+
+---
+
+## 10. Deserialization Safety (`deserialization`)
+
+### 10a. JSON Deserialization
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 10.1 | `System.Text.Json` used (not Newtonsoft with `TypeNameHandling`) | CWE-502 | CRITICAL |
+| 10.2 | No `JsonSerializerOptions` with `TypeInfoResolver` allowing arbitrary types | CWE-502 | CRITICAL |
+| 10.3 | Polymorphic deserialization uses `[JsonDerivedType]` with closed type set | CWE-502 | HIGH |
+| 10.4 | `JsonSerializerOptions.MaxDepth` set (default 64 is acceptable) | CWE-400 | MEDIUM |
+
+### 10b. Wolverine Message Deserialization
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 10.5 | Message envelope uses schema-first deserialization (known types only) | CWE-502 | CRITICAL |
+| 10.6 | Outbox messages cannot contain polymorphic payloads from external input | CWE-502 | HIGH |
+| 10.7 | Dead-letter queue replay validates message schema before re-processing | CWE-502 | HIGH |
+| 10.8 | `ClaimCheckReference` payload deserialized with type validation | CWE-502 | HIGH |
+
+### 10c. Cache Deserialization
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 10.9 | FusionCache serializer does not resolve arbitrary types | CWE-502 | CRITICAL |
+| 10.10 | `EncryptingFusionCacheSerializer` validates integrity before deserializing | CWE-502 | HIGH |
+| 10.11 | Redis cache values cannot trigger type instantiation on deserialization | CWE-502 | HIGH |
+
+---
+
+## 11. Cross-Cutting Concerns
+
+These checks apply across all domains:
+
+| # | Check | Standard | Severity if missing |
+|---|-------|----------|---------------------|
+| 11.1 | No hardcoded secrets (connection strings, API keys, passwords) in code | CWE-798 | CRITICAL |
+| 11.2 | `appsettings.json` / `appsettings.Development.json` contain no secrets | CWE-798 | CRITICAL |
+| 11.3 | `.gitignore` excludes sensitive files (`.env`, `*.pfx`, `*.key`) | CWE-798 | HIGH |
+| 11.4 | All external HTTP calls use HTTPS (no plain HTTP) | ASVS 9.1.1 | HIGH |
+| 11.5 | Content-Type validation on all input endpoints | CWE-20 | MEDIUM |
+| 11.6 | Request size limits configured (to prevent large payload DoS) | CWE-400 | MEDIUM |
+| 11.7 | Dependency injection: no service locator anti-pattern for security services | CWE-284 | LOW |
+| 11.8 | Error responses use RFC 7807 Problem Details (no internal data leak) | CWE-209 | MEDIUM |
+| 11.9 | All `async` methods accept and forward `CancellationToken` | CWE-400 | LOW |
+| 11.10 | Architecture tests in `Granit.ArchitectureTests` cover security conventions | ISO A.8.25 | MEDIUM |

--- a/.claude/skills/security/threat-models.md
+++ b/.claude/skills/security/threat-models.md
@@ -1,0 +1,338 @@
+# Threat Models — Granit .NET
+
+Pre-built STRIDE threat models for the most critical Granit components.
+Used by the `/security` skill as starting points — adapt based on actual
+code analysis.
+
+---
+
+## Trust Boundaries
+
+```text
+ZONE 1 — Untrusted (Internet)
+├── Browser / SPA
+├── External AI Agents
+└── Webhook callers
+
+ZONE 2 — DMZ (Edge)
+├── BFF / YARP Reverse Proxy
+├── MCP Server (stdio/SSE endpoint)
+├── Rate Limiter
+└── CORS / HSTS middleware
+
+ZONE 3 — Internal (Application)
+├── API Modules (*.Endpoints)
+├── Authorization engine
+├── Wolverine message handlers
+├── Background jobs
+└── Business logic
+
+ZONE 4 — Trusted (Data)
+├── PostgreSQL (persistence + outbox)
+├── Redis (cache, sessions, rate limiting)
+├── Vault (secrets, transit encryption)
+└── Blob Storage (S3 / Azure)
+
+ZONE 5 — External Identity
+├── Keycloak / EntraId / Cognito / Google
+├── OpenIddict (self-hosted IdP)
+└── ACME / Certificate authorities
+```
+
+---
+
+## TM-01: BFF Authentication Flow
+
+**Data Flow:** Browser → BFF Login → IdP Authorization → BFF Callback → Redis Token Store → YARP → API
+
+### STRIDE Analysis
+
+| Threat | Vector | Mitigation (expected) | Verify |
+|--------|--------|----------------------|--------|
+| **Spoofing** | Attacker replays stolen session cookie | Session cookie: `Secure`, `HttpOnly`, `SameSite=Strict`; session rotation after login | Check `BffLoginEndpoints` cookie settings |
+| **Spoofing** | Attacker forges CSRF token | HMAC-SHA256 with server-side secret, bound to session | Check `HmacBffCsrfTokenGenerator` key source |
+| **Tampering** | Attacker modifies `redirect_uri` in auth request | Allowlist-based validation, exact match | Check `BffLoginEndpoints` redirect validation |
+| **Tampering** | Attacker modifies token in Redis | Redis connection TLS, token encryption at rest | Check `DistributedCacheBffTokenStore` |
+| **Repudiation** | User denies performing an action | Audit trail via `Granit.Auditing`, session correlation | Check audit interceptor coverage |
+| **Info Disclosure** | Token leaked via URL, referrer, or logs | Tokens in headers only, `[LoggerMessage]` templates reviewed | Grep for token in query strings or log templates |
+| **DoS** | Login endpoint flooded | Rate limiting on `/bff/login` | Check rate limit policy on BFF endpoints |
+| **EoP** | Attacker escalates via token injection in YARP header | BFF validates token before injection, YARP strips external auth headers | Check `BffTokenInjectionTransform` |
+
+### Attack Tree: Session Hijacking via BFF
+
+```text
+Goal: Steal user session
+├── [AND] Obtain session cookie
+│   ├── XSS in SPA → steal cookie
+│   │   └── Mitigated by: HttpOnly flag
+│   ├── Network sniffing
+│   │   └── Mitigated by: Secure flag + HSTS
+│   └── CSRF to perform actions as user
+│       └── Mitigated by: SameSite + CSRF token
+├── [OR] Obtain access token from Redis
+│   ├── Redis unauthenticated access
+│   │   └── Mitigated by: Redis AUTH + TLS
+│   └── Redis key enumeration
+│       └── Check: Are keys unpredictable?
+└── [OR] Forge session
+    ├── Predict session ID
+    │   └── Check: Session ID entropy >= 128 bits
+    └── Session fixation
+        └── Check: Session regenerated after login
+```
+
+---
+
+## TM-02: MCP Tool Execution Flow
+
+**Data Flow:** AI Agent → MCP Transport → MCP Server → Visibility Filter → Tool Resolution → Authorization → Tool Execution → Output Sanitizer → Response
+
+### STRIDE Analysis
+
+| Threat | Vector | Mitigation (expected) | Verify |
+|--------|--------|----------------------|--------|
+| **Spoofing** | Attacker impersonates authorized AI agent | MCP transport authentication (API key, mTLS, session) | Check MCP server auth middleware |
+| **Spoofing** | Tool executes with wrong user context | `McpTenantScopeAttribute` + permission check on calling user | Check `TenantAwareVisibilityFilter` |
+| **Tampering** | Prompt injection in tool parameters | Input validation against schema, parameterized queries | Check tool input handling |
+| **Tampering** | Malicious tool response injected | Output sanitizer applied, response signed/integrity-checked | Check `IMcpOutputSanitizer` pipeline |
+| **Repudiation** | AI agent denies tool invocation | Audit log of all MCP tool calls | Check MCP audit integration |
+| **Info Disclosure** | Tool returns cross-tenant data | Tenant-scoped query filters, `TenantAwareVisibilityFilter` | Check all tool implementations |
+| **Info Disclosure** | Error leaks internal details | `ErrorSanitizer` strips stack traces, paths | Check error handling in MCP server |
+| **DoS** | Recursive tool calls exhaust resources | Max recursion depth, per-tool timeout, rate limiting | Check MCP tool execution pipeline |
+| **EoP** | Tool chaining escalates privileges | Each tool call re-validates permissions independently | Check authorization per-call |
+| **Tampering** | SSRF via `IMcpClientFactory` — client connects to internal service | URL allowlist, reject RFC 1918/link-local/localhost IPs | Check `McpConnectionOptions` validation |
+| **Info Disclosure** | SSRF response from internal service returned to attacker | Response sanitization, deny internal IP ranges | Check `DefaultMcpClientFactory` IP validation |
+
+### Attack Tree: SSRF via MCP Client
+
+```text
+Goal: Access internal services via MCP client connection
+├── [OR] Direct SSRF
+│   ├── MCP connection URL points to internal IP (10.x, 172.16-31.x, 192.168.x)
+│   │   └── Check: IP allowlist/denylist in IMcpClientFactory
+│   ├── MCP connection URL points to localhost/127.0.0.1/::1
+│   │   └── Check: Loopback rejection
+│   └── MCP connection URL points to cloud metadata (169.254.169.254)
+│       └── Check: Link-local rejection
+├── [OR] DNS rebinding
+│   ├── Attacker domain resolves to internal IP after initial validation
+│   │   └── Check: Re-validate resolved IP before connecting
+│   └── DNS TTL manipulation
+│       └── Check: Pin DNS resolution for connection lifetime
+└── [OR] Redirect-based SSRF
+    ├── MCP server returns HTTP redirect to internal endpoint
+    │   └── Check: Client does not follow redirects (or re-validates target)
+    └── Credential forwarding to attacker-controlled redirect target
+        └── Check: Credentials stripped on redirect to different origin
+```
+
+### Attack Tree: Cross-Tenant Data Exfiltration via MCP
+
+```text
+Goal: Access Tenant B data from Tenant A context
+├── [OR] Bypass tenant visibility filter
+│   ├── Tool not decorated with McpTenantScopeAttribute
+│   │   └── Check: All data-accessing tools have attribute
+│   ├── Filter implementation bug (null tenant = all tenants)
+│   │   └── Check: NullTenantContext handling
+│   └── Tool uses direct SQL (bypasses EF query filters)
+│       └── Check: No raw SQL in MCP tools
+├── [OR] Inject tenant ID in parameters
+│   ├── Tool accepts tenant ID as parameter
+│   │   └── Check: Tenant ID comes from context, not input
+│   └── IDOR on entity IDs across tenants
+│       └── Check: Entity lookups include tenant filter
+└── [OR] Cache poisoning
+    ├── Cached tool response from Tenant B served to Tenant A
+    │   └── Check: Cache key includes tenant ID
+    └── Stale cache after tenant switch
+        └── Check: Cache invalidation on tenant context change
+```
+
+---
+
+## TM-03: Multi-Tenant Data Access
+
+**Data Flow:** Request → Tenant Resolution → DbContext → Named Query Filters → Entity → Response
+
+### STRIDE Analysis
+
+| Threat | Vector | Mitigation (expected) | Verify |
+|--------|--------|----------------------|--------|
+| **Spoofing** | Attacker sends `X-Tenant-Id` header for another tenant | JWT claim takes precedence, header only for internal calls | Check resolver pipeline priority |
+| **Tampering** | Modify entity's `TenantId` field after creation | `TenantId` has `private set`, set by interceptor | Check entity configuration |
+| **Info Disclosure** | Query returns entities from other tenants | Named query filter on `TenantId` via `ApplyGranitConventions` | Check filter registration for all entities |
+| **Info Disclosure** | `IgnoreQueryFilters()` used without re-adding tenant clause | Code review: every `IgnoreQueryFilters()` must be justified | Grep all occurrences |
+| **Info Disclosure** | `ExecuteUpdate`/`ExecuteDelete` bypasses filters | Must manually add `.Where(e => e.TenantId == tenantId)` | Grep all bulk operations |
+| **DoS** | Noisy neighbor: one tenant monopolizes resources | Tenant-partitioned rate limiting, connection pooling | Check resource isolation |
+| **EoP** | Tenant admin assigns permissions beyond tenant scope | Permission scope bound to tenant context | Check permission assignment logic |
+
+---
+
+## TM-04: DPoP Token Binding
+
+**Data Flow:** Client generates DPoP proof → Token Request + DPoP header → Server validates proof → Binds token to key → API call + DPoP proof → Server re-validates
+
+### STRIDE Analysis
+
+| Threat | Vector | Mitigation (expected) | Verify |
+|--------|--------|----------------------|--------|
+| **Spoofing** | Stolen access token used without DPoP proof | Token bound to JWK thumbprint, proof required on every request | Check `DPoPValidationMiddleware` enforcement |
+| **Spoofing** | Attacker generates DPoP proof with different key | `cnf.jkt` in token must match proof's JWK thumbprint | Check thumbprint validation |
+| **Tampering** | DPoP proof replayed | Nonce tracking (server-issued) or `jti` uniqueness check | Check replay detection mechanism |
+| **Tampering** | DPoP proof `htm`/`htu` claims forged for different endpoint | Validate `htm` matches HTTP method, `htu` matches request URI | Check claim validation in middleware |
+| **Info Disclosure** | DPoP public key leaks client identity | JWK in proof is ephemeral (not long-lived client cert) | Check key generation guidance |
+| **DoS** | DPoP nonce endpoint flooded | Rate limiting on nonce issuance | Check nonce endpoint protection |
+
+---
+
+## TM-05: Crypto-Shredding (GDPR Erasure)
+
+**Data Flow:** Deletion Request → GdprDeletionSaga → ICryptoShredder → Destroy Entity Key → ICryptoShreddingAuditRecorder → Confirm Deletion
+
+### STRIDE Analysis
+
+| Threat | Vector | Mitigation (expected) | Verify |
+|--------|--------|----------------------|--------|
+| **Spoofing** | Unauthorized deletion request | Request requires authenticated user + self-service or admin permission | Check deletion endpoint authorization |
+| **Tampering** | Deletion saga partially executes (key destroyed but audit missed) | Saga uses compensation, atomic transaction for key + audit | Check saga transaction boundaries |
+| **Repudiation** | Organization denies deletion was performed | Immutable audit record via `ICryptoShreddingAuditRecorder` | Check audit immutability |
+| **Info Disclosure** | Encrypted data recoverable after key destruction | All key copies destroyed (primary, cache, backup references) | Check `ICryptoShredder` completeness |
+| **Info Disclosure** | Backups contain unshredded data | Backups themselves encrypted with rotatable keys, or backup retention < GDPR deadline | Check backup strategy |
+| **DoS** | Mass deletion request triggers cascading re-encryption | Deletion is shredding (no re-encryption), bounded concurrency | Check saga resource limits |
+
+---
+
+## TM-06: Wolverine Outbox Messaging
+
+**Data Flow:** Domain Event → Outbox (same transaction) → Outbox Agent → Message Broker → Consumer Handler
+
+### STRIDE Analysis
+
+| Threat | Vector | Mitigation (expected) | Verify |
+|--------|--------|----------------------|--------|
+| **Spoofing** | Fake message injected into outbox table | Outbox table writes via EF Core transaction only (no direct SQL access) | Check outbox table permissions |
+| **Tampering** | Message content modified between outbox and consumer | Message integrity (envelope signing or DB-level integrity) | Check message envelope |
+| **Repudiation** | Message processed but no trace | W3C Trace Context propagation, audit correlation | Check `TraceContextBehavior` |
+| **Info Disclosure** | DLQ messages contain PII exposed to support team | PII redaction in DLQ messages or access controls on DLQ | Check DLQ handling policy |
+| **DoS** | Poison message causes infinite retry loop | Max retry count + exponential backoff + dead-letter after N failures | Check retry policy configuration |
+| **DoS** | Outbox table grows unbounded (messages not consumed) | Outbox agent polling, metrics on outbox lag, alerting | Check outbox monitoring |
+| **EoP** | Consumer handler processes message without restoring user/tenant context | `UserContextBehavior` + `TenantContextBehavior` applied as middleware | Check handler pipeline |
+
+---
+
+## TM-07: API Key Authentication
+
+**Data Flow:** Client → API Key in Header → Middleware → Hash & Lookup → CIDR Validation → Claims Injection → Authorization
+
+### STRIDE Analysis
+
+| Threat | Vector | Mitigation (expected) | Verify |
+|--------|--------|----------------------|--------|
+| **Spoofing** | Brute-force API key | High entropy (256-bit), rate limiting, account lockout | Check key generation + rate limiting |
+| **Spoofing** | Timing attack on key comparison | `CryptographicOperations.FixedTimeEquals` | Check comparison implementation |
+| **Spoofing** | X-Forwarded-For spoofing to bypass CIDR | Trust proxy headers only from known load balancer IPs | Check `CidrValidator` IP source |
+| **Tampering** | API key cached after revocation | Cache invalidation on revocation event | Check `IApiKeyCacheService` invalidation |
+| **Repudiation** | API call made with stolen key | API key tied to service account, all calls audited | Check audit on API key auth |
+| **Info Disclosure** | API key logged in plaintext | Key masked in logs (show only last 4 chars) | Check logging templates |
+| **DoS** | Key enumeration via timing differences | Constant-time lookup even for non-existent keys | Check lookup implementation |
+
+---
+
+## TM-08: Deserialization Across Trust Boundaries
+
+**Data Flow:** External Input → JSON/Binary Deserializer → Domain Object → Business Logic
+
+Deserialization is a cross-cutting concern affecting multiple components:
+Wolverine messages (outbox → consumer), FusionCache (Redis → app),
+Claim Check payloads (blob → handler), MCP tool responses (external → server).
+
+### STRIDE Analysis
+
+| Threat | Vector | Mitigation (expected) | Verify |
+|--------|--------|----------------------|--------|
+| **Tampering** | Attacker injects type discriminator in JSON to instantiate arbitrary types | `System.Text.Json` with closed `[JsonDerivedType]` set, no `TypeNameHandling` | Grep for `TypeNameHandling`, `JsonPolymorphicAttribute` with open type sets |
+| **Tampering** | Wolverine outbox message contains crafted payload | Schema-first deserialization with known message types only | Check Wolverine serializer configuration |
+| **Tampering** | Cache poisoning with malicious serialized object | FusionCache serializer does not resolve arbitrary types | Check `EncryptingFusionCacheSerializer` chain |
+| **Tampering** | Claim Check payload replaced in blob storage | Integrity validation (hash/signature) on retrieval | Check `ClaimCheckReference` validation |
+| **DoS** | Deeply nested JSON causes stack overflow | `MaxDepth` configured in `JsonSerializerOptions` | Check global serializer defaults |
+| **DoS** | Extremely large payload exhausts memory | Request size limits, message size limits | Check Wolverine + Kestrel limits |
+| **EoP** | Deserialized object triggers constructor with side effects | Immutable records, no logic in constructors/init | Check message/DTO design patterns |
+
+### Attack Tree: Deserialization-Based Remote Code Execution
+
+```text
+Goal: Execute arbitrary code via crafted serialized payload
+├── [OR] Polymorphic JSON deserialization
+│   ├── Newtonsoft.Json with TypeNameHandling != None
+│   │   └── Check: grep for "Newtonsoft" and "TypeNameHandling"
+│   ├── System.Text.Json with open [JsonDerivedType] set
+│   │   └── Check: all polymorphic types use closed discriminator list
+│   └── Custom IJsonTypeInfoResolver that resolves untrusted types
+│       └── Check: custom resolvers restrict type resolution
+├── [OR] Wolverine message forgery
+│   ├── Direct INSERT into outbox table (SQL injection elsewhere)
+│   │   └── Check: outbox table permissions (app user has INSERT only?)
+│   ├── Replay modified DLQ message with altered type
+│   │   └── Check: DLQ replay validates message schema
+│   └── Message type not validated on consumption
+│       └── Check: Wolverine handler type mapping is explicit
+├── [OR] Cache value poisoning
+│   ├── Redis MITM (unencrypted connection)
+│   │   └── Check: Redis TLS enabled
+│   ├── Direct Redis write (compromised credentials)
+│   │   └── Check: Redis ACL with minimal permissions
+│   └── Encrypted cache value replaced (breaks integrity)
+│       └── Check: authenticated encryption (GCM tag verified)
+└── [OR] Claim Check payload swap
+    ├── Blob storage object replaced
+    │   └── Check: integrity hash stored alongside reference
+    └── Claim Check reference points to attacker-controlled blob
+        └── Check: blob path validated against expected pattern
+```
+
+---
+
+## Methodology Notes
+
+### Using these threat models
+
+1. **Start with the relevant TM** for the domain being audited
+2. **Verify each mitigation** exists in the actual code
+3. **Follow attack trees** to find gaps
+4. **Score findings** with CVSS 3.1
+5. **Check compensating controls** before assigning final severity
+6. **Update the TM** if new attack vectors are discovered
+
+### Revision triggers — when to revisit a threat model
+
+Threat models are point-in-time artifacts. Revisit when:
+
+| Change | Affected TMs | Why |
+|--------|-------------|-----|
+| MCP transport changes (stdio → HTTP/SSE) | TM-02 | New network attack surface, authentication model changes |
+| New identity provider added | TM-01, TM-04 | New trust boundary, token format differences |
+| Redis replaced with another cache | TM-01, TM-03, TM-08 | Encryption-at-rest, authentication model |
+| New Wolverine transport (RabbitMQ, Kafka) | TM-06, TM-08 | Message envelope format, authentication, encryption |
+| New MCP tool contributor module | TM-02 | New data access patterns, new output sanitization needs |
+| Multi-region deployment | TM-03, TM-05 | Cross-region tenant isolation, data residency |
+| Public API gateway added | TM-01, TM-07 | New trust boundary, rate limiting changes |
+| Serialization library change | TM-08 | Entire deserialization threat model may change |
+
+**Rule:** Any PR that modifies a trust boundary crossing should reference the
+relevant TM and confirm mitigations still hold.
+
+### CVSS 3.1 Quick Reference
+
+| Metric | Values |
+|--------|--------|
+| Attack Vector (AV) | Network (N), Adjacent (A), Local (L), Physical (P) |
+| Attack Complexity (AC) | Low (L), High (H) |
+| Privileges Required (PR) | None (N), Low (L), High (H) |
+| User Interaction (UI) | None (N), Required (R) |
+| Scope (S) | Unchanged (U), Changed (C) |
+| Confidentiality (C) | None (N), Low (L), High (H) |
+| Integrity (I) | None (N), Low (L), High (H) |
+| Availability (A) | None (N), Low (L), High (H) |
+
+Example: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N` = 10.0 (Critical)

--- a/docs-site/src/content/docs/contributing/index.md
+++ b/docs-site/src/content/docs/contributing/index.md
@@ -36,21 +36,21 @@ Open an issue using the **Feature** template. Describe:
 ### Submitting changes
 
 1. **Fork** the repository
-2. **Create a branch** from `develop` (see [Git Workflow](./git-workflow.md))
-3. **Write your code** following the [Coding Standards](./coding-standards.md)
-4. **Write or update tests** (see [Testing Guide](./testing-guide.md))
-5. **Run the [Definition of Done](./definition-of-done.md) checks**
+2. **Create a branch** from `develop` (see [Git Workflow](./git-workflow/))
+3. **Write your code** following the [Coding Standards](./coding-standards/)
+4. **Write or update tests** (see [Testing Guide](./testing-guide/))
+5. **Run the [Definition of Done](./definition-of-done/) checks**
 6. **Commit** using Conventional Commits
 7. **Open a merge request** against `develop`
 
 ## Section contents
 
-- [Development Setup](./development-setup.md) -- prerequisites, build, test, project structure
-- [Coding Standards](./coding-standards.md) -- C# style, naming, architecture conventions
-- [Module Structure](./module-structure.md) -- how to create a new Granit module
-- [Testing Guide](./testing-guide.md) -- xUnit, Shouldly, NSubstitute, Bogus
-- [Definition of Done](./definition-of-done.md) -- blocking checklist before any push
-- [Git Workflow](./git-workflow.md) -- branches, commits, MR targets, releases
+- [Development Setup](./development-setup/) -- prerequisites, build, test, project structure
+- [Coding Standards](./coding-standards/) -- C# style, naming, architecture conventions
+- [Module Structure](./module-structure/) -- how to create a new Granit module
+- [Testing Guide](./testing-guide/) -- xUnit, Shouldly, NSubstitute, Bogus
+- [Definition of Done](./definition-of-done/) -- blocking checklist before any push
+- [Git Workflow](./git-workflow/) -- branches, commits, MR targets, releases
 
 ## License
 

--- a/docs-site/src/content/docs/dotnet/architecture/adr/003-testing-stack.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/003-testing-stack.md
@@ -65,7 +65,7 @@ Requirements:
 - Disadvantage: young project (v1.x), single maintainer, limited ecosystem
   (Testcontainers, Verify primarily target xUnit/NUnit)
 - Re-evaluation planned via a future ADR when the project reaches sufficient
-  maturity (cf. [ADR-014](014-migration-shouldly.md))
+  maturity (cf. [ADR-014](./014-migration-shouldly/))
 
 ### Mocking
 

--- a/docs-site/src/content/docs/dotnet/data/persistence.mdx
+++ b/docs-site/src/content/docs/dotnet/data/persistence.mdx
@@ -397,5 +397,5 @@ For integration tests with real PostgreSQL, use Testcontainers to get full fidel
 - [Zero-downtime migrations](./migrations/) — Expand & Contract pattern
 - [Adding Persistence guide](/dotnet/getting-started/adding-persistence/) — step-by-step tutorial
 - [Core module](../core/module-system/) — domain base types, filter interfaces, `IDataFilter`
-- [Multi-tenancy concept](../../concepts/multi-tenancy.md) — isolation strategies in depth
+- [Multi-tenancy concept](../../concepts/multi-tenancy/) — isolation strategies in depth
 - [Wolverine module](/dotnet/infrastructure/wolverine-messaging/) — domain event dispatch and durable messaging


### PR DESCRIPTION
## Summary

- Add `/security` skill — Principal Application Security Architect for exhaustive framework-wide security auditing
- **3 files, 1625 lines** across `SKILL.md`, `checklist.md`, `threat-models.md`
- **10 security domains:** `iam`, `ai`, `data`, `tenancy`, `infra`, `supply-chain`, `crypto`, `observability`, `headers`, `deserialization`
- **150+ checks** mapped to OWASP ASVS 4.0, FAPI 2.0, ISO 27001:2022, OWASP LLM Top 10, RFC 9449/9126, and CWE references
- **8 STRIDE threat models** with attack trees for BFF, MCP (incl. SSRF), multi-tenancy, DPoP, crypto-shredding, Wolverine outbox, API keys, and deserialization
- **Report format:** Executive Summary, STRIDE analysis, CVSS 3.1-scored findings, compliance gap analysis (FAPI/ISO/GDPR/OWASP LLM), residual risk register (P×I matrix), and prioritized remediation roadmap

## Structure

| File | Lines | Content |
|------|-------|---------|
| `SKILL.md` | 810 | Persona, invocation modes, analysis method per domain, report template, strict rules |
| `checklist.md` | 477 | 150+ security checks with standard references and severity levels |
| `threat-models.md` | 338 | 8 STRIDE threat models, attack trees, CVSS quick-ref, revision triggers |

## Invocation

```
/security              # Full audit
/security iam          # Identity & Access Management only
/security ai           # AI/MCP security
/security diff         # Security-relevant changes in current branch
/security help         # Reference card
```

## Test plan

- [ ] Run `/security help` — verify reference card renders correctly
- [ ] Run `/security iam` on a module with known auth patterns — verify findings are evidence-based
- [ ] Run `/security ai` — verify MCP SSRF checks and output sanitization analysis
- [ ] Run `/security diff` on a branch with auth changes — verify scoping works
