### PR TITLE
fix(authorization): harden authorization security — privilege escalation, AlwaysAllow bypass, PII leak, AI guardrails

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -6216,7 +6216,7 @@
       "kind": "class",
       "project": "Granit.Bff.EntityFrameworkCore",
       "file": "src/Granit.Bff.EntityFrameworkCore/GranitBffEntityFrameworkCoreModule.cs",
-      "line": 16,
+      "line": 22,
       "members": [
         {
           "name": "ConfigureServices",
@@ -6295,22 +6295,6 @@
           "kind": "method",
           "signature": "GetSessionIdsByUserAsync(string frontendName, string userId, CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyList<string>>"
-        }
-      ]
-    },
-    {
-      "name": "ILogoutTokenValidator",
-      "fqn": "Granit.Bff.ILogoutTokenValidator",
-      "kind": "interface",
-      "project": "Granit.Bff",
-      "file": "src/Granit.Bff/ILogoutTokenValidator.cs",
-      "line": 7,
-      "members": [
-        {
-          "name": "ValidateAsync",
-          "kind": "method",
-          "signature": "ValidateAsync(string logoutToken, string expectedClientId, CancellationToken cancellationToken = default)",
-          "returnType": "Task<ValidatedLogoutToken?>"
         }
       ]
     },
@@ -6444,15 +6428,6 @@
           "returnType": "string?"
         }
       ]
-    },
-    {
-      "name": "ValidatedLogoutToken",
-      "fqn": "Granit.Bff.ValidatedLogoutToken",
-      "kind": "record",
-      "project": "Granit.Bff",
-      "file": "src/Granit.Bff/ILogoutTokenValidator.cs",
-      "line": 23,
-      "members": []
     },
     {
       "name": "BffYarpApplicationBuilderExtensions",
@@ -7447,6 +7422,22 @@
           "kind": "method",
           "signature": "ValidateAsync(BlobValidationContext context, CancellationToken cancellationToken = default)",
           "returnType": "int Order { get; } Task<BlobValidationResult>"
+        }
+      ]
+    },
+    {
+      "name": "ContentDispositionHelper",
+      "fqn": "Granit.BlobStorage.Internal.ContentDispositionHelper",
+      "kind": "class",
+      "project": "Granit.BlobStorage",
+      "file": "src/Granit.BlobStorage/Internal/ContentDispositionHelper.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "BuildAttachmentHeader",
+          "kind": "method",
+          "signature": "BuildAttachmentHeader(string fileName)",
+          "returnType": "string"
         }
       ]
     },

--- a/docs-site/src/content/docs/dotnet/ai/authorization-ai.mdx
+++ b/docs-site/src/content/docs/dotnet/ai/authorization-ai.mdx
@@ -24,7 +24,7 @@ The detector is called **after** the permission check succeeds. It analyzes thre
 
 | Signal | What's passed to the LLM |
 |--------|--------------------------|
-| `userId` | The user performing the access |
+| `userId` | **Pseudonymized** (SHA-256 hash) — the real user ID never leaves the system |
 | `permission` | The permission being checked (e.g. `invoices.read`) |
 | `context` | Optional JSON: resource type, count, time, previous access patterns |
 
@@ -33,10 +33,19 @@ throttle — without blocking the operation:
 
 ```csharp
 public sealed record AccessRiskScore(
-    double Score,                         // 0.0 (normal) – 1.0 (high risk)
+    double Score,                         // 0.0 (normal) – 1.0 (high risk), clamped
     string Reasoning,                     // "800 reads in 5 minutes at 2am"
-    IReadOnlyList<string> RiskFactors);   // ["unusual time", "high volume", "bulk export"]
+    IReadOnlyList<string> RiskFactors)    // ["unusual time", "high volume", "bulk export"]
+{
+    public bool IsAdvisoryOnly => true;   // MUST NOT be used as sole deny factor
+}
 ```
+
+:::caution[Advisory only — OWASP LLM09]
+`IsAdvisoryOnly` is always `true`. AI scores are non-deterministic and susceptible
+to prompt injection. **Never** use this score as the sole factor in an authorization
+deny decision — always combine with deterministic checks.
+:::
 
 ## Setup
 
@@ -71,7 +80,8 @@ builder.AddGranitAuthorizationAI();
 </Tabs>
 
 Note the **2-second timeout**: access evaluation is in the request path.
-Fail-open design: timeout returns `Score = 0.0` and access proceeds normally.
+Fail-open design: timeout returns `Score = UnavailableRiskScore` (default `0.5`)
+and access proceeds normally.
 
 ## Using the detector
 
@@ -197,18 +207,22 @@ denial-of-service vector — it always returns a score, never throws.
 
 ## Prompt injection protection
 
-All user-controlled inputs (`userId`, `permission`, `context`) are sanitized via
-`PromptBuilder` before being sent to the LLM. The builder wraps user data in
-structured `<data>` delimiters and neutralizes injection patterns, preventing
-an attacker from manipulating the risk score via crafted context strings.
+All user-controlled inputs are sanitized before being sent to the LLM:
+
+- **`userId`** — pseudonymized via SHA-256 hash (GDPR Art. 5 data minimization)
+- **`context`** — Unicode control characters, zero-width chars, and bidirectional
+  overrides are stripped before entering `PromptBuilder`
+- **All inputs** — `PromptBuilder` wraps user data in structured `<data>` delimiters
+  and neutralizes injection patterns, preventing an attacker from manipulating
+  the risk score via crafted context strings
 
 ## Configuration reference
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `WorkspaceName` | `string` | `"default"` | AI workspace for access evaluation |
-| `TimeoutSeconds` | `int` | `5` | Timeout — keep low, access evaluation is in the request path |
-| `UnavailableRiskScore` | `double` | `0.5` | Risk score returned when LLM is unavailable (0.0 = fail-open, 1.0 = fail-closed) |
+| `TimeoutSeconds` | `int` | `5` | Timeout in seconds (validated: 1–30) |
+| `UnavailableRiskScore` | `double` | `0.5` | Risk score when LLM is unavailable (validated: 0.0–1.0) |
 
 ## See also
 

