### PR TITLE
refactor(reference-data): remove redundant [NotMapped] on Label property

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -25318,7 +25318,7 @@
       "kind": "class",
       "project": "Granit.ReferenceData",
       "file": "src/Granit.ReferenceData/Domain/ReferenceDataEntity.cs",
-      "line": 32,
+      "line": 31,
       "members": [
         {
           "name": "Code",

--- a/src/Granit.ReferenceData/Domain/ReferenceDataEntity.cs
+++ b/src/Granit.ReferenceData/Domain/ReferenceDataEntity.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations.Schema;
 using System.Globalization;
 
 using Granit.Domain;
@@ -92,7 +91,6 @@ public abstract class ReferenceDataEntity : AuditedEntity, IActive, IHasExtraPro
     /// code and API responses where culture-specific labels are needed.
     /// Override in derived entities to provide custom resolution logic.
     /// </remarks>
-    [NotMapped]
     public virtual string Label => CultureInfo.CurrentUICulture.TwoLetterISOLanguageName switch
     {
         "fr" when LabelFr.Length > 0 => LabelFr,


### PR DESCRIPTION
## Summary

- Remove `[NotMapped]` attribute from `ReferenceDataEntity.Label`
- `Label` is an expression-bodied getter-only property — EF Core does not map properties without a setter by convention, making `[NotMapped]` redundant
- Also removes unused `using System.ComponentModel.DataAnnotations.Schema`

## Test plan

- [ ] `dotnet build` passes
- [ ] `Granit.ReferenceData.Tests` passes