### PR TITLE
fix(cookies): make CookieRegistry.Register idempotent

### DIFF
--- a/src/Granit.Http.Cookies/Internal/CookieRegistry.cs
+++ b/src/Granit.Http.Cookies/Internal/CookieRegistry.cs
@@ -16,7 +16,8 @@ internal sealed class CookieRegistry : ICookieRegistry
 
         if (!_cookies.TryAdd(definition.Name, definition))
         {
-            throw new InvalidOperationException($"Cookie '{definition.Name}' is already registered.");
+            // Idempotent: allow re-registration of the same cookie (hot-reload, module restart).
+            _cookies[definition.Name] = definition;
         }
     }
 


### PR DESCRIPTION
## Summary

- Make `CookieRegistry.Register` idempotent: replace existing definition instead of throwing `InvalidOperationException` when a cookie name is already registered
- Fixes BFF startup crash (`Cookie '__Host-granit-bff-admin' is already registered`) during hot-reload and module restart scenarios

## Test plan

- [ ] Verify BFF showcase starts without `InvalidOperationException`
- [ ] Verify hot-reload does not crash on cookie re-registration
- [ ] Verify existing cookie registration tests pass
