### PR TITLE
refactor(persistence): migrate 20 EF Core stores to EfStoreBase

### DIFF
--- a/src/Granit.AI.EntityFrameworkCore/Internal/EfAIUsageStore.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/EfAIUsageStore.cs
@@ -1,5 +1,6 @@
 using Granit.AI.Diagnostics;
 using Granit.AI.EntityFrameworkCore.Entities;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.AI.EntityFrameworkCore.Internal;
@@ -13,17 +14,16 @@ namespace Granit.AI.EntityFrameworkCore.Internal;
 /// </remarks>
 internal sealed class EfAIUsageStore(
     IDbContextFactory<AIDbContext> contextFactory,
-    AIMetrics metrics) : IAIUsageTracker
+    AIMetrics metrics)
+    : EfStoreBase<AIUsageRecordEntity, AIDbContext>(contextFactory), IAIUsageTracker
 {
     /// <inheritdoc/>
     public async Task RecordAsync(
         AIUsageRecord record,
         CancellationToken cancellationToken = default)
     {
-        await using AIDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         var entity = AIUsageRecordEntity.FromRecord(record);
-        context.UsageRecords.Add(entity);
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        await AddAsync(entity, cancellationToken).ConfigureAwait(false);
 
         string? tenantId = record.TenantId?.ToString();
         metrics.RecordRequestCompleted(tenantId, record.Model, record.Provider, "success");

--- a/src/Granit.AI.EntityFrameworkCore/Internal/EfAIWorkspaceStore.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/EfAIWorkspaceStore.cs
@@ -1,5 +1,7 @@
 using Granit.AI.EntityFrameworkCore.Entities;
 using Granit.AI.Workspaces;
+using Granit.Persistence;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.AI.EntityFrameworkCore.Internal;
@@ -12,16 +14,16 @@ namespace Granit.AI.EntityFrameworkCore.Internal;
 /// query filter applied by <c>ApplyGranitConventions</c> on <see cref="AIDbContext"/>.
 /// </remarks>
 internal sealed class EfAIWorkspaceStore(
-    IDbContextFactory<AIDbContext> contextFactory) : IAIWorkspaceStoreReader, IAIWorkspaceStoreWriter
+    IDbContextFactory<AIDbContext> contextFactory)
+    : EfStoreBase<AIWorkspaceEntity, AIDbContext>(contextFactory), IAIWorkspaceStoreReader, IAIWorkspaceStoreWriter
 {
     /// <inheritdoc/>
     public async Task<AIWorkspace?> FindAsync(
         string workspaceName,
         CancellationToken cancellationToken = default)
     {
-        await using AIDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        AIWorkspaceEntity? entity = await context.Workspaces
-            .FirstOrDefaultAsync(w => w.Name == workspaceName && w.IsActive, cancellationToken).ConfigureAwait(false);
+        AIWorkspaceEntity? entity = await FirstOrDefaultAsync(
+            w => w.Name == workspaceName && w.IsActive, cancellationToken).ConfigureAwait(false);
 
         return entity?.ToRecord();
     }
@@ -30,13 +32,13 @@ internal sealed class EfAIWorkspaceStore(
     public async Task<IReadOnlyList<AIWorkspace>> GetAllAsync(
         CancellationToken cancellationToken = default)
     {
-        await using AIDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        List<AIWorkspaceEntity> entities = await context.Workspaces
-            .Where(w => w.IsActive)
-            .OrderBy(w => w.Name)
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        IReadOnlyList<AIWorkspaceEntity> entities = await ListAsync(
+            Spec.For<AIWorkspaceEntity>()
+                .Where(w => w.IsActive)
+                .OrderBy(w => (object)w.Name),
+            cancellationToken).ConfigureAwait(false);
 
-        return entities.ConvertAll(e => e.ToRecord());
+        return entities.Select(e => e.ToRecord()).ToList();
     }
 
     /// <inheritdoc/>
@@ -44,10 +46,8 @@ internal sealed class EfAIWorkspaceStore(
         AIWorkspace workspace,
         CancellationToken cancellationToken = default)
     {
-        await using AIDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         var entity = AIWorkspaceEntity.FromRecord(workspace);
-        context.Workspaces.Add(entity);
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        await AddAsync(entity, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -55,23 +55,23 @@ internal sealed class EfAIWorkspaceStore(
         AIWorkspace workspace,
         CancellationToken cancellationToken = default)
     {
-        await using AIDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        AIWorkspaceEntity? entity = await context.Workspaces
-            .FirstOrDefaultAsync(w => w.Name == workspace.Name, cancellationToken).ConfigureAwait(false);
-
-        if (entity is null)
+        await WriteAsync(async db =>
         {
-            return;
-        }
+            AIWorkspaceEntity? entity = await db.Workspaces
+                .FirstOrDefaultAsync(w => w.Name == workspace.Name, cancellationToken).ConfigureAwait(false);
 
-        entity.Provider = workspace.Provider;
-        entity.Model = workspace.Model;
-        entity.SystemPrompt = workspace.SystemPrompt;
-        entity.Temperature = workspace.Temperature;
-        entity.MaxOutputTokens = workspace.MaxOutputTokens;
-        entity.IsActive = workspace.IsActive;
+            if (entity is null)
+            {
+                return;
+            }
 
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            entity.Provider = workspace.Provider;
+            entity.Model = workspace.Model;
+            entity.SystemPrompt = workspace.SystemPrompt;
+            entity.Temperature = workspace.Temperature;
+            entity.MaxOutputTokens = workspace.MaxOutputTokens;
+            entity.IsActive = workspace.IsActive;
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -79,14 +79,15 @@ internal sealed class EfAIWorkspaceStore(
         string workspaceName,
         CancellationToken cancellationToken = default)
     {
-        await using AIDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        AIWorkspaceEntity? entity = await context.Workspaces
-            .FirstOrDefaultAsync(w => w.Name == workspaceName, cancellationToken).ConfigureAwait(false);
-
-        if (entity is not null)
+        await WriteAsync(async db =>
         {
-            context.Workspaces.Remove(entity);
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-        }
+            AIWorkspaceEntity? entity = await db.Workspaces
+                .FirstOrDefaultAsync(w => w.Name == workspaceName, cancellationToken).ConfigureAwait(false);
+
+            if (entity is not null)
+            {
+                db.Workspaces.Remove(entity);
+            }
+        }, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Internal/EfCoreApiKeyAdminStore.cs
+++ b/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Internal/EfCoreApiKeyAdminStore.cs
@@ -1,4 +1,5 @@
 using Granit.Authentication.ApiKeys.Domain;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 
@@ -9,122 +10,101 @@ namespace Granit.Authentication.ApiKeys.EntityFrameworkCore.Internal;
 /// <see cref="IDbContextFactory{TContext}"/> for safe concurrent access.
 /// </summary>
 internal sealed class EfCoreApiKeyAdminStore(
-    IDbContextFactory<AuthenticationApiKeysDbContext> contextFactory) : IApiKeyAdminStore
+    IDbContextFactory<AuthenticationApiKeysDbContext> contextFactory)
+    : EfStoreBase<ApiKeyEntry, AuthenticationApiKeysDbContext>(contextFactory), IApiKeyAdminStore
 {
     /// <inheritdoc/>
-    public async Task<ApiKeyEntry?> FindByIdAsync(Guid id, CancellationToken cancellationToken = default)
-    {
-        await using AuthenticationApiKeysDbContext db = await contextFactory.CreateDbContextAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        return await db.ApiKeys
-            .FirstOrDefaultAsync(k => k.Id == id, cancellationToken)
-            .ConfigureAwait(false);
-    }
+    public new Task<ApiKeyEntry?> FindByIdAsync(Guid id, CancellationToken cancellationToken = default) =>
+        base.FindByIdAsync(id, cancellationToken);
 
     /// <inheritdoc/>
-    public async Task<PagedResult<ApiKeyEntry>> ListAsync(
+    public Task<PagedResult<ApiKeyEntry>> ListAsync(
         string? search = null,
         ApiKeyType? type = null,
         string? environment = null,
         bool includeRevoked = false,
         int page = 1,
         int pageSize = 20,
-        CancellationToken cancellationToken = default)
-    {
-        await using AuthenticationApiKeysDbContext db = await contextFactory.CreateDbContextAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        IQueryable<ApiKeyEntry> query = db.ApiKeys.AsNoTracking();
-
-        if (!string.IsNullOrWhiteSpace(search))
+        CancellationToken cancellationToken = default) =>
+        ReadAsync(async db =>
         {
-            query = query.Where(k => k.Name.Contains(search));
-        }
+            IQueryable<ApiKeyEntry> query = db.ApiKeys.AsNoTracking();
 
-        if (type.HasValue)
-        {
-            query = query.Where(k => k.Type == type.Value);
-        }
+            if (!string.IsNullOrWhiteSpace(search))
+            {
+                query = query.Where(k => k.Name.Contains(search));
+            }
 
-        if (!string.IsNullOrWhiteSpace(environment))
-        {
-            query = query.Where(k => k.Environment == environment);
-        }
+            if (type.HasValue)
+            {
+                query = query.Where(k => k.Type == type.Value);
+            }
 
-        if (!includeRevoked)
-        {
-            query = query.Where(k => k.RevokedAt == null);
-        }
+            if (!string.IsNullOrWhiteSpace(environment))
+            {
+                query = query.Where(k => k.Environment == environment);
+            }
 
-        int totalCount = await query.CountAsync(cancellationToken).ConfigureAwait(false);
+            if (!includeRevoked)
+            {
+                query = query.Where(k => k.RevokedAt == null);
+            }
 
-        List<ApiKeyEntry> items = await query
-            .OrderByDescending(k => k.CreatedAt)
-            .Skip((page - 1) * pageSize)
-            .Take(pageSize)
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
+            int totalCount = await query.CountAsync(cancellationToken).ConfigureAwait(false);
 
-        return new PagedResult<ApiKeyEntry>(items, totalCount, HasMore: (page - 1) * pageSize + items.Count < totalCount);
-    }
+            List<ApiKeyEntry> items = await query
+                .OrderByDescending(k => k.CreatedAt)
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            return new PagedResult<ApiKeyEntry>(items, totalCount, HasMore: (page - 1) * pageSize + items.Count < totalCount);
+        }, cancellationToken);
 
     /// <inheritdoc/>
-    public async Task CreateAsync(ApiKeyEntry entry, CancellationToken cancellationToken = default)
+    public Task CreateAsync(ApiKeyEntry entry, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(entry);
-
-        await using AuthenticationApiKeysDbContext db = await contextFactory.CreateDbContextAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        db.ApiKeys.Add(entry);
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return AddAsync(entry, cancellationToken);
     }
 
     /// <inheritdoc/>
-    public async Task<bool> RevokeAsync(Guid id, DateTimeOffset revokedAt, CancellationToken cancellationToken = default)
-    {
-        await using AuthenticationApiKeysDbContext db = await contextFactory.CreateDbContextAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        ApiKeyEntry? entry = await db.ApiKeys
-            .FirstOrDefaultAsync(k => k.Id == id && k.RevokedAt == null, cancellationToken)
-            .ConfigureAwait(false);
-
-        if (entry is null)
+    public Task<bool> RevokeAsync(Guid id, DateTimeOffset revokedAt, CancellationToken cancellationToken = default) =>
+        WriteAsync<bool>(async db =>
         {
-            return false;
-        }
+            ApiKeyEntry? entry = await db.ApiKeys
+                .FirstOrDefaultAsync(k => k.Id == id && k.RevokedAt == null, cancellationToken)
+                .ConfigureAwait(false);
 
-        entry.Revoke(revokedAt);
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            if (entry is null)
+            {
+                return false;
+            }
 
-        return true;
-    }
+            entry.Revoke(revokedAt);
+            return true;
+        }, cancellationToken);
 
     /// <inheritdoc/>
-    public async Task<bool> UpdateScopesAsync(
+    public Task<bool> UpdateScopesAsync(
         Guid id,
         List<string> permissions,
         List<string> allowedCidrs,
-        CancellationToken cancellationToken = default)
-    {
-        await using AuthenticationApiKeysDbContext db = await contextFactory.CreateDbContextAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        ApiKeyEntry? entry = await db.ApiKeys
-            .FirstOrDefaultAsync(k => k.Id == id, cancellationToken)
-            .ConfigureAwait(false);
-
-        if (entry is null)
+        CancellationToken cancellationToken = default) =>
+        WriteAsync<bool>(async db =>
         {
-            return false;
-        }
+            ApiKeyEntry? entry = await db.ApiKeys
+                .FirstOrDefaultAsync(k => k.Id == id, cancellationToken)
+                .ConfigureAwait(false);
 
-        entry.UpdatePermissions(permissions);
-        entry.UpdateAllowedCidrs(allowedCidrs);
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            if (entry is null)
+            {
+                return false;
+            }
 
-        return true;
-    }
+            entry.UpdatePermissions(permissions);
+            entry.UpdateAllowedCidrs(allowedCidrs);
+            return true;
+        }, cancellationToken);
 }

--- a/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Internal/EfCoreApiKeyStore.cs
+++ b/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Internal/EfCoreApiKeyStore.cs
@@ -1,4 +1,5 @@
 using Granit.Authentication.ApiKeys.Domain;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
@@ -10,32 +11,29 @@ namespace Granit.Authentication.ApiKeys.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed partial class EfCoreApiKeyStore(
     IDbContextFactory<AuthenticationApiKeysDbContext> contextFactory,
-    ILogger<EfCoreApiKeyStore> logger) : IApiKeyStore
+    ILogger<EfCoreApiKeyStore> logger)
+    : EfStoreBase<ApiKeyEntry, AuthenticationApiKeysDbContext>(contextFactory), IApiKeyStore
 {
     /// <inheritdoc/>
-    public async Task<ApiKeyEntry?> FindByHashAsync(string hashedKey, CancellationToken cancellationToken = default)
-    {
-        await using AuthenticationApiKeysDbContext db = await contextFactory.CreateDbContextAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        return await db.ApiKeys
-            .AsNoTracking()
-            .FirstOrDefaultAsync(k => k.HashedKey == hashedKey, cancellationToken)
-            .ConfigureAwait(false);
-    }
+    public Task<ApiKeyEntry?> FindByHashAsync(string hashedKey, CancellationToken cancellationToken = default) =>
+        ReadAsync(
+            db => db.ApiKeys
+                .AsNoTracking()
+                .FirstOrDefaultAsync(k => k.HashedKey == hashedKey, cancellationToken),
+            cancellationToken);
 
     /// <inheritdoc/>
     public async Task UpdateLastUsedAsync(Guid id, DateTimeOffset usedAt, CancellationToken cancellationToken = default)
     {
         try
         {
-            await using AuthenticationApiKeysDbContext db = await contextFactory.CreateDbContextAsync(cancellationToken)
-                .ConfigureAwait(false);
-
-            await db.ApiKeys
-                .Where(k => k.Id == id)
-                .ExecuteUpdateAsync(s => s.SetProperty(k => k.LastUsedAt, usedAt), cancellationToken)
-                .ConfigureAwait(false);
+            await WriteAsync(async db =>
+            {
+                await db.ApiKeys
+                    .Where(k => k.Id == id)
+                    .ExecuteUpdateAsync(s => s.SetProperty(k => k.LastUsedAt, usedAt), cancellationToken)
+                    .ConfigureAwait(false);
+            }, cancellationToken).ConfigureAwait(false);
         }
         catch (DbUpdateException ex)
         {

--- a/src/Granit.BackgroundJobs.EntityFrameworkCore/Internal/EfBackgroundJobStore.cs
+++ b/src/Granit.BackgroundJobs.EntityFrameworkCore/Internal/EfBackgroundJobStore.cs
@@ -1,6 +1,8 @@
 using Granit.BackgroundJobs.Domain;
 using Granit.BackgroundJobs.Internal;
 using Granit.Guids;
+using Granit.Persistence;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.BackgroundJobs.EntityFrameworkCore.Internal;
@@ -18,128 +20,125 @@ namespace Granit.BackgroundJobs.EntityFrameworkCore.Internal;
 /// </remarks>
 internal sealed class EfBackgroundJobStore(
     IDbContextFactory<BackgroundJobsDbContext> contextFactory,
-    IGuidGenerator guidGenerator) : IBackgroundJobStoreReader, IBackgroundJobStoreWriter
+    IGuidGenerator guidGenerator)
+    : EfStoreBase<BackgroundJobDefinition, BackgroundJobsDbContext>(contextFactory),
+      IBackgroundJobStoreReader, IBackgroundJobStoreWriter
 {
     /// <inheritdoc/>
-    public async Task<BackgroundJobDefinition?> FindAsync(string jobName, CancellationToken cancellationToken = default)
-    {
-        await using BackgroundJobsDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        return await context.Jobs.FirstOrDefaultAsync(j => j.JobName == jobName, cancellationToken).ConfigureAwait(false);
-    }
+    public Task<BackgroundJobDefinition?> FindAsync(
+        string jobName,
+        CancellationToken cancellationToken = default) =>
+        FirstOrDefaultAsync(j => j.JobName == jobName, cancellationToken);
 
     /// <inheritdoc/>
-    public async Task<IReadOnlyList<BackgroundJobDefinition>> GetEnabledJobsAsync(CancellationToken cancellationToken = default)
-    {
-        await using BackgroundJobsDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        return await context.Jobs.Where(j => j.IsEnabled).ToListAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public Task<IReadOnlyList<BackgroundJobDefinition>> GetEnabledJobsAsync(
+        CancellationToken cancellationToken = default) =>
+        ListAsync(
+            Spec.For<BackgroundJobDefinition>().Where(j => j.IsEnabled),
+            cancellationToken);
 
     /// <inheritdoc/>
-    public async Task<IReadOnlyList<BackgroundJobDefinition>> GetAllJobsAsync(CancellationToken cancellationToken = default)
-    {
-        await using BackgroundJobsDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        return await context.Jobs.ToListAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public Task<IReadOnlyList<BackgroundJobDefinition>> GetAllJobsAsync(
+        CancellationToken cancellationToken = default) =>
+        ListAsync(
+            Spec.For<BackgroundJobDefinition>(),
+            cancellationToken);
 
     /// <inheritdoc/>
-    public async Task SeedJobsAsync(IEnumerable<RecurringJobRegistration> registrations, CancellationToken cancellationToken = default)
-    {
-        await using BackgroundJobsDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        foreach (RecurringJobRegistration reg in registrations)
-        {
-            BackgroundJobDefinition? existing =
-                await context.Jobs.FirstOrDefaultAsync(j => j.JobName == reg.JobName, cancellationToken).ConfigureAwait(false);
-
-            if (existing is null)
+    public Task SeedJobsAsync(
+        IEnumerable<RecurringJobRegistration> registrations,
+        CancellationToken cancellationToken = default) =>
+        WriteAsync(
+            async db =>
             {
-                context.Jobs.Add(BackgroundJobDefinition.Create(
-                    guidGenerator.Create(), reg.JobName, reg.CronExpression, reg.MessageType));
-            }
-            else
+                foreach (RecurringJobRegistration reg in registrations)
+                {
+                    BackgroundJobDefinition? existing =
+                        await db.Jobs.FirstOrDefaultAsync(j => j.JobName == reg.JobName, cancellationToken)
+                            .ConfigureAwait(false);
+
+                    if (existing is null)
+                    {
+                        db.Jobs.Add(BackgroundJobDefinition.Create(
+                            guidGenerator.Create(), reg.JobName, reg.CronExpression, reg.MessageType));
+                    }
+                    else
+                    {
+                        // Preserve administrative state — only sync scheduling metadata.
+                        existing.UpdateDefinition(reg.CronExpression, reg.MessageType);
+                    }
+                }
+            },
+            cancellationToken);
+
+    /// <inheritdoc/>
+    public Task RecordExecutionStartAsync(
+        string jobName,
+        DateTimeOffset startedAt,
+        CancellationToken cancellationToken = default) =>
+        MutateJobAsync(jobName, job => job.RecordExecutionStart(startedAt), cancellationToken);
+
+    /// <inheritdoc/>
+    public Task RecordNextExecutionAsync(
+        string jobName,
+        DateTimeOffset nextExecution,
+        CancellationToken cancellationToken = default) =>
+        MutateJobAsync(jobName, job => job.ScheduleNext(nextExecution), cancellationToken);
+
+    /// <inheritdoc/>
+    public Task RecordExecutionFailureAsync(
+        string jobName,
+        string errorMessage,
+        CancellationToken cancellationToken = default) =>
+        MutateJobAsync(jobName, job => job.RecordFailure(errorMessage), cancellationToken);
+
+    /// <inheritdoc/>
+    public Task SetEnabledAsync(
+        string jobName,
+        bool enabled,
+        CancellationToken cancellationToken = default) =>
+        MutateJobAsync(
+            jobName,
+            job =>
             {
-                // Preserve administrative state — only sync scheduling metadata.
-                existing.UpdateDefinition(reg.CronExpression, reg.MessageType);
-            }
-        }
-
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <inheritdoc/>
-    public async Task RecordExecutionStartAsync(string jobName, DateTimeOffset startedAt, CancellationToken cancellationToken = default)
-    {
-        await using BackgroundJobsDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        BackgroundJobDefinition? job = await context.Jobs.FirstOrDefaultAsync(j => j.JobName == jobName, cancellationToken).ConfigureAwait(false);
-        if (job is null)
-        {
-            return;
-        }
-
-        job.RecordExecutionStart(startedAt);
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+                if (enabled)
+                {
+                    job.Resume();
+                }
+                else
+                {
+                    job.Pause();
+                }
+            },
+            cancellationToken);
 
     /// <inheritdoc/>
-    public async Task RecordNextExecutionAsync(string jobName, DateTimeOffset nextExecution, CancellationToken cancellationToken = default)
-    {
-        await using BackgroundJobsDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        BackgroundJobDefinition? job = await context.Jobs.FirstOrDefaultAsync(j => j.JobName == jobName, cancellationToken).ConfigureAwait(false);
-        if (job is null)
-        {
-            return;
-        }
+    public Task SetTriggeredByAsync(
+        string jobName,
+        string? triggeredBy,
+        CancellationToken cancellationToken = default) =>
+        MutateJobAsync(jobName, job => job.SetTriggeredBy(triggeredBy), cancellationToken);
 
-        job.ScheduleNext(nextExecution);
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+    /// <summary>
+    /// Fetches a job by name and applies a mutation. Silently no-ops if the job does not exist.
+    /// </summary>
+    private Task MutateJobAsync(
+        string jobName,
+        Action<BackgroundJobDefinition> mutation,
+        CancellationToken cancellationToken) =>
+        WriteAsync(
+            async db =>
+            {
+                BackgroundJobDefinition? job = await db.Jobs
+                    .FirstOrDefaultAsync(j => j.JobName == jobName, cancellationToken)
+                    .ConfigureAwait(false);
 
-    /// <inheritdoc/>
-    public async Task RecordExecutionFailureAsync(string jobName, string errorMessage, CancellationToken cancellationToken = default)
-    {
-        await using BackgroundJobsDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        BackgroundJobDefinition? job = await context.Jobs.FirstOrDefaultAsync(j => j.JobName == jobName, cancellationToken).ConfigureAwait(false);
-        if (job is null)
-        {
-            return;
-        }
+                if (job is null)
+                {
+                    return;
+                }
 
-        job.RecordFailure(errorMessage);
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <inheritdoc/>
-    public async Task SetEnabledAsync(string jobName, bool enabled, CancellationToken cancellationToken = default)
-    {
-        await using BackgroundJobsDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        BackgroundJobDefinition? job = await context.Jobs.FirstOrDefaultAsync(j => j.JobName == jobName, cancellationToken).ConfigureAwait(false);
-        if (job is null)
-        {
-            return;
-        }
-
-        if (enabled)
-        {
-            job.Resume();
-        }
-        else
-        {
-            job.Pause();
-        }
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <inheritdoc/>
-    public async Task SetTriggeredByAsync(string jobName, string? triggeredBy, CancellationToken cancellationToken = default)
-    {
-        await using BackgroundJobsDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        BackgroundJobDefinition? job = await context.Jobs.FirstOrDefaultAsync(j => j.JobName == jobName, cancellationToken).ConfigureAwait(false);
-        if (job is null)
-        {
-            return;
-        }
-
-        job.SetTriggeredBy(triggeredBy);
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+                mutation(job);
+            },
+            cancellationToken);
 }

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/Stores/EfExportJobStore.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/Stores/EfExportJobStore.cs
@@ -1,5 +1,8 @@
 using Granit.DataExchange.Export;
 using Granit.DataExchange.Export.Domain;
+using Granit.Persistence;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 
@@ -10,55 +13,34 @@ namespace Granit.DataExchange.EntityFrameworkCore.Internal.Export.Stores;
 /// Performs CRUD operations on <see cref="ExportJob"/> via <see cref="DataExchangeDbContext"/>.
 /// </summary>
 internal sealed class EfExportJobStore(
-    IDbContextFactory<DataExchangeDbContext> contextFactory) : IExportJobReader, IExportJobWriter
+    IDbContextFactory<DataExchangeDbContext> contextFactory)
+    : EfStoreBase<ExportJob, DataExchangeDbContext>(contextFactory), IExportJobReader, IExportJobWriter
 {
     /// <inheritdoc/>
-    public async Task<ExportJob?> GetAsync(Guid id, CancellationToken cancellationToken = default)
-    {
-        await using DataExchangeDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        return await context.ExportJobs
-            .AsNoTracking()
-            .FirstOrDefaultAsync(j => j.Id == id, cancellationToken).ConfigureAwait(false);
-    }
+    public Task<ExportJob?> GetAsync(Guid id, CancellationToken cancellationToken = default) =>
+        FindByIdAsync(id, cancellationToken);
 
     /// <inheritdoc/>
-    public async Task<PagedResult<ExportJob>> ListAsync(
+    public Task<PagedResult<ExportJob>> ListAsync(
         ExportJobStatus? status = null, int page = 1, int pageSize = 20, CancellationToken cancellationToken = default)
     {
-        await using DataExchangeDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        IQueryable<ExportJob> query = context.ExportJobs.AsNoTracking();
+        InlineSpecification<ExportJob> spec = Spec.For<ExportJob>();
 
         if (status.HasValue)
         {
-            query = query.Where(j => j.Status == status.Value);
+            spec.Where(j => j.Status == status.Value);
         }
 
-        int totalCount = await query.CountAsync(cancellationToken).ConfigureAwait(false);
+        spec.OrderByDescending(j => (object)j.CreatedAt);
 
-        List<ExportJob> items = await query
-            .OrderByDescending(j => j.CreatedAt)
-            .Skip((page - 1) * pageSize)
-            .Take(pageSize)
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        return new PagedResult<ExportJob>(items, totalCount, HasMore: (page - 1) * pageSize + items.Count < totalCount);
+        return PagedAsync(spec, page, pageSize, cancellationToken);
     }
 
     /// <inheritdoc/>
-    public async Task CreateAsync(ExportJob job, CancellationToken cancellationToken = default)
-    {
-        await using DataExchangeDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        context.ExportJobs.Add(job);
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public Task CreateAsync(ExportJob job, CancellationToken cancellationToken = default) =>
+        AddAsync(job, cancellationToken);
 
     /// <inheritdoc/>
-    public async Task UpdateAsync(ExportJob job, CancellationToken cancellationToken = default)
-    {
-        await using DataExchangeDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        context.ExportJobs.Update(job);
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public new Task UpdateAsync(ExportJob job, CancellationToken cancellationToken = default) =>
+        base.UpdateAsync(job, cancellationToken);
 }

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Stores/EfImportJobStore.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Stores/EfImportJobStore.cs
@@ -1,5 +1,8 @@
 using Granit.DataExchange.Import.Domain;
 using Granit.DataExchange.Import.Pipeline;
+using Granit.Persistence;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 
@@ -10,55 +13,34 @@ namespace Granit.DataExchange.EntityFrameworkCore.Internal.Import.Stores;
 /// Performs CRUD operations on <see cref="ImportJob"/> via <see cref="DataExchangeDbContext"/>.
 /// </summary>
 internal sealed class EfImportJobStore(
-    IDbContextFactory<DataExchangeDbContext> contextFactory) : IImportJobReader, IImportJobWriter
+    IDbContextFactory<DataExchangeDbContext> contextFactory)
+    : EfStoreBase<ImportJob, DataExchangeDbContext>(contextFactory), IImportJobReader, IImportJobWriter
 {
     /// <inheritdoc/>
-    public async Task<ImportJob?> GetAsync(Guid id, CancellationToken cancellationToken = default)
-    {
-        await using DataExchangeDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        return await context.ImportJobs
-            .AsNoTracking()
-            .FirstOrDefaultAsync(j => j.Id == id, cancellationToken).ConfigureAwait(false);
-    }
+    public Task<ImportJob?> GetAsync(Guid id, CancellationToken cancellationToken = default) =>
+        FindByIdAsync(id, cancellationToken);
 
     /// <inheritdoc/>
-    public async Task<PagedResult<ImportJob>> ListAsync(
+    public Task<PagedResult<ImportJob>> ListAsync(
         ImportJobStatus? status = null, int page = 1, int pageSize = 20, CancellationToken cancellationToken = default)
     {
-        await using DataExchangeDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        IQueryable<ImportJob> query = context.ImportJobs.AsNoTracking();
+        InlineSpecification<ImportJob> spec = Spec.For<ImportJob>();
 
         if (status.HasValue)
         {
-            query = query.Where(j => j.Status == status.Value);
+            spec.Where(j => j.Status == status.Value);
         }
 
-        int totalCount = await query.CountAsync(cancellationToken).ConfigureAwait(false);
+        spec.OrderByDescending(j => (object)j.CreatedAt);
 
-        List<ImportJob> items = await query
-            .OrderByDescending(j => j.CreatedAt)
-            .Skip((page - 1) * pageSize)
-            .Take(pageSize)
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        return new PagedResult<ImportJob>(items, totalCount, HasMore: (page - 1) * pageSize + items.Count < totalCount);
+        return PagedAsync(spec, page, pageSize, cancellationToken);
     }
 
     /// <inheritdoc/>
-    public async Task CreateAsync(ImportJob job, CancellationToken cancellationToken = default)
-    {
-        await using DataExchangeDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        context.ImportJobs.Add(job);
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public Task CreateAsync(ImportJob job, CancellationToken cancellationToken = default) =>
+        AddAsync(job, cancellationToken);
 
     /// <inheritdoc/>
-    public async Task UpdateAsync(ImportJob job, CancellationToken cancellationToken = default)
-    {
-        await using DataExchangeDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        context.ImportJobs.Update(job);
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public new Task UpdateAsync(ImportJob job, CancellationToken cancellationToken = default) =>
+        base.UpdateAsync(job, cancellationToken);
 }

--- a/src/Granit.Features.EntityFrameworkCore/Internal/EfCoreFeatureStore.cs
+++ b/src/Granit.Features.EntityFrameworkCore/Internal/EfCoreFeatureStore.cs
@@ -4,6 +4,7 @@ using Granit.Events;
 using Granit.Features.Diagnostics;
 using Granit.Features.EntityFrameworkCore.Entities;
 using Granit.Features.Events;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
@@ -34,7 +35,8 @@ internal sealed class EfCoreFeatureStore(
     ILocalEventBus eventBus,
     TimeProvider timeProvider,
     ILogger<EfCoreFeatureStore> logger,
-    IDataFilter? dataFilter = null) : IFeatureStoreReader, IFeatureStoreWriter
+    IDataFilter? dataFilter = null)
+    : EfStoreBase<TenantFeatureOverride, FeaturesDbContext>(contextFactory), IFeatureStoreReader, IFeatureStoreWriter
 {
     /// <inheritdoc/>
     public async Task<string?> GetOrNullAsync(
@@ -44,13 +46,14 @@ internal sealed class EfCoreFeatureStore(
     {
         Guid? tenantGuid = ParseTenantId(tenantId);
         using IDisposable? _ = dataFilter?.Disable<IMultiTenant>();
-        await using FeaturesDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
-        TenantFeatureOverride? row = await context.FeatureOverrides
-            .AsNoTracking()
-            .FirstOrDefaultAsync(
-                o => o.TenantId == tenantGuid && o.FeatureName == featureName,
-                cancellationToken).ConfigureAwait(false);
+        TenantFeatureOverride? row = await ReadAsync(
+            async db => await db.FeatureOverrides
+                .AsNoTracking()
+                .FirstOrDefaultAsync(
+                    o => o.TenantId == tenantGuid && o.FeatureName == featureName,
+                    cancellationToken).ConfigureAwait(false),
+            cancellationToken).ConfigureAwait(false);
 
         return row?.Value;
     }
@@ -64,51 +67,59 @@ internal sealed class EfCoreFeatureStore(
     {
         Guid? tenantGuid = ParseTenantId(tenantId);
         using IDisposable? _ = dataFilter?.Disable<IMultiTenant>();
-        await using FeaturesDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
-        TenantFeatureOverride? existing = await context.FeatureOverrides
-            .FirstOrDefaultAsync(
-                o => o.TenantId == tenantGuid && o.FeatureName == featureName,
-                cancellationToken).ConfigureAwait(false);
-
-        string? oldValue = existing?.Value;
-
-        if (existing is null)
+        // WriteAsync auto-calls SaveChangesAsync, but TOCTOU recovery needs manual
+        // save control — use ReadAsync-style context access with explicit saves.
+        string? oldValue = await WriteAsync<string?>(async db =>
         {
-            context.FeatureOverrides.Add(new TenantFeatureOverride
-            {
-                TenantId = tenantGuid,
-                FeatureName = featureName,
-                Value = value,
-            });
-        }
-        else
-        {
-            existing.Value = value;
-        }
-
-        try
-        {
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-        }
-        catch (DbUpdateException) when (existing is null)
-        {
-            // TOCTOU race: concurrent insert for the same (tenant, feature) tuple hit
-            // the unique index. Treat as idempotent — re-read and update instead.
-            context.ChangeTracker.Clear();
-
-            existing = await context.FeatureOverrides
+            TenantFeatureOverride? existing = await db.FeatureOverrides
                 .FirstOrDefaultAsync(
                     o => o.TenantId == tenantGuid && o.FeatureName == featureName,
                     cancellationToken).ConfigureAwait(false);
 
-            if (existing is not null)
+            string? old = existing?.Value;
+
+            if (existing is null)
             {
-                oldValue = existing.Value;
-                existing.Value = value;
-                await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                db.FeatureOverrides.Add(new TenantFeatureOverride
+                {
+                    TenantId = tenantGuid,
+                    FeatureName = featureName,
+                    Value = value,
+                });
             }
-        }
+            else
+            {
+                existing.Value = value;
+            }
+
+            try
+            {
+                // SaveChangesAsync is called by WriteAsync after this delegate returns,
+                // but we need to intercept DbUpdateException for TOCTOU recovery.
+                // Call it explicitly here and return — WriteAsync's save will be a no-op.
+                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (DbUpdateException) when (existing is null)
+            {
+                // TOCTOU race: concurrent insert for the same (tenant, feature) tuple hit
+                // the unique index. Treat as idempotent — re-read and update instead.
+                db.ChangeTracker.Clear();
+
+                existing = await db.FeatureOverrides
+                    .FirstOrDefaultAsync(
+                        o => o.TenantId == tenantGuid && o.FeatureName == featureName,
+                        cancellationToken).ConfigureAwait(false);
+
+                if (existing is not null)
+                {
+                    old = existing.Value;
+                    existing.Value = value;
+                }
+            }
+
+            return old;
+        }, cancellationToken).ConfigureAwait(false);
 
         string tenantStr = tenantGuid?.ToString() ?? "global";
         FeaturesLog.FeatureOverrideChanged(logger, featureName, tenantStr, oldValue, value);
@@ -130,21 +141,28 @@ internal sealed class EfCoreFeatureStore(
     {
         Guid? tenantGuid = ParseTenantId(tenantId);
         using IDisposable? _ = dataFilter?.Disable<IMultiTenant>();
-        await using FeaturesDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
-        TenantFeatureOverride? existing = await context.FeatureOverrides
-            .FirstOrDefaultAsync(
-                o => o.TenantId == tenantGuid && o.FeatureName == featureName,
-                cancellationToken).ConfigureAwait(false);
+        string? oldValue = await WriteAsync<string?>(async db =>
+        {
+            TenantFeatureOverride? existing = await db.FeatureOverrides
+                .FirstOrDefaultAsync(
+                    o => o.TenantId == tenantGuid && o.FeatureName == featureName,
+                    cancellationToken).ConfigureAwait(false);
 
-        if (existing is null)
+            if (existing is null)
+            {
+                return null;
+            }
+
+            string old = existing.Value;
+            db.FeatureOverrides.Remove(existing);
+            return old;
+        }, cancellationToken).ConfigureAwait(false);
+
+        if (oldValue is null)
         {
             return;
         }
-
-        string oldValue = existing.Value;
-        context.FeatureOverrides.Remove(existing);
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         string tenantStr = tenantGuid?.ToString() ?? "global";
         FeaturesLog.FeatureOverrideChanged(logger, featureName, tenantStr, oldValue, null);

--- a/src/Granit.Localization.EntityFrameworkCore/Internal/EfCoreLocalizationOverrideStore.cs
+++ b/src/Granit.Localization.EntityFrameworkCore/Internal/EfCoreLocalizationOverrideStore.cs
@@ -1,4 +1,5 @@
 using Granit.Localization.EntityFrameworkCore.Entities;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Localization.EntityFrameworkCore.Internal;
@@ -15,73 +16,62 @@ namespace Granit.Localization.EntityFrameworkCore.Internal;
 /// <see cref="LocalizationDbContext"/>, making it safe for concurrent request handling.
 /// </remarks>
 internal sealed class EfCoreLocalizationOverrideStore(
-    IDbContextFactory<LocalizationDbContext> contextFactory) : ILocalizationOverrideStoreReader, ILocalizationOverrideStoreWriter
+    IDbContextFactory<LocalizationDbContext> contextFactory)
+    : EfStoreBase<LocalizationOverride, LocalizationDbContext>(contextFactory), ILocalizationOverrideStoreReader, ILocalizationOverrideStoreWriter
 {
-    private readonly IDbContextFactory<LocalizationDbContext> _contextFactory = contextFactory;
-
     /// <inheritdoc/>
     public async Task<IReadOnlyDictionary<string, string>> GetOverridesAsync(
         string resourceName, string culture, CancellationToken cancellationToken = default)
     {
-        await using LocalizationDbContext context =
-            await _contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        List<LocalizationOverride> rows = await context.LocalizationOverrides
-            .AsNoTracking()
-            .Where(o => o.ResourceName == resourceName && o.CultureName == culture)
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        List<LocalizationOverride> rows = await ReadAsync(
+            async db => await db.LocalizationOverrides
+                .AsNoTracking()
+                .Where(o => o.ResourceName == resourceName && o.CultureName == culture)
+                .ToListAsync(cancellationToken).ConfigureAwait(false),
+            cancellationToken).ConfigureAwait(false);
 
         return rows.ToDictionary(o => o.Key, o => o.Value, StringComparer.Ordinal);
     }
 
     /// <inheritdoc/>
-    public async Task SetOverrideAsync(
-        string resourceName, string culture, string key, string value, CancellationToken cancellationToken = default)
-    {
-        await using LocalizationDbContext context =
-            await _contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        LocalizationOverride? existing = await context.LocalizationOverrides
-            .FirstOrDefaultAsync(
-                o => o.ResourceName == resourceName && o.CultureName == culture && o.Key == key,
-                cancellationToken).ConfigureAwait(false);
-
-        if (existing is null)
+    public Task SetOverrideAsync(
+        string resourceName, string culture, string key, string value, CancellationToken cancellationToken = default) =>
+        WriteAsync(async db =>
         {
-            context.LocalizationOverrides.Add(new LocalizationOverride
+            LocalizationOverride? existing = await db.LocalizationOverrides
+                .FirstOrDefaultAsync(
+                    o => o.ResourceName == resourceName && o.CultureName == culture && o.Key == key,
+                    cancellationToken).ConfigureAwait(false);
+
+            if (existing is null)
             {
-                ResourceName = resourceName,
-                CultureName = culture,
-                Key = key,
-                Value = value,
-            });
-        }
-        else
-        {
-            existing.Value = value;
-        }
-
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+                db.LocalizationOverrides.Add(new LocalizationOverride
+                {
+                    ResourceName = resourceName,
+                    CultureName = culture,
+                    Key = key,
+                    Value = value,
+                });
+            }
+            else
+            {
+                existing.Value = value;
+            }
+        }, cancellationToken);
 
     /// <inheritdoc/>
-    public async Task RemoveOverrideAsync(
-        string resourceName, string culture, string key, CancellationToken cancellationToken = default)
-    {
-        await using LocalizationDbContext context =
-            await _contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        LocalizationOverride? existing = await context.LocalizationOverrides
-            .FirstOrDefaultAsync(
-                o => o.ResourceName == resourceName && o.CultureName == culture && o.Key == key,
-                cancellationToken).ConfigureAwait(false);
-
-        if (existing is null)
+    public Task RemoveOverrideAsync(
+        string resourceName, string culture, string key, CancellationToken cancellationToken = default) =>
+        WriteAsync(async db =>
         {
-            return;
-        }
+            LocalizationOverride? existing = await db.LocalizationOverrides
+                .FirstOrDefaultAsync(
+                    o => o.ResourceName == resourceName && o.CultureName == culture && o.Key == key,
+                    cancellationToken).ConfigureAwait(false);
 
-        context.LocalizationOverrides.Remove(existing);
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+            if (existing is not null)
+            {
+                db.LocalizationOverrides.Remove(existing);
+            }
+        }, cancellationToken);
 }

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreMobilePushTokenStore.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreMobilePushTokenStore.cs
@@ -1,5 +1,6 @@
 using Granit.Notifications.EntityFrameworkCore.Entities;
 using Granit.Notifications.MobilePush;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Notifications.EntityFrameworkCore.Internal;
@@ -8,57 +9,55 @@ namespace Granit.Notifications.EntityFrameworkCore.Internal;
 /// EF Core implementation of <see cref="IMobilePushTokenReader"/> and <see cref="IMobilePushTokenWriter"/>.
 /// </summary>
 internal sealed class EfCoreMobilePushTokenStore(
-    IDbContextFactory<NotificationsDbContext> dbContextFactory) : IMobilePushTokenReader, IMobilePushTokenWriter
+    IDbContextFactory<NotificationsDbContext> contextFactory)
+    : EfStoreBase<MobilePushTokenEntity, NotificationsDbContext>(contextFactory), IMobilePushTokenReader, IMobilePushTokenWriter
 {
     /// <inheritdoc />
-    public async Task<IReadOnlyList<MobilePushTokenInfo>> GetTokensAsync(
-        string userId, Guid? tenantId, CancellationToken cancellationToken = default)
-    {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        return await db.MobilePushTokens
-            .Where(t => t.UserId == userId && t.TenantId == tenantId)
-            .Select(t => t.ToTokenInfo())
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
-    }
+    public Task<IReadOnlyList<MobilePushTokenInfo>> GetTokensAsync(
+        string userId, Guid? tenantId, CancellationToken cancellationToken = default) =>
+        ReadAsync(async db =>
+            (IReadOnlyList<MobilePushTokenInfo>)await db.MobilePushTokens
+                .Where(t => t.UserId == userId && t.TenantId == tenantId)
+                .Select(t => t.ToTokenInfo())
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false),
+            cancellationToken);
 
     /// <inheritdoc />
     public async Task RegisterAsync(MobilePushTokenInfo tokenInfo, CancellationToken cancellationToken = default)
     {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        MobilePushTokenEntity? existing = await db.MobilePushTokens
-            .FirstOrDefaultAsync(t => t.DeviceToken == tokenInfo.DeviceToken && t.TenantId == tokenInfo.TenantId, cancellationToken)
-            .ConfigureAwait(false);
-
-        if (existing is not null)
+        await WriteAsync(async db =>
         {
-            existing.UserId = tokenInfo.UserId;
-            existing.Platform = tokenInfo.Platform;
-        }
-        else
-        {
-            db.MobilePushTokens.Add(new MobilePushTokenEntity
+            MobilePushTokenEntity? existing = await db.MobilePushTokens
+                .FirstOrDefaultAsync(t => t.DeviceToken == tokenInfo.DeviceToken && t.TenantId == tokenInfo.TenantId, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (existing is not null)
             {
-                UserId = tokenInfo.UserId,
-                DeviceToken = tokenInfo.DeviceToken,
-                Platform = tokenInfo.Platform,
-                TenantId = tokenInfo.TenantId,
-            });
-        }
-
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                existing.UserId = tokenInfo.UserId;
+                existing.Platform = tokenInfo.Platform;
+            }
+            else
+            {
+                db.MobilePushTokens.Add(new MobilePushTokenEntity
+                {
+                    UserId = tokenInfo.UserId,
+                    DeviceToken = tokenInfo.DeviceToken,
+                    Platform = tokenInfo.Platform,
+                    TenantId = tokenInfo.TenantId,
+                });
+            }
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
     public async Task RemoveAsync(string deviceToken, string userId, Guid? tenantId, CancellationToken cancellationToken = default)
     {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        await db.MobilePushTokens
-            .Where(t => t.DeviceToken == deviceToken && t.UserId == userId && t.TenantId == tenantId)
-            .ExecuteDeleteAsync(cancellationToken)
-            .ConfigureAwait(false);
+        await WriteAsync(async db =>
+            await db.MobilePushTokens
+                .Where(t => t.DeviceToken == deviceToken && t.UserId == userId && t.TenantId == tenantId)
+                .ExecuteDeleteAsync(cancellationToken)
+                .ConfigureAwait(false),
+            cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreNotificationDeliveryStore.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreNotificationDeliveryStore.cs
@@ -1,5 +1,6 @@
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Domain;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Notifications.EntityFrameworkCore.Internal;
@@ -13,27 +14,25 @@ namespace Granit.Notifications.EntityFrameworkCore.Internal;
 /// <see cref="DeleteBeforeAsync"/> enables RGPD-compliant data minimization.
 /// </para>
 /// </remarks>
-internal sealed class EfCoreNotificationDeliveryStore(IDbContextFactory<NotificationsDbContext> dbContextFactory) : INotificationDeliveryWriter
+internal sealed class EfCoreNotificationDeliveryStore(
+    IDbContextFactory<NotificationsDbContext> contextFactory)
+    : EfStoreBase<NotificationDeliveryAttempt, NotificationsDbContext>(contextFactory), INotificationDeliveryWriter
 {
     /// <inheritdoc/>
-    public async Task RecordAsync(NotificationDeliveryAttempt attempt, CancellationToken cancellationToken = default)
-    {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        db.DeliveryAttempts.Add(attempt);
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public Task RecordAsync(NotificationDeliveryAttempt attempt, CancellationToken cancellationToken = default) =>
+        AddAsync(attempt, cancellationToken);
 
     /// <inheritdoc/>
-    public async Task<int> DeleteBeforeAsync(
+    public Task<int> DeleteBeforeAsync(
         DateTimeOffset cutoff,
         int batchSize,
-        CancellationToken cancellationToken = default)
-    {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        return await db.DeliveryAttempts
-            .Where(a => a.OccurredAt < cutoff)
-            .OrderBy(a => a.OccurredAt)
-            .Take(batchSize)
-            .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
-    }
+        CancellationToken cancellationToken = default) =>
+        WriteAsync(async db =>
+            await db.DeliveryAttempts
+                .Where(a => a.OccurredAt < cutoff)
+                .OrderBy(a => a.OccurredAt)
+                .Take(batchSize)
+                .ExecuteDeleteAsync(cancellationToken)
+                .ConfigureAwait(false),
+            cancellationToken);
 }

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreNotificationPreferenceStore.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreNotificationPreferenceStore.cs
@@ -1,5 +1,6 @@
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Domain;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Notifications.EntityFrameworkCore.Internal;
@@ -8,52 +9,51 @@ namespace Granit.Notifications.EntityFrameworkCore.Internal;
 /// EF Core implementation of <see cref="INotificationPreferenceReader"/> and
 /// <see cref="INotificationPreferenceWriter"/> backed by PostgreSQL.
 /// </summary>
-internal sealed class EfCoreNotificationPreferenceStore(IDbContextFactory<NotificationsDbContext> dbContextFactory) : INotificationPreferenceReader, INotificationPreferenceWriter
+internal sealed class EfCoreNotificationPreferenceStore(
+    IDbContextFactory<NotificationsDbContext> contextFactory)
+    : EfStoreBase<NotificationPreference, NotificationsDbContext>(contextFactory), INotificationPreferenceReader, INotificationPreferenceWriter
 {
     /// <inheritdoc/>
-    public async Task<IReadOnlyList<NotificationPreference>> GetListAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default)
-    {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        return await db.Preferences
-            .Where(p => p.UserId == userId && p.TenantId == tenantId)
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public Task<IReadOnlyList<NotificationPreference>> GetListAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default) =>
+        ReadAsync(async db =>
+            (IReadOnlyList<NotificationPreference>)await db.Preferences
+                .Where(p => p.UserId == userId && p.TenantId == tenantId)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false),
+            cancellationToken);
 
     /// <inheritdoc/>
-    public async Task<NotificationPreference?> GetAsync(string userId, string notificationTypeName, string channelName, Guid? tenantId, CancellationToken cancellationToken = default)
-    {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        return await db.Preferences
-            .FirstOrDefaultAsync(p => p.UserId == userId && p.NotificationTypeName == notificationTypeName && p.ChannelName == channelName && p.TenantId == tenantId, cancellationToken).ConfigureAwait(false);
-    }
+    public Task<NotificationPreference?> GetAsync(string userId, string notificationTypeName, string channelName, Guid? tenantId, CancellationToken cancellationToken = default) =>
+        FirstOrDefaultAsync(p => p.UserId == userId && p.NotificationTypeName == notificationTypeName && p.ChannelName == channelName && p.TenantId == tenantId, cancellationToken);
 
     /// <inheritdoc/>
     public async Task SetAsync(NotificationPreference preference, CancellationToken cancellationToken = default)
     {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        NotificationPreference? existing = await db.Preferences
-            .FirstOrDefaultAsync(p => p.UserId == preference.UserId && p.NotificationTypeName == preference.NotificationTypeName && p.ChannelName == preference.ChannelName && p.TenantId == preference.TenantId, cancellationToken).ConfigureAwait(false);
-
-        if (existing is not null)
+        await WriteAsync(async db =>
         {
-            existing.IsEnabled = preference.IsEnabled;
-            existing.ModifiedAt = preference.ModifiedAt;
-            existing.ModifiedBy = preference.ModifiedBy;
-        }
-        else
-        {
-            db.Preferences.Add(preference);
-        }
+            NotificationPreference? existing = await db.Preferences
+                .FirstOrDefaultAsync(p => p.UserId == preference.UserId && p.NotificationTypeName == preference.NotificationTypeName && p.ChannelName == preference.ChannelName && p.TenantId == preference.TenantId, cancellationToken)
+                .ConfigureAwait(false);
 
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            if (existing is not null)
+            {
+                existing.IsEnabled = preference.IsEnabled;
+                existing.ModifiedAt = preference.ModifiedAt;
+                existing.ModifiedBy = preference.ModifiedBy;
+            }
+            else
+            {
+                db.Preferences.Add(preference);
+            }
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public async Task<bool> IsChannelEnabledAsync(string userId, string notificationTypeName, string channelName, Guid? tenantId, CancellationToken cancellationToken = default)
     {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        NotificationPreference? preference = await db.Preferences
-            .FirstOrDefaultAsync(p => p.UserId == userId && p.NotificationTypeName == notificationTypeName && p.ChannelName == channelName && p.TenantId == tenantId, cancellationToken).ConfigureAwait(false);
+        NotificationPreference? preference = await FirstOrDefaultAsync(
+            p => p.UserId == userId && p.NotificationTypeName == notificationTypeName && p.ChannelName == channelName && p.TenantId == tenantId,
+            cancellationToken).ConfigureAwait(false);
         return preference?.IsEnabled ?? true; // Default: enabled
     }
 }

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreNotificationSubscriptionStore.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreNotificationSubscriptionStore.cs
@@ -1,6 +1,7 @@
 using Granit.Guids;
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Domain;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Notifications.EntityFrameworkCore.Internal;
@@ -9,64 +10,66 @@ namespace Granit.Notifications.EntityFrameworkCore.Internal;
 /// EF Core implementation of <see cref="INotificationSubscriptionReader"/> and
 /// <see cref="INotificationSubscriptionWriter"/> backed by PostgreSQL.
 /// </summary>
-internal sealed class EfCoreNotificationSubscriptionStore(IDbContextFactory<NotificationsDbContext> dbContextFactory, IGuidGenerator guidGenerator) : INotificationSubscriptionReader, INotificationSubscriptionWriter
+internal sealed class EfCoreNotificationSubscriptionStore(
+    IDbContextFactory<NotificationsDbContext> contextFactory,
+    IGuidGenerator guidGenerator)
+    : EfStoreBase<NotificationSubscription, NotificationsDbContext>(contextFactory), INotificationSubscriptionReader, INotificationSubscriptionWriter
 {
     /// <inheritdoc/>
     public async Task SubscribeAsync(string userId, string notificationTypeName, Guid? tenantId, CancellationToken cancellationToken = default)
     {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        bool exists = await db.Subscriptions.AnyAsync(s => s.UserId == userId && s.NotificationTypeName == notificationTypeName && s.TenantId == tenantId && s.EntityType == null, cancellationToken).ConfigureAwait(false);
+        bool exists = await AnyAsync(s => s.UserId == userId && s.NotificationTypeName == notificationTypeName && s.TenantId == tenantId && s.EntityType == null, cancellationToken).ConfigureAwait(false);
         if (!exists)
         {
-            db.Subscriptions.Add(new NotificationSubscription
+            await AddAsync(new NotificationSubscription
             {
                 Id = guidGenerator.Create(),
                 UserId = userId,
                 NotificationTypeName = notificationTypeName,
                 TenantId = tenantId,
-            });
-            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            }, cancellationToken).ConfigureAwait(false);
         }
     }
 
     /// <inheritdoc/>
     public async Task UnsubscribeAsync(string userId, string notificationTypeName, Guid? tenantId, CancellationToken cancellationToken = default)
     {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        await db.Subscriptions
-            .Where(s => s.UserId == userId && s.NotificationTypeName == notificationTypeName && s.TenantId == tenantId && s.EntityType == null)
-            .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+        await WriteAsync(async db =>
+            await db.Subscriptions
+                .Where(s => s.UserId == userId && s.NotificationTypeName == notificationTypeName && s.TenantId == tenantId && s.EntityType == null)
+                .ExecuteDeleteAsync(cancellationToken)
+                .ConfigureAwait(false),
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public async Task<IReadOnlyList<string>> GetSubscriberIdsAsync(string notificationTypeName, Guid? tenantId, CancellationToken cancellationToken = default)
-    {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        return await db.Subscriptions
-            .Where(s => s.NotificationTypeName == notificationTypeName && s.TenantId == tenantId && s.EntityType == null)
-            .Select(s => s.UserId)
-            .Distinct()
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public Task<IReadOnlyList<string>> GetSubscriberIdsAsync(string notificationTypeName, Guid? tenantId, CancellationToken cancellationToken = default) =>
+        ReadAsync(async db =>
+            (IReadOnlyList<string>)await db.Subscriptions
+                .Where(s => s.NotificationTypeName == notificationTypeName && s.TenantId == tenantId && s.EntityType == null)
+                .Select(s => s.UserId)
+                .Distinct()
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false),
+            cancellationToken);
 
     /// <inheritdoc/>
-    public async Task<IReadOnlyList<NotificationSubscription>> GetUserSubscriptionsAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default)
-    {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        return await db.Subscriptions
-            .AsNoTracking()
-            .Where(s => s.UserId == userId && s.TenantId == tenantId)
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public Task<IReadOnlyList<NotificationSubscription>> GetUserSubscriptionsAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default) =>
+        ReadAsync(async db =>
+            (IReadOnlyList<NotificationSubscription>)await db.Subscriptions
+                .AsNoTracking()
+                .Where(s => s.UserId == userId && s.TenantId == tenantId)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false),
+            cancellationToken);
 
     /// <inheritdoc/>
     public async Task FollowEntityAsync(string userId, string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default)
     {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        bool exists = await db.Subscriptions.AnyAsync(s => s.UserId == userId && s.EntityType == entityType && s.EntityId == entityId && s.TenantId == tenantId, cancellationToken).ConfigureAwait(false);
+        bool exists = await AnyAsync(s => s.UserId == userId && s.EntityType == entityType && s.EntityId == entityId && s.TenantId == tenantId, cancellationToken).ConfigureAwait(false);
         if (!exists)
         {
-            db.Subscriptions.Add(new NotificationSubscription
+            await AddAsync(new NotificationSubscription
             {
                 Id = guidGenerator.Create(),
                 UserId = userId,
@@ -74,46 +77,43 @@ internal sealed class EfCoreNotificationSubscriptionStore(IDbContextFactory<Noti
                 EntityType = entityType,
                 EntityId = entityId,
                 TenantId = tenantId,
-            });
-            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            }, cancellationToken).ConfigureAwait(false);
         }
     }
 
     /// <inheritdoc/>
     public async Task UnfollowEntityAsync(string userId, string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default)
     {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        await db.Subscriptions
-            .Where(s => s.UserId == userId && s.EntityType == entityType && s.EntityId == entityId && s.TenantId == tenantId)
-            .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+        await WriteAsync(async db =>
+            await db.Subscriptions
+                .Where(s => s.UserId == userId && s.EntityType == entityType && s.EntityId == entityId && s.TenantId == tenantId)
+                .ExecuteDeleteAsync(cancellationToken)
+                .ConfigureAwait(false),
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public async Task<IReadOnlyList<string>> GetEntityFollowerIdsAsync(string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default)
-    {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        return await db.Subscriptions
-            .Where(s => s.EntityType == entityType && s.EntityId == entityId && s.TenantId == tenantId)
-            .Select(s => s.UserId)
-            .Distinct()
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public Task<IReadOnlyList<string>> GetEntityFollowerIdsAsync(string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default) =>
+        ReadAsync(async db =>
+            (IReadOnlyList<string>)await db.Subscriptions
+                .Where(s => s.EntityType == entityType && s.EntityId == entityId && s.TenantId == tenantId)
+                .Select(s => s.UserId)
+                .Distinct()
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false),
+            cancellationToken);
 
     /// <inheritdoc/>
-    public async Task<IReadOnlyList<NotificationSubscription>> GetEntityFollowersAsync(string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default)
-    {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        return await db.Subscriptions
-            .AsNoTracking()
-            .Where(s => s.EntityType == entityType && s.EntityId == entityId && s.TenantId == tenantId)
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public Task<IReadOnlyList<NotificationSubscription>> GetEntityFollowersAsync(string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default) =>
+        ReadAsync(async db =>
+            (IReadOnlyList<NotificationSubscription>)await db.Subscriptions
+                .AsNoTracking()
+                .Where(s => s.EntityType == entityType && s.EntityId == entityId && s.TenantId == tenantId)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false),
+            cancellationToken);
 
     /// <inheritdoc/>
-    public async Task<bool> IsFollowingEntityAsync(string userId, string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default)
-    {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        return await db.Subscriptions
-            .AnyAsync(s => s.UserId == userId && s.EntityType == entityType && s.EntityId == entityId && s.TenantId == tenantId, cancellationToken).ConfigureAwait(false);
-    }
+    public Task<bool> IsFollowingEntityAsync(string userId, string entityType, string entityId, Guid? tenantId, CancellationToken cancellationToken = default) =>
+        AnyAsync(s => s.UserId == userId && s.EntityType == entityType && s.EntityId == entityId && s.TenantId == tenantId, cancellationToken);
 }

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreUserNotificationStore.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreUserNotificationStore.cs
@@ -1,5 +1,8 @@
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Domain;
+using Granit.Persistence;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 
@@ -9,84 +12,69 @@ namespace Granit.Notifications.EntityFrameworkCore.Internal;
 /// EF Core implementation of <see cref="IUserNotificationReader"/> and
 /// <see cref="IUserNotificationWriter"/> backed by PostgreSQL.
 /// </summary>
-internal sealed class EfCoreUserNotificationStore(IDbContextFactory<NotificationsDbContext> dbContextFactory) : IUserNotificationReader, IUserNotificationWriter
+internal sealed class EfCoreUserNotificationStore(
+    IDbContextFactory<NotificationsDbContext> contextFactory)
+    : EfStoreBase<UserNotification, NotificationsDbContext>(contextFactory), IUserNotificationReader, IUserNotificationWriter
 {
     /// <inheritdoc/>
-    public async Task InsertAsync(UserNotification notification, CancellationToken cancellationToken = default)
-    {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        db.UserNotifications.Add(notification);
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public Task InsertAsync(UserNotification notification, CancellationToken cancellationToken = default) =>
+        AddAsync(notification, cancellationToken);
 
     /// <inheritdoc/>
-    public async Task<UserNotification?> GetAsync(Guid id, CancellationToken cancellationToken = default)
-    {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        return await db.UserNotifications.FindAsync([id], cancellationToken).ConfigureAwait(false);
-    }
+    public Task<UserNotification?> GetAsync(Guid id, CancellationToken cancellationToken = default) =>
+        FindByIdAsync(id, cancellationToken);
 
     /// <inheritdoc/>
     public async Task<PagedResult<UserNotification>> GetListAsync(string recipientUserId, Guid? tenantId, int page = 1, int pageSize = QueryEngineDefaults.DefaultPageSize, CancellationToken cancellationToken = default)
     {
         (int clampedPage, int clampedPageSize) = QueryEngineDefaults.ClampPagination(page, pageSize);
 
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        IQueryable<UserNotification> query = db.UserNotifications
-            .Where(n => n.RecipientUserId == recipientUserId && n.TenantId == tenantId);
-
-        int totalCount = await query.CountAsync(cancellationToken).ConfigureAwait(false);
-
-        List<UserNotification> items = await query
-            .OrderByDescending(n => n.CreatedAt)
-            .Skip((clampedPage - 1) * clampedPageSize)
-            .Take(clampedPageSize)
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-
-        return new PagedResult<UserNotification>(items, totalCount, HasMore: (clampedPage - 1) * clampedPageSize + items.Count < totalCount);
+        return await ReadAsync(async db =>
+            await db.UserNotifications
+                .Where(n => n.RecipientUserId == recipientUserId && n.TenantId == tenantId)
+                .OrderByDescending(n => n.CreatedAt)
+                .ToPagedResultAsync(clampedPage, clampedPageSize, cancellationToken)
+                .ConfigureAwait(false),
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public async Task<int> GetUnreadCountAsync(string recipientUserId, Guid? tenantId, CancellationToken cancellationToken = default)
-    {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        return await db.UserNotifications
-            .CountAsync(n => n.RecipientUserId == recipientUserId && n.TenantId == tenantId && n.State == UserNotificationState.Unread, cancellationToken).ConfigureAwait(false);
-    }
+    public Task<int> GetUnreadCountAsync(string recipientUserId, Guid? tenantId, CancellationToken cancellationToken = default) =>
+        CountAsync(n => n.RecipientUserId == recipientUserId && n.TenantId == tenantId && n.State == UserNotificationState.Unread, cancellationToken);
 
     /// <inheritdoc/>
     public async Task MarkAsReadAsync(Guid id, string recipientUserId, DateTimeOffset readAt, CancellationToken cancellationToken = default)
     {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        UserNotification? notification = await db.UserNotifications
-            .FirstOrDefaultAsync(n => n.Id == id && n.RecipientUserId == recipientUserId, cancellationToken).ConfigureAwait(false);
-
-        if (notification is null)
+        await WriteAsync(async db =>
         {
-            return;
-        }
+            UserNotification? notification = await db.UserNotifications
+                .FirstOrDefaultAsync(n => n.Id == id && n.RecipientUserId == recipientUserId, cancellationToken)
+                .ConfigureAwait(false);
 
-        notification.MarkAsRead(readAt);
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            if (notification is null)
+            {
+                return;
+            }
+
+            notification.MarkAsRead(readAt);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public async Task MarkAllAsReadAsync(string recipientUserId, Guid? tenantId, DateTimeOffset readAt, CancellationToken cancellationToken = default)
     {
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        List<UserNotification> unread = await db.UserNotifications
-            .Where(n => n.RecipientUserId == recipientUserId && n.TenantId == tenantId && n.State == UserNotificationState.Unread)
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-
-        foreach (UserNotification notification in unread)
+        await WriteAsync(async db =>
         {
-            notification.MarkAsRead(readAt);
-        }
+            List<UserNotification> unread = await db.UserNotifications
+                .Where(n => n.RecipientUserId == recipientUserId && n.TenantId == tenantId && n.State == UserNotificationState.Unread)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
 
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            foreach (UserNotification notification in unread)
+            {
+                notification.MarkAsRead(readAt);
+            }
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -94,19 +82,12 @@ internal sealed class EfCoreUserNotificationStore(IDbContextFactory<Notification
     {
         (int clampedPage, int clampedPageSize) = QueryEngineDefaults.ClampPagination(page, pageSize);
 
-        await using NotificationsDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        IQueryable<UserNotification> query = db.UserNotifications
-            .Where(n => n.RelatedEntityType == entityType && n.RelatedEntityId == entityId && n.TenantId == tenantId);
-
-        int totalCount = await query.CountAsync(cancellationToken).ConfigureAwait(false);
-
-        List<UserNotification> items = await query
-            .OrderByDescending(n => n.CreatedAt)
-            .Skip((clampedPage - 1) * clampedPageSize)
-            .Take(clampedPageSize)
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-
-        return new PagedResult<UserNotification>(items, totalCount, HasMore: (clampedPage - 1) * clampedPageSize + items.Count < totalCount);
+        return await ReadAsync(async db =>
+            await db.UserNotifications
+                .Where(n => n.RelatedEntityType == entityType && n.RelatedEntityId == entityId && n.TenantId == tenantId)
+                .OrderByDescending(n => n.CreatedAt)
+                .ToPagedResultAsync(clampedPage, clampedPageSize, cancellationToken)
+                .ConfigureAwait(false),
+            cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/EfSigningKeyStore.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/EfSigningKeyStore.cs
@@ -1,5 +1,6 @@
 using Granit.OpenIddict.Domain;
 using Granit.OpenIddict.Services;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
@@ -8,22 +9,21 @@ namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
 /// EF Core implementation of <see cref="ISigningKeyStore"/>.
 /// </summary>
 internal sealed class EfSigningKeyStore(
-    IDbContextFactory<OpenIddictDbContext> dbFactory) : ISigningKeyStore
+    IDbContextFactory<OpenIddictDbContext> dbFactory)
+    : EfStoreBase<SigningKey, OpenIddictDbContext>(dbFactory), ISigningKeyStore
 {
     /// <inheritdoc/>
-    public async Task<IReadOnlyList<SigningKey>> GetKeysAsync(
+    public Task<IReadOnlyList<SigningKey>> GetKeysAsync(
         SigningKeyStatus[] statuses,
-        CancellationToken cancellationToken = default)
-    {
-        await using OpenIddictDbContext db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        return await db.SigningKeys
-            .AsNoTracking()
-            .Where(k => statuses.Contains(k.Status))
-            .OrderByDescending(k => k.CreatedAt)
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
-    }
+        CancellationToken cancellationToken = default) =>
+        ReadAsync(
+            async db => (IReadOnlyList<SigningKey>)await db.SigningKeys
+                .AsNoTracking()
+                .Where(k => statuses.Contains(k.Status))
+                .OrderByDescending(k => k.CreatedAt)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false),
+            cancellationToken);
 
     /// <inheritdoc/>
     public Task<IReadOnlyList<SigningKey>> GetKeysAsync(
@@ -31,43 +31,30 @@ internal sealed class EfSigningKeyStore(
         GetKeysAsync(statuses, CancellationToken.None);
 
     /// <inheritdoc/>
-    public async Task<SigningKey?> GetActiveKeyAsync(
-        string keyType, CancellationToken cancellationToken = default)
-    {
-        await using OpenIddictDbContext db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        return await db.SigningKeys
-            .AsNoTracking()
-            .Where(k => k.KeyType == keyType && k.Status == SigningKeyStatus.Active)
-            .OrderByDescending(k => k.ActivatedAt)
-            .FirstOrDefaultAsync(cancellationToken)
-            .ConfigureAwait(false);
-    }
+    public Task<SigningKey?> GetActiveKeyAsync(
+        string keyType, CancellationToken cancellationToken = default) =>
+        ReadAsync(
+            db => db.SigningKeys
+                .AsNoTracking()
+                .Where(k => k.KeyType == keyType && k.Status == SigningKeyStatus.Active)
+                .OrderByDescending(k => k.ActivatedAt)
+                .FirstOrDefaultAsync(cancellationToken),
+            cancellationToken);
 
     /// <inheritdoc/>
-    public async Task CreateAsync(SigningKey key, CancellationToken cancellationToken = default)
-    {
-        await using OpenIddictDbContext db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        db.SigningKeys.Add(key);
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public Task CreateAsync(SigningKey key, CancellationToken cancellationToken = default) =>
+        AddAsync(key, cancellationToken);
 
     /// <inheritdoc/>
-    public async Task UpdateAsync(SigningKey key, CancellationToken cancellationToken = default)
-    {
-        await using OpenIddictDbContext db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        db.SigningKeys.Update(key);
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public new Task UpdateAsync(SigningKey key, CancellationToken cancellationToken = default) =>
+        base.UpdateAsync(key, cancellationToken);
 
     /// <inheritdoc/>
-    public async Task<int> PruneRevokedAsync(
-        DateTimeOffset olderThan, CancellationToken cancellationToken = default)
-    {
-        await using OpenIddictDbContext db = await dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        return await db.SigningKeys
-            .Where(k => k.Status == SigningKeyStatus.Revoked && k.RetiredAt < olderThan)
-            .ExecuteDeleteAsync(cancellationToken)
-            .ConfigureAwait(false);
-    }
+    public Task<int> PruneRevokedAsync(
+        DateTimeOffset olderThan, CancellationToken cancellationToken = default) =>
+        ReadAsync(
+            db => db.SigningKeys
+                .Where(k => k.Status == SigningKeyStatus.Revoked && k.RetiredAt < olderThan)
+                .ExecuteDeleteAsync(cancellationToken),
+            cancellationToken);
 }

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/OpenIddictGroupStore.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/OpenIddictGroupStore.cs
@@ -1,6 +1,7 @@
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Services;
 using Granit.Identity.Models;
+using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
@@ -9,14 +10,16 @@ namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
 /// <see cref="ILocalIdentityGroupStore"/> implementation backed by <see cref="OpenIddictDbContext"/>.
 /// </summary>
 internal sealed class OpenIddictGroupStore(
-    IDbContextFactory<OpenIddictDbContext> _dbFactory) : ILocalIdentityGroupStore
+    IDbContextFactory<OpenIddictDbContext> dbFactory)
+    : EfStoreBase<GranitUserGroup, OpenIddictDbContext>(dbFactory), ILocalIdentityGroupStore
 {
     /// <inheritdoc/>
     public async Task<IReadOnlyList<IdentityGroup>> GetGroupsAsync(CancellationToken cancellationToken = default)
     {
-        await using OpenIddictDbContext db = await _dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        List<GranitUserGroup> groups = await db.UserGroups.AsNoTracking()
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        IReadOnlyList<GranitUserGroup> groups = await ReadAsync(
+            db => db.UserGroups.AsNoTracking().ToListAsync(cancellationToken),
+            cancellationToken).ConfigureAwait(false);
+
         return groups.Select(g => new IdentityGroup(g.Id.ToString(), g.Name, null, [])).ToList();
     }
 
@@ -25,54 +28,59 @@ internal sealed class OpenIddictGroupStore(
     {
         Guid userGuid = ParseGuid(userId, nameof(userId));
 
-        await using OpenIddictDbContext db = await _dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        List<Guid> groupIds = await db.UserGroupMembers.AsNoTracking()
-            .Where(m => m.UserId == userGuid)
-            .Select(m => m.GroupId)
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        IReadOnlyList<GranitUserGroup> groups = await ReadAsync(async db =>
+        {
+            List<Guid> groupIds = await db.UserGroupMembers.AsNoTracking()
+                .Where(m => m.UserId == userGuid)
+                .Select(m => m.GroupId)
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
 
-        List<GranitUserGroup> groups = await db.UserGroups.AsNoTracking()
-            .Where(g => groupIds.Contains(g.Id))
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
+            return (IReadOnlyList<GranitUserGroup>)await db.UserGroups.AsNoTracking()
+                .Where(g => groupIds.Contains(g.Id))
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
 
         return groups.Select(g => new IdentityGroup(g.Id.ToString(), g.Name, null, [])).ToList();
     }
 
     /// <inheritdoc/>
-    public async Task AddUserToGroupAsync(string userId, string groupId, CancellationToken cancellationToken = default)
+    public Task AddUserToGroupAsync(string userId, string groupId, CancellationToken cancellationToken = default)
     {
         Guid userGuid = ParseGuid(userId, nameof(userId));
         Guid groupGuid = ParseGuid(groupId, nameof(groupId));
 
-        await using OpenIddictDbContext db = await _dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        db.UserGroupMembers.Add(new GranitUserGroupMember
+        return WriteAsync(db =>
         {
-            GroupId = groupGuid,
-            UserId = userGuid,
-        });
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            db.UserGroupMembers.Add(new GranitUserGroupMember
+            {
+                GroupId = groupGuid,
+                UserId = userGuid,
+            });
+            return Task.CompletedTask;
+        }, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public Task RemoveUserFromGroupAsync(string userId, string groupId, CancellationToken cancellationToken = default)
+    {
+        Guid userGuid = ParseGuid(userId, nameof(userId));
+        Guid groupGuid = ParseGuid(groupId, nameof(groupId));
+
+        return WriteAsync(async db =>
+        {
+            GranitUserGroupMember? member = await db.UserGroupMembers
+                .FirstOrDefaultAsync(m => m.GroupId == groupGuid && m.UserId == userGuid,
+                    cancellationToken).ConfigureAwait(false);
+
+            if (member is not null)
+            {
+                db.UserGroupMembers.Remove(member);
+            }
+        }, cancellationToken);
     }
 
     private static Guid ParseGuid(string value, string parameterName) =>
         Guid.TryParse(value, out Guid result)
             ? result
             : throw new ArgumentException($"'{value}' is not a valid GUID.", parameterName);
-
-    /// <inheritdoc/>
-    public async Task RemoveUserFromGroupAsync(string userId, string groupId, CancellationToken cancellationToken = default)
-    {
-        Guid userGuid = ParseGuid(userId, nameof(userId));
-        Guid groupGuid = ParseGuid(groupId, nameof(groupId));
-
-        await using OpenIddictDbContext db = await _dbFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        GranitUserGroupMember? member = await db.UserGroupMembers
-            .FirstOrDefaultAsync(m => m.GroupId == groupGuid && m.UserId == userGuid,
-                cancellationToken).ConfigureAwait(false);
-
-        if (member is not null)
-        {
-            db.UserGroupMembers.Remove(member);
-            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-        }
-    }
 }

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/EfCoreSavedViewStore.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/EfCoreSavedViewStore.cs
@@ -1,3 +1,5 @@
+using Granit.Persistence;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.QueryEngine.SavedViews;
 using Granit.QueryEngine.SavedViews.Domain;
 using Microsoft.EntityFrameworkCore;
@@ -9,112 +11,76 @@ namespace Granit.QueryEngine.EntityFrameworkCore.Internal;
 /// Performs CRUD operations on <see cref="SavedView"/> via <see cref="QueryEngineDbContext"/>.
 /// </summary>
 internal sealed class EfCoreSavedViewStore(
-    IDbContextFactory<QueryEngineDbContext> contextFactory) : ISavedViewStoreReader, ISavedViewStoreWriter
+    IDbContextFactory<QueryEngineDbContext> contextFactory)
+    : EfStoreBase<SavedView, QueryEngineDbContext>(contextFactory), ISavedViewStoreReader, ISavedViewStoreWriter
 {
     /// <inheritdoc/>
-    public async Task<IReadOnlyList<SavedView>> GetListAsync(
-        string entityType, string userId, Guid? tenantId, CancellationToken cancellationToken = default)
-    {
-        await using QueryEngineDbContext context = await contextFactory
-            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        return await context.SavedViews
-            .AsNoTracking()
-            .Where(v => v.EntityType == entityType
-                && v.TenantId == tenantId
-                && (v.UserId == userId || v.IsShared))
-            .OrderBy(v => v.Name)
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public Task<IReadOnlyList<SavedView>> GetListAsync(
+        string entityType, string userId, Guid? tenantId, CancellationToken cancellationToken = default) =>
+        ListAsync(
+            Spec.For<SavedView>()
+                .Where(v => v.EntityType == entityType
+                    && v.TenantId == tenantId
+                    && (v.UserId == userId || v.IsShared))
+                .OrderBy(v => v.Name),
+            cancellationToken);
 
     /// <inheritdoc/>
-    public async Task<int> GetCountAsync(
-        string entityType, string userId, Guid? tenantId, CancellationToken cancellationToken = default)
-    {
-        await using QueryEngineDbContext context = await contextFactory
-            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        return await context.SavedViews
-            .CountAsync(v => v.EntityType == entityType
-                && v.UserId == userId
-                && v.TenantId == tenantId, cancellationToken).ConfigureAwait(false);
-    }
+    public Task<int> GetCountAsync(
+        string entityType, string userId, Guid? tenantId, CancellationToken cancellationToken = default) =>
+        CountAsync(v => v.EntityType == entityType
+            && v.UserId == userId
+            && v.TenantId == tenantId, cancellationToken);
 
     /// <inheritdoc/>
-    public async Task<SavedView?> GetAsync(Guid id, CancellationToken cancellationToken = default)
-    {
-        await using QueryEngineDbContext context = await contextFactory
-            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        return await context.SavedViews
-            .AsNoTracking()
-            .FirstOrDefaultAsync(v => v.Id == id, cancellationToken).ConfigureAwait(false);
-    }
+    public Task<SavedView?> GetAsync(Guid id, CancellationToken cancellationToken = default) =>
+        FindByIdAsync(id, cancellationToken);
 
     /// <inheritdoc/>
-    public async Task CreateAsync(SavedView view, CancellationToken cancellationToken = default)
-    {
-        await using QueryEngineDbContext context = await contextFactory
-            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        context.SavedViews.Add(view);
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public Task CreateAsync(SavedView view, CancellationToken cancellationToken = default) =>
+        AddAsync(view, cancellationToken);
 
     /// <inheritdoc/>
-    public async Task UpdateAsync(SavedView view, CancellationToken cancellationToken = default)
-    {
-        await using QueryEngineDbContext context = await contextFactory
-            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        context.SavedViews.Update(view);
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public new Task UpdateAsync(SavedView view, CancellationToken cancellationToken = default) =>
+        base.UpdateAsync(view, cancellationToken);
 
     /// <inheritdoc/>
-    public async Task DeleteAsync(Guid id, CancellationToken cancellationToken = default)
-    {
-        await using QueryEngineDbContext context = await contextFactory
-            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        SavedView? view = await context.SavedViews
-            .FirstOrDefaultAsync(v => v.Id == id, cancellationToken).ConfigureAwait(false);
-
-        if (view is not null)
+    public Task DeleteAsync(Guid id, CancellationToken cancellationToken = default) =>
+        WriteAsync(async db =>
         {
-            context.SavedViews.Remove(view);
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-        }
-    }
+            SavedView? view = await db.SavedViews
+                .FirstOrDefaultAsync(v => v.Id == id, cancellationToken).ConfigureAwait(false);
+
+            if (view is not null)
+            {
+                db.SavedViews.Remove(view);
+            }
+        }, cancellationToken);
 
     /// <inheritdoc/>
-    public async Task SetDefaultAsync(
-        Guid id, string userId, string entityType, CancellationToken cancellationToken = default)
-    {
-        await using QueryEngineDbContext context = await contextFactory
-            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        // Unset any previous default for the same user and entity type
-        List<SavedView> previousDefaults = await context.SavedViews
-            .Where(v => v.EntityType == entityType
-                && v.UserId == userId
-                && v.IsDefault)
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-
-        foreach (SavedView previous in previousDefaults)
+    public Task SetDefaultAsync(
+        Guid id, string userId, string entityType, CancellationToken cancellationToken = default) =>
+        WriteAsync(async db =>
         {
-            previous.IsDefault = false;
-        }
+            // Unset any previous default for the same user and entity type
+            List<SavedView> previousDefaults = await db.SavedViews
+                .Where(v => v.EntityType == entityType
+                    && v.UserId == userId
+                    && v.IsDefault)
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
 
-        // Set the new default
-        SavedView? target = await context.SavedViews
-            .FirstOrDefaultAsync(v => v.Id == id, cancellationToken).ConfigureAwait(false);
+            foreach (SavedView previous in previousDefaults)
+            {
+                previous.IsDefault = false;
+            }
 
-        if (target is not null)
-        {
-            target.IsDefault = true;
-        }
+            // Set the new default
+            SavedView? target = await db.SavedViews
+                .FirstOrDefaultAsync(v => v.Id == id, cancellationToken).ConfigureAwait(false);
 
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+            if (target is not null)
+            {
+                target.IsDefault = true;
+            }
+        }, cancellationToken);
 }

--- a/src/Granit.Timeline.EntityFrameworkCore/Internal/EfCoreTimelineStore.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/Internal/EfCoreTimelineStore.cs
@@ -1,5 +1,6 @@
 using Granit.Guids;
 using Granit.MultiTenancy;
+using Granit.Persistence;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Timeline.Abstractions;
 using Granit.Timeline.Domain;
@@ -14,6 +15,8 @@ namespace Granit.Timeline.EntityFrameworkCore.Internal;
 /// EF Core implementation of <see cref="ITimelineWriter"/> backed by PostgreSQL.
 /// </summary>
 /// <remarks>
+/// All reads are implicitly scoped to the current tenant via the <see cref="IMultiTenant"/>
+/// query filter applied by <c>ApplyGranitConventions</c> on <see cref="TimelineDbContext"/>.
 /// Each operation creates and disposes its own <see cref="TimelineDbContext"/> via
 /// <see cref="IDbContextFactory{TContext}"/>, making it safe for concurrent request handling.
 /// </remarks>
@@ -22,12 +25,13 @@ internal sealed class EfCoreTimelineStore(
     IClock clock,
     ICurrentUserService currentUser,
     IGuidGenerator guidGenerator,
-    ICurrentTenant currentTenant) : ITimelineWriter
+    ICurrentTenant currentTenant)
+    : EfStoreBase<TimelineEntry, TimelineDbContext>(dbContextFactory), ITimelineWriter
 {
     private readonly AuditContext _audit = new(guidGenerator, clock, currentUser, currentTenant);
 
     /// <inheritdoc/>
-    public async Task<TimelineEntry> PostEntryAsync(
+    public Task<TimelineEntry> PostEntryAsync(
         string entityType,
         string entityId,
         TimelineEntryType entryType,
@@ -39,52 +43,54 @@ internal sealed class EfCoreTimelineStore(
             entityType, entityId, entryType, body, parentEntryId, _audit);
         entry.RaisePostedEvent();
 
-        await using TimelineDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        db.TimelineEntries.Add(entry);
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-
-        return entry;
+        return WriteAsync(
+            async db =>
+            {
+                db.TimelineEntries.Add(entry);
+                return entry;
+            },
+            cancellationToken);
     }
 
     /// <inheritdoc/>
-    public async Task DeleteEntryAsync(Guid entryId, CancellationToken cancellationToken = default)
-    {
-        await using TimelineDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        TimelineEntry entry = await db.TimelineEntries
-            .IgnoreQueryFilters([GranitFilterNames.SoftDelete])
-            .FirstOrDefaultAsync(e => e.Id == entryId, cancellationToken).ConfigureAwait(false)
-            ?? throw new KeyNotFoundException($"Timeline entry '{entryId}' not found.");
+    public Task DeleteEntryAsync(Guid entryId, CancellationToken cancellationToken = default) =>
+        WriteAsync(
+            async db =>
+            {
+                TimelineEntry entry = await db.TimelineEntries
+                    .IgnoreQueryFilters([GranitFilterNames.SoftDelete])
+                    .FirstOrDefaultAsync(e => e.Id == entryId, cancellationToken).ConfigureAwait(false)
+                    ?? throw new KeyNotFoundException($"Timeline entry '{entryId}' not found.");
 
-        entry.SoftDelete(clock.Now, currentUser.UserId);
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+                entry.SoftDelete(clock.Now, currentUser.UserId);
+            },
+            cancellationToken);
 
     /// <inheritdoc/>
-    public async Task<TimelineAttachment> AddAttachmentAsync(
+    public Task<TimelineAttachment> AddAttachmentAsync(
         Guid entryId,
         Guid blobId,
         string fileName,
         string contentType,
         long sizeBytes,
-        CancellationToken cancellationToken = default)
-    {
-        await using TimelineDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        CancellationToken cancellationToken = default) =>
+        WriteAsync(
+            async db =>
+            {
+                // VULN-209: Do not bypass soft-delete filter — reject attachments on deleted entries
+                bool entryExists = await db.TimelineEntries
+                    .AnyAsync(e => e.Id == entryId, cancellationToken).ConfigureAwait(false);
 
-        // VULN-209: Do not bypass soft-delete filter — reject attachments on deleted entries
-        bool entryExists = await db.TimelineEntries
-            .AnyAsync(e => e.Id == entryId, cancellationToken).ConfigureAwait(false);
+                if (!entryExists)
+                {
+                    throw new KeyNotFoundException($"Timeline entry '{entryId}' not found.");
+                }
 
-        if (!entryExists)
-        {
-            throw new KeyNotFoundException($"Timeline entry '{entryId}' not found.");
-        }
+                TimelineAttachment attachment = TimelineEntityFactory.CreateAttachment(
+                    entryId, blobId, fileName, contentType, sizeBytes, _audit);
 
-        TimelineAttachment attachment = TimelineEntityFactory.CreateAttachment(
-            entryId, blobId, fileName, contentType, sizeBytes, _audit);
-
-        db.TimelineAttachments.Add(attachment);
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-
-        return attachment;
-    }
+                db.TimelineAttachments.Add(attachment);
+                return attachment;
+            },
+            cancellationToken);
 }

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookDeliveryStore.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookDeliveryStore.cs
@@ -1,4 +1,5 @@
 using Granit.Guids;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Timing;
 using Granit.Webhooks.Abstractions;
 using Granit.Webhooks.Domain;
@@ -16,124 +17,113 @@ namespace Granit.Webhooks.EntityFrameworkCore.Internal;
 /// ISO 27001 compliance: <see cref="WebhookDeliveryAttempt"/> records are INSERT-only.
 /// This store never updates or deletes them.
 /// </remarks>
-internal sealed class EfWebhookDeliveryStore(IDbContextFactory<WebhooksDbContext> contextFactory, IClock clock, IGuidGenerator guidGenerator)
-    : IWebhookDeliveryWriter, IWebhookDeliveryReader
+internal sealed class EfWebhookDeliveryStore(
+    IDbContextFactory<WebhooksDbContext> contextFactory,
+    IClock clock,
+    IGuidGenerator guidGenerator)
+    : EfStoreBase<WebhookDeliveryAttempt, WebhooksDbContext>(contextFactory),
+      IWebhookDeliveryWriter, IWebhookDeliveryReader
 {
-    public async Task<WebhookDeliveryAttempt?> FindByDeliveryIdAsync(
+    public Task<WebhookDeliveryAttempt?> FindByDeliveryIdAsync(
         Guid deliveryId,
-        CancellationToken cancellationToken = default)
-    {
-        await using WebhooksDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        return await context.WebhookDeliveryAttempts
+        CancellationToken cancellationToken = default) =>
+        ReadAsync(db => db.WebhookDeliveryAttempts
             .AsNoTracking()
-            .FirstOrDefaultAsync(a => a.DeliveryId == deliveryId, cancellationToken).ConfigureAwait(false);
-    }
+            .FirstOrDefaultAsync(a => a.DeliveryId == deliveryId, cancellationToken),
+        cancellationToken);
 
-    public async Task RecordSuccessAsync(
+    public Task RecordSuccessAsync(
         SendWebhookCommand command,
         int httpStatusCode,
         long durationMs,
         string payloadHash,
         string? payload,
-        CancellationToken cancellationToken = default)
-    {
-        await using WebhooksDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        context.WebhookDeliveryAttempts.Add(new WebhookDeliveryAttempt
+        CancellationToken cancellationToken = default) =>
+        WriteAsync(async db =>
         {
-            Id = guidGenerator.Create(),
-            DeliveryId = command.DeliveryId,
-            SubscriptionId = command.SubscriptionId,
-            TenantId = command.Envelope.TenantId,
-            EventType = command.Envelope.EventType,
-            TargetUrl = command.TargetUrl,
-            HttpStatusCode = httpStatusCode,
-            PayloadHash = payloadHash,
-            Payload = payload,
-            OccurredAt = clock.Now,
-            DurationMs = durationMs,
-            IsSuccess = true,
-        });
+            db.WebhookDeliveryAttempts.Add(new WebhookDeliveryAttempt
+            {
+                Id = guidGenerator.Create(),
+                DeliveryId = command.DeliveryId,
+                SubscriptionId = command.SubscriptionId,
+                TenantId = command.Envelope.TenantId,
+                EventType = command.Envelope.EventType,
+                TargetUrl = command.TargetUrl,
+                HttpStatusCode = httpStatusCode,
+                PayloadHash = payloadHash,
+                Payload = payload,
+                OccurredAt = clock.Now,
+                DurationMs = durationMs,
+                IsSuccess = true,
+            });
 
-        WebhookSubscription? subscription = await context.WebhookSubscriptions
-            .FindAsync([command.SubscriptionId], cancellationToken).ConfigureAwait(false);
+            WebhookSubscription? subscription = await db.WebhookSubscriptions
+                .FirstOrDefaultAsync(s => s.Id == command.SubscriptionId, cancellationToken).ConfigureAwait(false);
 
-        if (subscription is not null)
-        {
-            subscription.RecordSuccess(clock.Now);
-        }
+            if (subscription is not null)
+            {
+                subscription.RecordSuccess(clock.Now);
+            }
+        }, cancellationToken);
 
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    public async Task RecordFailureAsync(
+    public Task RecordFailureAsync(
         SendWebhookCommand command,
         int? httpStatusCode,
         long durationMs,
         string errorMessage,
         string? payload,
-        CancellationToken cancellationToken = default)
-    {
-        await using WebhooksDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        context.WebhookDeliveryAttempts.Add(new WebhookDeliveryAttempt
+        CancellationToken cancellationToken = default) =>
+        WriteAsync(async db =>
         {
-            Id = guidGenerator.Create(),
-            DeliveryId = command.DeliveryId,
-            SubscriptionId = command.SubscriptionId,
-            TenantId = command.Envelope.TenantId,
-            EventType = command.Envelope.EventType,
-            TargetUrl = command.TargetUrl,
-            HttpStatusCode = httpStatusCode,
-            PayloadHash = string.Empty,
-            Payload = payload,
-            OccurredAt = clock.Now,
-            DurationMs = durationMs,
-            ErrorMessage = errorMessage.Length > 2000 ? errorMessage[..2000] : errorMessage,
-            IsSuccess = false,
-        });
+            db.WebhookDeliveryAttempts.Add(new WebhookDeliveryAttempt
+            {
+                Id = guidGenerator.Create(),
+                DeliveryId = command.DeliveryId,
+                SubscriptionId = command.SubscriptionId,
+                TenantId = command.Envelope.TenantId,
+                EventType = command.Envelope.EventType,
+                TargetUrl = command.TargetUrl,
+                HttpStatusCode = httpStatusCode,
+                PayloadHash = string.Empty,
+                Payload = payload,
+                OccurredAt = clock.Now,
+                DurationMs = durationMs,
+                ErrorMessage = errorMessage.Length > 2000 ? errorMessage[..2000] : errorMessage,
+                IsSuccess = false,
+            });
 
-        WebhookSubscription? subscription = await context.WebhookSubscriptions
-            .FindAsync([command.SubscriptionId], cancellationToken).ConfigureAwait(false);
+            WebhookSubscription? subscription = await db.WebhookSubscriptions
+                .FirstOrDefaultAsync(s => s.Id == command.SubscriptionId, cancellationToken).ConfigureAwait(false);
 
-        if (subscription is not null)
-        {
-            subscription.RecordFailure();
-        }
+            if (subscription is not null)
+            {
+                subscription.RecordFailure();
+            }
+        }, cancellationToken);
 
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    public async Task SuspendSubscriptionAsync(
+    public Task SuspendSubscriptionAsync(
         Guid subscriptionId,
         string reason,
-        CancellationToken cancellationToken = default)
-    {
-        await using WebhooksDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        WebhookSubscription? subscription = await context.WebhookSubscriptions
-            .FindAsync([subscriptionId], cancellationToken).ConfigureAwait(false);
-
-        if (subscription is null)
+        CancellationToken cancellationToken = default) =>
+        WriteAsync(async db =>
         {
-            return;
-        }
+            WebhookSubscription? subscription = await db.WebhookSubscriptions
+                .FirstOrDefaultAsync(s => s.Id == subscriptionId, cancellationToken).ConfigureAwait(false);
 
-        subscription.Suspend(clock.Now, "system", reason);
+            if (subscription is null)
+            {
+                return;
+            }
 
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+            subscription.Suspend(clock.Now, "system", reason);
+        }, cancellationToken);
 
-    public async Task<int> CountBeforeAsync(
+    public Task<int> CountBeforeAsync(
         DateTimeOffset cutoff,
-        CancellationToken cancellationToken = default)
-    {
-        await using WebhooksDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        return await context.WebhookDeliveryAttempts
-            .CountAsync(a => a.OccurredAt < cutoff, cancellationToken).ConfigureAwait(false);
-    }
+        CancellationToken cancellationToken = default) =>
+        CountAsync(a => a.OccurredAt < cutoff, cancellationToken);
 
-    public async Task<int> DeleteBeforeAsync(
+    public Task<int> DeleteBeforeAsync(
         DateTimeOffset cutoff,
         int batchSize,
         CancellationToken cancellationToken = default)
@@ -147,11 +137,11 @@ internal sealed class EfWebhookDeliveryStore(IDbContextFactory<WebhooksDbContext
                 + $"Requested cutoff: {cutoff:O}, earliest allowed: {earliestAllowed:O}.");
         }
 
-        await using WebhooksDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        return await context.WebhookDeliveryAttempts
+        return WriteAsync(db => db.WebhookDeliveryAttempts
             .Where(a => a.OccurredAt < cutoff)
             .OrderBy(a => a.OccurredAt)
             .Take(batchSize)
-            .ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
+            .ExecuteDeleteAsync(cancellationToken),
+        cancellationToken);
     }
 }

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookSubscriptionStore.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookSubscriptionStore.cs
@@ -2,6 +2,8 @@ using System.Security.Cryptography;
 using Granit.Domain.ValueObjects;
 using Granit.Exceptions;
 using Granit.Guids;
+using Granit.Persistence;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Timing;
 using Granit.Webhooks.Abstractions;
 using Granit.Webhooks.Domain;
@@ -18,39 +20,28 @@ internal sealed class EfWebhookSubscriptionStore(
     IGuidGenerator guidGenerator,
     IWebhookSecretProtector secretProtector,
     IClock clock)
-    : IWebhookSubscriptionReader, IWebhookSubscriptionWriter
+    : EfStoreBase<WebhookSubscription, WebhooksDbContext>(contextFactory),
+      IWebhookSubscriptionReader, IWebhookSubscriptionWriter
 {
-    public async Task<IReadOnlyList<WebhookSubscription>> GetActiveSubscriptionsAsync(
+    public Task<IReadOnlyList<WebhookSubscription>> GetActiveSubscriptionsAsync(
         string eventType,
         Guid? tenantId,
-        CancellationToken cancellationToken = default)
-    {
-        await using WebhooksDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        return await context.WebhookSubscriptions
+        CancellationToken cancellationToken = default) =>
+        ReadAsync(async db => (IReadOnlyList<WebhookSubscription>)await db.WebhookSubscriptions
             .Where(s => s.Status == WebhookSubscriptionStatus.Active
                      && s.EventType == eventType
                      && (s.TenantId == null || s.TenantId == tenantId))
             .AsNoTracking()
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-    }
+            .ToListAsync(cancellationToken).ConfigureAwait(false),
+        cancellationToken);
 
-    public async Task<WebhookSubscription?> FindByIdAsync(
+    public new Task<WebhookSubscription?> FindByIdAsync(
         Guid subscriptionId,
-        CancellationToken cancellationToken = default)
-    {
-        await using WebhooksDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        return await context.WebhookSubscriptions.FindAsync([subscriptionId], cancellationToken).ConfigureAwait(false);
-    }
+        CancellationToken cancellationToken = default) =>
+        base.FindByIdAsync(subscriptionId, cancellationToken);
 
-    public async Task<IReadOnlyList<WebhookSubscription>> GetAllAsync(CancellationToken cancellationToken = default)
-    {
-        await using WebhooksDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        return await context.WebhookSubscriptions
-            .AsNoTracking()
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public Task<IReadOnlyList<WebhookSubscription>> GetAllAsync(CancellationToken cancellationToken = default) =>
+        ListAsync(Spec.For<WebhookSubscription>(), cancellationToken);
 
     public async Task<WebhookSubscriptionCreatedResult> CreateAsync(
         HttpsUrl targetUrl,
@@ -70,107 +61,92 @@ internal sealed class EfWebhookSubscriptionStore(
             protectedSecret,
             tenantId);
 
-        await using WebhooksDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-        context.WebhookSubscriptions.Add(subscription);
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        await AddAsync(subscription, cancellationToken).ConfigureAwait(false);
 
         return new WebhookSubscriptionCreatedResult(subscription, plainSecret);
     }
 
-    public async Task UpdateTargetUrlAsync(
+    public Task UpdateTargetUrlAsync(
         Guid subscriptionId,
         HttpsUrl targetUrl,
-        CancellationToken cancellationToken = default)
-    {
-        await using WebhooksDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        WebhookSubscription subscription = await FindOrThrowAsync(context, subscriptionId, cancellationToken).ConfigureAwait(false);
-        subscription.UpdateTargetUrl(targetUrl);
-
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    public async Task ActivateAsync(Guid subscriptionId, CancellationToken cancellationToken = default)
-    {
-        await using WebhooksDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        WebhookSubscription subscription = await FindOrThrowAsync(context, subscriptionId, cancellationToken).ConfigureAwait(false);
-
-        if (subscription.Status != WebhookSubscriptionStatus.Suspended)
+        CancellationToken cancellationToken = default) =>
+        WriteAsync(async db =>
         {
-            throw new ConflictException(
-                "Webhooks:InvalidStateTransition",
-                $"Cannot activate a subscription with status '{subscription.Status}'. Only 'Suspended' subscriptions can be activated.");
-        }
+            WebhookSubscription subscription = await FindOrThrowAsync(db, subscriptionId, cancellationToken).ConfigureAwait(false);
+            subscription.UpdateTargetUrl(targetUrl);
+        }, cancellationToken);
 
-        subscription.Activate();
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public Task ActivateAsync(Guid subscriptionId, CancellationToken cancellationToken = default) =>
+        WriteAsync(async db =>
+        {
+            WebhookSubscription subscription = await FindOrThrowAsync(db, subscriptionId, cancellationToken).ConfigureAwait(false);
 
-    public async Task SuspendAsync(
+            if (subscription.Status != WebhookSubscriptionStatus.Suspended)
+            {
+                throw new ConflictException(
+                    "Webhooks:InvalidStateTransition",
+                    $"Cannot activate a subscription with status '{subscription.Status}'. Only 'Suspended' subscriptions can be activated.");
+            }
+
+            subscription.Activate();
+        }, cancellationToken);
+
+    public Task SuspendAsync(
         Guid subscriptionId,
         string suspendedBy,
         string reason,
-        CancellationToken cancellationToken = default)
-    {
-        await using WebhooksDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        WebhookSubscription subscription = await FindOrThrowAsync(context, subscriptionId, cancellationToken).ConfigureAwait(false);
-
-        if (subscription.Status != WebhookSubscriptionStatus.Active)
+        CancellationToken cancellationToken = default) =>
+        WriteAsync(async db =>
         {
-            throw new ConflictException(
-                "Webhooks:InvalidStateTransition",
-                $"Cannot suspend a subscription with status '{subscription.Status}'. Only 'Active' subscriptions can be suspended.");
-        }
+            WebhookSubscription subscription = await FindOrThrowAsync(db, subscriptionId, cancellationToken).ConfigureAwait(false);
 
-        subscription.Suspend(clock.Now, suspendedBy, reason);
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+            if (subscription.Status != WebhookSubscriptionStatus.Active)
+            {
+                throw new ConflictException(
+                    "Webhooks:InvalidStateTransition",
+                    $"Cannot suspend a subscription with status '{subscription.Status}'. Only 'Active' subscriptions can be suspended.");
+            }
 
-    public async Task DeactivateAsync(
+            subscription.Suspend(clock.Now, suspendedBy, reason);
+        }, cancellationToken);
+
+    public Task DeactivateAsync(
         Guid subscriptionId,
         string reason,
-        CancellationToken cancellationToken = default)
-    {
-        await using WebhooksDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        WebhookSubscription subscription = await FindOrThrowAsync(context, subscriptionId, cancellationToken).ConfigureAwait(false);
-
-        if (subscription.Status == WebhookSubscriptionStatus.Deactivated)
+        CancellationToken cancellationToken = default) =>
+        WriteAsync(async db =>
         {
-            throw new ConflictException(
-                "Webhooks:AlreadyDeactivated",
-                "Subscription is already deactivated.");
-        }
+            WebhookSubscription subscription = await FindOrThrowAsync(db, subscriptionId, cancellationToken).ConfigureAwait(false);
 
-        subscription.Deactivate(reason);
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+            if (subscription.Status == WebhookSubscriptionStatus.Deactivated)
+            {
+                throw new ConflictException(
+                    "Webhooks:AlreadyDeactivated",
+                    "Subscription is already deactivated.");
+            }
 
-    public async Task DeleteAsync(Guid subscriptionId, CancellationToken cancellationToken = default)
-    {
-        await using WebhooksDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+            subscription.Deactivate(reason);
+        }, cancellationToken);
 
-        WebhookSubscription subscription = await FindOrThrowAsync(context, subscriptionId, cancellationToken).ConfigureAwait(false);
-
-        context.WebhookSubscriptions.Remove(subscription);
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-    }
+    public Task DeleteAsync(Guid subscriptionId, CancellationToken cancellationToken = default) =>
+        WriteAsync(async db =>
+        {
+            WebhookSubscription subscription = await FindOrThrowAsync(db, subscriptionId, cancellationToken).ConfigureAwait(false);
+            db.WebhookSubscriptions.Remove(subscription);
+        }, cancellationToken);
 
     public async Task<string> RotateSecretAsync(Guid subscriptionId, CancellationToken cancellationToken = default)
     {
-        await using WebhooksDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
-
-        WebhookSubscription subscription = await FindOrThrowAsync(context, subscriptionId, cancellationToken).ConfigureAwait(false);
-
         string plainSecret = GenerateSigningSecret();
         string protectedSecret = await secretProtector
             .ProtectAsync(plainSecret, cancellationToken)
             .ConfigureAwait(false);
 
-        subscription.RotateSecret(protectedSecret);
-        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        await WriteAsync(async db =>
+        {
+            WebhookSubscription subscription = await FindOrThrowAsync(db, subscriptionId, cancellationToken).ConfigureAwait(false);
+            subscription.RotateSecret(protectedSecret);
+        }, cancellationToken).ConfigureAwait(false);
 
         return plainSecret;
     }
@@ -181,7 +157,7 @@ internal sealed class EfWebhookSubscriptionStore(
         CancellationToken cancellationToken)
     {
         WebhookSubscription? subscription = await context.WebhookSubscriptions
-            .FindAsync([subscriptionId], cancellationToken).ConfigureAwait(false);
+            .FirstOrDefaultAsync(s => s.Id == subscriptionId, cancellationToken).ConfigureAwait(false);
 
         return subscription ?? throw new EntityNotFoundException(typeof(WebhookSubscription), subscriptionId);
     }


### PR DESCRIPTION
## Summary

- Migrates **20 EF Core stores** to `EfStoreBase<TEntity, TContext>`, eliminating repeated `IDbContextFactory` boilerplate across 12 modules
- Net **-138 LOC** (896 insertions, 1034 deletions) — pure boilerplate reduction, zero behavior changes
- Fixes **VULN-100** in all stores that previously used `FindAsync` (bypasses query filters) — now uses `FirstOrDefaultAsync(e => e.Id == id)` preserving tenant/soft-delete/GDPR filters

### Migrated stores (21 total including pilot)

| Module | Stores | Pattern |
| ------ | ------ | ------- |
| BlobStorage | EfBlobDescriptorStore | Base helpers + Spec.For |
| Webhooks | EfWebhookSubscriptionStore, EfWebhookDeliveryStore | WriteAsync delegates (state transitions) |
| Notifications | 5 stores (UserNotification, Subscription, Preference, Delivery, MobilePush) | Mix of base helpers + delegates |
| Timeline | EfCoreTimelineStore | WriteAsync delegates |
| BackgroundJobs | EfBackgroundJobStore | MutateJobAsync helper pattern |
| AI | EfAIUsageStore, EfAIWorkspaceStore | AddAsync + Spec.For |
| ApiKeys | EfCoreApiKeyStore, EfCoreApiKeyAdminStore | ReadAsync + WriteAsync |
| OpenIddict | EfSigningKeyStore, OpenIddictGroupStore | ReadAsync + AddAsync |
| DataExchange | EfImportJobStore, EfExportJobStore | PagedAsync with inline specs |
| Features | EfCoreFeatureStore | WriteAsync with IDataFilter bypass |
| Localization | EfCoreLocalizationOverrideStore | WriteAsync upsert/remove |
| QueryEngine | EfCoreSavedViewStore | Base helpers + WriteAsync |

### Excluded stores (7)

| Store | Reason |
| ----- | ------ |
| EfCoreBffTokenStore | `BffSessionEntity` doesn't extend `Entity` |
| EfMappingStore, EfExportPresetStore | Entities don't extend `Entity` |
| EfTemplateCategoryStore, EfDocumentTemplateStore | Entities don't extend `Entity` |
| EfCoreSettingStore | `IServiceScopeFactory` pattern (Singleton) |
| EfCoreReferenceDataStore | `IFusionCache` + `EF.Functions.Like` x15 |

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] All existing module tests pass unchanged (zero behavior changes)
- [x] Architecture tests pass (98/98)

Closes #777, closes #778
