### PR TITLE
fix(query-engine): fix SavedViews CI failures

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2505,7 +2505,7 @@
       "kind": "class",
       "project": "Granit.AI",
       "file": "src/Granit.AI/PromptBuilder.cs",
-      "line": 11,
+      "line": 12,
       "members": [
         {
           "name": "ToString",
@@ -26458,7 +26458,7 @@
       "kind": "class",
       "project": "Granit.Templating.AI",
       "file": "src/Granit.Templating.AI/AITemplateDataEnricher.cs",
-      "line": 21,
+      "line": 28,
       "members": [
         {
           "name": "BuildPrompt",
@@ -26480,7 +26480,7 @@
       "kind": "class",
       "project": "Granit.Templating.AI",
       "file": "src/Granit.Templating.AI/Extensions/TemplatingAIHostApplicationBuilderExtensions.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitTemplatingAI",
@@ -27728,6 +27728,12 @@
           "name": "MaxEntriesToAnalyze",
           "kind": "property",
           "signature": "int MaxEntriesToAnalyze",
+          "returnType": "int"
+        },
+        {
+          "name": "MaxConcurrentRequests",
+          "kind": "property",
+          "signature": "int MaxConcurrentRequests",
           "returnType": "int"
         }
       ]
@@ -29125,6 +29131,12 @@
           "returnType": "string ErrorCode { get; } = errorCode ?? throw"
         },
         {
+          "name": "IsSensitive",
+          "kind": "property",
+          "signature": "bool IsSensitive",
+          "returnType": "bool"
+        },
+        {
           "name": "Validate",
           "kind": "method",
           "signature": "Validate(string? value)",
@@ -29141,10 +29153,16 @@
       "line": 12,
       "members": [
         {
+          "name": "ErrorCode",
+          "kind": "property",
+          "signature": "string ErrorCode",
+          "returnType": "string"
+        },
+        {
           "name": "Validate",
           "kind": "method",
           "signature": "Validate(string? value)",
-          "returnType": "string ErrorCode { get; } bool"
+          "returnType": "bool"
         }
       ]
     },
@@ -29177,6 +29195,12 @@
           "kind": "method",
           "signature": "GetAllErrorCodes()",
           "returnType": "IReadOnlyCollection<string>"
+        },
+        {
+          "name": "GetAll",
+          "kind": "method",
+          "signature": "GetAll()",
+          "returnType": "IReadOnlyCollection<IServerValidator>"
         }
       ]
     },

--- a/src/Granit.QueryEngine.Endpoints/Internal/SavedViewEndpoints.cs
+++ b/src/Granit.QueryEngine.Endpoints/Internal/SavedViewEndpoints.cs
@@ -171,7 +171,7 @@ internal static class SavedViewEndpoints
         return TypedResults.Created($"/saved-views/{view.Id}", MapView(view, userId));
     }
 
