### PR TITLE
feat(openiddict): add OIDC server passthrough endpoint handlers

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1121,6 +1121,7 @@
         "Granit.Caching",
         "Granit.Http.ApiDocumentation",
         "Granit.OpenIddict",
+        "Granit.OpenIddict.Server",
         "Granit.QueryEngine",
         "Granit.Validation"
       ],
@@ -21453,8 +21454,15 @@
       "kind": "class",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs",
-      "line": 29,
-      "members": []
+      "line": 32,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "OpenIddictEndpointsOptions",
@@ -21486,6 +21494,28 @@
           "name": "AdminTagName",
           "kind": "property",
           "signature": "string AdminTagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "OpenIddictServerEndpointsOptions",
+      "fqn": "Granit.OpenIddict.Endpoints.Options.OpenIddictServerEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.OpenIddict.Endpoints",
+      "file": "src/Granit.OpenIddict.Endpoints/Options/OpenIddictServerEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "LoginPath",
+          "kind": "property",
+          "signature": "string LoginPath",
+          "returnType": "string"
+        },
+        {
+          "name": "PostLogoutRedirectPath",
+          "kind": "property",
+          "signature": "string PostLogoutRedirectPath",
           "returnType": "string"
         }
       ]
@@ -21805,7 +21835,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs",
-      "line": 32,
+      "line": 33,
       "members": []
     },
     {
@@ -21814,7 +21844,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs",
-      "line": 47,
+      "line": 49,
       "members": []
     },
     {

--- a/src/Granit.Http.ApiDocumentation/packages.lock.json
+++ b/src/Granit.Http.ApiDocumentation/packages.lock.json
@@ -20,8 +20,8 @@
       "Scalar.AspNetCore": {
         "type": "Direct",
         "requested": "[2.*, )",
-        "resolved": "2.13.15",
-        "contentHash": "ufSBk0vdDnrhn+YLGElUdegUkM+hb7xUoySH+oaZrNHi2fAm+oeSCr60Lqmm4OeLBhPKd2htr/DANOvjuNT6rg=="
+        "resolved": "2.13.16",
+        "contentHash": "zOWRQLnD7RbcbqnEeP6oUQNy+JeyXDcgmyz3ui7O5QntW7CdbItSC+KOZYRgzaFqh9hPNgSlp1uuTn96Y+gfww=="
       },
       "Asp.Versioning.Abstractions": {
         "type": "Transitive",

--- a/src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs
@@ -27,7 +27,7 @@ public static class ObservabilityServiceCollectionExtensions
             .BindConfiguration(ObservabilityOptions.SectionName)
             // Apply smart fallbacks when the Observability section is absent or incomplete.
             // PostConfigure runs after BindConfiguration so explicit config always wins.
-            .PostConfigure<IHostEnvironment>((opts, env) =>
+            .PostConfigure<IHostEnvironment, IConfiguration>((opts, env, config) =>
             {
                 if (string.IsNullOrWhiteSpace(opts.ServiceName) || opts.ServiceName is "unknown-service")
                 {
@@ -37,6 +37,17 @@ public static class ObservabilityServiceCollectionExtensions
                 if (string.IsNullOrWhiteSpace(opts.Environment) || opts.Environment is "development")
                 {
                     opts.Environment = env.EnvironmentName.ToLowerInvariant();
+                }
+
+                // Respect OTEL_EXPORTER_OTLP_ENDPOINT injected by Aspire when OtlpEndpoint
+                // is not explicitly configured (still at default value).
+                if (opts.OtlpEndpoint is "http://localhost:4317")
+                {
+                    string? envEndpoint = config["OTEL_EXPORTER_OTLP_ENDPOINT"];
+                    if (!string.IsNullOrWhiteSpace(envEndpoint))
+                    {
+                        opts.OtlpEndpoint = envEndpoint;
+                    }
                 }
             })
             .ValidateDataAnnotations()
@@ -58,6 +69,17 @@ public static class ObservabilityServiceCollectionExtensions
         if (string.IsNullOrWhiteSpace(options.Environment) || options.Environment is "development")
         {
             options.Environment = builder.Environment.EnvironmentName.ToLowerInvariant();
+        }
+
+        // Respect OTEL_EXPORTER_OTLP_ENDPOINT injected by Aspire when OtlpEndpoint
+        // is not explicitly configured (still at default value).
+        if (options.OtlpEndpoint is "http://localhost:4317")
+        {
+            string? envEndpoint = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
+            if (!string.IsNullOrWhiteSpace(envEndpoint))
+            {
+                options.OtlpEndpoint = envEndpoint;
+            }
         }
 
         ConfigureSerilog(builder, options);

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs
@@ -1,0 +1,182 @@
+using System.Collections.Immutable;
+using System.Security.Claims;
+using Granit.Identity.Local.Domain;
+using Granit.OpenIddict.Endpoints.Internal;
+using Granit.OpenIddict.Endpoints.Options;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OpenIddict.Abstractions;
+using OpenIddict.Server.AspNetCore;
+
+namespace Granit.OpenIddict.Endpoints.Endpoints;
+
+/// <summary>
+/// OIDC authorization endpoint (<c>GET/POST /connect/authorize</c>).
+/// Validates user authentication, auto-grants consent for implicit clients,
+/// and issues an authorization code via OpenIddict.
+/// </summary>
+#pragma warning disable GRAPI001 // OpenIddict requires Results.SignIn/Forbid/Challenge with explicit auth scheme
+internal static partial class ConnectAuthorizationEndpoints
+{
+    internal static IEndpointRouteBuilder MapConnectAuthorizationEndpoints(
+        this IEndpointRouteBuilder endpoints,
+        OpenIddictServerEndpointsOptions options)
+    {
+        endpoints.MapMethods("/connect/authorize", ["GET", "POST"],
+                (Delegate)((HttpContext context) => HandleAuthorizeAsync(context, options)))
+            .AllowAnonymous()
+            .ExcludeFromDescription();
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> HandleAuthorizeAsync(
+        HttpContext context,
+        OpenIddictServerEndpointsOptions options)
+    {
+        OpenIddictRequest request = context.GetOpenIddictServerRequest()
+            ?? throw new InvalidOperationException("The OpenIddict server request is not available.");
+
+        ILogger logger = context.RequestServices
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger("Granit.OpenIddict.Endpoints.ConnectAuthorizationEndpoints");
+
+        // Authenticate the user via the Identity cookie.
+        AuthenticateResult authenticateResult = await context.AuthenticateAsync(
+            IdentityConstants.ApplicationScheme).ConfigureAwait(false);
+
+        if (!authenticateResult.Succeeded || authenticateResult.Principal is null)
+        {
+            // Not authenticated — challenge to redirect to the login page.
+            // The cookie handler appends ReturnUrl with the current request URI.
+            LogUnauthenticatedRedirect(logger, request.ClientId ?? "(null)");
+
+            return Results.Challenge(
+                new AuthenticationProperties
+                {
+                    RedirectUri = context.Request.PathBase + context.Request.Path + context.Request.QueryString,
+                },
+                [IdentityConstants.ApplicationScheme]);
+        }
+
+        // Resolve the application to check consent type.
+        IOpenIddictApplicationManager applicationManager = context.RequestServices
+            .GetRequiredService<IOpenIddictApplicationManager>();
+
+        object? application = await applicationManager
+            .FindByClientIdAsync(request.ClientId!, context.RequestAborted)
+            .ConfigureAwait(false);
+
+        if (application is null)
+        {
+            LogApplicationNotFound(logger, request.ClientId!);
+            return Results.Forbid(
+                authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
+        }
+
+        // Check consent type — only implicit and systematic are auto-granted in v1.
+        string? consentType = await applicationManager
+            .GetConsentTypeAsync(application, context.RequestAborted)
+            .ConfigureAwait(false);
+
+        if (!string.Equals(consentType, OpenIddictConstants.ConsentTypes.Implicit, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(consentType, OpenIddictConstants.ConsentTypes.Systematic, StringComparison.OrdinalIgnoreCase))
+        {
+            LogExplicitConsentNotSupported(logger, request.ClientId!, consentType ?? "(null)");
+            return Results.Forbid(
+                authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
+        }
+
+        // Resolve the user.
+        UserManager<GranitUser> userManager = context.RequestServices
+            .GetRequiredService<UserManager<GranitUser>>();
+        GranitUser? user = await userManager
+            .GetUserAsync(authenticateResult.Principal)
+            .ConfigureAwait(false);
+
+        if (user is null)
+        {
+            LogUserNotFound(logger);
+            return Results.Forbid(
+                authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
+        }
+
+        // Build the principal with requested scopes.
+        ImmutableArray<string> scopes = request.GetScopes();
+        OidcPrincipalFactory principalFactory = context.RequestServices
+            .GetRequiredService<OidcPrincipalFactory>();
+
+        ClaimsPrincipal principal = await principalFactory
+            .CreateUserPrincipalAsync(
+                user, scopes, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,
+                context.RequestAborted)
+            .ConfigureAwait(false);
+
+        // Reuse or create an authorization for this subject + client + scopes.
+        IOpenIddictAuthorizationManager authorizationManager = context.RequestServices
+            .GetRequiredService<IOpenIddictAuthorizationManager>();
+        string? applicationId = await applicationManager
+            .GetIdAsync(application, context.RequestAborted)
+            .ConfigureAwait(false);
+
+        object? authorization = null;
+        List<object> authorizations = [];
+
+        await foreach (object auth in authorizationManager.FindAsync(
+            subject: user.Id.ToString(),
+            client: applicationId!,
+            status: OpenIddictConstants.Statuses.Valid,
+            type: OpenIddictConstants.AuthorizationTypes.Permanent,
+            scopes: scopes,
+            cancellationToken: context.RequestAborted).ConfigureAwait(false))
+        {
+            authorizations.Add(auth);
+        }
+
+        authorization = authorizations.Find(_ => true);
+
+        if (authorization is null)
+        {
+            authorization = await authorizationManager.CreateAsync(
+                principal: principal,
+                subject: user.Id.ToString(),
+                client: applicationId!,
+                type: OpenIddictConstants.AuthorizationTypes.Permanent,
+                scopes: scopes,
+                cancellationToken: context.RequestAborted).ConfigureAwait(false);
+        }
+
+        string? authorizationId = await authorizationManager
+            .GetIdAsync(authorization, context.RequestAborted)
+            .ConfigureAwait(false);
+        principal.SetAuthorizationId(authorizationId);
+
+        LogAuthorizationGranted(logger, user.Id.ToString(), request.ClientId!);
+
+        return Results.SignIn(principal,
+            authenticationScheme: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+    }
+
+    // ──── Source-generated log messages ────
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Authorization: unauthenticated user redirected to login for client '{ClientId}'")]
+    private static partial void LogUnauthenticatedRedirect(ILogger logger, string clientId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Authorization: application '{ClientId}' not found")]
+    private static partial void LogApplicationNotFound(ILogger logger, string clientId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Authorization: explicit consent not supported for client '{ClientId}' (consent type: '{ConsentType}')")]
+    private static partial void LogExplicitConsentNotSupported(ILogger logger, string clientId, string consentType);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Authorization: authenticated user not found in identity store")]
+    private static partial void LogUserNotFound(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Authorization granted for subject '{Subject}' to client '{ClientId}'")]
+    private static partial void LogAuthorizationGranted(ILogger logger, string subject, string clientId);
+}

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectLogoutEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectLogoutEndpoints.cs
@@ -1,0 +1,42 @@
+using Granit.OpenIddict.Endpoints.Options;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Routing;
+using OpenIddict.Server.AspNetCore;
+
+namespace Granit.OpenIddict.Endpoints.Endpoints;
+
+/// <summary>
+/// OIDC end-session endpoint (<c>GET/POST /connect/logout</c>).
+/// Signs out the Identity cookie and lets OpenIddict handle the post-logout redirect.
+/// </summary>
+#pragma warning disable GRAPI001 // OpenIddict requires Results.SignOut with explicit auth scheme
+internal static class ConnectLogoutEndpoints
+{
+    internal static IEndpointRouteBuilder MapConnectLogoutEndpoints(
+        this IEndpointRouteBuilder endpoints,
+        OpenIddictServerEndpointsOptions options)
+    {
+        endpoints.MapMethods("/connect/logout", ["GET", "POST"],
+                (Delegate)((HttpContext context) => HandleLogoutAsync(context, options)))
+            .AllowAnonymous()
+            .ExcludeFromDescription();
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> HandleLogoutAsync(
+        HttpContext context,
+        OpenIddictServerEndpointsOptions options)
+    {
+        // Sign out the Identity application cookie.
+        await context.SignOutAsync(IdentityConstants.ApplicationScheme).ConfigureAwait(false);
+
+        // Let OpenIddict handle post_logout_redirect_uri validation and redirect.
+        return Results.SignOut(
+            new AuthenticationProperties { RedirectUri = options.PostLogoutRedirectPath },
+            [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
+    }
+}

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
@@ -1,0 +1,155 @@
+using System.Collections.Immutable;
+using System.Security.Claims;
+using Granit.Identity.Local.Domain;
+using Granit.MultiTenancy;
+using Granit.OpenIddict.Diagnostics;
+using Granit.OpenIddict.Endpoints.Internal;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OpenIddict.Abstractions;
+using OpenIddict.Server.AspNetCore;
+
+namespace Granit.OpenIddict.Endpoints.Endpoints;
+
+/// <summary>
+/// OIDC token endpoint (<c>POST /connect/token</c>).
+/// Handles authorization_code, client_credentials, and refresh_token grant types.
+/// </summary>
+#pragma warning disable GRAPI001 // OpenIddict requires Results.SignIn/Forbid with explicit auth scheme
+#pragma warning disable GRAPI003 // Private handler methods — not exposed as endpoint parameters
+internal static partial class ConnectTokenEndpoints
+{
+    internal static IEndpointRouteBuilder MapConnectTokenEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapPost("/connect/token", (Delegate)HandleTokenAsync)
+            .ExcludeFromDescription();
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> HandleTokenAsync(HttpContext context)
+    {
+        OpenIddictRequest request = context.GetOpenIddictServerRequest()
+            ?? throw new InvalidOperationException("The OpenIddict server request is not available.");
+
+        OidcPrincipalFactory principalFactory = context.RequestServices
+            .GetRequiredService<OidcPrincipalFactory>();
+        OpenIddictMetrics metrics = context.RequestServices
+            .GetRequiredService<OpenIddictMetrics>();
+        ILogger logger = context.RequestServices
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger("Granit.OpenIddict.Endpoints.ConnectTokenEndpoints");
+        ICurrentTenant? currentTenant = context.RequestServices
+            .GetService<ICurrentTenant>();
+        string? tenantId = currentTenant is { IsAvailable: true } ? currentTenant.Id?.ToString() : null;
+
+        if (request.IsAuthorizationCodeGrantType() || request.IsRefreshTokenGrantType())
+        {
+            return await HandleCodeOrRefreshAsync(
+                context, request, principalFactory, metrics, logger, tenantId)
+                .ConfigureAwait(false);
+        }
+
+        if (request.IsClientCredentialsGrantType())
+        {
+            return HandleClientCredentials(request, principalFactory, metrics, logger, tenantId);
+        }
+
+        LogUnsupportedGrantType(logger, request.GrantType ?? "(null)");
+        return Results.Forbid(
+            authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
+    }
+
+    private static async Task<IResult> HandleCodeOrRefreshAsync(
+        HttpContext context,
+        OpenIddictRequest request,
+        OidcPrincipalFactory principalFactory,
+        OpenIddictMetrics metrics,
+        ILogger logger,
+        string? tenantId)
+    {
+        // OpenIddict has already validated the code/refresh_token — authenticate to get the principal.
+        AuthenticateResult authenticateResult = await context.AuthenticateAsync(
+            OpenIddictServerAspNetCoreDefaults.AuthenticationScheme).ConfigureAwait(false);
+
+        if (!authenticateResult.Succeeded || authenticateResult.Principal is null)
+        {
+            LogAuthenticationFailed(logger, request.GrantType!);
+            metrics.RecordAuthenticationFailure(tenantId, "invalid_token");
+            return Results.Forbid(
+                authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
+        }
+
+        // Retrieve the user from the subject claim.
+        string? subject = authenticateResult.Principal.GetClaim(OpenIddictConstants.Claims.Subject);
+        UserManager<GranitUser> userManager = context.RequestServices
+            .GetRequiredService<UserManager<GranitUser>>();
+
+        GranitUser? user = subject is not null
+            ? await userManager.FindByIdAsync(subject).ConfigureAwait(false)
+            : null;
+
+        if (user is null)
+        {
+            LogUserNotFound(logger, subject ?? "(null)");
+            metrics.RecordAuthenticationFailure(tenantId, "invalid_credentials");
+            return Results.Forbid(
+                authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
+        }
+
+        // Rebuild the principal with up-to-date claims.
+        // Preserve scopes from the original principal (including offline_access for refresh tokens).
+        ImmutableArray<string> scopes = authenticateResult.Principal.GetScopes();
+
+        ClaimsPrincipal principal = await principalFactory.CreateUserPrincipalAsync(
+            user, scopes, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme)
+            .ConfigureAwait(false);
+
+        string grantType = request.GrantType!;
+        metrics.RecordTokenIssued(tenantId, grantType);
+        metrics.RecordAuthenticationSuccess(tenantId, grantType);
+        LogTokenIssued(logger, user.Id.ToString(), grantType);
+
+        return Results.SignIn(principal,
+            authenticationScheme: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+    }
+
+    private static IResult HandleClientCredentials(
+        OpenIddictRequest request,
+        OidcPrincipalFactory principalFactory,
+        OpenIddictMetrics metrics,
+        ILogger logger,
+        string? tenantId)
+    {
+        ClaimsPrincipal principal = OidcPrincipalFactory.CreateClientPrincipal(
+            request.ClientId!,
+            request.GetScopes(),
+            OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+
+        metrics.RecordTokenIssued(tenantId, "client_credentials");
+        LogTokenIssued(logger, request.ClientId!, "client_credentials");
+
+        return Results.SignIn(principal,
+            authenticationScheme: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+    }
+
+    // ──── Source-generated log messages ────
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Token issued for subject '{Subject}' using grant type '{GrantType}'")]
+    private static partial void LogTokenIssued(ILogger logger, string subject, string grantType);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Token authentication failed for grant type '{GrantType}'")]
+    private static partial void LogAuthenticationFailed(ILogger logger, string grantType);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Token request denied: user '{Subject}' not found")]
+    private static partial void LogUserNotFound(ILogger logger, string subject);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Unsupported grant type '{GrantType}'")]
+    private static partial void LogUnsupportedGrantType(ILogger logger, string grantType);
+}

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectUserInfoEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectUserInfoEndpoints.cs
@@ -1,0 +1,114 @@
+using System.Collections.Immutable;
+using System.Security.Claims;
+using Granit.Identity.Local.Domain;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using OpenIddict.Abstractions;
+using OpenIddict.Server.AspNetCore;
+
+namespace Granit.OpenIddict.Endpoints.Endpoints;
+
+/// <summary>
+/// OIDC UserInfo endpoint (<c>GET /connect/userinfo</c>).
+/// Returns user claims based on the granted scopes in the access token.
+/// </summary>
+#pragma warning disable GRAPI001 // OpenIddict requires Results.Forbid with explicit auth scheme
+internal static class ConnectUserInfoEndpoints
+{
+    internal static IEndpointRouteBuilder MapConnectUserInfoEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/connect/userinfo", (Delegate)HandleUserInfoAsync)
+            .ExcludeFromDescription();
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> HandleUserInfoAsync(HttpContext context)
+    {
+        // OpenIddict has already validated the access token via the middleware.
+        AuthenticateResult authenticateResult = await context.AuthenticateAsync(
+            OpenIddictServerAspNetCoreDefaults.AuthenticationScheme).ConfigureAwait(false);
+
+        if (!authenticateResult.Succeeded || authenticateResult.Principal is null)
+        {
+            return Results.Forbid(
+                authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
+        }
+
+        ClaimsPrincipal principal = authenticateResult.Principal;
+        string? subject = principal.GetClaim(OpenIddictConstants.Claims.Subject);
+
+        if (string.IsNullOrEmpty(subject))
+        {
+            return Results.Forbid(
+                authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
+        }
+
+        UserManager<GranitUser> userManager = context.RequestServices
+            .GetRequiredService<UserManager<GranitUser>>();
+        GranitUser? user = await userManager.FindByIdAsync(subject).ConfigureAwait(false);
+
+        if (user is null)
+        {
+            return Results.Forbid(
+                authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
+        }
+
+        // Build claims based on granted scopes.
+        ImmutableArray<string> scopes = principal.GetScopes();
+        Dictionary<string, object> claims = new(StringComparer.Ordinal)
+        {
+            [OpenIddictConstants.Claims.Subject] = subject,
+        };
+
+        if (scopes.Contains(OpenIddictConstants.Scopes.Profile))
+        {
+            if (user.UserName is not null)
+            {
+                claims[OpenIddictConstants.Claims.PreferredUsername] = user.UserName;
+            }
+
+            if (user.FirstName is not null || user.LastName is not null)
+            {
+                claims[OpenIddictConstants.Claims.Name] = $"{user.FirstName} {user.LastName}".Trim();
+            }
+
+            if (user.FirstName is not null)
+            {
+                claims[OpenIddictConstants.Claims.GivenName] = user.FirstName;
+            }
+
+            if (user.LastName is not null)
+            {
+                claims[OpenIddictConstants.Claims.FamilyName] = user.LastName;
+            }
+        }
+
+        if (scopes.Contains(OpenIddictConstants.Scopes.Email) && user.Email is not null)
+        {
+            claims[OpenIddictConstants.Claims.Email] = user.Email;
+            claims[OpenIddictConstants.Claims.EmailVerified] = user.EmailConfirmed;
+        }
+
+        if (scopes.Contains(OpenIddictConstants.Scopes.Phone) && user.PhoneNumber is not null)
+        {
+            claims[OpenIddictConstants.Claims.PhoneNumber] = user.PhoneNumber;
+            claims[OpenIddictConstants.Claims.PhoneNumberVerified] = user.PhoneNumberConfirmed;
+        }
+
+        if (scopes.Contains(OpenIddictConstants.Scopes.Roles))
+        {
+            IList<string> roles = await userManager.GetRolesAsync(user).ConfigureAwait(false);
+            if (roles.Count > 0)
+            {
+                claims[OpenIddictConstants.Claims.Role] = roles;
+            }
+        }
+
+        return Results.Ok(claims);
+    }
+}

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectVerifyEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectVerifyEndpoints.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.OpenIddict.Endpoints.Endpoints;
+
+/// <summary>
+/// OIDC end-user verification endpoint (<c>GET/POST /connect/verify</c>).
+/// Stub implementation — device authorization flow is not yet supported.
+/// </summary>
+internal static class ConnectVerifyEndpoints
+{
+    internal static IEndpointRouteBuilder MapConnectVerifyEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapMethods("/connect/verify", ["GET", "POST"],
+                () => TypedResults.Problem(
+                    detail: "Device authorization verification is not yet implemented.",
+                    statusCode: StatusCodes.Status501NotImplemented))
+            .AllowAnonymous()
+            .ExcludeFromDescription();
+
+        return endpoints;
+    }
+}

--- a/src/Granit.OpenIddict.Endpoints/Extensions/OpenIddictEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.Endpoints/Extensions/OpenIddictEndpointRouteBuilderExtensions.cs
@@ -47,4 +47,40 @@ public static class OpenIddictEndpointRouteBuilderExtensions
 
         return accountGroup;
     }
+
+    /// <summary>
+    /// Maps the OIDC server protocol endpoints (<c>/connect/authorize</c>,
+    /// <c>/connect/token</c>, <c>/connect/userinfo</c>, <c>/connect/logout</c>,
+    /// <c>/connect/verify</c>).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These are OpenIddict passthrough handlers — the OpenIddict middleware validates
+    /// protocol parameters (client authentication, scopes, PKCE, redirect URIs) and
+    /// passes through to these handlers for business logic (user authentication,
+    /// consent, token issuance).
+    /// </para>
+    /// <para>
+    /// Routes are mapped at the root path (<c>/connect/*</c>) without API versioning
+    /// or group prefix. They are excluded from OpenAPI documentation.
+    /// </para>
+    /// </remarks>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="configure">Optional delegate to customize <see cref="OpenIddictServerEndpointsOptions"/>.</param>
+    /// <returns>The endpoint route builder for chaining.</returns>
+    public static IEndpointRouteBuilder MapOpenIddictServerEndpoints(
+        this IEndpointRouteBuilder endpoints,
+        Action<OpenIddictServerEndpointsOptions>? configure = null)
+    {
+        OpenIddictServerEndpointsOptions options = new();
+        configure?.Invoke(options);
+
+        endpoints.MapConnectAuthorizationEndpoints(options);
+        endpoints.MapConnectTokenEndpoints();
+        endpoints.MapConnectUserInfoEndpoints();
+        endpoints.MapConnectLogoutEndpoints(options);
+        endpoints.MapConnectVerifyEndpoints();
+
+        return endpoints;
+    }
 }

--- a/src/Granit.OpenIddict.Endpoints/Granit.OpenIddict.Endpoints.csproj
+++ b/src/Granit.OpenIddict.Endpoints/Granit.OpenIddict.Endpoints.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\Granit.Caching\Granit.Caching.csproj" />
     <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
     <ProjectReference Include="..\Granit.OpenIddict\Granit.OpenIddict.csproj" />
+    <ProjectReference Include="..\Granit.OpenIddict.Server\Granit.OpenIddict.Server.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine\Granit.QueryEngine.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
   </ItemGroup>

--- a/src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs
+++ b/src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs
@@ -2,15 +2,18 @@ using Granit.Authorization;
 using Granit.Caching;
 using Granit.Http.ApiDocumentation;
 using Granit.Modularity;
+using Granit.OpenIddict.Endpoints.Internal;
 using Granit.QueryEngine;
 using Granit.Validation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Granit.OpenIddict.Endpoints;
 
 /// <summary>
-/// Module for OpenIddict REST API endpoints: account self-service (<c>/api/account</c>)
-/// and admin management (<c>/api/admin/users</c>, <c>/api/admin/roles</c>,
-/// <c>/api/admin/groups</c>, <c>/api/admin/oidc</c>).
+/// Module for OpenIddict REST API endpoints: account self-service (<c>/api/account</c>),
+/// admin management (<c>/api/admin/oidc</c>), and OIDC server protocol endpoints
+/// (<c>/connect/*</c>).
 /// </summary>
 /// <remarks>
 /// <para>Permission definition providers are auto-discovered by <c>GranitAuthorizationModule</c>.</para>
@@ -26,4 +29,11 @@ namespace Granit.OpenIddict.Endpoints;
     typeof(GranitOpenIddictModule),
     typeof(GranitQueryEngineModule),
     typeof(GranitValidationModule))]
-public sealed class GranitOpenIddictEndpointsModule : GranitModule;
+public sealed class GranitOpenIddictEndpointsModule : GranitModule
+{
+    /// <inheritdoc />
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.TryAddScoped<OidcPrincipalFactory>();
+    }
+}

--- a/src/Granit.OpenIddict.Endpoints/Internal/OidcPrincipalFactory.cs
+++ b/src/Granit.OpenIddict.Endpoints/Internal/OidcPrincipalFactory.cs
@@ -1,0 +1,113 @@
+using System.Collections.Immutable;
+using System.Security.Claims;
+using Granit.Identity.Local.Domain;
+using Granit.OpenIddict.Extensions;
+using Granit.OpenIddict.Services;
+using Microsoft.AspNetCore.Identity;
+using OpenIddict.Abstractions;
+
+namespace Granit.OpenIddict.Endpoints.Internal;
+
+/// <summary>
+/// Builds a <see cref="ClaimsPrincipal"/> from a <see cref="GranitUser"/> for OIDC token issuance.
+/// Isolated from OpenIddict-specific types so the logic is reusable with other OIDC providers.
+/// </summary>
+internal sealed class OidcPrincipalFactory(
+    UserManager<GranitUser> userManager,
+    IClaimsDestinationProvider destinationProvider)
+{
+    /// <summary>
+    /// Creates a <see cref="ClaimsPrincipal"/> with standard OIDC claims from the user,
+    /// sets requested scopes, and applies claim destinations.
+    /// </summary>
+    /// <param name="user">The authenticated user.</param>
+    /// <param name="scopes">The requested OIDC scopes.</param>
+    /// <param name="authenticationScheme">The authentication scheme for the <see cref="ClaimsIdentity"/>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A principal ready for token issuance.</returns>
+    internal async Task<ClaimsPrincipal> CreateUserPrincipalAsync(
+        GranitUser user,
+        ImmutableArray<string> scopes,
+        string authenticationScheme,
+        CancellationToken cancellationToken = default)
+    {
+        ClaimsIdentity identity = new(authenticationScheme);
+
+        // Subject (mandatory)
+        identity.AddClaim(OpenIddictConstants.Claims.Subject, user.Id.ToString());
+
+        // Profile claims
+        if (user.UserName is not null)
+        {
+            identity.AddClaim(OpenIddictConstants.Claims.PreferredUsername, user.UserName);
+        }
+
+        if (user.FirstName is not null || user.LastName is not null)
+        {
+            string fullName = $"{user.FirstName} {user.LastName}".Trim();
+            identity.AddClaim(OpenIddictConstants.Claims.Name, fullName);
+        }
+
+        if (user.FirstName is not null)
+        {
+            identity.AddClaim(OpenIddictConstants.Claims.GivenName, user.FirstName);
+        }
+
+        if (user.LastName is not null)
+        {
+            identity.AddClaim(OpenIddictConstants.Claims.FamilyName, user.LastName);
+        }
+
+        // Email
+        if (user.Email is not null)
+        {
+            identity.AddClaim(OpenIddictConstants.Claims.Email, user.Email);
+            identity.AddClaim(OpenIddictConstants.Claims.EmailVerified,
+                user.EmailConfirmed ? "true" : "false");
+        }
+
+        // Phone
+        if (user.PhoneNumber is not null)
+        {
+            identity.AddClaim(OpenIddictConstants.Claims.PhoneNumber, user.PhoneNumber);
+            identity.AddClaim(OpenIddictConstants.Claims.PhoneNumberVerified,
+                user.PhoneNumberConfirmed ? "true" : "false");
+        }
+
+        // Roles
+        IList<string> roles = await userManager.GetRolesAsync(user).ConfigureAwait(false);
+        foreach (string role in roles)
+        {
+            identity.AddClaim(OpenIddictConstants.Claims.Role, role);
+        }
+
+        // Custom claims from UserManager store
+        IList<Claim> customClaims = await userManager.GetClaimsAsync(user).ConfigureAwait(false);
+        identity.AddClaims(customClaims);
+
+        // Scopes
+        identity.SetScopes(scopes);
+
+        // Destinations
+        ClaimsPrincipal principal = new(identity);
+        principal.SetDestinations(destinationProvider);
+
+        return principal;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="ClaimsPrincipal"/> for client credentials (no user).
+    /// </summary>
+    internal static ClaimsPrincipal CreateClientPrincipal(
+        string clientId,
+        ImmutableArray<string> scopes,
+        string authenticationScheme)
+    {
+        ClaimsIdentity identity = new(authenticationScheme);
+        identity.AddClaim(OpenIddictConstants.Claims.Subject, clientId);
+        identity.SetScopes(scopes);
+        identity.SetDestinations(static _ => [OpenIddictConstants.Destinations.AccessToken]);
+
+        return new ClaimsPrincipal(identity);
+    }
+}

--- a/src/Granit.OpenIddict.Endpoints/Options/OpenIddictServerEndpointsOptions.cs
+++ b/src/Granit.OpenIddict.Endpoints/Options/OpenIddictServerEndpointsOptions.cs
@@ -1,0 +1,20 @@
+namespace Granit.OpenIddict.Endpoints.Options;
+
+/// <summary>
+/// Options for the OIDC server protocol endpoints (<c>/connect/*</c>).
+/// </summary>
+public sealed class OpenIddictServerEndpointsOptions
+{
+    /// <summary>
+    /// Path to redirect unauthenticated users during authorization.
+    /// The cookie authentication handler appends a <c>ReturnUrl</c> query parameter.
+    /// Default: <c>"/account/login"</c>.
+    /// </summary>
+    public string LoginPath { get; set; } = "/account/login";
+
+    /// <summary>
+    /// Fallback path to redirect after logout when no <c>post_logout_redirect_uri</c>
+    /// is specified in the OIDC request. Default: <c>"/"</c>.
+    /// </summary>
+    public string PostLogoutRedirectPath { get; set; } = "/";
+}

--- a/src/Granit.OpenIddict.Endpoints/packages.lock.json
+++ b/src/Granit.OpenIddict.Endpoints/packages.lock.json
@@ -31,10 +31,84 @@
         "resolved": "10.0.3",
         "contentHash": "lVABgJTyTUNE7Bi0bSu4dWHiCHIXEGzTh/kLh0N07IgU/tIKwTeBPp8tgV4x2iKj4h7iPLo8oXzyHmLDGtAE1g=="
       },
+      "Microsoft.Extensions.AmbientMetadata.Application": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "Oh/FQJrTZqiqZuFktqDCwLFgxIUnNATZx46AwUTf5A/+FmK/TzPf/iwSqMK85QlioLD9ehOxWe0NBfsCSkp5pw=="
+      },
+      "Microsoft.Extensions.Compliance.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "b3gmxtyX0n8bQFuZ679f8QiOWqjeZKFc6XXPUsYNFzMcWi0Q44Ej3pB41N/QQ0maX380kmOMF36bLSBHNThXAg=="
+      },
+      "Microsoft.Extensions.DependencyInjection.AutoActivation": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "g6/S5rhP1XNBqeDa9zKXri/uDKe6gjzSqGsocuySb1OdVm8fz/M9YcWTJsCw5RHF8xIb/B3NgsfBPQF9Emjk3Q=="
+      },
+      "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "TZAZsAFThNQDqCnWaGxV/X7OPSA7b+kY7wNTPNvPvSWa0jcTbmGVyzIY/feF4OgyAUUdzSnnLW6ri2Q+4keM4A=="
+      },
+      "Microsoft.Extensions.Http.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "/xuNWNxI4WLVatiTvaqfLd5ijFhQ/qvE14bOyWxeEWmXJkjh/g2G/5TdzMfoe0afq16OdWLGbrD9gWHo178hbg==",
+        "dependencies": {
+          "Microsoft.Extensions.Telemetry": "10.3.0"
+        }
+      },
+      "Microsoft.Extensions.Http.Polly": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "Dl3wUj5Fdk6AuPDCDBBcpnAW/mYfmfr+48g3fE4JCQiVSIjLGqjg1tyw5/dZnLHlC+tgzr6rntD7bBgigpZBhw==",
+        "dependencies": {
+          "Polly": "7.2.4",
+          "Polly.Extensions.Http": "3.0.0"
+        }
+      },
+      "Microsoft.Extensions.Resilience": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "xc0dZuPkBaVIdMlODDppmNY/dxE27wIQ46gTzStoFXO4/yVcOMKlPmtr9vTP4edyXBRizGxPtcAFmqxZ5gPTkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.3.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.3.0",
+          "Polly.Extensions": "8.4.2",
+          "Polly.RateLimiting": "8.4.2"
+        }
+      },
+      "Microsoft.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "M1esrIGmwU2JBY0JpwdlUTXTNBXSBFEs+41bYBd59+9/vCaXw+vGhtYcCL+JXeGmxTLUHmuXcKbX/uVCSFcuzA==",
+        "dependencies": {
+          "Microsoft.Extensions.AmbientMetadata.Application": "10.3.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.3.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.3.0"
+        }
+      },
+      "Microsoft.Extensions.Telemetry.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "aKxH6ZsGAewGF8uSXyx1WkjqItwZA+hd1hhQ/4i7o5injCWSdr9vIZ3R3djJfy8OG3xaWK+LZY/+slVvlnwEHw==",
+        "dependencies": {
+          "Microsoft.Extensions.Compliance.Abstractions": "10.3.0"
+        }
+      },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
         "resolved": "8.16.0",
         "contentHash": "gSxKLWRZzBpIsEoeUPkxfywNCCvRvl7hkq146XHPk5vOQc9izSf1I+uL1vh4y2U19QPxd9Z8K/8AdWyxYz2lSg=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "prBU72cIP4V8E9fhN+o/YdskTsLeIcnKPbhZf0X6mD7fdxoZqnS/NdEkSr+9Zp+2q7OZBOMfNBKGbTbhXODO4w==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
@@ -42,6 +116,14 @@
         "contentHash": "MTzXmETkNQPACR7/XCXM1OGM6oU9RkyibqeJRtO9Ndew2LnGjMf9Atqj2VSf4XC27X0FQycUAlzxxEgQMWn2xQ==",
         "dependencies": {
           "Microsoft.IdentityModel.Abstractions": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "UFrU7d46UTsPQTa2HIEIpB9H1uJe1BW9FLw5uhEJ2ZuKdur8bcUA/bO5caq5dlBt5gNJeRIB3QQXYNs5fCQCZA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
@@ -65,6 +147,43 @@
           "Microsoft.IdentityModel.Tokens": "8.16.0"
         }
       },
+      "OpenIddict.Client": {
+        "type": "Transitive",
+        "resolved": "7.4.0",
+        "contentHash": "OXIa4LdLlRX61xq/9y/57ZcWxg4QvQvjbP/imGEUToETYWrIwEqje5KPFnpO7V3eVDXgl1acfanGo5BnoK6Yjw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Protocols": "8.16.0",
+          "OpenIddict.Abstractions": "7.4.0"
+        }
+      },
+      "OpenIddict.Client.SystemIntegration": {
+        "type": "Transitive",
+        "resolved": "7.4.0",
+        "contentHash": "0iEpO+TZ7CxWV+Wydiaaue8PKLvmOy13hLhLiewT3p8JZm8xkKBnC3qoKbFUYEHn7Z2ZdIpCUvkJIrb7aF7VBA==",
+        "dependencies": {
+          "OpenIddict.Client": "7.4.0"
+        }
+      },
+      "OpenIddict.Client.SystemNetHttp": {
+        "type": "Transitive",
+        "resolved": "7.4.0",
+        "contentHash": "0jYaa6Ezg5CVcmZhiDcxKrAMS1Lwlju84VpqJw/YBnQ9IISvmLrSRSCDfJ1dZKeSeX9DMTyUV8ng3F3JqyhgDQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Polly": "10.0.3",
+          "Microsoft.Extensions.Http.Resilience": "10.3.0",
+          "OpenIddict.Client": "7.4.0"
+        }
+      },
+      "OpenIddict.Client.WebIntegration": {
+        "type": "Transitive",
+        "resolved": "7.4.0",
+        "contentHash": "vYsEVPxoPxVwylkechXoF0mokts+FyFoL/46i9eWi2J05KbNbErBz43rEwVmq0qFn6ou0gQZ25dj+f8PA9rOlQ==",
+        "dependencies": {
+          "OpenIddict.Client": "7.4.0",
+          "OpenIddict.Client.SystemNetHttp": "7.4.0"
+        }
+      },
       "OpenIddict.Core": {
         "type": "Transitive",
         "resolved": "7.4.0",
@@ -77,6 +196,68 @@
         "type": "Transitive",
         "resolved": "7.4.0",
         "contentHash": "n13CeYAPImXpM2Vb83dCQoMSC2VYPgRp2q4GLp4YG/TA5Qd+X/Jza6eG+MLwx/2mYt8Xhxp+fVusDrUlpe8ZkA=="
+      },
+      "OpenIddict.Server": {
+        "type": "Transitive",
+        "resolved": "7.4.0",
+        "contentHash": "ZzFZWuPZS5NKzQq7V+u6lzgU56IhfJRxoTbySdimv1OYYsqOhEFRq19gCZMWBNCYOTHBxipAPdjnAXFytyGtrw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "OpenIddict.Abstractions": "7.4.0"
+        }
+      },
+      "OpenIddict.Validation": {
+        "type": "Transitive",
+        "resolved": "7.4.0",
+        "contentHash": "SrRjeHnMF7h1hY0ZykQVyI4t+PmJ3Gq1PhQJr+LuLcO+fYkpEqyfCRdOxY+ThnXQJjSOYQxLhrBRg0u330TnKw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Protocols": "8.16.0",
+          "OpenIddict.Abstractions": "7.4.0"
+        }
+      },
+      "OpenIddict.Validation.ServerIntegration": {
+        "type": "Transitive",
+        "resolved": "7.4.0",
+        "contentHash": "7X9uh3T64DroGN0AQgXKC9FDjvWV7IBtW3yTjEdzk0ZqeXKEuTRPzrJdfUwkMx/60iLhAX8zQ2TToO15Z7i5pA==",
+        "dependencies": {
+          "OpenIddict.Server": "7.4.0",
+          "OpenIddict.Validation": "7.4.0"
+        }
+      },
+      "Polly": {
+        "type": "Transitive",
+        "resolved": "7.2.4",
+        "contentHash": "bw00Ck5sh6ekduDE3mnCo1ohzuad946uslCDEENu3091+6UKnBuKLo4e+yaNcCzXxOZCXWY2gV4a35+K1d4LDA=="
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "BpE2I6HBYYA5tF0Vn4eoQOGYTYIK1BlF5EXVgkWGn3mqUUjbXAr13J6fZVbp7Q3epRR8yshacBMlsHMhpOiV3g=="
+      },
+      "Polly.Extensions": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "GZ9vRVmR0jV2JtZavt+pGUsQ1O1cuRKG7R7VOZI6ZDy9y6RNPvRvXK1tuS4ffUrv8L0FTea59oEuQzgS0R7zSA==",
+        "dependencies": {
+          "Polly.Core": "8.4.2"
+        }
+      },
+      "Polly.Extensions.Http": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "drrG+hB3pYFY7w1c3BD+lSGYvH2oIclH8GRSehgfyP5kjnFnHKQuuBhuHLv+PWyFuaTDyk/vfRpnxOzd11+J8g==",
+        "dependencies": {
+          "Polly": "7.1.0"
+        }
+      },
+      "Polly.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "ehTImQ/eUyO07VYW2WvwSmU9rRH200SKJ/3jku9rOkyWE0A2JxNFmAVms8dSn49QLSjmjFRRSgfNyOgr/2PSmA==",
+        "dependencies": {
+          "Polly.Core": "8.4.2"
+        }
       },
       "ZString": {
         "type": "Transitive",
@@ -169,6 +350,15 @@
           "OpenIddict.EntityFrameworkCore": "[7.*, )"
         }
       },
