### PR TITLE
fix(wolverine,validation): read-only service collection + validator cleanup

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -30464,7 +30464,7 @@
       "kind": "class",
       "project": "Granit.Wolverine.Postgresql",
       "file": "src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs",
-      "line": 19,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitWolverineWithPostgresql",
@@ -30512,7 +30512,7 @@
       "kind": "class",
       "project": "Granit.Wolverine.SqlServer",
       "file": "src/Granit.Wolverine.SqlServer/Extensions/WolverineSqlServerHostApplicationBuilderExtensions.cs",
-      "line": 19,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitWolverineWithSqlServer",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -3171,15 +3171,6 @@
       "members": []
     },
     {
-      "name": "AuditSensitiveAttribute",
-      "fqn": "Granit.Auditing.Attributes.AuditSensitiveAttribute",
-      "kind": "class",
-      "project": "Granit.Auditing",
-      "file": "src/Granit.Auditing/Attributes/AuditSensitiveAttribute.cs",
-      "line": 12,
-      "members": []
-    },
-    {
       "name": "GranitAuditingConfigurationChangesModule",
       "fqn": "Granit.Auditing.ConfigurationChanges.GranitAuditingConfigurationChangesModule",
       "kind": "class",
@@ -3201,7 +3192,7 @@
       "kind": "class",
       "project": "Granit.Auditing.ConfigurationChanges",
       "file": "src/Granit.Auditing.ConfigurationChanges/Handlers/FeatureOverrideChangedAuditHandler.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "HandleAsync",
@@ -3217,7 +3208,7 @@
       "kind": "class",
       "project": "Granit.Auditing.ConfigurationChanges",
       "file": "src/Granit.Auditing.ConfigurationChanges/Handlers/SettingChangedAuditHandler.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "HandleAsync",
@@ -3366,7 +3357,7 @@
       "kind": "record",
       "project": "Granit.Auditing.Endpoints",
       "file": "src/Granit.Auditing.Endpoints/Dtos/AuditEntryResponse.cs",
-      "line": 15,
+      "line": 18,
       "members": []
     },
     {
@@ -3384,15 +3375,6 @@
       "kind": "class",
       "project": "Granit.Auditing.Endpoints",
       "file": "src/Granit.Auditing.Endpoints/Dtos/AuditingQueryParameters.cs",
-      "line": 9,
-      "members": []
-    },
-    {
-      "name": "AuditingQueryRequest",
-      "fqn": "Granit.Auditing.Endpoints.Dtos.AuditingQueryRequest",
-      "kind": "class",
-      "project": "Granit.Auditing.Endpoints",
-      "file": "src/Granit.Auditing.Endpoints/Dtos/AuditingQueryRequest.cs",
       "line": 9,
       "members": []
     },
@@ -3467,7 +3449,7 @@
       "kind": "class",
       "project": "Granit.Auditing.EntityFrameworkCore",
       "file": "src/Granit.Auditing.EntityFrameworkCore/Extensions/AuditingEntityFrameworkCoreServiceCollectionExtensions.cs",
