### PR TITLE
fix(openiddict): skip seeder update when scope/application values are unchanged

### DIFF
--- a/docs-site/src/content/docs/blog/nis2-ready-dotnet-applications.mdx
+++ b/docs-site/src/content/docs/blog/nis2-ready-dotnet-applications.mdx
@@ -46,12 +46,12 @@ NIS 2 Art. 21 §3 requires that you know what is in your software and can demons
 
 ```mermaid
 graph LR
-    TAG[\"Tagged release\"] --> SBOM[\"CycloneDX\\nSBOM\"]
-    TAG --> SLSA[\"SLSA Level 2\\nProvenance\"]
-    PR[\"Pull Request\"] --> CQ[\"CodeQL\\nSAST\"]
-    PR --> TV[\"Trivy\\nDependency CVEs\"]
-    PR --> GL[\"Gitleaks\\nSecret scan\"]
-    SBOM --> REL[\"GitHub Release\\nartifact\"]
+    TAG[\"Tagged release\"] --> SBOM[\"CycloneDX<br/>SBOM\"]
+    TAG --> SLSA[\"SLSA Level 2<br/>Provenance\"]
+    PR[\"Pull Request\"] --> CQ[\"CodeQL<br/>SAST\"]
+    PR --> TV[\"Trivy<br/>Dependency CVEs\"]
+    PR --> GL[\"Gitleaks<br/>Secret scan\"]
+    SBOM --> REL[\"GitHub Release<br/>artifact\"]
     SLSA --> REL
 
     style TAG fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Seeding/OpenIddictSeedContributor.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Seeding/OpenIddictSeedContributor.cs
@@ -86,12 +86,79 @@ internal sealed partial class OpenIddictSeedContributor(
             await applicationManager.PopulateAsync(appDescriptor, existing, cancellationToken)
                 .ConfigureAwait(false);
 
+            // Skip update when values are already up to date — prevents ConcurrencyException
+            // when migrator and API both execute seeders concurrently at startup.
+            if (!ApplicationNeedsUpdate(appDescriptor, descriptor))
+            {
+                Log.ApplicationUnchanged(logger, descriptor.ClientId);
+                return;
+            }
+
             PopulateDescriptor(appDescriptor, descriptor);
 
             await applicationManager.UpdateAsync(existing, appDescriptor, cancellationToken)
                 .ConfigureAwait(false);
             Log.ApplicationUpdated(logger, descriptor.ClientId);
         }
+    }
+
+    private static bool ApplicationNeedsUpdate(
+        OpenIddictApplicationDescriptor current, OidcApplicationSeedDescriptor desired)
+    {
+        if (current.DisplayName != desired.DisplayName)
+        {
+            return true;
+        }
+
+        if (!current.Permissions.SetEquals(desired.Permissions))
+        {
+            return true;
+        }
+
+        if (!current.RedirectUris.SetEquals(desired.RedirectUris.Select(u => new Uri(u))))
+        {
+            return true;
+        }
+
+        if (!current.PostLogoutRedirectUris.SetEquals(desired.PostLogoutRedirectUris.Select(u => new Uri(u))))
+        {
+            return true;
+        }
+
+        JsonWebKeySet? desiredJwks = !string.IsNullOrEmpty(desired.SigningKeyJwk)
+            ? BuildJsonWebKeySet(desired.SigningKeyJwk)
+            : null;
+
+        return !JwksEqual(current.JsonWebKeySet, desiredJwks);
+    }
+
+    /// <summary>
+    /// Compares two <see cref="JsonWebKeySet"/> instances by public key material
+    /// (Kty, Crv, N, E, X, Y, Use). Private key parameters are never stored.
+    /// </summary>
+    private static bool JwksEqual(JsonWebKeySet? a, JsonWebKeySet? b)
+    {
+        if (a is null && b is null)
+        {
+            return true;
+        }
+
+        if (a is null || b is null)
+        {
+            return false;
+        }
+
+        if (a.Keys.Count != b.Keys.Count)
+        {
+            return false;
+        }
+
+        IEnumerable<string> Fingerprints(JsonWebKeySet ks) =>
+            ks.Keys
+              .Select(k => $"{k.Kty}:{k.Crv}:{k.N}:{k.E}:{k.X}:{k.Y}:{k.Use}")
+              .Order(StringComparer.Ordinal);
+
+        return Fingerprints(a).SequenceEqual(Fingerprints(b));
     }
 
     /// <summary>
@@ -157,6 +224,15 @@ internal sealed partial class OpenIddictSeedContributor(
             await scopeManager.PopulateAsync(scopeDescriptor, existing, cancellationToken)
                 .ConfigureAwait(false);
 
+            // Skip update when values are already up to date — prevents ConcurrencyException
+            // when migrator and API both execute seeders concurrently at startup.
+            if (scopeDescriptor.DisplayName == descriptor.DisplayName
+                && scopeDescriptor.Resources.SetEquals(descriptor.Resources))
+            {
+                Log.ScopeUnchanged(logger, descriptor.Name);
+                return;
+            }
+
             scopeDescriptor.DisplayName = descriptor.DisplayName;
 
             scopeDescriptor.Resources.Clear();
@@ -206,10 +282,16 @@ internal sealed partial class OpenIddictSeedContributor(
         [LoggerMessage(Level = LogLevel.Debug, Message = "Updated OIDC application '{ClientId}'.")]
         public static partial void ApplicationUpdated(ILogger logger, string clientId);
 
+        [LoggerMessage(Level = LogLevel.Debug, Message = "OIDC application '{ClientId}' is already up to date — skipping update.")]
+        public static partial void ApplicationUnchanged(ILogger logger, string clientId);
+
         [LoggerMessage(Level = LogLevel.Debug, Message = "Created OIDC scope '{ScopeName}'.")]
         public static partial void ScopeCreated(ILogger logger, string scopeName);
 
         [LoggerMessage(Level = LogLevel.Debug, Message = "Updated OIDC scope '{ScopeName}'.")]
         public static partial void ScopeUpdated(ILogger logger, string scopeName);
+
+        [LoggerMessage(Level = LogLevel.Debug, Message = "OIDC scope '{ScopeName}' is already up to date — skipping update.")]
+        public static partial void ScopeUnchanged(ILogger logger, string scopeName);
     }
 }

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/Granit.OpenIddict.EntityFrameworkCore.Tests.csproj
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/Granit.OpenIddict.EntityFrameworkCore.Tests.csproj
@@ -5,7 +5,8 @@
     <IsPackable>false</IsPackable>
     <!-- EF1001 fires when testing internal types via InternalsVisibleTo — expected for internal infrastructure tests -->
     <!-- CA5350: HMAC-SHA1 is mandated by RFC 6238 for TOTP interoperability — test helper mirrors the production algorithm -->
-    <NoWarn>$(NoWarn);EF1001;CA5350</NoWarn>
+    <!-- CA2012: NSubstitute's .Returns() chain on ValueTask-returning methods is a known false positive -->
+    <NoWarn>$(NoWarn);EF1001;CA5350;CA2012</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/OpenIddictSeedContributorTests.cs
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/OpenIddictSeedContributorTests.cs
@@ -1,0 +1,296 @@
+using Granit.OpenIddict.EntityFrameworkCore.Seeding;
+using Granit.OpenIddict.Options;
+using Granit.Persistence.DataSeeding;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using OpenIddict.Abstractions;
+using Xunit;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+
+public sealed class OpenIddictSeedContributorTests
+{
+    private readonly IOpenIddictApplicationManager _appManager = Substitute.For<IOpenIddictApplicationManager>();
+    private readonly IOpenIddictScopeManager _scopeManager = Substitute.For<IOpenIddictScopeManager>();
+    private static readonly DataSeedContext Ctx = new(null);
+
+    private OpenIddictSeedContributor CreateContributor(
+        OidcApplicationSeedDescriptor[]? apps = null,
+        OidcScopeSeedDescriptor[]? scopes = null)
+    {
+        GranitOpenIddictSeedingOptions opts = new()
+        {
+            Applications = apps ?? [],
+            Scopes = scopes ?? [],
+        };
+
+        return new OpenIddictSeedContributor(
+            _appManager,
+            _scopeManager,
+            Microsoft.Extensions.Options.Options.Create(opts),
+            NullLogger<OpenIddictSeedContributor>.Instance);
+    }
+
+    /// <summary>
+    /// Makes FindByNameAsync return null for every scope name except <paramref name="existingName"/>,
+    /// which returns <paramref name="existingScope"/>. Standard scopes take the create path,
+    /// isolating the test to the single scope under test.
+    /// </summary>
+    private void SetupStandardScopesNotFound(string existingName, object existingScope)
+    {
+        _scopeManager.FindByNameAsync(
+                Arg.Is<string>(n => n != existingName),
+                Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+
+        _scopeManager.FindByNameAsync(existingName, Arg.Any<CancellationToken>())
+            .Returns(existingScope);
+    }
+
+    // -------------------------------------------------------------------------
+    // SeedScopeAsync — skip when already up to date
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SeedScopeAsync_AlreadyUpToDate_SkipsUpdate()
+    {
+        const string scopeName = "api";
+        object existingScope = new();
+        SetupStandardScopesNotFound(scopeName, existingScope);
+
+        _scopeManager.When(m => m.PopulateAsync(
+                Arg.Any<OpenIddictScopeDescriptor>(), existingScope, Arg.Any<CancellationToken>()))
+            .Do(ci =>
+            {
+                OpenIddictScopeDescriptor d = ci.ArgAt<OpenIddictScopeDescriptor>(0);
+                d.DisplayName = "API";
+                d.Resources.Add("my-api");
+            });
+
+        OidcScopeSeedDescriptor userScope = new(scopeName, "API", ["my-api"]);
+        OpenIddictSeedContributor contributor = CreateContributor(scopes: [userScope]);
+        await contributor.SeedAsync(Ctx, TestContext.Current.CancellationToken);
+
+        await _scopeManager.DidNotReceive().UpdateAsync(
+            existingScope,
+            Arg.Any<OpenIddictScopeDescriptor>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SeedScopeAsync_DisplayNameChanged_PerformsUpdate()
+    {
+        const string scopeName = "api";
+        object existingScope = new();
+        SetupStandardScopesNotFound(scopeName, existingScope);
+
+        _scopeManager.When(m => m.PopulateAsync(
+                Arg.Any<OpenIddictScopeDescriptor>(), existingScope, Arg.Any<CancellationToken>()))
+            .Do(ci =>
+            {
+                OpenIddictScopeDescriptor d = ci.ArgAt<OpenIddictScopeDescriptor>(0);
+                d.DisplayName = "Old API display name";
+                d.Resources.Add("my-api");
+            });
+
+        OidcScopeSeedDescriptor userScope = new(scopeName, "New API display name", ["my-api"]);
+        OpenIddictSeedContributor contributor = CreateContributor(scopes: [userScope]);
+        await contributor.SeedAsync(Ctx, TestContext.Current.CancellationToken);
+
+        await _scopeManager.Received(1).UpdateAsync(
+            existingScope,
+            Arg.Any<OpenIddictScopeDescriptor>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SeedScopeAsync_ResourcesChanged_PerformsUpdate()
+    {
+        const string scopeName = "api";
+        object existingScope = new();
+        SetupStandardScopesNotFound(scopeName, existingScope);
+
+        _scopeManager.When(m => m.PopulateAsync(
+                Arg.Any<OpenIddictScopeDescriptor>(), existingScope, Arg.Any<CancellationToken>()))
+            .Do(ci =>
+            {
+                OpenIddictScopeDescriptor d = ci.ArgAt<OpenIddictScopeDescriptor>(0);
+                d.DisplayName = "API";
+                d.Resources.Add("old-resource");
+            });
+
+        OidcScopeSeedDescriptor userScope = new(scopeName, "API", ["new-resource"]);
+        OpenIddictSeedContributor contributor = CreateContributor(scopes: [userScope]);
+        await contributor.SeedAsync(Ctx, TestContext.Current.CancellationToken);
+
+        await _scopeManager.Received(1).UpdateAsync(
+            existingScope,
+            Arg.Is<OpenIddictScopeDescriptor>(d => d.Resources.Contains("new-resource")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SeedScopeAsync_ScopeNotFound_CreatesNew()
+    {
+        _scopeManager.FindByNameAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+
+        OidcScopeSeedDescriptor userScope = new("custom", "Custom scope", []);
+        OpenIddictSeedContributor contributor = CreateContributor(scopes: [userScope]);
+        await contributor.SeedAsync(Ctx, TestContext.Current.CancellationToken);
+
+        // 7 standard + 1 user scope = 8 creates, 0 updates
+        await _scopeManager.Received(8).CreateAsync(
+            Arg.Any<OpenIddictScopeDescriptor>(), Arg.Any<CancellationToken>());
+
+        await _scopeManager.DidNotReceive().UpdateAsync(
+            Arg.Any<object>(), Arg.Any<OpenIddictScopeDescriptor>(), Arg.Any<CancellationToken>());
+    }
+
+    // -------------------------------------------------------------------------
+    // SeedApplicationAsync — skip when already up to date
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SeedApplicationAsync_AlreadyUpToDate_SkipsUpdate()
+    {
+        _scopeManager.FindByNameAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+
+        const string clientId = "showcase-web";
+        object existingApp = new();
+        _appManager.FindByClientIdAsync(clientId, Arg.Any<CancellationToken>()).Returns(existingApp);
+
+        _appManager.When(m => m.PopulateAsync(
+                Arg.Any<OpenIddictApplicationDescriptor>(), existingApp, Arg.Any<CancellationToken>()))
+            .Do(ci =>
+            {
+                OpenIddictApplicationDescriptor d = ci.ArgAt<OpenIddictApplicationDescriptor>(0);
+                d.DisplayName = "Showcase Web";
+                d.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode);
+                d.RedirectUris.Add(new Uri("https://app.example.com/callback"));
+            });
+
+        OidcApplicationSeedDescriptor app = new(
+            ClientId: clientId,
+            ClientSecret: "secret",
+            DisplayName: "Showcase Web",
+            Permissions: [OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode],
+            RedirectUris: ["https://app.example.com/callback"],
+            PostLogoutRedirectUris: [],
+            SigningKeyJwk: null);
+
+        OpenIddictSeedContributor contributor = CreateContributor(apps: [app]);
+        await contributor.SeedAsync(Ctx, TestContext.Current.CancellationToken);
+
+        await _appManager.DidNotReceive().UpdateAsync(
+            existingApp,
+            Arg.Any<OpenIddictApplicationDescriptor>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SeedApplicationAsync_PermissionsChanged_PerformsUpdate()
+    {
+        _scopeManager.FindByNameAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+
+        const string clientId = "showcase-web";
+        object existingApp = new();
+        _appManager.FindByClientIdAsync(clientId, Arg.Any<CancellationToken>()).Returns(existingApp);
+
+        _appManager.When(m => m.PopulateAsync(
+                Arg.Any<OpenIddictApplicationDescriptor>(), existingApp, Arg.Any<CancellationToken>()))
+            .Do(ci =>
+            {
+                OpenIddictApplicationDescriptor d = ci.ArgAt<OpenIddictApplicationDescriptor>(0);
+                d.DisplayName = "Showcase Web";
+                // Current permissions are empty — new permission in seed config must trigger update
+            });
+
+        OidcApplicationSeedDescriptor app = new(
+            ClientId: clientId,
+            ClientSecret: "secret",
+            DisplayName: "Showcase Web",
+            Permissions: [OpenIddictConstants.Permissions.GrantTypes.ClientCredentials],
+            RedirectUris: [],
+            PostLogoutRedirectUris: [],
+            SigningKeyJwk: null);
+
+        OpenIddictSeedContributor contributor = CreateContributor(apps: [app]);
+        await contributor.SeedAsync(Ctx, TestContext.Current.CancellationToken);
+
+        await _appManager.Received(1).UpdateAsync(
+            existingApp,
+            Arg.Any<OpenIddictApplicationDescriptor>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SeedApplicationAsync_RedirectUriChanged_PerformsUpdate()
+    {
+        _scopeManager.FindByNameAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+
+        const string clientId = "showcase-web";
+        object existingApp = new();
+        _appManager.FindByClientIdAsync(clientId, Arg.Any<CancellationToken>()).Returns(existingApp);
+
+        _appManager.When(m => m.PopulateAsync(
+                Arg.Any<OpenIddictApplicationDescriptor>(), existingApp, Arg.Any<CancellationToken>()))
+            .Do(ci =>
+            {
+                OpenIddictApplicationDescriptor d = ci.ArgAt<OpenIddictApplicationDescriptor>(0);
+                d.DisplayName = "Showcase Web";
+                d.RedirectUris.Add(new Uri("https://old.example.com/callback"));
+            });
+
+        OidcApplicationSeedDescriptor app = new(
+            ClientId: clientId,
+            ClientSecret: "secret",
+            DisplayName: "Showcase Web",
+            Permissions: [],
+            RedirectUris: ["https://new.example.com/callback"],
+            PostLogoutRedirectUris: [],
+            SigningKeyJwk: null);
+
+        OpenIddictSeedContributor contributor = CreateContributor(apps: [app]);
+        await contributor.SeedAsync(Ctx, TestContext.Current.CancellationToken);
+
+        await _appManager.Received(1).UpdateAsync(
+            existingApp,
+            Arg.Any<OpenIddictApplicationDescriptor>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SeedApplicationAsync_AppNotFound_CreatesNew()
+    {
+        _scopeManager.FindByNameAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+        _appManager.FindByClientIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+
+        OidcApplicationSeedDescriptor app = new(
+            ClientId: "new-client",
+            ClientSecret: null,
+            DisplayName: "New Client",
+            Permissions: [],
+            RedirectUris: [],
+            PostLogoutRedirectUris: [],
+            SigningKeyJwk: null);
+
+        OpenIddictSeedContributor contributor = CreateContributor(apps: [app]);
+        await contributor.SeedAsync(Ctx, TestContext.Current.CancellationToken);
+
+        await _appManager.Received(1).CreateAsync(
+            Arg.Is<OpenIddictApplicationDescriptor>(d => d.ClientId == "new-client"),
+            Arg.Any<CancellationToken>());
+
+        await _appManager.DidNotReceive().UpdateAsync(
+            Arg.Any<object>(),
+            Arg.Any<OpenIddictApplicationDescriptor>(),
+            Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
Fix ConcurrencyException when migrator and API both seed at startup. Skip UpdateAsync if values already match.