+      "granit.openiddict.server": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.OpenIddict": "[0.1.0-dev, )",
+          "OpenIddict": "[7.*, )",
+          "OpenIddict.Server.AspNetCore": "[7.*, )",
+          "OpenIddict.Validation.AspNetCore": "[7.*, )"
+        }
+      },
       "granit.queryengine": {
         "type": "Project",
         "dependencies": {
@@ -252,6 +442,34 @@
           "Microsoft.EntityFrameworkCore": "10.0.3"
         }
       },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.3.0",
+        "contentHash": "P4+s/eUH3dZdn1HnivSL2dh6/Jb0ndLt2l88oQPZ9BYdyb4tSRAsnz4QkJHGfPA9lS/XblI5QYsxEdfkurPvIg==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Diagnostics": "10.3.0",
+          "Microsoft.Extensions.Resilience": "10.3.0"
+        }
+      },
+      "OpenIddict": {
+        "type": "CentralTransitive",
+        "requested": "[7.*, )",
+        "resolved": "7.4.0",
+        "contentHash": "oum61BkFI5tEPZ96L23QE4kX51neQbTd2sbpHvgOTkCDc+r0oBI8VYwR3EBYrVdt3fqKvtCt8bKJVn73PBbtyQ==",
+        "dependencies": {
+          "OpenIddict.Abstractions": "7.4.0",
+          "OpenIddict.Client": "7.4.0",
+          "OpenIddict.Client.SystemIntegration": "7.4.0",
+          "OpenIddict.Client.SystemNetHttp": "7.4.0",
+          "OpenIddict.Client.WebIntegration": "7.4.0",
+          "OpenIddict.Core": "7.4.0",
+          "OpenIddict.Server": "7.4.0",
+          "OpenIddict.Validation": "7.4.0",
+          "OpenIddict.Validation.ServerIntegration": "7.4.0",
+          "OpenIddict.Validation.SystemNetHttp": "7.4.0"
+        }
+      },
       "OpenIddict.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[7.*, )",