-    private static async Task<Results<NoContent, NotFound, ForbidHttpResult, UnauthorizedHttpResult>> UpdateAsync(
+    private static async Task<Results<NoContent, ProblemHttpResult, UnauthorizedHttpResult>> UpdateAsync(
         Guid id,
         UpdateSavedViewRequest request,
         [FromServices] ISavedViewStoreReader reader,
@@ -189,12 +189,12 @@ internal static class SavedViewEndpoints
         SavedView? existing = await reader.GetAsync(id, cancellationToken).ConfigureAwait(false);
         if (existing is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(detail: "Saved view not found.", statusCode: StatusCodes.Status404NotFound);
         }
 
         if (!string.Equals(existing.UserId, userId, StringComparison.Ordinal))
         {
-            return TypedResults.Forbid();
+            return TypedResults.Problem(detail: "You do not own this saved view.", statusCode: StatusCodes.Status403Forbidden);
         }
 
         existing.Name = request.Name;
@@ -210,7 +210,7 @@ internal static class SavedViewEndpoints
         return TypedResults.NoContent();
     }
 
-    private static async Task<Results<NoContent, NotFound, ForbidHttpResult, UnauthorizedHttpResult>> DeleteAsync(
+    private static async Task<Results<NoContent, ProblemHttpResult, UnauthorizedHttpResult>> DeleteAsync(
         Guid id,
         [FromServices] ISavedViewStoreReader reader,
         [FromServices] ISavedViewStoreWriter store,
@@ -226,19 +226,19 @@ internal static class SavedViewEndpoints
         SavedView? existing = await reader.GetAsync(id, cancellationToken).ConfigureAwait(false);
         if (existing is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(detail: "Saved view not found.", statusCode: StatusCodes.Status404NotFound);
         }
 
         if (!string.Equals(existing.UserId, userId, StringComparison.Ordinal))
         {
-            return TypedResults.Forbid();
+            return TypedResults.Problem(detail: "You do not own this saved view.", statusCode: StatusCodes.Status403Forbidden);
         }
 
         await store.DeleteAsync(id, cancellationToken).ConfigureAwait(false);
         return TypedResults.NoContent();
     }
 
-    private static async Task<Results<NoContent, NotFound, ForbidHttpResult, UnauthorizedHttpResult>> SetDefaultAsync(
+    private static async Task<Results<NoContent, ProblemHttpResult, UnauthorizedHttpResult>> SetDefaultAsync(
         Guid id,
         [FromServices] ISavedViewStoreReader reader,
         [FromServices] ISavedViewStoreWriter store,
@@ -255,12 +255,12 @@ internal static class SavedViewEndpoints
         SavedView? existing = await reader.GetAsync(id, cancellationToken).ConfigureAwait(false);
         if (existing is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(detail: "Saved view not found.", statusCode: StatusCodes.Status404NotFound);
         }
 
         if (!string.Equals(existing.UserId, userId, StringComparison.Ordinal) && !existing.IsShared)
         {
-            return TypedResults.Forbid();
+            return TypedResults.Problem(detail: "You do not own this saved view.", statusCode: StatusCodes.Status403Forbidden);
         }
 
         await store.SetDefaultAsync(id, userId, entityType, cancellationToken).ConfigureAwait(false);

--- a/tests/Granit.QueryEngine.Endpoints.Tests.Integration/QueryEndpointIntegrationTests.cs
+++ b/tests/Granit.QueryEngine.Endpoints.Tests.Integration/QueryEndpointIntegrationTests.cs
@@ -307,6 +307,16 @@ public sealed class QueryEndpointIntegrationTests : IAsyncDisposable
     public async Task SavedViews_Delete_returns_204()
     {
         var viewId = Guid.NewGuid();
+        _savedViewStoreReader.GetAsync(viewId, Arg.Any<CancellationToken>())
+            .Returns(new SavedView
+            {
+                Id = viewId,
+                EntityType = "Test.Products",
+                Name = "To Delete",
+                UserId = "test-user-id",
+                CreatedAt = DateTimeOffset.UtcNow,
+                CreatedBy = "test-user-id",
+            });
 
         HttpResponseMessage response = await _authClient.DeleteAsync(
             $"{Prefix}/saved-views/{viewId}", TestContext.Current.CancellationToken);
@@ -320,6 +330,16 @@ public sealed class QueryEndpointIntegrationTests : IAsyncDisposable
     public async Task SavedViews_SetDefault_returns_204()
     {
         var viewId = Guid.NewGuid();
+        _savedViewStoreReader.GetAsync(viewId, Arg.Any<CancellationToken>())
+            .Returns(new SavedView
+            {
+                Id = viewId,
+                EntityType = "Test.Products",
+                Name = "Default View",
+                UserId = "test-user-id",
+                CreatedAt = DateTimeOffset.UtcNow,
+                CreatedBy = "test-user-id",
+            });
 
         HttpResponseMessage response = await _authClient.PostAsync(
             $"{Prefix}/saved-views/{viewId}/set-default", null, TestContext.Current.CancellationToken);


### PR DESCRIPTION
## Summary

- **Integration tests**: `SavedViews_Delete_returns_204` and `SavedViews_SetDefault_returns_204` failed because the `ISavedViewStoreReader.GetAsync()` mock was not configured — NSubstitute returned `null`, causing the handlers to return 404 instead of 204. Added mock setup matching the existing `Update` test pattern.
- **Architecture test**: `Complex_results_unions_should_include_ProblemHttpResult` failed because `UpdateAsync`, `DeleteAsync`, and `SetDefaultAsync` used `Results<NoContent, NotFound, ForbidHttpResult, UnauthorizedHttpResult>`. Replaced with `Results<NoContent, ProblemHttpResult, UnauthorizedHttpResult>` using `TypedResults.Problem()` (RFC 7807) for 404/403 responses.

## Test plan

- [ ] `dotnet test tests/Granit.QueryEngine.Endpoints.Tests.Integration` — all 12 tests pass
- [ ] `dotnet test tests/Granit.ArchitectureTests` — `Complex_results_unions_should_include_ProblemHttpResult` passes
- [ ] CI integration + architecture shards green