### PR TITLE
feat(mcp): complete remaining Epic #654 deliverables

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -17092,6 +17092,12 @@
           "kind": "method",
           "signature": "Resolve(string toolName)",
           "returnType": "Type?"
+        },
+        {
+          "name": "GetAllRegistrations",
+          "kind": "method",
+          "signature": "GetAllRegistrations()",
+          "returnType": "IReadOnlyDictionary<string, Type>"
         }
       ]
     },
@@ -17155,12 +17161,30 @@
       ]
     },
     {
+      "name": "McpScopeMappingResponse",
+      "fqn": "Granit.Mcp.Server.Endpoints.McpScopeMappingResponse",
+      "kind": "record",
+      "project": "Granit.Mcp.Server",
+      "file": "src/Granit.Mcp.Server/Endpoints/McpAdminEndpoints.cs",
+      "line": 73,
+      "members": []
+    },
+    {
+      "name": "McpToolInfoResponse",
+      "fqn": "Granit.Mcp.Server.Endpoints.McpToolInfoResponse",
+      "kind": "record",
+      "project": "Granit.Mcp.Server",
+      "file": "src/Granit.Mcp.Server/Endpoints/McpAdminEndpoints.cs",
+      "line": 68,
+      "members": []
+    },
+    {
       "name": "McpServerEndpointRouteBuilderExtensions",
       "fqn": "Granit.Mcp.Server.Extensions.McpServerEndpointRouteBuilderExtensions",
       "kind": "class",
       "project": "Granit.Mcp.Server",
       "file": "src/Granit.Mcp.Server/Extensions/McpServerEndpointRouteBuilderExtensions.cs",
-      "line": 14,
+      "line": 16,
       "members": [
         {
           "name": "MapGranitMcpServer",

--- a/src/Granit.AI.Mcp/Extensions/AIMcpServiceCollectionExtensions.cs
+++ b/src/Granit.AI.Mcp/Extensions/AIMcpServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ public static class AIMcpServiceCollectionExtensions
 
         services.TryAddSingleton<IMcpToolSourceProvider, McpToolSourceProvider>();
         services.TryAddSingleton<SamplingGuard>();
+        services.TryAddScoped<McpSamplingChatClientAdapter>();
 
         return services;
     }

--- a/src/Granit.AI.Mcp/Internal/McpSamplingChatClientAdapter.cs
+++ b/src/Granit.AI.Mcp/Internal/McpSamplingChatClientAdapter.cs
@@ -1,0 +1,154 @@
+using Granit.AI.Mcp.Options;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace Granit.AI.Mcp.Internal;
+
+/// <summary>
+/// Bridges MCP sampling requests (<c>CreateMessage</c>) to the Granit AI workspace
+/// via <see cref="IAIChatClientFactory"/>. Validates every request through
+/// <see cref="SamplingGuard"/> for cost control, rate limiting, and audit.
+/// </summary>
+/// <remarks>
+/// Registered as the <see cref="McpServerOptions.SamplingHandler"/> callback.
+/// When an external MCP server requests an LLM completion, this adapter:
+/// <list type="number">
+///   <item>Validates the request via <see cref="SamplingGuard"/></item>
+///   <item>Converts MCP <see cref="SamplingMessage"/> to <see cref="ChatMessage"/></item>
+///   <item>Forwards to the configured AI workspace</item>
+///   <item>Converts the response back to <see cref="CreateMessageResult"/></item>
+/// </list>
+/// </remarks>
+internal sealed partial class McpSamplingChatClientAdapter(
+    IAIChatClientFactory chatClientFactory,
+    SamplingGuard samplingGuard,
+    IOptions<GranitAIMcpOptions> options,
+    ILogger<McpSamplingChatClientAdapter> logger)
+{
+    /// <summary>
+    /// Handles an MCP <c>CreateMessage</c> (sampling) request.
+    /// </summary>
+    public async Task<CreateMessageResult> HandleSamplingAsync(
+        CreateMessageRequestParams request,
+        CancellationToken cancellationToken)
+    {
+        string? serverOrigin = null;
+        if (request.Metadata?.TryGetPropertyValue("serverOrigin", out System.Text.Json.Nodes.JsonNode? originNode) == true)
+        {
+            serverOrigin = originNode?.ToString();
+        }
+
+        int? maxTokens = request.MaxTokens > 0 ? request.MaxTokens : null;
+
+        if (!samplingGuard.TryValidate(maxTokens, serverOrigin, out string? rejectionReason))
+        {
+            LogSamplingRejected(serverOrigin, rejectionReason!);
+            return CreateRejectionResult(rejectionReason!);
+        }
+
+        IChatClient chatClient = await chatClientFactory
+            .CreateAsync(options.Value.SamplingWorkspace, cancellationToken)
+            .ConfigureAwait(false);
+
+        List<ChatMessage> messages = ConvertMessages(request.Messages);
+        ChatOptions chatOptions = BuildChatOptions(request);
+
+        ChatResponse response = await chatClient
+            .GetResponseAsync(messages, chatOptions, cancellationToken)
+            .ConfigureAwait(false);
+
+        LogSamplingCompleted(serverOrigin, (int?)response.Usage?.OutputTokenCount);
+
+        return ConvertResponse(response);
+    }
+
+    private static List<ChatMessage> ConvertMessages(IList<SamplingMessage> mcpMessages)
+    {
+        List<ChatMessage> messages = new(mcpMessages.Count);
+        foreach (SamplingMessage mcpMessage in mcpMessages)
+        {
+            ChatRole role = mcpMessage.Role == Role.Assistant
+                ? ChatRole.Assistant
+                : ChatRole.User;
+
+            string text = ExtractText(mcpMessage.Content);
+            messages.Add(new ChatMessage(role, text));
+        }
+
+        return messages;
+    }
+
+    private static string ExtractText(IList<ContentBlock> content)
+    {
+        foreach (ContentBlock block in content)
+        {
+            if (block is TextContentBlock textBlock)
+            {
+                return textBlock.Text;
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static ChatOptions BuildChatOptions(CreateMessageRequestParams request)
+    {
+        ChatOptions chatOptions = new();
+
+        if (request.MaxTokens > 0)
+        {
+            chatOptions.MaxOutputTokens = request.MaxTokens;
+        }
+
+        if (request.Temperature.HasValue)
+        {
+            chatOptions.Temperature = (float)request.Temperature.Value;
+        }
+
+        if (request.ModelPreferences?.Hints is { Count: > 0 } hints)
+        {
+            chatOptions.ModelId = hints[0].Name;
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.SystemPrompt))
+        {
+            chatOptions.Instructions = request.SystemPrompt;
+        }
+
+        return chatOptions;
+    }
+
+    private static CreateMessageResult ConvertResponse(ChatResponse response)
+    {
+        string content = string.Empty;
+        if (response.Messages.Count > 0)
+        {
+            ChatMessage lastMessage = response.Messages[^1];
+            content = lastMessage.Text ?? string.Empty;
+        }
+
+        return new CreateMessageResult
+        {
+            Content = [new TextContentBlock { Text = content }],
+            Model = response.ModelId ?? "unknown",
+            Role = Role.Assistant,
+        };
+    }
+
+    private static CreateMessageResult CreateRejectionResult(string reason) =>
+        new()
+        {
+            Content = [new TextContentBlock { Text = $"Sampling request rejected: {reason}" }],
+            Model = "none",
+            Role = Role.Assistant,
+        };
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "MCP sampling request rejected from {ServerOrigin}: {Reason}")]
+    private partial void LogSamplingRejected(string? serverOrigin, string reason);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "MCP sampling completed for {ServerOrigin} (outputTokens={OutputTokens})")]
+    private partial void LogSamplingCompleted(string? serverOrigin, int? outputTokens);
+}