-      "line": 22,
+      "line": 23,
       "members": [
         {
           "name": "AddGranitAuditingEntityFrameworkCore",
@@ -3681,6 +3663,12 @@
           "name": "CleanupBatchSize",
           "kind": "property",
           "signature": "int CleanupBatchSize",
+          "returnType": "int"
+        },
+        {
+          "name": "ChannelCapacity",
+          "kind": "property",
+          "signature": "int ChannelCapacity",
           "returnType": "int"
         },
         {
@@ -9586,6 +9574,15 @@
       "members": []
     },
     {
+      "name": "SensitiveDataAttribute",
+      "fqn": "Granit.DataProtection.SensitiveDataAttribute",
+      "kind": "class",
+      "project": "Granit",
+      "file": "src/Granit/DataProtection/SensitiveDataAttribute.cs",
+      "line": 22,
+      "members": []
+    },
+    {
       "name": "IHealthCheckAggregator",
       "fqn": "Granit.Diagnostics.Abstractions.IHealthCheckAggregator",
       "kind": "interface",
@@ -14319,7 +14316,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.EntityFrameworkCore",
       "file": "src/Granit.Identity.Federated.EntityFrameworkCore/Entities/UserCacheEntry.cs",
-      "line": 22,
+      "line": 23,
       "members": [
         {
           "name": "ExternalUserId",
@@ -23382,7 +23379,7 @@
       "kind": "class",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/LegalAgreements/Domain/LegalAgreementBase.cs",
-      "line": 13,
+      "line": 14,
       "members": [
         {
           "name": "UserId",
@@ -28454,6 +28451,28 @@
       "file": "src/Granit.Validation/Extensions/NetworkValidatorExtensions.cs",
       "line": 9,
       "members": []
+    },
+    {
+      "name": "PaginationValidatorExtensions",
+      "fqn": "Granit.Validation.Extensions.PaginationValidatorExtensions",
+      "kind": "class",
+      "project": "Granit.Validation",
+      "file": "src/Granit.Validation/Extensions/PaginationValidatorExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "maxPageSize",
+          "kind": "property",
+          "signature": "IRuleBuilderOptions<T, int> ValidPageSize<T>( this IRuleBuilder<T, int> ruleBuilder, int maxPageSize",
+          "returnType": "IRuleBuilderOptions<T, int> ValidPageSize<T>( this IRuleBuilder<T, int> ruleBuilder, int"
+        },
+        {
+          "name": "maxPageSize",
+          "kind": "property",
+          "signature": "IRuleBuilderOptions<T, int?> ValidPageSize<T>( this IRuleBuilder<T, int?> ruleBuilder, int maxPageSize",
+          "returnType": "IRuleBuilderOptions<T, int?> ValidPageSize<T>( this IRuleBuilder<T, int?> ruleBuilder, int"
+        }
+      ]
     },
     {
       "name": "PaymentValidatorExtensions",

--- a/src/Granit.Auditing.Endpoints/Validators/AuditingQueryParametersValidator.cs
+++ b/src/Granit.Auditing.Endpoints/Validators/AuditingQueryParametersValidator.cs
@@ -1,0 +1,32 @@
+using FluentValidation;
+using Granit.Auditing.Endpoints.Dtos;
+using Granit.Validation;
+using Granit.Validation.Extensions;
+
+namespace Granit.Auditing.Endpoints.Validators;
+
+/// <summary>
+/// Validates <see cref="AuditingQueryParameters"/> query parameters.
+/// Auto-discovered by <c>GranitValidationModule</c>.
+/// </summary>
+internal sealed class AuditingQueryParametersValidator : GranitValidator<AuditingQueryParameters>
+{
+    internal const int MaxStringFilterLength = 500;
+
+    public AuditingQueryParametersValidator()
+    {
+        RuleFor(x => x.Page).ValidPage();
+
+        RuleFor(x => x.PageSize).ValidPageSize();
+
+        RuleFor(x => x.UserId).MaximumLength(MaxStringFilterLength);
+
+        RuleFor(x => x.EntityType).MaximumLength(MaxStringFilterLength);
+
+        RuleFor(x => x.EntityId).MaximumLength(MaxStringFilterLength);
+
+        RuleFor(x => x.From)
+            .LessThan(x => x.To)
+            .When(x => x.From.HasValue && x.To.HasValue);
+    }
+}

--- a/src/Granit.Authentication.ApiKeys.Endpoints/Endpoints/ApiKeyReadEndpoints.cs
+++ b/src/Granit.Authentication.ApiKeys.Endpoints/Endpoints/ApiKeyReadEndpoints.cs
@@ -37,8 +37,7 @@ internal static class ApiKeyReadEndpoints
         [AsParameters] ApiKeyListRequest request,
         CancellationToken cancellationToken)
     {
-        int page = Math.Max(request.Page, 1);
-        int pageSize = Math.Clamp(request.PageSize, 1, 100);
+        (int page, int pageSize) = QueryEngineDefaults.ClampPagination(request.Page, request.PageSize);
 
         PagedResult<ApiKeyEntry> result = await adminStore.ListAsync(
             request.Search,

--- a/src/Granit.BackgroundJobs.Endpoints/Endpoints/BackgroundJobsReadEndpoints.cs
+++ b/src/Granit.BackgroundJobs.Endpoints/Endpoints/BackgroundJobsReadEndpoints.cs
@@ -39,8 +39,7 @@ internal static class BackgroundJobsReadEndpoints
         [FromQuery] int pageSize = QueryEngineDefaults.DefaultPageSize,
         CancellationToken cancellationToken = default)
     {
-        int clampedPage = Math.Max(page, 1);
-        int clampedPageSize = Math.Clamp(pageSize, 1, QueryEngineDefaults.MaxPageSize);
+        (int clampedPage, int clampedPageSize) = QueryEngineDefaults.ClampPagination(page, pageSize);
 
         IReadOnlyList<BackgroundJobStatus> all = await reader.GetAllAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Granit.DataExchange.Endpoints/Endpoints/Export/ExportJobListEndpoints.cs
+++ b/src/Granit.DataExchange.Endpoints/Endpoints/Export/ExportJobListEndpoints.cs
@@ -36,8 +36,7 @@ internal static class ExportJobListEndpoints
         [FromQuery] int pageSize = 20,
         CancellationToken cancellationToken = default)
     {
-        int clampedPageSize = Math.Clamp(pageSize, 1, 100);
-        int clampedPage = Math.Max(page, 1);
+        (int clampedPage, int clampedPageSize) = QueryEngineDefaults.ClampPagination(page, pageSize);
 
         PagedResult<ExportJob> result = await jobReader
             .ListAsync(status, clampedPage, clampedPageSize, cancellationToken)

--- a/src/Granit.DataExchange.Endpoints/Endpoints/Import/ImportJobListEndpoints.cs
+++ b/src/Granit.DataExchange.Endpoints/Endpoints/Import/ImportJobListEndpoints.cs
@@ -36,8 +36,7 @@ internal static class ImportJobListEndpoints
         [FromQuery] int pageSize = 20,
         CancellationToken cancellationToken = default)
     {
-        int clampedPageSize = Math.Clamp(pageSize, 1, 100);
-        int clampedPage = Math.Max(page, 1);
+        (int clampedPage, int clampedPageSize) = QueryEngineDefaults.ClampPagination(page, pageSize);
 
         PagedResult<ImportJob> result = await jobReader
             .ListAsync(status, clampedPage, clampedPageSize, cancellationToken)

--- a/src/Granit.Identity.Endpoints/Endpoints/IdentityUserCacheReadEndpoints.cs
+++ b/src/Granit.Identity.Endpoints/Endpoints/IdentityUserCacheReadEndpoints.cs
@@ -44,8 +44,8 @@ internal static class IdentityUserCacheReadEndpoints
         CancellationToken cancellationToken)
     {
         QueryRequest query = request.Value;
-        int page = query.Page ?? 1;
-        int pageSize = Math.Clamp(query.PageSize ?? QueryEngineDefaults.DefaultPageSize, 1, QueryEngineDefaults.MaxPageSize);
+        (int page, int pageSize) = QueryEngineDefaults.ClampPagination(
+            query.Page ?? 1, query.PageSize ?? QueryEngineDefaults.DefaultPageSize);
 
         PagedResult<IIdentityUser> result = await lookupService.SearchAsync(
             query.Search ?? "",

--- a/src/Granit.Identity.Federated.EntityFrameworkCore/Internal/CachedUserLookupService.cs
+++ b/src/Granit.Identity.Federated.EntityFrameworkCore/Internal/CachedUserLookupService.cs
@@ -153,7 +153,8 @@ internal sealed partial class CachedUserLookupService(
             .ConfigureAwait(false);
 
         var items = entries.Cast<IIdentityUser>().ToList();
-        int skip = (Math.Max(page, 1) - 1) * Math.Clamp(pageSize, 1, QueryEngineDefaults.MaxPageSize);
+        (int clampedPage, int clampedPageSize) = QueryEngineDefaults.ClampPagination(page, pageSize);
+        int skip = (clampedPage - 1) * clampedPageSize;
         return new PagedResult<IIdentityUser>(items, totalCount, HasMore: skip + items.Count < totalCount);
     }
 

--- a/src/Granit.Mcp/Sanitization/PropertyRedactionSanitizer.cs
+++ b/src/Granit.Mcp/Sanitization/PropertyRedactionSanitizer.cs
@@ -136,12 +136,9 @@ internal sealed class PropertyRedactionSanitizer : IMcpOutputSanitizer
         }
         else if (node is JsonArray arr)
         {
-            foreach (JsonNode? item in arr)
+            foreach (JsonNode item in arr.Where(item => item is not null)!)
             {
-                if (item is not null)
-                {
-                    changed |= RedactNode(item);
-                }
+                changed |= RedactNode(item);
             }
         }
 

--- a/src/Granit.Notifications.Endpoints/Extensions/NotificationEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Notifications.Endpoints/Extensions/NotificationEndpointRouteBuilderExtensions.cs
@@ -84,8 +84,7 @@ public static class NotificationEndpointRouteBuilderExtensions
         ClaimsPrincipal user,
         int page = 1, int pageSize = QueryEngineDefaults.DefaultPageSize)
     {
-        int clampedPage = Math.Max(page, 1);
-        int clampedPageSize = Math.Clamp(pageSize, 1, QueryEngineDefaults.MaxPageSize);
+        (int clampedPage, int clampedPageSize) = QueryEngineDefaults.ClampPagination(page, pageSize);
 
         string userId = GetUserId(user);
         Guid? tenantId = tenant.IsAvailable ? tenant.Id : null;
@@ -145,8 +144,7 @@ public static class NotificationEndpointRouteBuilderExtensions
         [FromServices] ICurrentTenant tenant,
         int page = 1, int pageSize = QueryEngineDefaults.DefaultPageSize)
     {
-        int clampedPage = Math.Max(page, 1);
-        int clampedPageSize = Math.Clamp(pageSize, 1, QueryEngineDefaults.MaxPageSize);
+        (int clampedPage, int clampedPageSize) = QueryEngineDefaults.ClampPagination(page, pageSize);
 
         Guid? tenantId = tenant.IsAvailable ? tenant.Id : null;
         PagedResult<UserNotification> result = await reader.GetByEntityAsync(entityType, entityId, tenantId, clampedPage, clampedPageSize).ConfigureAwait(false);

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreUserNotificationStore.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreUserNotificationStore.cs
@@ -29,8 +29,7 @@ internal sealed class EfCoreUserNotificationStore(IDbContextFactory<Notification
     /// <inheritdoc/>
     public async Task<PagedResult<UserNotification>> GetListAsync(string recipientUserId, Guid? tenantId, int page = 1, int pageSize = QueryEngineDefaults.DefaultPageSize, CancellationToken cancellationToken = default)
     {
-        int clampedPage = Math.Max(page, 1);
-        int clampedPageSize = Math.Clamp(pageSize, 1, QueryEngineDefaults.MaxPageSize);
+        (int clampedPage, int clampedPageSize) = QueryEngineDefaults.ClampPagination(page, pageSize);
 
         await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
@@ -93,8 +92,7 @@ internal sealed class EfCoreUserNotificationStore(IDbContextFactory<Notification
     /// <inheritdoc/>
     public async Task<PagedResult<UserNotification>> GetByEntityAsync(string entityType, string entityId, Guid? tenantId, int page = 1, int pageSize = QueryEngineDefaults.DefaultPageSize, CancellationToken cancellationToken = default)
     {
-        int clampedPage = Math.Max(page, 1);
-        int clampedPageSize = Math.Clamp(pageSize, 1, QueryEngineDefaults.MaxPageSize);
+        (int clampedPage, int clampedPageSize) = QueryEngineDefaults.ClampPagination(page, pageSize);
 
         await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Granit.Notifications/Internal/InMemoryUserNotificationStore.cs
+++ b/src/Granit.Notifications/Internal/InMemoryUserNotificationStore.cs
@@ -20,8 +20,7 @@ internal sealed class InMemoryUserNotificationStore : IUserNotificationReader, I
 
     public Task<PagedResult<UserNotification>> GetListAsync(string recipientUserId, Guid? tenantId, int page = 1, int pageSize = QueryEngineDefaults.DefaultPageSize, CancellationToken cancellationToken = default)
     {
-        int clampedPage = Math.Max(page, 1);
-        int clampedPageSize = Math.Clamp(pageSize, 1, QueryEngineDefaults.MaxPageSize);
+        (int clampedPage, int clampedPageSize) = QueryEngineDefaults.ClampPagination(page, pageSize);
 
         var filtered = _notifications.Values
             .Where(n => n.RecipientUserId == recipientUserId && n.TenantId == tenantId)
@@ -66,8 +65,7 @@ internal sealed class InMemoryUserNotificationStore : IUserNotificationReader, I
 
     public Task<PagedResult<UserNotification>> GetByEntityAsync(string entityType, string entityId, Guid? tenantId, int page = 1, int pageSize = QueryEngineDefaults.DefaultPageSize, CancellationToken cancellationToken = default)
     {
-        int clampedPage = Math.Max(page, 1);
-        int clampedPageSize = Math.Clamp(pageSize, 1, QueryEngineDefaults.MaxPageSize);
+        (int clampedPage, int clampedPageSize) = QueryEngineDefaults.ClampPagination(page, pageSize);
 
         var filtered = _notifications.Values
             .Where(n => n.RelatedEntityType == entityType && n.RelatedEntityId == entityId && n.TenantId == tenantId)

--- a/src/Granit.QueryEngine/QueryEngineDefaults.cs
+++ b/src/Granit.QueryEngine/QueryEngineDefaults.cs
@@ -13,4 +13,13 @@ public static class QueryEngineDefaults
 
     /// <summary>Maximum number of items returned by <c>ExecuteStreamAsync</c>.</summary>
     public const int MaxStreamSize = 100_000;
+
+    /// <summary>
+    /// Clamps <paramref name="page"/> and <paramref name="pageSize"/> to valid pagination ranges.
+    /// </summary>
+    /// <param name="page">One-based page number (clamped to minimum 1).</param>
+    /// <param name="pageSize">Items per page (clamped between 1 and <see cref="MaxPageSize"/>).</param>
+    /// <returns>A tuple of clamped (Page, PageSize) values.</returns>
+    public static (int Page, int PageSize) ClampPagination(int page, int pageSize) =>
+        (Math.Max(page, 1), Math.Clamp(pageSize, 1, MaxPageSize));
 }

--- a/src/Granit.Timeline.EntityFrameworkCore/Internal/EfCoreTimelineQuery.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/Internal/EfCoreTimelineQuery.cs
@@ -23,8 +23,7 @@ internal sealed class EfCoreTimelineQuery(
         int pageSize = QueryEngineDefaults.DefaultPageSize,
         CancellationToken cancellationToken = default)
     {
-        int clampedPageSize = Math.Clamp(pageSize, 1, QueryEngineDefaults.MaxPageSize);
-        int clampedPage = Math.Max(page, 1);
+        (int clampedPage, int clampedPageSize) = QueryEngineDefaults.ClampPagination(page, pageSize);
 
         await using TimelineDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Granit.Timeline/Internal/InMemoryTimelineQuery.cs
+++ b/src/Granit.Timeline/Internal/InMemoryTimelineQuery.cs
@@ -17,8 +17,7 @@ internal sealed class InMemoryTimelineQuery(InMemoryTimelineStore store) : ITime
         int pageSize = QueryEngineDefaults.DefaultPageSize,
         CancellationToken cancellationToken = default)
     {
-        int clampedPageSize = Math.Clamp(pageSize, 1, QueryEngineDefaults.MaxPageSize);
-        int clampedPage = Math.Max(page, 1);
+        (int clampedPage, int clampedPageSize) = QueryEngineDefaults.ClampPagination(page, pageSize);
 
         var entries = store.Entries.Values
             .Where(e => e.EntityType == entityType

--- a/src/Granit.Validation/Extensions/PaginationValidatorExtensions.cs
+++ b/src/Granit.Validation/Extensions/PaginationValidatorExtensions.cs
@@ -1,0 +1,50 @@
+using FluentValidation;
+
+namespace Granit.Validation.Extensions;
+
+/// <summary>
+/// FluentValidation extension methods for pagination parameters (page number and page size).
+/// </summary>
+/// <remarks>
+/// These extensions use built-in FluentValidation validators (<c>GreaterThanOrEqualTo</c>,
+/// <c>InclusiveBetween</c>) whose error codes are already localized by
+/// <see cref="GranitErrorCodeLanguageManager"/>. No additional localization keys are required.
+/// </remarks>
+public static class PaginationValidatorExtensions
+{
+    /// <summary>
+    /// Default maximum page size, consistent with <c>QueryEngineDefaults.MaxPageSize</c>.
+    /// </summary>
+    /// <remarks>
+    /// Defined locally to avoid coupling <c>Granit.Validation</c> to <c>Granit.QueryEngine</c>.
+    /// </remarks>
+    public const int DefaultMaxPageSize = 100;
+
+    /// <summary>
+    /// Validates that a page number is at least 1.
+    /// </summary>
+    public static IRuleBuilderOptions<T, int> ValidPage<T>(
+        this IRuleBuilder<T, int> ruleBuilder) =>
+        ruleBuilder.GreaterThanOrEqualTo(1);
+
+    /// <summary>
+    /// Validates that a page size is between 1 and <paramref name="maxPageSize"/>.
+    /// </summary>
+    public static IRuleBuilderOptions<T, int> ValidPageSize<T>(
+        this IRuleBuilder<T, int> ruleBuilder, int maxPageSize = DefaultMaxPageSize) =>
+        ruleBuilder.InclusiveBetween(1, maxPageSize);
+
+    /// <summary>
+    /// Validates that a nullable page number is at least 1 (when provided).
+    /// </summary>
+    public static IRuleBuilderOptions<T, int?> ValidPage<T>(
+        this IRuleBuilder<T, int?> ruleBuilder) =>
+        ruleBuilder.GreaterThanOrEqualTo(1);
+
+    /// <summary>
+    /// Validates that a nullable page size is between 1 and <paramref name="maxPageSize"/> (when provided).
+    /// </summary>
+    public static IRuleBuilderOptions<T, int?> ValidPageSize<T>(
+        this IRuleBuilder<T, int?> ruleBuilder, int maxPageSize = DefaultMaxPageSize) =>
+        ruleBuilder.InclusiveBetween(1, maxPageSize);
+}

--- a/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Granit.Persistence.Extensions;
 using Granit.Persistence.MultiTenancy;
+using Granit.Wolverine.Internal;
 using Granit.Wolverine.Postgresql.Internal;
 using Granit.Wolverine.Postgresql.Options;
 using Microsoft.EntityFrameworkCore;
@@ -121,17 +122,26 @@ public static class WolverinePostgresqlHostApplicationBuilderExtensions
 
         string connectionString = ResolveConnectionString(builder.Configuration, options);
 
-        // ConfigureWolverine (not UseWolverine): UseWolverine is called once by
-        // AddGranitWolverine() in the base module. ConfigureWolverine accumulates
-        // additional configuration delegates that run during the same phase —
-        // services are still writable. Wolverine 5.24 throws on duplicate UseWolverine.
-        builder.Services.ConfigureWolverine(opts =>
-        {
-            opts.PersistMessagesWithPostgresql(connectionString);
-            opts.UseEntityFrameworkCoreTransactions(options.TransactionMode);
-            opts.Policies.AutoApplyTransactions();
-            configure?.Invoke(opts);
-        });
+        // Resolve the WolverineOptions instance captured by AddGranitWolverine().
+        // We apply PostgreSQL configuration directly on this instance instead of using
+        // ConfigureWolverine(), which registers a deferred LambdaWolverineExtension in
+        // the IoC container. As of Wolverine 3.0, deferred extensions face a read-only
+        // IServiceCollection during DI resolution — PersistMessagesWithPostgresql()
+        // needs to register services and would throw InvalidOperationException.
+        // Calling it here (during ConfigureServices, Phase 1) keeps services writable.
+        WolverineOptions wolverineOptions = builder.Services
+            .Select(d => d.ImplementationInstance)
+            .OfType<WolverineOptionsHolder>()
+            .FirstOrDefault()
+            ?.Options
+            ?? throw new InvalidOperationException(
+                "AddGranitWolverine() must be called before AddGranitWolverineWithPostgresql(). " +
+                "Ensure GranitWolverineModule is declared in the [DependsOn] chain.");
+
+        wolverineOptions.PersistMessagesWithPostgresql(connectionString);
+        wolverineOptions.UseEntityFrameworkCoreTransactions(options.TransactionMode);
+        wolverineOptions.Policies.AutoApplyTransactions();
+        configure?.Invoke(wolverineOptions);
 
         return builder;
     }

--- a/src/Granit.Wolverine.SqlServer/Extensions/WolverineSqlServerHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine.SqlServer/Extensions/WolverineSqlServerHostApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Granit.Persistence.Extensions;
 using Granit.Persistence.MultiTenancy;
+using Granit.Wolverine.Internal;
 using Granit.Wolverine.SqlServer.Internal;
 using Granit.Wolverine.SqlServer.Options;
 using Microsoft.EntityFrameworkCore;
@@ -119,13 +120,26 @@ public static class WolverineSqlServerHostApplicationBuilderExtensions
             .GetSection(WolverineSqlServerOptions.SectionName)
             .Bind(options);
 
-        builder.Services.ConfigureWolverine(opts =>
-        {
-            opts.PersistMessagesWithSqlServer(options.TransportConnectionString);
-            opts.UseEntityFrameworkCoreTransactions(options.TransactionMode);
-            opts.Policies.AutoApplyTransactions();
-            configure?.Invoke(opts);
-        });
+        // Resolve the WolverineOptions instance captured by AddGranitWolverine().
+        // We apply SQL Server configuration directly on this instance instead of using
+        // ConfigureWolverine(), which registers a deferred LambdaWolverineExtension in
+        // the IoC container. As of Wolverine 3.0, deferred extensions face a read-only
+        // IServiceCollection during DI resolution — PersistMessagesWithSqlServer()
+        // needs to register services and would throw InvalidOperationException.
+        // Calling it here (during ConfigureServices, Phase 1) keeps services writable.
+        WolverineOptions wolverineOptions = builder.Services
+            .Select(d => d.ImplementationInstance)
+            .OfType<WolverineOptionsHolder>()
+            .FirstOrDefault()
+            ?.Options
+            ?? throw new InvalidOperationException(
+                "AddGranitWolverine() must be called before AddGranitWolverineWithSqlServer(). " +
+                "Ensure GranitWolverineModule is declared in the [DependsOn] chain.");
+
+        wolverineOptions.PersistMessagesWithSqlServer(options.TransportConnectionString);
+        wolverineOptions.UseEntityFrameworkCoreTransactions(options.TransactionMode);
+        wolverineOptions.Policies.AutoApplyTransactions();
+        configure?.Invoke(wolverineOptions);
 
         return builder;
     }

--- a/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
@@ -128,6 +128,14 @@ public static class WolverineHostApplicationBuilderExtensions
             opts.Policies.AddMiddleware<TraceContextBehavior>();
 
             configure?.Invoke(opts);
+
+            // Expose the WolverineOptions instance for provider modules (PostgreSQL, SqlServer).
+            // Provider modules call extension methods like PersistMessagesWithPostgresql()
+            // directly on this instance during their ConfigureServices phase, when the
+            // service collection is still writable. This avoids ConfigureWolverine() which
+            // defers extension processing to DI resolution (Wolverine 3.0+ blocks service
+            // modifications at that point).
+            builder.Services.TryAddSingleton(new WolverineOptionsHolder(opts));
         });
 
         return builder;

--- a/src/Granit.Wolverine/Granit.Wolverine.csproj
+++ b/src/Granit.Wolverine/Granit.Wolverine.csproj
@@ -12,6 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Granit.Wolverine.Postgresql" />
+    <InternalsVisibleTo Include="Granit.Wolverine.SqlServer" />
     <InternalsVisibleTo Include="Granit.Wolverine.Tests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
     <ProjectReference Include="..\..\src\Granit\Granit.csproj" />

--- a/src/Granit.Wolverine/Internal/WolverineOptionsHolder.cs
+++ b/src/Granit.Wolverine/Internal/WolverineOptionsHolder.cs
@@ -1,0 +1,25 @@
+using Wolverine;
+
+namespace Granit.Wolverine.Internal;
+
+/// <summary>
+/// Holds a reference to the <see cref="WolverineOptions"/> instance created during
+/// <c>UseWolverine()</c>, allowing provider modules (PostgreSQL, SqlServer) to apply
+/// configuration directly on the options while the service collection is still writable.
+/// </summary>
+/// <remarks>
+/// As of Wolverine 3.0, <c>ConfigureWolverine()</c> registers deferred extensions
+/// (<c>LambdaWolverineExtension</c>) in the IoC container. When Wolverine processes
+/// these extensions during DI resolution, the service collection is already read-only,
+/// causing <see cref="InvalidOperationException"/> for extensions that register services
+/// (e.g., <c>PersistMessagesWithPostgresql()</c>).
+/// <para>
+/// This holder allows provider modules to call extension methods like
+/// <c>PersistMessagesWithPostgresql()</c> during their <c>ConfigureServices</c> phase
+/// (Phase 1), when the service collection is still mutable.
+/// </para>
+/// </remarks>
+internal sealed class WolverineOptionsHolder(WolverineOptions options)
+{
+    public WolverineOptions Options { get; } = options;
+}

--- a/src/Granit.Workflow.Endpoints/Endpoints/WorkflowReadEndpoints.cs
+++ b/src/Granit.Workflow.Endpoints/Endpoints/WorkflowReadEndpoints.cs
@@ -35,8 +35,7 @@ internal static class WorkflowReadEndpoints
         [FromQuery] int pageSize = QueryEngineDefaults.DefaultPageSize,
         CancellationToken cancellationToken = default)
     {
-        int clampedPage = Math.Max(page, 1);
-        int clampedPageSize = Math.Clamp(pageSize, 1, QueryEngineDefaults.MaxPageSize);
+        (int clampedPage, int clampedPageSize) = QueryEngineDefaults.ClampPagination(page, pageSize);
 
         PagedResult<WorkflowTransitionHistoryResponse> result = await historyQuery.GetHistoryAsync(
             entityType, entityId, clampedPage, clampedPageSize, cancellationToken).ConfigureAwait(false);

--- a/src/Granit.Workflow.EntityFrameworkCore/Internal/DefaultWorkflowHistoryQuery.cs
+++ b/src/Granit.Workflow.EntityFrameworkCore/Internal/DefaultWorkflowHistoryQuery.cs
@@ -23,8 +23,7 @@ internal sealed class DefaultWorkflowHistoryQuery<TDbContext>(TDbContext dbConte
         int pageSize = QueryEngineDefaults.DefaultPageSize,
         CancellationToken cancellationToken = default)
     {
-        int clampedPage = Math.Max(page, 1);
-        int clampedPageSize = Math.Clamp(pageSize, 1, QueryEngineDefaults.MaxPageSize);
+        (int clampedPage, int clampedPageSize) = QueryEngineDefaults.ClampPagination(page, pageSize);
 
         IQueryable<Domain.WorkflowTransitionRecord> query = _dbContext.WorkflowTransitionRecords
             .Where(r => r.EntityType == entityType && r.EntityId == entityId);

--- a/tests/Granit.Wolverine.Postgresql.Tests/AddGranitWolverineWithPostgresqlPerTenantTests.cs
+++ b/tests/Granit.Wolverine.Postgresql.Tests/AddGranitWolverineWithPostgresqlPerTenantTests.cs
@@ -7,6 +7,7 @@
 // built to avoid requiring a live PostgreSQL Outbox connection.
 // =============================================================================
 
+using Granit.Wolverine.Extensions;
 using Granit.Wolverine.Postgresql.Extensions;
 using Granit.Wolverine.Postgresql.Options;
 using Microsoft.EntityFrameworkCore;
@@ -38,7 +39,9 @@ public sealed class AddGranitWolverineWithPostgresqlPerTenantTests
             [$"{WolverinePostgresqlOptions.SectionName}:TransportConnectionString"] =
                 ValidTransportConnStr,
         });
-        return Host.CreateApplicationBuilder(settings);
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder(settings);
+        builder.AddGranitWolverine();
+        return builder;
     }
 
     // -----------------------------------------------------------------------

--- a/tests/Granit.Wolverine.Postgresql.Tests/AddGranitWolverineWithPostgresqlTests.cs
+++ b/tests/Granit.Wolverine.Postgresql.Tests/AddGranitWolverineWithPostgresqlTests.cs
@@ -5,6 +5,7 @@
 // connection string name resolution, and missing connection string scenarios.
 // =============================================================================
 
+using Granit.Wolverine.Extensions;
 using Granit.Wolverine.Postgresql.Extensions;
 using Granit.Wolverine.Postgresql.Options;
 using Microsoft.Extensions.Configuration;
@@ -12,7 +13,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Shouldly;
-using Wolverine;
 using Xunit;
 
 namespace Granit.Wolverine.Postgresql.Tests;
@@ -23,7 +23,8 @@ public sealed class AddGranitWolverineWithPostgresqlTests
         "Host=localhost;Database=wolverine_transport;Username=test;Password=test";
 
     private static HostApplicationBuilder CreateBuilder(
-        Dictionary<string, string?>? config = null)
+        Dictionary<string, string?>? config = null,
+        bool withWolverine = true)
     {
         HostApplicationBuilderSettings settings = new()
         {
@@ -34,25 +35,31 @@ public sealed class AddGranitWolverineWithPostgresqlTests
             [$"{WolverinePostgresqlOptions.SectionName}:TransportConnectionString"] =
                 ValidTransportConnStr,
         });
-        return Host.CreateApplicationBuilder(settings);
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder(settings);
+
+        if (withWolverine)
+        {
+            builder.AddGranitWolverine();
+        }
+
+        return builder;
     }
 
     // -----------------------------------------------------------------------
-    // Configure callback — ConfigureWolverine defers invocation until
-    // WolverineOptions is resolved. We verify the IWolverineExtension
-    // registration exists (ConfigureWolverine wraps the callback as a
-    // LambdaWolverineExtension).
+    // Configure callback — invoked synchronously during registration
+    // (applied directly on the WolverineOptions instance, not as a deferred
+    // extension, to avoid Wolverine 3.0 read-only service collection restriction).
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void AddGranitWolverineWithPostgresql_WithConfigureCallback_RegistersWolverineExtension()
+    public void AddGranitWolverineWithPostgresql_WithConfigureCallback_InvokesCallbackSynchronously()
     {
         HostApplicationBuilder builder = CreateBuilder();
+        bool callbackInvoked = false;
 
-        builder.AddGranitWolverineWithPostgresql(opts => { });
+        builder.AddGranitWolverineWithPostgresql(_ => callbackInvoked = true);
 
-        builder.Services.ShouldContain(d =>
-            d.ServiceType == typeof(IWolverineExtension));
+        callbackInvoked.ShouldBeTrue();
     }
 
     // -----------------------------------------------------------------------
@@ -95,10 +102,13 @@ public sealed class AddGranitWolverineWithPostgresqlTests
     [Fact]
     public void AddGranitWolverineWithPostgresql_WithMissingConnectionStringName_ThrowsInvalidOperationException()
     {
-        HostApplicationBuilder builder = CreateBuilder(new Dictionary<string, string?>
-        {
-            [$"{WolverinePostgresqlOptions.SectionName}:TransportConnectionStringName"] = "non-existent-db",
-        });
+        // Throws before WolverineOptionsHolder lookup, so AddGranitWolverine() is not needed.
+        HostApplicationBuilder builder = CreateBuilder(
+            config: new Dictionary<string, string?>
+            {
+                [$"{WolverinePostgresqlOptions.SectionName}:TransportConnectionStringName"] = "non-existent-db",
+            },
+            withWolverine: false);
 
         Action act = () => builder.AddGranitWolverineWithPostgresql();
 
@@ -121,18 +131,18 @@ public sealed class AddGranitWolverineWithPostgresqlTests
     }
 
     // -----------------------------------------------------------------------
-    // PerTenant — configure callback (deferred by ConfigureWolverine)
+    // PerTenant — configure callback (invoked synchronously)
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void AddGranitWolverineWithPostgresqlPerTenant_WithConfigureCallback_RegistersWolverineExtension()
+    public void AddGranitWolverineWithPostgresqlPerTenant_WithConfigureCallback_InvokesCallbackSynchronously()
     {
         HostApplicationBuilder builder = CreateBuilder();
+        bool callbackInvoked = false;
 
-        builder.AddGranitWolverineWithPostgresqlPerTenant<StubTenantDbContext>(opts => { });
+        builder.AddGranitWolverineWithPostgresqlPerTenant<StubTenantDbContext>(_ => callbackInvoked = true);
 
-        builder.Services.ShouldContain(d =>
-            d.ServiceType == typeof(IWolverineExtension));
+        callbackInvoked.ShouldBeTrue();
     }
 
     // -----------------------------------------------------------------------

--- a/tests/Granit.Wolverine.Postgresql.Tests/GranitWolverinePostgresqlModuleTests.cs
+++ b/tests/Granit.Wolverine.Postgresql.Tests/GranitWolverinePostgresqlModuleTests.cs
@@ -7,6 +7,7 @@
 
 using Granit.Modularity;
 using Granit.Persistence;
+using Granit.Wolverine.Extensions;
 using Granit.Wolverine.Postgresql.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
@@ -57,7 +58,8 @@ public sealed class GranitWolverinePostgresqlModuleTests
             ["WolverinePostgresql:TransportConnectionString"] =
                 "Host=localhost;Database=test;Username=test;Password=test",
         });
-        IHostApplicationBuilder builder = Host.CreateApplicationBuilder(settings);
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder(settings);
+        builder.AddGranitWolverine();
 
         Action act = () => builder.AddGranitWolverineWithPostgresql();
 

--- a/tests/Granit.Wolverine.SqlServer.Tests/AddGranitWolverineWithSqlServerPerTenantTests.cs
+++ b/tests/Granit.Wolverine.SqlServer.Tests/AddGranitWolverineWithSqlServerPerTenantTests.cs
@@ -7,6 +7,7 @@
 // built to avoid requiring a live SQL Server Outbox connection.
 // =============================================================================
 
+using Granit.Wolverine.Extensions;
 using Granit.Wolverine.SqlServer.Extensions;
 using Granit.Wolverine.SqlServer.Options;
 using Microsoft.EntityFrameworkCore;
@@ -38,7 +39,9 @@ public sealed class AddGranitWolverineWithSqlServerPerTenantTests
             [$"{WolverineSqlServerOptions.SectionName}:TransportConnectionString"] =
                 ValidTransportConnStr,
         });