--- a/docs-site/src/content/docs/dotnet/security/authorization.mdx
+++ b/docs-site/src/content/docs/dotnet/security/authorization.mdx
@@ -92,25 +92,28 @@ Standard actions: `Read`, `Create`, `Update`, `Delete`, `Manage` (all CRUD), `Ex
 
 ```mermaid
 flowchart LR
-    A[Request] --> B{AlwaysAllow?}
-    B -->|yes| C[Granted]
-    B -->|no| D{AdminRole?}
-    D -->|yes| C
-    D -->|no| E{Cache hit?}
-    E -->|yes| F{Granted?}
-    E -->|no| G[IPermissionGrantStore]
-    G --> H[Cache result]
-    H --> F
-    F -->|yes| C
-    F -->|no| I[Denied]
+    A[Request] --> B{Authenticated?}
+    B -->|no| I[Denied]
+    B -->|yes| C{AlwaysAllow?}
+    C -->|yes| D[Granted]
+    C -->|no| E{AdminRole?}
+    E -->|yes| D
+    E -->|no| F{Cache hit?}
+    F -->|yes| G{Granted?}
+    F -->|no| H[IPermissionGrantStore]
+    H --> J[Cache result]
+    J --> G
+    G -->|yes| D
+    G -->|no| I
 ```
 
 The `PermissionChecker` evaluates in order:
 
-1. `AlwaysAllow` option (development only)
-2. Admin role bypass — users with any role in `AdminRoles` get all permissions
-3. Per-role cache lookup (key: `perm:{tenantId}:{roleName}:{permissionName}`)
-4. `IPermissionGrantStore` fallback (default: `NullPermissionGrantStore` — always denied)
+1. **Not authenticated → denied** — anonymous users are always rejected, even with `AlwaysAllow`
+2. `AlwaysAllow` option (development only, authenticated users only)
+3. Admin role bypass — users with any role in `AdminRoles` get all permissions (case-insensitive)
+4. Per-role cache lookup (key: `perm:{tenantId}:{roleName}:{permissionName}`)
+5. `IPermissionGrantStore` fallback (default: `NullPermissionGrantStore` — always denied)
 
 ## Using permissions
 
@@ -155,13 +158,14 @@ public class InvoiceService(IPermissionChecker permissionChecker)
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `AdminRoles` | `["admin"]` | Roles that bypass all permission checks |
-| `CacheDuration` | `00:05:00` | Per-role permission cache TTL |
-| `AlwaysAllow` | `false` | Skip all checks (development only) |
+| `AdminRoles` | `["admin"]` | Roles that bypass all permission checks (case-insensitive) |
+| `CacheDuration` | `00:05:00` | Per-role permission cache TTL (10s – 30min) |
+| `AlwaysAllow` | `false` | Skip all checks for authenticated users (development only) |
 
 :::danger
-Never set `AlwaysAllow: true` in production. This disables the entire authorization
-pipeline. The option validator rejects it outside `Development` environment.
+Never set `AlwaysAllow: true` in production. This bypasses all permission checks
+for authenticated users. The startup validator rejects it in `Production` environment.
+Anonymous users are always denied regardless of this setting.
 :::
 
 ## EF Core permission store
@@ -174,9 +178,9 @@ real store backed by EF Core.
 ```csharp
 public class PermissionGrant : AuditedEntity, IMultiTenant
 {
-    public string Name { get; set; } = string.Empty;     // Permission name
-    public string RoleName { get; set; } = string.Empty;  // Role granted to
-    public Guid? TenantId { get; set; }                   // Tenant scope (null = global)
+    public string Name { get; init; } = string.Empty;     // Permission name (immutable)
+    public string RoleName { get; init; } = string.Empty;  // Role granted to (immutable)
+    public Guid? TenantId { get; set; }                    // Tenant scope (null = global)
 }
 // Unique index: (TenantId, Name, RoleName)
 ```
@@ -216,6 +220,12 @@ public class PermissionAdminService(
 ```
 
 All grant changes are audit-logged via `AuditedEntity` (ISO 27001 — 3-year retention).
+
+:::note[Privilege escalation prevention]
+The `PUT /roles/{roleName}/{permissionName}` grant endpoint requires the calling user
+to **hold the permission they are granting**. A user with `Authorization.Grants.Manage`
+cannot grant permissions they do not themselves possess (returns 403 Forbidden).
+:::
 
 ## Public API summary
 

--- a/src/Granit.Authorization.AI/AccessRiskScore.cs
+++ b/src/Granit.Authorization.AI/AccessRiskScore.cs
@@ -3,13 +3,31 @@ namespace Granit.Authorization.AI;
 /// <summary>
 /// Result of an AI access anomaly evaluation, containing a risk score and supporting details.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="IsAdvisoryOnly"/> is always <c>true</c>: this score MUST NOT be used as the sole
+/// factor in authorization deny decisions. AI output is non-deterministic and susceptible to
+/// prompt injection — always combine with deterministic authorization checks.
+/// </para>
+/// </remarks>
 /// <param name="Score">
