### PR TITLE
fix(openiddict): remap OpenIddict core tables to snake_case naming

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4940,8 +4940,21 @@
       "kind": "record",
       "project": "Granit.Authorization.AI",
       "file": "src/Granit.Authorization.AI/AccessRiskScore.cs",
-      "line": 12,
-      "members": []
+      "line": 18,
+      "members": [
+        {
+          "name": "Clamp",
+          "kind": "method",
+          "signature": "Clamp(Score, 0.0, 1.0)",
+          "returnType": "double Score { get; } = Math."
+        },
+        {
+          "name": "IsAdvisoryOnly",
+          "kind": "property",
+          "signature": "bool IsAdvisoryOnly",
+          "returnType": "bool"
+        }
+      ]
     },
     {
       "name": "AuthorizationAIHostApplicationBuilderExtensions",
@@ -4949,7 +4962,7 @@
       "kind": "class",
       "project": "Granit.Authorization.AI",
       "file": "src/Granit.Authorization.AI/Extensions/AuthorizationAIHostApplicationBuilderExtensions.cs",
-      "line": 14,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitAuthorizationAI",
@@ -5228,7 +5241,7 @@
       "kind": "class",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/Cache/PermissionCacheInvalidationHandler.cs",
-      "line": 17,
+      "line": 25,
       "members": [
         {
           "name": "HandleAsync",
@@ -5258,7 +5271,7 @@
         {
           "name": "RecordCheckDenied",
           "kind": "method",
-          "signature": "RecordCheckDenied(string? tenantId, string permissionName)",
+          "signature": "RecordCheckDenied(string? tenantId)",
           "returnType": "void"
         },
         {
@@ -5481,7 +5494,7 @@
       "kind": "class",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/Extensions/AuthorizationServiceCollectionExtensions.cs",
-      "line": 13,
+      "line": 14,
       "members": [
         {
           "name": "AddGranitAuthorization",
@@ -5513,7 +5526,7 @@
       "kind": "class",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/Options/GranitAuthorizationOptions.cs",
-      "line": 4,
+      "line": 6,
       "members": [
         {
           "name": "AdminRoles",
@@ -10661,7 +10674,7 @@
       "kind": "class",
       "project": "Granit.Encryption.BackgroundJobs",
       "file": "src/Granit.Encryption.BackgroundJobs/DefaultReEncryptionJob.cs",
-      "line": 25,
+      "line": 33,
       "members": []
     },
     {
@@ -20864,7 +20877,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.EntityFrameworkCore",
       "file": "src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictModelBuilderExtensions.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "ConfigureOpenIddictModule",

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictModelBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictModelBuilderExtensions.cs
@@ -3,6 +3,7 @@ using Granit.DataFiltering;
 using Granit.Domain;
 using Granit.OpenIddict.Domain;
 using Granit.OpenIddict.Entities;
+using Granit.OpenIddict.Entities.OpenIddict;
 using Granit.Persistence.ExtraProperties;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -94,6 +95,13 @@ public static class OpenIddictModelBuilderExtensions
         modelBuilder.Entity<IdentityUserLogin<Guid>>().ToTable(prefix + "user_logins", schema);
         modelBuilder.Entity<IdentityUserToken<Guid>>().ToTable(prefix + "user_tokens", schema);
         modelBuilder.Entity<IdentityRoleClaim<Guid>>().ToTable(prefix + "role_claims", schema);
+
+        // ──── Remap OpenIddict core tables to openiddict_* prefix ────
+
+        modelBuilder.Entity<GranitOpenIddictApplication>().ToTable(prefix + "applications", schema);
+        modelBuilder.Entity<GranitOpenIddictAuthorization>().ToTable(prefix + "authorizations", schema);
+        modelBuilder.Entity<GranitOpenIddictScope>().ToTable(prefix + "scopes", schema);
+        modelBuilder.Entity<GranitOpenIddictToken>().ToTable(prefix + "tokens", schema);
 
         // ──── Custom group tables ────
 


### PR DESCRIPTION
## Summary

- **Bug**: `UseOpenIddict<…>()` registers the four core entities (`OpenIddictApplications`, `OpenIddictAuthorizations`, `OpenIddictScopes`, `OpenIddictTokens`) with PascalCase table names. `ConfigureOpenIddictModule` already remaps Identity and custom tables to the `openiddict_*` snake_case prefix but was missing these four, causing `relation "OpenIddictScopes" does not exist` on PostgreSQL.
- **Fix**: Add explicit `ToTable()` calls for `GranitOpenIddictApplication`, `GranitOpenIddictAuthorization`, `GranitOpenIddictScope`, and `GranitOpenIddictToken` in `ConfigureOpenIddictModule`.

## Consumer impact

Applications using `Granit.OpenIddict.EntityFrameworkCore` must regenerate their EF Core migrations after upgrading. Existing databases need a `RenameTable` migration for the four affected tables.

## Test plan

- [x] `dotnet build src/Granit.OpenIddict.EntityFrameworkCore` — 0 errors, 0 warnings
- [x] `dotnet test tests/Granit.OpenIddict.Tests` — 155/155 passed
- [ ] Verify in consumer app (`guava-backend`): add migration, confirm table names are `openiddict_applications`, `openiddict_authorizations`, `openiddict_scopes`, `openiddict_tokens`
- [ ] Verify `OpenIddictSeedContributor` runs without `42P01` error