-        return Host.CreateApplicationBuilder(settings);
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder(settings);
+        builder.AddGranitWolverine();
+        return builder;
     }
 
     // -----------------------------------------------------------------------

--- a/tests/Granit.Wolverine.SqlServer.Tests/AddGranitWolverineWithSqlServerTests.cs
+++ b/tests/Granit.Wolverine.SqlServer.Tests/AddGranitWolverineWithSqlServerTests.cs
@@ -5,6 +5,7 @@
 // value for both single-tenant and per-tenant extension methods.
 // =============================================================================
 
+using Granit.Wolverine.Extensions;
 using Granit.Wolverine.SqlServer.Extensions;
 using Granit.Wolverine.SqlServer.Options;
 using Microsoft.Extensions.Configuration;
@@ -12,7 +13,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Shouldly;
-using Wolverine;
 using Xunit;
 
 namespace Granit.Wolverine.SqlServer.Tests;
@@ -33,25 +33,26 @@ public sealed class AddGranitWolverineWithSqlServerTests
             [$"{WolverineSqlServerOptions.SectionName}:TransportConnectionString"] =
                 ValidTransportConnStr,
         });
-        return Host.CreateApplicationBuilder(settings);
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder(settings);
+        builder.AddGranitWolverine();
+        return builder;
     }
 
     // -----------------------------------------------------------------------
