### PR TITLE
docs(bff,blob-storage): clarify security comments and refresh lock files

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -305,6 +305,7 @@
       "name": "Granit.Bff.EntityFrameworkCore",
       "deps": [
         "Granit.Bff",
+        "Granit.Encryption",
         "Granit.Guids",
         "Granit.Persistence"
       ],
@@ -363,6 +364,7 @@
         "Granit.Authorization",
         "Granit.BlobStorage",
         "Granit.QueryEngine.Endpoints",
+        "Granit.RateLimiting",
         "Granit.Validation"
       ],
       "framework": "net10.0"
@@ -7060,7 +7062,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage.Endpoints",
       "file": "src/Granit.BlobStorage.Endpoints/GranitBlobStorageEndpointsModule.cs",
-      "line": 16,
+      "line": 18,
       "members": []
     },
     {
@@ -7346,7 +7348,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage",
       "file": "src/Granit.BlobStorage/GranitBlobStorageModule.cs",
-      "line": 24,
+      "line": 25,
       "members": [
         {
           "name": "ConfigureServices",
@@ -7556,6 +7558,12 @@
           "kind": "method",
           "signature": "FromMinutes(5)",
           "returnType": "TimeSpan DownloadUrlExpiry { get; set; } = TimeSpan."
+        },
+        {
+          "name": "AllowedContentTypes",
+          "kind": "property",
+          "signature": "HashSet<string> AllowedContentTypes",
+          "returnType": "HashSet<string>"
         }
       ]
     },
@@ -7800,7 +7808,7 @@
       "kind": "class",
       "project": "Granit.BlobStorage",
       "file": "src/Granit.BlobStorage/Validators/MagicBytesValidator.cs",