@@ -263,6 +481,35 @@
           "OpenIddict.EntityFrameworkCore.Models": "7.4.0"
         }
       },
+      "OpenIddict.Server.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[7.*, )",
+        "resolved": "7.4.0",
+        "contentHash": "zqftzqo2j/+tf6rGZMbcTz9wUcXZNqwtG9G+hg5qUG0F8nsDyt6dC608pB6ikJtW0xO1p+OmP3q0UmpNMhsBug==",
+        "dependencies": {
+          "OpenIddict.Server": "7.4.0"
+        }
+      },
+      "OpenIddict.Validation.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[7.*, )",
+        "resolved": "7.4.0",
+        "contentHash": "KQkDiHFUrTkCt6+kB51sVkTAlpia3Mz04lFFPvUL3nunro0aqysk4I5DhI7qjRyKIVrQGafjSVQcf+0V77t6ww==",
+        "dependencies": {
+          "OpenIddict.Validation": "7.4.0"
+        }
+      },
+      "OpenIddict.Validation.SystemNetHttp": {
+        "type": "CentralTransitive",
+        "requested": "[7.*, )",
+        "resolved": "7.4.0",
+        "contentHash": "zBkL9kx6Z5PDnZjFUrkUnT/9jt2kjNVPoh9zw41BBkP8NKRPGjZk3y7av0qR51IgN1V+ZRQqmc1fQoK4qeOtjg==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Polly": "10.0.3",
+          "Microsoft.Extensions.Http.Resilience": "10.3.0",
+          "OpenIddict.Validation": "7.4.0"
+        }
+      },
       "OpenTelemetry.Api": {
         "type": "CentralTransitive",
         "requested": "[1.15.*, )",
@@ -272,8 +519,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.13.15",
-        "contentHash": "ufSBk0vdDnrhn+YLGElUdegUkM+hb7xUoySH+oaZrNHi2fAm+oeSCr60Lqmm4OeLBhPKd2htr/DANOvjuNT6rg=="
+        "resolved": "2.13.16",
+        "contentHash": "zOWRQLnD7RbcbqnEeP6oUQNy+JeyXDcgmyz3ui7O5QntW7CdbItSC+KOZYRgzaFqh9hPNgSlp1uuTn96Y+gfww=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Seeding/OpenIddictSeedContributor.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Seeding/OpenIddictSeedContributor.cs
@@ -194,6 +194,9 @@ internal sealed partial class OpenIddictSeedContributor(
         appDescriptor.JsonWebKeySet = !string.IsNullOrEmpty(source.SigningKeyJwk)
             ? BuildJsonWebKeySet(source.SigningKeyJwk)
             : null;
+
+        // Consent type (default: implicit — auto-grant for first-party apps)
+        appDescriptor.ConsentType = source.ConsentType ?? OpenIddictConstants.ConsentTypes.Implicit;
     }
 
     private async Task SeedScopeAsync(

--- a/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
@@ -125,7 +125,7 @@ public static class OpenIddictServerHostApplicationBuilderExtensions
             }
 
             // ──── ASP.NET Core integration ────
-            options
+            OpenIddictServerAspNetCoreBuilder aspNetCore = options
                 .UseAspNetCore()
                 .EnableAuthorizationEndpointPassthrough()
                 .EnableTokenEndpointPassthrough()
@@ -133,6 +133,11 @@ public static class OpenIddictServerHostApplicationBuilderExtensions
                 .EnableEndSessionEndpointPassthrough()
                 .EnableEndUserVerificationEndpointPassthrough()
                 .EnableStatusCodePagesIntegration();
+
+            if (builder.Environment.IsDevelopment())
+            {
+                aspNetCore.DisableTransportSecurityRequirement();
+            }
 
             // ──── Custom grant types ────
             options.AllowCustomFlow("urn:granit:grant_type:two_factor");

--- a/src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs
+++ b/src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs
@@ -29,6 +29,7 @@ public sealed class GranitOpenIddictSeedingOptions
 /// <param name="RedirectUris">Allowed redirect URIs.</param>
 /// <param name="PostLogoutRedirectUris">Allowed post-logout redirect URIs.</param>
 /// <param name="SigningKeyJwk">Optional public signing key as JWK JSON for <c>private_key_jwt</c> client authentication (RFC 7523). When set, the client authenticates with a signed JWT assertion instead of a shared secret.</param>
+/// <param name="ConsentType">The consent type for the application (<c>"implicit"</c>, <c>"explicit"</c>, or <c>"systematic"</c>). Default: <c>"implicit"</c> (auto-grant for first-party apps).</param>
 public sealed record OidcApplicationSeedDescriptor(
     string ClientId,
     string? ClientSecret,
@@ -36,7 +37,8 @@ public sealed record OidcApplicationSeedDescriptor(
     string[] Permissions,
     string[] RedirectUris,
     string[] PostLogoutRedirectUris,
-    string? SigningKeyJwk = null);
+    string? SigningKeyJwk = null,
+    string? ConsentType = null);
 
 /// <summary>
 /// Describes an OIDC scope to seed.

--- a/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
+++ b/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
@@ -607,6 +607,7 @@
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.OpenIddict.Server": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
@@ -973,8 +974,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.13.15",
-        "contentHash": "ufSBk0vdDnrhn+YLGElUdegUkM+hb7xUoySH+oaZrNHi2fAm+oeSCr60Lqmm4OeLBhPKd2htr/DANOvjuNT6rg=="
+        "resolved": "2.13.16",
+        "contentHash": "zOWRQLnD7RbcbqnEeP6oUQNy+JeyXDcgmyz3ui7O5QntW7CdbItSC+KOZYRgzaFqh9hPNgSlp1uuTn96Y+gfww=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -93,8 +93,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.23",
-        "contentHash": "H5c8YSn8U0zSBAk9mRP/w1shbowfmkdW7nWidHt/4GNSq2VLtNptDTTKkqmTPYvUxC9i3hMHnlQxe1mCXHyXwA=="
+        "resolved": "4.0.3.24",
+        "contentHash": "Bq3mONgVTGheBWfqiVxPDgy/qpcEbsHuH9ColyGFgIiW4Smr/zizfPWI5OjUmxFJ2wlsX/Ooa5654C9bZh2wvg=="
       },
       "Azure.Core": {
         "type": "Transitive",
@@ -2433,6 +2433,7 @@
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.OpenIddict.Server": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
@@ -2964,55 +2965,55 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.6.4",
-        "contentHash": "xERfZcf91tApUKMECoGb8FKVibxW8h/18TdQp6KQU0JEQ7MsICEyzs/NsGBHGfLOILlJnZuQOfN6TQAPxCSfGA==",
+        "resolved": "4.0.6.5",
+        "contentHash": "lB5OUn7w4nu53TRah+r51L+vtSiFpRxnluII0B52Wn/fTqlJY1UGebFZtkOPTDdKYP9Kk2/cAoVRnVPjk0e8UQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.23, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.24, 5.0.0)"
         }
       },
       "AWSSDK.KeyManagementService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.9.5",