-/// Risk score between 0.0 (no risk) and 1.0 (critical risk).
-/// Values above 0.7 typically indicate suspicious access patterns.
+/// Risk score clamped to [0.0, 1.0]. Values above 0.7 typically indicate suspicious access patterns.
 /// </param>
 /// <param name="Reasoning">Human-readable explanation of the risk assessment.</param>
 /// <param name="RiskFactors">Specific risk factors identified during the evaluation.</param>
 public sealed record AccessRiskScore(
     double Score,
     string Reasoning,
-    IReadOnlyList<string> RiskFactors);
+    IReadOnlyList<string> RiskFactors)
+{
+    /// <summary>Risk score clamped to [0.0, 1.0].</summary>
+    public double Score { get; } = Math.Clamp(Score, 0.0, 1.0);
+
+    /// <summary>
+    /// Always <c>true</c>. AI-generated risk scores are advisory only and MUST NOT
+    /// be used as the sole factor in authorization deny decisions (OWASP LLM09).
+    /// </summary>
+#pragma warning disable CA1822 // Instance property by design — signals to callers that this score is advisory
+    public bool IsAdvisoryOnly => true;
+#pragma warning restore CA1822
+}

--- a/src/Granit.Authorization.AI/Extensions/AuthorizationAIHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Authorization.AI/Extensions/AuthorizationAIHostApplicationBuilderExtensions.cs
@@ -4,30 +4,36 @@ using Granit.Authorization.AI.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Authorization.AI.Extensions;
 
 /// <summary>
 /// Extension methods for registering AI access anomaly detection services.
 /// </summary>