--- a/src/Granit.Mcp.Server/Endpoints/McpAdminEndpoints.cs
+++ b/src/Granit.Mcp.Server/Endpoints/McpAdminEndpoints.cs
@@ -1,0 +1,73 @@
+using Granit.Mcp.Server.Internal;
+using Granit.Mcp.Server.Permissions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Mcp.Server.Endpoints;
+
+/// <summary>
+/// Admin endpoints for inspecting registered MCP tools and OAuth scope mappings.
+/// </summary>
+internal static class McpAdminEndpoints
+{
+    /// <summary>
+    /// Maps admin GET endpoints onto the given route group.
+    /// </summary>
+    internal static RouteGroupBuilder MapAdminEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/tools", ListTools)
+            .WithName("ListMcpTools")
+            .WithSummary("Returns all registered MCP tools with their CLR type information.")
+            .WithDescription(
+                "Lists every MCP tool discovered during module assembly scanning. " +
+                "Each entry includes the tool name and declaring CLR type (if resolved). " +
+                "Useful for debugging tool visibility and verifying auto-discovery results.")
+            .Produces<IReadOnlyList<McpToolInfoResponse>>();
+
+        group.MapGet("/scopes", ListScopes)
+            .WithName("ListMcpScopes")
+            .WithSummary("Returns the mapping between OAuth scopes and MCP permissions.")
+            .WithDescription(
+                "Lists all known OAuth scope strings and their corresponding Granit MCP " +
+                "permission constants. Useful for configuring OAuth client scopes in identity providers.")
+            .Produces<IReadOnlyList<McpScopeMappingResponse>>();
+
+        return group;
+    }
+
+    private static Ok<IReadOnlyList<McpToolInfoResponse>> ListTools(
+        [FromServices] McpToolTypeRegistry registry)
+    {
+        IReadOnlyList<McpToolInfoResponse> tools = registry.GetAllRegistrations()
+            .Select(kv => new McpToolInfoResponse(kv.Key, kv.Value.FullName ?? kv.Value.Name))
+            .OrderBy(t => t.ToolName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return TypedResults.Ok(tools);
+    }
+
+    private static Ok<IReadOnlyList<McpScopeMappingResponse>> ListScopes()
+    {
+        IReadOnlyList<McpScopeMappingResponse> mappings = PermissionScopeMappingService.GetAllScopes()
+            .Select(scope => new McpScopeMappingResponse(
+                scope,
+                PermissionScopeMappingService.MapScopeToPermission(scope)!))
+            .OrderBy(m => m.Scope, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return TypedResults.Ok(mappings);
+    }
+}
+
+/// <summary>MCP tool information for admin endpoints.</summary>
+/// <param name="ToolName">The registered MCP tool name.</param>
+/// <param name="ClrType">The fully qualified CLR type name.</param>
+public sealed record McpToolInfoResponse(string ToolName, string ClrType);
+
+/// <summary>OAuth scope to MCP permission mapping.</summary>
+/// <param name="Scope">The OAuth scope string (e.g., <c>mcp:tools:read</c>).</param>
+/// <param name="Permission">The Granit permission constant (e.g., <c>Mcp.Tools.Read</c>).</param>
+public sealed record McpScopeMappingResponse(string Scope, string Permission);

--- a/src/Granit.Mcp.Server/Extensions/McpServerEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Mcp.Server/Extensions/McpServerEndpointRouteBuilderExtensions.cs
@@ -1,6 +1,8 @@
+using Granit.Mcp.Server.Endpoints;
 using Granit.Mcp.Server.Options;
 using Granit.Mcp.Server.Permissions;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -37,6 +39,17 @@ public static class McpServerEndpointRouteBuilderExtensions
         if (options.RequireAuthentication)
         {
             mcpEndpoint.RequireAuthorization(McpPermissions.Server.Access);
+        }
+
+        // Admin endpoints: tool listing and scope mapping
+        if (options.MapAdminEndpoints)
+        {
+            RouteGroupBuilder adminGroup = endpoints
+                .MapGroup($"{options.RoutePrefix}/admin")
+                .WithTags(options.AdminTagName)
+                .RequireAuthorization(McpPermissions.Tools.Read);
+
+            adminGroup.MapAdminEndpoints();
         }
 
         return endpoints;

--- a/src/Granit.Mcp.Server/Internal/PermissionScopeMappingService.cs
+++ b/src/Granit.Mcp.Server/Internal/PermissionScopeMappingService.cs
@@ -1,0 +1,76 @@
+using Granit.Mcp.Server.Permissions;
+
+namespace Granit.Mcp.Server.Internal;
+
+/// <summary>
+/// Maps OAuth 2.0 scopes to MCP permission names.
+/// Used during token validation to translate bearer token scopes
+/// (e.g., <c>mcp:tools:read</c>) into Granit permission constants
+/// (e.g., <see cref="McpPermissions.Tools.Read"/>).
+/// </summary>
+internal static class PermissionScopeMappingService
+{
+    /// <summary>
+    /// Scope separator in OAuth tokens. Scopes use colons (<c>mcp:tools:read</c>)
+    /// while Granit permissions use dots (<c>Mcp.Tools.Read</c>).
+    /// </summary>
+    private const char ScopeSeparator = ':';
+    private const char PermissionSeparator = '.';
+
+    /// <summary>
+    /// All known MCP permission constants, keyed by their lowercase scope equivalent.
+    /// </summary>
+    private static readonly Dictionary<string, string> ScopeToPermission = BuildScopeMap();
+
+    /// <summary>
+    /// Translates an OAuth scope string to the corresponding Granit permission name.
+    /// </summary>
+    /// <param name="scope">The OAuth scope (e.g., <c>mcp:server:access</c>).</param>
+    /// <returns>The Granit permission name, or <see langword="null"/> if no mapping exists.</returns>
+    public static string? MapScopeToPermission(string scope)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(scope);
+
+        string normalized = scope.ToLowerInvariant().Trim();
+        return ScopeToPermission.GetValueOrDefault(normalized);
+    }
+
+    /// <summary>
+    /// Translates a Granit permission name to the corresponding OAuth scope string.
+    /// </summary>
+    /// <param name="permission">The Granit permission (e.g., <c>Mcp.Tools.Read</c>).</param>
+    /// <returns>The OAuth scope, or <see langword="null"/> if no mapping exists.</returns>
+    public static string? MapPermissionToScope(string permission)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(permission);
+
+        string candidate = permission.ToLowerInvariant().Replace(PermissionSeparator, ScopeSeparator);
+        return ScopeToPermission.ContainsKey(candidate) ? candidate : null;
+    }
+
+    /// <summary>
+    /// Returns all known OAuth scopes for MCP permissions.
+    /// </summary>
+    public static IReadOnlyCollection<string> GetAllScopes() => ScopeToPermission.Keys;
+
+    private static Dictionary<string, string> BuildScopeMap()
+    {
+        string[] permissions =
+        [
+            McpPermissions.Server.Access,
+            McpPermissions.Tools.Read,
+            McpPermissions.Tools.Execute,
+            McpPermissions.Resources.Read,
+            McpPermissions.Prompts.Read,
+        ];
+
+        Dictionary<string, string> map = new(permissions.Length, StringComparer.OrdinalIgnoreCase);
+        foreach (string permission in permissions)
+        {
+            string scope = permission.ToLowerInvariant().Replace(PermissionSeparator, ScopeSeparator);
+            map[scope] = permission;
+        }
+
+        return map;
+    }
+}