-        "contentHash": "eph5TNRjldo+f0/CpGiGDgJI5JTlZu0g+qRqpdxTAjRtYBwfyVjFdtsdzKcdanua6Bj8wqqq5a01zKWlWLcEjQ==",
+        "resolved": "4.0.9.6",
+        "contentHash": "G1FOTRbIY8BZF7JsnhdYfCu8oK7RvlNFaJdr8kYt/piQHMSX60XFspZF+w2wN1NU/vB0rsEiu6Xfcb2eEdueZw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.23, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.24, 5.0.0)"
         }
       },
       "AWSSDK.S3": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.19.3",
-        "contentHash": "aa/ChYJBQVU8xQ4wmAQdFxS0C3jQJUztZgaCb++fxsmSsZkimg8wHfzaWyAfxMIIqN4DXX2/pSkkI9gXC+7Hvw==",
+        "resolved": "4.0.19.4",
+        "contentHash": "kzyjlrmwJk6vTtNCTSyMi3JLiwXlY4pXyVcWo998/a++nAk50DGxIvk6ZXr1fAgdm8AWwdZI4glBTGhbzhfY7Q==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.23, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.24, 5.0.0)"
         }
       },
       "AWSSDK.SecretsManager": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.4.11",
-        "contentHash": "VP/aew8LGB4mk5CU9nDBGy4LoGeIy2ge/kgPIdNyCE+PT7Ov+15/HdTuMix3jHVAw7yAfJwbZtxeVom1gcd8AQ==",
+        "resolved": "4.0.4.12",
+        "contentHash": "Bp+7XSvN3kMelRfW3S4n51NjHusQsp1byoXu6Cow55zSA/CxRuMMek19P8V1bCOToygSjtUUH8ejHw3UxCPaVg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.23, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.24, 5.0.0)"
         }
       },
       "AWSSDK.SimpleEmailV2": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.12.4",
