### PR TITLE
refactor(persistence): delegate MigrationStartupService to IMigrationProgressDbEnsurer

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -30180,7 +30180,7 @@
       "kind": "class",
       "project": "Granit.Webhooks",
       "file": "src/Granit.Webhooks/Domain/WebhookDeliveryAttempt.cs",
-      "line": 22,
+      "line": 21,
       "members": [
         {
           "name": "DeliveryId",
@@ -31351,6 +31351,12 @@
           "kind": "property",
           "signature": "DateTimeOffset TransitionedAt",
           "returnType": "DateTimeOffset"
+        },
+        {
+          "name": "Comment",
+          "kind": "property",
+          "signature": "string? Comment",
+          "returnType": "string?"
         }
       ]
     },

--- a/src/Granit.AI/PromptBuilder.cs
+++ b/src/Granit.AI/PromptBuilder.cs
@@ -132,7 +132,7 @@ public sealed partial class PromptBuilder
     internal static string StripControlCharacters(string input) =>
         ControlCharacterRegex().Replace(input, string.Empty);
 
-    [GeneratedRegex(@"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F\u200B-\u200F\u202A-\u202E\uFEFF]")]
+    [GeneratedRegex(@"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F\u200B-\u200F\u202A-\u202E\uFEFF]", RegexOptions.None, 100)]
     private static partial Regex ControlCharacterRegex();
 
     private static string StripDangerousPatterns(string input) =>

