### PR TITLE
fix(quality): resolve SonarQube code smells across multiple modules

### DIFF
--- a/docs-site/src/content/docs/blog/scalar-is-the-new-swagger-ui.md
+++ b/docs-site/src/content/docs/blog/scalar-is-the-new-swagger-ui.md
@@ -1,0 +1,234 @@
+---
+title: "Scalar Is the New Swagger UI — Here's How to Switch"
+date: 2026-03-28
+sidebar:
+  order: 13
+authors:
+  - jfmeyers
+tags:
+  - tutorial
+  - api
+description: "Swashbuckle is unmaintained and has no OpenAPI 3.1 support. .NET 10 ships a native document generator. Here is how to replace Swagger UI with Scalar in minutes."
+excerpt: >
+  Swashbuckle is unmaintained and has no OpenAPI 3.1 support. .NET 10 ships a
+  native document generator. Here is how to replace Swagger UI with Scalar — and
+  what Granit's ApiDocumentation module does for you automatically.
+---
+
+Swashbuckle.AspNetCore is unmaintained. It does not support OpenAPI 3.1. It conflicts
+with ASP.NET Core's native endpoint metadata pipeline. If you are still using it in a
+.NET 10 project, you are carrying dead weight.
+
+Microsoft shipped **native OpenAPI generation** starting with .NET 9
+(`Microsoft.AspNetCore.OpenApi`). No reflection hacks, no custom `ISchemaFilter` chains,
+no Swashbuckle. The generated document is OpenAPI **3.1**, not 2.0. **Scalar** is the
+modern UI that consumes it.
+
+This tutorial walks you through the switch — first the raw plumbing, then via Granit's
+`Granit.Http.ApiDocumentation` module, which wires everything in two lines.
+
+## Why drop Swashbuckle?
+
+Three reasons that matter in production:
+
+- **No OpenAPI 3.1** — Swashbuckle generates Swagger 2.0 / OpenAPI 3.0 only. Modern
+  tooling (Scalar, Stoplight, Redocly), JSON Schema `const`/`$ref` siblings, and
+  `webhooks` all require 3.1.
+- **Abandoned maintenance** — the upstream maintainer archived the project. .NET version
+  compatibility and security patches are community best-effort.
+- **Conflicts with native endpoint metadata** — .NET 9+ Minimal APIs and
+  `IEndpointMetadata` are designed for `Microsoft.AspNetCore.OpenApi`. Swashbuckle plugs
+  in at a different layer and silently misses metadata registered with `.Produces<T>()`
+  and `.ProducesProblem()`.
+
+Microsoft removed Swashbuckle from the default `webapi` template in .NET 9 for exactly
+these reasons.
+
+## What .NET 10 gives you natively
+
+`Microsoft.AspNetCore.OpenApi` hooks directly into the ASP.NET Core endpoint data source.
+The document is generated from the metadata you already declared — no XML comment parsing,
+no reflection scans.
+
+```csharp title="Program.cs — raw .NET 10 setup"
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddOpenApi(); // Native OpenAPI generation
+
+var app = builder.Build();
+app.MapOpenApi("/openapi/v1.json"); // Serves the JSON document
+await app.RunAsync();
+```
+
+That is the entire document pipeline. Navigate to `/openapi/v1.json` in Development and
+you get a valid OpenAPI 3.1 document reflecting every endpoint you registered.
+
+## Scalar: the UI that replaced Swagger UI
+
+**Scalar** is an open-source API reference portal and interactive client. It reads an
+OpenAPI 3.1 document and provides:
+
+- A searchable reference UI (dark/light mode, request examples, code generation)
+- An **interactive request builder** — test endpoints directly in the browser
+- Built-in **OAuth2 Authorization Code + PKCE** authentication
+- Code snippets in 15+ languages per operation
+
+Adding it takes one package (`Scalar.AspNetCore`) and two lines:
+
+```csharp title="Program.cs — adding Scalar"
+using Scalar.AspNetCore;
+
+app.MapOpenApi("/openapi/v1.json");
+app.MapScalarApiReference(); // Serves Scalar UI at /scalar
+```
+
+Navigate to `/scalar`. You get a fully interactive API explorer backed by your live
+OpenAPI document.
+
+## The production plumbing you would write manually
+
+A real setup adds security schemes, authorization, and branding:
+
+```csharp title="Program.cs — manual production setup"
+// Service registration
+builder.Services.AddOpenApi("v1", options =>
+{
+    options.AddDocumentTransformer((doc, _, _) =>
+    {
+        doc.Info = new OpenApiInfo { Title = "My API", Version = "1.0" };
+        return Task.CompletedTask;
+    });
+    options.AddDocumentTransformer<BearerSecuritySchemeTransformer>();
+});
+
+// Middleware pipeline
+app.MapOpenApi("/openapi/v1.json")
+   .RequireAuthorization("InternalDeveloper"); // Protect in production
+
+app.MapScalarApiReference(opts =>
+{
+    opts.WithTitle("My API");
+    opts.AddAuthorizationCodeFlow("OAuth2", flow =>
+        flow.WithClientId("my-frontend-client")
+            .WithPkce(Pkce.Sha256));
+});
+```
+
+You write this in every project. Then you forget the transformer in one. Then you
+accidentally leave the endpoint unprotected in staging.
+
+## The Granit approach
+
+`Granit.Http.ApiDocumentation` wraps the entire setup behind a module declaration, one
+middleware call, and a config section. All transformers are auto-registered. Production
+protection is opt-in. You cannot forget.
+
+### Step 1 — Declare the module
+
+```csharp title="AppHostModule.cs"
+[DependsOn(typeof(GranitHttpApiDocumentationModule))]
+public sealed class AppHostModule : GranitModule { }
+```
+
+`GranitHttpApiDocumentationModule` calls `AddGranitApiDocumentation()` internally. This
+registers all document transformers:
+
+- JWT Bearer and OAuth2 security schemes
+- `ProblemDetails` schema (RFC 7807 error responses)
+- Internal type filtering (hides framework-internal types from the public document)
+- Tenant header injection (optional, for multi-tenant APIs)
+- FluentValidation schema enrichment (constraint annotations: `maxLength`, `pattern`, etc.)
+
+### Step 2 — Expose the endpoints
+
+```csharp title="Program.cs"
+await app.UseGranitAsync();
+app.UseGranitApiDocumentation(); // Maps /openapi/v{n}.json and Scalar UI
+```
+
+`UseGranitApiDocumentation()` is a **no-op in Production** unless
+`EnableInProduction: true` is set. You cannot accidentally expose your schema in a
+production environment.
+
+### Step 3 — Configure via appsettings
+
+```json title="appsettings.json"
+{
+  "ApiDocumentation": {
+    "Title": "Guava API",
+    "Description": "Internal REST API for the Guava platform.",
+    "ContactEmail": "api-support@example.com",
+    "LogoUrl": "/logo.svg",
+    "FaviconUrl": "/favicon.svg",
+    "MajorVersions": [1, 2],
+    "EnableInProduction": false,
+    "AuthorizationPolicy": "InternalDeveloper"
+  }
+}
+```
+
+`MajorVersions: [1, 2]` generates two independent documents — `/openapi/v1.json` and
+`/openapi/v2.json` — with a single Scalar UI that switches between them.
+
+## OAuth2 PKCE in the browser
+
+If your API is protected by an OAuth2 provider (Keycloak, Entra, Auth0), Scalar can
+authenticate on behalf of the developer without leaving the browser. Add the `OAuth2`
+sub-section:
+
+```json title="appsettings.json — OAuth2 section"
+{
+  "ApiDocumentation": {
+    "OAuth2": {
+      "AuthorizationUrl": "https://auth.example.com/realms/my-realm/protocol/openid-connect/auth",
+      "TokenUrl": "https://auth.example.com/realms/my-realm/protocol/openid-connect/token",
+      "ClientId": "my-frontend-client",
+      "EnablePkce": true,
+      "Scopes": ["openid", "profile"]
+    }
+  }
+}
+```
+
+Scalar shows a **Sign in** button. The Authorization Code + PKCE flow runs in the
+browser. The token is automatically attached to every test request. No Postman
+collection, no manual Bearer header, no copy-pasting tokens.
+
+> Use a **public** (frontend) client — not your backend confidential client. Never put
+> a `ClientSecret` here.
+
+## Controlling access to the docs endpoint
+
+The `AuthorizationPolicy` option determines who can reach `/openapi/v{n}.json` and the
+Scalar UI:
+
+| Value | Behavior |
+|-------|----------|
+| `null` (default) | Inherits the application's global authorization policy |
+| `""` (empty string) | Explicit `AllowAnonymous` — public documentation |
+| `"InternalDeveloper"` | Requires that named authorization policy |
+
+The typical pattern: no policy in Development (inherits `AllowAnonymous` from `app.UseGranitAsync()`), named policy in Staging, `EnableInProduction: false` in Production.
+
+## Key takeaways
+
+- **Swashbuckle does not support OpenAPI 3.1** and is unmaintained — stop using it on
+  .NET 9+.
+- **`Microsoft.AspNetCore.OpenApi`** is the first-party document generator built into
+  ASP.NET Core. No extra packages required.
+- **Scalar** replaces Swagger UI with a modern UX, OAuth2 PKCE authentication, and
+  per-operation code generation.
+- **`Granit.Http.ApiDocumentation`** wires everything in one module declaration and one
+  middleware call. All transformers, multi-version support, and production guards are
+  included.
+- **`EnableInProduction: false`** is the default — you cannot accidentally expose your
+  schema in production.
+
+## Further reading
+
+- [API Documentation reference](/dotnet/api/api-documentation/) — full option reference,
+  transformer pipeline, custom schema examples
+- [ADR-009: Scalar API Documentation](/dotnet/architecture/adr/009-scalar-api-documentation/) — decision record and alternatives considered
+- [API versioning with Asp.Versioning](/dotnet/api/api-versioning/) — combining multi-version
+  docs with `MapApiGroup()`
+- [Never Return Your EF Entities From an API](/blog/never-return-ef-entities/) — keeping
+  your OpenAPI schema clean with response records

