### PR TITLE
fix(wolverine): avoid read-only service collection in ConfigureWolverine extensions

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -30464,7 +30464,7 @@
       "kind": "class",
       "project": "Granit.Wolverine.Postgresql",
       "file": "src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs",
-      "line": 19,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitWolverineWithPostgresql",
@@ -30512,7 +30512,7 @@
       "kind": "class",
       "project": "Granit.Wolverine.SqlServer",
       "file": "src/Granit.Wolverine.SqlServer/Extensions/WolverineSqlServerHostApplicationBuilderExtensions.cs",
-      "line": 19,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitWolverineWithSqlServer",

--- a/src/Granit.Mcp/Sanitization/PropertyRedactionSanitizer.cs
+++ b/src/Granit.Mcp/Sanitization/PropertyRedactionSanitizer.cs
@@ -136,12 +136,9 @@ internal sealed class PropertyRedactionSanitizer : IMcpOutputSanitizer
         }
         else if (node is JsonArray arr)
         {
-            foreach (JsonNode? item in arr)
+            foreach (JsonNode item in arr.Where(item => item is not null)!)
             {
-                if (item is not null)
-                {
-                    changed |= RedactNode(item);
-                }
+                changed |= RedactNode(item);
             }
         }
 

--- a/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Granit.Persistence.Extensions;
 using Granit.Persistence.MultiTenancy;
+using Granit.Wolverine.Internal;
 using Granit.Wolverine.Postgresql.Internal;
 using Granit.Wolverine.Postgresql.Options;
 using Microsoft.EntityFrameworkCore;
@@ -121,17 +122,26 @@ public static class WolverinePostgresqlHostApplicationBuilderExtensions
 
         string connectionString = ResolveConnectionString(builder.Configuration, options);
 
-        // ConfigureWolverine (not UseWolverine): UseWolverine is called once by
-        // AddGranitWolverine() in the base module. ConfigureWolverine accumulates
-        // additional configuration delegates that run during the same phase —
-        // services are still writable. Wolverine 5.24 throws on duplicate UseWolverine.
-        builder.Services.ConfigureWolverine(opts =>
-        {
-            opts.PersistMessagesWithPostgresql(connectionString);
-            opts.UseEntityFrameworkCoreTransactions(options.TransactionMode);
-            opts.Policies.AutoApplyTransactions();
-            configure?.Invoke(opts);
-        });
+        // Resolve the WolverineOptions instance captured by AddGranitWolverine().
+        // We apply PostgreSQL configuration directly on this instance instead of using
+        // ConfigureWolverine(), which registers a deferred LambdaWolverineExtension in
+        // the IoC container. As of Wolverine 3.0, deferred extensions face a read-only
+        // IServiceCollection during DI resolution — PersistMessagesWithPostgresql()
+        // needs to register services and would throw InvalidOperationException.
+        // Calling it here (during ConfigureServices, Phase 1) keeps services writable.
+        WolverineOptions wolverineOptions = builder.Services
+            .Select(d => d.ImplementationInstance)
+            .OfType<WolverineOptionsHolder>()
+            .FirstOrDefault()
+            ?.Options
+            ?? throw new InvalidOperationException(
+                "AddGranitWolverine() must be called before AddGranitWolverineWithPostgresql(). " +
+                "Ensure GranitWolverineModule is declared in the [DependsOn] chain.");
+
+        wolverineOptions.PersistMessagesWithPostgresql(connectionString);
+        wolverineOptions.UseEntityFrameworkCoreTransactions(options.TransactionMode);
+        wolverineOptions.Policies.AutoApplyTransactions();
+        configure?.Invoke(wolverineOptions);
 
         return builder;
     }

--- a/src/Granit.Wolverine.SqlServer/Extensions/WolverineSqlServerHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine.SqlServer/Extensions/WolverineSqlServerHostApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Granit.Persistence.Extensions;
 using Granit.Persistence.MultiTenancy;
+using Granit.Wolverine.Internal;
 using Granit.Wolverine.SqlServer.Internal;
 using Granit.Wolverine.SqlServer.Options;
 using Microsoft.EntityFrameworkCore;
@@ -119,13 +120,26 @@ public static class WolverineSqlServerHostApplicationBuilderExtensions
             .GetSection(WolverineSqlServerOptions.SectionName)
             .Bind(options);
 