+/// <remarks>
+/// Binds <see cref="AuthorizationAIOptions"/> from the <c>AI:Authorization</c> configuration section
+/// and registers <see cref="IAIAccessAnomalyDetector"/> as a scoped service backed by an LLM.
+/// Requires an AI provider to be registered (e.g. <c>AddGranitAIOpenAI()</c>).
+/// </remarks>
 [ExcludeFromCodeCoverage]
 public static class AuthorizationAIHostApplicationBuilderExtensions
 {
     /// <summary>
     /// Adds AI-powered access anomaly detection to the application.
     /// </summary>
-    /// <remarks>
-    /// Binds <see cref="AuthorizationAIOptions"/> from the <c>AI:Authorization</c> configuration section
-    /// and registers <see cref="IAIAccessAnomalyDetector"/> as a scoped service backed by an LLM.
-    /// Requires an AI provider to be registered (e.g. <c>AddGranitAIOpenAI()</c>).
-    /// </remarks>
     /// <param name="builder">The host application builder.</param>
     /// <returns>The builder for chaining.</returns>
     public static IHostApplicationBuilder AddGranitAuthorizationAI(this IHostApplicationBuilder builder)
     {
         builder.Services
             .AddOptions<AuthorizationAIOptions>()
-            .BindConfiguration(AuthorizationAIOptions.SectionName);
+            .BindConfiguration(AuthorizationAIOptions.SectionName)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        builder.Services.TryAddSingleton<IValidateOptions<AuthorizationAIOptions>,
+            AuthorizationAIOptionsValidator>();
 
         builder.Services.TryAddScoped<IAIAccessAnomalyDetector, LlmAccessAnomalyDetector>();
 

--- a/src/Granit.Authorization.AI/Internal/LlmAccessAnomalyDetector.cs
+++ b/src/Granit.Authorization.AI/Internal/LlmAccessAnomalyDetector.cs
@@ -1,4 +1,7 @@
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Granit.AI;
 using Granit.AI.Internal;
 using Granit.Authorization.AI.Options;
@@ -80,12 +83,16 @@ internal sealed partial class LlmAccessAnomalyDetector(
 
         pb.AppendInstruction("Analyze the following access request for anomalies and suspicious behavior.");
         pb.AppendInstruction(string.Empty);
-        pb.AppendUserData("User ID", userId);
+
+        // VULN-101 fix: pseudonymize userId to prevent PII leakage to external AI services.
+        pb.AppendUserData("User ID", PseudonymizeUserId(userId));
         pb.AppendUserData("Permission requested", permission);
 
         if (context is not null)
         {
-            pb.AppendUserData("Additional context", context);
+            // VULN-200 fix: strip control characters that could bypass PromptBuilder's
+            // blocklist sanitization (Unicode tricks, bidirectional overrides, zero-width chars).
+            pb.AppendUserData("Additional context", StripControlCharacters(context));
         }
 
         pb.AppendInstruction(string.Empty);
@@ -121,7 +128,26 @@ internal sealed partial class LlmAccessAnomalyDetector(
     }
 
     private static AccessRiskScore UnavailableScore(AuthorizationAIOptions config) =>
-        new(config.UnavailableRiskScore, "AI evaluation unavailable — flagged for manual review", []);
+        new(Math.Clamp(config.UnavailableRiskScore, 0.0, 1.0),
+            "AI evaluation unavailable — flagged for manual review", []);
+
+    /// <summary>
+    /// One-way SHA-256 hash of the user ID, truncated to 16 hex characters.
+    /// The LLM can still detect patterns for the same pseudonymized user
+    /// without receiving the actual user identifier (GDPR Art. 5 data minimization).
+    /// </summary>
+    internal static string PseudonymizeUserId(string userId) =>
+        Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(userId)))[..16];
+
+    /// <summary>
+    /// Strips Unicode control characters, zero-width chars, and bidirectional overrides
+    /// that could be used to obfuscate prompt injection payloads.
+    /// </summary>
+    internal static string StripControlCharacters(string input) =>
+        ControlCharacterRegex().Replace(input, string.Empty);
+
+    [GeneratedRegex(@"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F\u200B-\u200F\u202A-\u202E\uFEFF]")]
+    private static partial Regex ControlCharacterRegex();
 
     [LoggerMessage(Level = LogLevel.Warning,
         Message = "AI access anomaly evaluation timed out after {TimeoutSeconds}s — flagged for manual review")]

--- a/src/Granit.Authorization.AI/Options/AuthorizationAIOptionsValidator.cs
+++ b/src/Granit.Authorization.AI/Options/AuthorizationAIOptionsValidator.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.Options;
+
+namespace Granit.Authorization.AI.Options;
+
+/// <summary>
+/// Validates <see cref="AuthorizationAIOptions"/> at startup to catch
+/// misconfigurations that could degrade AI anomaly detection security.
+/// </summary>
+internal sealed class AuthorizationAIOptionsValidator
+    : IValidateOptions<AuthorizationAIOptions>
+{
+    public ValidateOptionsResult Validate(string? name, AuthorizationAIOptions options)
+    {
+        List<string>? failures = null;
+
+        if (options.UnavailableRiskScore is < 0.0 or > 1.0)
+        {
+            (failures ??= []).Add(
+                $"UnavailableRiskScore must be between 0.0 and 1.0, got {options.UnavailableRiskScore}.");
+        }
+
+        if (options.TimeoutSeconds is < 1 or > 30)
+        {
+            (failures ??= []).Add(
+                $"TimeoutSeconds must be between 1 and 30, got {options.TimeoutSeconds}.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.WorkspaceName))
+        {
+            (failures ??= []).Add(
+                "WorkspaceName must not be empty.");
+        }
+
+        return failures is null
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/Granit.Authorization.Endpoints/Endpoints/PermissionGrantEndpoints.cs
+++ b/src/Granit.Authorization.Endpoints/Endpoints/PermissionGrantEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Granit.Authorization.Abstractions;
 using Granit.Authorization.Endpoints.Dtos;
 using Granit.Authorization.Endpoints.Permissions;
@@ -13,7 +14,7 @@ namespace Granit.Authorization.Endpoints.Endpoints;
 /// <summary>
 /// Admin endpoints for viewing and managing role → permission grants.
 /// </summary>
-internal static class PermissionGrantEndpoints
+internal static partial class PermissionGrantEndpoints
 {
     /// <summary>
     /// Registers GET /roles/{roleName}, PUT /roles/{roleName}/{permissionName},
@@ -33,9 +34,10 @@ internal static class PermissionGrantEndpoints
         adminGroup.MapPut("/{roleName}/{permissionName}", GrantPermissionAsync)
             .WithName("GrantPermission")
             .WithSummary("Grants a permission to a role. No-op if already granted.")
-            .WithDescription("Grants the specified permission to the role for the current tenant. The permission name must match a registered permission definition (returns 422 otherwise). Idempotent — granting an already-granted permission is a no-op.")
+            .WithDescription("Grants the specified permission to the role for the current tenant. The permission name must match a registered permission definition (returns 422 otherwise). The calling user must hold the permission being granted (privilege escalation prevention). Idempotent — granting an already-granted permission is a no-op.")
             .Produces(StatusCodes.Status204NoContent)
-            .ProducesValidationProblem();
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status403Forbidden);
 
         adminGroup.MapDelete("/{roleName}/{permissionName}", RevokePermissionAsync)
             .WithName("RevokePermission")
@@ -47,12 +49,21 @@ internal static class PermissionGrantEndpoints
         return group;
     }
 
-    private static async Task<Ok<PermissionGrantResponse>> GetGrantedPermissionsAsync(
+    private static async Task<Results<Ok<PermissionGrantResponse>, ValidationProblem>> GetGrantedPermissionsAsync(
         string roleName,
         [FromServices] IPermissionManagerReader permissionManagerReader,
         [FromServices] ICurrentTenant currentTenant,
         CancellationToken cancellationToken)
     {
+        if (!IsValidName(roleName))
+        {
+            return TypedResults.ValidationProblem(
+                new Dictionary<string, string[]>
+                {
+                    ["roleName"] = ["Role name must be 1-256 characters (alphanumeric, dots, hyphens, underscores)."]
+                });
+        }
+
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
 
         IReadOnlyList<string> permissions = await permissionManagerReader
@@ -62,21 +73,40 @@ internal static class PermissionGrantEndpoints
         return TypedResults.Ok(new PermissionGrantResponse(roleName, permissions));
     }
 
-    private static async Task<Results<NoContent, ValidationProblem>> GrantPermissionAsync(
+    private static async Task<Results<NoContent, ValidationProblem, ProblemHttpResult>> GrantPermissionAsync(
         string roleName,
         string permissionName,
         [FromServices] IPermissionManagerWriter permissionManagerWriter,
         [FromServices] IPermissionDefinitionManager definitionManager,
+        [FromServices] IPermissionChecker permissionChecker,
         [FromServices] ICurrentTenant currentTenant,
         CancellationToken cancellationToken)
     {
+        if (!IsValidName(roleName) || !IsValidName(permissionName))
+        {
+            return TypedResults.ValidationProblem(
+                new Dictionary<string, string[]>
+                {
+                    ["name"] = ["Role and permission names must be 1-256 characters (alphanumeric, dots, hyphens, underscores)."]
+                });
+        }
+
         if (!definitionManager.Exists(permissionName))
         {
             return TypedResults.ValidationProblem(
                 new Dictionary<string, string[]>
                 {
-                    ["permissionName"] = [$"Permission '{permissionName}' is not defined."]
+                    ["permissionName"] = ["The specified permission is not registered."]
                 });
+        }
+
+        // VULN-100 fix: prevent privilege escalation — callers can only grant
+        // permissions they themselves hold (or are in an AdminRole).
+        if (!await permissionChecker.IsGrantedAsync(permissionName, cancellationToken).ConfigureAwait(false))
+        {
+            return TypedResults.Problem(
+                detail: "Cannot grant a permission that the current user does not hold.",
+                statusCode: StatusCodes.Status403Forbidden);
         }
 
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
@@ -95,12 +125,21 @@ internal static class PermissionGrantEndpoints
         [FromServices] ICurrentTenant currentTenant,
         CancellationToken cancellationToken)
     {
+        if (!IsValidName(roleName) || !IsValidName(permissionName))
+        {
+            return TypedResults.ValidationProblem(
+                new Dictionary<string, string[]>
+                {
+                    ["name"] = ["Role and permission names must be 1-256 characters (alphanumeric, dots, hyphens, underscores)."]
+                });
+        }
+
         if (!definitionManager.Exists(permissionName))
         {
             return TypedResults.ValidationProblem(
                 new Dictionary<string, string[]>
                 {
-                    ["permissionName"] = [$"Permission '{permissionName}' is not defined."]
+                    ["permissionName"] = ["The specified permission is not registered."]
                 });
         }
 
@@ -111,4 +150,10 @@ internal static class PermissionGrantEndpoints
 
         return TypedResults.NoContent();
     }
+
+    private static bool IsValidName(string name) =>
+        name.Length is > 0 and <= 256 && ValidNameRegex().IsMatch(name);
+
+    [GeneratedRegex(@"^[\w.\-]{1,256}$")]
+    private static partial Regex ValidNameRegex();
 }

--- a/src/Granit.Authorization.Endpoints/Internal/AuthorizationSchemaExampleProvider.cs
+++ b/src/Granit.Authorization.Endpoints/Internal/AuthorizationSchemaExampleProvider.cs
@@ -18,8 +18,8 @@ internal sealed class AuthorizationSchemaExampleProvider : ISchemaExampleProvide
                 ["permissions"] = new JsonArray
                 {
                     "Settings.Global.Read",
-                    "BlobStorage.Read",
-                    "BlobStorage.Write",
+                    "BlobStorage.Blobs.Read",
+                    "BlobStorage.Blobs.Write",
                 },
             },
             [typeof(PermissionGroupResponse)] = new JsonObject
@@ -30,12 +30,12 @@ internal sealed class AuthorizationSchemaExampleProvider : ISchemaExampleProvide
                 {
                     new JsonObject
                     {
-                        ["name"] = "BlobStorage.Read",
+                        ["name"] = "BlobStorage.Blobs.Read",
                         ["displayName"] = "Read files",
                     },
                     new JsonObject
                     {
-                        ["name"] = "BlobStorage.Write",
+                        ["name"] = "BlobStorage.Blobs.Write",
                         ["displayName"] = "Upload and delete files",
                     },
                 },
@@ -47,8 +47,8 @@ internal sealed class AuthorizationSchemaExampleProvider : ISchemaExampleProvide
                 {
                     "Settings.Global.Read",
                     "Settings.Global.Manage",
-                    "BlobStorage.Read",
-                    "BlobStorage.Write",
+                    "BlobStorage.Blobs.Read",
+                    "BlobStorage.Blobs.Write",
                 },
             },
         };

--- a/src/Granit.Authorization.EntityFrameworkCore/Entities/PermissionGrant.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/Entities/PermissionGrant.cs
@@ -10,14 +10,15 @@ namespace Granit.Authorization.EntityFrameworkCore.Entities;
 public sealed class PermissionGrant : AuditedEntity, IMultiTenant
 {
     /// <summary>Permission name, e.g. "Invoices.Delete". Max 256 characters.</summary>
-    public string Name { get; set; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
 
     /// <summary>
     /// Role name from the identity provider (Keycloak realm role, ASP.NET Core Identity role, etc.).
     /// Max 256 characters.
     /// </summary>
-    public string RoleName { get; set; } = string.Empty;
+    public string RoleName { get; init; } = string.Empty;
 
     /// <summary>Tenant scope. Null means the grant applies at the host (cross-tenant) level.</summary>
+    /// <remarks>Keeps <c>set</c> to satisfy <see cref="IMultiTenant"/> interceptor injection.</remarks>
     public Guid? TenantId { get; set; }
 }

--- a/src/Granit.Authorization.EntityFrameworkCore/Services/PermissionManager.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/Services/PermissionManager.cs
@@ -61,7 +61,16 @@ internal sealed partial class PermissionManager<TContext>(
             return; // no-op: state already matches requested value
         }
 
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateException) when (isGranted)
+        {
+            // VULN-205 fix: TOCTOU race — concurrent grant for the same tuple hit
+            // the unique index. Treat as idempotent no-op (grant already exists).
+            return;
+        }
 
         // Event-driven cache invalidation — consumed by PermissionCacheInvalidationHandler.
         // Decoupled from the store so other modules can react to permission changes.

--- a/src/Granit.Authorization/Authorization/DynamicPermissionPolicyProvider.cs
+++ b/src/Granit.Authorization/Authorization/DynamicPermissionPolicyProvider.cs
@@ -27,6 +27,7 @@ internal sealed class DynamicPermissionPolicyProvider(
         definitionManager.Exists(policyName)
             ? Task.FromResult<AuthorizationPolicy?>(
                 new AuthorizationPolicyBuilder()
+                    .RequireAuthenticatedUser()
                     .AddRequirements(new PermissionRequirement(policyName))
                     .Build())
             : _fallback.GetPolicyAsync(policyName);

--- a/src/Granit.Authorization/Cache/PermissionCacheInvalidationHandler.cs
+++ b/src/Granit.Authorization/Cache/PermissionCacheInvalidationHandler.cs
@@ -5,19 +5,27 @@ using ZiggyCreatures.Caching.Fusion;
 namespace Granit.Authorization.Cache;
 
 /// <summary>
-/// Wolverine message handler — expires the stale <see cref="IFusionCache"/>
+/// Wolverine message handler — invalidates the stale <see cref="IFusionCache"/>
 /// entry when a permission grant is created or revoked.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Discovered by Wolverine's handler scanning convention: class name ends in
 /// <c>"Handler"</c>, method named <c>HandleAsync</c> with the message as first parameter.
 /// Additional parameters are resolved from the application's DI container.
 /// No WolverineFx package reference is required in this project.
+/// </para>
+/// <para>
+/// VULN-204 fix: revocations use <see cref="IFusionCache.RemoveAsync"/> (hard delete)
+/// to prevent stale-while-revalidate from serving a revoked grant. Grants use
+/// <see cref="IFusionCache.ExpireAsync"/> (soft expire) for resilience — a stale
+/// "denied" entry is safe if the factory fails.
+/// </para>
 /// </remarks>
 public static class PermissionCacheInvalidationHandler
 {
     /// <summary>
-    /// Expires the cached permission grant entry for the changed role and tenant scope.
+    /// Invalidates the cached permission grant entry for the changed role and tenant scope.
     /// </summary>
     public static async Task HandleAsync(
         PermissionGrantChangedEvent @event,
@@ -26,6 +34,18 @@ public static class PermissionCacheInvalidationHandler
     {
         string key = PermissionChecker.BuildCacheKey(
             @event.TenantId, @event.RoleName, @event.PermissionName);
-        await cache.ExpireAsync(key, token: cancellationToken).ConfigureAwait(false);
+
+        if (@event.IsGranted)
+        {
+            // Grant created: soft-expire the old "denied" entry.
+            // Stale "denied" is safe — factory will refresh to "granted".
+            await cache.ExpireAsync(key, token: cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            // Grant revoked: hard-remove to prevent stale-while-revalidate
+            // from serving the old "granted" entry.
+            await cache.RemoveAsync(key, token: cancellationToken).ConfigureAwait(false);
+        }
     }
 }

--- a/src/Granit.Authorization/Diagnostics/AuthorizationMetrics.cs
+++ b/src/Granit.Authorization/Diagnostics/AuthorizationMetrics.cs
@@ -40,18 +40,16 @@ public sealed class AuthorizationMetrics
             description: "Number of permission grant cache misses.");
     }
 
-    public void RecordCheckGranted(string? tenantId, string permissionName) =>
+    public void RecordCheckGranted(string? tenantId) =>
         _checksGranted.Add(1, new TagList
         {
             { TagTenantId, tenantId ?? DefaultTenant },
-            { "permission_name", permissionName },
         });
 
-    public void RecordCheckDenied(string? tenantId, string permissionName) =>
+    public void RecordCheckDenied(string? tenantId) =>
         _checksDenied.Add(1, new TagList
         {
             { TagTenantId, tenantId ?? DefaultTenant },
-            { "permission_name", permissionName },
         });
 
     public void RecordCacheHit(string? tenantId) =>

--- a/src/Granit.Authorization/Extensions/AuthorizationServiceCollectionExtensions.cs
+++ b/src/Granit.Authorization/Extensions/AuthorizationServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using Granit.Authorization.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Authorization.Extensions;
 
@@ -24,6 +25,9 @@ public static class AuthorizationServiceCollectionExtensions
             .BindConfiguration(GranitAuthorizationOptions.SectionName)
             .ValidateDataAnnotations()
             .ValidateOnStart();
+
+        services.TryAddSingleton<IValidateOptions<GranitAuthorizationOptions>,
+            GranitAuthorizationOptionsValidator>();
 
         services.AddSingleton<IPermissionDefinitionManager, PermissionDefinitionManager>();
 

--- a/src/Granit.Authorization/Options/GranitAuthorizationOptions.cs
+++ b/src/Granit.Authorization/Options/GranitAuthorizationOptions.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Granit.Authorization.Options;
 
 /// <summary>Configuration options for the Granit.Authorization module.</summary>
@@ -9,19 +11,23 @@ public sealed class GranitAuthorizationOptions
     /// <summary>
     /// Roles that bypass all permission checks. These roles are the root of trust
     /// and cannot be restricted via <c>IPermissionManagerWriter.SetAsync()</c>.
-    /// Defaults to <c>["admin"]</c>.
+    /// Defaults to <c>["admin"]</c>. Comparison is case-insensitive.
     /// </summary>
+    [MinLength(1)]
     public IList<string> AdminRoles { get; set; } = ["admin"];
 
     /// <summary>
     /// Duration for which permission check results are cached per (TenantId, RoleName, PermissionName).
-    /// Defaults to 5 minutes. Should be less than or equal to the JWT token lifetime.
+    /// Defaults to 5 minutes. Must be between 10 seconds and 30 minutes.
+    /// Should be less than or equal to the JWT token lifetime.
     /// </summary>
+    [Range(typeof(TimeSpan), "00:00:10", "00:30:00")]
     public TimeSpan CacheDuration { get; set; } = TimeSpan.FromMinutes(5);
 
     /// <summary>
-    /// When true, all permission checks return granted without hitting the cache or store.
+    /// When true, all permission checks return granted for authenticated users.
     /// For development and testing only — never enable in production.
+    /// Anonymous users are always denied regardless of this setting.
     /// </summary>
     public bool AlwaysAllow { get; set; }
 }

--- a/src/Granit.Authorization/Options/GranitAuthorizationOptionsValidator.cs
+++ b/src/Granit.Authorization/Options/GranitAuthorizationOptionsValidator.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Authorization.Options;
+
+/// <summary>
+/// Validates <see cref="GranitAuthorizationOptions"/> at startup to catch
+/// misconfigurations that would silently degrade authorization security.
+/// </summary>
+internal sealed class GranitAuthorizationOptionsValidator(
+    IHostEnvironment environment) : IValidateOptions<GranitAuthorizationOptions>
+{
+    public ValidateOptionsResult Validate(string? name, GranitAuthorizationOptions options)
+    {
+        List<string>? failures = null;
+
+        if (options.AlwaysAllow && environment.IsProduction())
+        {
+            (failures ??= []).Add(
+                "AlwaysAllow must not be enabled in production — it bypasses all permission checks for authenticated users.");
+        }
+
+        if (options.AdminRoles.Count == 0)
+        {
+            (failures ??= []).Add(
+                "AdminRoles must contain at least one role name.");
+        }
+
+        if (options.CacheDuration < TimeSpan.FromSeconds(10))
+        {
+            (failures ??= []).Add(
+                $"CacheDuration must be at least 10 seconds, got {options.CacheDuration}.");
+        }
+
+        if (options.CacheDuration > TimeSpan.FromMinutes(30))
+        {
+            (failures ??= []).Add(
+                $"CacheDuration must not exceed 30 minutes, got {options.CacheDuration}.");
+        }
+
+        return failures is null
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/Granit.Authorization/Services/PermissionChecker.cs
+++ b/src/Granit.Authorization/Services/PermissionChecker.cs
@@ -1,5 +1,6 @@
 using Granit.Authorization.Abstractions;
 using Granit.Authorization.Cache;
+using Granit.Authorization.Diagnostics;
 using Granit.Authorization.Options;
 using Granit.MultiTenancy;
 using Granit.Users;
@@ -11,9 +12,9 @@ namespace Granit.Authorization.Services;
 /// <summary>
 /// Scoped permission checker implementing the full RBAC verification pipeline:
 /// <list type="number">
-/// <item>AlwaysAllow (dev/test) → granted</item>
 /// <item>Not authenticated → denied</item>
-/// <item>AdminRole bypass (root of trust) → granted without DB</item>
+/// <item>AlwaysAllow (dev/test, authenticated users only) → granted</item>
+/// <item>AdminRole bypass (root of trust, case-insensitive) → granted without DB</item>
 /// <item>Permission undefined → <see cref="InvalidOperationException"/></item>
 /// <item>For each role: cache hit or store query; any true → granted</item>
 /// </list>
@@ -25,6 +26,7 @@ internal sealed class PermissionChecker(
     IPermissionDefinitionManager definitionManager,
     IPermissionGrantStore grantStore,
     IFusionCache cache,
+    AuthorizationMetrics metrics,
     IOptions<GranitAuthorizationOptions> options) : IPermissionChecker
 {
     /// <inheritdoc />
@@ -32,17 +34,23 @@ internal sealed class PermissionChecker(
     {
         GranitAuthorizationOptions opts = options.Value;
 
-        if (opts.AlwaysAllow)
-        {
-            return true;
-        }
-
+        // VULN-001 fix: authentication MUST be checked before AlwaysAllow to prevent
+        // a configuration error from granting access to anonymous users.
         if (!currentUserService.IsAuthenticated)
         {
             return false;
         }
 
-        if (opts.AdminRoles.Any(currentUserService.IsInRole))
+        if (opts.AlwaysAllow)
+        {
+            return true;
+        }
+
+        IReadOnlyList<string> roles = currentUserService.GetRoles();
+
+        // VULN-301 fix: case-insensitive comparison prevents mismatch with IdP role casing.
+        if (opts.AdminRoles.Any(adminRole => roles.Any(
+            r => string.Equals(r, adminRole, StringComparison.OrdinalIgnoreCase))))
         {
             return true;
         }
@@ -55,7 +63,7 @@ internal sealed class PermissionChecker(
 
         // Explicit IsAvailable check per soft-dependency contract (NullTenantContext returns null).
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
-        IReadOnlyList<string> roles = currentUserService.GetRoles();
+        string tenantIdStr = tenantId?.ToString() ?? "global";
 
         foreach (string role in roles)
         {
@@ -70,10 +78,12 @@ internal sealed class PermissionChecker(
 
             if (result.IsGranted)
             {
+                metrics.RecordCheckGranted(tenantIdStr);
                 return true;
             }
         }
 
+        metrics.RecordCheckDenied(tenantIdStr);
         return false;
     }
 

--- a/tests/Granit.Authorization.AI.Tests/LlmAccessAnomalyDetectorTests.cs
+++ b/tests/Granit.Authorization.AI.Tests/LlmAccessAnomalyDetectorTests.cs
@@ -148,7 +148,7 @@ public sealed class LlmAccessAnomalyDetectorTests
         string prompt = LlmAccessAnomalyDetector.BuildPrompt("user-1", "Admin.Access", "off-hours login");
 
         prompt.ShouldContain("off-hours login");
-        prompt.ShouldContain("user-1");
+        prompt.ShouldContain(LlmAccessAnomalyDetector.PseudonymizeUserId("user-1"));
         prompt.ShouldContain("Admin.Access");
     }
 
@@ -158,7 +158,7 @@ public sealed class LlmAccessAnomalyDetectorTests
         string prompt = LlmAccessAnomalyDetector.BuildPrompt("user-1", "Documents.Read", null);
 
         prompt.ShouldNotContain("Additional context:");
-        prompt.ShouldContain("user-1");
+        prompt.ShouldContain(LlmAccessAnomalyDetector.PseudonymizeUserId("user-1"));
         prompt.ShouldContain("Documents.Read");
     }
 }

--- a/tests/Granit.Authorization.Endpoints.Tests/AuthorizationEndpointsTests.cs
+++ b/tests/Granit.Authorization.Endpoints.Tests/AuthorizationEndpointsTests.cs
@@ -231,6 +231,7 @@ public sealed class AuthorizationEndpointsTests : IAsyncDisposable
     {
         // Arrange
         _definitionManager.Exists("Invoices.Read").Returns(true);
+        _permissionChecker.IsGrantedAsync("Invoices.Read", Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
         HttpResponseMessage response = await _adminClient.PutAsync(

--- a/tests/Granit.Authorization.Tests/DynamicPermissionPolicyProviderTests.cs
+++ b/tests/Granit.Authorization.Tests/DynamicPermissionPolicyProviderTests.cs
@@ -35,7 +35,8 @@ public sealed class DynamicPermissionPolicyProviderTests
 
         // Assert
         policy.ShouldNotBeNull();
-        policy!.Requirements.ShouldHaveSingleItem().ShouldBeOfType<PermissionRequirement>()
+        policy!.Requirements.Count.ShouldBe(2);
+        policy.Requirements.OfType<PermissionRequirement>().ShouldHaveSingleItem()
             .PermissionName.ShouldBe("Invoices.Delete");
     }
 

--- a/tests/Granit.Authorization.Tests/PermissionCacheInvalidationHandlerTests.cs
+++ b/tests/Granit.Authorization.Tests/PermissionCacheInvalidationHandlerTests.cs
@@ -42,6 +42,6 @@ public sealed class PermissionCacheInvalidationHandlerTests
         // Assert
         string expectedKey = PermissionChecker.BuildCacheKey(null, "accountant", "Invoices.Delete");
         expectedKey.ShouldStartWith("perm:global:");
-        await cache.Received(1).ExpireAsync(expectedKey, Arg.Any<FusionCacheEntryOptions?>(), Arg.Any<CancellationToken>());
+        await cache.Received(1).RemoveAsync(expectedKey, Arg.Any<FusionCacheEntryOptions?>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Granit.Authorization.Tests/PermissionCheckerTests.cs
+++ b/tests/Granit.Authorization.Tests/PermissionCheckerTests.cs
@@ -2,17 +2,19 @@
 // Tests - PermissionChecker
 // =============================================================================
 // Verifies the full RBAC pipeline:
-//   1. AlwaysAllow → true without store or cache
-//   2. Not authenticated → false
-//   3. AdminRole bypass → true without store or cache
+//   1. Not authenticated → false
+//   2. AlwaysAllow (authenticated only) → true without store or cache
+//   3. AdminRole bypass (case-insensitive) → true without store or cache
 //   4. Unknown permission → InvalidOperationException
 //   5. Cache miss → store called, result cached
 //   6. Cache hit → store NOT called
 //   7. Multi-role OR logic
 // =============================================================================
 
+using System.Diagnostics.Metrics;
 using Granit.Authorization.Abstractions;
 using Granit.Authorization.Cache;
+using Granit.Authorization.Diagnostics;
 using Granit.Authorization.Options;
 using Granit.Authorization.Services;
 using Granit.MultiTenancy;
@@ -42,7 +44,7 @@ public sealed class PermissionCheckerTests
         IPermissionGrantStore store = Substitute.For<IPermissionGrantStore>();
         PermissionChecker checker = BuildChecker(
             alwaysAllow: true,
-            isAuthenticated: false,
+            isAuthenticated: true,
             cache: cache,
             store: store);
 
@@ -267,7 +269,11 @@ public sealed class PermissionCheckerTests
             CacheDuration = TimeSpan.FromMinutes(5)
         };
 
-        return new PermissionChecker(user, tenant, manager, grantStore, cacheService, Microsoft.Extensions.Options.Options.Create(opts));
+        IMeterFactory meterFactory = Substitute.For<IMeterFactory>();
+        meterFactory.Create(Arg.Any<MeterOptions>()).Returns(new Meter("test"));
+        AuthorizationMetrics metrics = new(meterFactory);
+
+        return new PermissionChecker(user, tenant, manager, grantStore, cacheService, metrics, Microsoft.Extensions.Options.Options.Create(opts));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Security audit and hardening of all `Granit.Authorization.*` modules (1 Critical, 4 High, 7 Medium, 6 Low findings remediated).

- **VULN-001 (CRITICAL):** `AlwaysAllow` now checked after authentication — anonymous users always denied, startup validator blocks it in production
- **VULN-100 (HIGH):** Grant endpoint requires caller to hold the permission being granted (privilege escalation prevention)
- **VULN-102 (HIGH):** Dynamic permission policies enforce `.RequireAuthenticatedUser()` (defense-in-depth)
- **VULN-101 (HIGH):** `userId` pseudonymized via SHA-256 before sending to LLM (GDPR Art. 5)
- **VULN-103 (HIGH):** `AccessRiskScore.IsAdvisoryOnly` marker + score clamping (OWASP LLM09)
- **VULN-204/205:** Cache uses `RemoveAsync` for revocations; `DbUpdateException` caught for idempotent TOCTOU handling
- **VULN-200/202:** Control character stripping on LLM context; `IValidateOptions` for AI options
- **LOW/INFO:** Case-insensitive `AdminRoles`, `init` properties, route validation, generic error messages, metrics wired, OpenAPI examples fixed

### Modules changed

| Module | Files | Key changes |
|--------|-------|-------------|
| `Granit.Authorization` | 7 + 1 new | AlwaysAllow reorder, validator, metrics, cache |
| `Granit.Authorization.Endpoints` | 2 | Caller-holds check, route validation |
| `Granit.Authorization.EntityFrameworkCore` | 2 | init properties, TOCTOU catch |
| `Granit.Authorization.AI` | 3 + 1 new | Pseudonymize, control chars, score clamp |
| Docs | 2 | Updated pipeline diagram, AI pseudonymization |
| Tests | 5 | Updated for new behavior |

## Test plan

- [x] `Granit.Authorization.Tests` — 82 pass
- [x] `Granit.Authorization.AI.Tests` — 34 pass
- [x] `Granit.Authorization.Endpoints.Tests` — 45 pass
- [x] `Granit.Authorization.EntityFrameworkCore.Tests` — 29 pass
- [x] All 4 modules build with 0 warnings, 0 errors
- [ ] CI pipeline validates all 6 shards
