### PR TITLE
fix(ci): allow publish-github to run on develop when sbom is skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,10 +467,16 @@ jobs:
         run: gh release upload ${{ github.ref_name }} sbom/bom.json --clobber
 
   # GitHub Packages — dev packages on develop/main
+  # sbom is kept in needs for ordering on main, but skipped on develop.
+  # The if condition uses always() so the job runs even when sbom is skipped.
   publish-github:
     needs: [pack, sbom]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'
+    if: |
+      always()
+      && needs.pack.result == 'success'
+      && (needs.sbom.result == 'success' || needs.sbom.result == 'skipped')
+      && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
     permissions:
       packages: write
     steps:


### PR DESCRIPTION
## Summary

- Fix `publish-github` job being skipped on `develop` because it depends on `sbom` which only runs on `main`/tags
- Use `always()` with explicit result checks: publish runs when sbom is skipped (develop) or successful (main), but blocks if pack fails or sbom fails

## Test plan

- [ ] CI on this PR: `publish-github` should still be skipped (PR, not develop)
- [ ] After merge to develop: `publish-github` should run (sbom skipped, pack success)
- [ ] On main: `publish-github` runs after sbom completes successfully