-        builder.Services.ConfigureWolverine(opts =>
-        {
-            opts.PersistMessagesWithSqlServer(options.TransportConnectionString);
-            opts.UseEntityFrameworkCoreTransactions(options.TransactionMode);
-            opts.Policies.AutoApplyTransactions();
-            configure?.Invoke(opts);
-        });
+        // Resolve the WolverineOptions instance captured by AddGranitWolverine().
+        // We apply SQL Server configuration directly on this instance instead of using
+        // ConfigureWolverine(), which registers a deferred LambdaWolverineExtension in
+        // the IoC container. As of Wolverine 3.0, deferred extensions face a read-only
+        // IServiceCollection during DI resolution — PersistMessagesWithSqlServer()
+        // needs to register services and would throw InvalidOperationException.
+        // Calling it here (during ConfigureServices, Phase 1) keeps services writable.
+        WolverineOptions wolverineOptions = builder.Services
+            .Select(d => d.ImplementationInstance)
+            .OfType<WolverineOptionsHolder>()
+            .FirstOrDefault()
+            ?.Options
+            ?? throw new InvalidOperationException(
+                "AddGranitWolverine() must be called before AddGranitWolverineWithSqlServer(). " +
+                "Ensure GranitWolverineModule is declared in the [DependsOn] chain.");
+
+        wolverineOptions.PersistMessagesWithSqlServer(options.TransportConnectionString);
+        wolverineOptions.UseEntityFrameworkCoreTransactions(options.TransactionMode);
+        wolverineOptions.Policies.AutoApplyTransactions();
+        configure?.Invoke(wolverineOptions);
 
         return builder;
     }

--- a/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
@@ -128,6 +128,14 @@ public static class WolverineHostApplicationBuilderExtensions
             opts.Policies.AddMiddleware<TraceContextBehavior>();
 
             configure?.Invoke(opts);
+
+            // Expose the WolverineOptions instance for provider modules (PostgreSQL, SqlServer).
+            // Provider modules call extension methods like PersistMessagesWithPostgresql()
+            // directly on this instance during their ConfigureServices phase, when the
+            // service collection is still writable. This avoids ConfigureWolverine() which
+            // defers extension processing to DI resolution (Wolverine 3.0+ blocks service
+            // modifications at that point).
+            builder.Services.TryAddSingleton(new WolverineOptionsHolder(opts));
         });
 
         return builder;

--- a/src/Granit.Wolverine/Granit.Wolverine.csproj
+++ b/src/Granit.Wolverine/Granit.Wolverine.csproj
@@ -12,6 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Granit.Wolverine.Postgresql" />
+    <InternalsVisibleTo Include="Granit.Wolverine.SqlServer" />
     <InternalsVisibleTo Include="Granit.Wolverine.Tests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
     <ProjectReference Include="..\..\src\Granit\Granit.csproj" />

--- a/src/Granit.Wolverine/Internal/WolverineOptionsHolder.cs
+++ b/src/Granit.Wolverine/Internal/WolverineOptionsHolder.cs
@@ -1,0 +1,25 @@
+using Wolverine;
+
+namespace Granit.Wolverine.Internal;
+
+/// <summary>
+/// Holds a reference to the <see cref="WolverineOptions"/> instance created during
+/// <c>UseWolverine()</c>, allowing provider modules (PostgreSQL, SqlServer) to apply
+/// configuration directly on the options while the service collection is still writable.
+/// </summary>
+/// <remarks>
+/// As of Wolverine 3.0, <c>ConfigureWolverine()</c> registers deferred extensions
+/// (<c>LambdaWolverineExtension</c>) in the IoC container. When Wolverine processes
+/// these extensions during DI resolution, the service collection is already read-only,
+/// causing <see cref="InvalidOperationException"/> for extensions that register services
+/// (e.g., <c>PersistMessagesWithPostgresql()</c>).
+/// <para>
+/// This holder allows provider modules to call extension methods like
+/// <c>PersistMessagesWithPostgresql()</c> during their <c>ConfigureServices</c> phase
+/// (Phase 1), when the service collection is still mutable.
+/// </para>
+/// </remarks>
+internal sealed class WolverineOptionsHolder(WolverineOptions options)
+{
+    public WolverineOptions Options { get; } = options;
+}