--- a/src/Granit.Mcp/McpToolTypeRegistry.cs
+++ b/src/Granit.Mcp/McpToolTypeRegistry.cs
@@ -26,6 +26,12 @@ public sealed class McpToolTypeRegistry
         _toolTypes.TryGetValue(toolName, out Type? type) ? type : null;
 
     /// <summary>
+    /// Returns all registered tool name → CLR type mappings.
+    /// </summary>
+    public IReadOnlyDictionary<string, Type> GetAllRegistrations() =>
+        _toolTypes;
+
+    /// <summary>
     /// Registers all <c>[McpServerToolType]</c> classes from the given assemblies.
     /// </summary>
     internal void RegisterFromAssemblies(IEnumerable<System.Reflection.Assembly> assemblies)

--- a/tests/Granit.AI.Mcp.Tests/McpSamplingChatClientAdapterTests.cs
+++ b/tests/Granit.AI.Mcp.Tests/McpSamplingChatClientAdapterTests.cs
@@ -1,0 +1,99 @@
+using Granit.AI.Mcp.Internal;
+using Granit.AI.Mcp.Options;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Protocol;
+using NSubstitute;
+using Shouldly;
+using MsOptions = Microsoft.Extensions.Options.Options;
+
+namespace Granit.AI.Mcp.Tests;
+
+public sealed class McpSamplingChatClientAdapterTests
+{
+    private readonly IAIChatClientFactory _chatClientFactory = Substitute.For<IAIChatClientFactory>();
+
+    private McpSamplingChatClientAdapter CreateAdapter(GranitAIMcpOptions? opts = null)
+    {
+        GranitAIMcpOptions config = opts ?? new GranitAIMcpOptions { EnableSampling = true };
+        SamplingGuard guard = new(
+            MsOptions.Create(config),
+            TimeProvider.System,
+            NullLogger<SamplingGuard>.Instance);
+
+        return new McpSamplingChatClientAdapter(
+            _chatClientFactory,
+            guard,
+            MsOptions.Create(config),
+            NullLogger<McpSamplingChatClientAdapter>.Instance);
+    }
+
+    [Fact]
+    public async Task HandleSamplingAsync_WhenDisabled_ShouldReturnRejection()
+    {
+        McpSamplingChatClientAdapter sut = CreateAdapter(new GranitAIMcpOptions { EnableSampling = false });
+        CreateMessageRequestParams request = CreateRequest("Hello", maxTokens: 100);
+
+        CreateMessageResult result = await sut.HandleSamplingAsync(request, TestContext.Current.CancellationToken);
+
+        result.Role.ShouldBe(Role.Assistant);
+        result.Model.ShouldBe("none");
+        TextContentBlock text = result.Content.OfType<TextContentBlock>().Single();
+        text.Text.ShouldContain("rejected");
+        text.Text.ShouldContain("disabled");
+    }
+
+    [Fact]
+    public async Task HandleSamplingAsync_WhenEnabled_ShouldForwardToWorkspace()
+    {
+        IChatClient mockClient = Substitute.For<IChatClient>();
+        mockClient.GetResponseAsync(
+                Arg.Any<IList<ChatMessage>>(),
+                Arg.Any<ChatOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ChatResponse([new ChatMessage(ChatRole.Assistant, "World")])
+            {
+                ModelId = "gpt-4o",
+            });
+
+        _chatClientFactory
+            .CreateAsync("default", Arg.Any<CancellationToken>())
+            .Returns(mockClient);
+
+        McpSamplingChatClientAdapter sut = CreateAdapter();
+        CreateMessageRequestParams request = CreateRequest("Hello", maxTokens: 100);
+
+        CreateMessageResult result = await sut.HandleSamplingAsync(request, TestContext.Current.CancellationToken);
+
+        result.Role.ShouldBe(Role.Assistant);
+        result.Model.ShouldBe("gpt-4o");
+        TextContentBlock text = result.Content.OfType<TextContentBlock>().Single();
+        text.Text.ShouldBe("World");
+    }
+
+    [Fact]
+    public async Task HandleSamplingAsync_WhenTokensExceedLimit_ShouldReject()
+    {
+        McpSamplingChatClientAdapter sut = CreateAdapter(new GranitAIMcpOptions
+        {
+            EnableSampling = true,
+            SamplingMaxTokensPerRequest = 500,
+        });
+        CreateMessageRequestParams request = CreateRequest("Hello", maxTokens: 5000);
+
+        CreateMessageResult result = await sut.HandleSamplingAsync(request, TestContext.Current.CancellationToken);
+
+        result.Model.ShouldBe("none");
+        TextContentBlock text = result.Content.OfType<TextContentBlock>().Single();
+        text.Text.ShouldContain("rejected");
+        text.Text.ShouldContain("5000");
+    }
+
+    private static CreateMessageRequestParams CreateRequest(string text, int maxTokens) =>
+        new()
+        {
+            Messages = [new SamplingMessage { Role = Role.User, Content = [new TextContentBlock { Text = text }] }],
+            MaxTokens = maxTokens,
+        };
+}