-    // Configure callback — ConfigureWolverine defers invocation until
-    // WolverineOptions is resolved. We verify the IWolverineExtension
-    // registration exists (ConfigureWolverine wraps the callback as a
-    // LambdaWolverineExtension).
+    // Configure callback — invoked synchronously during registration
+    // (applied directly on the WolverineOptions instance, not as a deferred
+    // extension, to avoid Wolverine 3.0 read-only service collection restriction).
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void AddGranitWolverineWithSqlServer_WithConfigureCallback_RegistersWolverineExtension()
+    public void AddGranitWolverineWithSqlServer_WithConfigureCallback_InvokesCallbackSynchronously()
     {
         HostApplicationBuilder builder = CreateBuilder();
+        bool callbackInvoked = false;
 
-        builder.AddGranitWolverineWithSqlServer(opts => { });
+        builder.AddGranitWolverineWithSqlServer(_ => callbackInvoked = true);
 
-        builder.Services.ShouldContain(d =>
-            d.ServiceType == typeof(IWolverineExtension));
+        callbackInvoked.ShouldBeTrue();
     }
 
     // -----------------------------------------------------------------------
@@ -84,18 +85,18 @@ public sealed class AddGranitWolverineWithSqlServerTests
     }
 
     // -----------------------------------------------------------------------
