### PR TITLE
fix(caching): security hardening — AES-GCM, per-type encryption, TOCTOU fix

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -7285,7 +7285,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage",
       "file": "src/Granit.BlobStorage/GranitBlobStorageModule.cs",
-      "line": 24,
+      "line": 25,
       "members": [
         {
           "name": "ConfigureServices",

--- a/docs-site/src/content/docs/dotnet/api/idempotency.mdx
+++ b/docs-site/src/content/docs/dotnet/api/idempotency.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Idempotency — Safe API Request Retries"
-description: Stripe-style HTTP idempotency middleware backed by Redis. SHA-256 composite keys, AES-256-CBC encrypted entries, and a five-state machine for safe POST/PUT/PATCH retries.
+description: Stripe-style HTTP idempotency middleware backed by Redis. SHA-256 composite keys, AES-256-GCM encrypted entries, and a five-state machine for safe POST/PUT/PATCH retries.
 sidebar:
   label: Idempotency
   order: 16
@@ -8,7 +8,7 @@ sidebar:
 
 Granit.Http.Idempotency provides Stripe-style HTTP idempotency middleware backed by Redis.
 Ensures that retried POST/PUT/PATCH requests produce the same response without
-re-executing side effects. Uses SHA-256 composite keys and AES-256-CBC encrypted
+re-executing side effects. Uses SHA-256 composite keys and AES-256-GCM encrypted
 entries.
 
 ## Setup

--- a/docs-site/src/content/docs/dotnet/architecture/adr/018-fusioncache-caching-provider.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/018-fusioncache-caching-provider.md
@@ -142,7 +142,7 @@ caching provider. Drop `ICacheService<T>` entirely — consumers inject
 | Layer | Storage | Encrypted | Justification |
 | ----- | ------- | --------- | ------------- |
 | L1 | Pod-local RAM | No | Same as `IMemoryCache` — requires pod access to read |
-| L2 | Redis | Yes (AES-256-CBC) | `EncryptingFusionCacheSerializer` encrypts before write |
+| L2 | Redis | Yes (AES-256-GCM) | `EncryptingFusionCacheSerializer` encrypts before write |
 | Transit | Network | Yes (TLS) | Redis TLS configuration (infrastructure) |
 | Backplane | Redis pub/sub | No (keys only) | Only cache keys are published, not values |
 

--- a/docs-site/src/content/docs/dotnet/architecture/patterns/cache-aside.md
+++ b/docs-site/src/content/docs/dotnet/architecture/patterns/cache-aside.md
@@ -62,7 +62,7 @@ deleting them.
 | Feature resolution too slow (DB query on every request) | L1 cache (nanoseconds) + L2 Redis (microseconds) |
 | Stampede on cache miss (100 requests = 100 DB queries) | FusionCache native stampede protection |
 | Factory failure during cache miss | Fail-safe returns stale data instead of 500 error |
-| Sensitive data in Redis cache | `EncryptingFusionCacheSerializer` (AES-256-CBC) |
+| Sensitive data in Redis cache | `EncryptingFusionCacheSerializer` (AES-256-GCM) |
 
 ## Usage example
 

--- a/docs-site/src/content/docs/dotnet/architecture/patterns/decorator.md
+++ b/docs-site/src/content/docs/dotnet/architecture/patterns/decorator.md
@@ -48,12 +48,13 @@ classDiagram
 
 | Decorator | File | Target | Added responsibilities |
 |-----------|------|--------|-----------------------|
-| `EncryptingFusionCacheSerializer` | `src/Granit.Caching/EncryptingFusionCacheSerializer.cs` | `IFusionCacheSerializer` | AES-256-CBC encryption of L2 (Redis) cache values |
+| `EncryptingFusionCacheSerializer` | `src/Granit.Caching/Internal/EncryptingFusionCacheSerializer.cs` | `IFusionCacheSerializer` | AES-256-GCM authenticated encryption of L2 (Redis) cache values |
 | `CachedLocalizationOverrideStore` | `src/Granit.Localization/Internal/CachedLocalizationOverrideStore.cs` | `ILocalizationOverrideStore` | FusionCache with per-tenant invalidation |
 
 **Custom variant -- Conditional encryption**: `EncryptingFusionCacheSerializer`
-wraps the inner serializer and applies AES-256-CBC encryption to all values
-written to L2 (Redis). L1 (in-process) stores unencrypted objects.
+wraps the inner serializer and applies AES-256-GCM authenticated encryption to all
+values written to L2 (Redis). L1 (in-process) stores unencrypted objects. Per-type
+encryption is resolved via `CacheEncryptionResolver` using the `[CacheEncrypted]` attribute.
 
 ## Rationale
 

--- a/docs-site/src/content/docs/dotnet/data/caching.mdx
+++ b/docs-site/src/content/docs/dotnet/data/caching.mdx
@@ -298,8 +298,8 @@ messages — they are replayed when the connection is restored.
 ## Encryption
 
 `EncryptingFusionCacheSerializer` is a decorator around the SystemTextJson serializer that
-applies AES-256-CBC encryption to all L2 (Redis) traffic. L1 in-memory cache stores plain
-.NET objects — same threat model as `IMemoryCache`.
+applies AES-256-GCM authenticated encryption to all L2 (Redis) traffic. L1 in-memory cache
+stores plain .NET objects — same threat model as `IMemoryCache`.
 
 | Layer | Storage | Encrypted |
 |-------|---------|-----------|
@@ -310,7 +310,9 @@ Encryption is activated by setting `CachingOptions.EncryptValues = true` and pro
 an AES-256 key in `CacheEncryptionOptions.Key`. The `GranitCachingStackExchangeRedisModule` replaces
 the no-op `NullCacheValueEncryptor` with `AesCacheValueEncryptor` at startup.
 
-Each encryption operation generates a random 16-byte IV, prepended to the ciphertext.
+Each encryption operation generates a random 12-byte nonce and produces a 16-byte
+authentication tag. Ciphertext format: `[12B nonce][16B tag][NB ciphertext]`.
+Tampered values are detected and rejected via the GCM tag.
 
 :::caution
 The encryption key must be exactly 32 bytes (256 bits) when base64-decoded. In production,

--- a/docs-site/src/content/docs/dotnet/guides/configure-caching.mdx
+++ b/docs-site/src/content/docs/dotnet/guides/configure-caching.mdx
@@ -230,13 +230,15 @@ Use a consistent pattern: `{entity}:{identifier}` or `{module}:{scope}:{identifi
 
 ## Encryption configuration
 
-AES-256-CBC encryption protects values stored in Redis (L2 only). The L1
-in-memory cache stores plain .NET objects -- same threat model as `IMemoryCache`.
+AES-256-GCM authenticated encryption protects values stored in Redis (L2 only).
+The L1 in-memory cache stores plain .NET objects -- same threat model as `IMemoryCache`.
+GCM provides both confidentiality and integrity -- tampered cache values are detected
+and rejected via the 128-bit authentication tag.
 
 ### Global encryption
 
 Set `EncryptValues: true` in the `Cache` section. All values serialized to Redis
-are encrypted with AES-256-CBC via `EncryptingFusionCacheSerializer`.
+are encrypted with AES-256-GCM via `EncryptingFusionCacheSerializer`.
 
 ```json
 {

--- a/docs-site/src/content/docs/dotnet/guides/configure-idempotency.mdx
+++ b/docs-site/src/content/docs/dotnet/guides/configure-idempotency.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Configure Idempotency \u2014 Safe Retries"
-description: Add Stripe-style idempotency to Minimal API endpoints — Redis-backed state machine, SHA-256 composite keys, AES-256-CBC encryption, and safe retry handling for POST/PUT/PATCH requests.
+description: Add Stripe-style idempotency to Minimal API endpoints — Redis-backed state machine, SHA-256 composite keys, AES-256-GCM encryption, and safe retry handling for POST/PUT/PATCH requests.
 sidebar:
   order: 19
   label: Configure Idempotency
@@ -11,7 +11,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 Granit.Http.Idempotency provides Stripe-style HTTP idempotency for your API endpoints.
 When a client retries a request (network failure, timeout, double-click), the
 middleware returns the original response without re-executing the business logic.
-State is managed in Redis with atomic locks and AES-256-CBC encryption.
+State is managed in Redis with atomic locks and AES-256-GCM authenticated encryption.
 
 ## Prerequisites
 
@@ -156,7 +156,7 @@ Absent --(SET NX PX)--> InProgress --(SET XX PX)--> Completed
 2. **Execute handler**: The business logic runs with a `CancellationToken` that
    expires at `ExecutionTimeout`.
 3. **Store response**: On success, the response (status code, headers, body) is
-   encrypted with AES-256-CBC and stored with `CompletedTtl`.
+   encrypted with AES-256-GCM and stored with `CompletedTtl`.
 4. **On failure**: 5xx responses or exceptions release the lock so the client
    can retry.
 
@@ -192,7 +192,7 @@ change on every request, making the hash non-deterministic.
 
 - **Tenant isolation**: The Redis key includes `tenantId + userId`, preventing
   cross-tenant response replay even with identical idempotency keys.
-- **Encryption**: Cached responses are encrypted with AES-256-CBC via
+- **Encryption**: Cached responses are encrypted with AES-256-GCM via
   `ICacheValueEncryptor` (provided by `Granit.Caching`). This is mandatory for
   ISO 27001 compliance when response bodies contain health data.
 - **No side-channel**: The idempotency key is hashed before storage, preventing

--- a/docs-site/src/content/docs/dotnet/security/bff/architecture.mdx
+++ b/docs-site/src/content/docs/dotnet/security/bff/architecture.mdx
@@ -352,7 +352,7 @@ A clear picture of where each piece of sensitive data resides:
 The default `DistributedCacheBffTokenStore` uses `IDistributedCache` directly.
 For production deployments, enable Redis TLS and consider integrating
 [`Granit.Caching`](/dotnet/data/caching/) with `ICacheValueEncryptor`
-(AES-256-CBC) for encryption at rest. See the
+(AES-256-GCM) for encryption at rest. See the
 [Security](/dotnet/security/bff/token-security/) page for details.
 </Aside>
 

--- a/docs-site/src/content/docs/dotnet/security/bff/token-security.mdx
+++ b/docs-site/src/content/docs/dotnet/security/bff/token-security.mdx
@@ -298,7 +298,7 @@ internal sealed class EncryptedBffTokenStore(
         CancellationToken cancellationToken = default)
     {
         byte[] json = JsonSerializer.SerializeToUtf8Bytes(tokens);
-        byte[] encrypted = encryptor.Encrypt(json); // AES-256-CBC
+        byte[] encrypted = encryptor.Encrypt(json); // AES-256-GCM
 
         await cache.SetAsync(
             $"{KeyPrefix}{sessionId}",
@@ -334,9 +334,9 @@ Register it in DI to replace the default:
 services.AddScoped<IBffTokenStore, EncryptedBffTokenStore>();
 ```
 
-With `Granit.Caching`, the `AesCacheValueEncryptor` uses AES-256-CBC with a
-random IV per encryption call. The key is configured via `CachingOptions.EncryptionKey`
-(sourced from Vault in production).
+With `Granit.Caching`, the `AesCacheValueEncryptor` uses AES-256-GCM with a
+random nonce per encryption call and a 128-bit authentication tag for tamper detection.
+The key is configured via `CacheEncryptionOptions.Key` (sourced from Vault in production).
 
 </TabItem>
 </Tabs>

--- a/src/Granit.Caching.StackExchangeRedis/Extensions/RedisCachingServiceCollectionExtensions.cs
+++ b/src/Granit.Caching.StackExchangeRedis/Extensions/RedisCachingServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Granit.Caching.StackExchangeRedis.Internal;
 using Granit.Caching.StackExchangeRedis.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using StackExchange.Redis;
 using ZiggyCreatures.Caching.Fusion;
@@ -14,8 +15,14 @@ namespace Granit.Caching.StackExchangeRedis.Extensions;
 /// <summary>
 /// DI registration extensions for the Redis cache provider.
 /// </summary>
-public static class RedisCachingServiceCollectionExtensions
+public static partial class RedisCachingServiceCollectionExtensions
 {
+    [LoggerMessage(Level = LogLevel.Warning, Message =
+        "Redis distributed cache is active but Cache:EncryptValues is disabled — " +
+        "cached values are stored in plaintext in Redis. " +
+        "Set Cache:EncryptValues to true for production deployments")]
+    private static partial void LogCacheEncryptionDisabled(ILogger logger);
+
     /// <summary>
     /// Upgrades FusionCache with L2 Redis distributed cache and Redis pub/sub backplane.
     /// Enables AES-256 encryption (<see cref="AesCacheValueEncryptor"/>) when
@@ -55,13 +62,20 @@ public static class RedisCachingServiceCollectionExtensions
                 redis.InstanceName = granitOpts.Value.InstanceName;
             });
 
-        // Conditional AES-256 encryption: factory resolves at runtime based on CachingOptions.EncryptValues.
+        // Conditional AES-256-GCM encryption: factory resolves at runtime based on CachingOptions.EncryptValues.
         services.AddSingleton<ICacheValueEncryptor>(sp =>
         {
             CachingOptions cachingOpts = sp.GetRequiredService<IOptions<CachingOptions>>().Value;
             if (cachingOpts.EncryptValues)
             {
                 return ActivatorUtilities.CreateInstance<AesCacheValueEncryptor>(sp);
+            }
+
+            ILogger? logger = sp.GetService<ILoggerFactory>()
+                ?.CreateLogger(typeof(RedisCachingServiceCollectionExtensions));
+            if (logger is not null)
+            {
+                LogCacheEncryptionDisabled(logger);
             }
 
             return new NullCacheValueEncryptor();

--- a/src/Granit.Caching.StackExchangeRedis/Internal/RedisConditionalCache.cs
+++ b/src/Granit.Caching.StackExchangeRedis/Internal/RedisConditionalCache.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Granit.Caching.Internal;
 using Granit.Caching.Options;
 using Microsoft.Extensions.Options;
 using StackExchange.Redis;
@@ -50,7 +51,9 @@ internal sealed class RedisConditionalCache(
     private RedisValue Serialize<T>(T value)
     {
         byte[] json = JsonSerializer.SerializeToUtf8Bytes(value, _options.JsonOptions);
-        return _options.EncryptValues ? encryptor.Encrypt(json) : json;
+        return CacheEncryptionResolver.ShouldEncrypt(typeof(T), _options)
+            ? encryptor.Encrypt(json)
+            : json;
     }
 
     private T? Deserialize<T>(RedisValue raw)
@@ -61,7 +64,9 @@ internal sealed class RedisConditionalCache(
             return default;
         }
 
-        byte[] json = _options.EncryptValues ? encryptor.Decrypt(bytes) : bytes;
+        byte[] json = CacheEncryptionResolver.ShouldEncrypt(typeof(T), _options)
+            ? encryptor.Decrypt(bytes)
+            : bytes;
         return JsonSerializer.Deserialize<T>(json, _options.JsonOptions);
     }
 }

--- a/src/Granit.Caching/AesCacheValueEncryptor.cs
+++ b/src/Granit.Caching/AesCacheValueEncryptor.cs
@@ -5,14 +5,15 @@ using Microsoft.Extensions.Options;
 namespace Granit.Caching;
 
 /// <summary>
-/// AES-256-CBC implementation of <see cref="ICacheValueEncryptor"/> for ISO 27001 compliance.
+/// AES-256-GCM implementation of <see cref="ICacheValueEncryptor"/> for ISO 27001 compliance.
 /// </summary>
 /// <remarks>
 /// Security characteristics:
 /// <list type="bullet">
-///   <item>Algorithm: AES-256-CBC via <see cref="Aes.Create()"/></item>
-///   <item>IV: 16 bytes generated randomly by <see cref="RandomNumberGenerator.Fill"/> for each <see cref="Encrypt"/> call</item>
-///   <item>Ciphertext format: <c>[16 bytes IV][N bytes CipherText]</c></item>
+///   <item>Algorithm: AES-256-GCM (authenticated encryption — tamper detection via 128-bit tag)</item>
+///   <item>Nonce: 12 bytes generated randomly by <see cref="RandomNumberGenerator.Fill"/> for each <see cref="Encrypt"/> call</item>
+///   <item>Tag: 16 bytes (128-bit authentication tag, verified on <see cref="Decrypt"/>)</item>
+///   <item>Ciphertext format: <c>[12 bytes Nonce][16 bytes Tag][N bytes CipherText]</c></item>
 ///   <item>Key: 256 bits (32 bytes) provided as base64 via <c>Cache:Encryption:Key</c></item>
 /// </list>
 /// The AES key must be provided exclusively via Vault or secure configuration.
@@ -20,9 +21,11 @@ namespace Granit.Caching;
 /// </remarks>
 public sealed class AesCacheValueEncryptor(IOptions<CacheEncryptionOptions> options) : ICacheValueEncryptor
 {
-    private const int IvSizeBytes = 16;
+    private const int NonceSizeBytes = 12;
+    private const int TagSizeBytes = 16;
     private const int KeySizeBits = 256;
     private const int KeySizeBytes = KeySizeBits / 8;
+    private const int OverheadBytes = NonceSizeBytes + TagSizeBytes;
 
     private readonly byte[] _key = ParseAndValidateKey(options.Value.Key);
 
@@ -48,60 +51,60 @@ public sealed class AesCacheValueEncryptor(IOptions<CacheEncryptionOptions> opti
     }
 
     /// <summary>
-    /// Encrypts the provided data using AES-256-CBC with a random IV.
+    /// Encrypts the provided data using AES-256-GCM with a random nonce.
     /// </summary>
     /// <param name="plaintext">The plaintext data.</param>
-    /// <returns>Data in the format <c>[16 bytes IV][N bytes CipherText]</c>.</returns>
+    /// <returns>Data in the format <c>[12 bytes Nonce][16 bytes Tag][N bytes CipherText]</c>.</returns>
     public byte[] Encrypt(byte[] plaintext)
     {
-        byte[] iv = new byte[IvSizeBytes];
-        RandomNumberGenerator.Fill(iv);
+        byte[] nonce = new byte[NonceSizeBytes];
+        RandomNumberGenerator.Fill(nonce);
 
-        using var aes = Aes.Create();
-        aes.Key = _key;
-        aes.IV = iv;
-        aes.Mode = CipherMode.CBC;
-        aes.Padding = PaddingMode.PKCS7;
+        byte[] ciphertext = new byte[plaintext.Length];
+        byte[] tag = new byte[TagSizeBytes];
 
-        using ICryptoTransform encryptor = aes.CreateEncryptor();
-        byte[] ciphertext = encryptor.TransformFinalBlock(plaintext, 0, plaintext.Length);
+        using var aesGcm = new AesGcm(_key, TagSizeBytes);
+        aesGcm.Encrypt(nonce, plaintext, ciphertext, tag);
 
-        byte[] result = new byte[IvSizeBytes + ciphertext.Length];
-        Buffer.BlockCopy(iv, 0, result, 0, IvSizeBytes);
-        Buffer.BlockCopy(ciphertext, 0, result, IvSizeBytes, ciphertext.Length);
+        byte[] result = new byte[OverheadBytes + ciphertext.Length];
+        Buffer.BlockCopy(nonce, 0, result, 0, NonceSizeBytes);
+        Buffer.BlockCopy(tag, 0, result, NonceSizeBytes, TagSizeBytes);
+        Buffer.BlockCopy(ciphertext, 0, result, OverheadBytes, ciphertext.Length);
 
         return result;
     }
 
     /// <summary>
-    /// Decrypts data in the format <c>[16 bytes IV][N bytes CipherText]</c>.
+    /// Decrypts data in the format <c>[12 bytes Nonce][16 bytes Tag][N bytes CipherText]</c>.
+    /// Throws <see cref="CryptographicException"/> if the authentication tag is invalid (tampered data).
     /// </summary>
     /// <param name="ciphertext">The encrypted data.</param>
     /// <returns>The decrypted data.</returns>
-    /// <exception cref="ArgumentException">Thrown when the ciphertext is too short (fewer than 16 bytes).</exception>
+    /// <exception cref="ArgumentException">Thrown when the ciphertext is too short.</exception>
+    /// <exception cref="CryptographicException">Thrown when the authentication tag is invalid (tampered data).</exception>
     public byte[] Decrypt(byte[] ciphertext)
     {
-        if (ciphertext.Length < IvSizeBytes)
+        if (ciphertext.Length < OverheadBytes)
         {
             throw new ArgumentException(
-                $"Invalid ciphertext: minimum {IvSizeBytes} bytes required (IV), " +
+                $"Invalid ciphertext: minimum {OverheadBytes} bytes required (nonce + tag), " +
                 $"received {ciphertext.Length} bytes.");
         }
 
-        byte[] iv = new byte[IvSizeBytes];
-        Buffer.BlockCopy(ciphertext, 0, iv, 0, IvSizeBytes);
+        byte[] nonce = new byte[NonceSizeBytes];
+        Buffer.BlockCopy(ciphertext, 0, nonce, 0, NonceSizeBytes);
 
-        int cipherLength = ciphertext.Length - IvSizeBytes;
+        byte[] tag = new byte[TagSizeBytes];
+        Buffer.BlockCopy(ciphertext, NonceSizeBytes, tag, 0, TagSizeBytes);
+
+        int cipherLength = ciphertext.Length - OverheadBytes;
         byte[] cipher = new byte[cipherLength];
-        Buffer.BlockCopy(ciphertext, IvSizeBytes, cipher, 0, cipherLength);
+        Buffer.BlockCopy(ciphertext, OverheadBytes, cipher, 0, cipherLength);
 
-        using var aes = Aes.Create();
-        aes.Key = _key;
-        aes.IV = iv;
-        aes.Mode = CipherMode.CBC;
-        aes.Padding = PaddingMode.PKCS7;
+        byte[] plaintext = new byte[cipherLength];
+        using var aesGcm = new AesGcm(_key, TagSizeBytes);
+        aesGcm.Decrypt(nonce, cipher, tag, plaintext);
 
-        using ICryptoTransform decryptor = aes.CreateDecryptor();
-        return decryptor.TransformFinalBlock(cipher, 0, cipher.Length);
+        return plaintext;
     }
 }

--- a/src/Granit.Caching/Extensions/CachingServiceCollectionExtensions.cs
+++ b/src/Granit.Caching/Extensions/CachingServiceCollectionExtensions.cs
@@ -96,13 +96,13 @@ public static class CachingServiceCollectionExtensions
                     fc.EnableAutoRecovery = true;
                 });
 
-        // Replace the serializer with the encrypting decorator
+        // Replace the serializer with the encrypting decorator (per-type via CacheEncryptionResolver)
         services.AddSingleton<ZiggyCreatures.Caching.Fusion.Serialization.IFusionCacheSerializer>(sp =>
         {
             CachingOptions cachingOpts = sp.GetRequiredService<IOptions<CachingOptions>>().Value;
             ICacheValueEncryptor encryptor = sp.GetRequiredService<ICacheValueEncryptor>();
             var jsonSerializer = new FusionCacheSystemTextJsonSerializer(cachingOpts.JsonOptions);
-            return new EncryptingFusionCacheSerializer(jsonSerializer, encryptor, cachingOpts.EncryptValues);
+            return new EncryptingFusionCacheSerializer(jsonSerializer, encryptor, cachingOpts);
         });
 
         return services;

--- a/src/Granit.Caching/ICacheValueEncryptor.cs
+++ b/src/Granit.Caching/ICacheValueEncryptor.cs
@@ -8,7 +8,7 @@ namespace Granit.Caching;
 /// Two implementations are provided:
 /// <list type="bullet">
 ///   <item><see cref="NullCacheValueEncryptor"/> — no-op, used in development with the Memory provider.</item>
-///   <item><see cref="AesCacheValueEncryptor"/> — AES-256-CBC with a random IV, used in production with Redis.</item>
+///   <item><see cref="AesCacheValueEncryptor"/> — AES-256-GCM (authenticated encryption) with a random nonce, used in production with Redis.</item>
 /// </list>
 /// Encryption is enabled per type via <see cref="CacheEncryptedAttribute"/> or globally via
 /// <see cref="CachingOptions.EncryptValues"/>.
@@ -16,14 +16,15 @@ namespace Granit.Caching;
 public interface ICacheValueEncryptor
 {
     /// <summary>
-    /// Encrypts the provided bytes. Generates a random IV per call (AES-256-CBC).
+    /// Encrypts the provided bytes. Generates a random nonce per call (AES-256-GCM).
     /// </summary>
     /// <param name="plaintext">Plaintext data (serialized JSON).</param>
-    /// <returns>Encrypted data in the format <c>[16 bytes IV][N bytes CipherText]</c>.</returns>
+    /// <returns>Encrypted data in the format <c>[12 bytes Nonce][16 bytes Tag][N bytes CipherText]</c>.</returns>
     byte[] Encrypt(byte[] plaintext);
 
     /// <summary>
-    /// Decrypts the provided bytes in the format <c>[16 bytes IV][N bytes CipherText]</c>.
+    /// Decrypts the provided bytes in the format <c>[12 bytes Nonce][16 bytes Tag][N bytes CipherText]</c>.
+    /// Throws <see cref="System.Security.Cryptography.CryptographicException"/> if the data has been tampered with.
     /// </summary>
     /// <param name="ciphertext">Encrypted data.</param>
     /// <returns>Decrypted data (serialized JSON).</returns>

--- a/src/Granit.Caching/Internal/CacheEncryptionResolver.cs
+++ b/src/Granit.Caching/Internal/CacheEncryptionResolver.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using Granit.Caching.Options;
 
@@ -6,9 +7,12 @@ namespace Granit.Caching.Internal;
 /// <summary>
 /// Resolves whether AES encryption should be applied for a given type.
 /// Considers the <see cref="CacheEncryptedAttribute"/> attribute and the global <see cref="CachingOptions.EncryptValues"/> flag.
+/// Results are cached per type to avoid repeated reflection.
 /// </summary>
 internal static class CacheEncryptionResolver
 {
+    private static readonly ConcurrentDictionary<Type, bool?> s_attributeCache = new();
+
     /// <summary>
     /// Determines whether values of type <paramref name="type"/> should be encrypted.
     /// </summary>
@@ -17,10 +21,10 @@ internal static class CacheEncryptionResolver
     /// <returns><c>true</c> if encryption should be applied.</returns>
     internal static bool ShouldEncrypt(Type type, CachingOptions options)
     {
-        CacheEncryptedAttribute? attribute = type.GetCustomAttribute<CacheEncryptedAttribute>();
+        bool? attributeValue = s_attributeCache.GetOrAdd(
+            type,
+            static t => t.GetCustomAttribute<CacheEncryptedAttribute>()?.Encrypt);
 
-        return attribute is not null
-            ? attribute.Encrypt
-            : options.EncryptValues;
+        return attributeValue ?? options.EncryptValues;
     }
 }

--- a/src/Granit.Caching/Internal/EncryptingFusionCacheSerializer.cs
+++ b/src/Granit.Caching/Internal/EncryptingFusionCacheSerializer.cs
@@ -1,9 +1,10 @@
+using Granit.Caching.Options;
 using ZiggyCreatures.Caching.Fusion.Serialization;
 
 namespace Granit.Caching.Internal;
 
 /// <summary>
-/// Decorator that applies AES-256-CBC encryption on top of an inner <see cref="IFusionCacheSerializer"/>.
+/// Decorator that applies AES-256-GCM encryption on top of an inner <see cref="IFusionCacheSerializer"/>.
 /// Used as the FusionCache serializer for the distributed L2 cache (Redis).
 /// </summary>
 /// <remarks>
@@ -12,29 +13,35 @@ namespace Granit.Caching.Internal;
 /// The L1 in-memory cache stores plain .NET objects — same threat model as <c>IMemoryCache</c>.
 /// </para>
 /// <para>
-/// When <paramref name="encrypt"/> is <c>false</c>, the decorator is a transparent pass-through.
+/// Per-type encryption is resolved by <see cref="CacheEncryptionResolver"/>:
+/// types decorated with <see cref="CacheEncryptedAttribute"/> override the global
+/// <see cref="CachingOptions.EncryptValues"/> flag.
 /// </para>
 /// </remarks>
 internal sealed class EncryptingFusionCacheSerializer(
     IFusionCacheSerializer inner,
     ICacheValueEncryptor encryptor,
-    bool encrypt) : IFusionCacheSerializer
+    CachingOptions options) : IFusionCacheSerializer
 {
     private readonly IFusionCacheSerializer _inner = inner;
     private readonly ICacheValueEncryptor _encryptor = encryptor;
-    private readonly bool _encrypt = encrypt;
+    private readonly CachingOptions _options = options;
 
     /// <inheritdoc/>
     public byte[] Serialize<T>(T? obj)
     {
         byte[] serialized = _inner.Serialize(obj);
-        return _encrypt ? _encryptor.Encrypt(serialized) : serialized;
+        return CacheEncryptionResolver.ShouldEncrypt(typeof(T), _options)
+            ? _encryptor.Encrypt(serialized)
+            : serialized;
     }
 
     /// <inheritdoc/>
     public T? Deserialize<T>(byte[] data)
     {
-        byte[] plain = _encrypt ? _encryptor.Decrypt(data) : data;
+        byte[] plain = CacheEncryptionResolver.ShouldEncrypt(typeof(T), _options)
+            ? _encryptor.Decrypt(data)
+            : data;
         return _inner.Deserialize<T>(plain);
     }
 
@@ -42,14 +49,18 @@ internal sealed class EncryptingFusionCacheSerializer(
     public ValueTask<byte[]> SerializeAsync<T>(T? obj, CancellationToken token = default)
     {
         byte[] serialized = _inner.Serialize(obj);
-        byte[] result = _encrypt ? _encryptor.Encrypt(serialized) : serialized;
+        byte[] result = CacheEncryptionResolver.ShouldEncrypt(typeof(T), _options)
+            ? _encryptor.Encrypt(serialized)
+            : serialized;
         return new ValueTask<byte[]>(result);
     }
 
     /// <inheritdoc/>
     public ValueTask<T?> DeserializeAsync<T>(byte[] data, CancellationToken token = default)
     {
-        byte[] plain = _encrypt ? _encryptor.Decrypt(data) : data;
+        byte[] plain = CacheEncryptionResolver.ShouldEncrypt(typeof(T), _options)
+            ? _encryptor.Decrypt(data)
+            : data;
         T? result = _inner.Deserialize<T>(plain);
         return new ValueTask<T?>(result);
     }

--- a/src/Granit.Caching/Internal/InMemoryConditionalCache.cs
+++ b/src/Granit.Caching/Internal/InMemoryConditionalCache.cs
@@ -18,18 +18,19 @@ internal sealed class InMemoryConditionalCache(TimeProvider timeProvider) : ICon
     /// <inheritdoc/>
     public Task<bool> SetIfAbsentAsync<T>(string key, T value, TimeSpan ttl, CancellationToken cancellationToken)
     {
-        Cleanup();
-        DateTimeOffset expiresAt = timeProvider.GetUtcNow() + ttl;
-
-        // ConcurrentDictionary.TryAdd is atomic for the "absent" case.
-        // If the key exists but is expired, remove it first then try again.
-        if (_store.TryGetValue(key, out (object? Value, DateTimeOffset ExpiresAt) existing) && timeProvider.GetUtcNow() >= existing.ExpiresAt)
+        lock (_lock)
         {
-            _store.TryRemove(key, out _);
-        }
+            Cleanup();
+            DateTimeOffset expiresAt = timeProvider.GetUtcNow() + ttl;
 
-        bool added = _store.TryAdd(key, (value, expiresAt));
-        return Task.FromResult(added);
+            if (_store.TryGetValue(key, out (object? Value, DateTimeOffset ExpiresAt) existing) && timeProvider.GetUtcNow() >= existing.ExpiresAt)
+            {
+                _store.TryRemove(key, out _);
+            }
+
+            bool added = _store.TryAdd(key, (value, expiresAt));
+            return Task.FromResult(added);
+        }
     }
 
     /// <inheritdoc/>

--- a/tests/Granit.Caching.FusionCache.Tests/EncryptingFusionCacheSerializerAdditionalTests.cs
+++ b/tests/Granit.Caching.FusionCache.Tests/EncryptingFusionCacheSerializerAdditionalTests.cs
@@ -1,4 +1,5 @@
 using Granit.Caching.Internal;
+using Granit.Caching.Options;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -11,11 +12,14 @@ public sealed class EncryptingFusionCacheSerializerAdditionalTests
 {
     private readonly FusionCacheSystemTextJsonSerializer _innerSerializer = new();
 
+    private static CachingOptions EncryptionEnabled() => new() { EncryptValues = true };
+    private static CachingOptions EncryptionDisabled() => new();
+
     [Fact]
     public void Deserialize_WithEncryptionDisabled_PassesThroughWithoutDecryption()
     {
         ICacheValueEncryptor encryptor = Substitute.For<ICacheValueEncryptor>();
-        EncryptingFusionCacheSerializer sut = new(_innerSerializer, encryptor, encrypt: false);
+        EncryptingFusionCacheSerializer sut = new(_innerSerializer, encryptor, EncryptionDisabled());
 
         byte[] serialized = _innerSerializer.Serialize("hello");
         string? result = sut.Deserialize<string>(serialized);
@@ -28,7 +32,7 @@ public sealed class EncryptingFusionCacheSerializerAdditionalTests
     public async Task SerializeAsync_WithEncryptionDisabled_PassesThroughWithoutEncryption()
     {
         ICacheValueEncryptor encryptor = Substitute.For<ICacheValueEncryptor>();
-        EncryptingFusionCacheSerializer sut = new(_innerSerializer, encryptor, encrypt: false);
+        EncryptingFusionCacheSerializer sut = new(_innerSerializer, encryptor, EncryptionDisabled());
 
         byte[] expected = _innerSerializer.Serialize("async-passthrough");
         byte[] result = await sut.SerializeAsync("async-passthrough", TestContext.Current.CancellationToken);
@@ -41,7 +45,7 @@ public sealed class EncryptingFusionCacheSerializerAdditionalTests
     public async Task DeserializeAsync_WithEncryptionDisabled_PassesThroughWithoutDecryption()
     {
         ICacheValueEncryptor encryptor = Substitute.For<ICacheValueEncryptor>();
-        EncryptingFusionCacheSerializer sut = new(_innerSerializer, encryptor, encrypt: false);
+        EncryptingFusionCacheSerializer sut = new(_innerSerializer, encryptor, EncryptionDisabled());
 
         byte[] serialized = _innerSerializer.Serialize(42);
         int? result = await sut.DeserializeAsync<int>(serialized, TestContext.Current.CancellationToken);
@@ -54,11 +58,11 @@ public sealed class EncryptingFusionCacheSerializerAdditionalTests
     public async Task DeserializeAsync_WithEncryptionEnabled_CallsDecrypt()
     {
         ICacheValueEncryptor encryptor = new AesCacheValueEncryptor(
-            Microsoft.Extensions.Options.Options.Create(new Caching.Options.CacheEncryptionOptions
+            Microsoft.Extensions.Options.Options.Create(new CacheEncryptionOptions
             {
                 Key = Convert.ToBase64String(System.Security.Cryptography.RandomNumberGenerator.GetBytes(32))
             }));
-        EncryptingFusionCacheSerializer sut = new(_innerSerializer, encryptor, encrypt: true);
+        EncryptingFusionCacheSerializer sut = new(_innerSerializer, encryptor, EncryptionEnabled());
 
         byte[] encrypted = await sut.SerializeAsync("decrypt-test", TestContext.Current.CancellationToken);
         string? result = await sut.DeserializeAsync<string>(encrypted, TestContext.Current.CancellationToken);
@@ -78,7 +82,7 @@ public sealed class EncryptingFusionCacheSerializerAdditionalTests
         ICacheValueEncryptor encryptor = Substitute.For<ICacheValueEncryptor>();
         encryptor.Encrypt(plainBytes).Returns(encryptedBytes);
 
-        EncryptingFusionCacheSerializer sut = new(inner, encryptor, encrypt: true);
+        EncryptingFusionCacheSerializer sut = new(inner, encryptor, EncryptionEnabled());
 
         byte[] result = sut.Serialize("test");
 
@@ -98,7 +102,7 @@ public sealed class EncryptingFusionCacheSerializerAdditionalTests
         ICacheValueEncryptor encryptor = Substitute.For<ICacheValueEncryptor>();
         encryptor.Decrypt(encryptedBytes).Returns(plainBytes);
 
-        EncryptingFusionCacheSerializer sut = new(inner, encryptor, encrypt: true);
+        EncryptingFusionCacheSerializer sut = new(inner, encryptor, EncryptionEnabled());
 
         string? result = sut.Deserialize<string>(encryptedBytes);
 
@@ -110,7 +114,7 @@ public sealed class EncryptingFusionCacheSerializerAdditionalTests
     public void RoundTrip_NullValue_PreservesNull()
     {
         ICacheValueEncryptor encryptor = new NullCacheValueEncryptor();
-        EncryptingFusionCacheSerializer sut = new(_innerSerializer, encryptor, encrypt: false);
+        EncryptingFusionCacheSerializer sut = new(_innerSerializer, encryptor, EncryptionDisabled());
 
         byte[] serialized = sut.Serialize<string?>(null);
         string? result = sut.Deserialize<string?>(serialized);

--- a/tests/Granit.Caching.FusionCache.Tests/EncryptingFusionCacheSerializerTests.cs
+++ b/tests/Granit.Caching.FusionCache.Tests/EncryptingFusionCacheSerializerTests.cs
@@ -1,5 +1,6 @@
 using Granit.Caching;
 using Granit.Caching.Internal;
+using Granit.Caching.Options;
 using Shouldly;
 using Xunit;
 using ZiggyCreatures.Caching.Fusion.Serialization;
@@ -11,27 +12,30 @@ public sealed class EncryptingFusionCacheSerializerTests
 {
     private readonly FusionCacheSystemTextJsonSerializer _innerSerializer = new();
     private readonly ICacheValueEncryptor _encryptor = new AesCacheValueEncryptor(
-        Microsoft.Extensions.Options.Options.Create(new Granit.Caching.Options.CacheEncryptionOptions
+        Microsoft.Extensions.Options.Options.Create(new CacheEncryptionOptions
         {
             Key = Convert.ToBase64String(System.Security.Cryptography.RandomNumberGenerator.GetBytes(32))
         }));
 
+    private static CachingOptions EncryptionEnabled() => new() { EncryptValues = true };
+    private static CachingOptions EncryptionDisabled() => new();
+
     [Fact]
     public void Serialize_WithEncryptionEnabled_EncryptsData()
     {
-        var sut = new EncryptingFusionCacheSerializer(_innerSerializer, _encryptor, encrypt: true);
+        var sut = new EncryptingFusionCacheSerializer(_innerSerializer, _encryptor, EncryptionEnabled());
         byte[] plain = _innerSerializer.Serialize("hello");
 
         byte[] encrypted = sut.Serialize("hello");
 
         encrypted.ShouldNotBe(plain);
-        encrypted.Length.ShouldBeGreaterThan(plain.Length); // IV + ciphertext overhead
+        encrypted.Length.ShouldBeGreaterThan(plain.Length); // nonce + tag overhead
     }
 
     [Fact]
     public void Deserialize_WithEncryptionEnabled_DecryptsData()
     {
-        var sut = new EncryptingFusionCacheSerializer(_innerSerializer, _encryptor, encrypt: true);
+        var sut = new EncryptingFusionCacheSerializer(_innerSerializer, _encryptor, EncryptionEnabled());
 
         byte[] encrypted = sut.Serialize("hello");
         string? result = sut.Deserialize<string>(encrypted);
@@ -42,7 +46,7 @@ public sealed class EncryptingFusionCacheSerializerTests
     [Fact]
     public void Serialize_WithEncryptionDisabled_PassesThrough()
     {
-        var sut = new EncryptingFusionCacheSerializer(_innerSerializer, _encryptor, encrypt: false);
+        var sut = new EncryptingFusionCacheSerializer(_innerSerializer, _encryptor, EncryptionDisabled());
         byte[] plain = _innerSerializer.Serialize("hello");
 
         byte[] result = sut.Serialize("hello");
@@ -53,7 +57,7 @@ public sealed class EncryptingFusionCacheSerializerTests
     [Fact]
     public void RoundTrip_ComplexObject_PreservesData()
     {
-        var sut = new EncryptingFusionCacheSerializer(_innerSerializer, _encryptor, encrypt: true);
+        var sut = new EncryptingFusionCacheSerializer(_innerSerializer, _encryptor, EncryptionEnabled());
         var original = new TestCacheItem { Name = "test", Value = 42 };
 
         byte[] encrypted = sut.Serialize(original);
@@ -67,7 +71,7 @@ public sealed class EncryptingFusionCacheSerializerTests
     [Fact]
     public async Task SerializeAsync_WithEncryption_EncryptsData()
     {
-        var sut = new EncryptingFusionCacheSerializer(_innerSerializer, _encryptor, encrypt: true);
+        var sut = new EncryptingFusionCacheSerializer(_innerSerializer, _encryptor, EncryptionEnabled());
 
         byte[] encrypted = await sut.SerializeAsync("async-test", TestContext.Current.CancellationToken);
         string? result = await sut.DeserializeAsync<string>(encrypted, TestContext.Current.CancellationToken);
@@ -75,9 +79,30 @@ public sealed class EncryptingFusionCacheSerializerTests
         result.ShouldBe("async-test");
     }
 
+    [Fact]
+    public void Serialize_PerTypeAttribute_OverridesGlobalFlag()
+    {
+        // Arrange — global encryption disabled, but [CacheEncrypted] on the type
+        var sut = new EncryptingFusionCacheSerializer(_innerSerializer, _encryptor, EncryptionDisabled());
+        byte[] plain = _innerSerializer.Serialize(new AlwaysEncryptedItem { Data = "sensitive" });
+
+        // Act
+        byte[] result = sut.Serialize(new AlwaysEncryptedItem { Data = "sensitive" });
+
+        // Assert — [CacheEncrypted] should force encryption even with EncryptValues=false
+        result.ShouldNotBe(plain);
+        result.Length.ShouldBeGreaterThan(plain.Length);
+    }
+
     private sealed class TestCacheItem
     {
         public string Name { get; set; } = string.Empty;
         public int Value { get; set; }
+    }
+
+    [CacheEncrypted]
+    private sealed class AlwaysEncryptedItem
+    {
+        public string Data { get; set; } = string.Empty;
     }
 }

--- a/tests/Granit.Caching.Tests/AesCacheValueEncryptorAdditionalTests.cs
+++ b/tests/Granit.Caching.Tests/AesCacheValueEncryptorAdditionalTests.cs
@@ -58,17 +58,17 @@ public sealed class AesCacheValueEncryptorAdditionalTests
     }
 
     [Fact]
-    public void Encrypt_OutputLength_IsIvPlusCiphertext()
+    public void Encrypt_OutputLength_IsNoncePlusTagPlusCiphertext()
     {
-        // Arrange — AES-CBC with PKCS7 padding adds up to 16 bytes
+        // Arrange — AES-GCM : pas de padding, ciphertext.Length == plaintext.Length
         AesCacheValueEncryptor encryptor = CreateEncryptor();
         byte[] plaintext = "test data"u8.ToArray();
 
         // Act
         byte[] ciphertext = encryptor.Encrypt(plaintext);
 
-        // Assert — [16 bytes IV] + [at least 1 block of ciphertext]
-        ciphertext.Length.ShouldBeGreaterThanOrEqualTo(16 + 16);
+        // Assert — [12 bytes Nonce] + [16 bytes Tag] + [plaintext.Length bytes CipherText]
+        ciphertext.Length.ShouldBe(12 + 16 + plaintext.Length);
     }
 
     [Fact]
@@ -86,15 +86,31 @@ public sealed class AesCacheValueEncryptorAdditionalTests
     }
 
     [Fact]
-    public void Decrypt_ExactlyIvSize_EmptyCiphertextBody_ReturnsEmpty()
+    public void Decrypt_TamperedTag_ThrowsCryptographicException()
     {
-        // Arrange — 16 bytes is exactly IV size, empty ciphertext body
-        // AES-CBC with PKCS7 padding: TransformFinalBlock with 0 bytes returns empty
+        // Arrange — flip a bit in the authentication tag (bytes 12-27)
         AesCacheValueEncryptor encryptor = CreateEncryptor();
-        byte[] exactIvSize = new byte[16];
+        byte[] plaintext = "tag integrity check"u8.ToArray();
+        byte[] ciphertext = encryptor.Encrypt(plaintext);
 
-        // Act — should not throw ArgumentException (ciphertext.Length >= IvSizeBytes passes)
-        byte[] result = encryptor.Decrypt(exactIvSize);
+        ciphertext[15] ^= 0x01; // tamper with tag byte
+
+        // Act & Assert — GCM tag validation must detect tampering
+        Should.Throw<CryptographicException>(() => encryptor.Decrypt(ciphertext));
+    }
+
+    [Fact]
+    public void Decrypt_ExactlyOverhead_EmptyCiphertextBody_ReturnsEmpty()
+    {
+        // Arrange — encrypt an empty plaintext, then decrypt
+        AesCacheValueEncryptor encryptor = CreateEncryptor();
+        byte[] ciphertext = encryptor.Encrypt([]);
+
+        // Assert — overhead only: 12 (nonce) + 16 (tag) + 0 (ciphertext)
+        ciphertext.Length.ShouldBe(28);
+
+        // Act
+        byte[] result = encryptor.Decrypt(ciphertext);
 
         // Assert
         result.ShouldBeEmpty();

--- a/tests/Granit.Caching.Tests/AesCacheValueEncryptorTests.cs
+++ b/tests/Granit.Caching.Tests/AesCacheValueEncryptorTests.cs
@@ -1,10 +1,11 @@
 // =============================================================================
 // Tests - AesCacheValueEncryptor
 // =============================================================================
-// Vérifie que le chiffrement/déchiffrement AES-256-CBC fonctionne correctement :
+// Vérifie que le chiffrement/déchiffrement AES-256-GCM fonctionne correctement :
 //   - Encrypt(Decrypt(x)) == x (round-trip)
-//   - IV aléatoire : deux chiffrements du même plaintext donnent des ciphertexts différents
+//   - Nonce aléatoire : deux chiffrements du même plaintext donnent des ciphertexts différents
 //   - Rejet d'une clé invalide (taille != 32 octets)
+//   - Détection de falsification via le tag d'authentification GCM
 // =============================================================================
 
 using System.Security.Cryptography;
@@ -48,7 +49,7 @@ public sealed class AesCacheValueEncryptorTests
     [Fact]
     public void Encrypt_SamePlaintext_ProducesDifferentCiphertexts()
     {
-        // Arrange — IV aléatoire par opération (Gemini: jamais de IV hardcodé)
+        // Arrange — nonce aléatoire par opération
         AesCacheValueEncryptor encryptor = CreateEncryptor();
         byte[] plaintext = "test stampede ISO27001"u8.ToArray();
 
@@ -57,21 +58,21 @@ public sealed class AesCacheValueEncryptorTests
         byte[] cipher2 = encryptor.Encrypt(plaintext);
 
         // Assert
-        cipher1.ShouldNotBe(cipher2, "l'IV aléatoire doit produire des ciphertexts distincts");
+        cipher1.ShouldNotBe(cipher2, "le nonce aléatoire doit produire des ciphertexts distincts");
     }
 
     [Fact]
-    public void Decrypt_CiphertextPrefixedWithIv_ExtractsCorrectIv()
+    public void Encrypt_OutputFormat_ContainsNonceAndTag()
     {
-        // Arrange — format : [16 octets IV][N octets CipherText]
+        // Arrange — format : [12 octets Nonce][16 octets Tag][N octets CipherText]
         AesCacheValueEncryptor encryptor = CreateEncryptor();
-        byte[] plaintext = "vérification format IV"u8.ToArray();
+        byte[] plaintext = "vérification format nonce+tag"u8.ToArray();
 
         // Act
         byte[] ciphertext = encryptor.Encrypt(plaintext);
 
-        // Assert — le ciphertext doit être plus long que l'IV seul (16 octets)
-        ciphertext.Length.ShouldBeGreaterThan(16);
+        // Assert — le ciphertext doit être plus long que l'overhead (28 octets)
+        ciphertext.Length.ShouldBeGreaterThan(28);
     }
 
     [Fact]
@@ -118,16 +119,34 @@ public sealed class AesCacheValueEncryptorTests
     }
 
     [Fact]
-    public void Decrypt_CiphertextShorterThan16Bytes_ThrowsArgumentException()
+    public void Decrypt_CiphertextShorterThanOverhead_ThrowsArgumentException()
     {
-        // Arrange — ciphertext invalide : moins de 16 octets (taille de l'IV)
+        // Arrange — ciphertext invalide : moins de 28 octets (nonce 12 + tag 16)
         AesCacheValueEncryptor encryptor = CreateEncryptor();
-        byte[] tooShort = new byte[10];
+        byte[] tooShort = new byte[20];
 
         // Act
         Action act = () => encryptor.Decrypt(tooShort);
 
         // Assert
-        Should.Throw<ArgumentException>(act).Message.ShouldContain("16");
+        Should.Throw<ArgumentException>(act).Message.ShouldContain("28");
+    }
+
+    [Fact]
+    public void Decrypt_TamperedCiphertext_ThrowsCryptographicException()
+    {
+        // Arrange — GCM détecte la falsification via le tag d'authentification
+        AesCacheValueEncryptor encryptor = CreateEncryptor();
+        byte[] plaintext = "données intègres"u8.ToArray();
+        byte[] ciphertext = encryptor.Encrypt(plaintext);
+
+        // Tamper with the ciphertext body (after nonce+tag, byte index 28+)
+        if (ciphertext.Length > 28)
+        {
+            ciphertext[28] ^= 0xFF;
+        }
+
+        // Act & Assert
+        Should.Throw<CryptographicException>(() => encryptor.Decrypt(ciphertext));
     }
 }


### PR DESCRIPTION
## Summary

- **AES-256-CBC → AES-256-GCM**: `AesCacheValueEncryptor` now uses authenticated encryption (128-bit tag) — tampered cache values in Redis are detected and rejected (`CryptographicException`)
- **`[CacheEncrypted]` attribute activated**: `CacheEncryptionResolver` is now wired into `EncryptingFusionCacheSerializer` and `RedisConditionalCache` — per-type encryption works at runtime (was dead code before)
- **TOCTOU race fix**: `InMemoryConditionalCache.SetIfAbsentAsync` wrapped in `lock` to prevent race between check-remove-add
- **Startup warning**: `[LoggerMessage]` warning when Redis is active but `Cache:EncryptValues` is disabled
- **Docs updated**: 9 pages updated from CBC → GCM references (caching, idempotency, BFF, ADR, patterns)

## Security findings addressed

| ID | Severity | Title |
|----|----------|-------|
| VULN-100 | HIGH | AES-CBC without authenticated encryption |
| VULN-101 | HIGH | `[CacheEncrypted]` attribute dead code |
| VULN-200 | MEDIUM | Encryption disabled by default with no warning |
| VULN-201 | MEDIUM | `RedisConditionalCache` ignores `[CacheEncrypted]` |
| VULN-300 | LOW | TOCTOU race in `InMemoryConditionalCache` |

## Breaking changes

- Ciphertext format changes from `[16B IV][NB ciphertext]` to `[12B nonce][16B tag][NB ciphertext]` — existing encrypted values in Redis become unreadable after deploy. **Cache flush required** (values auto-repopulate via FusionCache factories).
- `EncryptingFusionCacheSerializer` constructor signature changes from `bool encrypt` to `CachingOptions options` (internal class — no public API break).

## Test plan

- [x] 98/98 caching tests pass (58 + 15 + 25)
- [x] New tamper detection tests (GCM tag validation, bit-flip, wrong key)
- [x] New `[CacheEncrypted]` per-type integration test
- [x] `dotnet format --verify-no-changes` clean
- [x] markdownlint clean on updated docs
