### PR TITLE
ci(sbom): restrict to main + tags, run in parallel with pack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,9 +427,9 @@ jobs:
   # SBOM — CycloneDX JSON, uploaded as artifact and attached to GitHub releases
   # ---------------------------------------------------------------------------
   sbom:
-    needs: pack
+    needs: test
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write  # read for checkout, write for release asset upload
     steps:


### PR DESCRIPTION
## Summary

- Restrict SBOM generation to `main` branch and version tags only (was also running on every push to `develop`)
- Run the `sbom` job in parallel with `pack` — both depend on `test`, saving the full `pack` duration (~2-3 min) on the critical path

## Why

The SBOM is a release artifact, not a development artifact. Generating it on every merge to `develop` adds unnecessary CI time with no consumer for the output.

## Test plan

- [ ] Verify SBOM job does not trigger on a PR targeting `develop`
- [ ] Verify SBOM job triggers on push to `main`
- [ ] Verify SBOM job triggers on version tags (`v*.*.*`)
- [ ] Verify `publish-github` and `publish-nuget` still wait for `[pack, sbom]`
