### PR TITLE
feat(openiddict): add headless login endpoint for BFF/SPA architectures

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -21289,6 +21289,24 @@
       "members": []
     },
     {
+      "name": "AccountLoginRequest",
+      "fqn": "Granit.OpenIddict.Endpoints.Dtos.AccountLoginRequest",
+      "kind": "record",
+      "project": "Granit.OpenIddict.Endpoints",
+      "file": "src/Granit.OpenIddict.Endpoints/Dtos/AccountLoginRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "AccountLoginResponse",
+      "fqn": "Granit.OpenIddict.Endpoints.Dtos.AccountLoginResponse",
+      "kind": "record",
+      "project": "Granit.OpenIddict.Endpoints",
+      "file": "src/Granit.OpenIddict.Endpoints/Dtos/AccountLoginResponse.cs",
+      "line": 10,
+      "members": []
+    },
+    {
       "name": "AccountPasswordChangeRequest",
       "fqn": "Granit.OpenIddict.Endpoints.Dtos.AccountPasswordChangeRequest",
       "kind": "record",
@@ -21320,8 +21338,8 @@
       "fqn": "Granit.OpenIddict.Endpoints.Dtos.AccountProfileUpdateRequest",
       "kind": "record",
       "project": "Granit.OpenIddict.Endpoints",
-      "file": "src/Granit.OpenIddict.Endpoints/Dtos/AccountProfileResponse.cs",
-      "line": 29,
+      "file": "src/Granit.OpenIddict.Endpoints/Dtos/AccountProfileUpdateRequest.cs",
+      "line": 8,
       "members": []
     },
     {
@@ -21481,7 +21499,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.Endpoints",
       "file": "src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs",
-      "line": 32,
+      "line": 34,
       "members": [
         {
           "name": "ConfigureServices",
@@ -21509,18 +21527,6 @@
           "name": "AdminRoutePrefix",
           "kind": "property",
           "signature": "string AdminRoutePrefix",
-          "returnType": "string"
-        },
-        {
-          "name": "AccountTagName",
-          "kind": "property",
-          "signature": "string AccountTagName",
-          "returnType": "string"
-        },
-        {
-          "name": "AdminTagName",
-          "kind": "property",
-          "signature": "string AdminTagName",
           "returnType": "string"
         }
       ]

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AccountLoginRequest.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AccountLoginRequest.cs
@@ -1,0 +1,6 @@
+namespace Granit.OpenIddict.Endpoints.Dtos;
+
+/// <summary>
+/// Request body for the headless login endpoint.
+/// </summary>
+public sealed record AccountLoginRequest(string Login, string Password);

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AccountLoginResponse.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AccountLoginResponse.cs
@@ -1,0 +1,14 @@
+namespace Granit.OpenIddict.Endpoints.Dtos;
+
+/// <summary>
+/// Response body for the headless login endpoint.
+/// </summary>
+/// <param name="Succeeded">Whether authentication succeeded.</param>
+/// <param name="RequiresTwoFactor">Whether two-factor authentication is required.</param>
+/// <param name="IsLockedOut">Whether the account is locked out.</param>
+/// <param name="IsNotAllowed">Whether sign-in is not allowed (email not confirmed, etc.).</param>
+public sealed record AccountLoginResponse(
+    bool Succeeded,
+    bool RequiresTwoFactor = false,
+    bool IsLockedOut = false,
+    bool IsNotAllowed = false);

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AccountProfileResponse.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AccountProfileResponse.cs
@@ -20,12 +20,3 @@ public sealed record AccountProfileResponse(
     bool TwoFactorEnabled,
     bool HasPassword,
     IReadOnlyList<string> ExternalLogins);
-
-/// <summary>
-/// Request DTO for profile update.
-/// </summary>
-/// <param name="FirstName">The new first name (max 256).</param>
-/// <param name="LastName">The new last name (max 256).</param>
-public sealed record AccountProfileUpdateRequest(
-    string? FirstName,
-    string? LastName);

--- a/src/Granit.OpenIddict.Endpoints/Dtos/AccountProfileUpdateRequest.cs
+++ b/src/Granit.OpenIddict.Endpoints/Dtos/AccountProfileUpdateRequest.cs
@@ -1,0 +1,10 @@
+namespace Granit.OpenIddict.Endpoints.Dtos;
+
+/// <summary>
+/// Request DTO for profile update.
+/// </summary>
+/// <param name="FirstName">The new first name (max 256).</param>
+/// <param name="LastName">The new last name (max 256).</param>
+public sealed record AccountProfileUpdateRequest(
+    string? FirstName,
+    string? LastName);

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/AccountLoginEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/AccountLoginEndpoints.cs
@@ -1,0 +1,134 @@
+using Granit.Identity.Local.Domain;
+using Granit.OpenIddict.Diagnostics;
+using Granit.OpenIddict.Endpoints.Dtos;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.OpenIddict.Endpoints.Endpoints;
+
+/// <summary>
+/// Headless login endpoint for SPA/BFF architectures.
+/// Authenticates the user via ASP.NET Core Identity and sets the Identity
+/// session cookie without any HTTP redirects.
+/// </summary>
+internal static partial class AccountLoginEndpoints
+{
+    internal static RouteGroupBuilder MapAccountLoginEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapPost("/login", HandleLoginAsync)
+            .WithName("AccountLogin")
+            .WithSummary("Authenticates a user and sets the Identity session cookie.")
+            .WithDescription(
+                "Validates credentials (email or username + password) against ASP.NET Core Identity. "
+                + "On success, sets the Identity authentication cookie and returns 200. "
+                + "On failure, returns the specific failure reason (invalid credentials, 2FA required, "
+                + "locked out, sign-in not allowed). This endpoint is designed for headless/BFF "
+                + "architectures where the SPA handles the login UI and redirects back to "
+                + "/connect/authorize after successful authentication.")
+            .Produces<AccountLoginResponse>()
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status423Locked)
+            .AllowAnonymous();
+
+        return group;
+    }
+
+#pragma warning disable GRSEC003 // Method handles user credentials — server-side authentication
+    private static async Task<Results<Ok<AccountLoginResponse>, ProblemHttpResult>> HandleLoginAsync(
+        AccountLoginRequest request,
+        [FromServices] SignInManager<GranitUser> signInManager,
+        [FromServices] UserManager<GranitUser> userManager,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        ILogger logger = httpContext.RequestServices
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger("Granit.OpenIddict.Endpoints.AccountLoginEndpoints");
+        OpenIddictMetrics? metrics = httpContext.RequestServices.GetService<OpenIddictMetrics>();
+
+        // Resolve user by email or username
+        GranitUser? user = await userManager.FindByEmailAsync(request.Login).ConfigureAwait(false)
+            ?? await userManager.FindByNameAsync(request.Login).ConfigureAwait(false);
+
+        if (user is null)
+        {
+            LogLoginFailed(logger, request.Login, "user_not_found");
+            metrics?.RecordAuthenticationFailure(null, "invalid_credentials");
+
+            return TypedResults.Problem(
+                detail: "Invalid credentials.",
+                statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        Microsoft.AspNetCore.Identity.SignInResult result = await signInManager
+            .PasswordSignInAsync(user, request.Password, isPersistent: false, lockoutOnFailure: true)
+            .ConfigureAwait(false);
+
+        if (result.Succeeded)
+        {
+            LogLoginSuccess(logger, user.Id.ToString());
+            metrics?.RecordAuthenticationSuccess(null, "password");
+
+            return TypedResults.Ok(new AccountLoginResponse(Succeeded: true));
+        }
+
+        if (result.RequiresTwoFactor)
+        {
+            LogLoginTwoFactor(logger, user.Id.ToString());
+            return TypedResults.Ok(new AccountLoginResponse(
+                Succeeded: false, RequiresTwoFactor: true));
+        }
+
+        if (result.IsLockedOut)
+        {
+            LogLoginLockedOut(logger, user.Id.ToString());
+            metrics?.RecordAuthenticationFailure(null, "account_locked");
+
+            return TypedResults.Problem(
+                detail: "Account is locked out. Try again later.",
+                statusCode: StatusCodes.Status423Locked);
+        }
+
+        if (result.IsNotAllowed)
+        {
+            LogLoginNotAllowed(logger, user.Id.ToString());
+            metrics?.RecordAuthenticationFailure(null, "email_not_confirmed");
+
+            return TypedResults.Problem(
+                detail: "Sign-in is not allowed. Verify your email address.",
+                statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        // Generic failure (wrong password)
+        LogLoginFailed(logger, request.Login, "invalid_password");
+        metrics?.RecordAuthenticationFailure(null, "invalid_credentials");
+
+        return TypedResults.Problem(
+            detail: "Invalid credentials.",
+            statusCode: StatusCodes.Status401Unauthorized);
+    }
+#pragma warning restore GRSEC003
+
+    // ──── Source-generated log messages ────
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Headless login: user {UserId} authenticated successfully")]
+    private static partial void LogLoginSuccess(ILogger logger, string userId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Headless login: user {UserId} requires two-factor authentication")]
+    private static partial void LogLoginTwoFactor(ILogger logger, string userId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Headless login: user {UserId} is locked out")]
+    private static partial void LogLoginLockedOut(ILogger logger, string userId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Headless login: user {UserId} sign-in not allowed")]
+    private static partial void LogLoginNotAllowed(ILogger logger, string userId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Headless login: failed for '{Login}' — {Reason}")]
+    private static partial void LogLoginFailed(ILogger logger, string login, string reason);
+}

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/AdminOidcEndpoints.cs
@@ -49,7 +49,7 @@ internal static class AdminOidcEndpoints
             .WithDescription(
                 "Generates a new client secret, invalidating the old one immediately. "
                 + "The new plaintext secret is returned once in the response (never stored in plaintext).")
-            .Produces<AdminOidcApplicationResponse>()
+            .Produces<AdminOidcRotateSecretResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(OpenIddictPermissions.Applications.Rotate);
 
@@ -312,14 +312,24 @@ internal static class AdminOidcEndpoints
 
     private static async Task<NoContent> RevokeUserAuthorizationsAsync(
         Guid userId,
+        [FromServices] IOpenIddictAuthorizationManager authorizationManager,
         [FromServices] IOpenIddictTokenManager tokenManager,
         CancellationToken cancellationToken)
     {
+        string subject = userId.ToString();
+
         // Revoke all tokens for this user (security incident / GDPR erasure)
         await foreach (object token in tokenManager.FindBySubjectAsync(
-            userId.ToString(), cancellationToken).ConfigureAwait(false))
+            subject, cancellationToken).ConfigureAwait(false))
         {
             await tokenManager.TryRevokeAsync(token, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Revoke all authorizations for this user
+        await foreach (object authorization in authorizationManager.FindBySubjectAsync(
+            subject, cancellationToken).ConfigureAwait(false))
+        {
+            await authorizationManager.DeleteAsync(authorization, cancellationToken).ConfigureAwait(false);
         }
 
         return TypedResults.NoContent();

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs
@@ -1,6 +1,8 @@
 using System.Collections.Immutable;
 using System.Security.Claims;
 using Granit.Identity.Local.Domain;
+using Granit.MultiTenancy;
+using Granit.OpenIddict.Diagnostics;
 using Granit.OpenIddict.Endpoints.Internal;
 using Granit.OpenIddict.Endpoints.Options;
 using Microsoft.AspNetCore;
@@ -53,16 +55,16 @@ internal static partial class ConnectAuthorizationEndpoints
 
         if (!authenticateResult.Succeeded || authenticateResult.Principal is null)
         {
-            // Not authenticated — challenge to redirect to the login page.
-            // The cookie handler appends ReturnUrl with the current request URI.
+            // Not authenticated — redirect to the configured login page.
+            // In headless/BFF mode this points to the SPA login route; in MVC mode
+            // it points to a Razor page. The returnUrl lets the login page redirect
+            // back to /connect/authorize after successful authentication.
+            string returnUrl = context.Request.PathBase + context.Request.Path + context.Request.QueryString;
+            string loginUrl = $"{options.LoginPath}?returnUrl={Uri.EscapeDataString(returnUrl)}";
+
             LogUnauthenticatedRedirect(logger, request.ClientId ?? "(null)");
 
-            return Results.Challenge(
-                new AuthenticationProperties
-                {
-                    RedirectUri = context.Request.PathBase + context.Request.Path + context.Request.QueryString,
-                },
-                [IdentityConstants.ApplicationScheme]);
+            return Results.Redirect(loginUrl);
         }
 
         // Resolve the application to check consent type.
@@ -139,7 +141,7 @@ internal static partial class ConnectAuthorizationEndpoints
             authorizations.Add(auth);
         }
 
-        authorization = authorizations.Find(_ => true);
+        authorization = authorizations.FirstOrDefault();
 
         if (authorization is null)
         {
@@ -158,6 +160,11 @@ internal static partial class ConnectAuthorizationEndpoints
         principal.SetAuthorizationId(authorizationId);
 
         LogAuthorizationGranted(logger, user.Id.ToString(), request.ClientId!);
+
+        ICurrentTenant? currentTenant = context.RequestServices.GetService<ICurrentTenant>();
+        string? tenantId = currentTenant is { IsAvailable: true } ? currentTenant.Id?.ToString() : null;
+        OpenIddictMetrics metrics = context.RequestServices.GetRequiredService<OpenIddictMetrics>();
+        metrics.RecordAuthenticationSuccess(tenantId, "authorization_code");
 
         return Results.SignIn(principal,
             authenticationScheme: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);

--- a/src/Granit.OpenIddict.Endpoints/Extensions/OpenIddictEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.Endpoints/Extensions/OpenIddictEndpointRouteBuilderExtensions.cs
@@ -28,6 +28,7 @@ public static class OpenIddictEndpointRouteBuilderExtensions
         RouteGroupBuilder accountGroup = endpoints
             .MapGranitGroup(options.AccountRoutePrefix);
 
+        accountGroup.MapAccountLoginEndpoints();
         accountGroup.MapAccountRegistrationEndpoints();
         accountGroup.MapAccountProfileEndpoints();
         accountGroup.MapAccountPasswordEndpoints();

--- a/src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs
+++ b/src/Granit.OpenIddict.Endpoints/GranitOpenIddictEndpointsModule.cs
@@ -3,6 +3,7 @@ using Granit.Caching;
 using Granit.Http.ApiDocumentation;
 using Granit.Modularity;
 using Granit.OpenIddict.Endpoints.Internal;
+using Granit.OpenIddict.Server;
 using Granit.QueryEngine;
 using Granit.Validation;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,6 +28,7 @@ namespace Granit.OpenIddict.Endpoints;
     typeof(GranitCachingModule),
     typeof(GranitHttpApiDocumentationModule),
     typeof(GranitOpenIddictModule),
+    typeof(GranitOpenIddictServerModule),
     typeof(GranitQueryEngineAbstractionsModule),
     typeof(GranitValidationModule))]
 public sealed class GranitOpenIddictEndpointsModule : GranitModule

--- a/src/Granit.OpenIddict.Endpoints/Options/OpenIddictEndpointsOptions.cs
+++ b/src/Granit.OpenIddict.Endpoints/Options/OpenIddictEndpointsOptions.cs
@@ -10,10 +10,4 @@ public sealed class OpenIddictEndpointsOptions
 
     /// <summary>Route prefix for admin management endpoints. Default: <c>"api/admin"</c>.</summary>
     public string AdminRoutePrefix { get; set; } = "api/admin";
-
-    /// <summary>OpenAPI tag for account endpoints. Default: <c>"Account"</c>.</summary>
-    public string AccountTagName { get; set; } = "Account";
-
-    /// <summary>OpenAPI tag for admin endpoints. Default: <c>"Administration"</c>.</summary>
-    public string AdminTagName { get; set; } = "Administration";
 }

--- a/src/Granit.OpenIddict.Endpoints/Validators/AccountLoginRequestValidator.cs
+++ b/src/Granit.OpenIddict.Endpoints/Validators/AccountLoginRequestValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+using Granit.OpenIddict.Endpoints.Dtos;
+using Granit.Validation;
+
+namespace Granit.OpenIddict.Endpoints.Validators;
+
+/// <summary>
+/// Validates <see cref="AccountLoginRequest"/>.
+/// </summary>
+internal sealed class AccountLoginRequestValidator : GranitValidator<AccountLoginRequest>
+{
+    public AccountLoginRequestValidator()
+    {
+        RuleFor(x => x.Login)
+            .NotEmpty()
+            .MaximumLength(256);
+
+        RuleFor(x => x.Password)
+            .NotEmpty()
+            .MaximumLength(256);
+    }
+}


### PR DESCRIPTION
## Summary

- Replace `Results.Challenge()` in `/connect/authorize` with explicit `Results.Redirect(options.LoginPath)` to avoid ASP.NET Identity cookie handler converting 401 into 302 redirect to non-existent `/Account/Login` in headless deployments
- Add `POST /api/account/login` headless endpoint (SignInManager + Identity cookie, JSON response, 2FA/lockout support) for SPA/BFF architectures
- Extract `AccountProfileUpdateRequest` to its own file, fix `Produces` type on secret rotation endpoint, add authorization revocation to user token revocation

## Headless login flow

```
SPA LoginPage → POST /api/account/login → 200 + Identity cookie
      ↓
Redirect to /connect/authorize?returnUrl=...
      ↓
OpenIddict sees Identity cookie → auth code → 302 /bff/callback
      ↓
BFF exchanges code → tokens → session cookie → SPA loaded
```

## Test plan

- [ ] Verify `POST /api/account/login` returns 200 with valid credentials
- [ ] Verify 401 for invalid credentials (no user enumeration)
- [ ] Verify 423 for locked out accounts
- [ ] Verify 2FA challenge response (`RequiresTwoFactor: true`)
- [ ] Verify `/connect/authorize` redirects to configured `LoginPath` when unauthenticated
- [ ] Verify existing OpenIddict endpoint tests still pass
- [ ] Run architecture tests