-        "contentHash": "62pJUxvEaNK7OWTEAGRO9vO1akB/yKvZAxy/TIh/WiFfvoM9RmgR/Mu2pRWwNWnT03h+iyOwPmI75rvdzWOIvQ==",
+        "resolved": "4.0.12.5",
+        "contentHash": "pC7JyOEcYI2YdVi+bGVss/ic74m7GKCL83oTGQKqkXIgzlm8l1slwxkDBQ35nHRNlHhY/9pdCXAjvt0zjmvWnw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.23, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.24, 5.0.0)"
         }
       },
       "AWSSDK.SimpleNotificationService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.21",
-        "contentHash": "5mSY3oQ9A933OvwxjgE9RMFhopI9WJBjDUvzNP1vUbQ1Y2nYOunfIwnsnske4UyU2zRdGKDmpPQ8I1JG8epGAA==",
+        "resolved": "4.0.2.22",
+        "contentHash": "1sfTjDluaplIcQ4fXV7a+3UA8eNrORg0OaxtIMiu9Hnbfx3CCHDg5JRL3zLglCPxLw13WtA1HWRN/WQJMEQ9QA==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.23, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.24, 5.0.0)"
         }
       },
       "Azure.AI.OpenAI": {
@@ -3581,14 +3582,14 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.13.15",
-        "contentHash": "ufSBk0vdDnrhn+YLGElUdegUkM+hb7xUoySH+oaZrNHi2fAm+oeSCr60Lqmm4OeLBhPKd2htr/DANOvjuNT6rg=="
+        "resolved": "2.13.16",
+        "contentHash": "zOWRQLnD7RbcbqnEeP6oUQNy+JeyXDcgmyz3ui7O5QntW7CdbItSC+KOZYRgzaFqh9hPNgSlp1uuTn96Y+gfww=="
       },
       "Scriban": {
         "type": "CentralTransitive",
         "requested": "[7.*, )",
-        "resolved": "7.0.5",
-        "contentHash": "GmK0nHYvmUV7ue93eaEWwVU4NQLcW1MlBckAT6BTUIIJm9UA92pVWdcJH5BGqzgWkrA+xVt065gjP2vpQ47h6g=="
+        "resolved": "7.0.6",
+        "contentHash": "bOtHyk30sjl0y3+KYImIJv0ETZYLuFFJvlBF2ks2YLNtydhJqxRTGe4WaBDvg/3VRhhI6uf+qVfixuFROsOi+w=="
       },
       "Sep": {
         "type": "CentralTransitive",

--- a/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
@@ -127,10 +127,84 @@
         "resolved": "10.0.3",
         "contentHash": "lVABgJTyTUNE7Bi0bSu4dWHiCHIXEGzTh/kLh0N07IgU/tIKwTeBPp8tgV4x2iKj4h7iPLo8oXzyHmLDGtAE1g=="
       },