-    // PerTenant — configure callback (deferred by ConfigureWolverine)
+    // PerTenant — configure callback (invoked synchronously)
     // -----------------------------------------------------------------------
 
     [Fact]
-    public void AddGranitWolverineWithSqlServerPerTenant_WithConfigureCallback_RegistersWolverineExtension()
+    public void AddGranitWolverineWithSqlServerPerTenant_WithConfigureCallback_InvokesCallbackSynchronously()
     {
         HostApplicationBuilder builder = CreateBuilder();
+        bool callbackInvoked = false;
 
-        builder.AddGranitWolverineWithSqlServerPerTenant<StubTenantDbContext>(opts => { });
+        builder.AddGranitWolverineWithSqlServerPerTenant<StubTenantDbContext>(_ => callbackInvoked = true);
 
-        builder.Services.ShouldContain(d =>
-            d.ServiceType == typeof(IWolverineExtension));
+        callbackInvoked.ShouldBeTrue();
     }
 
     // -----------------------------------------------------------------------

--- a/tests/Granit.Wolverine.SqlServer.Tests/GranitWolverineSqlServerModuleTests.cs
+++ b/tests/Granit.Wolverine.SqlServer.Tests/GranitWolverineSqlServerModuleTests.cs
@@ -7,6 +7,7 @@
 
 using Granit.Modularity;
 using Granit.Persistence;
+using Granit.Wolverine.Extensions;
 using Granit.Wolverine.SqlServer.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
@@ -57,7 +58,8 @@ public sealed class GranitWolverineSqlServerModuleTests
             ["WolverineSqlServer:TransportConnectionString"] =
                 "Server=localhost;Database=test;User Id=sa;Password=test;TrustServerCertificate=True",
         });
-        IHostApplicationBuilder builder = Host.CreateApplicationBuilder(settings);
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder(settings);
+        builder.AddGranitWolverine();
 
         Action act = () => builder.AddGranitWolverineWithSqlServer();
 


### PR DESCRIPTION
## Summary

- **fix(wolverine):** avoid read-only service collection in `ConfigureWolverine` extensions
- **fix(validation):** remove redundant `.When()` guards in `AuditingQueryParametersValidator` — FluentValidation comparison validators skip null on nullable types, and `MaximumLength` returns true for null strings

## Test plan

- [ ] `dotnet build` passes
- [ ] `dotnet test tests/Granit.Wolverine.Postgresql.Tests`
- [ ] `dotnet test tests/Granit.Wolverine.SqlServer.Tests`
- [ ] `dotnet test tests/Granit.Auditing.Endpoints.Tests`