--- a/tests/Granit.Wolverine.Postgresql.Tests/AddGranitWolverineWithPostgresqlPerTenantTests.cs
+++ b/tests/Granit.Wolverine.Postgresql.Tests/AddGranitWolverineWithPostgresqlPerTenantTests.cs
@@ -7,6 +7,7 @@
 // built to avoid requiring a live PostgreSQL Outbox connection.
 // =============================================================================
 
+using Granit.Wolverine.Extensions;
 using Granit.Wolverine.Postgresql.Extensions;
 using Granit.Wolverine.Postgresql.Options;
 using Microsoft.EntityFrameworkCore;
@@ -38,7 +39,9 @@ public sealed class AddGranitWolverineWithPostgresqlPerTenantTests
             [$"{WolverinePostgresqlOptions.SectionName}:TransportConnectionString"] =
                 ValidTransportConnStr,
         });
-        return Host.CreateApplicationBuilder(settings);
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder(settings);
+        builder.AddGranitWolverine();
+        return builder;
     }
 
     // -----------------------------------------------------------------------

--- a/tests/Granit.Wolverine.Postgresql.Tests/AddGranitWolverineWithPostgresqlTests.cs
+++ b/tests/Granit.Wolverine.Postgresql.Tests/AddGranitWolverineWithPostgresqlTests.cs
@@ -5,6 +5,7 @@
 // connection string name resolution, and missing connection string scenarios.
 // =============================================================================
 
+using Granit.Wolverine.Extensions;
 using Granit.Wolverine.Postgresql.Extensions;
 using Granit.Wolverine.Postgresql.Options;
 using Microsoft.Extensions.Configuration;
@@ -12,7 +13,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Shouldly;
-using Wolverine;
 using Xunit;
 
 namespace Granit.Wolverine.Postgresql.Tests;
@@ -23,7 +23,8 @@ public sealed class AddGranitWolverineWithPostgresqlTests
         "Host=localhost;Database=wolverine_transport;Username=test;Password=test";
 
     private static HostApplicationBuilder CreateBuilder(
-        Dictionary<string, string?>? config = null)
+        Dictionary<string, string?>? config = null,
+        bool withWolverine = true)
     {
         HostApplicationBuilderSettings settings = new()
         {
@@ -34,25 +35,31 @@ public sealed class AddGranitWolverineWithPostgresqlTests
             [$"{WolverinePostgresqlOptions.SectionName}:TransportConnectionString"] =
                 ValidTransportConnStr,
         });
-        return Host.CreateApplicationBuilder(settings);
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder(settings);
+
+        if (withWolverine)
+        {
+            builder.AddGranitWolverine();
+        }
+
+        return builder;
     }
 
     // -----------------------------------------------------------------------
-    // Configure callback — ConfigureWolverine defers invocation until
-    // WolverineOptions is resolved. We verify the IWolverineExtension
-    // registration exists (ConfigureWolverine wraps the callback as a
-    // LambdaWolverineExtension).
+    // Configure callback — invoked synchronously during registration
+    // (applied directly on the WolverineOptions instance, not as a deferred
+    // extension, to avoid Wolverine 3.0 read-only service collection restriction).
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void AddGranitWolverineWithPostgresql_WithConfigureCallback_RegistersWolverineExtension()
+    public void AddGranitWolverineWithPostgresql_WithConfigureCallback_InvokesCallbackSynchronously()
     {
         HostApplicationBuilder builder = CreateBuilder();
+        bool callbackInvoked = false;
 
-        builder.AddGranitWolverineWithPostgresql(opts => { });
+        builder.AddGranitWolverineWithPostgresql(_ => callbackInvoked = true);
 
-        builder.Services.ShouldContain(d =>
-            d.ServiceType == typeof(IWolverineExtension));
+        callbackInvoked.ShouldBeTrue();
     }
 
     // -----------------------------------------------------------------------
@@ -95,10 +102,13 @@ public sealed class AddGranitWolverineWithPostgresqlTests
     [Fact]
     public void AddGranitWolverineWithPostgresql_WithMissingConnectionStringName_ThrowsInvalidOperationException()
     {
-        HostApplicationBuilder builder = CreateBuilder(new Dictionary<string, string?>
-        {
-            [$"{WolverinePostgresqlOptions.SectionName}:TransportConnectionStringName"] = "non-existent-db",
-        });
+        // Throws before WolverineOptionsHolder lookup, so AddGranitWolverine() is not needed.
+        HostApplicationBuilder builder = CreateBuilder(
+            config: new Dictionary<string, string?>
+            {
+                [$"{WolverinePostgresqlOptions.SectionName}:TransportConnectionStringName"] = "non-existent-db",
+            },
+            withWolverine: false);
 
         Action act = () => builder.AddGranitWolverineWithPostgresql();
 
@@ -121,18 +131,18 @@ public sealed class AddGranitWolverineWithPostgresqlTests
     }
 
     // -----------------------------------------------------------------------
