### PR TITLE
fix(bff): guard against duplicate registration + refine cookie idempotency

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -6270,7 +6270,7 @@
       "kind": "class",
       "project": "Granit.Bff.Endpoints",
       "file": "src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs",
-      "line": 163,
+      "line": 172,
       "members": [
         {
           "name": "InvokeAsync",

--- a/src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs
@@ -18,6 +18,8 @@ namespace Granit.Bff.Endpoints.Extensions;
 /// </summary>
 public static class BffEndpointRouteBuilderExtensions
 {
+    private static bool s_bffEndpointsMapped;
+
     /// <summary>
     /// Maps BFF authentication endpoints for each configured frontend.
     /// Each frontend gets its own route group under <c>/{pathPrefix}/bff</c> with
@@ -28,6 +30,13 @@ public static class BffEndpointRouteBuilderExtensions
     /// <returns>The endpoint route builder for further chaining.</returns>
     public static IEndpointRouteBuilder MapGranitBffEndpoints(this IEndpointRouteBuilder endpoints)
     {
+        if (s_bffEndpointsMapped)
+        {
+            return endpoints;
+        }
+
+        s_bffEndpointsMapped = true;
+
         GranitBffOptions options = endpoints.ServiceProvider
             .GetRequiredService<IOptions<GranitBffOptions>>().Value;
         ICookieRegistry cookieRegistry = endpoints.ServiceProvider

--- a/src/Granit.Http.Cookies/Internal/CookieRegistry.cs
+++ b/src/Granit.Http.Cookies/Internal/CookieRegistry.cs
@@ -16,8 +16,17 @@ internal sealed class CookieRegistry : ICookieRegistry
 
         if (!_cookies.TryAdd(definition.Name, definition))
         {
-            // Idempotent: allow re-registration of the same cookie (hot-reload, module restart).
-            _cookies[definition.Name] = definition;
+            CookieDefinition existing = _cookies[definition.Name];
+
+            // Idempotent: same definition re-registered (hot-reload, module restart) — no-op.
+            if (existing == definition)
+            {
+                return;
+            }
+
+            // Different definition with same name — genuine conflict between modules.
+            throw new InvalidOperationException(
+                $"Cookie '{definition.Name}' is already registered with a different definition.");
         }
     }
 

--- a/tests/Granit.Http.Cookies.Tests/CookieRegistryTests.cs
+++ b/tests/Granit.Http.Cookies.Tests/CookieRegistryTests.cs
@@ -24,16 +24,25 @@ public sealed class CookieRegistryTests
     }
 
     [Fact]
-    public void Register_DuplicateName_ReplacesDefinition()
+    public void Register_SameDefinitionTwice_IsIdempotent()
     {
-        CookieDefinition original = CreateDefinition();
-        CookieDefinition replacement = new("test_cookie", CookieCategory.Marketing, 30, false, "Updated purpose");
-        _sut.Register(original);
+        CookieDefinition definition = CreateDefinition();
+        _sut.Register(definition);
 
-        _sut.Register(replacement);
+        _sut.Register(definition);
 
-        CookieDefinition? result = _sut.GetDefinition("test_cookie");
-        result.ShouldBe(replacement);
+        _sut.GetDefinition("test_cookie").ShouldBe(definition);
+    }
+
+    [Fact]
+    public void Register_DifferentDefinitionSameName_ThrowsInvalidOperationException()
+    {
+        _sut.Register(CreateDefinition());
+        CookieDefinition different = new("test_cookie", CookieCategory.Marketing, 30, false, "Different");
+
+        Action act = () => _sut.Register(different);
+
+        Should.Throw<InvalidOperationException>(act).Message.ShouldContain("different definition");
     }
 
     [Fact]

--- a/tests/Granit.Http.Cookies.Tests/CookieRegistryTests.cs
+++ b/tests/Granit.Http.Cookies.Tests/CookieRegistryTests.cs
@@ -24,14 +24,16 @@ public sealed class CookieRegistryTests
     }
 
     [Fact]
-    public void Register_DuplicateName_ThrowsInvalidOperationException()
+    public void Register_DuplicateName_ReplacesDefinition()
     {
-        CookieDefinition definition = CreateDefinition();
-        _sut.Register(definition);
+        CookieDefinition original = CreateDefinition();
+        CookieDefinition replacement = new("test_cookie", CookieCategory.Marketing, 30, false, "Updated purpose");
+        _sut.Register(original);
 
-        Action act = () => _sut.Register(definition);
+        _sut.Register(replacement);
 
-        Should.Throw<InvalidOperationException>(act).Message.ShouldContain("already registered");
+        CookieDefinition? result = _sut.GetDefinition("test_cookie");
+        result.ShouldBe(replacement);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Add static guard in `MapGranitBffEndpoints` to prevent duplicate endpoint registration during hot-reload (fixes `Duplicate endpoint name 'BffLogin_admin'` crash)
- Refine `CookieRegistry.Register` from PR #739: same definition re-registered is a no-op (hot-reload safe), but a **different** definition with the same name still throws `InvalidOperationException` (detects genuine module conflicts)
- Update `CookieRegistryTests` with two distinct test cases (idempotent + conflict)

## Test plan

- [ ] Verify BFF showcase starts without `InvalidOperationException`
- [ ] Verify hot-reload does not crash on cookie or endpoint re-registration
- [ ] Verify registering a different cookie definition with the same name still throws
- [ ] 57 cookie tests pass