+      "Microsoft.Extensions.AmbientMetadata.Application": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "Oh/FQJrTZqiqZuFktqDCwLFgxIUnNATZx46AwUTf5A/+FmK/TzPf/iwSqMK85QlioLD9ehOxWe0NBfsCSkp5pw=="
+      },
+      "Microsoft.Extensions.Compliance.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "b3gmxtyX0n8bQFuZ679f8QiOWqjeZKFc6XXPUsYNFzMcWi0Q44Ej3pB41N/QQ0maX380kmOMF36bLSBHNThXAg=="
+      },
+      "Microsoft.Extensions.DependencyInjection.AutoActivation": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "g6/S5rhP1XNBqeDa9zKXri/uDKe6gjzSqGsocuySb1OdVm8fz/M9YcWTJsCw5RHF8xIb/B3NgsfBPQF9Emjk3Q=="
+      },
+      "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "TZAZsAFThNQDqCnWaGxV/X7OPSA7b+kY7wNTPNvPvSWa0jcTbmGVyzIY/feF4OgyAUUdzSnnLW6ri2Q+4keM4A=="
+      },
+      "Microsoft.Extensions.Http.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "/xuNWNxI4WLVatiTvaqfLd5ijFhQ/qvE14bOyWxeEWmXJkjh/g2G/5TdzMfoe0afq16OdWLGbrD9gWHo178hbg==",
+        "dependencies": {
+          "Microsoft.Extensions.Telemetry": "10.3.0"
+        }
+      },
+      "Microsoft.Extensions.Http.Polly": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "Dl3wUj5Fdk6AuPDCDBBcpnAW/mYfmfr+48g3fE4JCQiVSIjLGqjg1tyw5/dZnLHlC+tgzr6rntD7bBgigpZBhw==",
+        "dependencies": {
+          "Polly": "7.2.4",
+          "Polly.Extensions.Http": "3.0.0"
+        }
+      },
+      "Microsoft.Extensions.Resilience": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "xc0dZuPkBaVIdMlODDppmNY/dxE27wIQ46gTzStoFXO4/yVcOMKlPmtr9vTP4edyXBRizGxPtcAFmqxZ5gPTkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.3.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.3.0",
+          "Polly.Extensions": "8.4.2",
+          "Polly.RateLimiting": "8.4.2"
+        }
+      },
+      "Microsoft.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "M1esrIGmwU2JBY0JpwdlUTXTNBXSBFEs+41bYBd59+9/vCaXw+vGhtYcCL+JXeGmxTLUHmuXcKbX/uVCSFcuzA==",
+        "dependencies": {
+          "Microsoft.Extensions.AmbientMetadata.Application": "10.3.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.3.0",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.3.0"
+        }
+      },
+      "Microsoft.Extensions.Telemetry.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.3.0",
+        "contentHash": "aKxH6ZsGAewGF8uSXyx1WkjqItwZA+hd1hhQ/4i7o5injCWSdr9vIZ3R3djJfy8OG3xaWK+LZY/+slVvlnwEHw==",
+        "dependencies": {
+          "Microsoft.Extensions.Compliance.Abstractions": "10.3.0"
+        }
+      },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
         "resolved": "8.16.0",
         "contentHash": "gSxKLWRZzBpIsEoeUPkxfywNCCvRvl7hkq146XHPk5vOQc9izSf1I+uL1vh4y2U19QPxd9Z8K/8AdWyxYz2lSg=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "prBU72cIP4V8E9fhN+o/YdskTsLeIcnKPbhZf0X6mD7fdxoZqnS/NdEkSr+9Zp+2q7OZBOMfNBKGbTbhXODO4w==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