-    // PerTenant — configure callback (deferred by ConfigureWolverine)
+    // PerTenant — configure callback (invoked synchronously)
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void AddGranitWolverineWithPostgresqlPerTenant_WithConfigureCallback_RegistersWolverineExtension()
+    public void AddGranitWolverineWithPostgresqlPerTenant_WithConfigureCallback_InvokesCallbackSynchronously()
     {
         HostApplicationBuilder builder = CreateBuilder();
+        bool callbackInvoked = false;
 
-        builder.AddGranitWolverineWithPostgresqlPerTenant<StubTenantDbContext>(opts => { });
+        builder.AddGranitWolverineWithPostgresqlPerTenant<StubTenantDbContext>(_ => callbackInvoked = true);
 
-        builder.Services.ShouldContain(d =>
-            d.ServiceType == typeof(IWolverineExtension));
+        callbackInvoked.ShouldBeTrue();
     }
 
     // -----------------------------------------------------------------------

--- a/tests/Granit.Wolverine.Postgresql.Tests/GranitWolverinePostgresqlModuleTests.cs
+++ b/tests/Granit.Wolverine.Postgresql.Tests/GranitWolverinePostgresqlModuleTests.cs
@@ -7,6 +7,7 @@
 
 using Granit.Modularity;
 using Granit.Persistence;
+using Granit.Wolverine.Extensions;
 using Granit.Wolverine.Postgresql.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
@@ -57,7 +58,8 @@ public sealed class GranitWolverinePostgresqlModuleTests
             ["WolverinePostgresql:TransportConnectionString"] =
                 "Host=localhost;Database=test;Username=test;Password=test",
         });
-        IHostApplicationBuilder builder = Host.CreateApplicationBuilder(settings);
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder(settings);
+        builder.AddGranitWolverine();
 
         Action act = () => builder.AddGranitWolverineWithPostgresql();
 

--- a/tests/Granit.Wolverine.SqlServer.Tests/AddGranitWolverineWithSqlServerPerTenantTests.cs
+++ b/tests/Granit.Wolverine.SqlServer.Tests/AddGranitWolverineWithSqlServerPerTenantTests.cs
@@ -7,6 +7,7 @@
 // built to avoid requiring a live SQL Server Outbox connection.
 // =============================================================================
 
+using Granit.Wolverine.Extensions;
 using Granit.Wolverine.SqlServer.Extensions;
 using Granit.Wolverine.SqlServer.Options;
 using Microsoft.EntityFrameworkCore;
@@ -38,7 +39,9 @@ public sealed class AddGranitWolverineWithSqlServerPerTenantTests
             [$"{WolverineSqlServerOptions.SectionName}:TransportConnectionString"] =
                 ValidTransportConnStr,
         });
-        return Host.CreateApplicationBuilder(settings);
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder(settings);
+        builder.AddGranitWolverine();
+        return builder;
     }
 
     // -----------------------------------------------------------------------

--- a/tests/Granit.Wolverine.SqlServer.Tests/AddGranitWolverineWithSqlServerTests.cs
+++ b/tests/Granit.Wolverine.SqlServer.Tests/AddGranitWolverineWithSqlServerTests.cs
@@ -5,6 +5,7 @@
 // value for both single-tenant and per-tenant extension methods.
 // =============================================================================
 
+using Granit.Wolverine.Extensions;
 using Granit.Wolverine.SqlServer.Extensions;
 using Granit.Wolverine.SqlServer.Options;
 using Microsoft.Extensions.Configuration;
@@ -12,7 +13,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Shouldly;
-using Wolverine;
 using Xunit;
 
 namespace Granit.Wolverine.SqlServer.Tests;
@@ -33,25 +33,26 @@ public sealed class AddGranitWolverineWithSqlServerTests
             [$"{WolverineSqlServerOptions.SectionName}:TransportConnectionString"] =
                 ValidTransportConnStr,
         });
