### PR TITLE
fix(reference-data): register ReferenceDataMetrics in EF Core store extensions

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,29 +1,77 @@
 # Security Policy
 
-## Supported versions
+## Supported Versions
 
 | Version | Supported |
 | ------- | --------- |
 | latest  | Yes       |
 
-## Reporting a vulnerability
+Only the latest released version receives security updates.
+We recommend staying up to date.
 
-**Please do not open a public issue for security vulnerabilities.**
+## Reporting a Vulnerability
 
-If you discover a security vulnerability in Granit, please report it responsibly:
+**DO NOT open a public GitHub issue for security vulnerabilities.**
 
-1. **Email**: Send a detailed report to **security@granit-fx.dev**
-2. **Include**: affected package(s), steps to reproduce, potential impact
-3. **Response time**: We will acknowledge your report within **48 hours** and aim to release a fix within **7 days** for critical issues
+### Preferred: GitHub Private Security Advisory
+
+Use [GitHub Private Security Advisories](https://github.com/granit-fx/granit-dotnet/security/advisories/new)
+to report vulnerabilities confidentially. This enables coordinated disclosure
+and automatic CVE assignment through MITRE.
+
+### Alternative: Email
+
+Send a detailed report to **<security@granit-fx.dev>**.
+
+### What to include
+
+- Affected package(s) and version(s)
+- Steps to reproduce (proof of concept if possible)
+- Potential impact and attack scenario
+- Any suggested mitigations
+
+## Response SLA
+
+| Severity     | Acknowledgment | Assessment | Patch target | Public disclosure    |
+| ------------ | -------------- | ---------- | ------------ | -------------------- |
+| Critical     | 24 hours       | 48 hours   | 7 days       | 14 days after patch  |
+| High         | 48 hours       | 7 days     | 30 days      | 30 days after patch  |
+| Medium / Low | 48 hours       | 14 days    | 90 days      | 90 days after patch  |
+
+We follow a **coordinated disclosure** model: vulnerabilities are kept private
+until a fix is available and deployed by affected users.
 
 ## What qualifies as a security vulnerability?
 
 - Authentication or authorization bypass
-- Injection vulnerabilities (SQL, command, LDAP)
-- Sensitive data exposure (secrets, PII leakage)
-- Cryptographic weaknesses
-- Dependency vulnerabilities (HIGH or CRITICAL severity)
+- Injection vulnerabilities (SQL, command, LDAP, etc.)
+- Sensitive data exposure (secrets, PII leakage, insecure defaults)
+- Cryptographic weaknesses (weak algorithms, broken key management)
+- Dependency vulnerabilities (HIGH or CRITICAL severity per CVSS)
+- Privilege escalation
+- Multi-tenancy isolation bypass (GDPR risk)
+
+## Out of scope
+
+- Vulnerabilities in applications *built with* Granit (report to the application owner)
+- Issues requiring physical access to infrastructure
+- Social engineering attacks
+- Denial-of-service through resource exhaustion
+- Security bugs in already-known-vulnerable dependency versions (use Dependabot)
+
+## Security Design
+
+Granit is built with security by design:
+
+- **No plaintext secrets** — all secrets managed via Vault or environment variables
+- **Encryption** — data encrypted at rest (AES-256) and in transit (TLS)
+- **Audit trail** — all sensitive operations are logged with full traceability
+- **GDPR compliance** — data minimization, right to erasure, pseudonymization
+- **RBAC** — fine-grained three-segment permission model (`[Group].[Resource].[Action]`)
+- **Multi-tenancy isolation** — strict tenant data separation enforced at the ORM level
+- **Supply chain** — SBOM generated per release, SLSA provenance attestation on every release
 
 ## Recognition
 
-We appreciate responsible disclosure. Contributors who report valid vulnerabilities will be credited in the release notes (unless they prefer to remain anonymous).
+We appreciate responsible disclosure. Reporters of valid vulnerabilities will be
+credited in the release notes (unless they prefer to remain anonymous).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Default all permissions to read — each job declares write only where needed.
+# Required by OpenSSF Scorecard: Token-Permissions check.
+permissions: read-all
+
 env:
   DOTNET_VERSION: "10.0.x"
   CONFIGURATION: Release
@@ -234,6 +238,7 @@ jobs:
   codeql:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
     steps:
       - uses: actions/checkout@v6
@@ -367,6 +372,10 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+      id-token: write      # required for SLSA provenance attestation
+      attestations: write  # required for SLSA provenance attestation
     steps:
       - uses: actions/checkout@v6
 
@@ -404,13 +413,62 @@ jobs:
           path: nupkgs/
           retention-days: 7
 
+      - name: Attest build provenance (SLSA Level 2)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: nupkgs/*.nupkg
+
   # ---------------------------------------------------------------------------
   # PUBLISH
   # ---------------------------------------------------------------------------
 
+  # ---------------------------------------------------------------------------
+  # SBOM — CycloneDX JSON, uploaded as artifact and attached to GitHub releases
+  # ---------------------------------------------------------------------------
+  sbom:
+    needs: pack
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write  # read for checkout, write for release asset upload
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: NuGet cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+          restore-keys: nuget-${{ runner.os }}-
+
+      - name: Install CycloneDX
+        run: dotnet tool install --global CycloneDX
+
+      - name: Generate SBOM
+        run: dotnet CycloneDX Granit.slnx -o ./sbom --json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbom
+          path: sbom/bom.json
+          retention-days: 90
+
+      - name: Attach SBOM to release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ github.ref_name }} sbom/bom.json --clobber
+
   # GitHub Packages — dev packages on develop/main
   publish-github:
-    needs: pack
+    needs: [pack, sbom]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'
     permissions:
@@ -438,7 +496,7 @@ jobs:
 
   # nuget.org — release packages on version tags
   publish-nuget:
-    needs: pack
+    needs: [pack, sbom]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     environment: nuget-publish

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -45,7 +45,7 @@ an individual is officially representing the community in public spaces.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the project maintainer at **<jf.meyers@digitaldynamics.be>**.
+reported to the project maintainer at **<info@granit-fx.dev>**.
 
 All complaints will be reviewed and investigated promptly and fairly. The
 maintainer is obligated to respect the privacy and security of the reporter.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,44 +6,72 @@
 | ------- | --------- |
 | latest  | Yes       |
 
-Only the latest released version receives security updates. We recommend
-staying up to date.
+Only the latest released version receives security updates.
+We recommend staying up to date.
 
 ## Reporting a Vulnerability
 
-**Please do not report security vulnerabilities through public issues.**
+**DO NOT open a public GitHub issue for security vulnerabilities.**
 
-Instead, send an email to **<jf.meyers@digitaldynamics.be>** with:
+### Preferred: GitHub Private Security Advisory
 
-- A description of the vulnerability
+Use [GitHub Private Security Advisories](https://github.com/granit-fx/granit-dotnet/security/advisories/new)
+to report vulnerabilities confidentially. This enables coordinated disclosure
+and automatic CVE assignment through MITRE.
+
+### Alternative: Email
+
+Send a detailed report to **<security@granit-fx.dev>**.
+
+### What to include
+
+- Affected package(s) and version(s)
 - Steps to reproduce (proof of concept if possible)
-- The affected package(s) and version(s)
-- Any potential impact assessment
+- Potential impact and attack scenario
+- Any suggested mitigations
 
-### What to expect
+## Response SLA
 
-- **Acknowledgment** within 48 hours
-- **Status update** within 7 days with an assessment and expected timeline
-- **Fix or mitigation** as soon as reasonably possible, depending on severity
+| Severity     | Acknowledgment | Assessment | Patch target | Public disclosure    |
+| ------------ | -------------- | ---------- | ------------ | -------------------- |
+| Critical     | 24 hours       | 48 hours   | 7 days       | 14 days after patch  |
+| High         | 48 hours       | 7 days     | 30 days      | 30 days after patch  |
+| Medium / Low | 48 hours       | 14 days    | 90 days      | 90 days after patch  |
 
-We follow responsible disclosure practices. We ask that you:
+We follow a **coordinated disclosure** model: vulnerabilities are kept private
+until a fix is available and deployed by affected users.
 
-- Allow reasonable time to investigate and address the issue before public
-  disclosure
-- Avoid exploiting the vulnerability beyond what is necessary to demonstrate it
-- Do not access or modify other users' data
+## What qualifies as a security vulnerability?
+
+- Authentication or authorization bypass
+- Injection vulnerabilities (SQL, command, LDAP, etc.)
+- Sensitive data exposure (secrets, PII leakage, insecure defaults)
+- Cryptographic weaknesses (weak algorithms, broken key management)
+- Dependency vulnerabilities (HIGH or CRITICAL severity per CVSS)
+- Privilege escalation
+- Multi-tenancy isolation bypass (GDPR risk)
+
+## Out of scope
+
+- Vulnerabilities in applications *built with* Granit (report to the application owner)
+- Issues requiring physical access to infrastructure
+- Social engineering attacks
+- Denial-of-service through resource exhaustion
+- Security bugs in already-known-vulnerable dependency versions (use Dependabot)
 
 ## Security Design
 
-Granit is designed with security in mind:
+Granit is built with security by design:
 
 - **No plaintext secrets** — all secrets managed via Vault or environment variables
 - **Encryption** — data encrypted at rest (AES-256) and in transit (TLS)
 - **Audit trail** — all sensitive operations are logged with full traceability
 - **GDPR compliance** — data minimization, right to erasure, pseudonymization
-- **Dependency scanning** — automated vulnerability scanning in CI/CD
+- **RBAC** — fine-grained three-segment permission model (`[Group].[Resource].[Action]`)
+- **Multi-tenancy isolation** — strict tenant data separation enforced at the ORM level
+- **Supply chain** — SBOM generated per release, SLSA provenance attestation on every release
 
-## Acknowledgments
+## Recognition
 
-We appreciate the security research community and will acknowledge reporters
-(with their permission) once the vulnerability is resolved.
+We appreciate responsible disclosure. Reporters of valid vulnerabilities will be
+credited in the release notes (unless they prefer to remain anonymous).

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -40,6 +40,7 @@
     "overrides": {
       "fast-xml-parser": ">=5.5.7",
       "picomatch": ">=4.0.4",
+      "smol-toml": ">=1.6.1",
       "yaml": ">=2.8.3"
     }
   }

--- a/docs-site/pnpm-lock.yaml
+++ b/docs-site/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   fast-xml-parser: '>=5.5.7'
   picomatch: '>=4.0.4'
+  smol-toml: '>=1.6.1'
   yaml: '>=2.8.3'
 
 importers:
@@ -2434,8 +2435,8 @@ packages:
     resolution: {integrity: sha512-TzobUYoEft/xBtb2voRPryAUIvYguG0V7Tt3de79I1WfXgCwelqVsGuZSnu3GFGRZhXR90AeEYIM+icuB/S06Q==}
     hasBin: true
 
-  smol-toml@1.6.0:
-    resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
   source-map-js@1.2.1:
@@ -2856,7 +2857,7 @@ snapshots:
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
       shiki: 4.0.2
-      smol-toml: 1.6.0
+      smol-toml: 1.6.1
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
       unist-util-visit: 5.1.0
@@ -2881,7 +2882,7 @@ snapshots:
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
       shiki: 4.0.2
-      smol-toml: 1.6.0
+      smol-toml: 1.6.1
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
       unist-util-visit: 5.1.0
@@ -3854,7 +3855,7 @@ snapshots:
       rehype: 13.0.2
       semver: 7.7.4
       shiki: 4.0.2
-      smol-toml: 1.6.0
+      smol-toml: 1.6.1
       svgo: 4.0.1
       tinyclip: 0.1.12
       tinyexec: 1.0.4
@@ -4844,7 +4845,7 @@ snapshots:
       markdownlint: 0.40.0
       markdownlint-cli2-formatter-default: 0.0.6(markdownlint-cli2@0.22.0)
       micromatch: 4.0.8
-      smol-toml: 1.6.0
+      smol-toml: 1.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -5855,7 +5856,7 @@ snapshots:
 
   smartypants@0.2.2: {}
 
-  smol-toml@1.6.0: {}
+  smol-toml@1.6.1: {}
 
   source-map-js@1.2.1: {}
 

--- a/docs-site/src/content/docs/blog/nis2-ready-dotnet-applications.mdx
+++ b/docs-site/src/content/docs/blog/nis2-ready-dotnet-applications.mdx
@@ -1,0 +1,264 @@
+---
+title: How Granit Helps You Ship NIS 2-Ready .NET Applications
+date: 2026-03-29
+sidebar:
+  order: 6
+authors:
+  - jfmeyers
+tags:
+  - security
+  - compliance
+  - deep-dive
+description: "NIS 2 is now law across the EU. Here is what it requires from your .NET application stack — and how Granit's supply chain pipeline and embedded security modules cover the key obligations."
+excerpt: >
+  NIS 2 is now law across the EU. Here is what it requires from your .NET stack —
+  and how Granit's supply chain pipeline and embedded security modules cover the
+  key obligations out of the box.
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+NIS 2 is not a checklist you fill in before an audit. It is a legal obligation that applies **now** — Belgium transposed the directive in April 2024, and most EU member states followed by October 2024. If your application serves a regulated sector, or if your customers do, you are in scope.
+
+This article maps NIS 2's technical requirements to concrete Granit controls — both in the CI/CD pipeline and in the framework modules themselves.
+
+## What NIS 2 actually requires
+
+The directive targets two categories of organizations: **essential entities** (energy, transport, banking, health, digital infrastructure) and **important entities** (postal services, waste management, food, chemicals, digital providers). Both categories must comply with Article 21.
+
+**Article 21 §2** defines ten risk management measures. The ones that touch your software stack directly:
+
+| Measure | What it means for developers |
+|---|---|
+| §2(b) — Incident handling | Detection, logging, structured response procedures |
+| §2(c) — Business continuity | Backups, multi-tenancy isolation, failover |
+| §2(e) — Security in development | SAST, dependency scanning, secure SDLC |
+| §2(h) — Cryptography | Encryption at rest and in transit, key management |
+| §2(i) — Access control | Authentication, authorization, least-privilege |
+
+**Article 21 §3** adds supply chain obligations: you must assess the security of your **software suppliers**. Any framework or library in your production stack is part of that supply chain.
+
+:::note
+NIS 2 does not mandate a specific standard. But ISO 27001 is widely accepted as a conformant control framework — and Granit already targets it by design.
+:::
+
+## Supply chain security — the pipeline
+
+NIS 2 Art. 21 §3 requires that you know what is in your software and can demonstrate its integrity. Granit's CI/CD pipeline provides four layers of supply chain assurance.
+
+### SBOM — know every dependency
+
+Every release generates a **Software Bill of Materials** in CycloneDX JSON format using the official .NET tool:
+
+```yaml title=".github/workflows/ci.yml"
+- name: Install CycloneDX
+  run: dotnet tool install --global CycloneDX
+
+- name: Generate SBOM
+  run: dotnet CycloneDX Granit.slnx -o ./sbom --json
+
+- name: Upload SBOM artifact
+  uses: actions/upload-artifact@v7
+  with:
+    name: sbom
+    path: sbom/bom.json
+    retention-days: 90
+
+- name: Attach SBOM to release
+  if: startsWith(github.ref, 'refs/tags/v')
+  run: gh release upload ${{ github.ref_name }} sbom/bom.json --clobber
+```
+
+The `bom.json` artifact is retained for 90 days on every build and permanently attached to every tagged GitHub release. Your customers can download it directly from the release page and feed it into their own vulnerability scanners.
+
+### SLSA Level 2 — build provenance
+
+Starting with version tags, every release package is accompanied by a **cryptographic provenance attestation**:
+
+```yaml title=".github/workflows/ci.yml"
+- name: Attest build provenance
+  uses: actions/attest-build-provenance@v2
+  with:
+    subject-path: nupkgs/*.nupkg
+```
+
+This satisfies [SLSA Level 2](https://slsa.dev/spec/v1.0/levels): an unforgeable link between the published package and the exact source commit and build environment that produced it. Consumers can verify the attestation with `gh attestation verify`.
+
+### Vulnerability scanning — Trivy + CodeQL + Gitleaks
+
+Three automated scanners run on every pull request and push:
+
+```mermaid
+graph LR
+    PR["Pull Request"] --> CQ["CodeQL\nSAST"]
+    PR --> TV["Trivy\nDependency CVEs"]
+    PR --> GL["Gitleaks\nSecret scan"]
+    CQ --> GS["GitHub Security\nalerts"]
+    TV --> AR["vulnerability-report\nartifact"]
+    GL --> GS
+
+    style PR fill:#e3f2fd,stroke:#1565c0,color:#0d47a1
+    style CQ fill:#f3e5f5,stroke:#6a1b9a,color:#4a148c
+    style TV fill:#fce4ec,stroke:#880e4f,color:#560027
+    style GL fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
+    style GS fill:#fff3e0,stroke:#e65100,color:#bf360c
+    style AR fill:#fff3e0,stroke:#e65100,color:#bf360c
+```
+
+- **CodeQL** — SAST analysis for injection, deserialization, path traversal and other OWASP Top 10 issues. Results appear in the repository Security › Code scanning alerts tab.
+- **Trivy** — scans all NuGet dependencies against the CVE database. The `vulnerability-report` artifact gives you a full list of known CVEs in the dependency tree.
+- **Gitleaks** — blocks commits containing API keys, connection strings, or other secrets before they reach the repository.
+
+### Reproducible builds
+
+```xml title="Directory.Build.props"
+<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+<RestoreLockedMode Condition="'$(CI)' == 'true'">true</RestoreLockedMode>
+```
+
+`packages.lock.json` pins the exact resolved version of every transitive dependency. CI runs in locked mode — any undeclared version drift fails the build. This prevents dependency confusion attacks and ensures the build you tested is the build you shipped.
+
+### Least-privilege CI tokens
+
+```yaml title=".github/workflows/ci.yml"
+permissions: read-all  # OpenSSF Token-Permissions — workflow-level default
+```
+
+Individual jobs declare only the permissions they need (`contents: write` for release uploads, `id-token: write` for provenance attestation). A compromised workflow step cannot exfiltrate secrets or push to branches it has no business touching.
+
+## Embedded technical controls
+
+The pipeline covers supply chain. The framework modules cover the runtime obligations.
+
+### Access control and authentication (Art. 21 §2(i))
+
+`Granit.Authorization` provides dynamic RBAC/ABAC: permissions are stored in the database, evaluated at runtime, and can differ per tenant. There is no hardcoded role-to-permission mapping to recompile when your access model changes.
+
+```csharp title="Program.cs"
+builder.AddGranit(granit => granit
+    .AddModule<GranitAuthorizationModule>()
+    .AddModule<GranitAuthorizationEntityFrameworkCoreModule>());
+```
+
+For modern OAuth 2.0 flows, `Granit.Bff` and `Granit.Authentication.DPoP` implement the full FAPI 2.0 security profile:
+
+| Mechanism | Protection | RFC |
+|---|---|---|
+| PKCE | Authorization code interception | RFC 7636 |
+| PAR | Parameter tampering + PII leakage | RFC 9126 |
+| DPoP | Token replay + theft | RFC 9449 |
+| `private_key_jwt` | Client authentication without shared secrets | RFC 7523 |
+
+Tokens never reach the browser. The BFF pattern keeps `access_token` and `refresh_token` server-side in an encrypted session cookie (`HttpOnly`, `Secure`, `SameSite=Strict`).
+
+### Audit trail (Art. 21 §2(b))
+
+`AuditedEntityInterceptor` runs inside every `SaveChangesAsync` call. No application code is needed:
+
+```csharp title="Any entity inheriting AuditedEntity"
+// These four fields are set automatically — application code never touches them
+// CreatedAt  → IClock.Now (always UTC)
+// CreatedBy  → ICurrentUserService.UserId (or "system" for background jobs)
+// ModifiedAt → IClock.Now
+// ModifiedBy → ICurrentUserService.UserId
+public sealed class Invoice : FullAuditedEntity<Guid>
+{
+    public decimal Amount { get; private set; }
+    public string Currency { get; private set; } = default!;
+}
+```
+
+The interceptor participates in the same database transaction as the business write — the audit record is atomic with the change it describes. Retention minimum: 3 years.
+
+For business-level events ("Invoice approved by Marie"), the `Timeline` module records actor, timestamp, and a Markdown body independently of the field-level audit trail.
+
+### Cryptography (Art. 21 §2(h))
+
+`Granit.Encryption` provides field-level encryption at rest via `IStringEncryptionService`. In production, `Granit.Vault.HashiCorp` delegates to HashiCorp Vault Transit — the encryption key never leaves Vault:
+
+```csharp title="PatientService.cs"
+public class PatientService(IStringEncryptionService encryption)
+{
+    public async Task StoreNationalIdAsync(
+        string nationalId, CancellationToken cancellationToken)
+    {
+        string encrypted = await encryption
+            .EncryptAsync(nationalId, cancellationToken)
+            .ConfigureAwait(false);
+        // Only the encrypted value is persisted
+    }
+}
+```
+
+Encryption in transit is enforced unconditionally: `RequireHttpsMetadata = true` with no override in production.
+
+`Granit.Privacy` adds **crypto-shredding** for the right to erasure: destroying a tenant's encryption key renders all their encrypted data unreadable without touching the audit trail.
+
+### Incident detection and observability (Art. 21 §2(b))
+
+`Granit.Observability` wires Serilog + OpenTelemetry in a single module registration:
+
+```csharp title="Program.cs"
+builder.AddGranit(granit => granit
+    .AddModule<GranitObservabilityModule>());
+```
+
+Every module emits structured logs (`[LoggerMessage]` source-generated, no string interpolation), metrics via `IMeterFactory`, and distributed traces via `ActivitySource`. The Grafana LGTM stack (Loki, Grafana, Tempo, Mimir) provides the production visualization layer — correlating a user-visible error to the exact trace span and log lines that caused it.
+
+:::tip
+Structured logs with a `trace_id` field satisfy the NIS 2 incident traceability requirement. You can reconstruct the exact sequence of events for any incident from the Tempo trace alone.
+:::
+
+### Business continuity (Art. 21 §2(c))
+
+Multi-tenancy isolation prevents data leaks between customers. Granit supports three isolation strategies:
+
+| Strategy | Isolation | Data residency |
+|---|---|---|
+| `SharedDatabase` | Query filter on `TenantId` | Same database |
+| `SchemaPerTenant` | PostgreSQL schema separation | Same server |
+| `DatabasePerTenant` | Physical separation | Separate databases |
+
+The `IMultiTenant` query filter is applied by `ApplyGranitConventions` in `OnModelCreating` — application code never writes `WHERE TenantId = ...` and cannot accidentally omit it.
+
+`Granit.RateLimiting` protects availability against abusive traffic patterns. `Granit.Persistence` with named EF Core 10 query filters (`HasQueryFilter(name, expr)`) ensures filters are individually toggleable for administrative operations without disabling all isolation.
+
+## NIS 2 compliance matrix
+
+| Art. 21 requirement | Granit control | Layer |
+|---|---|---|
+| §2(b) — Incident handling | `Granit.Observability` (LGTM stack) + `Granit.Auditing` | Framework |
+| §2(b) — Incident traceability | Structured logs + distributed traces (OpenTelemetry) | Framework |
+| §2(c) — Business continuity | Multi-tenancy isolation + soft-delete + `Granit.Persistence` | Framework |
+| §2(e) — Secure development | CodeQL + Trivy + Gitleaks + SonarCloud | Pipeline |
+| §2(h) — Cryptography at rest | `Granit.Encryption` + `Granit.Vault.HashiCorp` | Framework |
+| §2(h) — Cryptography in transit | HTTPS enforcement (`RequireHttpsMetadata = true`) | Framework |
+| §2(h) — Secret scanning | Gitleaks | Pipeline |
+| §2(i) — Authentication | PKCE + PAR + DPoP + `private_key_jwt`, FAPI 2.0 | Framework |
+| §2(i) — Authorization | `Granit.Authorization` (dynamic RBAC/ABAC) | Framework |
+| §2(i) — Least-privilege CI | `permissions: read-all` + per-job scopes | Pipeline |
+| §3 — Supply chain — SBOM | CycloneDX JSON on every release | Pipeline |
+| §3 — Supply chain — integrity | SLSA Level 2 build provenance | Pipeline |
+| §3 — Supply chain — reproducibility | `packages.lock.json` locked builds | Pipeline |
+| §3 — Supply chain — license inventory | `THIRD-PARTY-NOTICES.md` | Repository |
+
+:::caution
+Granit covers the **technical controls**. NIS 2 also requires organizational measures: incident response procedures, governance policies, executive accountability, and registration with your national authority (CCN in Belgium). These are not something a framework can provide.
+:::
+
+## Key takeaways
+
+- NIS 2 Art. 21 §3 makes your framework a supply chain concern — Granit publishes a CycloneDX SBOM and SLSA Level 2 provenance on every release.
+- The pipeline enforces OpenSSF Token-Permissions (least-privilege tokens), CodeQL SAST, Trivy CVE scanning, and Gitleaks secret detection on every PR.
+- The framework modules cover the runtime obligations: FAPI 2.0 authentication, dynamic RBAC/ABAC, field-level encryption with Vault key management, tamper-proof audit trails, and structured observability.
+- `packages.lock.json` ensures the build you tested is the build you shipped — no surprise transitive upgrades.
+- The compliant path is the default path: you cannot accidentally skip the audit trail, tenant filter, or HTTPS enforcement.
+
+## Further reading
+
+- [Security overview](/dotnet/security/security-overview/) — choosing the right security modules
+- [GDPR & ISO 27001 compliance](/dotnet/concepts/compliance/) — full compliance architecture
+- [FAPI 2.0 security profile](/dotnet/security/openiddict/advanced/fapi-2-security-profile/) — banking-grade OAuth 2.0
+- [Observability](/dotnet/core/observability/) — Serilog + OpenTelemetry + Grafana LGTM
+- [Multi-tenancy](/dotnet/concepts/multi-tenancy/) — isolation strategies
+- [CI/CD pipeline](/dotnet/operations/ci-cd/) — full GitHub Actions workflow documentation

--- a/docs-site/src/content/docs/blog/soc2-type2-ready-saas-granit.mdx
+++ b/docs-site/src/content/docs/blog/soc2-type2-ready-saas-granit.mdx
@@ -1,0 +1,287 @@
+---
+title: Building SOC 2 Type 2-Ready SaaS with Granit
+date: 2026-03-30
+sidebar:
+  order: 7
+authors:
+  - jfmeyers
+tags:
+  - security
+  - compliance
+  - deep-dive
+description: "Enterprise customers ask for SOC 2 Type 2 reports before signing. Here is how Granit's modules map to the five Trust Service Criteria — and what the framework cannot replace."
+excerpt: >
+  Enterprise customers ask for a SOC 2 Type 2 report before signing. Here is how
+  Granit's modules map to the five Trust Service Criteria — and what the
+  framework cannot replace.
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+You close a deal with a large enterprise customer. Their security team sends a vendor assessment form. Question 3: "Do you have a SOC 2 Type 2 report?" If the answer is no, you go on a watch list. If it stays no for six months, the deal dies.
+
+SOC 2 is not a regulation — but it is effectively a gate for selling to enterprise, healthcare, and financial services customers in North America and increasingly in Europe. This article maps Granit's modules to the five **Trust Service Criteria (TSC)** so you know exactly which technical controls you already have in place when you start your audit preparation.
+
+## SOC 2 Type 2 in 90 seconds
+
+The AICPA framework defines two report types:
+
+| | Type 1 | Type 2 |
+|---|---|---|
+| **What it certifies** | Controls exist at a point in time | Controls operated effectively over a period (6–12 months) |
+| **Audit duration** | 2–4 weeks | 6–12 months observation window |
+| **Customer value** | Low ("you had the controls on day one") | High ("the controls actually work over time") |
+
+The audit covers five Trust Service Criteria:
+
+```mermaid
+graph TD
+    S["Security (CC)\nMandatory"]
+    AV["Availability (A)"]
+    C["Confidentiality (C)"]
+    PI["Processing Integrity (PI)"]
+    P["Privacy (P)"]
+    S --> AV
+    S --> C
+    S --> PI
+    S --> P
+
+    style S fill:#fce4ec,stroke:#880e4f,color:#560027
+    style AV fill:#e3f2fd,stroke:#1565c0,color:#0d47a1
+    style C fill:#f3e5f5,stroke:#6a1b9a,color:#4a148c
+    style PI fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
+    style P fill:#fff3e0,stroke:#e65100,color:#bf360c
+```
+
+**Security (CC)** is mandatory. The other four are optional — but most enterprise customers require Availability and Confidentiality as a minimum.
+
+:::note
+A SOC 2 audit certifies your **processes and controls**, not your code. The auditor reviews your policies, interviews your team, samples your logs, and tests your controls over the observation window. Granit gives you the *technical* controls. The *operational* controls around them — incident response runbooks, access review cadence, employee training — are on you.
+:::
+
+## CC6 — Logical access controls (Security TSC)
+
+CC6 is the largest control family in SOC 2. It covers who can access what, how access is granted and revoked, and how you detect unauthorized access.
+
+### CC6.1 — Authentication
+
+`Granit.Authentication` supports JWT Bearer tokens with provider packages for Keycloak, Entra ID, Cognito, and Google Cloud. For high-security scenarios, `Granit.Authentication.DPoP` adds proof-of-possession tokens — access tokens are cryptographically bound to the client's private key and cannot be replayed by a third party even if intercepted:
+
+```csharp title="Program.cs"
+builder.AddGranit(granit => granit
+    .AddModule<GranitAuthenticationJwtBearerKeycloakModule>()
+    .AddModule<GranitAuthenticationDPoPModule>());
+```
+
+`RequireHttpsMetadata = true` is enforced unconditionally. There is no way to disable it in production — the option validator rejects the configuration at startup. (CC6.1 requires encrypted communications for authentication.)
+
+### CC6.3 — Authorization and least-privilege
+
+`Granit.Authorization` stores permissions in the database and evaluates them at runtime. There is no recompile cycle when your access model changes:
+
+```csharp title="InvoiceEndpoints.cs"
+group.MapDelete("/{id:guid}", DeleteAsync)
+    .RequirePermission(InvoicePermissions.Invoices.Manage);
+```
+
+Permissions follow the `[Group].[Resource].[Action]` format, enforced by architecture tests. `Granit.MultiTenancy` isolates data at the query layer — permission policies can differ per tenant without duplicating application logic.
+
+### CC6.6 — External access (FAPI 2.0)
+
+For machine-to-machine and third-party integrations, `Granit.OpenIddict` implements the full **FAPI 2.0 security profile**:
+
+| Mechanism | Threat it prevents | RFC |
+|---|---|---|
+| PKCE | Authorization code interception | RFC 7636 |
+| PAR | Parameter tampering + PII leakage in URL | RFC 9126 |
+| DPoP | Token replay + theft | RFC 9449 |
+| `private_key_jwt` | Client impersonation without shared secrets | RFC 7523 |
+
+### CC6.8 — Malware and supply chain protection
+
+`Granit.Bff` implements the Backend For Frontend pattern: tokens are stored server-side in an encrypted, `HttpOnly`, `SameSite=Strict` session cookie. The browser never receives an `access_token` or `refresh_token`. A successful XSS attack — including a compromised npm dependency — cannot exfiltrate tokens that the browser never had access to.
+
+:::tip
+This is the most underrated SOC 2 control in frontend-heavy applications. Most auditors specifically ask about token storage in SPAs. "Tokens live server-side in HttpOnly cookies managed by Granit.Bff" is a much stronger answer than "stored in localStorage with CSP headers."
+:::
+
+## CC7 — System operations and incident response
+
+### CC7.1 — Anomaly detection
+
+`Granit.Observability` exports three pillars via a single module registration:
+
+```csharp title="Program.cs"
+builder.AddGranit(granit => granit
+    .AddModule<GranitObservabilityModule>());
+```
+
+- **Logs**: Serilog with `[LoggerMessage]` source generation. No string interpolation, no PII in log output, structured output to the Grafana Loki stack.
+- **Metrics**: every module emits named metrics via `IMeterFactory` (e.g. `granit.authorization.permission.check`, `granit.persistence.query.duration`). Mimir stores and alerts on them.
+- **Traces**: `ActivitySource` per module, correlated with logs via `trace_id`. Grafana Tempo provides flame graphs for any production request.
+
+The Grafana LGTM stack ships as a Docker Compose overlay for local development. The same configuration deploys to production.
+
+### CC7.2 — Audit trail
+
+`AuditedEntityInterceptor` populates four fields on every database write — automatically, inside the same transaction:
+
+```csharp title="Invoice.cs"
+// Inheriting FullAuditedEntity<Guid> gives you:
+// CreatedAt, CreatedBy, ModifiedAt, ModifiedBy
+// DeletedAt, DeletedBy, IsDeleted (via ISoftDeletable)
+public sealed class Invoice : FullAuditedAggregateRoot<Guid>
+{
+    public decimal Amount { get; private set; }
+
+    public static Invoice Create(decimal amount)
+    {
+        // Factory method — audit fields set by interceptor, not by application code
+        return new Invoice { Amount = amount };
+    }
+}
+```
+
+Application code cannot skip the audit trail. The interceptor runs unconditionally on every `SaveChangesAsync` call for entities that inherit from `AuditedEntity`.
+
+For business-level events, `Granit.Webhooks` records delivery attempts with `SuspendedAt` and `SuspendedBy` fields — the auditor can trace exactly when a webhook was suspended and who triggered the state change.
+
+:::note
+SOC 2 CC7.2 requires that you detect unauthorized changes to data. The audit trail satisfies the detection requirement. Combine it with Grafana alerting on unexpected `ModifiedBy = "system"` patterns outside scheduled job windows for active anomaly detection.
+:::
+
+## CC6.7 and Confidentiality TSC — Encryption
+
+### Encryption at rest
+
+`Granit.Encryption` provides field-level encryption via `IStringEncryptionService`. In development, it uses AES-256-CBC with a local key. In production, `Granit.Vault.HashiCorp` delegates to HashiCorp Vault Transit:
+
+```csharp title="PatientService.cs"
+public class PatientService(IStringEncryptionService encryption)
+{
+    public async Task<Patient> CreateAsync(
+        string name,
+        string nationalId,
+        CancellationToken cancellationToken)
+    {
+        string encryptedId = await encryption
+            .EncryptAsync(nationalId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return Patient.Create(name, encryptedId);
+        // nationalId never persisted in plaintext
+    }
+}
+```
+
+The Vault module disables itself automatically in `Development` environment — no running Vault instance is needed locally. The same application code runs in both environments.
+
+`Granit.Vault.HashiCorp` provides automatic key rotation via the Transit engine. Key rotation produces a new key version; existing ciphertext can be decrypted with old key versions until you explicitly rewrap it. The key **never leaves Vault** — this satisfies CC6.7 (encryption key management) and ISO 27001 A.8.24.
+
+### Crypto-shredding — right to erasure without deleting rows
+
+`Granit.Privacy` implements crypto-shredding for the GDPR right to erasure. When a tenant is offboarded:
+
+1. The tenant's encryption key is destroyed in Vault.
+2. All encrypted fields in the database become permanently unreadable.
+3. The audit trail remains intact — no rows are deleted.
+
+This resolves the compliance contradiction between GDPR (erase personal data) and SOC 2 (maintain immutable audit trails): the data is effectively erased without touching the rows that the audit trail references.
+
+## Availability TSC — resilience
+
+### A1.1 — Performance and capacity
+
+`Granit.RateLimiting` protects endpoints against abusive traffic patterns with configurable sliding window, fixed window, and token bucket policies. Rate limit violations return a `429 Too Many Requests` with a `Retry-After` header — standard behavior that load testing and synthetic monitoring can validate for the auditor.
+
+`Granit.Caching` reduces database pressure with FusionCache: a two-tier cache (in-memory L1 + distributed Redis L2) with fail-silent semantics. The cache layer is transparent to application code — queries that miss L1 and L2 fall through to the database without application changes.
+
+### A1.2 — Multi-tenancy isolation
+
+The three tenant isolation strategies map to different availability risk profiles:
+
+| Strategy | Risk containment | Use case |
+|---|---|---|
+| `SharedDatabase` | One tenant's heavy queries can slow others | Cost-optimized SaaS |
+| `SchemaPerTenant` | Schema-level separation reduces cross-tenant query contention | Mid-tier isolation |
+| `DatabasePerTenant` | Full isolation — one tenant's database issue cannot affect others | Enterprise / regulated |
+
+Named EF Core 10 query filters (`HasQueryFilter(name, expr)`) make individual filters togglable without disabling all tenant isolation — useful for administrative operations and incident investigation.
+
+## Privacy TSC — personal data handling
+
+`Granit.Privacy` implements the GDPR processing principles that also satisfy SOC 2 Privacy TSC criteria:
+
+```csharp title="PatientPersonalDataProvider.cs"
+public class PatientPersonalDataProvider : IPersonalDataProvider
+{
+    public string Category => "Medical records";
+
+    public async Task<PersonalDataExport> ExportAsync(
+        string userId, CancellationToken cancellationToken)
+    {
+        // Aggregated by the Privacy module for data portability requests
+    }
+}
+```
+
+- **Data minimization**: modules store only what they need. No central 40-column user profile table.
+- **Processing restriction** (`IProcessingRestrictable`): records can be suspended from processing on data subject request. Global query filter applied by `ApplyGranitConventions`.
+- **No PII in logs**: `[LoggerMessage]` source generation with explicit parameters prevents accidental PII interpolation into log strings. The Roslyn analyzer `Granit.Analyzers` flags direct string interpolation in log calls at compile time.
+- **Data residency**: `DatabasePerTenant` strategy supports EU-only database placement, satisfying auditors in regulated industries.
+
+## SOC 2 compliance matrix
+
+| TSC criterion | Granit control | Module |
+|---|---|---|
+| CC6.1 — Authentication | JWT Bearer + DPoP + PKCE | `Granit.Authentication` |
+| CC6.1 — Encrypted transport | `RequireHttpsMetadata = true` | `Granit.Authentication` |
+| CC6.3 — Authorization | Dynamic RBAC/ABAC, runtime permissions | `Granit.Authorization` |
+| CC6.3 — Tenant isolation | Query filters, 3 isolation strategies | `Granit.MultiTenancy` |
+| CC6.6 — Third-party auth | FAPI 2.0 (PAR + DPoP + `private_key_jwt`) | `Granit.OpenIddict` |
+| CC6.7 — Encryption at rest | Field-level AES / Vault Transit | `Granit.Encryption`, `Granit.Vault` |
+| CC6.7 — Key management | HashiCorp Vault Transit, auto-rotation | `Granit.Vault.HashiCorp` |
+| CC6.8 — Token protection | BFF pattern, HttpOnly cookies | `Granit.Bff` |
+| CC7.1 — Anomaly detection | Structured logs + metrics + traces | `Granit.Observability` |
+| CC7.2 — Audit trail | Interceptor-based, immutable, actor-attributed | `Granit.Auditing` |
+| CC7.2 — Webhook audit | Delivery log + suspension tracking | `Granit.Webhooks` |
+| A1.1 — Availability | Rate limiting, distributed caching | `Granit.RateLimiting`, `Granit.Caching` |
+| A1.2 — Tenant isolation | Database/schema/filter strategies | `Granit.MultiTenancy`, `Granit.Persistence` |
+| C1.1 — Confidentiality | Field encryption + crypto-shredding | `Granit.Encryption`, `Granit.Privacy` |
+| P3.1 — Data minimization | Module-scoped storage, no shared profile table | Architecture |
+| P4.1 — Personal data portability | `IPersonalDataProvider` aggregation | `Granit.Privacy` |
+| P8.1 — Right to erasure | Crypto-shredding via Vault key destruction | `Granit.Privacy` |
+
+## What Granit does not replace
+
+SOC 2 auditors do not just review your code. They review:
+
+- **Incident response procedures**: a documented runbook, not just Grafana dashboards
+- **Access review cadence**: quarterly reviews of who has production access
+- **Change management**: pull request policies, approval gates, deployment procedures
+- **Employee training**: security awareness, phishing simulation records
+- **Vendor management**: due diligence records for your own third-party dependencies
+- **Penetration testing**: an annual external pen test with findings and remediation
+
+Granit gives you the technical controls. The observation window requires that those controls operated effectively — which means your team followed the procedures, reviewed the alerts, and acted on the findings every day for six to twelve months.
+
+:::caution
+Starting a SOC 2 audit without the operational controls in place is expensive. The auditor will find gaps. Starting with Granit means the technical controls are already there — you can focus your preparation time on the processes and evidence collection.
+:::
+
+## Key takeaways
+
+- SOC 2 Type 2 certifies that your controls operated effectively over 6–12 months — the observation window starts when you engage an auditor, not when you think you are ready.
+- `Granit.Authorization` + `Granit.Authentication.DPoP` + `Granit.Bff` covers the CC6 access control family; `Granit.Observability` + `Granit.Auditing` covers CC7.
+- `Granit.Vault.HashiCorp` satisfies CC6.7 key management — Vault Transit provides key rotation and HSM backing with the key never leaving Vault.
+- `Granit.Privacy` crypto-shredding resolves the GDPR-vs-SOC2 audit trail contradiction: keys are destroyed, rows stay.
+- The framework covers technical controls. Operational controls — procedures, training, access reviews — are the part that requires organizational investment.
+
+## Further reading
+
+- [GDPR & ISO 27001 compliance](/dotnet/concepts/compliance/) — architectural constraints for EU regulations
+- [Security overview](/dotnet/security/security-overview/) — choosing the right security modules
+- [Privacy module](/dotnet/compliance/privacy/) — GDPR erasure, data portability, crypto-shredding
+- [Vault & Encryption](/dotnet/data/vault-encryption/) — field-level encryption, key management
+- [BFF pattern](/dotnet/security/bff/) — token-safe frontend architecture
+- [Production checklist](/dotnet/operations/production-checklist/) — go-live readiness gates

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ReferenceDataEfCoreServiceCollectionExtensions.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ReferenceDataEfCoreServiceCollectionExtensions.cs
@@ -31,6 +31,10 @@ public static class ReferenceDataEfCoreServiceCollectionExtensions
         where TEntity : ReferenceDataEntity
         where TDbContext : DbContext
     {
+        // Defensive: ensure metrics are available even if the caller registers the store
+        // before GranitReferenceDataModule has loaded (TryAdd is idempotent).
+        services.TryAddSingleton<ReferenceDataMetrics>();
+
         services.AddScoped<EfCoreReferenceDataStore<TEntity, TDbContext>>(sp =>
             new EfCoreReferenceDataStore<TEntity, TDbContext>(
                 sp.GetRequiredService<IServiceScopeFactory>(),
@@ -103,6 +107,10 @@ public static class ReferenceDataEfCoreServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configure);
+
+        // Defensive: ensure metrics are available even if the caller registers stores
+        // before GranitReferenceDataModule has loaded (TryAdd is idempotent).
+        services.TryAddSingleton<ReferenceDataMetrics>();
 
         // Build the registrations
         ReferenceDataBuilder builder = new();

--- a/tests/Granit.Features.EntityFrameworkCore.Tests/FeaturesDbContextTests.cs
+++ b/tests/Granit.Features.EntityFrameworkCore.Tests/FeaturesDbContextTests.cs
@@ -102,7 +102,7 @@ public sealed class FeaturesDbContextTests
             FeatureName = "Acme.MaxUsersCount",
             Value = "5000",
             CreatedAt = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
-            CreatedBy = "admin@digitaldynamics.be",
+            CreatedBy = "info@granit-fx.dev",
         };
 
         ctx.FeatureOverrides.Add(entity);
@@ -116,7 +116,7 @@ public sealed class FeaturesDbContextTests
         loaded!.TenantId.ShouldBe(tenantId);
         loaded.FeatureName.ShouldBe("Acme.MaxUsersCount");
         loaded.Value.ShouldBe("5000");
-        loaded.CreatedBy.ShouldBe("admin@digitaldynamics.be");
+        loaded.CreatedBy.ShouldBe("info@granit-fx.dev");
         loaded.CreatedAt.ShouldBe(entity.CreatedAt);
     }
 }


### PR DESCRIPTION
## Summary

- `AddReferenceDataStore<TEntity, TDbContext>()` and `AddReferenceData<TDbContext>()` resolve `ReferenceDataMetrics` via `GetRequiredService` but the singleton is only registered by `GranitReferenceDataModule.ConfigureServices()`
- When the EF Core store is registered before the module loads (e.g., during data seeding), the resolution fails: `No service for type 'Granit.ReferenceData.Diagnostics.ReferenceDataMetrics' has been registered`
- Fix: add `TryAddSingleton<ReferenceDataMetrics>()` in both extension methods (`TryAdd` is idempotent — no double-registration if the module registered it first)

## Test plan

- [x] 68 ReferenceData.EntityFrameworkCore tests pass
- [ ] Showcase seeding completes without `InvalidOperationException`
