### PR TITLE
fix(persistence): fix PostgreSQL connection-state bug in MigrationProgressDbEnsurer

### DIFF
--- a/src/Granit.Persistence.Migrations/Internal/MigrationProgressDbEnsurer.cs
+++ b/src/Granit.Persistence.Migrations/Internal/MigrationProgressDbEnsurer.cs
@@ -9,10 +9,11 @@ namespace Granit.Persistence.Migrations.Internal;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <c>EnsureCreatedAsync()</c> is a no-op when the database already has tables
-/// (e.g., from host application migrations). This implementation uses the
-/// <see cref="IRelationalDatabaseCreator"/> to check table existence and create
-/// only the tables defined in the <see cref="MigrationProgressDbContext"/> model.
+/// Uses two separate <see cref="MigrationProgressDbContext"/> instances to avoid PostgreSQL
+/// connection-state contamination: one for probing table existence (which may throw) and a
+/// fresh one for <see cref="IRelationalDatabaseCreator.CreateTablesAsync"/>. This avoids the
+/// "current transaction is aborted" error that occurs when a failed query and a DDL command
+/// share the same connection.
 /// </para>
 /// </remarks>
 internal sealed class MigrationProgressDbEnsurer(
@@ -20,29 +21,48 @@ internal sealed class MigrationProgressDbEnsurer(
 {
     public async Task EnsureCreatedAsync(CancellationToken cancellationToken = default)
     {
+        if (await ProbeTableExistsAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        // Use a FRESH context — the probe context's connection may be in a failed state
+        // after the unsuccessful SELECT.
         await using MigrationProgressDbContext db = await factory
             .CreateDbContextAsync(cancellationToken)
             .ConfigureAwait(false);
 
         IRelationalDatabaseCreator creator = db.GetService<IRelationalDatabaseCreator>();
+        await creator.CreateTablesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<bool> ProbeTableExistsAsync(CancellationToken cancellationToken)
+    {
+        await using MigrationProgressDbContext db = await factory
+            .CreateDbContextAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!db.Database.IsRelational())
+        {
+            return true; // Non-relational providers don't need table creation
+        }
+
+        IRelationalDatabaseCreator creator = db.GetService<IRelationalDatabaseCreator>();
 
         if (!await creator.HasTablesAsync(cancellationToken).ConfigureAwait(false))
         {
-            // Database has no tables at all — safe to use EnsureCreated
-            await creator.CreateTablesAsync(cancellationToken).ConfigureAwait(false);
-            return;
+            return false; // Database has no tables at all
         }
 
-        // Database has tables (from host migrations) — EnsureCreated would be a no-op.
-        // Try to query the progress table; if it fails, create it.
+        // Database has tables (from host migrations) — probe the specific table.
         try
         {
             await db.MigrationProgresses.AnyAsync(cancellationToken).ConfigureAwait(false);
+            return true;
         }
         catch (Exception) when (!cancellationToken.IsCancellationRequested)
         {
-            // Table doesn't exist — create all tables from this model
-            await creator.CreateTablesAsync(cancellationToken).ConfigureAwait(false);
+            return false;
         }
     }
 }

--- a/src/Granit.Persistence.Migrations/Internal/MigrationStartupService.cs
+++ b/src/Granit.Persistence.Migrations/Internal/MigrationStartupService.cs
@@ -54,11 +54,12 @@ internal sealed partial class MigrationStartupService(
 
     private async Task ResumeAsync(CancellationToken cancellationToken)
     {
-        await using MigrationProgressDbContext db = await progressFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        // Ensure the progress table exists using a dedicated probe + DDL context pair
+        // to avoid PostgreSQL connection-state contamination.
+        await EnsureProgressTableAsync(cancellationToken).ConfigureAwait(false);
 
-        // EnsureCreatedAsync is a no-op when the database already has tables (from host migrations).
-        // Use the relational database creator to create only missing tables from this DbContext model.
-        await EnsureProgressTableAsync(db, cancellationToken).ConfigureAwait(false);
+        // Use a fresh context for the actual query — the probe contexts are disposed.
+        await using MigrationProgressDbContext db = await progressFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
         List<MigrationProgress> pending = await db.MigrationProgresses
             .Where(p => p.Status == MigrationStatus.Pending || p.Status == MigrationStatus.InProgress)
@@ -126,36 +127,50 @@ internal sealed partial class MigrationStartupService(
     /// Creates the <c>data_migration_progress</c> table if it doesn't exist.
     /// </summary>
     /// <remarks>
-    /// <c>EnsureCreatedAsync()</c> is a no-op when the database already has tables
-    /// (e.g., from host application migrations). We use <see cref="IRelationalDatabaseCreator"/>
-    /// with a try/catch probe to detect missing tables.
+    /// Uses two separate DbContext instances to avoid PostgreSQL connection-state contamination:
+    /// one for probing table existence (which may throw) and a fresh one for DDL.
     /// </remarks>
-    private static async Task EnsureProgressTableAsync(MigrationProgressDbContext db, CancellationToken ct)
+    private async Task EnsureProgressTableAsync(CancellationToken ct)
     {
-        if (!db.Database.IsRelational())
+        // Probe with a dedicated context
+        bool exists;
         {
-            // Non-relational providers (e.g. InMemory) don't need table creation.
+            await using MigrationProgressDbContext probeDb = await progressFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+
+            if (!probeDb.Database.IsRelational())
+            {
+                return;
+            }
+
+            IRelationalDatabaseCreator probeCreator = probeDb.GetService<IRelationalDatabaseCreator>();
+
+            if (!await probeCreator.HasTablesAsync(ct).ConfigureAwait(false))
+            {
+                exists = false;
+            }
+            else
+            {
+                try
+                {
+                    await probeDb.MigrationProgresses.AnyAsync(ct).ConfigureAwait(false);
+                    exists = true;
+                }
+                catch (Exception) when (!ct.IsCancellationRequested)
+                {
+                    exists = false;
+                }
+            }
+        }
+
+        if (exists)
+        {
             return;
         }
 
-        IRelationalDatabaseCreator creator = db.GetService<IRelationalDatabaseCreator>();
-
-        if (!await creator.HasTablesAsync(ct).ConfigureAwait(false))
-        {
-            await creator.CreateTablesAsync(ct).ConfigureAwait(false);
-            return;
-        }
-
-        // Database has tables (from host migrations) — EnsureCreated would be a no-op.
-        // Try to query the progress table; if it fails, create it.
-        try
-        {
-            await db.MigrationProgresses.AnyAsync(ct).ConfigureAwait(false);
-        }
-        catch (Exception) when (!ct.IsCancellationRequested)
-        {
-            await creator.CreateTablesAsync(ct).ConfigureAwait(false);
-        }
+        // Fresh context for DDL — probe context's connection may be in a failed state.
+        await using MigrationProgressDbContext ddlDb = await progressFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
+        IRelationalDatabaseCreator creator = ddlDb.GetService<IRelationalDatabaseCreator>();
+        await creator.CreateTablesAsync(ct).ConfigureAwait(false);
     }
 
     [LoggerMessage(Level = LogLevel.Information,


### PR DESCRIPTION
## Summary

- Fix PostgreSQL connection-state contamination bug in `MigrationProgressDbEnsurer` and `MigrationStartupService.EnsureProgressTableAsync`
- Same root-cause pattern fixed in PR #708 for `InternalDbContextEnsurer<T>`: a failed probe query (`AnyAsync` on a missing table) leaves the PostgreSQL connection in "current transaction is aborted" state, causing the subsequent `CreateTablesAsync` to fail on the same connection
- Apply the two-context pattern: one context for probing (disposed after), a fresh one for DDL

## Root cause analysis

This was the **cascade failure** preventing #708's 11 internal DbContext ensurers from ever running:

1. `--migrate` → host migrations succeed → DB has tables
2. `EnsureExpandContractDbAsync()` → `MigrationProgressDbEnsurer.EnsureCreatedAsync()` → `HasTablesAsync()` = true → `AnyAsync()` throws (table missing) → `CreateTablesAsync()` on **same connection** → "current transaction is aborted" → **exception**
3. `RunAsync` catches → **returns 1** → `EnsureInternalDbContextsAsync()` **never reached**
4. All 11 `IInternalDbContextEnsurer` registrations from #708 never execute
5. API starts → `ChannelCronSchedulerService` queries `background_jobs` → FATAL crash (StopHost)

Additionally, `MigrationStartupService` (API instance, not `--migrate`) had the same single-context pattern in `EnsureProgressTableAsync()`, causing `relation "data_migration_progress" does not exist` errors on first boot.

## Test plan

- [x] `dotnet test tests/Granit.Persistence.Migrations.Tests` — 75 tests pass
- [ ] Showcase: `dotnet run --migrate` on fresh PostgreSQL → all tables created (migration_progress + 11 internal contexts)
- [ ] Showcase: `dotnet run` (API) starts without "relation does not exist" errors