-      "line": 18,
+      "line": 21,
       "members": [
         {
           "name": "Order",
@@ -7844,7 +7852,7 @@
       "kind": "class",
       "project": "Granit.Caching",
       "file": "src/Granit.Caching/AesCacheValueEncryptor.cs",
-      "line": 21,
+      "line": 22,
       "members": []
     },
     {
@@ -8078,7 +8086,7 @@
       "kind": "class",
       "project": "Granit.Caching.StackExchangeRedis",
       "file": "src/Granit.Caching.StackExchangeRedis/Extensions/RedisCachingServiceCollectionExtensions.cs",
-      "line": 17,
+      "line": 18,
       "members": [
         {
           "name": "AddGranitCachingRedis",
@@ -8138,7 +8146,7 @@
       "kind": "class",
       "project": "Granit.DataExchange.AI",
       "file": "src/Granit.DataExchange.AI/Extensions/DataExchangeAIHostApplicationBuilderExtensions.cs",
-      "line": 15,
+      "line": 17,
       "members": [
         {
           "name": "AddGranitDataExchangeAI",
@@ -10055,12 +10063,18 @@
       "kind": "class",
       "project": "Granit.Diagnostics",
       "file": "src/Granit.Diagnostics/ResponseWriters/GranitHealthCheckWriter.cs",
-      "line": 16,
+      "line": 26,
       "members": [
         {
           "name": "WriteAsync",
           "kind": "method",
           "signature": "WriteAsync(HttpContext context, HealthReport report)",
+          "returnType": "Task"
+        },
+        {
+          "name": "WriteMinimalAsync",
+          "kind": "method",
+          "signature": "WriteMinimalAsync(HttpContext context, HealthReport report)",
           "returnType": "Task"
         }
       ]
@@ -10248,6 +10262,12 @@
           "kind": "property",
           "signature": "string? ChromiumExecutablePath",
           "returnType": "string?"
+        },
+        {
+          "name": "MaxConcurrentPages",
+          "kind": "property",
+          "signature": "int MaxConcurrentPages",
+          "returnType": "int"
         }
       ]
     },

--- a/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
@@ -33,6 +33,7 @@ internal static partial class BffLoginEndpoints
 
     /// <summary>
     /// Known OIDC error codes (RFC 6749 §4.1.2.1, §5.2 + OIDC Core §3.1.2.6).
+    /// Unknown codes are replaced with <c>"unknown_error"</c> to prevent reflection.
     /// </summary>
     private static readonly HashSet<string> KnownOidcErrors = new(StringComparer.Ordinal)
     {

--- a/src/Granit.Bff.EntityFrameworkCore/Internal/BffDbContext.cs
+++ b/src/Granit.Bff.EntityFrameworkCore/Internal/BffDbContext.cs
@@ -6,8 +6,9 @@ using Microsoft.EntityFrameworkCore;
 namespace Granit.Bff.EntityFrameworkCore.Internal;
 
 /// <summary>
-/// Isolated DbContext for BFF session persistence. Stores encrypted token sets
-/// as an alternative to <c>IDistributedCache</c>-backed storage.
+/// Isolated DbContext for BFF session persistence. Stores token sets (encrypted
+/// when <c>IStringEncryptionService</c> is registered) as an alternative to
+/// <c>IDistributedCache</c>-backed storage.
 /// </summary>
 internal sealed class BffDbContext(
     DbContextOptions<BffDbContext> options,

--- a/src/Granit.Bff/Internal/DistributedCacheBffTokenStore.cs
+++ b/src/Granit.Bff/Internal/DistributedCacheBffTokenStore.cs
@@ -72,6 +72,12 @@ internal sealed class DistributedCacheBffTokenStore(
         return maybe.HasValue ? maybe.Value ?? [] : [];
     }
 
+    // NOTE: AddToUserIndexAsync/RemoveFromUserIndexAsync use a non-atomic read-modify-write
+    // pattern. Two concurrent logins from the same user can race, causing one session to be
+    // omitted from the index (it remains active but invisible to session management).
+    // Accepted risk: the window is narrow, the EF Core store is not affected, and the
+    // cleanup job eventually removes orphaned sessions. A proper fix requires Redis SADD
+    // or distributed locking which is beyond the scope of the FusionCache abstraction.
     private async Task AddToUserIndexAsync(
         string frontendName, string userId, string sessionId, CancellationToken cancellationToken)
     {

--- a/src/Granit.Bff/Options/GranitBffOptions.cs
+++ b/src/Granit.Bff/Options/GranitBffOptions.cs
@@ -153,11 +153,15 @@ public sealed class BffFrontendOptions
     public bool UsePushedAuthorizationRequests { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether PAR is mandatory. When <see langword="true"/>,
-    /// a PAR failure returns 502 instead of falling back to direct authorization parameters.
-    /// Requires <see cref="UsePushedAuthorizationRequests"/> to be <see langword="true"/>.
-    /// Default: <see langword="false"/>.
+    /// Gets or sets a value indicating whether PAR (Pushed Authorization Requests)
+    /// is mandatory. When <see langword="true"/>, a PAR failure returns 502 instead
+    /// of falling back to direct authorization parameters.
     /// </summary>
+    /// <remarks>
+    /// Enable for FAPI 2.0 strict conformance. When <see langword="false"/>
+    /// (default), PAR failure falls back to direct parameters for availability.
+    /// Requires <see cref="UsePushedAuthorizationRequests"/> to be <see langword="true"/>.
+    /// </remarks>
     public bool RequirePushedAuthorizationRequests { get; set; }
 
     /// <summary>

--- a/src/Granit.BlobStorage.Endpoints/packages.lock.json
+++ b/src/Granit.BlobStorage.Endpoints/packages.lock.json
@@ -26,6 +26,16 @@
         "resolved": "2.0.0",
         "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
       },
+      "Pipelines.Sockets.Unofficial": {
+        "type": "Transitive",
+        "resolved": "2.2.8",
+        "contentHash": "zG2FApP5zxSx6OcdJQLbZDk2AVlN2BNQD6MorwIfV6gVj0RRxWPEp2LXAxqDGZqeNV1Zp0BNPcNaey/GXmTdvQ=="
+      },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "AKJknIFi9O3+rGExxTry188JPvUoZAPcCtS2qdqyFhIzsxQ1Ap94BeGDG0VzVEHakhmRxmJtVih6TsHoghIt/g=="
+      },
       "ZString": {
         "type": "Transitive",
         "resolved": "2.6.0",
@@ -55,6 +65,13 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.features": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
         }
       },
       "granit.guids": {
@@ -108,6 +125,15 @@
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.ratelimiting": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Features": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "StackExchange.Redis": "[2.*, )"
         }
       },
       "granit.timing": {
@@ -187,6 +213,16 @@
         "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
         "dependencies": {
           "ZString": "2.6.0"
+        }
+      },
+      "StackExchange.Redis": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.12.8",
+        "contentHash": "I2x/MZ+I0YR2KYYOtlIaEq0Thd+Uhioao6BIaEs+U1MeGkbJF+peLtoZucJwHmfrFxMDXAzWOZrLnOQqPgyGvA==",
+        "dependencies": {
+          "Pipelines.Sockets.Unofficial": "2.2.8",
+          "System.IO.Hashing": "10.0.2"
         }
       },
       "ZiggyCreatures.FusionCache": {

--- a/src/Granit.BlobStorage.S3/Options/S3BlobOptions.cs
+++ b/src/Granit.BlobStorage.S3/Options/S3BlobOptions.cs
@@ -81,6 +81,7 @@ internal sealed class S3BlobOptionsValidator : IValidateOptions<S3BlobOptions>
                 $"{nameof(options.ServiceUrl)} must be a valid absolute URI.");
         }
 
+        // Allow HTTP only for localhost (MinIO development). Enforce HTTPS for all other hosts.
         bool isLocalhost = serviceUri.Host is "localhost" or "127.0.0.1" or "::1";
         if (serviceUri.Scheme != Uri.UriSchemeHttps && !isLocalhost)
         {

--- a/src/Granit.BlobStorage/Internal/DefaultBlobStorage.cs
+++ b/src/Granit.BlobStorage/Internal/DefaultBlobStorage.cs
@@ -100,6 +100,7 @@ internal sealed partial class DefaultBlobStorage(
     {
         BlobDescriptor? descriptor = await reader.FindAsync(blobId, cancellationToken).ConfigureAwait(false);
 
+        // Verify the descriptor belongs to the requested container to prevent cross-container IDOR.
         if (descriptor is not null &&
             !string.Equals(descriptor.ContainerName, containerName, StringComparison.Ordinal))
         {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1705,6 +1705,7 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
           "Granit.QueryEngine.Endpoints": "[0.1.0-dev, )",
+          "Granit.RateLimiting": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
       },

--- a/tests/Granit.BlobStorage.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.BlobStorage.Endpoints.Tests/packages.lock.json
@@ -220,6 +220,11 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "Pipelines.Sockets.Unofficial": {
+        "type": "Transitive",
+        "resolved": "2.2.8",
+        "contentHash": "zG2FApP5zxSx6OcdJQLbZDk2AVlN2BNQD6MorwIfV6gVj0RRxWPEp2LXAxqDGZqeNV1Zp0BNPcNaey/GXmTdvQ=="
+      },
       "System.CodeDom": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -229,6 +234,11 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "AKJknIFi9O3+rGExxTry188JPvUoZAPcCtS2qdqyFhIzsxQ1Ap94BeGDG0VzVEHakhmRxmJtVih6TsHoghIt/g=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -335,6 +345,7 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.BlobStorage": "[0.1.0-dev, )",
           "Granit.QueryEngine.Endpoints": "[0.1.0-dev, )",
+          "Granit.RateLimiting": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
       },
@@ -352,6 +363,13 @@
           "ZiggyCreatures.FusionCache": "[2.*, )",
           "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.features": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
         }
       },
       "granit.guids": {
@@ -409,6 +427,15 @@
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.ratelimiting": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Features": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "StackExchange.Redis": "[2.*, )"
         }
       },
       "granit.timing": {
@@ -586,6 +613,17 @@
         "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
         "dependencies": {
           "ZString": "2.6.0"
+        }
+      },
+      "StackExchange.Redis": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.12.8",
+        "contentHash": "I2x/MZ+I0YR2KYYOtlIaEq0Thd+Uhioao6BIaEs+U1MeGkbJF+peLtoZucJwHmfrFxMDXAzWOZrLnOQqPgyGvA==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Pipelines.Sockets.Unofficial": "2.2.8",
+          "System.IO.Hashing": "10.0.2"
         }
       },
       "ZiggyCreatures.FusionCache": {


### PR DESCRIPTION
## Summary
- Add clarifying doc comments recovered from stash review across BFF and BlobStorage modules:
  - OIDC error reflection prevention note (`BffLoginEndpoints`)
  - Conditional encryption clarification (`BffDbContext`)
  - Race condition documentation on session user index (`DistributedCacheBffTokenStore`)
  - FAPI 2.0 PAR conformance remarks (`GranitBffOptions`)
  - MinIO localhost HTTP exception comment (`S3BlobOptions`)
  - Cross-container IDOR guard comment (`DefaultBlobStorage`)
- Refresh 3 stale `packages.lock.json` files

## Test plan
- [ ] CI build passes (changes are doc comments + lock files only)
- [ ] No functional changes — verify diff is comments-only