@@ -138,6 +212,14 @@
         "contentHash": "MTzXmETkNQPACR7/XCXM1OGM6oU9RkyibqeJRtO9Ndew2LnGjMf9Atqj2VSf4XC27X0FQycUAlzxxEgQMWn2xQ==",
         "dependencies": {
           "Microsoft.IdentityModel.Abstractions": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "UFrU7d46UTsPQTa2HIEIpB9H1uJe1BW9FLw5uhEJ2ZuKdur8bcUA/bO5caq5dlBt5gNJeRIB3QQXYNs5fCQCZA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
         }
       },
       "Microsoft.IdentityModel.Tokens": {
@@ -215,6 +297,43 @@
           "Microsoft.IdentityModel.Tokens": "8.16.0"
         }
       },
+      "OpenIddict.Client": {
+        "type": "Transitive",
+        "resolved": "7.4.0",
+        "contentHash": "OXIa4LdLlRX61xq/9y/57ZcWxg4QvQvjbP/imGEUToETYWrIwEqje5KPFnpO7V3eVDXgl1acfanGo5BnoK6Yjw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Protocols": "8.16.0",
+          "OpenIddict.Abstractions": "7.4.0"
+        }
+      },
+      "OpenIddict.Client.SystemIntegration": {
+        "type": "Transitive",
+        "resolved": "7.4.0",
+        "contentHash": "0iEpO+TZ7CxWV+Wydiaaue8PKLvmOy13hLhLiewT3p8JZm8xkKBnC3qoKbFUYEHn7Z2ZdIpCUvkJIrb7aF7VBA==",
+        "dependencies": {
+          "OpenIddict.Client": "7.4.0"
+        }
+      },
+      "OpenIddict.Client.SystemNetHttp": {
+        "type": "Transitive",
+        "resolved": "7.4.0",
+        "contentHash": "0jYaa6Ezg5CVcmZhiDcxKrAMS1Lwlju84VpqJw/YBnQ9IISvmLrSRSCDfJ1dZKeSeX9DMTyUV8ng3F3JqyhgDQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Polly": "10.0.3",
+          "Microsoft.Extensions.Http.Resilience": "10.3.0",
+          "OpenIddict.Client": "7.4.0"
+        }
+      },
+      "OpenIddict.Client.WebIntegration": {
+        "type": "Transitive",
+        "resolved": "7.4.0",
+        "contentHash": "vYsEVPxoPxVwylkechXoF0mokts+FyFoL/46i9eWi2J05KbNbErBz43rEwVmq0qFn6ou0gQZ25dj+f8PA9rOlQ==",
+        "dependencies": {
+          "OpenIddict.Client": "7.4.0",
+          "OpenIddict.Client.SystemNetHttp": "7.4.0"
+        }
+      },
       "OpenIddict.Core": {
         "type": "Transitive",
         "resolved": "7.4.0",
@@ -227,6 +346,68 @@
         "type": "Transitive",
         "resolved": "7.4.0",
         "contentHash": "n13CeYAPImXpM2Vb83dCQoMSC2VYPgRp2q4GLp4YG/TA5Qd+X/Jza6eG+MLwx/2mYt8Xhxp+fVusDrUlpe8ZkA=="
+      },
+      "OpenIddict.Server": {
+        "type": "Transitive",
+        "resolved": "7.4.0",
+        "contentHash": "ZzFZWuPZS5NKzQq7V+u6lzgU56IhfJRxoTbySdimv1OYYsqOhEFRq19gCZMWBNCYOTHBxipAPdjnAXFytyGtrw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "OpenIddict.Abstractions": "7.4.0"
+        }
+      },
+      "OpenIddict.Validation": {
+        "type": "Transitive",
+        "resolved": "7.4.0",
+        "contentHash": "SrRjeHnMF7h1hY0ZykQVyI4t+PmJ3Gq1PhQJr+LuLcO+fYkpEqyfCRdOxY+ThnXQJjSOYQxLhrBRg0u330TnKw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Protocols": "8.16.0",
+          "OpenIddict.Abstractions": "7.4.0"
+        }
+      },
+      "OpenIddict.Validation.ServerIntegration": {
+        "type": "Transitive",
+        "resolved": "7.4.0",
+        "contentHash": "7X9uh3T64DroGN0AQgXKC9FDjvWV7IBtW3yTjEdzk0ZqeXKEuTRPzrJdfUwkMx/60iLhAX8zQ2TToO15Z7i5pA==",
+        "dependencies": {
+          "OpenIddict.Server": "7.4.0",
+          "OpenIddict.Validation": "7.4.0"
+        }
+      },
+      "Polly": {
+        "type": "Transitive",
+        "resolved": "7.2.4",
+        "contentHash": "bw00Ck5sh6ekduDE3mnCo1ohzuad946uslCDEENu3091+6UKnBuKLo4e+yaNcCzXxOZCXWY2gV4a35+K1d4LDA=="
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "BpE2I6HBYYA5tF0Vn4eoQOGYTYIK1BlF5EXVgkWGn3mqUUjbXAr13J6fZVbp7Q3epRR8yshacBMlsHMhpOiV3g=="
+      },
+      "Polly.Extensions": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "GZ9vRVmR0jV2JtZavt+pGUsQ1O1cuRKG7R7VOZI6ZDy9y6RNPvRvXK1tuS4ffUrv8L0FTea59oEuQzgS0R7zSA==",
+        "dependencies": {
+          "Polly.Core": "8.4.2"
+        }
+      },
+      "Polly.Extensions.Http": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "drrG+hB3pYFY7w1c3BD+lSGYvH2oIclH8GRSehgfyP5kjnFnHKQuuBhuHLv+PWyFuaTDyk/vfRpnxOzd11+J8g==",
+        "dependencies": {
+          "Polly": "7.1.0"
+        }
+      },
+      "Polly.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "ehTImQ/eUyO07VYW2WvwSmU9rRH200SKJ/3jku9rOkyWE0A2JxNFmAVms8dSn49QLSjmjFRRSgfNyOgr/2PSmA==",
+        "dependencies": {
+          "Polly.Core": "8.4.2"
+        }
       },
       "System.CodeDom": {
         "type": "Transitive",
@@ -406,8 +587,18 @@
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.OpenIddict.Server": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.openiddict.server": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.OpenIddict": "[0.1.0-dev, )",
+          "OpenIddict": "[7.*, )",
+          "OpenIddict.Server.AspNetCore": "[7.*, )",
+          "OpenIddict.Validation.AspNetCore": "[7.*, )"
         }
       },
       "granit.queryengine": {
@@ -487,6 +678,34 @@
           "Microsoft.EntityFrameworkCore": "10.0.3"
         }
       },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.3.0",
