### PR TITLE
fix(wolverine): replace duplicate UseWolverine with ConfigureWolverine in PostgreSQL module

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -686,6 +686,13 @@
       "framework": "net10.0"
     },
     {
+      "name": "Granit.Http.Security",
+      "deps": [
+        "Granit"
+      ],
+      "framework": "net10.0"
+    },
+    {
       "name": "Granit.Identity",
       "deps": [
         "Granit",
@@ -13686,6 +13693,130 @@
           "kind": "property",
           "signature": "CompressionLevel GzipLevel",
           "returnType": "CompressionLevel"
+        }
+      ]
+    },
+    {
+      "name": "SecurityApplicationBuilderExtensions",
+      "fqn": "Granit.Http.Security.Extensions.SecurityApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Security",
+      "file": "src/Granit.Http.Security/Extensions/SecurityApplicationBuilderExtensions.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "UseGranitSecurityHeaders",
+          "kind": "method",
+          "signature": "UseGranitSecurityHeaders(this IApplicationBuilder app)",
+          "returnType": "IApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "SecurityHostApplicationBuilderExtensions",
+      "fqn": "Granit.Http.Security.Extensions.SecurityHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Http.Security",
+      "file": "src/Granit.Http.Security/Extensions/SecurityHostApplicationBuilderExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "AddGranitHttpSecurity",
+          "kind": "method",
+          "signature": "AddGranitHttpSecurity(this IHostApplicationBuilder builder)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "GranitHttpSecurityModule",
+      "fqn": "Granit.Http.Security.GranitHttpSecurityModule",
+      "kind": "class",
+      "project": "Granit.Http.Security",
+      "file": "src/Granit.Http.Security/GranitHttpSecurityModule.cs",
+      "line": 32,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "GranitSecurityHeadersOptions",
+      "fqn": "Granit.Http.Security.Options.GranitSecurityHeadersOptions",
+      "kind": "class",
+      "project": "Granit.Http.Security",
+      "file": "src/Granit.Http.Security/Options/GranitSecurityHeadersOptions.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "SuppressServerHeader",
+          "kind": "property",
+          "signature": "bool SuppressServerHeader",
+          "returnType": "bool"
+        },
+        {
+          "name": "EnableContentTypeOptions",
+          "kind": "property",
+          "signature": "bool EnableContentTypeOptions",
+          "returnType": "bool"
+        },
+        {
+          "name": "XFrameOptions",
+          "kind": "property",
+          "signature": "string? XFrameOptions",
+          "returnType": "string?"
+        },
+        {
+          "name": "ReferrerPolicy",
+          "kind": "property",
+          "signature": "string ReferrerPolicy",
+          "returnType": "string"
+        },
+        {
+          "name": "DisableXssProtection",
+          "kind": "property",
+          "signature": "bool DisableXssProtection",
+          "returnType": "bool"
+        },
+        {
+          "name": "PermissionsPolicy",
+          "kind": "property",
+          "signature": "string? PermissionsPolicy",
+          "returnType": "string?"
+        },
+        {
+          "name": "ContentSecurityPolicy",
+          "kind": "property",
+          "signature": "string? ContentSecurityPolicy",
+          "returnType": "string?"
+        },
+        {
+          "name": "HstsMaxAgeSeconds",
+          "kind": "property",
+          "signature": "int HstsMaxAgeSeconds",
+          "returnType": "int"
+        },
+        {
+          "name": "HstsIncludeSubDomains",
+          "kind": "property",
+          "signature": "bool HstsIncludeSubDomains",
+          "returnType": "bool"
+        },
+        {
+          "name": "HstsPreload",
+          "kind": "property",
+          "signature": "bool HstsPreload",
+          "returnType": "bool"
+        },
+        {
+          "name": "CrossOriginEmbedderPolicy",
+          "kind": "property",
+          "signature": "string? CrossOriginEmbedderPolicy",
+          "returnType": "string?"
         }
       ]
     },

--- a/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
@@ -121,11 +121,11 @@ public static class WolverinePostgresqlHostApplicationBuilderExtensions
 
         string connectionString = ResolveConnectionString(builder.Configuration, options);
 