--- a/src/Granit.Persistence.Migrations/Internal/MigrationStartupService.cs
+++ b/src/Granit.Persistence.Migrations/Internal/MigrationStartupService.cs
@@ -1,8 +1,6 @@
 using Granit.Persistence.Migrations.Messages;
 using Granit.Persistence.Migrations.Options;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -31,6 +29,7 @@ namespace Granit.Persistence.Migrations.Internal;
 /// </remarks>
 internal sealed partial class MigrationStartupService(
     IDbContextFactory<MigrationProgressDbContext> progressFactory,
+    IMigrationProgressDbEnsurer dbEnsurer,
     ITenantEnumerator tenantEnumerator,
     IMigrationBatchDispatcher dispatcher,
     IOptions<MigrationStartupOptions> options,
@@ -132,45 +131,7 @@ internal sealed partial class MigrationStartupService(
     /// </remarks>
     private async Task EnsureProgressTableAsync(CancellationToken ct)
     {
-        // Probe with a dedicated context
-        bool exists;
-        {
-            await using MigrationProgressDbContext probeDb = await progressFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
-
-            if (!probeDb.Database.IsRelational())
-            {
-                return;
-            }
-
-            IRelationalDatabaseCreator probeCreator = probeDb.GetService<IRelationalDatabaseCreator>();
-
-            if (!await probeCreator.HasTablesAsync(ct).ConfigureAwait(false))
-            {
-                exists = false;
-            }
-            else
-            {
-                try
-                {
-                    await probeDb.MigrationProgresses.AnyAsync(ct).ConfigureAwait(false);
-                    exists = true;
-                }
-                catch (Exception) when (!ct.IsCancellationRequested)
-                {
-                    exists = false;
-                }
-            }
-        }
-
-        if (exists)
-        {
-            return;
-        }
-
-        // Fresh context for DDL — probe context's connection may be in a failed state.
-        await using MigrationProgressDbContext ddlDb = await progressFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
-        IRelationalDatabaseCreator creator = ddlDb.GetService<IRelationalDatabaseCreator>();
-        await creator.CreateTablesAsync(ct).ConfigureAwait(false);
+        await dbEnsurer.EnsureCreatedAsync(ct).ConfigureAwait(false);
     }
 
     [LoggerMessage(Level = LogLevel.Information,

--- a/src/Granit.QueryEngine.Endpoints/Internal/SavedViewEndpoints.cs
+++ b/src/Granit.QueryEngine.Endpoints/Internal/SavedViewEndpoints.cs
@@ -53,7 +53,8 @@ internal static class SavedViewEndpoints
             .WithName($"CreateSavedView_{entityType}")
             .WithSummary("Creates a new saved view.")
             .WithDescription("Creates a new saved view for the current user and entity type. The view stores a reusable query configuration (filters, sort, column selection). Returns 201 Created with the saved view details.")
-            .Produces<SavedViewResponse>(StatusCodes.Status201Created);
+            .Produces<SavedViewResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
 
         savedViews.MapPut("/{id:guid}", (
             Guid id,

--- a/src/Granit.Templating.Endpoints/Extensions/TemplatingEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Templating.Endpoints/Extensions/TemplatingEndpointRouteBuilderExtensions.cs
@@ -305,7 +305,7 @@ public static class TemplatingEndpointRouteBuilderExtensions
     // GET /{name} — Template detail
     // -------------------------------------------------------------------------
 
-    private static async Task<Results<Ok<TemplateDetailResponse>, NotFound, ProblemHttpResult>> HandleGetDetailAsync(
+    private static async Task<Results<Ok<TemplateDetailResponse>, ProblemHttpResult>> HandleGetDetailAsync(
         HttpContext context,
         string name,
         string? culture,
@@ -341,7 +341,9 @@ public static class TemplatingEndpointRouteBuilderExtensions
 
         if (draft is null && published is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(
+                detail: "Template not found.",
+                statusCode: StatusCodes.Status404NotFound);
         }
 
         // For published, we need the full revision to build the response.
@@ -645,7 +647,7 @@ public static class TemplatingEndpointRouteBuilderExtensions
     // GET /{name}/lifecycle — Lifecycle status and available transitions
     // -------------------------------------------------------------------------
 
-    private static async Task<Results<Ok<TemplateLifecycleResponse>, NotFound, ProblemHttpResult>> HandleGetLifecycleAsync(
+    private static async Task<Results<Ok<TemplateLifecycleResponse>, ProblemHttpResult>> HandleGetLifecycleAsync(
         HttpContext context,
         string name,
         string? culture,
@@ -681,7 +683,9 @@ public static class TemplatingEndpointRouteBuilderExtensions
 
         if (draft is null && published is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(
+                detail: "Template not found.",
+                statusCode: StatusCodes.Status404NotFound);
         }
 
         // Determine the current status (Draft takes precedence for display)
@@ -790,7 +794,7 @@ public static class TemplatingEndpointRouteBuilderExtensions
     // GET /{name}/history/{revisionId} — Full detail of a specific revision
     // -------------------------------------------------------------------------
 
-    private static async Task<Results<Ok<TemplateRevisionResponse>, NotFound, ProblemHttpResult>> HandleGetRevisionDetailAsync(
+    private static async Task<Results<Ok<TemplateRevisionResponse>, ProblemHttpResult>> HandleGetRevisionDetailAsync(
         HttpContext context,
         string name,
         Guid revisionId,
@@ -827,7 +831,9 @@ public static class TemplatingEndpointRouteBuilderExtensions
         TemplateRevision? revision = history.FirstOrDefault(r => r.RevisionId == revisionId);
         if (revision is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(
+                detail: "Template revision not found.",
+                statusCode: StatusCodes.Status404NotFound);
         }
 
         return TypedResults.Ok(ToRevisionResponse(revision));

--- a/src/Granit.Templating.Scriban/Internal/ScribanTemplateEngine.cs
+++ b/src/Granit.Templating.Scriban/Internal/ScribanTemplateEngine.cs
@@ -32,6 +32,7 @@ internal sealed class ScribanTemplateEngine : ITemplateEngine
 
     // Parsed Template objects are immutable and thread-safe — bounded cache to prevent memory exhaustion.
     private readonly ConcurrentDictionary<string, Template> _templateCache = new();
+    private readonly Lock _evictionLock = new();
 
     /// <inheritdoc/>
     public bool CanRender(TemplateDescriptor descriptor) =>
@@ -49,12 +50,19 @@ internal sealed class ScribanTemplateEngine : ITemplateEngine
         string cacheKey = descriptor.RevisionId?.ToString() ?? descriptor.Content;
 
         // Evict oldest entries when cache exceeds size limit to prevent memory exhaustion.
+        // Lock to prevent TOCTOU race between Count check and TryRemove.
         if (_templateCache.Count >= MaxCachedTemplates && !_templateCache.ContainsKey(cacheKey))
         {
-            string? firstKey = _templateCache.Keys.FirstOrDefault();
-            if (firstKey is not null)
+            lock (_evictionLock)
             {
-                _templateCache.TryRemove(firstKey, out _);
+                if (_templateCache.Count >= MaxCachedTemplates)
+                {
+                    string? firstKey = _templateCache.Keys.FirstOrDefault();
+                    if (firstKey is not null)
+                    {
+                        _templateCache.TryRemove(firstKey, out _);
+                    }
+                }
             }
         }
 

--- a/src/Granit.Templating/Store/NullTemplateTransitionHook.cs
+++ b/src/Granit.Templating/Store/NullTemplateTransitionHook.cs
@@ -18,7 +18,7 @@ namespace Granit.Templating.Store;
 internal sealed partial class NullTemplateTransitionHook(
     ILogger<NullTemplateTransitionHook> logger) : ITemplateTransitionHook
 {
-    private bool _warningLogged;
+    private int _warningLogged;
 
     /// <inheritdoc/>
     public bool IsWorkflowEnabled => false;
@@ -29,10 +29,9 @@ internal sealed partial class NullTemplateTransitionHook(
         TemplateLifecycleStatus target,
         CancellationToken cancellationToken = default)
     {
-        if (!_warningLogged)
+        if (Interlocked.CompareExchange(ref _warningLogged, 1, 0) == 0)
         {
             LogNoWorkflowModule();
-            _warningLogged = true;
         }
 
         return Task.FromResult((from, target) is

--- a/src/Granit.Timeline.AI/Diagnostics/TimelineAIMetrics.cs
+++ b/src/Granit.Timeline.AI/Diagnostics/TimelineAIMetrics.cs
@@ -22,39 +22,49 @@ public sealed class TimelineAIMetrics(IMeterFactory meterFactory)
     private const string UnknownEntityType = "_unknown_";
     private const int MaxEntityTypeLength = 64;
 
-    private readonly Counter<long> _summarizationsCompleted = meterFactory.Create(MeterName).CreateCounter<long>(
+    private readonly Meter _meter = meterFactory.Create(MeterName);
+
+    private Counter<long>? _summarizationsCompleted;
+    private Counter<long>? _summarizationFailures;
+    private Histogram<double>? _summarizationDuration;
+    private Counter<long>? _anomalyDetectionsCompleted;
+    private Counter<long>? _anomalyDetectionFailures;
+    private Histogram<double>? _anomalyDetectionDuration;
+    private Counter<long>? _anomaliesFound;
+
+    private Counter<long> SummarizationsCompleted => _summarizationsCompleted ??= _meter.CreateCounter<long>(
         "granit.timeline.ai.summarization.completed",
         description: "Number of AI timeline summarizations completed successfully.");
 
-    private readonly Counter<long> _summarizationFailures = meterFactory.Create(MeterName).CreateCounter<long>(
+    private Counter<long> SummarizationFailures => _summarizationFailures ??= _meter.CreateCounter<long>(
         "granit.timeline.ai.summarization.failures",
         description: "Number of AI timeline summarizations that failed.");
 
-    private readonly Histogram<double> _summarizationDuration = meterFactory.Create(MeterName).CreateHistogram<double>(
+    private Histogram<double> SummarizationDuration => _summarizationDuration ??= _meter.CreateHistogram<double>(
         "granit.timeline.ai.summarization.duration",
         unit: "s",
         description: "Duration of AI timeline summarization in seconds.");
 
-    private readonly Counter<long> _anomalyDetectionsCompleted = meterFactory.Create(MeterName).CreateCounter<long>(
+    private Counter<long> AnomalyDetectionsCompleted => _anomalyDetectionsCompleted ??= _meter.CreateCounter<long>(
         "granit.timeline.ai.anomaly_detection.completed",
         description: "Number of AI timeline anomaly detections completed successfully.");
 
-    private readonly Counter<long> _anomalyDetectionFailures = meterFactory.Create(MeterName).CreateCounter<long>(
+    private Counter<long> AnomalyDetectionFailures => _anomalyDetectionFailures ??= _meter.CreateCounter<long>(
         "granit.timeline.ai.anomaly_detection.failures",
         description: "Number of AI timeline anomaly detections that failed.");
 
-    private readonly Histogram<double> _anomalyDetectionDuration = meterFactory.Create(MeterName).CreateHistogram<double>(
+    private Histogram<double> AnomalyDetectionDuration => _anomalyDetectionDuration ??= _meter.CreateHistogram<double>(
         "granit.timeline.ai.anomaly_detection.duration",
         unit: "s",
         description: "Duration of AI timeline anomaly detection in seconds.");
 
-    private readonly Counter<long> _anomaliesFound = meterFactory.Create(MeterName).CreateCounter<long>(
+    private Counter<long> AnomaliesFound => _anomaliesFound ??= _meter.CreateCounter<long>(
         "granit.timeline.ai.anomaly_detection.anomalies_found",
         description: "Number of anomalies detected by AI analysis.");
 
     /// <summary>Records a completed AI timeline summarization.</summary>
     public void RecordSummarizationCompleted(string? tenantId, string entityType) =>
-        _summarizationsCompleted.Add(1, new TagList
+        SummarizationsCompleted.Add(1, new TagList
         {
             { TagTenantId, tenantId ?? DefaultTenant },
             { TagEntityType, SanitizeEntityType(entityType) },
@@ -62,7 +72,7 @@ public sealed class TimelineAIMetrics(IMeterFactory meterFactory)
 
     /// <summary>Records a failed AI timeline summarization.</summary>
     public void RecordSummarizationFailure(string? tenantId, string entityType) =>
-        _summarizationFailures.Add(1, new TagList
+        SummarizationFailures.Add(1, new TagList
         {
             { TagTenantId, tenantId ?? DefaultTenant },
             { TagEntityType, SanitizeEntityType(entityType) },
@@ -70,7 +80,7 @@ public sealed class TimelineAIMetrics(IMeterFactory meterFactory)
 
     /// <summary>Records the duration of an AI timeline summarization.</summary>
     public void RecordSummarizationDuration(string? tenantId, string entityType, TimeSpan duration) =>
-        _summarizationDuration.Record(duration.TotalSeconds, new TagList
+        SummarizationDuration.Record(duration.TotalSeconds, new TagList
         {
             { TagTenantId, tenantId ?? DefaultTenant },
             { TagEntityType, SanitizeEntityType(entityType) },
@@ -78,7 +88,7 @@ public sealed class TimelineAIMetrics(IMeterFactory meterFactory)
 
     /// <summary>Records a completed AI timeline anomaly detection.</summary>
     public void RecordAnomalyDetectionCompleted(string? tenantId, string entityType) =>
-        _anomalyDetectionsCompleted.Add(1, new TagList
+        AnomalyDetectionsCompleted.Add(1, new TagList
         {
             { TagTenantId, tenantId ?? DefaultTenant },
             { TagEntityType, SanitizeEntityType(entityType) },
@@ -86,7 +96,7 @@ public sealed class TimelineAIMetrics(IMeterFactory meterFactory)
 
     /// <summary>Records a failed AI timeline anomaly detection.</summary>
     public void RecordAnomalyDetectionFailure(string? tenantId, string entityType) =>
-        _anomalyDetectionFailures.Add(1, new TagList
+        AnomalyDetectionFailures.Add(1, new TagList
         {
             { TagTenantId, tenantId ?? DefaultTenant },
             { TagEntityType, SanitizeEntityType(entityType) },
@@ -94,7 +104,7 @@ public sealed class TimelineAIMetrics(IMeterFactory meterFactory)
 
     /// <summary>Records the duration of an AI timeline anomaly detection.</summary>
     public void RecordAnomalyDetectionDuration(string? tenantId, string entityType, TimeSpan duration) =>
-        _anomalyDetectionDuration.Record(duration.TotalSeconds, new TagList
+        AnomalyDetectionDuration.Record(duration.TotalSeconds, new TagList
         {
             { TagTenantId, tenantId ?? DefaultTenant },
             { TagEntityType, SanitizeEntityType(entityType) },
@@ -102,7 +112,7 @@ public sealed class TimelineAIMetrics(IMeterFactory meterFactory)
 
     /// <summary>Records the number of anomalies found during detection.</summary>
     public void RecordAnomaliesFound(string? tenantId, string entityType, int count) =>
-        _anomaliesFound.Add(count, new TagList
+        AnomaliesFound.Add(count, new TagList
         {
             { TagTenantId, tenantId ?? DefaultTenant },
             { TagEntityType, SanitizeEntityType(entityType) },

--- a/src/Granit.Timeline.AI/Internal/LlmTimelineAnomalyDetector.cs
+++ b/src/Granit.Timeline.AI/Internal/LlmTimelineAnomalyDetector.cs
@@ -19,6 +19,7 @@ namespace Granit.Timeline.AI.Internal;
 /// Fetches timeline entries via <see cref="ITimelineReader"/> and asks the LLM to detect
 /// unusual patterns such as bulk edits, off-hours activity, and privilege escalation.
 /// </summary>
+#pragma warning disable CA1001 // Lifetime managed by DI container — SemaphoreSlim does not hold unmanaged resources
 internal sealed partial class LlmTimelineAnomalyDetector(
     IAIChatClientFactory chatClientFactory,
     ITimelineReader timelineReader,
@@ -26,9 +27,11 @@ internal sealed partial class LlmTimelineAnomalyDetector(
     ICurrentTenant currentTenant,
     TimelineAIMetrics metrics,
     ILogger<LlmTimelineAnomalyDetector> logger) : ITimelineAnomalyDetector
+#pragma warning restore CA1001
 {
-    // VULN-103: Shared concurrency limiter to prevent denial-of-wallet via unbounded LLM calls
-    private static readonly SemaphoreSlim ConcurrencyLimiter = new(3, 3);
+    // VULN-103: Concurrency limiter to prevent denial-of-wallet via unbounded LLM calls
+    private readonly SemaphoreSlim _concurrencyLimiter = new(
+        options.Value.MaxConcurrentRequests, options.Value.MaxConcurrentRequests);
 
     private static readonly AnomalyReport NoAnomalies = new(HasAnomalies: false, Anomalies: []);
 
@@ -57,7 +60,7 @@ internal sealed partial class LlmTimelineAnomalyDetector(
         }
 
         // VULN-103: Concurrency limiter to prevent denial-of-wallet
-        await ConcurrencyLimiter.WaitAsync(ct).ConfigureAwait(false);
+        await _concurrencyLimiter.WaitAsync(ct).ConfigureAwait(false);
         try
         {
             IChatClient chatClient = await chatClientFactory
@@ -104,7 +107,7 @@ internal sealed partial class LlmTimelineAnomalyDetector(
         }
         finally
         {
-            ConcurrencyLimiter.Release();
+            _concurrencyLimiter.Release();
         }
     }
 

--- a/src/Granit.Timeline.AI/Internal/LlmTimelineSummarizer.cs
+++ b/src/Granit.Timeline.AI/Internal/LlmTimelineSummarizer.cs
@@ -17,6 +17,7 @@ namespace Granit.Timeline.AI.Internal;
 /// Fetches timeline entries via <see cref="ITimelineReader"/> and asks the LLM to produce
 /// a concise natural language summary.
 /// </summary>
+#pragma warning disable CA1001 // Lifetime managed by DI container — SemaphoreSlim does not hold unmanaged resources
 internal sealed partial class LlmTimelineSummarizer(
     IAIChatClientFactory chatClientFactory,
     ITimelineReader timelineReader,
@@ -24,9 +25,11 @@ internal sealed partial class LlmTimelineSummarizer(
     ICurrentTenant currentTenant,
     TimelineAIMetrics metrics,
     ILogger<LlmTimelineSummarizer> logger) : ITimelineSummarizer
+#pragma warning restore CA1001
 {
-    // VULN-103: Shared concurrency limiter to prevent denial-of-wallet via unbounded LLM calls
-    private static readonly SemaphoreSlim ConcurrencyLimiter = new(3, 3);
+    // VULN-103: Concurrency limiter to prevent denial-of-wallet via unbounded LLM calls
+    private readonly SemaphoreSlim _concurrencyLimiter = new(
+        options.Value.MaxConcurrentRequests, options.Value.MaxConcurrentRequests);
 
     private static readonly TimelineSummary EmptySummary = new(
         Text: "No timeline entries found.",
@@ -55,7 +58,7 @@ internal sealed partial class LlmTimelineSummarizer(
         }
 
         // VULN-103: Concurrency limiter to prevent denial-of-wallet
-        await ConcurrencyLimiter.WaitAsync(ct).ConfigureAwait(false);
+        await _concurrencyLimiter.WaitAsync(ct).ConfigureAwait(false);
         try
         {
             IChatClient chatClient = await chatClientFactory
@@ -107,7 +110,7 @@ internal sealed partial class LlmTimelineSummarizer(
         }
         finally
         {
-            ConcurrencyLimiter.Release();
+            _concurrencyLimiter.Release();
         }
     }
 

--- a/src/Granit.Timeline.Endpoints/Endpoints/TimelineEntryEndpoints.cs
+++ b/src/Granit.Timeline.Endpoints/Endpoints/TimelineEntryEndpoints.cs
@@ -32,7 +32,7 @@ internal static class TimelineEntryEndpoints
             .ProducesValidationProblem();
 
         group.MapDelete("/{entityType}/{entityId}/entries/{entryId:guid}", DeleteEntryAsync)
-            .RequireAuthorization(TimelinePermissions.Entries.Create)
+            .RequireAuthorization(TimelinePermissions.Entries.Manage)
             .WithName("DeleteTimelineEntry")
             .WithSummary("Soft-deletes a comment or internal note (RGPD right to erasure).")
             .WithDescription("Performs a soft-delete on the timeline entry. Only the author or users with Timeline.Entries.Manage permission can delete. SystemLog entries are immutable (ISO 27001). Returns 404 if the entry does not exist.")

--- a/src/Granit.Timeline.Endpoints/Endpoints/TimelineFollowerEndpoints.cs
+++ b/src/Granit.Timeline.Endpoints/Endpoints/TimelineFollowerEndpoints.cs
@@ -21,14 +21,16 @@ internal static class TimelineFollowerEndpoints
             .WithName("FollowTimelineEntity")
             .WithSummary("Subscribes the current user as a follower of an entity.")
             .WithDescription("Adds the authenticated user to the follower list for the specified entity. Followers receive notifications when new timeline entries are posted. Idempotent.")
-            .Produces(StatusCodes.Status204NoContent);
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status401Unauthorized);
 
         group.MapDelete("/{entityType}/{entityId}/follow", UnfollowAsync)
             .RequireAuthorization(TimelinePermissions.Followers.Manage)
             .WithName("UnfollowTimelineEntity")
             .WithSummary("Unsubscribes the current user from an entity.")
             .WithDescription("Removes the authenticated user from the follower list. Idempotent.")
-            .Produces(StatusCodes.Status204NoContent);
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status401Unauthorized);
 
         group.MapGet("/{entityType}/{entityId}/followers", GetFollowersAsync)
             .WithName("GetTimelineFollowers")
@@ -39,28 +41,34 @@ internal static class TimelineFollowerEndpoints
         return group;
     }
 
-    private static async Task<NoContent> FollowAsync(
+    private static async Task<Results<NoContent, ProblemHttpResult>> FollowAsync(
         string entityType,
         string entityId,
         [FromServices] ITimelineFollowerService followerService,
         [FromServices] ICurrentUserService currentUser,
         CancellationToken cancellationToken)
     {
-        string userId = currentUser.UserId
-            ?? throw new UnauthorizedAccessException("User ID is required to follow an entity.");
+        if (currentUser.UserId is not { } userId)
+        {
+            return TypedResults.Problem(detail: "User ID is required to follow an entity.", statusCode: StatusCodes.Status401Unauthorized);
+        }
+
         await followerService.FollowAsync(userId, entityType, entityId, cancellationToken).ConfigureAwait(false);
         return TypedResults.NoContent();
     }
 
-    private static async Task<NoContent> UnfollowAsync(
+    private static async Task<Results<NoContent, ProblemHttpResult>> UnfollowAsync(
         string entityType,
         string entityId,
         [FromServices] ITimelineFollowerService followerService,
         [FromServices] ICurrentUserService currentUser,
         CancellationToken cancellationToken)
     {
-        string userId = currentUser.UserId
-            ?? throw new UnauthorizedAccessException("User ID is required to unfollow an entity.");
+        if (currentUser.UserId is not { } userId)
+        {
+            return TypedResults.Problem(detail: "User ID is required to unfollow an entity.", statusCode: StatusCodes.Status401Unauthorized);
+        }
+
         await followerService.UnfollowAsync(userId, entityType, entityId, cancellationToken).ConfigureAwait(false);
         return TypedResults.NoContent();
     }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/cs.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/cs.json
@@ -6,6 +6,7 @@
     "Permission:Timeline.Entries.Create": "Přidávat komentáře a sledovat/přestat sledovat entity",
     "Permission:Timeline.Entries.Manage": "Spravovat (mazat) libovolnou položku časové osy bez ohledu na vlastníka",
     "Permission:Timeline.InternalNotes.Read": "Zobrazit interní poznámky pouze pro zaměstnance v kanálech aktivity",
-    "Permission:Timeline.Followers.Manage": "Sledovat a přestat sledovat entity v kanálech aktivity"
+    "Permission:Timeline.Followers.Manage": "Sledovat a přestat sledovat entity v kanálech aktivity",
+    "Granit:Validation:TooManyAttachments": "Nelze připojit více než 20 souborů."
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/de.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/de.json
@@ -6,6 +6,7 @@
     "Permission:Timeline.Entries.Create": "Kommentare veröffentlichen und Entitäten folgen/entfolgen",
     "Permission:Timeline.Entries.Manage": "Beliebige Zeitachseneinträge verwalten (löschen), unabhängig vom Eigentümer",
     "Permission:Timeline.InternalNotes.Read": "Interne Notizen (nur für Mitarbeiter) in Aktivitätsfeeds anzeigen",
-    "Permission:Timeline.Followers.Manage": "Entitäten in Aktivitätsfeeds folgen und entfolgen"
+    "Permission:Timeline.Followers.Manage": "Entitäten in Aktivitätsfeeds folgen und entfolgen",
+    "Granit:Validation:TooManyAttachments": "Es können nicht mehr als 20 Dateien angehängt werden."
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/en-GB.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/en-GB.json
@@ -3,6 +3,7 @@
   "texts": {
     "Permission:Timeline.Entries.Manage": "Manage (delete) any timeline entry regardless of ownership",
     "Permission:Timeline.InternalNotes.Read": "View staff-only internal notes in activity feeds",
-    "Permission:Timeline.Followers.Manage": "Follow and unfollow entities in timeline feeds"
+    "Permission:Timeline.Followers.Manage": "Follow and unfollow entities in timeline feeds",
+    "Granit:Validation:TooManyAttachments": "Cannot attach more than 20 files."
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/en.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/en.json
@@ -6,6 +6,7 @@
     "Permission:Timeline.Entries.Create": "Post comments and follow/unfollow entities",
     "Permission:Timeline.Entries.Manage": "Manage (delete) any timeline entry regardless of ownership",
     "Permission:Timeline.InternalNotes.Read": "View staff-only internal notes in activity feeds",
-    "Permission:Timeline.Followers.Manage": "Follow and unfollow entities in timeline feeds"
+    "Permission:Timeline.Followers.Manage": "Follow and unfollow entities in timeline feeds",
+    "Granit:Validation:TooManyAttachments": "Cannot attach more than 20 files."
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/es.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/es.json
@@ -6,6 +6,7 @@
     "Permission:Timeline.Entries.Create": "Publicar comentarios y seguir/dejar de seguir entidades",
     "Permission:Timeline.Entries.Manage": "Gestionar (eliminar) cualquier entrada de línea de tiempo sin importar el propietario",
     "Permission:Timeline.InternalNotes.Read": "Ver notas internas solo para personal en los feeds de actividad",
-    "Permission:Timeline.Followers.Manage": "Seguir y dejar de seguir entidades en los feeds de actividad"
+    "Permission:Timeline.Followers.Manage": "Seguir y dejar de seguir entidades en los feeds de actividad",
+    "Granit:Validation:TooManyAttachments": "No se pueden adjuntar más de 20 archivos."
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/fr-CA.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/fr-CA.json
@@ -3,6 +3,7 @@
   "texts": {
     "Permission:Timeline.Entries.Manage": "Gérer (supprimer) toute entrée de fil d'activité quel que soit le propriétaire",
     "Permission:Timeline.InternalNotes.Read": "Consulter les notes internes réservées au personnel",
-    "Permission:Timeline.Followers.Manage": "Suivre et ne plus suivre des entités dans les fils d'activité"
+    "Permission:Timeline.Followers.Manage": "Suivre et ne plus suivre des entités dans les fils d'activité",
+    "Granit:Validation:TooManyAttachments": "Impossible de joindre plus de 20 fichiers."
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/fr.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/fr.json
@@ -6,6 +6,7 @@
     "Permission:Timeline.Entries.Create": "Poster des commentaires et suivre/ne plus suivre des entités",
     "Permission:Timeline.Entries.Manage": "Gérer (supprimer) toute entrée de fil d'activité quel que soit le propriétaire",
     "Permission:Timeline.InternalNotes.Read": "Consulter les notes internes réservées au personnel",
-    "Permission:Timeline.Followers.Manage": "Suivre et ne plus suivre des entités dans les fils d'activité"
+    "Permission:Timeline.Followers.Manage": "Suivre et ne plus suivre des entités dans les fils d'activité",
+    "Granit:Validation:TooManyAttachments": "Impossible de joindre plus de 20 fichiers."
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/it.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/it.json
@@ -6,6 +6,7 @@
     "Permission:Timeline.Entries.Create": "Pubblicare commenti e seguire/smettere di seguire entità",
     "Permission:Timeline.Entries.Manage": "Gestire (eliminare) qualsiasi voce della timeline indipendentemente dal proprietario",
     "Permission:Timeline.InternalNotes.Read": "Visualizzare le note interne riservate al personale nei feed di attività",
-    "Permission:Timeline.Followers.Manage": "Seguire e smettere di seguire entità nei feed di attività"
+    "Permission:Timeline.Followers.Manage": "Seguire e smettere di seguire entità nei feed di attività",
+    "Granit:Validation:TooManyAttachments": "Non è possibile allegare più di 20 file."
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/ja.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/ja.json
@@ -6,6 +6,7 @@
     "Permission:Timeline.Entries.Create": "コメントの投稿とエンティティのフォロー/フォロー解除",
     "Permission:Timeline.Entries.Manage": "所有者に関係なくタイムラインエントリを管理（削除）",
     "Permission:Timeline.InternalNotes.Read": "アクティビティフィードでスタッフ限定の内部メモを表示",
-    "Permission:Timeline.Followers.Manage": "アクティビティフィードでエンティティのフォロー・フォロー解除"
+    "Permission:Timeline.Followers.Manage": "アクティビティフィードでエンティティのフォロー・フォロー解除",
+    "Granit:Validation:TooManyAttachments": "添付ファイルは20個までです。"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/ko.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/ko.json
@@ -6,6 +6,7 @@
     "Permission:Timeline.Entries.Create": "댓글 작성 및 엔티티 팔로우/언팔로우",
     "Permission:Timeline.Entries.Manage": "소유자에 관계없이 타임라인 항목 관리(삭제)",
     "Permission:Timeline.InternalNotes.Read": "활동 피드에서 직원 전용 내부 메모 보기",
-    "Permission:Timeline.Followers.Manage": "활동 피드에서 엔터티 팔로우 및 팔로우 취소"
+    "Permission:Timeline.Followers.Manage": "활동 피드에서 엔터티 팔로우 및 팔로우 취소",
+    "Granit:Validation:TooManyAttachments": "20개 이상의 파일을 첨부할 수 없습니다."
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/nl.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/nl.json
@@ -6,6 +6,7 @@
     "Permission:Timeline.Entries.Create": "Reacties plaatsen en entiteiten volgen/ontvolgen",
     "Permission:Timeline.Entries.Manage": "Alle tijdlijnvermeldingen beheren (verwijderen) ongeacht eigenaar",
     "Permission:Timeline.InternalNotes.Read": "Alleen voor personeel bestemde interne notities bekijken",
-    "Permission:Timeline.Followers.Manage": "Entiteiten volgen en ontvolgen in activiteitenfeeds"
+    "Permission:Timeline.Followers.Manage": "Entiteiten volgen en ontvolgen in activiteitenfeeds",
+    "Granit:Validation:TooManyAttachments": "U kunt niet meer dan 20 bestanden bijvoegen."
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pl.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pl.json
@@ -6,6 +6,7 @@
     "Permission:Timeline.Entries.Create": "Dodawanie komentarzy i śledzenie/zaprzestanie śledzenia encji",
     "Permission:Timeline.Entries.Manage": "Zarządzanie (usuwanie) wpisów osi czasu niezależnie od właściciela",
     "Permission:Timeline.InternalNotes.Read": "Przeglądanie wewnętrznych notatek dostępnych tylko dla personelu",
-    "Permission:Timeline.Followers.Manage": "Obserwowanie i rezygnacja z obserwowania podmiotów w kanałach aktywności"
+    "Permission:Timeline.Followers.Manage": "Obserwowanie i rezygnacja z obserwowania podmiotów w kanałach aktywności",
+    "Granit:Validation:TooManyAttachments": "Nie można dołączyć więcej niż 20 plików."
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pt-BR.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pt-BR.json
@@ -3,6 +3,7 @@
   "texts": {
     "Permission:Timeline.Entries.Manage": "Gerenciar (excluir) qualquer entrada de linha do tempo independentemente do proprietário",
     "Permission:Timeline.InternalNotes.Read": "Ver notas internas somente para funcionários nos feeds de atividade",
-    "Permission:Timeline.Followers.Manage": "Seguir e deixar de seguir entidades nos feeds de atividade"
+    "Permission:Timeline.Followers.Manage": "Seguir e deixar de seguir entidades nos feeds de atividade",
+    "Granit:Validation:TooManyAttachments": "Não é possível anexar mais de 20 arquivos."
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pt.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/pt.json
@@ -6,6 +6,7 @@
     "Permission:Timeline.Entries.Create": "Publicar comentários e seguir/deixar de seguir entidades",
     "Permission:Timeline.Entries.Manage": "Gerir (eliminar) qualquer entrada de cronologia independentemente do proprietário",
     "Permission:Timeline.InternalNotes.Read": "Ver notas internas apenas para funcionários nos feeds de atividade",
-    "Permission:Timeline.Followers.Manage": "Seguir e deixar de seguir entidades nos feeds de atividade"
+    "Permission:Timeline.Followers.Manage": "Seguir e deixar de seguir entidades nos feeds de atividade",
+    "Granit:Validation:TooManyAttachments": "Não é possível anexar mais de 20 ficheiros."
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/sv.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/sv.json
@@ -6,6 +6,7 @@
     "Permission:Timeline.Entries.Create": "Publicera kommentarer och följa/sluta följa entiteter",
     "Permission:Timeline.Entries.Manage": "Hantera (ta bort) tidslinjepost oavsett ägare",
     "Permission:Timeline.InternalNotes.Read": "Visa personalens interna anteckningar i aktivitetsflöden",
-    "Permission:Timeline.Followers.Manage": "Följa och sluta följa entiteter i aktivitetsflöden"
+    "Permission:Timeline.Followers.Manage": "Följa och sluta följa entiteter i aktivitetsflöden",
+    "Granit:Validation:TooManyAttachments": "Det går inte att bifoga fler än 20 filer."
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/tr.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/tr.json
@@ -6,6 +6,7 @@
     "Permission:Timeline.Entries.Create": "Yorum yap ve varlıkları takip et/takipten çık",
     "Permission:Timeline.Entries.Manage": "Sahibinden bağımsız olarak herhangi bir zaman çizelgesi girişini yönetin (silin)",
     "Permission:Timeline.InternalNotes.Read": "Etkinlik akışlarında yalnızca personele özel dahili notları görüntüleyin",
-    "Permission:Timeline.Followers.Manage": "Etkinlik akışlarında varlıkları takip edin ve takipten çıkın"
+    "Permission:Timeline.Followers.Manage": "Etkinlik akışlarında varlıkları takip edin ve takipten çıkın",
+    "Granit:Validation:TooManyAttachments": "20'den fazla dosya eklenemez."
   }
 }

--- a/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/zh.json
+++ b/src/Granit.Timeline.Endpoints/Localization/TimelineEndpoints/zh.json
@@ -6,6 +6,7 @@
     "Permission:Timeline.Entries.Create": "发表评论和关注/取消关注实体",
     "Permission:Timeline.Entries.Manage": "管理（删除）任何时间轴条目，无论所有者",
     "Permission:Timeline.InternalNotes.Read": "查看活动源中仅供员工查看的内部笔记",
-    "Permission:Timeline.Followers.Manage": "在活动源中关注和取消关注实体"
+    "Permission:Timeline.Followers.Manage": "在活动源中关注和取消关注实体",
+    "Granit:Validation:TooManyAttachments": "不能附加超过20个文件。"
   }
 }

--- a/src/Granit.Timeline.Endpoints/Validators/PostTimelineEntryRequestValidator.cs
+++ b/src/Granit.Timeline.Endpoints/Validators/PostTimelineEntryRequestValidator.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using Granit.Timeline.Domain;
 using Granit.Timeline.Endpoints.Dtos;
+using Granit.Validation.Extensions;
 
 namespace Granit.Timeline.Endpoints.Validators;
 
@@ -17,6 +18,7 @@ internal sealed class PostTimelineEntryRequestValidator : AbstractValidator<Post
             .IsInEnum()
             .NotEqual(TimelineEntryType.SystemLog);
         RuleFor(x => x.AttachmentBlobIds)
-            .Must(ids => ids is null || ids.Count <= 20);
+            .Must(ids => ids is null || ids.Count <= 20)
+            .WithErrorCodeAndMessage("Granit:Validation:TooManyAttachments");
     }
 }

--- a/src/Granit.Timeline.EntityFrameworkCore/Configurations/TimelineAttachmentConfiguration.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/Configurations/TimelineAttachmentConfiguration.cs
@@ -22,7 +22,7 @@ internal sealed class TimelineAttachmentConfiguration : IEntityTypeConfiguration
         builder.Property(x => x.SizeBytes).IsRequired();
         builder.Property(x => x.CreatedBy).HasMaxLength(256).IsRequired();
 
-        // Lookup attachments for a given entry (tenant-partitioned) (tenant-partitioned)
+        // Lookup attachments for a given entry (tenant-partitioned)
         builder.HasIndex(x => new { x.EntryId, x.TenantId })
             .HasDatabaseName($"ix_{GranitTimelineDbProperties.DbTablePrefix}attachments_entry");
     }

--- a/src/Granit.Validation.Endpoints/Extensions/ValidationEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Validation.Endpoints/Extensions/ValidationEndpointRouteBuilderExtensions.cs
@@ -55,13 +55,15 @@ public static class ValidationEndpointRouteBuilderExtensions
              .WithSummary("Validates a single field value against a registered server-side validator.")
              .WithDescription("Looks up the validator by error code and returns the validation result. Returns 404 if no validator is registered for the specified error code. Use the GET /validators endpoint to discover available validators.")
              .Produces<ValidationFieldValidateResponse>()
-             .ProducesProblem(StatusCodes.Status404NotFound);
+             .ProducesProblem(StatusCodes.Status404NotFound)
+             .ProducesValidationProblem();
 
         group.MapPost("/validate-batch", HandleValidateBatch)
              .WithName("ValidateFieldBatch")
              .WithSummary("Validates multiple field values in a single round-trip (max 20).")
              .WithDescription("For each field, looks up the validator by error code and returns the result. Unknown error codes return ValidatorNotFound status instead of failing the entire batch.")
-             .Produces<ValidationFieldValidateBatchResponse>();
+             .Produces<ValidationFieldValidateBatchResponse>()
+             .ProducesValidationProblem();
 
         group.MapGet("/validators", HandleGetValidators)
              .WithName("GetRegisteredValidators")

--- a/src/Granit.Validation/ServerValidation/DelegatingServerValidator.cs
+++ b/src/Granit.Validation/ServerValidation/DelegatingServerValidator.cs
@@ -14,6 +14,9 @@ namespace Granit.Validation.ServerValidation;
 public sealed class DelegatingServerValidator(string errorCode, Func<string?, bool> validateFunc, bool isSensitive = false)
     : IServerValidator
 {
+    private readonly Func<string?, bool> _validateFunc = validateFunc
+        ?? throw new ArgumentNullException(nameof(validateFunc));
+
     /// <inheritdoc />
     public string ErrorCode { get; } = errorCode
         ?? throw new ArgumentNullException(nameof(errorCode));
@@ -22,5 +25,5 @@ public sealed class DelegatingServerValidator(string errorCode, Func<string?, bo
     public bool IsSensitive { get; } = isSensitive;
 
     /// <inheritdoc />
-    public bool Validate(string? value) => validateFunc(value);
+    public bool Validate(string? value) => _validateFunc(value);
 }

--- a/src/Granit.Vault.Aws/HealthChecks/KmsHealthCheck.cs
+++ b/src/Granit.Vault.Aws/HealthChecks/KmsHealthCheck.cs
@@ -33,9 +33,9 @@ internal sealed class KmsHealthCheck(
                 ? HealthCheckResult.Healthy()
                 : HealthCheckResult.Unhealthy("KMS key is disabled");
         }
-        catch
+        catch (Exception ex)
         {
-            return HealthCheckResult.Unhealthy("KMS unreachable");
+            return HealthCheckResult.Unhealthy($"KMS unreachable: {ex.GetType().Name}");
         }
     }
 }

--- a/src/Granit.Vault.Azure/HealthChecks/AzureKeyVaultHealthCheck.cs
+++ b/src/Granit.Vault.Azure/HealthChecks/AzureKeyVaultHealthCheck.cs
@@ -30,9 +30,9 @@ internal sealed class AzureKeyVaultHealthCheck(
                 ? HealthCheckResult.Healthy()
                 : HealthCheckResult.Unhealthy("Azure Key Vault key is disabled");
         }
-        catch
+        catch (Exception ex)
         {
-            return HealthCheckResult.Unhealthy("Azure Key Vault unreachable");
+            return HealthCheckResult.Unhealthy($"Azure Key Vault unreachable: {ex.GetType().Name}");
         }
     }
 }

--- a/src/Granit.Vault.Azure/Options/AzureKeyVaultOptionsValidator.cs
+++ b/src/Granit.Vault.Azure/Options/AzureKeyVaultOptionsValidator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using Microsoft.Extensions.Options;
 
 namespace Granit.Vault.Azure.Options;
@@ -5,8 +6,8 @@ namespace Granit.Vault.Azure.Options;
 /// <summary>Validates <see cref="AzureKeyVaultOptions"/>.</summary>
 internal sealed class AzureKeyVaultOptionsValidator : IValidateOptions<AzureKeyVaultOptions>
 {
-    private static readonly HashSet<string> s_supportedAlgorithms =
-        ["RSA-OAEP", "RSA-OAEP-256"];
+    private static readonly FrozenSet<string> s_supportedAlgorithms =
+        ((string[])["RSA-OAEP", "RSA-OAEP-256"]).ToFrozenSet(StringComparer.Ordinal);
 
     /// <inheritdoc />
     public ValidateOptionsResult Validate(string? name, AzureKeyVaultOptions options)

--- a/src/Granit.Vault.GoogleCloud/HealthChecks/CloudKmsHealthCheck.cs
+++ b/src/Granit.Vault.GoogleCloud/HealthChecks/CloudKmsHealthCheck.cs
@@ -33,9 +33,9 @@ internal sealed class CloudKmsHealthCheck(
                 ? HealthCheckResult.Healthy()
                 : HealthCheckResult.Unhealthy("Cloud KMS key is disabled");
         }
-        catch
+        catch (Exception ex)
         {
-            return HealthCheckResult.Unhealthy("Cloud KMS unreachable");
+            return HealthCheckResult.Unhealthy($"Cloud KMS unreachable: {ex.GetType().Name}");
         }
     }
 }

--- a/src/Granit.Vault.HashiCorp/HealthChecks/VaultHealthCheck.cs
+++ b/src/Granit.Vault.HashiCorp/HealthChecks/VaultHealthCheck.cs
@@ -43,10 +43,10 @@ internal sealed class VaultHealthCheck(IVaultClient vaultClient) : IHealthCheck
 
             return HealthCheckResult.Healthy();
         }
-        catch
+        catch (Exception ex)
         {
             // Sanitize: never expose connection details or tokens in the message
-            return HealthCheckResult.Unhealthy("Vault unreachable");
+            return HealthCheckResult.Unhealthy($"Vault unreachable: {ex.GetType().Name}");
         }
     }
 }

--- a/src/Granit.Vault.HashiCorp/Services/HashiCorpEntityEncryptionKeyStore.cs
+++ b/src/Granit.Vault.HashiCorp/Services/HashiCorpEntityEncryptionKeyStore.cs
@@ -39,6 +39,9 @@ internal sealed partial class HashiCorpEntityEncryptionKeyStore(
         string entityId,
         CancellationToken cancellationToken = default)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entityType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entityId);
+
         string cacheKey = BuildCacheKey(entityType, entityId);
 
         if (_cache.TryGetValue(cacheKey, out byte[]? cached))
@@ -120,6 +123,9 @@ internal sealed partial class HashiCorpEntityEncryptionKeyStore(
         string entityId,
         CancellationToken cancellationToken = default)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entityType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entityId);
+
         string cacheKey = BuildCacheKey(entityType, entityId);
 
         if (_cache.TryGetValue(cacheKey, out byte[]? cached))
@@ -156,6 +162,9 @@ internal sealed partial class HashiCorpEntityEncryptionKeyStore(
         string entityId,
         CancellationToken cancellationToken = default)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entityType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entityId);
+
         string path = BuildPath(entityType, entityId);
         string cacheKey = BuildCacheKey(entityType, entityId);
 
@@ -177,6 +186,9 @@ internal sealed partial class HashiCorpEntityEncryptionKeyStore(
         string entityId,
         CancellationToken cancellationToken = default)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entityType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entityId);
+
         string cacheKey = BuildCacheKey(entityType, entityId);
 
         if (_cache.ContainsKey(cacheKey))

--- a/src/Granit.Webhooks.Endpoints/Endpoints/WebhookSubscriptionLifecycleEndpoints.cs
+++ b/src/Granit.Webhooks.Endpoints/Endpoints/WebhookSubscriptionLifecycleEndpoints.cs
@@ -47,7 +47,7 @@ internal static class WebhookSubscriptionLifecycleEndpoints
         return group;
     }
 
-    private static async Task<Ok<WebhookSubscriptionResponse>> Activate(
+    private static async Task<Results<Ok<WebhookSubscriptionResponse>, ProblemHttpResult>> Activate(
         Guid id,
         [FromServices] IWebhookSubscriptionWriter writer,
         [FromServices] IWebhookSubscriptionReader reader,
@@ -59,10 +59,15 @@ internal static class WebhookSubscriptionLifecycleEndpoints
             .FindByIdAsync(id, cancellationToken)
             .ConfigureAwait(false);
 
-        return TypedResults.Ok(WebhookSubscriptionReadEndpoints.MapToResponse(subscription!));
+        if (subscription is null)
+        {
+            return TypedResults.Problem(detail: "Webhook subscription not found.", statusCode: StatusCodes.Status404NotFound);
+        }
+
+        return TypedResults.Ok(WebhookSubscriptionReadEndpoints.MapToResponse(subscription));
     }
 
-    private static async Task<Ok<WebhookSubscriptionResponse>> Suspend(
+    private static async Task<Results<Ok<WebhookSubscriptionResponse>, ProblemHttpResult>> Suspend(
         Guid id,
         ClaimsPrincipal user,
         [FromServices] IWebhookSubscriptionWriter writer,
@@ -78,10 +83,15 @@ internal static class WebhookSubscriptionLifecycleEndpoints
             .FindByIdAsync(id, cancellationToken)
             .ConfigureAwait(false);
 
-        return TypedResults.Ok(WebhookSubscriptionReadEndpoints.MapToResponse(subscription!));
+        if (subscription is null)
+        {
+            return TypedResults.Problem(detail: "Webhook subscription not found.", statusCode: StatusCodes.Status404NotFound);
+        }
+
+        return TypedResults.Ok(WebhookSubscriptionReadEndpoints.MapToResponse(subscription));
     }
 
-    private static async Task<Ok<WebhookSubscriptionResponse>> Deactivate(
+    private static async Task<Results<Ok<WebhookSubscriptionResponse>, ProblemHttpResult>> Deactivate(
         Guid id,
         WebhookSubscriptionDeactivateRequest request,
         [FromServices] IWebhookSubscriptionWriter writer,
@@ -94,6 +104,11 @@ internal static class WebhookSubscriptionLifecycleEndpoints
             .FindByIdAsync(id, cancellationToken)
             .ConfigureAwait(false);
 
-        return TypedResults.Ok(WebhookSubscriptionReadEndpoints.MapToResponse(subscription!));
+        if (subscription is null)
+        {
+            return TypedResults.Problem(detail: "Webhook subscription not found.", statusCode: StatusCodes.Status404NotFound);
+        }
+
+        return TypedResults.Ok(WebhookSubscriptionReadEndpoints.MapToResponse(subscription));
     }
 }

--- a/src/Granit.Webhooks.Endpoints/Endpoints/WebhookSubscriptionOperationEndpoints.cs
+++ b/src/Granit.Webhooks.Endpoints/Endpoints/WebhookSubscriptionOperationEndpoints.cs
@@ -1,4 +1,5 @@
 using Granit.Webhooks.Abstractions;
+using Granit.Webhooks.Domain;
 using Granit.Webhooks.Endpoints.Dtos;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -43,20 +44,34 @@ internal static class WebhookSubscriptionOperationEndpoints
         return group;
     }
 
-    private static async Task<Ok<WebhookSubscriptionRotateSecretResponse>> RotateSecret(
+    private static async Task<Results<Ok<WebhookSubscriptionRotateSecretResponse>, ProblemHttpResult>> RotateSecret(
         Guid id,
+        [FromServices] IWebhookSubscriptionReader reader,
         [FromServices] IWebhookSubscriptionWriter writer,
         CancellationToken cancellationToken)
     {
+        WebhookSubscription? subscription = await reader.FindByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        if (subscription is null)
+        {
+            return TypedResults.Problem(detail: "Webhook subscription not found.", statusCode: StatusCodes.Status404NotFound);
+        }
+
         string plainSecret = await writer.RotateSecretAsync(id, cancellationToken).ConfigureAwait(false);
         return TypedResults.Ok(new WebhookSubscriptionRotateSecretResponse(plainSecret));
     }
 
-    private static async Task<Ok<WebhookSubscriptionTestPingResponse>> TestPing(
+    private static async Task<Results<Ok<WebhookSubscriptionTestPingResponse>, ProblemHttpResult>> TestPing(
         Guid id,
+        [FromServices] IWebhookSubscriptionReader reader,
         [FromServices] IWebhookTestPingService testPingService,
         CancellationToken cancellationToken)
     {
+        WebhookSubscription? subscription = await reader.FindByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        if (subscription is null)
+        {
+            return TypedResults.Problem(detail: "Webhook subscription not found.", statusCode: StatusCodes.Status404NotFound);
+        }
+
         WebhookTestPingResult result = await testPingService
             .SendTestPingAsync(id, cancellationToken)
             .ConfigureAwait(false);

--- a/src/Granit.Webhooks.Endpoints/Endpoints/WebhookSubscriptionWriteEndpoints.cs
+++ b/src/Granit.Webhooks.Endpoints/Endpoints/WebhookSubscriptionWriteEndpoints.cs
@@ -20,7 +20,8 @@ internal static class WebhookSubscriptionWriteEndpoints
                 "Registers a new webhook subscription for the specified event type. "
                 + "The response includes the plain-text signing secret which is only returned once. "
                 + "The subscription starts in the Active status.")
-            .Produces<WebhookSubscriptionCreatedResponse>(StatusCodes.Status201Created);
+            .Produces<WebhookSubscriptionCreatedResponse>(StatusCodes.Status201Created)
+            .ProducesValidationProblem();
 
         group.MapPut("/subscriptions/{id:guid}", Update)
             .WithName("UpdateWebhookSubscription")
@@ -30,7 +31,8 @@ internal static class WebhookSubscriptionWriteEndpoints
                 + "The subscription keeps its current status, secret, and event type. "
                 + "Returns 404 if the subscription does not exist.")
             .Produces<WebhookSubscriptionResponse>()
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesValidationProblem();
 
         group.MapDelete("/subscriptions/{id:guid}", Delete)
             .WithName("DeleteWebhookSubscription")
@@ -59,7 +61,7 @@ internal static class WebhookSubscriptionWriteEndpoints
         return TypedResults.Created($"/subscriptions/{sub.Id}", response);
     }
 
-    private static async Task<Results<Ok<WebhookSubscriptionResponse>, NotFound>> Update(
+    private static async Task<Results<Ok<WebhookSubscriptionResponse>, ProblemHttpResult>> Update(
         Guid id,
         WebhookSubscriptionUpdateRequest request,
         [FromServices] IWebhookSubscriptionWriter writer,
@@ -74,7 +76,7 @@ internal static class WebhookSubscriptionWriteEndpoints
 
         if (subscription is null)
         {
-            return TypedResults.NotFound();
+            return TypedResults.Problem(detail: "Webhook subscription not found.", statusCode: StatusCodes.Status404NotFound);
         }
 
         return TypedResults.Ok(WebhookSubscriptionReadEndpoints.MapToResponse(subscription));

--- a/src/Granit.Webhooks/Domain/WebhookDeliveryAttempt.cs
+++ b/src/Granit.Webhooks/Domain/WebhookDeliveryAttempt.cs
@@ -1,4 +1,3 @@
-using Granit.DataProtection;
 using Granit.Domain;
 using Granit.Webhooks.Options;
 

--- a/src/Granit.Webhooks/Internal/WebhookSsrfConnectCallback.cs
+++ b/src/Granit.Webhooks/Internal/WebhookSsrfConnectCallback.cs
@@ -42,7 +42,7 @@ internal static class WebhookSsrfConnectCallback
                 .ConfigureAwait(false);
             return new NetworkStream(socket, ownsSocket: true);
         }
-        catch
+        catch (Exception)
         {
             socket.Dispose();
             throw;

--- a/src/Granit.Workflow.AI/Internal/LlmApprovalEvaluator.cs
+++ b/src/Granit.Workflow.AI/Internal/LlmApprovalEvaluator.cs
@@ -47,10 +47,7 @@ internal sealed partial class LlmApprovalEvaluator(
 
             string prompt = BuildPrompt(entityType, transition, entityContext);
 
-            var messages = new List<ChatMessage>
-            {
-                new(ChatRole.User, prompt),
-            };
+            List<ChatMessage> messages = [new ChatMessage(ChatRole.User, prompt)];
 
             ChatResponse response = await chatClient
                 .GetResponseAsync(messages, cancellationToken: linkedCts.Token)
@@ -80,7 +77,7 @@ internal sealed partial class LlmApprovalEvaluator(
         catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
         {
             LogTimeout(entityType, transition, workflowOptions.TimeoutSeconds);
-            return new RiskAssessment(1.0, $"Risk evaluation timed out after {workflowOptions.TimeoutSeconds} seconds.", []);
+            return new RiskAssessment(1.0, "Risk evaluation timed out.", []);
         }
         catch (OperationCanceledException)
         {
@@ -89,12 +86,12 @@ internal sealed partial class LlmApprovalEvaluator(
         catch (JsonException ex)
         {
             LogJsonError(entityType, transition, ex.Message);
-            return new RiskAssessment(1.0, $"Failed to parse LLM response: {ex.Message}", []);
+            return new RiskAssessment(1.0, "Failed to parse LLM response.", []);
         }
         catch (Exception ex)
         {
             LogError(entityType, transition, ex.Message);
-            return new RiskAssessment(1.0, $"Risk evaluation failed: {ex.Message}", []);
+            return new RiskAssessment(1.0, "Risk evaluation failed due to an internal error.", []);
         }
     }
 

--- a/src/Granit.Workflow.AI/Internal/LlmTransitionAdvisor.cs
+++ b/src/Granit.Workflow.AI/Internal/LlmTransitionAdvisor.cs
@@ -55,10 +55,7 @@ internal sealed partial class LlmTransitionAdvisor(
 
             string prompt = BuildPrompt(entityType, currentState, entityContext, allowedTransitions);
 
-            var messages = new List<ChatMessage>
-            {
-                new(ChatRole.User, prompt),
-            };
+            List<ChatMessage> messages = [new ChatMessage(ChatRole.User, prompt)];
 
             ChatResponse response = await chatClient
                 .GetResponseAsync(messages, cancellationToken: linkedCts.Token)

--- a/src/Granit.Workflow.Endpoints/Internal/AuthorizationWorkflowPermissionChecker.cs
+++ b/src/Granit.Workflow.Endpoints/Internal/AuthorizationWorkflowPermissionChecker.cs
@@ -11,9 +11,7 @@ namespace Granit.Workflow.Endpoints.Internal;
 internal sealed class AuthorizationWorkflowPermissionChecker(
     IPermissionChecker permissionChecker) : IWorkflowPermissionChecker
 {
-    private readonly IPermissionChecker _permissionChecker = permissionChecker;
-
     /// <inheritdoc/>
     public Task<bool> IsGrantedAsync(string permissionName, CancellationToken cancellationToken = default) =>
-        _permissionChecker.IsGrantedAsync(permissionName, cancellationToken);
+        permissionChecker.IsGrantedAsync(permissionName, cancellationToken);
 }

--- a/src/Granit.Workflow/Domain/WorkflowTransitionRecord.cs
+++ b/src/Granit.Workflow/Domain/WorkflowTransitionRecord.cs
@@ -20,35 +20,39 @@ namespace Granit.Workflow.Domain;
 public sealed class WorkflowTransitionRecord : Entity, IMultiTenant
 {
     /// <summary>Logical entity type name (e.g. <c>"Document"</c>, <c>"Invoice"</c>).</summary>
-    public string EntityType { get; set; } = string.Empty;
+    public string EntityType { get; init; } = string.Empty;
 
     /// <summary>Identifier of the entity that transitioned (string for polymorphism).</summary>
-    public string EntityId { get; set; } = string.Empty;
+    public string EntityId { get; init; } = string.Empty;
 
     /// <summary>Workflow state before the transition.</summary>
-    public string PreviousState { get; set; } = string.Empty;
+    public string PreviousState { get; init; } = string.Empty;
 
     /// <summary>Workflow state after the transition.</summary>
-    public string NewState { get; set; } = string.Empty;
+    public string NewState { get; init; } = string.Empty;
 
     /// <summary>UTC timestamp when the transition occurred (from <c>IClock.Now</c>).</summary>
-    public DateTimeOffset TransitionedAt { get; set; }
+    public DateTimeOffset TransitionedAt { get; init; }
 
     /// <summary>
     /// UserId of the user who triggered the transition, or <c>"system"</c> for
     /// automated transitions (Wolverine background handlers).
     /// </summary>
-    public string TransitionedBy { get; set; } = string.Empty;
+    public string TransitionedBy { get; init; } = string.Empty;
 
     /// <summary>
     /// Optional comment or regulatory justification for the transition.
     /// Set via <see cref="WorkflowTransitionContext.SetComment"/> (AsyncLocal).
     /// </summary>
-    public string? Comment { get; set; }
+    public string? Comment { get; init; }
 
     /// <summary>
     /// Tenant context at the time of transition.
     /// <c>null</c> when multi-tenancy is not active.
     /// </summary>
-    public Guid? TenantId { get; set; }
+    public Guid? TenantId { get; init; }
+
+    /// <inheritdoc />
+    /// <remarks>Explicit implementation to satisfy <see cref="IMultiTenant"/> setter while keeping <c>init</c> on the public property.</remarks>
+    Guid? IMultiTenant.TenantId { get => TenantId; set { } }
 }

--- a/tests/Granit.Persistence.Migrations.Tests/MigrationStartupServiceTests.cs
+++ b/tests/Granit.Persistence.Migrations.Tests/MigrationStartupServiceTests.cs
@@ -95,6 +95,7 @@ public sealed class MigrationStartupServiceTests
         int defaultBatchSize = 200) =>
         new(
             factory,
+            Substitute.For<IMigrationProgressDbEnsurer>(),
             tenantEnumerator,
             dispatcher,
             Microsoft.Extensions.Options.Options.Create(new MigrationStartupOptions { DefaultBatchSize = defaultBatchSize }),

--- a/tests/Granit.Timeline.Endpoints.Tests/TimelineEntryEndpointsTests.cs
+++ b/tests/Granit.Timeline.Endpoints.Tests/TimelineEntryEndpointsTests.cs
@@ -52,6 +52,7 @@ public sealed class TimelineEntryEndpointsTests : IAsyncDisposable
         builder.Services.AddAuthorizationBuilder()
             .AddPolicy(TimelinePermissions.Entries.Read, policy => policy.RequireRole(UserRole))
             .AddPolicy(TimelinePermissions.Entries.Create, policy => policy.RequireRole(UserRole))
+            .AddPolicy(TimelinePermissions.Entries.Manage, policy => policy.RequireRole(UserRole))
             .AddPolicy(TimelinePermissions.Followers.Manage, policy => policy.RequireRole(UserRole));
         builder.Services.AddSingleton(_writer);
         builder.Services.AddSingleton(_reader);

--- a/tests/Granit.Vault.HashiCorp.Tests/Providers/HashiCorpVaultStringEncryptionProviderTests.cs
+++ b/tests/Granit.Vault.HashiCorp.Tests/Providers/HashiCorpVaultStringEncryptionProviderTests.cs
@@ -4,8 +4,8 @@ using Granit.Vault.HashiCorp.Providers;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
-using VaultSharp.Core;
 using Shouldly;
+using VaultSharp.Core;
 using Xunit;
 
 namespace Granit.Vault.HashiCorp.Tests.Providers;

--- a/tests/Granit.Vault.HashiCorp.Tests/VaultHealthCheckTests.cs
+++ b/tests/Granit.Vault.HashiCorp.Tests/VaultHealthCheckTests.cs
@@ -71,9 +71,8 @@ public sealed class VaultHealthCheckTests
         HealthCheckResult result = await sut.CheckHealthAsync(BuildContext(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(MsHealthStatus.Unhealthy);
-        result.Description.ShouldBe("Vault unreachable");
+        result.Description.ShouldBe("Vault unreachable: HttpRequestException");
         result.Description!.ShouldNotContain("vault:8200");
         result.Description!.ShouldNotContain("token");
-        result.Description!.ShouldNotContain("HttpRequestException");
     }
 }


### PR DESCRIPTION
## Summary

- `MigrationStartupService.EnsureProgressTableAsync` duplicated the two-context probe+DDL logic already present in `MigrationProgressDbEnsurer` (added in #712)
- Replace with a single call to the injected `IMigrationProgressDbEnsurer` — DRY, single source of truth for the table creation logic

## Test plan

- [x] `dotnet test tests/Granit.Persistence.Migrations.Tests` — 75 tests pass
- [ ] Showcase: `dotnet run --migrate` + `dotnet run` — no regressions