+        "contentHash": "P4+s/eUH3dZdn1HnivSL2dh6/Jb0ndLt2l88oQPZ9BYdyb4tSRAsnz4QkJHGfPA9lS/XblI5QYsxEdfkurPvIg==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Diagnostics": "10.3.0",
+          "Microsoft.Extensions.Resilience": "10.3.0"
+        }
+      },
+      "OpenIddict": {
+        "type": "CentralTransitive",
+        "requested": "[7.*, )",
+        "resolved": "7.4.0",
+        "contentHash": "oum61BkFI5tEPZ96L23QE4kX51neQbTd2sbpHvgOTkCDc+r0oBI8VYwR3EBYrVdt3fqKvtCt8bKJVn73PBbtyQ==",
+        "dependencies": {
+          "OpenIddict.Abstractions": "7.4.0",
+          "OpenIddict.Client": "7.4.0",
+          "OpenIddict.Client.SystemIntegration": "7.4.0",
+          "OpenIddict.Client.SystemNetHttp": "7.4.0",
+          "OpenIddict.Client.WebIntegration": "7.4.0",
+          "OpenIddict.Core": "7.4.0",
+          "OpenIddict.Server": "7.4.0",
+          "OpenIddict.Validation": "7.4.0",
+          "OpenIddict.Validation.ServerIntegration": "7.4.0",
+          "OpenIddict.Validation.SystemNetHttp": "7.4.0"
+        }
+      },
       "OpenIddict.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[7.*, )",
@@ -498,6 +717,35 @@
           "OpenIddict.EntityFrameworkCore.Models": "7.4.0"
         }
       },
+      "OpenIddict.Server.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[7.*, )",
+        "resolved": "7.4.0",
+        "contentHash": "zqftzqo2j/+tf6rGZMbcTz9wUcXZNqwtG9G+hg5qUG0F8nsDyt6dC608pB6ikJtW0xO1p+OmP3q0UmpNMhsBug==",
+        "dependencies": {
+          "OpenIddict.Server": "7.4.0"
+        }
+      },
+      "OpenIddict.Validation.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[7.*, )",
+        "resolved": "7.4.0",
+        "contentHash": "KQkDiHFUrTkCt6+kB51sVkTAlpia3Mz04lFFPvUL3nunro0aqysk4I5DhI7qjRyKIVrQGafjSVQcf+0V77t6ww==",
+        "dependencies": {
+          "OpenIddict.Validation": "7.4.0"
+        }
+      },
+      "OpenIddict.Validation.SystemNetHttp": {
+        "type": "CentralTransitive",
+        "requested": "[7.*, )",
+        "resolved": "7.4.0",
+        "contentHash": "zBkL9kx6Z5PDnZjFUrkUnT/9jt2kjNVPoh9zw41BBkP8NKRPGjZk3y7av0qR51IgN1V+ZRQqmc1fQoK4qeOtjg==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Polly": "10.0.3",
+          "Microsoft.Extensions.Http.Resilience": "10.3.0",
+          "OpenIddict.Validation": "7.4.0"
+        }
+      },
       "OpenTelemetry.Api": {
         "type": "CentralTransitive",
         "requested": "[1.15.*, )",
@@ -507,8 +755,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.13.15",
-        "contentHash": "ufSBk0vdDnrhn+YLGElUdegUkM+hb7xUoySH+oaZrNHi2fAm+oeSCr60Lqmm4OeLBhPKd2htr/DANOvjuNT6rg=="
+        "resolved": "2.13.16",
+        "contentHash": "zOWRQLnD7RbcbqnEeP6oUQNy+JeyXDcgmyz3ui7O5QntW7CdbItSC+KOZYRgzaFqh9hPNgSlp1uuTn96Y+gfww=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
@@ -688,6 +688,7 @@
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.OpenIddict": "[0.1.0-dev, )",
+          "Granit.OpenIddict.Server": "[0.1.0-dev, )",
           "Granit.QueryEngine": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
@@ -905,8 +906,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.13.15",
-        "contentHash": "ufSBk0vdDnrhn+YLGElUdegUkM+hb7xUoySH+oaZrNHi2fAm+oeSCr60Lqmm4OeLBhPKd2htr/DANOvjuNT6rg=="
+        "resolved": "2.13.16",
+        "contentHash": "zOWRQLnD7RbcbqnEeP6oUQNy+JeyXDcgmyz3ui7O5QntW7CdbItSC+KOZYRgzaFqh9hPNgSlp1uuTn96Y+gfww=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Summary

- Add OIDC server passthrough endpoint handlers for `/connect/authorize`, `/connect/token`, `/connect/userinfo`, `/connect/logout`, and `/connect/verify` (stub)
- OpenIddict was configured with passthrough enabled but no minimal API handlers existed, causing 404 on all `/connect/*` endpoints
- Extract `OidcPrincipalFactory` as reusable ClaimsPrincipal builder (Duende-ready isolation)
- Add `ConsentType` to `OidcApplicationSeedDescriptor` (default: `implicit` for first-party auto-grant)
- Add `DisableTransportSecurityRequirement()` in Development environment for HTTP dev servers

### Technical guardrails applied

- `Results.Challenge` for login redirect (not manual `Results.Redirect`)
- `offline_access` scope preserved on refresh token grant
- All request data via `GetOpenIddictServerRequest()` (never bind `x-www-form-urlencoded` body via Minimal API params)

## Test plan

- [x] `dotnet build src/Granit.OpenIddict.Endpoints` — zero errors
- [x] `dotnet test tests/Granit.OpenIddict.Endpoints.Tests` — 40 tests pass
- [x] `dotnet test tests/Granit.OpenIddict.EntityFrameworkCore.Tests` — 32 tests pass
- [x] `dotnet format --verify-no-changes` — clean
- [ ] Showcase starts without 404 on `/connect/authorize`
- [ ] BFF login flow: `/bff/login` → PAR → authorize → callback → token → session cookie