-        // UseWolverine (not ConfigureWolverine): PersistMessagesWithPostgresql registers
-        // services internally. Since Wolverine 3.0/5.24, DI-registered IWolverineExtension
-        // instances run after the container is built (read-only). UseWolverine accumulates
-        // configuration delegates that run while the service collection is still writable.
-        builder.UseWolverine(opts =>
+        // ConfigureWolverine (not UseWolverine): UseWolverine is called once by
+        // AddGranitWolverine() in the base module. ConfigureWolverine accumulates
+        // additional configuration delegates that run during the same phase —
+        // services are still writable. Wolverine 5.24 throws on duplicate UseWolverine.
+        builder.Services.ConfigureWolverine(opts =>
         {
             opts.PersistMessagesWithPostgresql(connectionString);
             opts.UseEntityFrameworkCoreTransactions(options.TransactionMode);

--- a/tests/Granit.Wolverine.Postgresql.Tests/AddGranitWolverineWithPostgresqlTests.cs
+++ b/tests/Granit.Wolverine.Postgresql.Tests/AddGranitWolverineWithPostgresqlTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Shouldly;
+using Wolverine;
 using Xunit;
 
 namespace Granit.Wolverine.Postgresql.Tests;
@@ -37,20 +38,21 @@ public sealed class AddGranitWolverineWithPostgresqlTests
     }
 
     // -----------------------------------------------------------------------
-    // Configure callback — UseWolverine registers Wolverine core services
-    // directly (no IWolverineExtension in DI since Wolverine 3.0/5.24).
-    // We verify the hosted service is registered, proving UseWolverine ran.
+    // Configure callback — ConfigureWolverine defers invocation until
+    // WolverineOptions is resolved. We verify the IWolverineExtension
+    // registration exists (ConfigureWolverine wraps the callback as a
+    // LambdaWolverineExtension).
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void AddGranitWolverineWithPostgresql_WithConfigureCallback_RegistersWolverine()
+    public void AddGranitWolverineWithPostgresql_WithConfigureCallback_RegistersWolverineExtension()
     {
         HostApplicationBuilder builder = CreateBuilder();
 
         builder.AddGranitWolverineWithPostgresql(opts => { });
 
         builder.Services.ShouldContain(d =>
-            d.ServiceType == typeof(IHostedService));
+            d.ServiceType == typeof(IWolverineExtension));
     }
 
     // -----------------------------------------------------------------------
@@ -119,18 +121,18 @@ public sealed class AddGranitWolverineWithPostgresqlTests
     }
 
     // -----------------------------------------------------------------------
-    // PerTenant — configure callback (applied via UseWolverine)
+    // PerTenant — configure callback (deferred by ConfigureWolverine)
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void AddGranitWolverineWithPostgresqlPerTenant_WithConfigureCallback_RegistersWolverine()
+    public void AddGranitWolverineWithPostgresqlPerTenant_WithConfigureCallback_RegistersWolverineExtension()
     {
         HostApplicationBuilder builder = CreateBuilder();
 
         builder.AddGranitWolverineWithPostgresqlPerTenant<StubTenantDbContext>(opts => { });
 
         builder.Services.ShouldContain(d =>
-            d.ServiceType == typeof(IHostedService));
+            d.ServiceType == typeof(IWolverineExtension));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Wolverine 5.24 throws `InvalidOperationException` when `UseWolverine()` is called twice on the same service collection
- `GranitWolverinePostgresqlModule` was calling `builder.UseWolverine()` independently from the base `GranitWolverineModule`, causing a startup crash in the showcase
- Replaced with `builder.Services.ConfigureWolverine()` which accumulates delegates applied during the single `UseWolverine()` call — aligned with the existing SQL Server module pattern
- Updated tests to assert `IWolverineExtension` registration (what `ConfigureWolverine` produces) instead of `IHostedService` (what `UseWolverine` produces)

## Test plan

- [x] `dotnet test tests/Granit.Wolverine.Postgresql.Tests` — 35/35 passing
- [ ] Verify showcase starts without `UseWolverine() can only be called once` error