-        return Host.CreateApplicationBuilder(settings);
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder(settings);
+        builder.AddGranitWolverine();
+        return builder;
     }
 
     // -----------------------------------------------------------------------
-    // Configure callback — ConfigureWolverine defers invocation until
-    // WolverineOptions is resolved. We verify the IWolverineExtension
-    // registration exists (ConfigureWolverine wraps the callback as a
-    // LambdaWolverineExtension).
+    // Configure callback — invoked synchronously during registration
+    // (applied directly on the WolverineOptions instance, not as a deferred
+    // extension, to avoid Wolverine 3.0 read-only service collection restriction).
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void AddGranitWolverineWithSqlServer_WithConfigureCallback_RegistersWolverineExtension()
+    public void AddGranitWolverineWithSqlServer_WithConfigureCallback_InvokesCallbackSynchronously()
     {
         HostApplicationBuilder builder = CreateBuilder();
+        bool callbackInvoked = false;
 
-        builder.AddGranitWolverineWithSqlServer(opts => { });
+        builder.AddGranitWolverineWithSqlServer(_ => callbackInvoked = true);
 
-        builder.Services.ShouldContain(d =>
-            d.ServiceType == typeof(IWolverineExtension));
+        callbackInvoked.ShouldBeTrue();
     }
 
     // -----------------------------------------------------------------------
@@ -84,18 +85,18 @@ public sealed class AddGranitWolverineWithSqlServerTests
     }
 
     // -----------------------------------------------------------------------
-    // PerTenant — configure callback (deferred by ConfigureWolverine)
+    // PerTenant — configure callback (invoked synchronously)
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void AddGranitWolverineWithSqlServerPerTenant_WithConfigureCallback_RegistersWolverineExtension()
+    public void AddGranitWolverineWithSqlServerPerTenant_WithConfigureCallback_InvokesCallbackSynchronously()
     {
         HostApplicationBuilder builder = CreateBuilder();
+        bool callbackInvoked = false;
 
-        builder.AddGranitWolverineWithSqlServerPerTenant<StubTenantDbContext>(opts => { });
+        builder.AddGranitWolverineWithSqlServerPerTenant<StubTenantDbContext>(_ => callbackInvoked = true);
 
-        builder.Services.ShouldContain(d =>
-            d.ServiceType == typeof(IWolverineExtension));
+        callbackInvoked.ShouldBeTrue();
     }
 
     // -----------------------------------------------------------------------

--- a/tests/Granit.Wolverine.SqlServer.Tests/GranitWolverineSqlServerModuleTests.cs
+++ b/tests/Granit.Wolverine.SqlServer.Tests/GranitWolverineSqlServerModuleTests.cs
@@ -7,6 +7,7 @@
 
 using Granit.Modularity;
 using Granit.Persistence;
+using Granit.Wolverine.Extensions;
 using Granit.Wolverine.SqlServer.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
@@ -57,7 +58,8 @@ public sealed class GranitWolverineSqlServerModuleTests
             ["WolverineSqlServer:TransportConnectionString"] =
                 "Server=localhost;Database=test;User Id=sa;Password=test;TrustServerCertificate=True",
         });
-        IHostApplicationBuilder builder = Host.CreateApplicationBuilder(settings);
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder(settings);
+        builder.AddGranitWolverine();
 
         Action act = () => builder.AddGranitWolverineWithSqlServer();
 


### PR DESCRIPTION
## Summary

- **Fix Wolverine 3.0+ startup crash**: `ConfigureWolverine()` registers deferred `LambdaWolverineExtension` in the IoC container, but `PersistMessagesWithPostgresql()` / `PersistMessagesWithSqlServer()` need to register services — which fails because the service collection is read-only during DI resolution (Phase 2)
- **Solution**: Capture the `WolverineOptions` instance from the `UseWolverine()` callback via `WolverineOptionsHolder`, then apply provider configuration directly during `ConfigureServices` (Phase 1) where services are still writable
- **Code quality**: Replace `foreach` + `if` with explicit `.Where()` in `PropertyRedactionSanitizer`

## Test plan

- [x] `Granit.Wolverine.Tests` — 164 passed
- [x] `Granit.Wolverine.Postgresql.Tests` — 35 passed
- [x] `Granit.Wolverine.SqlServer.Tests` — 28 passed
- [x] `dotnet format --verify-no-changes` — clean
- [ ] Verify showcase app starts without `InvalidOperationException`
