### PR TITLE
fix(reference-data): make CreateAsync idempotent and SetActiveAsync filter-aware

### DIFF
--- a/src/Granit.ReferenceData.EntityFrameworkCore/Internal/EfCoreReferenceDataStore.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Internal/EfCoreReferenceDataStore.cs
@@ -137,6 +137,19 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
         await using AsyncServiceScope scope = _scopeFactory.CreateAsyncScope();
         TDbContext context = scope.ServiceProvider.GetRequiredService<TDbContext>();
 
+        // IgnoreQueryFilters ensures inactive records are also detected, preventing a
+        // duplicate-key error when the seeder runs a second time against an existing
+        // (possibly inactive) entry with the same Code.
+        bool exists = await context.Set<TEntity>()
+            .IgnoreQueryFilters()
+            .AnyAsync(e => e.Code == entity.Code, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (exists)
+        {
+            return;
+        }
+
         context.Set<TEntity>().Add(entity);
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
@@ -164,7 +177,9 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
         await using AsyncServiceScope scope = _scopeFactory.CreateAsyncScope();
         TDbContext context = scope.ServiceProvider.GetRequiredService<TDbContext>();
 
+        // IgnoreQueryFilters allows reactivating records that are currently inactive.
         TEntity? entity = await context.Set<TEntity>()
+            .IgnoreQueryFilters()
             .FirstOrDefaultAsync(e => e.Code == code, cancellationToken).ConfigureAwait(false);
 
         if (entity is not null)

--- a/src/Granit.ReferenceData/IReferenceDataStoreWriter.cs
+++ b/src/Granit.ReferenceData/IReferenceDataStoreWriter.cs
@@ -9,7 +9,9 @@ namespace Granit.ReferenceData;
 public interface IReferenceDataStoreWriter<in TEntity> where TEntity : ReferenceDataEntity
 {
     /// <summary>
-    /// Creates a new reference data entry. The <see cref="ReferenceDataEntity.Code"/> must be unique.
+    /// Creates a new reference data entry. Idempotent: if an entry with the same
+    /// <see cref="ReferenceDataEntity.Code"/> already exists (even when inactive),
+    /// the call is a no-op and no exception is thrown.
     /// </summary>
     /// <param name="entity">The entity to persist.</param>
     /// <param name="cancellationToken">Cancellation token.</param>

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreAdditionalTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreAdditionalTests.cs
@@ -255,6 +255,77 @@ public sealed class EfCoreReferenceDataStoreAdditionalTests
     }
 
     // -------------------------------------------------------------------------
+    // CreateAsync — idempotency
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateAsync_DuplicateCode_ActiveRecord_IsNoOp()
+    {
+        string db = Guid.NewGuid().ToString();
+        await SeedAsync(db, "BE", "Belgium", isActive: true, cancellationToken: TestContext.Current.CancellationToken);
+
+        EfCoreReferenceDataStore<TestEntity, TestDbContext> store = CreateStore(db);
+
+        // Second create with same Code must not throw
+        await Should.NotThrowAsync(() => store.CreateAsync(new TestEntity
+        {
+            Id = Guid.NewGuid(),
+            Code = "BE",
+            LabelEn = "Belgium (duplicate)",
+            IsActive = true,
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBy = "test",
+        }, TestContext.Current.CancellationToken));
+
+        // Original record is preserved
+        TestEntity? entity = await store.GetByCodeAsync("BE", TestContext.Current.CancellationToken);
+        entity!.LabelEn.ShouldBe("Belgium");
+    }
+
+    [Fact]
+    public async Task CreateAsync_DuplicateCode_InactiveRecord_IsNoOp()
+    {
+        // This is the exact scenario seen in production: seeder runs a second time,
+        // the existing record has IsActive=false (bypassed by the query filter in
+        // GetByCodeAsync), so the seeder calls CreateAsync which must not throw 23505.
+        string db = Guid.NewGuid().ToString();
+        await SeedAsync(db, "BE", "Belgium", isActive: false, cancellationToken: TestContext.Current.CancellationToken);
+
+        EfCoreReferenceDataStore<TestEntity, TestDbContext> store = CreateStore(db);
+
+        await Should.NotThrowAsync(() => store.CreateAsync(new TestEntity
+        {
+            Id = Guid.NewGuid(),
+            Code = "BE",
+            LabelEn = "Belgium",
+            IsActive = true,
+            CreatedAt = DateTimeOffset.UtcNow,
+            CreatedBy = "test",
+        }, TestContext.Current.CancellationToken));
+    }
+
+    // -------------------------------------------------------------------------
+    // SetActiveAsync — reactivating an inactive record
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SetActiveAsync_InactiveRecord_CanBeReactivated()
+    {
+        string db = Guid.NewGuid().ToString();
+        await SeedAsync(db, "BE", "Belgium", isActive: false, cancellationToken: TestContext.Current.CancellationToken);
+
+        EfCoreReferenceDataStore<TestEntity, TestDbContext> store = CreateStore(db);
+
+        // Should succeed even though the record is filtered out by IsActive=false
+        await store.SetActiveAsync("BE", true, TestContext.Current.CancellationToken);
+
+        PagedResult<TestEntity> result = await store.GetAllAsync(
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        result.Items.ShouldContain(e => e.Code == "BE" && e.IsActive);
+    }
+
+    // -------------------------------------------------------------------------
     // UpdateAsync — invalidates cache
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `EfCoreReferenceDataStore.CreateAsync` is now idempotent: uses `IgnoreQueryFilters()` to detect existing entries (including inactive ones) before inserting — turns a `23505 duplicate key` crash into a silent no-op
- `EfCoreReferenceDataStore.SetActiveAsync` also gains `IgnoreQueryFilters()` so inactive records can be reactivated through the API
- `IReferenceDataStoreWriter.CreateAsync` doc updated to reflect idempotency contract

## Root cause

`ApplyGranitConventions` registers a named `IsActive` query filter on `ReferenceDataEntity`. Without `IgnoreQueryFilters()`, any store operation that queries by Code is invisible to rows with `IsActive = false`.

The crash sequence was:

1. Seeder calls `storeReader.GetByCodeAsync("BE")` → `SELECT ... WHERE IsActive AND Code = 'BE'` → `null` (record exists but `IsActive = false`)
2. Seeder calls `storeWriter.CreateAsync(new Country { Code = "BE", ... })` → `INSERT` → `23505: duplicate key value violates unique constraint "uq_ref_countries_code"`

## Test plan

- [ ] `CreateAsync_DuplicateCode_ActiveRecord_IsNoOp` — second call for an active record is a no-op, original preserved
- [ ] `CreateAsync_DuplicateCode_InactiveRecord_IsNoOp` — exact production scenario, no exception thrown
- [ ] `SetActiveAsync_InactiveRecord_CanBeReactivated` — inactive record becomes active after the call
- [ ] Full test suite: `dotnet test tests/Granit.ReferenceData.EntityFrameworkCore.Tests` — 68 passed
