### PR TITLE
refactor(persistence): move entity classes from Internal/ to Entities/ folder

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2006,7 +2006,7 @@
       "kind": "class",
       "project": "Granit.AI.EntityFrameworkCore",
       "file": "src/Granit.AI.EntityFrameworkCore/Extensions/AIModelBuilderExtensions.cs",
-      "line": 11,
+      "line": 12,
       "members": [
         {
           "name": "ConfigureAIModule",
@@ -26867,7 +26867,7 @@
       "kind": "class",
       "project": "Granit.Templating.EntityFrameworkCore",
       "file": "src/Granit.Templating.EntityFrameworkCore/Extensions/TemplatingModelBuilderExtensions.cs",
-      "line": 10,
+      "line": 11,
       "members": [
         {
           "name": "ConfigureTemplatingModule",

--- a/src/Granit.AI.EntityFrameworkCore/Entities/AIUsageRecordEntity.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Entities/AIUsageRecordEntity.cs
@@ -1,6 +1,6 @@
 using Granit.Domain;
 
-namespace Granit.AI.EntityFrameworkCore.Internal;
+namespace Granit.AI.EntityFrameworkCore.Entities;
 
 /// <summary>
 /// EF Core entity for AI usage tracking records. Immutable after creation.

--- a/src/Granit.AI.EntityFrameworkCore/Entities/AIWorkspaceEntity.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Entities/AIWorkspaceEntity.cs
@@ -1,7 +1,7 @@
 using Granit.AI.Workspaces;
 using Granit.Domain;
 
-namespace Granit.AI.EntityFrameworkCore.Internal;
+namespace Granit.AI.EntityFrameworkCore.Entities;
 
 /// <summary>
 /// EF Core entity for dynamic AI workspace configurations.

--- a/src/Granit.AI.EntityFrameworkCore/Extensions/AIModelBuilderExtensions.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Extensions/AIModelBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.AI.EntityFrameworkCore.Entities;
 using Granit.AI.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;
 

--- a/src/Granit.AI.EntityFrameworkCore/Internal/AIDbContext.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/AIDbContext.cs
@@ -1,3 +1,4 @@
+using Granit.AI.EntityFrameworkCore.Entities;
 using Granit.AI.EntityFrameworkCore.Extensions;
 using Granit.DataFiltering;
 using Granit.MultiTenancy;

--- a/src/Granit.AI.EntityFrameworkCore/Internal/AIUsageRecordEntityConfiguration.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/AIUsageRecordEntityConfiguration.cs
@@ -1,3 +1,4 @@
+using Granit.AI.EntityFrameworkCore.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 

--- a/src/Granit.AI.EntityFrameworkCore/Internal/AIWorkspaceEntityConfiguration.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/AIWorkspaceEntityConfiguration.cs
@@ -1,3 +1,4 @@
+using Granit.AI.EntityFrameworkCore.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 

--- a/src/Granit.AI.EntityFrameworkCore/Internal/EfAIUsageQueryableProvider.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/EfAIUsageQueryableProvider.cs
@@ -1,3 +1,4 @@
+using Granit.AI.EntityFrameworkCore.Entities;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.AI.EntityFrameworkCore.Internal;

--- a/src/Granit.AI.EntityFrameworkCore/Internal/EfAIUsageStore.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/EfAIUsageStore.cs
@@ -1,4 +1,5 @@
 using Granit.AI.Diagnostics;
+using Granit.AI.EntityFrameworkCore.Entities;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.AI.EntityFrameworkCore.Internal;

--- a/src/Granit.AI.EntityFrameworkCore/Internal/EfAIWorkspaceStore.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/EfAIWorkspaceStore.cs
@@ -1,3 +1,4 @@
+using Granit.AI.EntityFrameworkCore.Entities;
 using Granit.AI.Workspaces;
 using Microsoft.EntityFrameworkCore;
 

--- a/src/Granit.Features.EntityFrameworkCore/Entities/TenantFeatureOverride.cs
+++ b/src/Granit.Features.EntityFrameworkCore/Entities/TenantFeatureOverride.cs
@@ -1,6 +1,6 @@
 using Granit.Domain;
 
-namespace Granit.Features.EntityFrameworkCore.Internal;
+namespace Granit.Features.EntityFrameworkCore.Entities;
 
 /// <summary>
 /// Represents a tenant-level override for a feature value.

--- a/src/Granit.Features.EntityFrameworkCore/Internal/EfCoreFeatureStore.cs
+++ b/src/Granit.Features.EntityFrameworkCore/Internal/EfCoreFeatureStore.cs
@@ -2,6 +2,7 @@ using Granit.DataFiltering;
 using Granit.Domain;
 using Granit.Events;
 using Granit.Features.Diagnostics;
+using Granit.Features.EntityFrameworkCore.Entities;
 using Granit.Features.Events;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;

--- a/src/Granit.Features.EntityFrameworkCore/Internal/FeaturesDbContext.cs
+++ b/src/Granit.Features.EntityFrameworkCore/Internal/FeaturesDbContext.cs
@@ -1,4 +1,5 @@
 using Granit.DataFiltering;
+using Granit.Features.EntityFrameworkCore.Entities;
 using Granit.Features.EntityFrameworkCore.Extensions;
 using Granit.MultiTenancy;
 using Granit.Persistence.Extensions;

--- a/src/Granit.Features.EntityFrameworkCore/Internal/TenantFeatureOverrideConfiguration.cs
+++ b/src/Granit.Features.EntityFrameworkCore/Internal/TenantFeatureOverrideConfiguration.cs
@@ -1,3 +1,4 @@
+using Granit.Features.EntityFrameworkCore.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 

--- a/src/Granit.Templating.EntityFrameworkCore/Entities/TemplateCategoryEntity.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Entities/TemplateCategoryEntity.cs
@@ -1,6 +1,6 @@
 using Granit.Domain;
 
-namespace Granit.Templating.EntityFrameworkCore.Internal;
+namespace Granit.Templating.EntityFrameworkCore.Entities;
 
 /// <summary>
 /// EF Core entity for template categories used to organize templates by domain.

--- a/src/Granit.Templating.EntityFrameworkCore/Entities/TemplateRevisionEntity.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Entities/TemplateRevisionEntity.cs
@@ -1,7 +1,7 @@
 using Granit.Domain;
 using Granit.Templating.Store;
 
-namespace Granit.Templating.EntityFrameworkCore.Internal;
+namespace Granit.Templating.EntityFrameworkCore.Entities;
 
 /// <summary>
 /// EF Core entity mapping a single revision of a template.

--- a/src/Granit.Templating.EntityFrameworkCore/Extensions/TemplatingModelBuilderExtensions.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Extensions/TemplatingModelBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Templating.EntityFrameworkCore.Entities;
 using Granit.Templating.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;
 

--- a/src/Granit.Templating.EntityFrameworkCore/Internal/EfDocumentTemplateStore.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Internal/EfDocumentTemplateStore.cs
@@ -2,6 +2,7 @@ using Granit.Domain;
 using Granit.Exceptions;
 using Granit.Guids;
 using Granit.MultiTenancy;
+using Granit.Templating.EntityFrameworkCore.Entities;
 using Granit.Templating.Exceptions;
 using Granit.Templating.Keys;
 using Granit.Templating.Pipeline;

--- a/src/Granit.Templating.EntityFrameworkCore/Internal/EfTemplateCategoryStore.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Internal/EfTemplateCategoryStore.cs
@@ -2,6 +2,7 @@ using Granit.Domain;
 using Granit.Exceptions;
 using Granit.Guids;
 using Granit.MultiTenancy;
+using Granit.Templating.EntityFrameworkCore.Entities;
 using Granit.Templating.Store;
 using Granit.Timing;
 using Microsoft.EntityFrameworkCore;

--- a/src/Granit.Templating.EntityFrameworkCore/Internal/StoreTemplateResolver.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Internal/StoreTemplateResolver.cs
@@ -1,3 +1,4 @@
+using Granit.Templating.EntityFrameworkCore.Entities;
 using Granit.Templating.Keys;
 using Granit.Templating.Pipeline;
 using Granit.Templating.Store;

--- a/src/Granit.Templating.EntityFrameworkCore/Internal/TemplateCategoryEntityConfiguration.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Internal/TemplateCategoryEntityConfiguration.cs
@@ -1,3 +1,4 @@
+using Granit.Templating.EntityFrameworkCore.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 

--- a/src/Granit.Templating.EntityFrameworkCore/Internal/TemplateRevisionEntityConfiguration.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Internal/TemplateRevisionEntityConfiguration.cs
@@ -1,3 +1,4 @@
+using Granit.Templating.EntityFrameworkCore.Entities;
 using Granit.Templating.Store;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;

--- a/src/Granit.Templating.EntityFrameworkCore/Internal/TemplatingDbContext.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Internal/TemplatingDbContext.cs
@@ -1,6 +1,7 @@
 using Granit.DataFiltering;
 using Granit.MultiTenancy;
 using Granit.Persistence.Extensions;
+using Granit.Templating.EntityFrameworkCore.Entities;
 using Granit.Templating.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 

--- a/tests/Granit.AI.EntityFrameworkCore.Tests/EfAIUsageStoreTests.cs
+++ b/tests/Granit.AI.EntityFrameworkCore.Tests/EfAIUsageStoreTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.Metrics;
 using Granit.AI.Diagnostics;
+using Granit.AI.EntityFrameworkCore.Entities;
 using Granit.AI.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;

--- a/tests/Granit.AI.EntityFrameworkCore.Tests/EfAIWorkspaceStoreTests.cs
+++ b/tests/Granit.AI.EntityFrameworkCore.Tests/EfAIWorkspaceStoreTests.cs
@@ -1,3 +1,4 @@
+using Granit.AI.EntityFrameworkCore.Entities;
 using Granit.AI.EntityFrameworkCore.Internal;
 using Granit.AI.Workspaces;
 using Microsoft.EntityFrameworkCore;

--- a/tests/Granit.Features.EntityFrameworkCore.Tests/EfCoreFeatureStoreAdditionalTests.cs
+++ b/tests/Granit.Features.EntityFrameworkCore.Tests/EfCoreFeatureStoreAdditionalTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.Metrics;
 using Granit.Events;
 using Granit.Features.Diagnostics;
+using Granit.Features.EntityFrameworkCore.Entities;
 using Granit.Features.EntityFrameworkCore.Internal;
 using Granit.Features.Events;
 using Microsoft.EntityFrameworkCore;

--- a/tests/Granit.Features.EntityFrameworkCore.Tests/EfCoreFeatureStoreTests.cs
+++ b/tests/Granit.Features.EntityFrameworkCore.Tests/EfCoreFeatureStoreTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.Metrics;
 using Granit.Events;
 using Granit.Features.Diagnostics;
+using Granit.Features.EntityFrameworkCore.Entities;
 using Granit.Features.EntityFrameworkCore.Internal;
 using Granit.Features.Events;
 using Microsoft.EntityFrameworkCore;

--- a/tests/Granit.Features.EntityFrameworkCore.Tests/FeaturesDbContextTests.cs
+++ b/tests/Granit.Features.EntityFrameworkCore.Tests/FeaturesDbContextTests.cs
@@ -1,3 +1,4 @@
+using Granit.Features.EntityFrameworkCore.Entities;
 using Granit.Features.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;

--- a/tests/Granit.Features.EntityFrameworkCore.Tests/FeaturesEfCoreDiRegistrationTests.cs
+++ b/tests/Granit.Features.EntityFrameworkCore.Tests/FeaturesEfCoreDiRegistrationTests.cs
@@ -1,3 +1,4 @@
+using Granit.Features.EntityFrameworkCore.Entities;
 using Granit.Features.EntityFrameworkCore.Extensions;
 using Granit.Features.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;

--- a/tests/Granit.Features.EntityFrameworkCore.Tests/FeaturesModelBuilderExtensionsTests.cs
+++ b/tests/Granit.Features.EntityFrameworkCore.Tests/FeaturesModelBuilderExtensionsTests.cs
@@ -1,3 +1,4 @@
+using Granit.Features.EntityFrameworkCore.Entities;
 using Granit.Features.EntityFrameworkCore.Extensions;
 using Granit.Features.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;

--- a/tests/Granit.Features.EntityFrameworkCore.Tests/GranitFeaturesEntityFrameworkCoreModuleTests.cs
+++ b/tests/Granit.Features.EntityFrameworkCore.Tests/GranitFeaturesEntityFrameworkCoreModuleTests.cs
@@ -1,5 +1,5 @@
+using Granit.Features.EntityFrameworkCore.Entities;
 using Granit.Features.EntityFrameworkCore.Extensions;
-using Granit.Features.EntityFrameworkCore.Internal;
 using Granit.Modularity;
 using Granit.Persistence;
 using Microsoft.EntityFrameworkCore;

--- a/tests/Granit.Features.EntityFrameworkCore.Tests/TenantFeatureOverrideConfigurationTests.cs
+++ b/tests/Granit.Features.EntityFrameworkCore.Tests/TenantFeatureOverrideConfigurationTests.cs
@@ -1,3 +1,4 @@
+using Granit.Features.EntityFrameworkCore.Entities;
 using Granit.Features.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;

--- a/tests/Granit.Features.EntityFrameworkCore.Tests/TenantFeatureOverrideTests.cs
+++ b/tests/Granit.Features.EntityFrameworkCore.Tests/TenantFeatureOverrideTests.cs
@@ -1,5 +1,5 @@
 using Granit.Domain;
-using Granit.Features.EntityFrameworkCore.Internal;
+using Granit.Features.EntityFrameworkCore.Entities;
 using Shouldly;
 using Xunit;
 

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Permissions/OpenIddictPermissionDefinitionProviderTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Permissions/OpenIddictPermissionDefinitionProviderTests.cs
@@ -35,7 +35,7 @@ public sealed class OpenIddictPermissionDefinitionProviderTests
 
         provider.DefinePermissions(context);
 
-        // 1 Users (Impersonate) + 5 Applications + 4 Scopes + 2 Authorizations = 12
-        group.Permissions.Count.ShouldBe(12);
+        // 1 Users (Impersonate) + 3 Applications (Read, Manage, Rotate) + 2 Scopes (Read, Manage) + 2 Authorizations = 8
+        group.Permissions.Count.ShouldBe(8);
     }
 }

--- a/tests/Granit.OpenIddict.Tests/Options/OptionsTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Options/OptionsTests.cs
@@ -45,7 +45,7 @@ public sealed class OptionsTests
         options.ServerDomain.ShouldBeEmpty();
         options.AuthenticatorTimeout.ShouldBe(TimeSpan.FromMinutes(5));
         options.ChallengeSize.ShouldBe(32);
-        GranitPasskeyOptions.SectionName.ShouldBe("OpenIddict:Passkeys");
+        GranitPasskeyOptions.SectionName.ShouldBe("Identity:Passkeys");
     }
 
     [Fact]

--- a/tests/Granit.Templating.EntityFrameworkCore.Tests/EfDocumentTemplateStoreAdditionalTests.cs
+++ b/tests/Granit.Templating.EntityFrameworkCore.Tests/EfDocumentTemplateStoreAdditionalTests.cs
@@ -1,4 +1,5 @@
 using Granit.Guids;
+using Granit.Templating.EntityFrameworkCore.Entities;
 using Granit.Templating.EntityFrameworkCore.Internal;
 using Granit.Templating.Keys;
 using Granit.Templating.Pipeline;

--- a/tests/Granit.Templating.EntityFrameworkCore.Tests/EfDocumentTemplateStoreTests.cs
+++ b/tests/Granit.Templating.EntityFrameworkCore.Tests/EfDocumentTemplateStoreTests.cs
@@ -1,5 +1,6 @@
 using Granit.Exceptions;
 using Granit.Guids;
+using Granit.Templating.EntityFrameworkCore.Entities;
 using Granit.Templating.EntityFrameworkCore.Internal;
 using Granit.Templating.Exceptions;
 using Granit.Templating.Keys;

--- a/tests/Granit.Templating.EntityFrameworkCore.Tests/EfTemplateCategoryStoreTests.cs
+++ b/tests/Granit.Templating.EntityFrameworkCore.Tests/EfTemplateCategoryStoreTests.cs
@@ -1,5 +1,6 @@
 using Granit.Exceptions;
 using Granit.Guids;
+using Granit.Templating.EntityFrameworkCore.Entities;
 using Granit.Templating.EntityFrameworkCore.Internal;
 using Granit.Templating.Store;
 using Granit.Timing;

--- a/tests/Granit.Templating.EntityFrameworkCore.Tests/StoreTemplateResolverTests.cs
+++ b/tests/Granit.Templating.EntityFrameworkCore.Tests/StoreTemplateResolverTests.cs
@@ -1,3 +1,4 @@
+using Granit.Templating.EntityFrameworkCore.Entities;
 using Granit.Templating.EntityFrameworkCore.Internal;
 using Granit.Templating.Keys;
 using Granit.Templating.Pipeline;

--- a/tests/Granit.Templating.EntityFrameworkCore.Tests/TemplateCacheEntryTests.cs
+++ b/tests/Granit.Templating.EntityFrameworkCore.Tests/TemplateCacheEntryTests.cs
@@ -1,3 +1,4 @@
+using Granit.Templating.EntityFrameworkCore.Entities;
 using Granit.Templating.EntityFrameworkCore.Internal;
 using Granit.Templating.Pipeline;
 using Shouldly;

--- a/tests/Granit.Templating.EntityFrameworkCore.Tests/TemplateCategoryEntityTests.cs
+++ b/tests/Granit.Templating.EntityFrameworkCore.Tests/TemplateCategoryEntityTests.cs
@@ -1,4 +1,4 @@
-using Granit.Templating.EntityFrameworkCore.Internal;
+using Granit.Templating.EntityFrameworkCore.Entities;
 using Shouldly;
 using Xunit;
 

--- a/tests/Granit.Templating.EntityFrameworkCore.Tests/TemplateRevisionEntityTests.cs
+++ b/tests/Granit.Templating.EntityFrameworkCore.Tests/TemplateRevisionEntityTests.cs
@@ -1,4 +1,4 @@
-using Granit.Templating.EntityFrameworkCore.Internal;
+using Granit.Templating.EntityFrameworkCore.Entities;
 using Granit.Templating.Store;
 using Shouldly;
 using Xunit;


### PR DESCRIPTION
## Summary

- Move entity classes to a dedicated `Entities/` subfolder across AI, Features, and Templating EFCore modules for better discoverability and separation from internal service code
- Affected: `AIUsageRecordEntity`, `AIWorkspaceEntity`, `TenantFeatureOverride`, `TemplateCategoryEntity`, `TemplateRevisionEntity`
- Fix stale test assertions from PR #717 (`GranitPasskeyOptions.SectionName`, OpenIddict permission count)

## Test plan

- [ ] `dotnet build` passes (0 errors)
- [ ] All affected test projects pass: `Granit.AI.EntityFrameworkCore.Tests`, `Granit.Features.EntityFrameworkCore.Tests`, `Granit.Templating.EntityFrameworkCore.Tests`
- [ ] `Granit.OpenIddict.Tests` and `Granit.OpenIddict.Endpoints.Tests` pass with corrected assertions