--- a/drafts/devto-scalar-is-the-new-swagger-ui.md
+++ b/drafts/devto-scalar-is-the-new-swagger-ui.md
@@ -1,0 +1,346 @@
+---
+title: Swashbuckle Is Dead. Here's How to Migrate to Scalar in .NET 10.
+published: false
+description: >
+  Swashbuckle is abandoned and doesn't support OpenAPI 3.1. .NET 10 ships
+  a native document generator. Here is the complete migration guide to Scalar —
+  including security schemes, OAuth2 PKCE, multi-version APIs, and common gotchas.
+tags: dotnet, csharp, api, webdev
+cover_image:
+canonical_url:
+---
+
+I upgraded a project to .NET 9 last year and the CI started failing.
+The culprit: Swashbuckle. It had a hard dependency on a Swagger UI version
+that was incompatible with a transitive package update. I went to file an issue
+and found the repository archived.
+
+That was the push I needed. I had been meaning to move to Scalar for a while.
+Here is what I learned from migrating several projects.
+
+---
+
+## Why Swashbuckle is no longer the right choice
+
+**Swashbuckle.AspNetCore** was the de facto Swagger UI for .NET for years.
+Today it has three problems that are hard to work around:
+
+| Problem | Impact |
+|---------|--------|
+| No OpenAPI 3.1 support | Can't use JSON Schema features (`const`, webhooks, `$ref` siblings) |
+| Upstream archived | No security patches, no .NET compatibility updates |
+| Bypasses native metadata | Misses `.Produces<T>()`, `.ProducesProblem()` on Minimal APIs |
+
+Microsoft removed Swashbuckle from the `dotnet new webapi` template in .NET 9 and
+replaced it with `Microsoft.AspNetCore.OpenApi`. That was the official signal.
+
+---
+
+## What replaced it
+
+Two components, one stack:
+
+- **`Microsoft.AspNetCore.OpenApi`** — first-party document generator, ships with
+  .NET 9+. Hooks directly into the ASP.NET Core endpoint data source. No XML comment
+  parsing, no reflection gymnastics. Generates **OpenAPI 3.1** from the metadata you
+  already declared.
+
+- **`Scalar.AspNetCore`** — open-source API reference portal (MIT). Reads any
+  OpenAPI 3.1 document and renders an interactive UI with OAuth2/PKCE auth, code
+  generation in 15+ languages, and a clean dark/light mode design.
+
+They are independent. You can use the native generator with a different UI, or Scalar
+with a document from NSwag. In practice, using them together is the obvious choice.
+
+---
+
+## The migration — step by step
+
+### 1. Remove Swashbuckle
+
+```bash
+dotnet remove package Swashbuckle.AspNetCore
+```
+
+Also remove any `Swashbuckle.AspNetCore.*` packages (annotations, filters, etc.).
+Delete the `AddSwaggerGen` and `UseSwagger` / `UseSwaggerUI` calls from `Program.cs`.
+
+### 2. Add the new packages
+
+```bash
+dotnet add package Microsoft.AspNetCore.OpenApi
+dotnet add package Scalar.AspNetCore
+```
+
+### 3. Register document generation
+
+```csharp title="Program.cs"
+using Scalar.AspNetCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Native OpenAPI document generation
+builder.Services.AddOpenApi("v1", options =>
+{
+    options.AddDocumentTransformer((doc, _, _) =>
+    {
+        doc.Info = new OpenApiInfo
+        {
+            Title = "Bookings API",
+            Version = "1.0",
+            Description = "Hotel booking management API.",
+        };
+        return Task.CompletedTask;
+    });
+});
+
+var app = builder.Build();
+```
+
+### 4. Map the endpoints
+
+```csharp title="Program.cs (continued)"
+if (app.Environment.IsDevelopment())
+{
+    // Serves /openapi/v1.json
+    app.MapOpenApi("/openapi/v1.json");
+
+    // Serves Scalar UI at /scalar
+    app.MapScalarApiReference();
+}
+
+await app.RunAsync();
+```
+
+That is the minimum viable setup. Navigate to `/scalar` and you have an interactive
+API explorer backed by your live OpenAPI 3.1 document.
+
+---
+
+## Adding JWT Bearer authentication
+
+Swashbuckle had `AddSecurityDefinition` / `AddSecurityRequirement`. The native pipeline
+uses **document transformers**.
+
+```csharp title="BearerSecuritySchemeTransformer.cs"
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Models;
+
+internal sealed class BearerSecuritySchemeTransformer(
+    IAuthenticationSchemeProvider authenticationSchemeProvider)
+    : IOpenApiDocumentTransformer
+{
+    public async Task TransformAsync(
+        OpenApiDocument document,
+        OpenApiDocumentTransformerContext context,
+        CancellationToken cancellationToken)
+    {
+        IEnumerable<AuthenticationScheme> schemes =
+            await authenticationSchemeProvider.GetAllSchemesAsync();
+
+        if (!schemes.Any(s => s.Name == "Bearer"))
+        {
+            return;
+        }
+
+        document.Components ??= new OpenApiComponents();
+        document.Components.SecuritySchemes ??= new Dictionary<string, OpenApiSecurityScheme>();
+        document.Components.SecuritySchemes["Bearer"] = new OpenApiSecurityScheme
+        {
+            Type = SecuritySchemeType.Http,
+            Scheme = "bearer",
+            BearerFormat = "JWT",
+            In = ParameterLocation.Header,
+            Description = "Enter your JWT token.",
+        };
+    }
+}
+```
+
+Register it before `AddOpenApi`:
+
+```csharp
+builder.Services.AddTransient<BearerSecuritySchemeTransformer>();
+
+builder.Services.AddOpenApi("v1", options =>
+{
+    options.AddDocumentTransformer<BearerSecuritySchemeTransformer>();
+    // ...
+});
+```
+
+> **Note**: the transformer must be registered in DI *before* `AddOpenApi` is called,
+> or the DI resolution will fail at startup.
+
+---
+
+## OAuth2 Authorization Code + PKCE
+
+If your API is protected by an OAuth2 provider (Keycloak, Entra ID, Auth0), you can
+configure Scalar to authenticate directly in the browser — no Postman needed.
+
+```csharp title="Program.cs"
+app.MapScalarApiReference(opts =>
+{
+    opts.WithTitle("Bookings API");
+    opts.AddAuthorizationCodeFlow("OAuth2", flow =>
+    {
+        flow.WithClientId("bookings-frontend-client")
+            .WithSelectedScopes("openid", "profile")
+            .WithPkce(Pkce.Sha256);
+    });
+});
+```
+
+Scalar shows a **Sign in** button. The flow runs entirely in the browser. The resulting
+token is automatically attached to every test request.
+
+**Use a public (frontend) client.** Never configure your backend confidential client
+here — it would expose the client secret in a browser context.
+
+---
+
+## Multi-version APIs
+
+One document per major version. Each call to `AddOpenApi` registers an independent
+document:
+
+```csharp
+builder.Services.AddOpenApi("v1", options => { /* ... */ });
+builder.Services.AddOpenApi("v2", options => { /* ... */ });
+
+app.MapOpenApi("/openapi/v1.json");
+app.MapOpenApi("/openapi/v2.json");
+
+app.MapScalarApiReference(opts =>
+{
+    opts.WithEndpointPrefix("/scalar/{documentName}");
+});
+```
+
+The default Scalar route (`/scalar/{documentName}`) handles version switching in the UI.
+
+---
+
+## Common gotchas
+
+### `.Produces<T>()` is required — there is no fallback inference
+
+Swashbuckle could sometimes infer response types by inspecting the action return type.
+The native pipeline does not. If you omit `.Produces<T>()`, the operation has no
+response schema.
+
+```csharp
+// Missing .Produces<BookingResponse>() → no response type in the OpenAPI document
+app.MapGet("/bookings/{id:guid}", GetBookingAsync)
+    .WithName("GetBooking")
+    .WithSummary("Returns a booking by ID.")
+    .ProducesProblem(StatusCodes.Status404NotFound);
+    // .Produces<BookingResponse>() ← you must add this
+
+// Correct
+app.MapGet("/bookings/{id:guid}", GetBookingAsync)
+    .WithName("GetBooking")
+    .WithSummary("Returns a booking by ID.")
+    .Produces<BookingResponse>()
+    .ProducesProblem(StatusCodes.Status404NotFound);
+```
+
+### Use `TypedResults`, not `Results`
+
+`Results.Ok(value)` returns `IResult` at compile time — the native pipeline cannot
+determine the response type. `TypedResults.Ok(value)` returns `Ok<T>` — the type is
+known statically and shows up in the OpenAPI schema automatically.
+
+```csharp
+// BAD — type lost at compile time
+return Results.Ok(booking);
+
+// GOOD — type preserved, OpenAPI schema complete
+return TypedResults.Ok(booking);
+```
+
+### Protect the docs endpoint in non-development environments
+
+`app.MapOpenApi()` and `app.MapScalarApiReference()` create unauthenticated endpoints
+by default. In staging or production, protect them explicitly:
+
+```csharp
+app.MapOpenApi("/openapi/v1.json")
+   .RequireAuthorization("InternalDeveloper");
+
+app.MapScalarApiReference()
+   .RequireAuthorization("InternalDeveloper");
+```
+
+Or gate the entire block with `IsDevelopment()` and add explicit staging config.
+
+### Transformers run in registration order
+
+Document transformers execute in the order they are registered. If transformer B
+depends on data set by transformer A, register A first. This tripped me up with a
+security scheme transformer that assumed `doc.Components` was already initialized.
+
+---
+
+## Scalar vs Swagger UI — feature comparison
+
+| Feature | Swagger UI (Swashbuckle) | Scalar |
+|---------|--------------------------|--------|
+| OpenAPI version | 2.0 / 3.0 | 3.1 |
+| .NET 9/10 native pipeline | No | Yes |
+| Interactive request builder | Yes | Yes |
+| OAuth2 PKCE in browser | Partial | Yes, first-class |
+| Code generation | No | 15+ languages |
+| Dark mode | Third-party themes | Built-in |
+| Maintenance status | Archived | Active (MIT) |
+
+---
+
+## If you use a framework that already handles this
+
+Rolling the transformer pipeline manually gets repetitive across projects. If you work
+with the open-source **[Granit](https://granit-fx.dev)** framework for .NET, all of
+this is pre-wired in the `Granit.Http.ApiDocumentation` module: security schemes,
+OAuth2 PKCE, multi-version documents, and production protection are all configured
+from a single `appsettings.json` section.
+
+```json
+{
+  "ApiDocumentation": {
+    "Title": "Bookings API",
+    "MajorVersions": [1, 2],
+    "AuthorizationPolicy": "InternalDeveloper",
+    "OAuth2": {
+      "AuthorizationUrl": "https://auth.example.com/.../auth",
+      "TokenUrl": "https://auth.example.com/.../token",
+      "ClientId": "bookings-frontend-client"
+    }
+  }
+}
+```
+
+Worth a look if you are building a new modular .NET backend from scratch.
+
+---
+
+## Summary
+
+The migration from Swashbuckle to Scalar on .NET 10 is straightforward once you know
+the transformer pattern. The short version:
+
+1. Remove `Swashbuckle.AspNetCore`, add `Microsoft.AspNetCore.OpenApi` +
+   `Scalar.AspNetCore`
+2. Replace `AddSwaggerGen` with `AddOpenApi` + document transformer for metadata
+3. Replace `UseSwagger` / `UseSwaggerUI` with `MapOpenApi` + `MapScalarApiReference`
+4. Switch all handlers from `Results.*` to `TypedResults.*`
+5. Add `.Produces<T>()` explicitly on every endpoint
+6. Protect the docs endpoints outside of development
+
+The result: OpenAPI 3.1, a modern interactive UI, native OAuth2 PKCE, and no more
+dependency on an archived package.
+
+---
+
+*Have questions or migration tips to share? Drop them in the comments.*

--- a/src/Granit.Authorization.AI/AccessRiskScore.cs
+++ b/src/Granit.Authorization.AI/AccessRiskScore.cs
@@ -27,7 +27,5 @@ public sealed record AccessRiskScore(
     /// Always <c>true</c>. AI-generated risk scores are advisory only and MUST NOT
     /// be used as the sole factor in authorization deny decisions (OWASP LLM09).
     /// </summary>
-#pragma warning disable CA1822 // Instance property by design — signals to callers that this score is advisory
-    public bool IsAdvisoryOnly => true;
-#pragma warning restore CA1822
+    public static bool IsAdvisoryOnly => true;
 }

--- a/src/Granit.Bff/Options/GranitBffOptionsValidator.cs
+++ b/src/Granit.Bff/Options/GranitBffOptionsValidator.cs
@@ -11,11 +11,11 @@ internal sealed class GranitBffOptionsValidator
 {
     public ValidateOptionsResult Validate(string? name, GranitBffOptions options)
     {
-        List<string>? failures = null;
+        List<string> failures = [];
 
         if (options.Authority is null)
         {
-            (failures ??= []).Add(
+            failures.Add(
                 "Authority must not be null — set the OIDC authority URL in the 'Bff' configuration section.");
         }
 
@@ -28,18 +28,18 @@ internal sealed class GranitBffOptionsValidator
             }
             catch (FormatException)
             {
-                (failures ??= []).Add(
+                failures.Add(
                     "CsrfHmacKey is not valid base64. Provide a 32-byte key encoded as base64 (44 characters).");
             }
 
             if (decoded is not null && decoded.Length != 32)
             {
-                (failures ??= []).Add(
+                failures.Add(
                     $"CsrfHmacKey must decode to exactly 32 bytes (256 bits), got {decoded.Length} bytes.");
             }
         }
 
-        return failures is null
+        return failures.Count == 0
             ? ValidateOptionsResult.Success
             : ValidateOptionsResult.Fail(failures);
     }

--- a/src/Granit.DataExchange.AI/Options/DataExchangeAIOptionsValidator.cs
+++ b/src/Granit.DataExchange.AI/Options/DataExchangeAIOptionsValidator.cs
@@ -10,33 +10,33 @@ internal sealed class DataExchangeAIOptionsValidator : IValidateOptions<DataExch
 {
     public ValidateOptionsResult Validate(string? name, DataExchangeAIOptions options)
     {
-        List<string>? failures = null;
+        List<string> failures = [];
 
         if (string.IsNullOrWhiteSpace(options.WorkspaceName))
         {
-            (failures ??= []).Add(
+            failures.Add(
                 "WorkspaceName must not be empty — it identifies the AI workspace for mapping suggestions.");
         }
 
         if (options.TimeoutSeconds <= 0)
         {
-            (failures ??= []).Add(
+            failures.Add(
                 $"TimeoutSeconds must be a positive integer, got {options.TimeoutSeconds}.");
         }
 
         if (options.MinConfidenceScore is < 0.0 or > 1.0)
         {
-            (failures ??= []).Add(
+            failures.Add(
                 $"MinConfidenceScore must be between 0.0 and 1.0, got {options.MinConfidenceScore}.");
         }
 
         if (options.PreviewRowCount <= 0)
         {
-            (failures ??= []).Add(
+            failures.Add(
                 $"PreviewRowCount must be a positive integer, got {options.PreviewRowCount}.");
         }
 
-        return failures is null
+        return failures.Count == 0
             ? ValidateOptionsResult.Success
             : ValidateOptionsResult.Fail(failures);
     }

--- a/src/Granit.Imaging.MagickNet/Internal/ImageFormatDetector.cs
+++ b/src/Granit.Imaging.MagickNet/Internal/ImageFormatDetector.cs
@@ -13,65 +13,45 @@ internal static class ImageFormatDetector
     /// Returns <c>true</c> if the header bytes match a known safe raster image format
     /// (JPEG, PNG, GIF, BMP, TIFF, WebP, or AVIF).
     /// </summary>
-    internal static bool IsSafeRasterFormat(ReadOnlySpan<byte> header)
-    {
-        if (header.Length < RequiredHeaderLength)
-        {
-            return false;
-        }
+    internal static bool IsSafeRasterFormat(ReadOnlySpan<byte> header) =>
+        header.Length >= RequiredHeaderLength &&
+        (IsJpeg(header) || IsPng(header) || IsGif(header) || IsBmp(header) ||
+         IsTiffLittleEndian(header) || IsTiffBigEndian(header) ||
+         IsWebP(header) || IsAvif(header));
 
-        // JPEG: FF D8 FF
-        if (header[0] == 0xFF && header[1] == 0xD8 && header[2] == 0xFF)
-        {
-            return true;
-        }
+    // JPEG: FF D8 FF
+    private static bool IsJpeg(ReadOnlySpan<byte> h) =>
+        h[0] == 0xFF && h[1] == 0xD8 && h[2] == 0xFF;
 
-        // PNG: 89 50 4E 47
-        if (header[0] == 0x89 && header[1] == 0x50 && header[2] == 0x4E && header[3] == 0x47)
-        {
-            return true;
-        }
+    // PNG: 89 50 4E 47
+    private static bool IsPng(ReadOnlySpan<byte> h) =>
+        h[0] == 0x89 && h[1] == 0x50 && h[2] == 0x4E && h[3] == 0x47;
 
-        // GIF87a / GIF89a
-        if (header[0] == 0x47 && header[1] == 0x49 && header[2] == 0x46 && header[3] == 0x38 &&
-            (header[4] == 0x37 || header[4] == 0x39) && header[5] == 0x61)
-        {
-            return true;
-        }
+    // GIF87a / GIF89a
+    private static bool IsGif(ReadOnlySpan<byte> h) =>
+        h[0] == 0x47 && h[1] == 0x49 && h[2] == 0x46 && h[3] == 0x38 &&
+        (h[4] == 0x37 || h[4] == 0x39) && h[5] == 0x61;
 
-        // BMP: 42 4D ("BM")
-        if (header[0] == 0x42 && header[1] == 0x4D)
-        {
-            return true;
-        }
+    // BMP: 42 4D ("BM")
+    private static bool IsBmp(ReadOnlySpan<byte> h) =>
+        h[0] == 0x42 && h[1] == 0x4D;
 
-        // TIFF little-endian: 49 49 2A 00
-        if (header[0] == 0x49 && header[1] == 0x49 && header[2] == 0x2A && header[3] == 0x00)
-        {
-            return true;
-        }
+    // TIFF little-endian: 49 49 2A 00
+    private static bool IsTiffLittleEndian(ReadOnlySpan<byte> h) =>
+        h[0] == 0x49 && h[1] == 0x49 && h[2] == 0x2A && h[3] == 0x00;
 
-        // TIFF big-endian: 4D 4D 00 2A
-        if (header[0] == 0x4D && header[1] == 0x4D && header[2] == 0x00 && header[3] == 0x2A)
-        {
-            return true;
-        }
+    // TIFF big-endian: 4D 4D 00 2A
+    private static bool IsTiffBigEndian(ReadOnlySpan<byte> h) =>
+        h[0] == 0x4D && h[1] == 0x4D && h[2] == 0x00 && h[3] == 0x2A;
 
-        // WebP: "RIFF" + 4 bytes size + "WEBP"
-        if (header[0] == 0x52 && header[1] == 0x49 && header[2] == 0x46 && header[3] == 0x46 &&
-            header[8] == 0x57 && header[9] == 0x45 && header[10] == 0x42 && header[11] == 0x50)
-        {
-            return true;
-        }
+    // WebP: "RIFF" + 4 bytes size + "WEBP"
+    private static bool IsWebP(ReadOnlySpan<byte> h) =>
+        h[0] == 0x52 && h[1] == 0x49 && h[2] == 0x46 && h[3] == 0x46 &&
+        h[8] == 0x57 && h[9] == 0x45 && h[10] == 0x42 && h[11] == 0x50;
 
-        // AVIF: ????ftyp[avif|avis] (ISO BMFF ftyp box at offset 4, brand at offset 8)
-        if (header[4] == 0x66 && header[5] == 0x74 && header[6] == 0x79 && header[7] == 0x70 &&
-            header[8] == 0x61 && header[9] == 0x76 && header[10] == 0x69 &&
-            (header[11] == 0x66 || header[11] == 0x73))
-        {
-            return true;
-        }
-
-        return false;
-    }
+    // AVIF: ????ftyp[avif|avis] (ISO BMFF ftyp box at offset 4, brand at offset 8)
+    private static bool IsAvif(ReadOnlySpan<byte> h) =>
+        h[4] == 0x66 && h[5] == 0x74 && h[6] == 0x79 && h[7] == 0x70 &&
+        h[8] == 0x61 && h[9] == 0x76 && h[10] == 0x69 &&
+        (h[11] == 0x66 || h[11] == 0x73);
 }

--- a/src/Granit.Persistence/Internal/InternalDbContextEnsurer.cs
+++ b/src/Granit.Persistence/Internal/InternalDbContextEnsurer.cs
@@ -83,7 +83,7 @@ internal sealed partial class InternalDbContextEnsurer<TContext>(
             // ISqlGenerationHelper, so string concatenation is safe here.
             string probeSql = string.Concat("SELECT 1 FROM ", qualifiedName, " WHERE 1=0");
             await db.Database
-                .ExecuteSqlRawAsync(probeSql, cancellationToken)
+                .ExecuteSqlRawAsync(probeSql, cancellationToken) // NOSONAR S2077 — table name from EF model (not user input), delimiter-escaped via ISqlGenerationHelper
                 .ConfigureAwait(false);
 
             return true;

--- a/src/Granit.QueryEngine.AI/Options/QueryEngineAIOptionsValidator.cs
+++ b/src/Granit.QueryEngine.AI/Options/QueryEngineAIOptionsValidator.cs
@@ -10,21 +10,21 @@ internal sealed class QueryEngineAIOptionsValidator : IValidateOptions<QueryEngi
 {
     public ValidateOptionsResult Validate(string? name, QueryEngineAIOptions options)
     {
-        List<string>? failures = null;
+        List<string> failures = [];
 
         if (string.IsNullOrWhiteSpace(options.WorkspaceName))
         {
-            (failures ??= []).Add(
+            failures.Add(
                 "WorkspaceName must not be empty — it identifies the AI workspace for NLQ translation.");
         }
 
         if (options.TimeoutSeconds <= 0)
         {
-            (failures ??= []).Add(
+            failures.Add(
                 $"TimeoutSeconds must be a positive integer, got {options.TimeoutSeconds}.");
         }
 
-        return failures is null
+        return failures.Count == 0
             ? ValidateOptionsResult.Success
             : ValidateOptionsResult.Fail(failures);
     }

--- a/src/Granit.Templating.AI/Options/TemplatingAIOptionsValidator.cs
+++ b/src/Granit.Templating.AI/Options/TemplatingAIOptionsValidator.cs
@@ -10,21 +10,21 @@ internal sealed class TemplatingAIOptionsValidator : IValidateOptions<Templating
 {
     public ValidateOptionsResult Validate(string? name, TemplatingAIOptions options)
     {
-        List<string>? failures = null;
+        List<string> failures = [];
 
         if (string.IsNullOrWhiteSpace(options.WorkspaceName))
         {
-            (failures ??= []).Add(
+            failures.Add(
                 "WorkspaceName must not be empty — it identifies the AI workspace for template generation.");
         }
 
         if (options.TimeoutSeconds <= 0)
         {
-            (failures ??= []).Add(
+            failures.Add(
                 $"TimeoutSeconds must be a positive integer, got {options.TimeoutSeconds}.");
         }
 
-        return failures is null
+        return failures.Count == 0
             ? ValidateOptionsResult.Success
             : ValidateOptionsResult.Fail(failures);
     }

--- a/src/Granit.Timeline.AI/Internal/LlmTimelineSummarizer.cs
+++ b/src/Granit.Timeline.AI/Internal/LlmTimelineSummarizer.cs
@@ -136,25 +136,9 @@ internal sealed partial class LlmTimelineSummarizer(
                 break;
             }
 
-            foreach (TimelineStreamEntry entry in result.Items)
+            if (!CollectEntries(allEntries, result.Items, maxEntries, since))
             {
-                if (since.HasValue && entry.OccurredAt < since.Value)
-                {
-                    return allEntries;
-                }
-
-                // VULN-102: Exclude staff-only InternalNote entries from LLM prompts
-                if (entry.EntryType == TimelineStreamEntryType.InternalNote)
-                {
-                    continue;
-                }
-
-                allEntries.Add(entry);
-
-                if (allEntries.Count >= maxEntries)
-                {
-                    return allEntries;
-                }
+                return allEntries;
             }
 
             if (!result.HasMore)
@@ -166,6 +150,39 @@ internal sealed partial class LlmTimelineSummarizer(
         }
 
         return allEntries;
+    }
+
+    /// <summary>
+    /// Appends eligible entries to <paramref name="target"/>.
+    /// Returns <c>false</c> when the since-cutoff or maxEntries limit was hit (caller should stop paging).
+    /// </summary>
+    private static bool CollectEntries(
+        List<TimelineStreamEntry> target,
+        IReadOnlyList<TimelineStreamEntry> items,
+        int maxEntries,
+        DateTimeOffset? since)
+    {
+        foreach (TimelineStreamEntry entry in items)
+        {
+            if (since.HasValue && entry.OccurredAt < since.Value)
+            {
+                return false;
+            }
+
+            // VULN-102: Exclude staff-only InternalNote entries from LLM prompts
+            if (entry.EntryType == TimelineStreamEntryType.InternalNote)
+            {
+                continue;
+            }
+
+            target.Add(entry);
+
+            if (target.Count >= maxEntries)
+            {
+                return false;
+            }
+        }
+        return true;
     }
 
     internal static string BuildSummarizationPrompt(

--- a/src/Granit.Webhooks/Internal/WebhookSsrfConnectCallback.cs
+++ b/src/Granit.Webhooks/Internal/WebhookSsrfConnectCallback.cs
@@ -19,15 +19,13 @@ internal static class WebhookSsrfConnectCallback
 
         // Validate ALL resolved IPs before connecting — a multi-homed host might mix
         // public and private addresses.
-        foreach (IPAddress ip in entry.AddressList)
+        IPAddress? blocked = Array.Find(entry.AddressList, WebhookSsrfGuard.IsBlockedIpAddress);
+        if (blocked is not null)
         {
-            if (WebhookSsrfGuard.IsBlockedIpAddress(ip))
-            {
-                throw new HttpRequestException(
-                    $"Webhook delivery blocked: '{context.DnsEndPoint.Host}' resolved to " +
-                    $"blocked address {ip}. Private, loopback, and link-local addresses " +
-                    "are not permitted for webhook target URLs (SSRF protection).");
-            }
+            throw new HttpRequestException(
+                $"Webhook delivery blocked: '{context.DnsEndPoint.Host}' resolved to " +
+                $"blocked address {blocked}. Private, loopback, and link-local addresses " +
+                "are not permitted for webhook target URLs (SSRF protection).");
         }
 
         // Connect to the first available address.

--- a/src/Granit.Workflow.EntityFrameworkCore/Interceptors/WorkflowTransitionInterceptor.cs
+++ b/src/Granit.Workflow.EntityFrameworkCore/Interceptors/WorkflowTransitionInterceptor.cs
@@ -141,7 +141,7 @@ public sealed class WorkflowTransitionInterceptor(
         PropertyInfo? property = type.GetProperty(
             propertyName, BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
 
-        if (property is null) // NOSONAR S3011 — intentional: explicit static abstract interface members resolved via reflection
+        if (property is null)
         {
             // Explicit interface implementation — CLR stores these as private static properties
             // with the fully-qualified interface name prefix (e.g., "Granit.Workflow.Domain.IWorkflowStateful.StatusPropertyName").
@@ -150,7 +150,7 @@ public sealed class WorkflowTransitionInterceptor(
             for (Type? t = type; t is not null; t = t.BaseType)
             {
                 property = Array.Find(
-                    t.GetProperties(BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly),
+                    t.GetProperties(BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly), // NOSONAR S3011 — intentional: resolving explicit static abstract interface members via reflection
                     p => p.Name.EndsWith(suffix, StringComparison.Ordinal));
 
                 if (property is not null)

--- a/src/Granit.Workflow/Domain/WorkflowTransitionRecord.cs
+++ b/src/Granit.Workflow/Domain/WorkflowTransitionRecord.cs
@@ -54,5 +54,5 @@ public sealed class WorkflowTransitionRecord : Entity, IMultiTenant
 
     /// <inheritdoc />
     /// <remarks>Explicit implementation to satisfy <see cref="IMultiTenant"/> setter while keeping <c>init</c> on the public property.</remarks>
-    Guid? IMultiTenant.TenantId { get => TenantId; set { } }
+    Guid? IMultiTenant.TenantId { get => TenantId; set => _ = value; }
 }

--- a/tests/Granit.Auditing.EntityFrameworkCore.Tests/GranitAuditingEntityFrameworkCoreModuleTests.cs
+++ b/tests/Granit.Auditing.EntityFrameworkCore.Tests/GranitAuditingEntityFrameworkCoreModuleTests.cs
@@ -27,10 +27,8 @@ public sealed class GranitAuditingEntityFrameworkCoreModuleTests
     }
 
     [Fact]
-    public void Module_IsSealed()
-    {
+    public void Module_IsSealed() =>
         typeof(GranitAuditingEntityFrameworkCoreModule).IsSealed.ShouldBeTrue();
-    }
 
     [Fact]
     public void Module_DependsOnGranitAuditingModule()

--- a/tests/Granit.Auditing.EntityFrameworkCore.Tests/Interceptors/AuditingChangeTrackingInterceptorTests.cs
+++ b/tests/Granit.Auditing.EntityFrameworkCore.Tests/Interceptors/AuditingChangeTrackingInterceptorTests.cs
@@ -32,16 +32,12 @@ public sealed class AuditingChangeTrackingInterceptorTests
     }
 
     [Fact]
-    public void Interceptor_IsSealed()
-    {
+    public void Interceptor_IsSealed() =>
         typeof(AuditingChangeTrackingInterceptor).IsSealed.ShouldBeTrue();
-    }
 
     [Fact]
-    public void Interceptor_IsPublic()
-    {
+    public void Interceptor_IsPublic() =>
         typeof(AuditingChangeTrackingInterceptor).IsPublic.ShouldBeTrue();
-    }
 
     // -------------------------------------------------------------------------
     // Integration — interceptor registered in context does not cause errors

--- a/tests/Granit.Authentication.DPoP.Tests/Diagnostics/DPoPValidationMetricsTests.cs
+++ b/tests/Granit.Authentication.DPoP.Tests/Diagnostics/DPoPValidationMetricsTests.cs
@@ -1,0 +1,52 @@
+using System.Diagnostics.Metrics;
+using Granit.Authentication.DPoP.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authentication.DPoP.Tests.Diagnostics;
+
+public sealed class DPoPValidationMetricsTests : IDisposable
+{
+    private readonly ServiceProvider _sp;
+    private readonly DPoPValidationMetrics _metrics;
+
+    public DPoPValidationMetricsTests()
+    {
+        ServiceCollection services = new();
+        services.AddMetrics();
+        _sp = services.BuildServiceProvider();
+        IMeterFactory meterFactory = _sp.GetRequiredService<System.Diagnostics.Metrics.IMeterFactory>();
+        _metrics = new DPoPValidationMetrics(meterFactory);
+    }
+
+    public void Dispose() => _sp.Dispose();
+
+    [Fact]
+    public void MeterName_IsCorrect() =>
+        DPoPValidationMetrics.MeterName.ShouldBe("Granit.Authentication.DPoP");
+
+    [Fact]
+    public void RecordSuccess_DoesNotThrow() =>
+        Should.NotThrow(() => _metrics.RecordSuccess("tenant-1"));
+
+    [Fact]
+    public void RecordSuccess_NullTenant_UsesGlobal() =>
+        Should.NotThrow(() => _metrics.RecordSuccess(null));
+
+    [Fact]
+    public void RecordFailure_DoesNotThrow() =>
+        Should.NotThrow(() => _metrics.RecordFailure("proof_expired", "tenant-1"));
+
+    [Fact]
+    public void RecordFailure_NullTenant_UsesGlobal() =>
+        Should.NotThrow(() => _metrics.RecordFailure("invalid_algorithm", null));
+
+    [Fact]
+    public void RecordReplayDetected_DoesNotThrow() =>
+        Should.NotThrow(() => _metrics.RecordReplayDetected("tenant-1"));
+
+    [Fact]
+    public void RecordReplayDetected_NullTenant_UsesGlobal() =>
+        Should.NotThrow(() => _metrics.RecordReplayDetected(null));
+}

--- a/tests/Granit.Authentication.DPoP.Tests/Middleware/DPoPValidationMiddlewareTests.cs
+++ b/tests/Granit.Authentication.DPoP.Tests/Middleware/DPoPValidationMiddlewareTests.cs
@@ -1,0 +1,189 @@
+using Granit.Authentication.DPoP.Middleware;
+using Granit.Authentication.DPoP.Options;
+using Granit.Authentication.DPoP.Validation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authentication.DPoP.Tests.Middleware;
+
+public sealed class DPoPValidationMiddlewareTests
+{
+    private readonly IDPoPProofValidator _validator = Substitute.For<IDPoPProofValidator>();
+
+    private DPoPValidationMiddleware CreateMiddleware(DPoPValidationOptions options, RequestDelegate next) =>
+        new(next, _validator, Options.Create(options), NullLogger<DPoPValidationMiddleware>.Instance);
+
+    [Fact]
+    public async Task InvokeAsync_NoDPoPHeader_RequireDPoPFalse_CallsNext()
+    {
+        bool nextCalled = false;
+        DefaultHttpContext context = new();
+        DPoPValidationMiddleware middleware = CreateMiddleware(new DPoPValidationOptions { RequireDPoP = false }, _ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.ShouldBeTrue();
+        context.Response.StatusCode.ShouldBe(200);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_NoDPoPHeader_RequireDPoPTrue_NotAuthenticated_CallsNext()
+    {
+        bool nextCalled = false;
+        DefaultHttpContext context = new();
+        // User.Identity.IsAuthenticated is false by default
+        DPoPValidationMiddleware middleware = CreateMiddleware(new DPoPValidationOptions { RequireDPoP = true }, _ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_NoDPoPHeader_RequireDPoPTrue_Authenticated_Returns401()
+    {
+        bool nextCalled = false;
+        DefaultHttpContext context = new();
+        // Simulate authenticated user
+        System.Security.Claims.ClaimsIdentity identity = new("test");
+        context.User = new System.Security.Claims.ClaimsPrincipal(identity);
+
+        DPoPValidationMiddleware middleware = CreateMiddleware(new DPoPValidationOptions { RequireDPoP = true }, _ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.ShouldBeFalse();
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ValidDPoPProof_CallsNext()
+    {
+        bool nextCalled = false;
+        DefaultHttpContext context = new();
+        context.Request.Method = "GET";
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("api.example.com");
+        context.Request.Path = "/data";
+        context.Request.Headers.Append("DPoP", "valid.proof.jwt");
+
+        _validator.ValidateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new DPoPValidationResult(true, "thumb123", null));
+
+        DPoPValidationMiddleware middleware = CreateMiddleware(new DPoPValidationOptions(), _ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.ShouldBeTrue();
+        context.Response.StatusCode.ShouldBe(200);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_InvalidDPoPProof_Returns401()
+    {
+        bool nextCalled = false;
+        DefaultHttpContext context = new();
+        context.Request.Method = "GET";
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("api.example.com");
+        context.Request.Path = "/data";
+        context.Request.Headers.Append("DPoP", "invalid.proof.jwt");
+
+        _validator.ValidateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new DPoPValidationResult(false, null, "proof_expired"));
+
+        DPoPValidationMiddleware middleware = CreateMiddleware(new DPoPValidationOptions(), _ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.ShouldBeFalse();
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_EmptyDPoPHeader_Returns401()
+    {
+        bool nextCalled = false;
+        DefaultHttpContext context = new();
+        context.Request.Headers.Append("DPoP", string.Empty);
+
+        DPoPValidationMiddleware middleware = CreateMiddleware(new DPoPValidationOptions(), _ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.ShouldBeFalse();
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_DPoPSchemeInAuthorization_TriggersValidation()
+    {
+        DefaultHttpContext context = new();
+        context.Request.Method = "POST";
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("api.example.com");
+        context.Request.Path = "/token";
+        context.Request.Headers.Authorization = "DPoP eyJhbGciOiJFUzI1NiJ9.proof";
+
+        _validator.ValidateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new DPoPValidationResult(true, "thumb123", null));
+
+        DPoPValidationMiddleware middleware = CreateMiddleware(new DPoPValidationOptions(), _ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context);
+
+        await _validator.Received(1).ValidateAsync(
+            "eyJhbGciOiJFUzI1NiJ9.proof",
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ValidProof_ServerNonceSet_AddsResponseHeader()
+    {
+        DefaultHttpContext context = new();
+        context.Request.Method = "GET";
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("api.example.com");
+        context.Request.Path = "/data";
+        context.Request.Headers.Append("DPoP", "proof.jwt");
+
+        _validator.ValidateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new DPoPValidationResult(true, "thumb", null) { ServerNonce = "server-nonce-123" });
+
+        DPoPValidationMiddleware middleware = CreateMiddleware(new DPoPValidationOptions(), _ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context);
+
+        context.Response.Headers["DPoP-Nonce"].ToString().ShouldBe("server-nonce-123");
+    }
+}

--- a/tests/Granit.Authentication.DPoP.Tests/Options/DPoPValidationOptionsTests.cs
+++ b/tests/Granit.Authentication.DPoP.Tests/Options/DPoPValidationOptionsTests.cs
@@ -1,0 +1,74 @@
+using Granit.Authentication.DPoP.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authentication.DPoP.Tests.Options;
+
+public sealed class DPoPValidationOptionsTests
+{
+    [Fact]
+    public void SectionName_IsCorrect() =>
+        DPoPValidationOptions.SectionName.ShouldBe("Authentication:DPoP");
+
+    [Fact]
+    public void RequireDPoP_DefaultsToFalse() =>
+        new DPoPValidationOptions().RequireDPoP.ShouldBeFalse();
+
+    [Fact]
+    public void AllowedAlgorithms_DefaultsToES256AndPS256()
+    {
+        DPoPValidationOptions options = new();
+        options.AllowedAlgorithms.ShouldContain("ES256");
+        options.AllowedAlgorithms.ShouldContain("PS256");
+        options.AllowedAlgorithms.Length.ShouldBe(2);
+    }
+
+    [Fact]
+    public void ClockSkew_DefaultsTo30Seconds() =>
+        new DPoPValidationOptions().ClockSkew.ShouldBe(TimeSpan.FromSeconds(30));
+
+    [Fact]
+    public void MaxProofLifetime_DefaultsTo5Minutes() =>
+        new DPoPValidationOptions().MaxProofLifetime.ShouldBe(TimeSpan.FromMinutes(5));
+
+    [Fact]
+    public void EnableReplayProtection_DefaultsToTrue() =>
+        new DPoPValidationOptions().EnableReplayProtection.ShouldBeTrue();
+
+    [Fact]
+    public void RequireNonce_DefaultsToFalse() =>
+        new DPoPValidationOptions().RequireNonce.ShouldBeFalse();
+
+    [Fact]
+    public void RequireTokenBinding_DefaultsToFalse() =>
+        new DPoPValidationOptions().RequireTokenBinding.ShouldBeFalse();
+
+    [Fact]
+    public void MinimumRsaKeySize_DefaultsTo2048() =>
+        new DPoPValidationOptions().MinimumRsaKeySize.ShouldBe(2048);
+
+    [Fact]
+    public void AllProperties_CanBeSet()
+    {
+        DPoPValidationOptions options = new()
+        {
+            RequireDPoP = true,
+            AllowedAlgorithms = ["ES256"],
+            ClockSkew = TimeSpan.FromSeconds(10),
+            MaxProofLifetime = TimeSpan.FromMinutes(2),
+            EnableReplayProtection = false,
+            RequireNonce = true,
+            RequireTokenBinding = true,
+            MinimumRsaKeySize = 4096,
+        };
+
+        options.RequireDPoP.ShouldBeTrue();
+        options.AllowedAlgorithms.ShouldBe(["ES256"]);
+        options.ClockSkew.ShouldBe(TimeSpan.FromSeconds(10));
+        options.MaxProofLifetime.ShouldBe(TimeSpan.FromMinutes(2));
+        options.EnableReplayProtection.ShouldBeFalse();
+        options.RequireNonce.ShouldBeTrue();
+        options.RequireTokenBinding.ShouldBeTrue();
+        options.MinimumRsaKeySize.ShouldBe(4096);
+    }
+}

--- a/tests/Granit.Authentication.OpenIddict.Tests/GranitAuthenticationOpenIddictModuleTests.cs
+++ b/tests/Granit.Authentication.OpenIddict.Tests/GranitAuthenticationOpenIddictModuleTests.cs
@@ -1,0 +1,17 @@
+using Granit.Authentication.OpenIddict;
+using Granit.Modularity;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authentication.OpenIddict.Tests;
+
+public sealed class GranitAuthenticationOpenIddictModuleTests
+{
+    [Fact]
+    public void Module_IsSealed() =>
+        typeof(GranitAuthenticationOpenIddictModule).IsSealed.ShouldBeTrue();
+
+    [Fact]
+    public void Module_InheritsGranitModule() =>
+        typeof(GranitAuthenticationOpenIddictModule).BaseType.ShouldBe(typeof(GranitModule));
+}

--- a/tests/Granit.Authentication.OpenIddict.Tests/Internal/RequireDPoPMiddlewareTests.cs
+++ b/tests/Granit.Authentication.OpenIddict.Tests/Internal/RequireDPoPMiddlewareTests.cs
@@ -1,0 +1,128 @@
+using Granit.Authentication.OpenIddict.Internal;
+using Microsoft.AspNetCore.Http;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authentication.OpenIddict.Tests.Internal;
+
+public sealed class RequireDPoPMiddlewareTests
+{
+    [Fact]
+    public async Task InvokeAsync_NoBearerScheme_CallsNext()
+    {
+        bool nextCalled = false;
+        DefaultHttpContext context = new();
+        RequireDPoPMiddleware middleware = new(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.ShouldBeTrue();
+        context.Response.StatusCode.ShouldBe(200);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_NoAuthorizationHeader_CallsNext()
+    {
+        bool nextCalled = false;
+        DefaultHttpContext context = new();
+        RequireDPoPMiddleware middleware = new(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.ShouldBeTrue();
+        context.Response.StatusCode.ShouldBe(200);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_BearerWithoutDPoP_Returns401()
+    {
+        bool nextCalled = false;
+        DefaultHttpContext context = new();
+        context.Request.Headers.Authorization = "Bearer eyJhbGciOiJSUzI1NiJ9.test";
+        RequireDPoPMiddleware middleware = new(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.ShouldBeFalse();
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_BearerWithoutDPoP_SetsWwwAuthenticateHeader()
+    {
+        DefaultHttpContext context = new();
+        context.Request.Headers.Authorization = "Bearer eyJhbGciOiJSUzI1NiJ9.test";
+        RequireDPoPMiddleware middleware = new(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context);
+
+        context.Response.Headers.WWWAuthenticate.ToString().ShouldBe("DPoP");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_DPoPScheme_CallsNext()
+    {
+        bool nextCalled = false;
+        DefaultHttpContext context = new();
+        context.Request.Headers.Authorization = "DPoP eyJhbGciOiJFUzI1NiJ9.proof";
+        RequireDPoPMiddleware middleware = new(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.ShouldBeTrue();
+        context.Response.StatusCode.ShouldBe(200);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_BearerWithDPoPHeader_CallsNext()
+    {
+        bool nextCalled = false;
+        DefaultHttpContext context = new();
+        context.Request.Headers.Authorization = "Bearer eyJhbGciOiJSUzI1NiJ9.test";
+        context.Request.Headers.Append("DPoP", "eyJhbGciOiJFUzI1NiJ9.proof");
+        RequireDPoPMiddleware middleware = new(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.ShouldBeTrue();
+        context.Response.StatusCode.ShouldBe(200);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_BearerCaseInsensitive_Returns401()
+    {
+        bool nextCalled = false;
+        DefaultHttpContext context = new();
+        context.Request.Headers.Authorization = "bearer eyJhbGciOiJSUzI1NiJ9.test";
+        RequireDPoPMiddleware middleware = new(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.ShouldBeFalse();
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status401Unauthorized);
+    }
+}

--- a/tests/Granit.Authentication.OpenIddict.Tests/Options/GranitOpenIddictValidationOptionsTests.cs
+++ b/tests/Granit.Authentication.OpenIddict.Tests/Options/GranitOpenIddictValidationOptionsTests.cs
@@ -1,0 +1,41 @@
+using Granit.Authentication.OpenIddict.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authentication.OpenIddict.Tests.Options;
+
+public sealed class GranitOpenIddictValidationOptionsTests
+{
+    [Fact]
+    public void SectionName_IsCorrect() =>
+        GranitOpenIddictValidationOptions.SectionName.ShouldBe("Authentication:OpenIddict");
+
+    [Fact]
+    public void RequireDPoP_DefaultsToFalse() =>
+        new GranitOpenIddictValidationOptions().RequireDPoP.ShouldBeFalse();
+
+    [Fact]
+    public void Issuer_DefaultsToNull() =>
+        new GranitOpenIddictValidationOptions().Issuer.ShouldBeNull();
+
+    [Fact]
+    public void Audience_DefaultsToNull() =>
+        new GranitOpenIddictValidationOptions().Audience.ShouldBeNull();
+
+    [Fact]
+    public void AllProperties_CanBeSet()
+    {
+        var issuer = new Uri("https://auth.example.com");
+
+        GranitOpenIddictValidationOptions options = new()
+        {
+            Issuer = issuer,
+            Audience = "api.example.com",
+            RequireDPoP = true,
+        };
+
+        options.Issuer.ShouldBe(issuer);
+        options.Audience.ShouldBe("api.example.com");
+        options.RequireDPoP.ShouldBeTrue();
+    }
+}

--- a/tests/Granit.Authorization.Tests/Diagnostics/AuthorizationMetricsTests.cs
+++ b/tests/Granit.Authorization.Tests/Diagnostics/AuthorizationMetricsTests.cs
@@ -177,8 +177,6 @@ public sealed class AuthorizationMetricsTests : IDisposable
     // =========================================================================
 
     [Fact]
-    public void MeterName_IsGranitAuthorization()
-    {
+    public void MeterName_IsGranitAuthorization() =>
         AuthorizationMetrics.MeterName.ShouldBe("Granit.Authorization");
-    }
 }

--- a/tests/Granit.Authorization.Tests/GranitAuthorizationModuleTests.cs
+++ b/tests/Granit.Authorization.Tests/GranitAuthorizationModuleTests.cs
@@ -59,8 +59,6 @@ public sealed class GranitAuthorizationModuleTests
     // =========================================================================
 
     [Fact]
-    public void ModuleClass_IsSealed()
-    {
+    public void ModuleClass_IsSealed() =>
         typeof(GranitAuthorizationModule).IsSealed.ShouldBeTrue();
-    }
 }

--- a/tests/Granit.Authorization.Tests/Options/GranitAuthorizationOptionsValidatorTests.cs
+++ b/tests/Granit.Authorization.Tests/Options/GranitAuthorizationOptionsValidatorTests.cs
@@ -283,8 +283,6 @@ public sealed class GranitAuthorizationOptionsValidatorTests
     // =========================================================================
 
     [Fact]
-    public void ImplementsIValidateOptions()
-    {
+    public void ImplementsIValidateOptions() =>
         _validator.ShouldBeAssignableTo<IValidateOptions<GranitAuthorizationOptions>>();
-    }
 }

--- a/tests/Granit.Bff.Yarp.Tests/Internal/BffTokenInjectionTransformTests.cs
+++ b/tests/Granit.Bff.Yarp.Tests/Internal/BffTokenInjectionTransformTests.cs
@@ -1,0 +1,226 @@
+using System.Diagnostics.Metrics;
+using Granit.Bff.Diagnostics;
+using Granit.Bff.Options;
+using Granit.Bff.Yarp.Internal;
+using Granit.Oidc.DPoP;
+using Granit.Timing;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Yarp.ReverseProxy.Configuration;
+using Yarp.ReverseProxy.Forwarder;
+using Yarp.ReverseProxy.Model;
+using Yarp.ReverseProxy.Transforms;
+
+namespace Granit.Bff.Yarp.Tests.Internal;
+
+public sealed class BffTokenInjectionTransformTests : IDisposable
+{
+    private readonly IBffTokenStore _tokenStore = Substitute.For<IBffTokenStore>();
+    private readonly IHttpClientFactory _httpClientFactory = Substitute.For<IHttpClientFactory>();
+    private readonly IDPoPProofService _dpopService = Substitute.For<IDPoPProofService>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly ServiceProvider _sp;
+    private readonly BffMetrics _metrics;
+
+    private readonly GranitBffOptions _bffOptions = new()
+    {
+        Authority = new Uri("https://auth.example.com"),
+        UseSessionSlidingExpiration = false,
+        RefreshGracePeriod = TimeSpan.FromSeconds(30),
+        Frontends =
+        [
+            new BffFrontendOptions { Name = "main", ClientId = "client", ClientSecret = "s3cr3t" },
+        ],
+    };
+
+    public BffTokenInjectionTransformTests()
+    {
+        ServiceCollection services = new();
+        services.AddMetrics();
+        _sp = services.BuildServiceProvider();
+        IMeterFactory meterFactory = _sp.GetRequiredService<System.Diagnostics.Metrics.IMeterFactory>();
+        _metrics = new BffMetrics(meterFactory);
+        _clock.Now.Returns(DateTimeOffset.UtcNow);
+    }
+
+    public void Dispose() => _sp.Dispose();
+
+    private BffTokenInjectionTransform CreateTransform() => new(
+        _tokenStore,
+        Options.Create(_bffOptions),
+        _httpClientFactory,
+        _dpopService,
+        _metrics,
+        _clock,
+        NullLogger<BffTokenInjectionTransform>.Instance);
+
+    [Fact]
+    public async Task ApplyAsync_NoProxyFeature_DoesNotReturn401()
+    {
+        DefaultHttpContext httpContext = new();
+        RequestTransformContext context = new()
+        {
+            HttpContext = httpContext,
+            ProxyRequest = new HttpRequestMessage(),
+        };
+
+        await CreateTransform().ApplyAsync(context);
+
+        httpContext.Response.StatusCode.ShouldBe(200);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_RequireAuthFalse_DoesNotReturn401()
+    {
+        RequestTransformContext context = CreateTransformContext(new Dictionary<string, string>
+        {
+            ["Granit.Bff.RequireAuth"] = "false",
+        });
+
+        await CreateTransform().ApplyAsync(context);
+
+        context.HttpContext.Response.StatusCode.ShouldBe(200);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_RequireAuthTrue_NoSessionCookie_Returns401()
+    {
+        RequestTransformContext context = CreateTransformContext(new Dictionary<string, string>
+        {
+            ["Granit.Bff.RequireAuth"] = "true",
+            ["Granit.Bff.Frontend"] = "main",
+        });
+
+        await CreateTransform().ApplyAsync(context);
+
+        context.HttpContext.Response.StatusCode.ShouldBe(StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_StoreReturnsNull_Returns401()
+    {
+        _tokenStore.GetAsync("main", "session-abc", Arg.Any<CancellationToken>())
+            .Returns((BffTokenSet?)null);
+
+        RequestTransformContext context = CreateTransformContext(new Dictionary<string, string>
+        {
+            ["Granit.Bff.RequireAuth"] = "true",
+            ["Granit.Bff.Frontend"] = "main",
+        });
+        context.HttpContext.Request.Cookies = CreateCookies(
+            new Dictionary<string, string> { ["__Host-granit-bff-main"] = "session-abc" });
+
+        await CreateTransform().ApplyAsync(context);
+
+        context.HttpContext.Response.StatusCode.ShouldBe(StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_ValidBearerToken_InjectsBearerAuthorizationHeader()
+    {
+        BffTokenSet tokens = new("access-token-xyz", null, null, DateTimeOffset.UtcNow.AddHours(1));
+        _tokenStore.GetAsync("main", "session-abc", Arg.Any<CancellationToken>())
+            .Returns(tokens);
+
+        RequestTransformContext context = CreateTransformContext(new Dictionary<string, string>
+        {
+            ["Granit.Bff.RequireAuth"] = "true",
+            ["Granit.Bff.Frontend"] = "main",
+        });
+        context.HttpContext.Request.Cookies = CreateCookies(
+            new Dictionary<string, string> { ["__Host-granit-bff-main"] = "session-abc" });
+
+        await CreateTransform().ApplyAsync(context);
+
+        context.HttpContext.Response.StatusCode.ShouldBe(200);
+        context.ProxyRequest.Headers.Authorization?.Scheme.ShouldBe("Bearer");
+        context.ProxyRequest.Headers.Authorization?.Parameter.ShouldBe("access-token-xyz");
+    }
+
+    [Fact]
+    public async Task ApplyAsync_DPoPToken_InjectsDPoPAuthorizationAndProofHeaders()
+    {
+        BffTokenSet tokens = new("dpop-access-token", null, null, DateTimeOffset.UtcNow.AddHours(1))
+        {
+            DPoPPrivateKeyJwk = """{"kty":"EC","crv":"P-256"}""",
+        };
+        _tokenStore.GetAsync("main", "session-abc", Arg.Any<CancellationToken>())
+            .Returns(tokens);
+        _dpopService
+            .CreateProof(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>())
+            .Returns("dpop-proof-value");
+
+        RequestTransformContext context = CreateTransformContext(new Dictionary<string, string>
+        {
+            ["Granit.Bff.RequireAuth"] = "true",
+            ["Granit.Bff.Frontend"] = "main",
+        });
+        context.HttpContext.Request.Cookies = CreateCookies(
+            new Dictionary<string, string> { ["__Host-granit-bff-main"] = "session-abc" });
+
+        await CreateTransform().ApplyAsync(context);
+
+        context.ProxyRequest.Headers.Authorization?.Scheme.ShouldBe("DPoP");
+        context.ProxyRequest.Headers.Authorization?.Parameter.ShouldBe("dpop-access-token");
+        context.ProxyRequest.Headers.TryGetValues("DPoP", out IEnumerable<string>? proofValues).ShouldBeTrue();
+        proofValues!.Single().ShouldBe("dpop-proof-value");
+    }
+
+    [Fact]
+    public async Task ApplyAsync_UnknownFrontend_Returns401()
+    {
+        RequestTransformContext context = CreateTransformContext(new Dictionary<string, string>
+        {
+            ["Granit.Bff.RequireAuth"] = "true",
+            ["Granit.Bff.Frontend"] = "unknown",
+        });
+
+        await CreateTransform().ApplyAsync(context);
+
+        context.HttpContext.Response.StatusCode.ShouldBe(StatusCodes.Status401Unauthorized);
+    }
+
+    private static RequestTransformContext CreateTransformContext(Dictionary<string, string> metadata)
+    {
+        DefaultHttpContext httpContext = new() { Request = { Method = "GET" } };
+
+        RouteConfig routeConfig = new()
+        {
+            RouteId = "test-route",
+            ClusterId = "test-cluster",
+            Metadata = metadata.AsReadOnly(),
+        };
+
+        ClusterState clusterState = new("test-cluster");
+        RouteModel routeModel = new(routeConfig, clusterState, HttpTransformer.Default);
+
+        IReverseProxyFeature proxyFeature = Substitute.For<IReverseProxyFeature>();
+        proxyFeature.Route.Returns(routeModel);
+        httpContext.Features.Set(proxyFeature);
+
+        return new RequestTransformContext
+        {
+            HttpContext = httpContext,
+            ProxyRequest = new HttpRequestMessage(),
+        };
+    }
+
+    private static IRequestCookieCollection CreateCookies(Dictionary<string, string> cookies)
+    {
+        IRequestCookieCollection cookieCollection = Substitute.For<IRequestCookieCollection>();
+        cookieCollection[Arg.Any<string>()].Returns(callInfo =>
+        {
+            string key = callInfo.Arg<string>();
+            return cookies.TryGetValue(key, out string? value) ? value : null;
+        });
+        cookieCollection.Count.Returns(cookies.Count);
+        cookieCollection.Keys.Returns(cookies.Keys);
+        cookieCollection.ContainsKey(Arg.Any<string>()).Returns(callInfo =>
+            cookies.ContainsKey(callInfo.Arg<string>()));
+        return cookieCollection;
+    }
+}

--- a/tests/Granit.BlobStorage.Database.Tests/Diagnostics/BlobStorageDatabaseActivitySourceTests.cs
+++ b/tests/Granit.BlobStorage.Database.Tests/Diagnostics/BlobStorageDatabaseActivitySourceTests.cs
@@ -1,0 +1,37 @@
+using Granit.BlobStorage.Database.Diagnostics;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BlobStorage.Database.Tests.Diagnostics;
+
+public sealed class BlobStorageDatabaseActivitySourceTests
+{
+    [Fact]
+    public void Name_IsCorrect() =>
+        BlobStorageDatabaseActivitySource.Name.ShouldBe("Granit.BlobStorage.Database");
+
+    [Fact]
+    public void Source_IsNotNull() =>
+        BlobStorageDatabaseActivitySource.Source.ShouldNotBeNull();
+
+    [Fact]
+    public void Source_HasCorrectName() =>
+        BlobStorageDatabaseActivitySource.Source.Name.ShouldBe(BlobStorageDatabaseActivitySource.Name);
+
+    [Fact]
+    public void OperationNames_AreCorrect()
+    {
+        BlobStorageDatabaseActivitySource.Save.ShouldBe("blobstorage.save");
+        BlobStorageDatabaseActivitySource.Read.ShouldBe("blobstorage.read");
+        BlobStorageDatabaseActivitySource.Delete.ShouldBe("blobstorage.delete");
+        BlobStorageDatabaseActivitySource.GetSize.ShouldBe("blobstorage.get-size");
+        BlobStorageDatabaseActivitySource.PartialStream.ShouldBe("blobstorage.partial-stream");
+    }
+
+    [Fact]
+    public void TagNames_AreCorrect()
+    {
+        BlobStorageDatabaseActivitySource.TagObjectKey.ShouldBe("blobstorage.object_key");
+        BlobStorageDatabaseActivitySource.TagContentType.ShouldBe("blobstorage.content_type");
+    }
+}

--- a/tests/Granit.BlobStorage.Database.Tests/Entities/DatabaseBlobContentTests.cs
+++ b/tests/Granit.BlobStorage.Database.Tests/Entities/DatabaseBlobContentTests.cs
@@ -1,0 +1,57 @@
+using Granit.BlobStorage.Database.Entities;
+using Granit.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BlobStorage.Database.Tests.Entities;
+
+public sealed class DatabaseBlobContentTests
+{
+    [Fact]
+    public void Id_DefaultsToEmpty() =>
+        new DatabaseBlobContent().Id.ShouldBe(Guid.Empty);
+
+    [Fact]
+    public void TenantId_DefaultsToNull() =>
+        new DatabaseBlobContent().TenantId.ShouldBeNull();
+
+    [Fact]
+    public void ObjectKey_DefaultsToEmpty() =>
+        new DatabaseBlobContent().ObjectKey.ShouldBe(string.Empty);
+
+    [Fact]
+    public void Content_DefaultsToEmptyArray() =>
+        new DatabaseBlobContent().Content.ShouldBeEmpty();
+
+    [Fact]
+    public void CreatedAt_DefaultsToMinValue() =>
+        new DatabaseBlobContent().CreatedAt.ShouldBe(default);
+
+    [Fact]
+    public void Implements_IMultiTenant() =>
+        typeof(DatabaseBlobContent).GetInterfaces().ShouldContain(typeof(IMultiTenant));
+
+    [Fact]
+    public void AllProperties_CanBeSet()
+    {
+        var id = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        byte[] content = [1, 2, 3];
+
+        DatabaseBlobContent entity = new()
+        {
+            Id = id,
+            TenantId = tenantId,
+            ObjectKey = "tenant/container/2026/01/blob-id",
+            Content = content,
+            CreatedAt = now,
+        };
+
+        entity.Id.ShouldBe(id);
+        entity.TenantId.ShouldBe(tenantId);
+        entity.ObjectKey.ShouldBe("tenant/container/2026/01/blob-id");
+        entity.Content.ShouldBe(content);
+        entity.CreatedAt.ShouldBe(now);
+    }
+}

--- a/tests/Granit.BlobStorage.Database.Tests/Entities/DbStoreBlobContentTests.cs
+++ b/tests/Granit.BlobStorage.Database.Tests/Entities/DbStoreBlobContentTests.cs
@@ -1,0 +1,57 @@
+using Granit.BlobStorage.Database.Entities;
+using Granit.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BlobStorage.Database.Tests.Entities;
+
+public sealed class DbStoreBlobContentTests
+{
+    [Fact]
+    public void Id_DefaultsToEmpty() =>
+        new DbStoreBlobContent().Id.ShouldBe(Guid.Empty);
+
+    [Fact]
+    public void TenantId_DefaultsToNull() =>
+        new DbStoreBlobContent().TenantId.ShouldBeNull();
+
+    [Fact]
+    public void ObjectKey_DefaultsToEmpty() =>
+        new DbStoreBlobContent().ObjectKey.ShouldBe(string.Empty);
+
+    [Fact]
+    public void Content_DefaultsToEmptyArray() =>
+        new DbStoreBlobContent().Content.ShouldBeEmpty();
+
+    [Fact]
+    public void CreatedAt_DefaultsToMinValue() =>
+        new DbStoreBlobContent().CreatedAt.ShouldBe(default);
+
+    [Fact]
+    public void Implements_IMultiTenant() =>
+        typeof(DbStoreBlobContent).GetInterfaces().ShouldContain(typeof(IMultiTenant));
+
+    [Fact]
+    public void AllProperties_CanBeSet()
+    {
+        var id = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        byte[] content = [0xDE, 0xAD, 0xBE, 0xEF];
+
+        DbStoreBlobContent entity = new()
+        {
+            Id = id,
+            TenantId = tenantId,
+            ObjectKey = "tenant/images/2026/03/photo.jpg",
+            Content = content,
+            CreatedAt = now,
+        };
+
+        entity.Id.ShouldBe(id);
+        entity.TenantId.ShouldBe(tenantId);
+        entity.ObjectKey.ShouldBe("tenant/images/2026/03/photo.jpg");
+        entity.Content.ShouldBe(content);
+        entity.CreatedAt.ShouldBe(now);
+    }
+}

--- a/tests/Granit.BlobStorage.Database.Tests/GranitBlobStorageDatabaseModuleTests.cs
+++ b/tests/Granit.BlobStorage.Database.Tests/GranitBlobStorageDatabaseModuleTests.cs
@@ -1,0 +1,32 @@
+using Granit.BlobStorage;
+using Granit.BlobStorage.Database;
+using Granit.Modularity;
+using Granit.Persistence;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BlobStorage.Database.Tests;
+
+public sealed class GranitBlobStorageDatabaseModuleTests
+{
+    [Fact]
+    public void Module_IsSealed() =>
+        typeof(GranitBlobStorageDatabaseModule).IsSealed.ShouldBeTrue();
+
+    [Fact]
+    public void Module_InheritsGranitModule() =>
+        typeof(GranitBlobStorageDatabaseModule).BaseType.ShouldBe(typeof(GranitModule));
+
+    [Fact]
+    public void Module_DependsOnBlobStorageAndPersistence()
+    {
+        DependsOnAttribute[] attributes = [.. typeof(GranitBlobStorageDatabaseModule)
+            .GetCustomAttributes(typeof(DependsOnAttribute), true)
+            .Cast<DependsOnAttribute>()];
+
+        Type[] allDependencies = [.. attributes.SelectMany(a => a.DependedTypes)];
+
+        allDependencies.ShouldContain(typeof(GranitBlobStorageModule));
+        allDependencies.ShouldContain(typeof(GranitPersistenceModule));
+    }
+}

--- a/tests/Granit.BlobStorage.Database.Tests/Internal/DatabaseBlobKeyStrategyTests.cs
+++ b/tests/Granit.BlobStorage.Database.Tests/Internal/DatabaseBlobKeyStrategyTests.cs
@@ -1,0 +1,35 @@
+using Granit.BlobStorage.Database.Internal;
+using Granit.MultiTenancy;
+using Granit.Timing;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BlobStorage.Database.Tests.Internal;
+
+public sealed class DatabaseBlobKeyStrategyTests
+{
+    private readonly ICurrentTenant _currentTenant = Substitute.For<ICurrentTenant>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+
+    public DatabaseBlobKeyStrategyTests()
+    {
+        _clock.Now.Returns(DateTimeOffset.UtcNow);
+        _currentTenant.IsAvailable.Returns(false);
+    }
+
+    [Fact]
+    public void ResolveBucketName_AlwaysReturnsDbstore() =>
+        new DatabaseBlobKeyStrategy(_currentTenant, _clock)
+            .ResolveBucketName("any-container")
+            .ShouldBe("dbstore");
+
+    [Theory]
+    [InlineData("documents")]
+    [InlineData("images")]
+    [InlineData("reports")]
+    public void ResolveBucketName_IgnoresContainerName(string containerName) =>
+        new DatabaseBlobKeyStrategy(_currentTenant, _clock)
+            .ResolveBucketName(containerName)
+            .ShouldBe("dbstore");
+}

--- a/tests/Granit.BlobStorage.Database.Tests/Internal/DbStoreBlobKeyStrategyTests.cs
+++ b/tests/Granit.BlobStorage.Database.Tests/Internal/DbStoreBlobKeyStrategyTests.cs
@@ -1,0 +1,35 @@
+using Granit.BlobStorage.Database.Internal;
+using Granit.MultiTenancy;
+using Granit.Timing;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BlobStorage.Database.Tests.Internal;
+
+public sealed class DbStoreBlobKeyStrategyTests
+{
+    private readonly ICurrentTenant _currentTenant = Substitute.For<ICurrentTenant>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+
+    public DbStoreBlobKeyStrategyTests()
+    {
+        _clock.Now.Returns(DateTimeOffset.UtcNow);
+        _currentTenant.IsAvailable.Returns(false);
+    }
+
+    [Fact]
+    public void ResolveBucketName_AlwaysReturnsDbstore() =>
+        new DbStoreBlobKeyStrategy(_currentTenant, _clock)
+            .ResolveBucketName("any-container")
+            .ShouldBe("dbstore");
+
+    [Theory]
+    [InlineData("documents")]
+    [InlineData("images")]
+    [InlineData("videos")]
+    public void ResolveBucketName_IgnoresContainerName(string containerName) =>
+        new DbStoreBlobKeyStrategy(_currentTenant, _clock)
+            .ResolveBucketName(containerName)
+            .ShouldBe("dbstore");
+}

--- a/tests/Granit.BlobStorage.Database.Tests/Options/DatabaseBlobOptionsTests.cs
+++ b/tests/Granit.BlobStorage.Database.Tests/Options/DatabaseBlobOptionsTests.cs
@@ -1,0 +1,24 @@
+using Granit.BlobStorage.Database.Options;
+using Granit.BlobStorage.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BlobStorage.Database.Tests.Options;
+
+public sealed class DatabaseBlobOptionsTests
+{
+    [Fact]
+    public void MaxBlobSizeBytes_DefaultsTo10MB() =>
+        new DatabaseBlobOptions().MaxBlobSizeBytes.ShouldBe(10 * 1024 * 1024);
+
+    [Fact]
+    public void SectionName_InheritsFromBlobStorageOptions() =>
+        BlobStorageOptions.SectionName.ShouldBe("BlobStorage");
+
+    [Fact]
+    public void MaxBlobSizeBytes_CanBeOverridden()
+    {
+        DatabaseBlobOptions options = new() { MaxBlobSizeBytes = 5 * 1024 * 1024 };
+        options.MaxBlobSizeBytes.ShouldBe(5 * 1024 * 1024);
+    }
+}

--- a/tests/Granit.BlobStorage.Database.Tests/Options/DatabaseBlobOptionsValidatorTests.cs
+++ b/tests/Granit.BlobStorage.Database.Tests/Options/DatabaseBlobOptionsValidatorTests.cs
@@ -1,0 +1,38 @@
+using Granit.BlobStorage.Database.Options;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BlobStorage.Database.Tests.Options;
+
+public sealed class DatabaseBlobOptionsValidatorTests
+{
+    private readonly DatabaseBlobOptionsValidator _validator = new();
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-1000)]
+    public void Validate_MaxBlobSizeBytesZeroOrNegative_ReturnsFail(long value)
+    {
+        DatabaseBlobOptions options = new() { MaxBlobSizeBytes = value };
+
+        ValidateOptionsResult result = _validator.Validate(null, options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain(nameof(DatabaseBlobOptions.MaxBlobSizeBytes));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(1024)]
+    [InlineData(10 * 1024 * 1024)]
+    public void Validate_MaxBlobSizeBytesPositive_ReturnsSuccess(long value)
+    {
+        DatabaseBlobOptions options = new() { MaxBlobSizeBytes = value };
+
+        ValidateOptionsResult result = _validator.Validate(null, options);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+}

--- a/tests/Granit.BlobStorage.Database.Tests/Options/DbStoreBlobOptionsTests.cs
+++ b/tests/Granit.BlobStorage.Database.Tests/Options/DbStoreBlobOptionsTests.cs
@@ -1,0 +1,19 @@
+using Granit.BlobStorage.Database.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BlobStorage.Database.Tests.Options;
+
+public sealed class DbStoreBlobOptionsTests
+{
+    [Fact]
+    public void MaxBlobSizeBytes_DefaultsTo10MB() =>
+        new DbStoreBlobOptions().MaxBlobSizeBytes.ShouldBe(10 * 1024 * 1024);
+
+    [Fact]
+    public void MaxBlobSizeBytes_CanBeOverridden()
+    {
+        DbStoreBlobOptions options = new() { MaxBlobSizeBytes = 20 * 1024 * 1024 };
+        options.MaxBlobSizeBytes.ShouldBe(20 * 1024 * 1024);
+    }
+}

--- a/tests/Granit.BlobStorage.Database.Tests/Options/DbStoreBlobOptionsValidatorTests.cs
+++ b/tests/Granit.BlobStorage.Database.Tests/Options/DbStoreBlobOptionsValidatorTests.cs
@@ -1,0 +1,38 @@
+using Granit.BlobStorage.Database.Options;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.BlobStorage.Database.Tests.Options;
+
+public sealed class DbStoreBlobOptionsValidatorTests
+{
+    private readonly DbStoreBlobOptionsValidator _validator = new();
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-5 * 1024 * 1024)]
+    public void Validate_MaxBlobSizeBytesZeroOrNegative_ReturnsFail(long value)
+    {
+        DbStoreBlobOptions options = new() { MaxBlobSizeBytes = value };
+
+        ValidateOptionsResult result = _validator.Validate(null, options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain(nameof(DbStoreBlobOptions.MaxBlobSizeBytes));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(512 * 1024)]
+    [InlineData(50 * 1024 * 1024)]
+    public void Validate_MaxBlobSizeBytesPositive_ReturnsSuccess(long value)
+    {
+        DbStoreBlobOptions options = new() { MaxBlobSizeBytes = value };
+
+        ValidateOptionsResult result = _validator.Validate(null, options);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+}

--- a/tests/Granit.Http.SecurityHeaders.Tests/SecurityHeadersMiddlewareTests.cs
+++ b/tests/Granit.Http.SecurityHeaders.Tests/SecurityHeadersMiddlewareTests.cs
@@ -175,7 +175,7 @@ public sealed class SecurityHeadersMiddlewareTests
     [Fact]
     public void ApplyHeaders_IsIdempotent()
     {
-        HeaderDictionary headers = new();
+        HeaderDictionary headers = [];
         GranitSecurityHeadersOptions options = new();
 
         SecurityHeadersMiddleware.ApplyHeaders(headers, options);

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/Internal/AspNetIdentityProviderCapabilitiesTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/Internal/AspNetIdentityProviderCapabilitiesTests.cs
@@ -1,0 +1,45 @@
+using Granit.Identity.Local.AspNetIdentity.Internal;
+using Shouldly;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Internal;
+
+public sealed class AspNetIdentityProviderCapabilitiesTests
+{
+    private readonly AspNetIdentityProviderCapabilities _sut = new();
+
+    [Fact]
+    public void ProviderName_IsAspNetIdentity() =>
+        _sut.ProviderName.ShouldBe("AspNetIdentity");
+
+    [Fact]
+    public void IsLocalStore_IsTrue() =>
+        _sut.IsLocalStore.ShouldBeTrue();
+
+    [Fact]
+    public void SupportsCredentialVerification_IsTrue() =>
+        _sut.SupportsCredentialVerification.ShouldBeTrue();
+
+    [Fact]
+    public void SupportsUserCreation_IsTrue() =>
+        _sut.SupportsUserCreation.ShouldBeTrue();
+
+    [Fact]
+    public void SupportsIndividualSessionTermination_IsFalse() =>
+        _sut.SupportsIndividualSessionTermination.ShouldBeFalse();
+
+    [Fact]
+    public void SupportsNativePasswordResetEmail_IsFalse() =>
+        _sut.SupportsNativePasswordResetEmail.ShouldBeFalse();
+
+    [Fact]
+    public void SupportsGroupHierarchy_IsFalse() =>
+        _sut.SupportsGroupHierarchy.ShouldBeFalse();
+
+    [Fact]
+    public void SupportsCustomAttributes_IsTrue() =>
+        _sut.SupportsCustomAttributes.ShouldBeTrue();
+
+    [Fact]
+    public void MaxCustomAttributes_IsIntMaxValue() =>
+        _sut.MaxCustomAttributes.ShouldBe(int.MaxValue);
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/Internal/AspNetIdentityUserLookupServiceTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/Internal/AspNetIdentityUserLookupServiceTests.cs
@@ -1,0 +1,80 @@
+using Granit.Identity.Local.AspNetIdentity.Internal;
+using Granit.Identity.Local.Domain;
+using Microsoft.AspNetCore.Identity;
+using NSubstitute;
+using Shouldly;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Internal;
+
+public sealed class AspNetIdentityUserLookupServiceTests
+{
+    private static UserManager<GranitUser> CreateUserManager()
+    {
+        IUserStore<GranitUser> store = Substitute.For<IUserStore<GranitUser>>();
+        return Substitute.For<UserManager<GranitUser>>(
+            store, null, null, null, null, null, null, null, null);
+    }
+
+    [Fact]
+    public async Task FindByIdAsync_WhenUserNotFound_ReturnsNull()
+    {
+        UserManager<GranitUser> userManager = CreateUserManager();
+        userManager.FindByIdAsync(Arg.Any<string>()).Returns((GranitUser?)null);
+        AspNetIdentityUserLookupService sut = new(userManager);
+
+        var result = await sut.FindByIdAsync("nonexistent", TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task FindByIdAsync_WhenUserFound_ReturnsUser()
+    {
+        UserManager<GranitUser> userManager = CreateUserManager();
+        var user = new GranitUser { UserName = "alice" };
+        userManager.FindByIdAsync("user-id").Returns(user);
+        AspNetIdentityUserLookupService sut = new(userManager);
+
+        var result = await sut.FindByIdAsync("user-id", TestContext.Current.CancellationToken);
+
+        result.ShouldBeSameAs(user);
+    }
+
+    [Fact]
+    public async Task RefreshAllAsync_ReturnsZero()
+    {
+        AspNetIdentityUserLookupService sut = new(CreateUserManager());
+
+        int result = await sut.RefreshAllAsync(TestContext.Current.CancellationToken);
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task RefreshStaleAsync_ReturnsZero()
+    {
+        AspNetIdentityUserLookupService sut = new(CreateUserManager());
+
+        int result = await sut.RefreshStaleAsync(TestContext.Current.CancellationToken);
+
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task DeleteByIdAsync_DoesNotThrow()
+    {
+        AspNetIdentityUserLookupService sut = new(CreateUserManager());
+
+        await Should.NotThrowAsync(() =>
+            sut.DeleteByIdAsync("user-id", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task PseudonymizeByIdAsync_DoesNotThrow()
+    {
+        AspNetIdentityUserLookupService sut = new(CreateUserManager());
+
+        await Should.NotThrowAsync(() =>
+            sut.PseudonymizeByIdAsync("user-id", TestContext.Current.CancellationToken));
+    }
+}

--- a/tests/Granit.Mcp.Client.Tests/GranitMcpClientModuleTests.cs
+++ b/tests/Granit.Mcp.Client.Tests/GranitMcpClientModuleTests.cs
@@ -1,0 +1,29 @@
+using Granit.Mcp;
+using Granit.Mcp.Client;
+using Granit.Modularity;
+using Shouldly;
+
+namespace Granit.Mcp.Client.Tests;
+
+public sealed class GranitMcpClientModuleTests
+{
+    [Fact]
+    public void Module_IsSealed() =>
+        typeof(GranitMcpClientModule).IsSealed.ShouldBeTrue();
+
+    [Fact]
+    public void Module_InheritsGranitModule() =>
+        typeof(GranitMcpClientModule).BaseType.ShouldBe(typeof(GranitModule));
+
+    [Fact]
+    public void Module_DependsOn_GranitMcpModule()
+    {
+        Type[] dependencies = typeof(GranitMcpClientModule)
+            .GetCustomAttributes(typeof(DependsOnAttribute), true)
+            .Cast<DependsOnAttribute>()
+            .SelectMany(a => a.DependedTypes)
+            .ToArray();
+
+        dependencies.ShouldContain(typeof(GranitMcpModule));
+    }
+}

--- a/tests/Granit.Mcp.Client.Tests/Options/GranitMcpClientOptionsTests.cs
+++ b/tests/Granit.Mcp.Client.Tests/Options/GranitMcpClientOptionsTests.cs
@@ -1,0 +1,30 @@
+using Granit.Mcp.Client.Options;
+using Shouldly;
+
+namespace Granit.Mcp.Client.Tests.Options;
+
+public sealed class GranitMcpClientOptionsTests
+{
+    [Fact]
+    public void SectionName_IsCorrect() =>
+        GranitMcpClientOptions.SectionName.ShouldBe("Mcp:Client");
+
+    [Fact]
+    public void Connections_DefaultsToEmptyDictionary()
+    {
+        var options = new GranitMcpClientOptions();
+
+        options.Connections.ShouldNotBeNull();
+        options.Connections.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Connections_CanBePopulated()
+    {
+        var options = new GranitMcpClientOptions();
+        options.Connections["server1"] = new McpConnectionOptions { Url = "http://localhost:5000" };
+
+        options.Connections.ShouldContainKey("server1");
+        options.Connections["server1"].Url.ShouldBe("http://localhost:5000");
+    }
+}

--- a/tests/Granit.Mcp.Client.Tests/Options/McpConnectionOptionsTests.cs
+++ b/tests/Granit.Mcp.Client.Tests/Options/McpConnectionOptionsTests.cs
@@ -1,0 +1,46 @@
+using Granit.Mcp.Client.Options;
+using Shouldly;
+
+namespace Granit.Mcp.Client.Tests.Options;
+
+public sealed class McpConnectionOptionsTests
+{
+    [Fact]
+    public void Url_DefaultsToNull() =>
+        new McpConnectionOptions().Url.ShouldBeNull();
+
+    [Fact]
+    public void Transport_DefaultsToHttp() =>
+        new McpConnectionOptions().Transport.ShouldBe("http");
+
+    [Fact]
+    public void AllowInsecureTransport_DefaultsToFalse() =>
+        new McpConnectionOptions().AllowInsecureTransport.ShouldBeFalse();
+
+    [Fact]
+    public void Command_DefaultsToNull() =>
+        new McpConnectionOptions().Command.ShouldBeNull();
+
+    [Fact]
+    public void Arguments_DefaultsToEmpty() =>
+        new McpConnectionOptions().Arguments.ShouldBeEmpty();
+
+    [Fact]
+    public void AllProperties_CanBeSet()
+    {
+        McpConnectionOptions options = new()
+        {
+            Url = "https://mcp.example.com",
+            Transport = "stdio",
+            AllowInsecureTransport = true,
+            Command = "dotnet",
+            Arguments = ["run", "--project", "MyServer"],
+        };
+
+        options.Url.ShouldBe("https://mcp.example.com");
+        options.Transport.ShouldBe("stdio");
+        options.AllowInsecureTransport.ShouldBeTrue();
+        options.Command.ShouldBe("dotnet");
+        options.Arguments.ShouldBe(["run", "--project", "MyServer"]);
+    }
+}

--- a/tests/Granit.Mcp.Tests/McpExposedAttributeTests.cs
+++ b/tests/Granit.Mcp.Tests/McpExposedAttributeTests.cs
@@ -1,0 +1,32 @@
+using Shouldly;
+
+namespace Granit.Mcp.Tests;
+
+public sealed class McpExposedAttributeTests
+{
+    [Fact]
+    public void Attribute_TargetsClass()
+    {
+        AttributeUsageAttribute usage = typeof(McpExposedAttribute)
+            .GetCustomAttributes(typeof(AttributeUsageAttribute), false)
+            .Cast<AttributeUsageAttribute>()
+            .Single();
+
+        usage.ValidOn.ShouldBe(AttributeTargets.Class);
+    }
+
+    [Fact]
+    public void Attribute_IsNotInherited()
+    {
+        AttributeUsageAttribute usage = typeof(McpExposedAttribute)
+            .GetCustomAttributes(typeof(AttributeUsageAttribute), false)
+            .Cast<AttributeUsageAttribute>()
+            .Single();
+
+        usage.Inherited.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Attribute_IsSealed() =>
+        typeof(McpExposedAttribute).IsSealed.ShouldBeTrue();
+}

--- a/tests/Granit.Mcp.Tests/McpTenantScopeAttributeTests.cs
+++ b/tests/Granit.Mcp.Tests/McpTenantScopeAttributeTests.cs
@@ -1,0 +1,29 @@
+using Shouldly;
+
+namespace Granit.Mcp.Tests;
+
+public sealed class McpTenantScopeAttributeTests
+{
+    [Fact]
+    public void RequireTenant_DefaultsToFalse() =>
+        new McpTenantScopeAttribute().RequireTenant.ShouldBeFalse();
+
+    [Fact]
+    public void RequireTenant_CanBeSetToTrue() =>
+        new McpTenantScopeAttribute { RequireTenant = true }.RequireTenant.ShouldBeTrue();
+
+    [Fact]
+    public void Attribute_TargetsClass()
+    {
+        AttributeUsageAttribute usage = typeof(McpTenantScopeAttribute)
+            .GetCustomAttributes(typeof(AttributeUsageAttribute), false)
+            .Cast<AttributeUsageAttribute>()
+            .Single();
+
+        usage.ValidOn.ShouldBe(AttributeTargets.Class);
+    }
+
+    [Fact]
+    public void Attribute_IsSealed() =>
+        typeof(McpTenantScopeAttribute).IsSealed.ShouldBeTrue();
+}

--- a/tests/Granit.Mcp.Tests/McpToolTypeRegistryTests.cs
+++ b/tests/Granit.Mcp.Tests/McpToolTypeRegistryTests.cs
@@ -1,0 +1,46 @@
+using Shouldly;
+
+namespace Granit.Mcp.Tests;
+
+public sealed class McpToolTypeRegistryTests
+{
+    private readonly McpToolTypeRegistry _registry = new();
+
+    [Fact]
+    public void Resolve_UnknownName_ReturnsNull() =>
+        _registry.Resolve("unknown").ShouldBeNull();
+
+    [Fact]
+    public void Register_ThenResolve_ReturnsType()
+    {
+        _registry.Register("MyTool", typeof(string));
+
+        _registry.Resolve("MyTool").ShouldBe(typeof(string));
+    }
+
+    [Fact]
+    public void Register_Overwrites_ExistingEntry()
+    {
+        _registry.Register("Tool", typeof(int));
+        _registry.Register("Tool", typeof(string));
+
+        _registry.Resolve("Tool").ShouldBe(typeof(string));
+    }
+
+    [Fact]
+    public void Resolve_IsCaseSensitive()
+    {
+        _registry.Register("MyTool", typeof(string));
+
+        _registry.Resolve("mytool").ShouldBeNull();
+    }
+
+    [Fact]
+    public void RegisterFromAssemblies_RegistersMarkedTypes()
+    {
+        _registry.RegisterFromAssemblies([typeof(McpToolTypeRegistryTests).Assembly]);
+
+        // No [McpServerToolType] classes in this test assembly — registry unchanged
+        _registry.Resolve("McpToolTypeRegistryTests").ShouldBeNull();
+    }
+}

--- a/tests/Granit.Mcp.Tests/Options/GranitMcpOptionsTests.cs
+++ b/tests/Granit.Mcp.Tests/Options/GranitMcpOptionsTests.cs
@@ -1,0 +1,50 @@
+using Granit.Mcp.Options;
+using Shouldly;
+
+namespace Granit.Mcp.Tests.Options;
+
+public sealed class GranitMcpOptionsTests
+{
+    [Fact]
+    public void SectionName_IsCorrect() =>
+        GranitMcpOptions.SectionName.ShouldBe("Mcp");
+
+    [Fact]
+    public void ServerName_DefaultsToGranit() =>
+        new GranitMcpOptions().ServerName.ShouldBe("Granit");
+
+    [Fact]
+    public void ServerVersion_DefaultsToNull() =>
+        new GranitMcpOptions().ServerVersion.ShouldBeNull();
+
+    [Fact]
+    public void ToolDiscovery_DefaultsToExplicit() =>
+        new GranitMcpOptions().ToolDiscovery.ShouldBe(McpToolDiscoveryMode.Explicit);
+
+    [Fact]
+    public void EnableTenantFiltering_DefaultsToTrue() =>
+        new GranitMcpOptions().EnableTenantFiltering.ShouldBeTrue();
+
+    [Fact]
+    public void MaxResponseSizeBytes_DefaultsTo51200() =>
+        new GranitMcpOptions().MaxResponseSizeBytes.ShouldBe(51_200);
+
+    [Fact]
+    public void AllProperties_CanBeSet()
+    {
+        GranitMcpOptions options = new()
+        {
+            ServerName = "MyServer",
+            ServerVersion = "1.0.0",
+            ToolDiscovery = McpToolDiscoveryMode.Auto,
+            EnableTenantFiltering = false,
+            MaxResponseSizeBytes = 102_400,
+        };
+
+        options.ServerName.ShouldBe("MyServer");
+        options.ServerVersion.ShouldBe("1.0.0");
+        options.ToolDiscovery.ShouldBe(McpToolDiscoveryMode.Auto);
+        options.EnableTenantFiltering.ShouldBeFalse();
+        options.MaxResponseSizeBytes.ShouldBe(102_400);
+    }
+}

--- a/tests/Granit.Mcp.Tests/Options/McpToolDiscoveryModeTests.cs
+++ b/tests/Granit.Mcp.Tests/Options/McpToolDiscoveryModeTests.cs
@@ -1,0 +1,19 @@
+using Granit.Mcp.Options;
+using Shouldly;
+
+namespace Granit.Mcp.Tests.Options;
+
+public sealed class McpToolDiscoveryModeTests
+{
+    [Fact]
+    public void Explicit_HasValueZero() =>
+        ((int)McpToolDiscoveryMode.Explicit).ShouldBe(0);
+
+    [Fact]
+    public void Auto_HasValueOne() =>
+        ((int)McpToolDiscoveryMode.Auto).ShouldBe(1);
+
+    [Fact]
+    public void Enum_HasTwoValues() =>
+        Enum.GetValues<McpToolDiscoveryMode>().Length.ShouldBe(2);
+}

--- a/tests/Granit.Mcp.Tests/Sanitization/PropertyRedactionSanitizerTests.cs
+++ b/tests/Granit.Mcp.Tests/Sanitization/PropertyRedactionSanitizerTests.cs
@@ -1,0 +1,161 @@
+using System.Text.Json.Nodes;
+using Granit.DataProtection;
+using Granit.Mcp.Sanitization;
+using ModelContextProtocol.Protocol;
+using NSubstitute;
+using Shouldly;
+
+namespace Granit.Mcp.Tests.Sanitization;
+
+public sealed class PropertyRedactionSanitizerTests
+{
+    private static PropertyRedactionSanitizer CreateSanitizer() =>
+        new(new SensitivePropertyRegistry([]));
+
+    private static IServiceProvider Services => Substitute.For<IServiceProvider>();
+
+    [Theory]
+    [InlineData("password")]
+    [InlineData("Password")]
+    [InlineData("userPassword")]
+    [InlineData("secret")]
+    [InlineData("clientSecret")]
+    [InlineData("apiKey")]
+    [InlineData("ApiKey")]
+    [InlineData("api_key")]
+    [InlineData("token")]
+    [InlineData("accessToken")]
+    [InlineData("connectionString")]
+    [InlineData("ConnectionString")]
+    [InlineData("connection_string")]
+    [InlineData("credential")]
+    [InlineData("ssn")]
+    [InlineData("socialSecurity")]
+    public async Task SanitizeAsync_WellKnownName_OmitsProperty(string propertyName)
+    {
+        PropertyRedactionSanitizer sut = CreateSanitizer();
+        string json = $$"""{"{{propertyName}}":"sensitive-value","name":"John"}""";
+        CallToolResult result = new() { Content = [new TextContentBlock { Text = json }] };
+
+        CallToolResult sanitized = await sut.SanitizeAsync(result, Services, TestContext.Current.CancellationToken);
+
+        TextContentBlock block = sanitized.Content.Single().ShouldBeOfType<TextContentBlock>();
+        JsonObject node = JsonNode.Parse(block.Text)!.AsObject();
+        node.ContainsKey(propertyName).ShouldBeFalse();
+        node["name"]!.GetValue<string>().ShouldBe("John");
+    }
+
+    [Fact]
+    public async Task SanitizeAsync_NonSensitiveProperty_PreservesIt()
+    {
+        PropertyRedactionSanitizer sut = CreateSanitizer();
+        CallToolResult result = new()
+        {
+            Content = [new TextContentBlock { Text = """{"name":"Alice","age":30}""" }],
+        };
+
+        CallToolResult sanitized = await sut.SanitizeAsync(result, Services, TestContext.Current.CancellationToken);
+
+        sanitized.ShouldBeSameAs(result);
+    }
+
+    [Fact]
+    public async Task SanitizeAsync_NonJsonText_ReturnsOriginal()
+    {
+        PropertyRedactionSanitizer sut = CreateSanitizer();
+        CallToolResult result = new()
+        {
+            Content = [new TextContentBlock { Text = "plain text response" }],
+        };
+
+        CallToolResult sanitized = await sut.SanitizeAsync(result, Services, TestContext.Current.CancellationToken);
+
+        sanitized.ShouldBeSameAs(result);
+    }
+
+    [Fact]
+    public async Task SanitizeAsync_EmptyContent_ReturnsOriginal()
+    {
+        PropertyRedactionSanitizer sut = CreateSanitizer();
+        CallToolResult result = new() { Content = [] };
+
+        CallToolResult sanitized = await sut.SanitizeAsync(result, Services, TestContext.Current.CancellationToken);
+
+        sanitized.ShouldBeSameAs(result);
+    }
+
+    [Fact]
+    public async Task SanitizeAsync_NestedObject_RedactsNestedWellKnownNames()
+    {
+        PropertyRedactionSanitizer sut = CreateSanitizer();
+        string json = """{"user":{"name":"Alice","password":"s3cr3t"}}""";
+        CallToolResult result = new() { Content = [new TextContentBlock { Text = json }] };
+
+        CallToolResult sanitized = await sut.SanitizeAsync(result, Services, TestContext.Current.CancellationToken);
+
+        TextContentBlock block = sanitized.Content.Single().ShouldBeOfType<TextContentBlock>();
+        JsonObject root = JsonNode.Parse(block.Text)!.AsObject();
+        JsonObject user = root["user"]!.AsObject();
+        user.ContainsKey("password").ShouldBeFalse();
+        user["name"]!.GetValue<string>().ShouldBe("Alice");
+    }
+
+    [Fact]
+    public async Task SanitizeAsync_ArrayOfObjects_RedactsWellKnownNames()
+    {
+        PropertyRedactionSanitizer sut = CreateSanitizer();
+        string json = """[{"name":"Alice","token":"abc"},{"name":"Bob","token":"xyz"}]""";
+        CallToolResult result = new() { Content = [new TextContentBlock { Text = json }] };
+
+        CallToolResult sanitized = await sut.SanitizeAsync(result, Services, TestContext.Current.CancellationToken);
+
+        TextContentBlock block = sanitized.Content.Single().ShouldBeOfType<TextContentBlock>();
+        JsonArray arr = JsonNode.Parse(block.Text)!.AsArray();
+        arr[0]!.AsObject().ContainsKey("token").ShouldBeFalse();
+        arr[1]!.AsObject().ContainsKey("token").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HashValue_ProducesConsistentSha256Prefix()
+    {
+        string hash = PropertyRedactionSanitizer.HashValue("test");
+
+        hash.ShouldStartWith("sha256:");
+        hash.Length.ShouldBe(7 + 16); // "sha256:" + 16 hex chars
+    }
+
+    [Fact]
+    public void HashValue_SameInput_SameOutput()
+    {
+        string h1 = PropertyRedactionSanitizer.HashValue("hello");
+        string h2 = PropertyRedactionSanitizer.HashValue("hello");
+
+        h1.ShouldBe(h2);
+    }
+
+    [Fact]
+    public void HashValue_DifferentInput_DifferentOutput()
+    {
+        string h1 = PropertyRedactionSanitizer.HashValue("hello");
+        string h2 = PropertyRedactionSanitizer.HashValue("world");
+
+        h1.ShouldNotBe(h2);
+    }
+
+    [Fact]
+    public void MaskValue_ShortValue_ReturnsFourStars()
+    {
+        PropertyRedactionSanitizer.MaskValue("ab").ShouldBe("****");
+        PropertyRedactionSanitizer.MaskValue("abcd").ShouldBe("****");
+    }
+
+    [Fact]
+    public void MaskValue_LongerValue_KeepsFirstAndLastTwoChars()
+    {
+        string masked = PropertyRedactionSanitizer.MaskValue("abcdef");
+
+        masked.ShouldStartWith("ab");
+        masked.ShouldEndWith("ef");
+        masked.ShouldContain("**");
+    }
+}

--- a/tests/Granit.Oidc.TokenManagement.Tests/Handlers/ClientCredentialsTokenHandlerTests.cs
+++ b/tests/Granit.Oidc.TokenManagement.Tests/Handlers/ClientCredentialsTokenHandlerTests.cs
@@ -1,0 +1,221 @@
+using System.Diagnostics.Metrics;
+using System.Net;
+using Granit.Oidc.DPoP;
+using Granit.Oidc.Responses;
+using Granit.Oidc.TokenManagement.Cache;
+using Granit.Oidc.TokenManagement.Diagnostics;
+using Granit.Oidc.TokenManagement.Handlers;
+using Granit.Oidc.TokenManagement.Options;
+using Granit.Oidc.TokenManagement.Services;
+using Granit.Timing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Oidc.TokenManagement.Tests.Handlers;
+
+public sealed class ClientCredentialsTokenHandlerTests : IDisposable
+{
+    private readonly ITokenEndpointService _tokenEndpointService = Substitute.For<ITokenEndpointService>();
+    private readonly IClientCredentialsTokenCache _tokenCache = Substitute.For<IClientCredentialsTokenCache>();
+    private readonly IDPoPProofService _dpopProofService = Substitute.For<IDPoPProofService>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly ServiceProvider _sp;
+    private readonly TokenManagementMetrics _metrics;
+
+    private readonly ClientCredentialsOptions _clientOptions = new()
+    {
+        Authority = "https://idp.example.com",
+        ClientId = "test-client",
+    };
+
+    private readonly IOptionsMonitor<ClientCredentialsOptions> _optionsMonitor =
+        Substitute.For<IOptionsMonitor<ClientCredentialsOptions>>();
+
+    public ClientCredentialsTokenHandlerTests()
+    {
+        ServiceCollection services = new();
+        services.AddMetrics();
+        _sp = services.BuildServiceProvider();
+        IMeterFactory meterFactory = _sp.GetRequiredService<System.Diagnostics.Metrics.IMeterFactory>();
+        _metrics = new TokenManagementMetrics(meterFactory);
+        _optionsMonitor.Get(Arg.Any<string>()).Returns(_clientOptions);
+    }
+
+    public void Dispose() => _sp.Dispose();
+
+    private (ClientCredentialsTokenHandler, HttpRequestMessage captured) CreateHandlerWithCapture(
+        HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        HttpRequestMessage? captured = null;
+        var innerHandler = new DelegateHttpHandler(req =>
+        {
+            captured = req;
+            return new HttpResponseMessage(statusCode);
+        });
+
+        var handler = new ClientCredentialsTokenHandler(
+            _tokenEndpointService,
+            _tokenCache,
+            _dpopProofService,
+            _optionsMonitor,
+            Options.Create(new TokenManagementOptions()),
+            _clock,
+            _metrics,
+            NullLogger<ClientCredentialsTokenHandler>.Instance)
+        {
+            ClientName = "test-client",
+            InnerHandler = innerHandler,
+        };
+
+        return (handler, captured!);
+    }
+
+    [Fact]
+    public async Task SendAsync_CachedToken_DoesNotCallTokenEndpoint()
+    {
+        _tokenCache.GetTokenAsync("test-client", Arg.Any<CancellationToken>())
+            .Returns("cached-token");
+
+        (ClientCredentialsTokenHandler? handler, HttpRequestMessage _) = CreateHandlerWithCapture();
+        using var client = new HttpClient(handler);
+
+        await client.GetAsync("https://api.example.com/data", TestContext.Current.CancellationToken);
+
+        await _tokenEndpointService.DidNotReceive().RequestTokenAsync(
+            Arg.Any<string>(),
+            Arg.Any<Granit.Oidc.Requests.TokenRequest>(),
+            Arg.Any<Granit.Oidc.ClientAuthentication.IClientAuthenticationStrategy?>(),
+            Arg.Any<DPoPOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SendAsync_CachedToken_InjectsBearerHeader()
+    {
+        _tokenCache.GetTokenAsync("test-client", Arg.Any<CancellationToken>())
+            .Returns("cached-bearer-token");
+
+        HttpRequestMessage? captured = null;
+        var innerHandler = new DelegateHttpHandler(req =>
+        {
+            captured = req;
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+
+        var handler = new ClientCredentialsTokenHandler(
+            _tokenEndpointService,
+            _tokenCache,
+            _dpopProofService,
+            _optionsMonitor,
+            Options.Create(new TokenManagementOptions()),
+            _clock,
+            _metrics,
+            NullLogger<ClientCredentialsTokenHandler>.Instance)
+        {
+            ClientName = "test-client",
+            InnerHandler = innerHandler,
+        };
+
+        using var client = new HttpClient(handler);
+        await client.GetAsync("https://api.example.com/data", TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Headers.Authorization?.Scheme.ShouldBe("Bearer");
+        captured.Headers.Authorization?.Parameter.ShouldBe("cached-bearer-token");
+    }
+
+    [Fact]
+    public async Task SendAsync_NoCachedToken_CallsTokenEndpointAndInjectsToken()
+    {
+        _tokenCache.GetTokenAsync("test-client", Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+
+        var tokenResponse = TokenResponse.FromJson(
+            System.Text.Json.JsonDocument.Parse(
+                """{"access_token":"fresh-token","expires_in":3600}""").RootElement,
+            null);
+
+        _tokenEndpointService.RequestTokenAsync(
+            Arg.Any<string>(),
+            Arg.Any<Granit.Oidc.Requests.TokenRequest>(),
+            Arg.Any<Granit.Oidc.ClientAuthentication.IClientAuthenticationStrategy?>(),
+            Arg.Any<DPoPOptions?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(tokenResponse);
+
+        HttpRequestMessage? captured = null;
+        var innerHandler = new DelegateHttpHandler(req =>
+        {
+            captured = req;
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+
+        var handler = new ClientCredentialsTokenHandler(
+            _tokenEndpointService,
+            _tokenCache,
+            _dpopProofService,
+            _optionsMonitor,
+            Options.Create(new TokenManagementOptions()),
+            _clock,
+            _metrics,
+            NullLogger<ClientCredentialsTokenHandler>.Instance)
+        {
+            ClientName = "test-client",
+            InnerHandler = innerHandler,
+        };
+
+        using var client = new HttpClient(handler);
+        await client.GetAsync("https://api.example.com/data", TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Headers.Authorization?.Parameter.ShouldBe("fresh-token");
+    }
+
+    [Fact]
+    public async Task SendAsync_On401_RemovesCachedTokenAndRetries()
+    {
+        _tokenCache.GetTokenAsync("test-client", Arg.Any<CancellationToken>())
+            .Returns("stale-token", "refreshed-token");
+
+        int callCount = 0;
+        var innerHandler = new DelegateHttpHandler(_ =>
+        {
+            callCount++;
+            return callCount == 1
+                ? new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                : new HttpResponseMessage(HttpStatusCode.OK);
+        });
+
+        var handler = new ClientCredentialsTokenHandler(
+            _tokenEndpointService,
+            _tokenCache,
+            _dpopProofService,
+            _optionsMonitor,
+            Options.Create(new TokenManagementOptions()),
+            _clock,
+            _metrics,
+            NullLogger<ClientCredentialsTokenHandler>.Instance)
+        {
+            ClientName = "test-client",
+            InnerHandler = innerHandler,
+        };
+
+        using var client = new HttpClient(handler);
+        HttpResponseMessage response = await client.GetAsync("https://api.example.com/data", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        await _tokenCache.Received(1).RemoveTokenAsync("test-client", Arg.Any<CancellationToken>());
+        callCount.ShouldBe(2);
+    }
+
+    private sealed class DelegateHttpHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(respond(request));
+    }
+}

--- a/tests/Granit.Oidc.TokenManagement.Tests/Options/ClientCredentialsOptionsTests.cs
+++ b/tests/Granit.Oidc.TokenManagement.Tests/Options/ClientCredentialsOptionsTests.cs
@@ -1,0 +1,67 @@
+using Granit.Oidc.ClientAuthentication;
+using Granit.Oidc.TokenManagement.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Oidc.TokenManagement.Tests.Options;
+
+public sealed class ClientCredentialsOptionsTests
+{
+    [Fact]
+    public void Authority_DefaultsToEmpty() =>
+        new ClientCredentialsOptions().Authority.ShouldBe(string.Empty);
+
+    [Fact]
+    public void ClientId_DefaultsToEmpty() =>
+        new ClientCredentialsOptions().ClientId.ShouldBe(string.Empty);
+
+    [Fact]
+    public void ClientSecret_DefaultsToNull() =>
+        new ClientCredentialsOptions().ClientSecret.ShouldBeNull();
+
+    [Fact]
+    public void Scope_DefaultsToNull() =>
+        new ClientCredentialsOptions().Scope.ShouldBeNull();
+
+    [Fact]
+    public void ClientAuthenticationMethod_DefaultsToClientSecretPost() =>
+        new ClientCredentialsOptions().ClientAuthenticationMethod
+            .ShouldBe(ClientAuthenticationMethod.ClientSecretPost);
+
+    [Fact]
+    public void ClientSigningKeyJwk_DefaultsToNull() =>
+        new ClientCredentialsOptions().ClientSigningKeyJwk.ShouldBeNull();
+
+    [Fact]
+    public void UseDPoP_DefaultsToFalse() =>
+        new ClientCredentialsOptions().UseDPoP.ShouldBeFalse();
+
+    [Fact]
+    public void CacheMargin_DefaultsToNull() =>
+        new ClientCredentialsOptions().CacheMargin.ShouldBeNull();
+
+    [Fact]
+    public void AllProperties_CanBeSet()
+    {
+        var options = new ClientCredentialsOptions
+        {
+            Authority = "https://idp.example.com",
+            ClientId = "my-client",
+            ClientSecret = "s3cr3t",
+            Scope = "api1 api2",
+            ClientAuthenticationMethod = ClientAuthenticationMethod.PrivateKeyJwt,
+            ClientSigningKeyJwk = """{"kty":"EC"}""",
+            UseDPoP = true,
+            CacheMargin = TimeSpan.FromSeconds(15),
+        };
+
+        options.Authority.ShouldBe("https://idp.example.com");
+        options.ClientId.ShouldBe("my-client");
+        options.ClientSecret.ShouldBe("s3cr3t");
+        options.Scope.ShouldBe("api1 api2");
+        options.ClientAuthenticationMethod.ShouldBe(ClientAuthenticationMethod.PrivateKeyJwt);
+        options.ClientSigningKeyJwk.ShouldBe("""{"kty":"EC"}""");
+        options.UseDPoP.ShouldBeTrue();
+        options.CacheMargin.ShouldBe(TimeSpan.FromSeconds(15));
+    }
+}

--- a/tests/Granit.Oidc.TokenManagement.Tests/Options/TokenManagementOptionsTests.cs
+++ b/tests/Granit.Oidc.TokenManagement.Tests/Options/TokenManagementOptionsTests.cs
@@ -1,0 +1,24 @@
+using Granit.Oidc.TokenManagement.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Oidc.TokenManagement.Tests.Options;
+
+public sealed class TokenManagementOptionsTests
+{
+    [Fact]
+    public void SectionName_IsCorrect() =>
+        TokenManagementOptions.SectionName.ShouldBe("TokenManagement");
+
+    [Fact]
+    public void DefaultCacheMargin_DefaultsTo30Seconds() =>
+        new TokenManagementOptions().DefaultCacheMargin.ShouldBe(TimeSpan.FromSeconds(30));
+
+    [Fact]
+    public void DefaultCacheMargin_CanBeSet()
+    {
+        var options = new TokenManagementOptions { DefaultCacheMargin = TimeSpan.FromMinutes(1) };
+
+        options.DefaultCacheMargin.ShouldBe(TimeSpan.FromMinutes(1));
+    }
+}

--- a/tests/Granit.Persistence.Tests/MultiTenancy/SharedDatabaseDbContextFactoryTests.cs
+++ b/tests/Granit.Persistence.Tests/MultiTenancy/SharedDatabaseDbContextFactoryTests.cs
@@ -19,7 +19,7 @@ public sealed class SharedDatabaseDbContextFactoryTests
     [Fact]
     public void CreateDbContext_ReturnsNonNullContext()
     {
-        ServiceCollection services = new();
+        ServiceCollection services = [];
         using ServiceProvider sp = services.BuildServiceProvider();
 
         SharedDatabaseDbContextOptions<StubSharedDbContext> opts = new()
@@ -37,7 +37,7 @@ public sealed class SharedDatabaseDbContextFactoryTests
     [Fact]
     public async Task CreateDbContextAsync_ReturnsNonNullContext()
     {
-        ServiceCollection services = new();
+        ServiceCollection services = [];
         using ServiceProvider sp = services.BuildServiceProvider();
 
         SharedDatabaseDbContextOptions<StubSharedDbContext> opts = new()
@@ -56,7 +56,7 @@ public sealed class SharedDatabaseDbContextFactoryTests
     [Fact]
     public void CreateDbContext_WithAuditInterceptorRegistered_ReturnsNonNullContext()
     {
-        ServiceCollection services = new();
+        ServiceCollection services = [];
         services.AddSingleton(Substitute.For<Granit.Timing.IClock>());
         services.AddSingleton(Substitute.For<Granit.Guids.IGuidGenerator>());
         services.AddSingleton(Substitute.For<Granit.Users.ICurrentUserService>());
@@ -85,7 +85,7 @@ public sealed class SharedDatabaseDbContextFactoryTests
     [Fact]
     public void CreateDbContext_WithoutAuditInterceptor_DoesNotThrow()
     {
-        ServiceCollection services = new();
+        ServiceCollection services = [];
         using ServiceProvider sp = services.BuildServiceProvider();
 
         SharedDatabaseDbContextOptions<StubSharedDbContext> opts = new()

--- a/tests/Granit.Tests/Diagnostics/LogRedactionTests.cs
+++ b/tests/Granit.Tests/Diagnostics/LogRedactionTests.cs
@@ -28,30 +28,22 @@ public sealed class LogRedactionTests
     [InlineData("ab@example.com", "ab***@example.com")]
     [InlineData("a@example.com", "a***@example.com")]
     [InlineData("alice.wonderland@corp.net", "ali***@corp.net")]
-    public void Email_RedactsLocalPart_PreservesDomain(string input, string expected)
-    {
+    public void Email_RedactsLocalPart_PreservesDomain(string input, string expected) =>
         LogRedaction.Email(input).ShouldBe(expected);
-    }
 
     [Fact]
-    public void Email_NoAtSign_ReturnsMask()
-    {
+    public void Email_NoAtSign_ReturnsMask() =>
         LogRedaction.Email("invalid-email").ShouldBe("***");
-    }
 
     [Fact]
-    public void Email_AtSignAtStart_ReturnsMask()
-    {
-        // "@example.com" has atIndex == 0, which is <= 0
+    // "@example.com" has atIndex == 0, which is <= 0
+    public void Email_AtSignAtStart_ReturnsMask() =>
         LogRedaction.Email("@example.com").ShouldBe("***");
-    }
 
     [Fact]
-    public void Email_ShortLocalPart_PreservesEntireLocalPart()
-    {
-        // "ab" has length 2, min(3, 2) = 2
+    // "ab" has length 2, min(3, 2) = 2
+    public void Email_ShortLocalPart_PreservesEntireLocalPart() =>
         LogRedaction.Email("ab@test.org").ShouldBe("ab***@test.org");
-    }
 
     // -------------------------------------------------------------------------
     // EmailDomain
@@ -60,16 +52,12 @@ public sealed class LogRedactionTests
     [Theory]
     [InlineData("john.doe@example.com", "example.com")]
     [InlineData("user@sub.domain.co.uk", "sub.domain.co.uk")]
-    public void EmailDomain_ExtractsDomainPart(string input, string expected)
-    {
+    public void EmailDomain_ExtractsDomainPart(string input, string expected) =>
         LogRedaction.EmailDomain(input).ShouldBe(expected);
-    }
 
     [Fact]
-    public void EmailDomain_NoAtSign_ReturnsUnknown()
-    {
+    public void EmailDomain_NoAtSign_ReturnsUnknown() =>
         LogRedaction.EmailDomain("no-at-sign").ShouldBe("unknown");
-    }
 
     // -------------------------------------------------------------------------
     // Phone
@@ -78,20 +66,16 @@ public sealed class LogRedactionTests
     [Theory]
     [InlineData("+33612345678", "+336*****78")]
     [InlineData("+1234567890", "+123*****90")]
-    public void Phone_PreservesPrefixAndLastTwoDigits(string input, string expected)
-    {
+    public void Phone_PreservesPrefixAndLastTwoDigits(string input, string expected) =>
         LogRedaction.Phone(input).ShouldBe(expected);
-    }
 
     [Theory]
     [InlineData("1234")]
     [InlineData("123")]
     [InlineData("12")]
     [InlineData("")]
-    public void Phone_ShortInput_ReturnsMask(string input)
-    {
+    public void Phone_ShortInput_ReturnsMask(string input) =>
         LogRedaction.Phone(input).ShouldBe("***");
-    }
 
     [Fact]
     public void Phone_FiveChars_PreservesPrefixAndSuffix()
@@ -106,27 +90,21 @@ public sealed class LogRedactionTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void Token_LongToken_PreservesPrefixAndSuffix()
-    {
+    public void Token_LongToken_PreservesPrefixAndSuffix() =>
         LogRedaction.Token("dLkj3FDmAbCdEfGh").ShouldBe("dLkj...fGh");
-    }
 
     [Fact]
-    public void Token_ExactlyNineChars_PreservesPrefixAndSuffix()
-    {
-        // Length 9: prefix 4, suffix 3 => "ABCD...GHI"
+    // Length 9: prefix 4, suffix 3 => "ABCD...GHI"
+    public void Token_ExactlyNineChars_PreservesPrefixAndSuffix() =>
         LogRedaction.Token("ABCDEFGHI").ShouldBe("ABCD...GHI");
-    }
 
     [Theory]
     [InlineData("12345678")]
     [InlineData("1234567")]
     [InlineData("short")]
     [InlineData("")]
-    public void Token_ShortToken_ReturnsMask(string input)
-    {
+    public void Token_ShortToken_ReturnsMask(string input) =>
         LogRedaction.Token(input).ShouldBe("***");
-    }
 
     // -------------------------------------------------------------------------
     // IpAddress — IPv4
@@ -136,10 +114,8 @@ public sealed class LogRedactionTests
     [InlineData("192.168.1.42", "192.168.1.***")]
     [InlineData("10.0.0.1", "10.0.0.***")]
     [InlineData("255.255.255.255", "255.255.255.***")]
-    public void IpAddress_IPv4_MasksLastOctet(string input, string expected)
-    {
+    public void IpAddress_IPv4_MasksLastOctet(string input, string expected) =>
         LogRedaction.IpAddress(input).ShouldBe(expected);
-    }
 
     // -------------------------------------------------------------------------
     // IpAddress — IPv6
@@ -164,17 +140,13 @@ public sealed class LogRedactionTests
     }
 
     [Fact]
-    public void IpAddress_NoDotsOrColons_ReturnsMask()
-    {
+    public void IpAddress_NoDotsOrColons_ReturnsMask() =>
         LogRedaction.IpAddress("localhost").ShouldBe("***");
-    }
 
     [Fact]
-    public void IpAddress_IPv6_FewerThanFourColons_ReturnsMask()
-    {
-        // "a:b:c:d" has only 3 colons — never reaches colonCount == 4 — falls through to mask.
+    // "a:b:c:d" has only 3 colons — never reaches colonCount == 4 — falls through to mask.
+    public void IpAddress_IPv6_FewerThanFourColons_ReturnsMask() =>
         LogRedaction.IpAddress("a:b:c:d").ShouldBe("***");
-    }
 
     // -------------------------------------------------------------------------
     // Username
@@ -184,26 +156,20 @@ public sealed class LogRedactionTests
     [InlineData("john_admin", "joh***")]
     [InlineData("alice", "ali***")]
     [InlineData("abcdefghij", "abc***")]
-    public void Username_PreservesThreeCharPrefix(string input, string expected)
-    {
+    public void Username_PreservesThreeCharPrefix(string input, string expected) =>
         LogRedaction.Username(input).ShouldBe(expected);
-    }
 
     [Theory]
     [InlineData("abc")]
     [InlineData("ab")]
     [InlineData("a")]
     [InlineData("")]
-    public void Username_ThreeOrFewerChars_ReturnsMask(string input)
-    {
+    public void Username_ThreeOrFewerChars_ReturnsMask(string input) =>
         LogRedaction.Username(input).ShouldBe("***");
-    }
 
     [Fact]
-    public void Username_ExactlyFourChars_PreservesPrefix()
-    {
+    public void Username_ExactlyFourChars_PreservesPrefix() =>
         LogRedaction.Username("abcd").ShouldBe("abc***");
-    }
 
     // -------------------------------------------------------------------------
     // HashPrefix


### PR DESCRIPTION
## Summary

- Make `AccessRiskScore.IsAdvisoryOnly` static (CA1822)
- Replace lazy null-init `??=` pattern with direct `List<string>` in option validators (BFF, DataExchange.AI, QueryEngine.AI, Templating.AI)
- Reduce cognitive complexity: `ImageFormatDetector.IsSafeRasterFormat` 19→8 (extracted per-format helpers), `LlmTimelineSummarizer.FetchEntriesAsync` 17→7+8 (extracted `CollectEntries`)
- Simplify `WebhookSsrfConnectCallback` IP validation loop: `foreach` + `if` → `Array.Find`
- Move `NOSONAR S3011` comment to the `BindingFlags.NonPublic` line in `WorkflowTransitionInterceptor`
- Fill no-op `IMultiTenant.TenantId` setter in `WorkflowTransitionRecord`: `set { }` → `set => _ = value;`
- Add `NOSONAR S2077` on safe dynamic SQL probe in `InternalDbContextEnsurer` (table name from EF model, delimiter-escaped via `ISqlGenerationHelper`)
- Convert single-statement test methods to expression-body form
- Simplify empty collection initializations in tests: `new()` → `[]`

## Won't fix

The following brain-overload issues are intentional and suppressed in SonarQube:

- `SavedViewEndpoints` — 8-param handler (minimal API, `[FromServices]` DI)
- `QueryablePaginationExtensions` — 9-param extension method
- `TimelineEntryEndpoints` — 8-param handler
- `TimelineAttachment` — 9-param factory method
- `SendWebhookHandler` — 8-param constructor (DI injection, per framework conventions)
- `PrivateKeyJwtAuthenticationTests` — `Skip` is intentional (requires OpenIddict 7.5+)

## Test plan

- [ ] CI green on all 6 test shards
- [ ] SonarQube quality gate passes (no new issues on changed files)