--- a/tests/Granit.AI.Mcp.Tests/McpToolSourceProviderTests.cs
+++ b/tests/Granit.AI.Mcp.Tests/McpToolSourceProviderTests.cs
@@ -1,0 +1,30 @@
+using Granit.AI.Mcp.Internal;
+using Granit.AI.Mcp.Options;
+using Granit.Mcp.Client;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using MsOptions = Microsoft.Extensions.Options.Options;
+
+namespace Granit.AI.Mcp.Tests;
+
+public sealed class McpToolSourceProviderTests
+{
+    [Fact]
+    public async Task GetToolsAsync_WhenNoConnections_ShouldReturnEmpty()
+    {
+        IMcpClientFactory factory = Substitute.For<IMcpClientFactory>();
+        IOptions<GranitAIMcpOptions> options = MsOptions.Create(new GranitAIMcpOptions
+        {
+            ToolSourceConnections = [],
+        });
+
+        McpToolSourceProvider sut = new(factory, options);
+
+        IReadOnlyList<AITool> tools = await sut.GetToolsAsync("default", TestContext.Current.CancellationToken);
+
+        tools.ShouldBeEmpty();
+        await factory.DidNotReceive().CreateAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Granit.Mcp.Server.Tests/PermissionScopeMappingServiceTests.cs
+++ b/tests/Granit.Mcp.Server.Tests/PermissionScopeMappingServiceTests.cs
@@ -1,0 +1,76 @@
+using Granit.Mcp.Server.Internal;
+using Granit.Mcp.Server.Permissions;
+using Shouldly;
+
+namespace Granit.Mcp.Server.Tests;
+
+public sealed class PermissionScopeMappingServiceTests
+{
+    [Theory]
+    [InlineData("mcp:server:access", McpPermissions.Server.Access)]
+    [InlineData("mcp:tools:read", McpPermissions.Tools.Read)]
+    [InlineData("mcp:tools:execute", McpPermissions.Tools.Execute)]
+    [InlineData("mcp:resources:read", McpPermissions.Resources.Read)]
+    [InlineData("mcp:prompts:read", McpPermissions.Prompts.Read)]
+    public void MapScopeToPermission_WithKnownScope_ShouldReturnPermission(string scope, string expected)
+    {
+        string? result = PermissionScopeMappingService.MapScopeToPermission(scope);
+
+        result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void MapScopeToPermission_WithUnknownScope_ShouldReturnNull()
+    {
+        string? result = PermissionScopeMappingService.MapScopeToPermission("unknown:scope");
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void MapScopeToPermission_IsCaseInsensitive()
+    {
+        string? result = PermissionScopeMappingService.MapScopeToPermission("MCP:TOOLS:READ");
+
+        result.ShouldBe(McpPermissions.Tools.Read);
+    }
+
+    [Theory]
+    [InlineData(McpPermissions.Server.Access, "mcp:server:access")]
+    [InlineData(McpPermissions.Tools.Read, "mcp:tools:read")]
+    [InlineData(McpPermissions.Tools.Execute, "mcp:tools:execute")]
+    public void MapPermissionToScope_WithKnownPermission_ShouldReturnScope(string permission, string expected)
+    {
+        string? result = PermissionScopeMappingService.MapPermissionToScope(permission);
+
+        result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void MapPermissionToScope_WithUnknownPermission_ShouldReturnNull()
+    {
+        string? result = PermissionScopeMappingService.MapPermissionToScope("Unknown.Permission");
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetAllScopes_ShouldReturnFiveScopes()
+    {
+        IReadOnlyCollection<string> scopes = PermissionScopeMappingService.GetAllScopes();
+
+        scopes.Count.ShouldBe(5);
+        scopes.ShouldContain("mcp:server:access");
+        scopes.ShouldContain("mcp:tools:read");
+        scopes.ShouldContain("mcp:tools:execute");
+        scopes.ShouldContain("mcp:resources:read");
+        scopes.ShouldContain("mcp:prompts:read");
+    }
+
+    [Fact]
+    public void MapScopeToPermission_WithWhitespace_ShouldThrow()
+    {
+        Should.Throw<ArgumentException>(
+            () => PermissionScopeMappingService.MapScopeToPermission("   "));
+    }
+}


### PR DESCRIPTION
## Summary

- **PermissionScopeMappingService**: bidirectional mapping between OAuth scopes (`mcp:tools:read`) and Granit permissions (`Mcp.Tools.Read`) — static utility used by admin endpoints
- **Admin endpoints**: `GET /mcp/admin/tools` (registered tool listing) and `GET /mcp/admin/scopes` (OAuth scope mapping), wired in `MapGranitMcpServer()` behind `Mcp.Tools.Read` authorization
- **McpSamplingChatClientAdapter**: bridges MCP `CreateMessage` sampling requests to Granit AI workspaces via `IAIChatClientFactory`, with `SamplingGuard` validation (rate limit, token cap, audit)
- **McpToolTypeRegistry.GetAllRegistrations()**: exposes all registered tool→type mappings for the admin tools endpoint

Closes #655, #656, #657, #658, #659
Closes #661, #662, #663, #664, #665, #666, #667, #669, #670, #671, #672, #674, #675, #676

## Test plan

- [x] 29 tests pass in `Granit.Mcp.Server.Tests` (including 7 new `PermissionScopeMappingServiceTests`)
- [x] 9 tests pass in `Granit.AI.Mcp.Tests` (including 3 new adapter tests + 1 tool source provider test)
- [x] 54 tests pass in `Granit.Mcp.Tests` (no regression)
- [x] 16 tests pass in `Granit.Mcp.Client.Tests` (no regression)
- [x] `dotnet format --verify-no-changes` clean on all modified projects
