### PR TITLE
fix(security): harden BackgroundJobs — type validation, key zeroization, error truncation

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -305,6 +305,7 @@
       "name": "Granit.Bff.EntityFrameworkCore",
       "deps": [
         "Granit.Bff",
+        "Granit.Encryption",
         "Granit.Guids",
         "Granit.Persistence"
       ],
@@ -6298,6 +6299,22 @@
       ]
     },
     {
+      "name": "ILogoutTokenValidator",
+      "fqn": "Granit.Bff.ILogoutTokenValidator",
+      "kind": "interface",
+      "project": "Granit.Bff",
+      "file": "src/Granit.Bff/ILogoutTokenValidator.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "ValidateAsync",
+          "kind": "method",
+          "signature": "ValidateAsync(string logoutToken, string expectedClientId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<ValidatedLogoutToken?>"
+        }
+      ]
+    },
+    {
       "name": "BffClientAuthenticationMethod",
       "fqn": "Granit.Bff.Options.BffClientAuthenticationMethod",
       "kind": "enum",
@@ -6312,7 +6329,7 @@
       "kind": "class",
       "project": "Granit.Bff",
       "file": "src/Granit.Bff/Options/GranitBffOptions.cs",
-      "line": 79,
+      "line": 91,
       "members": [
         {
           "name": "Name",
@@ -6421,12 +6438,21 @@
           "returnType": "bool"
         },
         {
-          "name": "Frontends",
+          "name": "CsrfHmacKey",
           "kind": "property",
-          "signature": "List<BffFrontendOptions> Frontends",
-          "returnType": "List<BffFrontendOptions>"
+          "signature": "string? CsrfHmacKey",
+          "returnType": "string?"
         }
       ]
+    },
+    {
+      "name": "ValidatedLogoutToken",
+      "fqn": "Granit.Bff.ValidatedLogoutToken",
+      "kind": "record",
+      "project": "Granit.Bff",
+      "file": "src/Granit.Bff/ILogoutTokenValidator.cs",
+      "line": 23,
+      "members": []
     },
     {
       "name": "BffYarpApplicationBuilderExtensions",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4940,8 +4940,21 @@
       "kind": "record",
       "project": "Granit.Authorization.AI",
       "file": "src/Granit.Authorization.AI/AccessRiskScore.cs",
-      "line": 12,
-      "members": []
+      "line": 18,
+      "members": [
+        {
+          "name": "Clamp",
+          "kind": "method",
+          "signature": "Clamp(Score, 0.0, 1.0)",
+          "returnType": "double Score { get; } = Math."
+        },
+        {
+          "name": "IsAdvisoryOnly",
+          "kind": "property",
+          "signature": "bool IsAdvisoryOnly",
+          "returnType": "bool"
+        }
+      ]
     },
     {
       "name": "AuthorizationAIHostApplicationBuilderExtensions",
@@ -4949,7 +4962,7 @@
       "kind": "class",
       "project": "Granit.Authorization.AI",
       "file": "src/Granit.Authorization.AI/Extensions/AuthorizationAIHostApplicationBuilderExtensions.cs",
-      "line": 14,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitAuthorizationAI",
@@ -5228,7 +5241,7 @@
       "kind": "class",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/Cache/PermissionCacheInvalidationHandler.cs",
-      "line": 17,
+      "line": 25,
       "members": [
         {
           "name": "HandleAsync",
@@ -5258,7 +5271,7 @@
         {
           "name": "RecordCheckDenied",
           "kind": "method",
-          "signature": "RecordCheckDenied(string? tenantId, string permissionName)",
+          "signature": "RecordCheckDenied(string? tenantId)",
           "returnType": "void"
         },
         {
@@ -5481,7 +5494,7 @@
       "kind": "class",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/Extensions/AuthorizationServiceCollectionExtensions.cs",
-      "line": 13,
+      "line": 14,
       "members": [
         {
           "name": "AddGranitAuthorization",
@@ -5513,7 +5526,7 @@
       "kind": "class",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/Options/GranitAuthorizationOptions.cs",
-      "line": 4,
+      "line": 6,
       "members": [
         {
           "name": "AdminRoles",
@@ -10661,7 +10674,7 @@
       "kind": "class",
       "project": "Granit.Encryption.BackgroundJobs",
       "file": "src/Granit.Encryption.BackgroundJobs/DefaultReEncryptionJob.cs",
-      "line": 25,
+      "line": 33,
       "members": []
     },
     {
@@ -20864,7 +20877,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.EntityFrameworkCore",
       "file": "src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictModelBuilderExtensions.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "ConfigureOpenIddictModule",

--- a/docs-site/src/content/docs/dotnet/infrastructure/background-jobs.mdx
+++ b/docs-site/src/content/docs/dotnet/infrastructure/background-jobs.mdx
@@ -207,7 +207,7 @@ The persistent administrative record for each recurring job:
 | `LastExecutedAt` | `DateTimeOffset?` | UTC timestamp of last execution start |
 | `NextExecutionAt` | `DateTimeOffset?` | UTC timestamp of next scheduled execution |
 | `ConsecutiveFailureCount` | `int` | Failures since last success (reset on success) |
-| `LastErrorMessage` | `string?` (max 2000) | Error from last failure (`null` on success) |
+| `LastErrorMessage` | `string?` (max 500 + suffix) | Error from last failure, truncated to 500 chars to limit information disclosure (`null` on success) |
 | `TriggeredBy` | `string?` (max 450) | UserId of manual trigger operator (ISO 27001 audit) |
 
 EF Core table: `background_jobs_background_jobs` with a unique index on `JobName`.
@@ -366,15 +366,16 @@ with Wolverine-backed implementations via `ServiceDescriptor.Replace()`.
 
 ## Endpoints
 
-Five Minimal API endpoints protected by the `BackgroundJobs.Jobs.Manage` permission:
+Five Minimal API endpoints with split permissions — `BackgroundJobs.Jobs.Read` for read
+operations and `BackgroundJobs.Jobs.Manage` for mutations:
 
-| Method | Route | Handler | Response |
-|--------|-------|---------|----------|
-| `GET` | `/{prefix}` | List all jobs (paginated) | `200 OK` with `PagedResult<BackgroundJobStatus>` |
-| `GET` | `/{prefix}/{name}` | Get job by name | `200 OK` / `404 Not Found` |
-| `POST` | `/{prefix}/{name}/pause` | Pause a job | `204 No Content` / `404 Not Found` |
-| `POST` | `/{prefix}/{name}/resume` | Resume a paused job | `204 No Content` / `404 Not Found` |
-| `POST` | `/{prefix}/{name}/trigger` | Trigger immediate execution | `202 Accepted` / `404 Not Found` |
+| Method | Route | Handler | Permission | Response |
+|--------|-------|---------|------------|----------|
+| `GET` | `/{prefix}` | List all jobs (paginated) | `Jobs.Read` | `200 OK` with `PagedResult<BackgroundJobStatus>` |
+| `GET` | `/{prefix}/{name}` | Get job by name | `Jobs.Read` | `200 OK` / `404 Not Found` |
+| `POST` | `/{prefix}/{name}/pause` | Pause a job | `Jobs.Manage` | `204 No Content` / `404 Not Found` |
+| `POST` | `/{prefix}/{name}/resume` | Resume a paused job | `Jobs.Manage` | `204 No Content` / `404 Not Found` |
+| `POST` | `/{prefix}/{name}/trigger` | Trigger immediate execution | `Jobs.Manage` | `202 Accepted` / `404 Not Found` |
 
 Default route prefix: `background-jobs`. Customize via `BackgroundJobsEndpointsOptions`:
 
@@ -389,15 +390,22 @@ app.MapBackgroundJobsEndpoints(opts =>
 
 ### Permission model
 
-The `BackgroundJobs.Jobs.Manage` permission grants access to all five endpoints.
-It integrates with the Granit RBAC pipeline:
+Two permissions control access with least-privilege separation:
+
+| Permission | Grants |
+|------------|--------|
+| `BackgroundJobs.Jobs.Read` | View job status and metadata (GET endpoints) |
+| `BackgroundJobs.Jobs.Manage` | Pause, resume, and trigger jobs (POST endpoints) |
+
+Both integrate with the Granit RBAC pipeline:
 
 1. `AlwaysAllow` bypass (dev/test: `GranitAuthorizationOptions.AlwaysAllow = true`)
 2. Admin role bypass (`GranitAuthorizationOptions.AdminRoles`)
 3. Permission grant store query per role
 
-In production, grant the permission via:
+In production, grant permissions via:
 - Add the role to `GranitAuthorizationOptions.AdminRoles`
+- Call `IPermissionManagerWriter.SetAsync("BackgroundJobs.Jobs.Read", "my-role", tenantId, true)`
 - Call `IPermissionManagerWriter.SetAsync("BackgroundJobs.Jobs.Manage", "my-role", tenantId, true)`
 
 ## Domain events
@@ -460,7 +468,7 @@ When `Granit.Observability` is loaded, the activity source is auto-discovered vi
 | Abstractions | `IBackgroundJobDispatcher`, `IDeadLetterQueueInspector` | `Granit.BackgroundJobs` |
 | Headers | `BackgroundJobHeaders` (`X-Triggered-By`) | `Granit.BackgroundJobs` |
 | Options | `BackgroundJobsOptions`, `BackgroundJobsEndpointsOptions` | -- |
-| Permissions | `BackgroundJobsPermissions.Jobs.Manage` | `Granit.BackgroundJobs.Endpoints` |
+| Permissions | `BackgroundJobsPermissions.Jobs.Read`, `BackgroundJobsPermissions.Jobs.Manage` | `Granit.BackgroundJobs.Endpoints` |
 | Middleware | `RecurringJobSchedulingMiddleware` | `Granit.BackgroundJobs.Wolverine` |
 | Extensions | `AddGranitBackgroundJobs()`, `AddGranitBackgroundJobsEntityFrameworkCore()`, `MapBackgroundJobsEndpoints()` | -- |
 
@@ -525,6 +533,25 @@ public async Task Cleanup_job_deletes_expired_records()
     remaining.ShouldBe(0);
 }
 ```
+
+## Security considerations
+
+**Error message truncation:** `BackgroundJobDefinition.RecordFailure()` truncates error messages
+to 500 characters before persisting them. This prevents accidental information disclosure through
+the admin API or integration events. Job handlers should still avoid including PII in exception
+messages.
+
+**Type validation:** `CronSchedulerHelper.CreateMessage()` validates that the resolved CLR type
+implements `IBackgroundJob` before instantiation, preventing arbitrary type activation from
+tampered database values.
+
+**Key material zeroization:** The `OpenIddictKeyRotationJob` clears RSA private key bytes from
+memory via `CryptographicOperations.ZeroMemory()` immediately after encryption, minimizing the
+window for key material exposure through memory dumps.
+
+**GDPR deletion ordering:** `DeletionDeadlineEnforcerHandler` publishes deletion events into the
+Wolverine outbox before marking the request as executed, ensuring deletion is never silently
+skipped on partial failure.
 
 ## See also
 

--- a/src/Granit.BackgroundJobs/Domain/BackgroundJobDefinition.cs
+++ b/src/Granit.BackgroundJobs/Domain/BackgroundJobDefinition.cs
@@ -125,12 +125,21 @@ public sealed class BackgroundJobDefinition : AggregateRoot
         NextExecutionAt = nextExecution;
 
     /// <summary>
-    /// Records an execution failure.
+    /// Maximum length of stored error messages. Prevents unbounded PII propagation
+    /// through API responses and integration events.
+    /// </summary>
+    internal const int MaxErrorMessageLength = 500;
+
+    /// <summary>
+    /// Records an execution failure. Error messages are truncated to
+    /// <see cref="MaxErrorMessageLength"/> characters to limit information disclosure.
     /// </summary>
     internal void RecordFailure(string? errorMessage)
     {
         ConsecutiveFailureCount++;
-        LastErrorMessage = errorMessage;
+        LastErrorMessage = errorMessage is not null && errorMessage.Length > MaxErrorMessageLength
+            ? string.Concat(errorMessage.AsSpan(0, MaxErrorMessageLength), "… [truncated]")
+            : errorMessage;
 
         if (ConsecutiveFailureCount >= 3)
         {

--- a/src/Granit.BackgroundJobs/Internal/CronSchedulerHelper.cs
+++ b/src/Granit.BackgroundJobs/Internal/CronSchedulerHelper.cs
@@ -7,6 +7,8 @@ internal static class CronSchedulerHelper
 {
     /// <summary>
     /// Creates an instance of the message type resolved from the assembly-qualified type name.
+    /// The resolved type must implement <see cref="IBackgroundJob"/> to prevent arbitrary type
+    /// instantiation if the persisted message type is tampered with.
     /// </summary>
     internal static object CreateMessage(string messageType, string jobName)
     {
@@ -16,6 +18,13 @@ internal static class CronSchedulerHelper
             throw new InvalidOperationException(
                 $"Cannot resolve message type '{messageType}' for job '{jobName}'. " +
                 "Ensure the assembly containing the message is loaded.");
+        }
+
+        if (!typeof(IBackgroundJob).IsAssignableFrom(type))
+        {
+            throw new InvalidOperationException(
+                $"Type '{type.FullName}' for job '{jobName}' does not implement IBackgroundJob. " +
+                "Only registered background job types can be instantiated.");
         }
 
         return Activator.CreateInstance(type)

--- a/src/Granit.Encryption.BackgroundJobs/DefaultReEncryptionJob.cs
+++ b/src/Granit.Encryption.BackgroundJobs/DefaultReEncryptionJob.cs
@@ -20,6 +20,14 @@ namespace Granit.Encryption.BackgroundJobs;
 /// each save re-encrypts with the latest key version. When using the AES provider,
 /// each save produces a fresh ciphertext (new IV).
 /// </para>
+/// <para>
+/// <b>Multi-tenancy:</b> In multi-tenant deployments with per-tenant encryption keys,
+/// callers MUST ensure the correct tenant context is active before invoking
+/// <see cref="ReEncryptAsync{TEntity}"/>. EF Core named query filters will scope the
+/// query to the current tenant if the entity implements <c>IMultiTenant</c>. For
+/// system-wide re-encryption, iterate tenants explicitly with
+/// <c>ICurrentTenant.Change(tenantId)</c> scopes.
+/// </para>
 /// </remarks>
 /// <typeparam name="TContext">The <see cref="DbContext"/> type that owns the entities.</typeparam>
 public sealed class DefaultReEncryptionJob<TContext>(IDbContextFactory<TContext> contextFactory)

--- a/src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictIdleSessionEnforcementHandler.cs
+++ b/src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictIdleSessionEnforcementHandler.cs
@@ -52,37 +52,52 @@ internal static partial class OpenIddictIdleSessionEnforcementHandler
         // with TTL = IdleSessionTimeout + 5 min. When the cache entry expires naturally
         // (user stopped sending heartbeats), the session is considered idle.
         //
-        // This job iterates active refresh tokens and checks whether their corresponding
-        // cache entry still exists. If not, the refresh token is revoked.
+        // This job iterates active refresh tokens in bounded pages and checks whether
+        // their corresponding cache entry still exists. If not, the refresh token is revoked.
+        const int pageSize = 1_000;
         int revokedCount = 0;
+        int offset = 0;
+        bool hasMore;
 
-        await foreach (object token in tokenManager.ListAsync(int.MaxValue, 0, cancellationToken))
+        do
         {
-            string? tokenType = await tokenManager.GetTypeAsync(token, cancellationToken).ConfigureAwait(false);
-            if (tokenType != global::OpenIddict.Abstractions.OpenIddictConstants.TokenTypeHints.RefreshToken)
+            hasMore = false;
+            int pageCount = 0;
+
+            await foreach (object token in tokenManager.ListAsync(pageSize, offset, cancellationToken))
             {
-                continue;
+                pageCount++;
+
+                string? tokenType = await tokenManager.GetTypeAsync(token, cancellationToken).ConfigureAwait(false);
+                if (tokenType != global::OpenIddict.Abstractions.OpenIddictConstants.TokenTypeHints.RefreshToken)
+                {
+                    continue;
+                }
+
+                string? subject = await tokenManager.GetSubjectAsync(token, cancellationToken).ConfigureAwait(false);
+                string? tokenId = await tokenManager.GetIdAsync(token, cancellationToken).ConfigureAwait(false);
+                if (subject is null || tokenId is null)
+                {
+                    continue;
+                }
+
+                // Check if session cache entry still exists
+                string cacheKey = $"session:{subject}:{tokenId}";
+                MaybeValue<UserSessionActivity> cachedEntry = await cache
+                    .TryGetAsync<UserSessionActivity>(cacheKey, token: cancellationToken).ConfigureAwait(false);
+
+                if (!cachedEntry.HasValue)
+                {
+                    // Cache entry expired → session idle → revoke refresh token
+                    await tokenManager.TryRevokeAsync(token, cancellationToken).ConfigureAwait(false);
+                    revokedCount++;
+                }
             }
 
-            string? subject = await tokenManager.GetSubjectAsync(token, cancellationToken).ConfigureAwait(false);
-            string? tokenId = await tokenManager.GetIdAsync(token, cancellationToken).ConfigureAwait(false);
-            if (subject is null || tokenId is null)
-            {
-                continue;
-            }
-
-            // Check if session cache entry still exists
-            string cacheKey = $"session:{subject}:{tokenId}";
-            MaybeValue<UserSessionActivity> cachedEntry = await cache
-                .TryGetAsync<UserSessionActivity>(cacheKey, token: cancellationToken).ConfigureAwait(false);
-
-            if (!cachedEntry.HasValue)
-            {
-                // Cache entry expired → session idle → revoke refresh token
-                await tokenManager.TryRevokeAsync(token, cancellationToken).ConfigureAwait(false);
-                revokedCount++;
-            }
+            offset += pageCount;
+            hasMore = pageCount == pageSize;
         }
+        while (hasMore);
 
         Log.IdleSessionEnforcementCompleted(logger, revokedCount);
     }

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictModelBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictModelBuilderExtensions.cs
@@ -3,6 +3,7 @@ using Granit.DataFiltering;
 using Granit.Domain;
 using Granit.OpenIddict.Domain;
 using Granit.OpenIddict.Entities;
+using Granit.OpenIddict.Entities.OpenIddict;
 using Granit.Persistence.ExtraProperties;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -94,6 +95,13 @@ public static class OpenIddictModelBuilderExtensions
         modelBuilder.Entity<IdentityUserLogin<Guid>>().ToTable(prefix + "user_logins", schema);
         modelBuilder.Entity<IdentityUserToken<Guid>>().ToTable(prefix + "user_tokens", schema);
         modelBuilder.Entity<IdentityRoleClaim<Guid>>().ToTable(prefix + "role_claims", schema);
+
+        // ──── Remap OpenIddict core tables to openiddict_* prefix ────
+
+        modelBuilder.Entity<GranitOpenIddictApplication>().ToTable(prefix + "applications", schema);
+        modelBuilder.Entity<GranitOpenIddictAuthorization>().ToTable(prefix + "authorizations", schema);
+        modelBuilder.Entity<GranitOpenIddictScope>().ToTable(prefix + "scopes", schema);
+        modelBuilder.Entity<GranitOpenIddictToken>().ToTable(prefix + "tokens", schema);
 
         // ──── Custom group tables ────
 

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/KeyRotationService.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/KeyRotationService.cs
@@ -106,25 +106,32 @@ internal sealed partial class KeyRotationService(
         using var rsa = RSA.Create(options.RsaKeySize);
         byte[] privateKey = rsa.ExportRSAPrivateKey();
 
+        try
+        {
 #pragma warning disable GRSEC002 // Key ID suffix, not a database entity ID
-        string keyId = $"{keyType}-{now:yyyyMMdd}-{Guid.NewGuid():N}";
+            string keyId = $"{keyType}-{now:yyyyMMdd}-{Guid.NewGuid():N}";
 #pragma warning restore GRSEC002
 
-        string algorithm = keyType == "signing"
-            ? options.SigningAlgorithm
-            : "RSA-OAEP";
+            string algorithm = keyType == "signing"
+                ? options.SigningAlgorithm
+                : "RSA-OAEP";
 
-        var newKey = SigningKey.Create(
-            keyId,
-            keyType,
-            algorithm,
-            encryptionService.Encrypt(Convert.ToBase64String(privateKey)),
-            activatedAt: now,
-            expiresAt: now + options.KeyLifetime,
-            keySize: options.RsaKeySize);
+            var newKey = SigningKey.Create(
+                keyId,
+                keyType,
+                algorithm,
+                encryptionService.Encrypt(Convert.ToBase64String(privateKey)),
+                activatedAt: now,
+                expiresAt: now + options.KeyLifetime,
+                keySize: options.RsaKeySize);
 
-        await keyStore.CreateAsync(newKey, cancellationToken).ConfigureAwait(false);
-        Log.KeyGenerated(logger, keyId, keyType, options.RsaKeySize);
+            await keyStore.CreateAsync(newKey, cancellationToken).ConfigureAwait(false);
+            Log.KeyGenerated(logger, keyId, keyType, options.RsaKeySize);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(privateKey);
+        }
     }
 
     private static partial class Log

--- a/src/Granit.Privacy.BackgroundJobs/Jobs/DeletionDeadlineEnforcerHandler.cs
+++ b/src/Granit.Privacy.BackgroundJobs/Jobs/DeletionDeadlineEnforcerHandler.cs
@@ -37,8 +37,11 @@ internal static partial class DeletionDeadlineEnforcerHandler
 
         foreach (DeletionRequestStatus request in expired)
         {
-            await trackerWriter.MarkExecutedAsync(request.RequestId, now, cancellationToken).ConfigureAwait(false);
-
+            // Publish events BEFORE marking executed. Events go into the Wolverine outbox
+            // (not committed yet). If MarkExecutedAsync fails, the exception propagates and
+            // the outbox is not committed — both operations roll back cleanly on retry.
+            // This ordering prevents a GDPR compliance gap where the request is marked
+            // "Executed" but the deletion event was never enqueued.
             await eventBus.PublishAsync(
                 new PersonalDataDeletionRequestedEto(
                     request.RequestId,
@@ -51,6 +54,8 @@ internal static partial class DeletionDeadlineEnforcerHandler
             await eventBus.PublishAsync(
                 new DeletionExecutedEto(request.RequestId, request.UserId, now),
                 cancellationToken).ConfigureAwait(false);
+
+            await trackerWriter.MarkExecutedAsync(request.RequestId, now, cancellationToken).ConfigureAwait(false);
 
             metrics.RecordDeletionExecuted(null);
             Log.DeletionEnforced(logger, request.RequestId, request.UserId);

--- a/tests/Granit.BackgroundJobs.Tests.Integration/BackgroundJobsIntegrationTests.cs
+++ b/tests/Granit.BackgroundJobs.Tests.Integration/BackgroundJobsIntegrationTests.cs
@@ -18,10 +18,10 @@ namespace Granit.BackgroundJobs.Tests.Integration;
 
 // Duplicated from Granit.BackgroundJobs.Tests to avoid cross-test-project references.
 [RecurringJob("0 8 * * *", "fake-daily-report")]
-public sealed class FakeDailyReportMessage;
+public sealed class FakeDailyReportMessage : IBackgroundJob;
 
 [RecurringJob("0 * * * *", "fake-hourly-cleanup")]
-public sealed class FakeHourlyCleanupMessage;
+public sealed class FakeHourlyCleanupMessage : IBackgroundJob;
 
 /// <summary>
 /// Integration tests validating interactions between real components

--- a/tests/Granit.BackgroundJobs.Tests/BackgroundJobDefinitionTests.cs
+++ b/tests/Granit.BackgroundJobs.Tests/BackgroundJobDefinitionTests.cs
@@ -155,6 +155,41 @@ public sealed class BackgroundJobDefinitionTests
         job.IntegrationEvents.Count.ShouldBe(3); // failures 3, 4, 5
     }
 
+    [Fact]
+    public void RecordFailure_LongErrorMessage_ShouldTruncate()
+    {
+        BackgroundJobDefinition job = BuildJob();
+        string longMessage = new('x', 1000);
+
+        job.RecordFailure(longMessage);
+
+        job.LastErrorMessage.ShouldNotBeNull();
+        job.LastErrorMessage.Length.ShouldBeLessThanOrEqualTo(
+            BackgroundJobDefinition.MaxErrorMessageLength + "… [truncated]".Length);
+        job.LastErrorMessage.ShouldEndWith("… [truncated]");
+    }
+
+    [Fact]
+    public void RecordFailure_ShortErrorMessage_ShouldNotTruncate()
+    {
+        BackgroundJobDefinition job = BuildJob();
+        string shortMessage = "timeout";
+
+        job.RecordFailure(shortMessage);
+
+        job.LastErrorMessage.ShouldBe("timeout");
+    }
+
+    [Fact]
+    public void RecordFailure_NullErrorMessage_ShouldStoreNull()
+    {
+        BackgroundJobDefinition job = BuildJob();
+
+        job.RecordFailure(null);
+
+        job.LastErrorMessage.ShouldBeNull();
+    }
+
     private static BackgroundJobDefinition BuildJob(bool enabled = true)
     {
         var job = BackgroundJobDefinition.Create(

--- a/tests/Granit.BackgroundJobs.Tests/ChannelCronSchedulerServiceTests.cs
+++ b/tests/Granit.BackgroundJobs.Tests/ChannelCronSchedulerServiceTests.cs
@@ -79,7 +79,7 @@ public sealed class ChannelCronSchedulerServiceTests
     }
 
     // Minimal job message class for testing
-    private sealed class FakeJobMessage;
+    private sealed class FakeJobMessage : IBackgroundJob;
 
     // =========================================================================
     // Scenario: job with null NextExecutionAt -> schedules first occurrence

--- a/tests/Granit.BackgroundJobs.Tests/Internal/CronSchedulerHelperTests.cs
+++ b/tests/Granit.BackgroundJobs.Tests/Internal/CronSchedulerHelperTests.cs
@@ -26,4 +26,19 @@ public sealed class CronSchedulerHelperTests
         ex.Message.ShouldContain("Cannot resolve message type");
         ex.Message.ShouldContain("test-job");
     }
+
+    [Fact]
+    public void CreateMessage_TypeNotImplementingIBackgroundJob_ThrowsInvalidOperationException()
+    {
+        string assemblyQualifiedName = typeof(NotABackgroundJob).AssemblyQualifiedName!;
+
+        Action act = () => CronSchedulerHelper.CreateMessage(assemblyQualifiedName, "rogue-job");
+
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(act);
+        ex.Message.ShouldContain("does not implement IBackgroundJob");
+        ex.Message.ShouldContain("rogue-job");
+    }
+
+    // A valid CLR type that does NOT implement IBackgroundJob — simulates a tampered MessageType.
+    private sealed class NotABackgroundJob;
 }

--- a/tests/Granit.BackgroundJobs.Tests/RecurringJobDiscoveryTests.cs
+++ b/tests/Granit.BackgroundJobs.Tests/RecurringJobDiscoveryTests.cs
@@ -74,10 +74,10 @@ public sealed class RecurringJobDiscoveryTests
 // =========================================================================
 
 [RecurringJob("0 8 * * *", "fake-daily-report")]
-public sealed class FakeDailyReportMessage;
+public sealed class FakeDailyReportMessage : IBackgroundJob;
 
 [RecurringJob("0 * * * *", "fake-hourly-cleanup")]
-public sealed class FakeHourlyCleanupMessage;
+public sealed class FakeHourlyCleanupMessage : IBackgroundJob;
 
 // Intentionally not decorated — must not appear in discovery results.
 public sealed class UndecoratedMessage;

--- a/tests/Granit.BackgroundJobs.Wolverine.Tests/CronSchedulerAgentTests.cs
+++ b/tests/Granit.BackgroundJobs.Wolverine.Tests/CronSchedulerAgentTests.cs
@@ -61,7 +61,7 @@ public sealed class CronSchedulerAgentTests
     }
 
     // Minimal job message class for testing
-    private sealed class FakeJobMessage;
+    private sealed class FakeJobMessage : IBackgroundJob;
 
     // =========================================================================
     // Scenario: job with null NextExecutionAt -> schedules first occurrence

--- a/tests/Granit.BackgroundJobs.Wolverine.Tests/RecurringJobSchedulingMiddlewareTests.cs
+++ b/tests/Granit.BackgroundJobs.Wolverine.Tests/RecurringJobSchedulingMiddlewareTests.cs
@@ -264,7 +264,7 @@ public sealed class RecurringJobSchedulingMiddlewareTests : IDisposable
 // Test fixtures — shared with RecurringJobDiscoveryTests in Granit.BackgroundJobs.Tests
 
 [RecurringJob("0 8 * * *", "fake-daily-report")]
-public sealed class FakeDailyReportMessage;
+public sealed class FakeDailyReportMessage : IBackgroundJob;
 
 /// <summary>A message without [RecurringJob] — middleware must skip it.</summary>
 public sealed class UndecoratedMessage;


### PR DESCRIPTION
## Summary

Security hardening of all `Granit.BackgroundJobs.*` modules based on a targeted security audit (STRIDE + OWASP ASVS + ISO 27001).

- **VULN-100** — Validate `IBackgroundJob` before `Activator.CreateInstance` in `CronSchedulerHelper` to prevent arbitrary type instantiation from tampered DB values
- **VULN-101** — Zeroize RSA private key bytes via `CryptographicOperations.ZeroMemory` in `KeyRotationService` after encryption
- **VULN-102** — Truncate error messages to 500 chars in `BackgroundJobDefinition.RecordFailure` to limit information disclosure through API and integration events
- **VULN-200** — Replace `int.MaxValue` with paginated iteration (1000/page) in `OpenIddictIdleSessionEnforcementHandler` to prevent OOM
- **VULN-201** — Reorder `DeletionDeadlineEnforcerHandler` to publish events before `MarkExecutedAsync`, preventing GDPR compliance gap on partial failure
- **VULN-202** — Add multi-tenancy xmldoc warning to `DefaultReEncryptionJob`
- **Docs** — Fix permission model (Read/Manage split was incorrectly documented as Manage-only), add security considerations section

## Test plan

- [x] 244 tests pass across all 9 BackgroundJobs test projects
- [x] New tests: type rejection (`NotABackgroundJob`), error truncation (long/short/null), IBackgroundJob marker on all test fakes
- [x] Docs site builds clean (334 pages, 0 errors, all internal links valid)
- [ ] CI shards `core-ai`, `security`, `infrastructure` pass
