### PR TITLE
fix(vault,blob-storage): resolve CI build errors

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -11820,6 +11820,34 @@
       ]
     },
     {
+      "name": "FeaturesMetrics",
+      "fqn": "Granit.Features.Diagnostics.FeaturesMetrics",
+      "kind": "class",
+      "project": "Granit.Features",
+      "file": "src/Granit.Features/Diagnostics/FeaturesMetrics.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "RecordOverrideChanged",
+          "kind": "method",
+          "signature": "RecordOverrideChanged(string? tenantId, string featureName, string operation)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordLimitChecked",
+          "kind": "method",
+          "signature": "RecordLimitChecked(string? tenantId, string featureName)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordLimitExceeded",
+          "kind": "method",
+          "signature": "RecordLimitExceeded(string? tenantId, string featureName)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
       "name": "FeatureDefinitionResponse",
       "fqn": "Granit.Features.Endpoints.Dtos.FeatureDefinitionResponse",
       "kind": "record",
@@ -11935,7 +11963,7 @@
       "kind": "class",
       "project": "Granit.Features.EntityFrameworkCore",
       "file": "src/Granit.Features.EntityFrameworkCore/Extensions/FeaturesEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitFeaturesEntityFrameworkCore",
@@ -12074,7 +12102,7 @@
       "kind": "class",
       "project": "Granit.Features",
       "file": "src/Granit.Features/Extensions/ServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 14,
       "members": [
         {
           "name": "AddGranitFeatures",
@@ -12099,7 +12127,7 @@
       "kind": "class",
       "project": "Granit.Features",
       "file": "src/Granit.Features/GranitFeaturesModule.cs",
-      "line": 33,
+      "line": 37,
       "members": [
         {
           "name": "ConfigureServices",

--- a/src/Granit.Vault.Azure/Services/AzureKeyVaultTransitEncryptionService.cs
+++ b/src/Granit.Vault.Azure/Services/AzureKeyVaultTransitEncryptionService.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Azure.Security.KeyVault.Keys.Cryptography;
 using Granit.MultiTenancy;
 using Granit.Vault.Azure.Diagnostics;
+using Granit.Vault.Azure.Options;
 using Granit.Vault.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/tests/Granit.BlobStorage.Tests/Validators/MagicBytesValidatorTests.cs
+++ b/tests/Granit.BlobStorage.Tests/Validators/MagicBytesValidatorTests.cs
@@ -1,5 +1,7 @@
 using Granit.BlobStorage.Domain;
+using Granit.BlobStorage.Options;
 using Granit.BlobStorage.Validators;
+using Microsoft.Extensions.Options;
 using Shouldly;
 using Xunit;
 
@@ -114,7 +116,7 @@ public sealed class MagicBytesValidatorTests
     [Fact]
     public async Task ValidateAsync_PdfBytesWithPdfDeclared_ReturnsSuccess()
     {
-        MagicBytesValidator validator = new();
+        MagicBytesValidator validator = new(Microsoft.Extensions.Options.Options.Create(new BlobStorageOptions()));
         byte[] pdfBytes = [0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34];
         BlobValidationContext context = MakeContext(MakeDescriptor("application/pdf"), pdfBytes);
 
@@ -128,7 +130,7 @@ public sealed class MagicBytesValidatorTests
     [Fact]
     public async Task ValidateAsync_JpegBytesDeclaredAsPdf_ReturnsFailure()
     {
-        MagicBytesValidator validator = new();
+        MagicBytesValidator validator = new(Microsoft.Extensions.Options.Options.Create(new BlobStorageOptions()));
         byte[] jpegBytes = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10];
         BlobValidationContext context = MakeContext(MakeDescriptor("application/pdf"), jpegBytes);
 
@@ -143,7 +145,7 @@ public sealed class MagicBytesValidatorTests
     [Fact]
     public async Task ValidateAsync_UnknownBytesWithAnyDeclaredType_PassesThroughWithDeclaredType()
     {
-        MagicBytesValidator validator = new();
+        MagicBytesValidator validator = new(Microsoft.Extensions.Options.Options.Create(new BlobStorageOptions()));
         byte[] unknownBytes = new byte[50]; // all zeros — no known signature
         BlobDescriptor descriptor = MakeDescriptor("application/octet-stream");
         BlobValidationContext context = MakeContext(descriptor, unknownBytes);
@@ -158,7 +160,7 @@ public sealed class MagicBytesValidatorTests
     [Fact]
     public async Task ValidateAsync_PngBytesCaseInsensitiveMatch_ReturnsSuccess()
     {
-        MagicBytesValidator validator = new();
+        MagicBytesValidator validator = new(Microsoft.Extensions.Options.Options.Create(new BlobStorageOptions()));
         byte[] pngBytes = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00];
         // Declared in uppercase (unusual but should work)
         BlobValidationContext context = MakeContext(MakeDescriptor("IMAGE/PNG"), pngBytes);


### PR DESCRIPTION
## Summary
- Add missing `using Granit.Vault.Azure.Options` in `AzureKeyVaultTransitEncryptionService` (CS0246)
- Pass `IOptions<BlobStorageOptions>` to `MagicBytesValidator` in 4 tests after constructor signature change (CS7036)

## Test plan
- [x] `dotnet build src/Granit.Vault.Azure` — passes
- [x] `dotnet test tests/Granit.BlobStorage.Tests` — 132 passed
- [ ] CI green