### PR TITLE
fix(identity): register IdentityLocalMetrics and add missing DependsOn

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -15897,8 +15897,15 @@
       "kind": "class",
       "project": "Granit.Identity.Local",
       "file": "src/Granit.Identity.Local/GranitIdentityLocalModule.cs",
-      "line": 24,
-      "members": []
+      "line": 27,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "GranitPasskeyOptions",
@@ -21953,7 +21960,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.EntityFrameworkCore",
       "file": "src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs",
-      "line": 42,
+      "line": 44,
       "members": [
         {
           "name": "ConfigureServices",

--- a/src/Granit.Identity.Local/GranitIdentityLocalModule.cs
+++ b/src/Granit.Identity.Local/GranitIdentityLocalModule.cs
@@ -1,8 +1,11 @@
 using Granit.Events;
 using Granit.Guids;
 using Granit.Identity;
+using Granit.Identity.Local.Diagnostics;
 using Granit.Modularity;
 using Granit.Timing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Granit.Identity.Local;
 
@@ -23,4 +26,9 @@ namespace Granit.Identity.Local;
     typeof(GranitTimingModule))]
 public sealed class GranitIdentityLocalModule : GranitModule
 {
+    /// <inheritdoc/>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.TryAddSingleton<IdentityLocalMetrics>();
+    }
 }

--- a/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
@@ -1,4 +1,5 @@
 using Granit.Encryption;
+using Granit.Identity.Local;
 using Granit.Identity.Local.Options;
 using Granit.Identity.Local.Services;
 using Granit.Modularity;
@@ -36,6 +37,7 @@ namespace Granit.OpenIddict.EntityFrameworkCore;
 /// </remarks>
 [DependsOn(
     typeof(GranitEncryptionModule),
+    typeof(GranitIdentityLocalModule),
     typeof(GranitMultiTenancyModule),
     typeof(GranitOpenIddictServerModule),
     typeof(GranitPersistenceEntityFrameworkCoreModule))]

--- a/tests/Granit.Authentication.DPoP.Tests/Validation/DPoPProofValidatorTests.cs
+++ b/tests/Granit.Authentication.DPoP.Tests/Validation/DPoPProofValidatorTests.cs
@@ -1,0 +1,518 @@
+// =============================================================================
+// Tests — DPoPProofValidator (RFC 9449 §4.3 / §7)
+// =============================================================================
+// Validates the full DPoP proof validation pipeline: structure, header claims,
+// payload claims, timing, replay protection, and signature verification.
+// =============================================================================
+
+using System.Diagnostics.Metrics;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Granit.Authentication.DPoP.Diagnostics;
+using Granit.Authentication.DPoP.Options;
+using Granit.Authentication.DPoP.Validation;
+using Granit.Authentication.DPoP.Validation.Internal;
+using Granit.Timing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Granit.Authentication.DPoP.Tests.Validation;
+
+public sealed class DPoPProofValidatorTests : IDisposable
+{
+    private const string DefaultMethod = "GET";
+    private const string DefaultUri = "https://api.example.com/resource";
+
+    private readonly IClock _clock;
+    private readonly IFusionCache _cache;
+    private readonly DPoPValidationOptions _options;
+    private readonly DPoPProofValidator _validator;
+    private readonly ServiceProvider _serviceProvider;
+
+    public DPoPProofValidatorTests()
+    {
+        _clock = Substitute.For<IClock>();
+        _clock.Now.Returns(DateTimeOffset.UtcNow);
+
+        _cache = Substitute.For<IFusionCache>();
+
+        _options = new DPoPValidationOptions
+        {
+            EnableReplayProtection = false,
+            RequireNonce = false,
+        };
+
+        ServiceCollection services = new();
+        services.AddMetrics();
+        _serviceProvider = services.BuildServiceProvider();
+
+        IOptions<DPoPValidationOptions> optionsWrapper = Microsoft.Extensions.Options.Options.Create(_options);
+        IMeterFactory meterFactory = _serviceProvider.GetRequiredService<IMeterFactory>();
+        DPoPValidationMetrics metrics = new(meterFactory);
+
+        _validator = new DPoPProofValidator(optionsWrapper, _clock, metrics, _cache);
+    }
+
+    public void Dispose() => _serviceProvider.Dispose();
+
+    // ── Structure validation ──
+
+    [Theory]
+    [InlineData("single-part")]
+    [InlineData("two.parts")]
+    [InlineData("four.parts.here.extra")]
+    public async Task ValidateAsync_InvalidJwtStructure_ReturnsFailure(string malformedJwt)
+    {
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            malformedJwt, DefaultMethod, DefaultUri, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+        result.Error.ShouldBe("Invalid JWT structure.");
+    }
+
+    // ── Header validation ──
+
+    [Fact]
+    public async Task ValidateAsync_InvalidHeaderEncoding_ReturnsFailure()
+    {
+        string jwt = "!!!invalid-base64!!!.eyJ0ZXN0IjoxfQ.signature";
+
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            jwt, DefaultMethod, DefaultUri, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+        result.Error.ShouldBe("Invalid JWT header encoding.");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_MissingTypClaim_ReturnsFailure()
+    {
+        string header = Base64UrlEncode("""{"alg":"ES256","jwk":{"kty":"EC"}}""");
+        string jwt = $"{header}.eyJ0ZXN0IjoxfQ.signature";
+
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            jwt, DefaultMethod, DefaultUri, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+        result.Error!.ShouldContain("Missing or invalid typ claim");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WrongTypClaim_ReturnsFailure()
+    {
+        string header = Base64UrlEncode("""{"typ":"JWT","alg":"ES256","jwk":{"kty":"EC"}}""");
+        string jwt = $"{header}.eyJ0ZXN0IjoxfQ.signature";
+
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            jwt, DefaultMethod, DefaultUri, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+        result.Error!.ShouldContain("Missing or invalid typ claim");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_MissingAlgClaim_ReturnsFailure()
+    {
+        string header = Base64UrlEncode("""{"typ":"dpop+jwt","jwk":{"kty":"EC"}}""");
+        string jwt = $"{header}.eyJ0ZXN0IjoxfQ.signature";
+
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            jwt, DefaultMethod, DefaultUri, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+        result.Error.ShouldBe("Missing alg claim.");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_DisallowedAlgorithm_ReturnsFailure()
+    {
+        string header = Base64UrlEncode("""{"typ":"dpop+jwt","alg":"RS256","jwk":{"kty":"RSA"}}""");
+        string jwt = $"{header}.eyJ0ZXN0IjoxfQ.signature";
+
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            jwt, DefaultMethod, DefaultUri, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+        result.Error.ShouldBe("Algorithm 'RS256' is not allowed.");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_MissingJwkClaim_ReturnsFailure()
+    {
+        string header = Base64UrlEncode("""{"typ":"dpop+jwt","alg":"ES256"}""");
+        string jwt = $"{header}.eyJ0ZXN0IjoxfQ.signature";
+
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            jwt, DefaultMethod, DefaultUri, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+        result.Error.ShouldBe("Missing jwk claim in header.");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_PrivateKeyInJwk_ReturnsFailure()
+    {
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        ECParameters ecParams = key.ExportParameters(includePrivateParameters: true);
+        string x = Base64UrlEncodeBytes(ecParams.Q.X!);
+        string y = Base64UrlEncodeBytes(ecParams.Q.Y!);
+        string d = Base64UrlEncodeBytes(ecParams.D!);
+
+        string jwkJson = $$$"""{"typ":"dpop+jwt","alg":"ES256","jwk":{"kty":"EC","crv":"P-256","x":"{{{x}}}","y":"{{{y}}}","d":"{{{d}}}"}}""";
+        string header = Base64UrlEncode(jwkJson);
+        string jwt = $"{header}.eyJ0ZXN0IjoxfQ.signature";
+
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            jwt, DefaultMethod, DefaultUri, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+        result.Error!.ShouldContain("JWK must not contain private key parameter");
+    }
+
+    // ── Payload validation ──
+
+    [Fact]
+    public async Task ValidateAsync_HtmMismatch_ReturnsFailure()
+    {
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        DateTimeOffset now = _clock.Now;
+
+        // Create proof with POST but validate against GET
+        string proof = CreateDPoPProof(key, "POST", DefaultUri, now);
+
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            proof, "GET", DefaultUri, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+        result.Error.ShouldBe("htm claim does not match request method.");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_HtuMismatch_ReturnsFailure()
+    {
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        DateTimeOffset now = _clock.Now;
+
+        string proof = CreateDPoPProof(key, DefaultMethod, "https://api.example.com/other", now);
+
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            proof, DefaultMethod, DefaultUri, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+        result.Error.ShouldBe("htu claim does not match request URI.");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_MissingIat_ReturnsFailure()
+    {
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        DateTimeOffset now = _clock.Now;
+
+        string proof = CreateDPoPProof(key, DefaultMethod, DefaultUri, now,
+            modifyPayload: payload => payload.Remove("iat"));
+
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            proof, DefaultMethod, DefaultUri, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+        result.Error.ShouldBe("Missing iat claim.");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_IatTooOld_ReturnsFailure()
+    {
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        DateTimeOffset now = _clock.Now;
+
+        // iat is 10 minutes ago — exceeds default MaxProofLifetime of 5 minutes
+        DateTimeOffset oldIat = now.AddMinutes(-10);
+        string proof = CreateDPoPProof(key, DefaultMethod, DefaultUri, oldIat);
+
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            proof, DefaultMethod, DefaultUri, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+        result.Error.ShouldBe("Proof is too old (iat).");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_IatInFuture_ReturnsFailure()
+    {
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        DateTimeOffset now = _clock.Now;
+
+        // iat is 2 minutes in the future — exceeds default ClockSkew of 30 seconds
+        DateTimeOffset futureIat = now.AddMinutes(2);
+        string proof = CreateDPoPProof(key, DefaultMethod, DefaultUri, futureIat);
+
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            proof, DefaultMethod, DefaultUri, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+        result.Error.ShouldBe("Proof iat is in the future.");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ExpiredProof_ReturnsFailure()
+    {
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        DateTimeOffset now = _clock.Now;
+
+        // exp was 2 minutes ago (well beyond ClockSkew)
+        long expiredExp = now.AddMinutes(-2).ToUnixTimeSeconds();
+        string proof = CreateDPoPProof(key, DefaultMethod, DefaultUri, now,
+            modifyPayload: payload => payload["exp"] = expiredExp);
+
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            proof, DefaultMethod, DefaultUri, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+        result.Error.ShouldBe("Proof has expired.");
+    }
+
+    // ── Signature validation ──
+
+    [Fact]
+    public async Task ValidateAsync_ValidEcProof_ReturnsSuccess()
+    {
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        DateTimeOffset now = _clock.Now;
+
+        string proof = CreateDPoPProof(key, DefaultMethod, DefaultUri, now);
+
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            proof, DefaultMethod, DefaultUri, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeTrue();
+        result.Error.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ValidProof_ReturnsThumbprint()
+    {
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        DateTimeOffset now = _clock.Now;
+
+        string proof = CreateDPoPProof(key, DefaultMethod, DefaultUri, now);
+
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            proof, DefaultMethod, DefaultUri, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeTrue();
+        result.JwkThumbprint.ShouldNotBeNullOrEmpty();
+        result.JwkThumbprint!.Length.ShouldBe(43, "SHA-256 base64url is always 43 chars");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_InvalidSignature_ReturnsFailure()
+    {
+        using var signingKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        using var differentKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        DateTimeOffset now = _clock.Now;
+
+        // Build header with differentKey's public key but sign with signingKey
+        ECParameters differentParams = differentKey.ExportParameters(includePrivateParameters: false);
+        string x = Base64UrlEncodeBytes(differentParams.Q.X!);
+        string y = Base64UrlEncodeBytes(differentParams.Q.Y!);
+
+        var headerClaims = new Dictionary<string, object>
+        {
+            ["typ"] = "dpop+jwt",
+            ["alg"] = "ES256",
+            ["jwk"] = new Dictionary<string, object>
+            {
+                ["kty"] = "EC",
+                ["crv"] = "P-256",
+                ["x"] = x,
+                ["y"] = y,
+            },
+        };
+
+        long iat = now.ToUnixTimeSeconds();
+        var payloadClaims = new Dictionary<string, object>
+        {
+            ["htm"] = DefaultMethod,
+            ["htu"] = DefaultUri,
+            ["iat"] = iat,
+            ["jti"] = Guid.NewGuid().ToString(),
+        };
+
+        string headerJson = JsonSerializer.Serialize(headerClaims);
+        string payloadJson = JsonSerializer.Serialize(payloadClaims);
+        string headerB64 = Base64UrlEncode(headerJson);
+        string payloadB64 = Base64UrlEncode(payloadJson);
+
+        // Sign with the WRONG key (signingKey, not differentKey)
+        byte[] signingInput = Encoding.ASCII.GetBytes($"{headerB64}.{payloadB64}");
+        byte[] signature = signingKey.SignData(signingInput, HashAlgorithmName.SHA256, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+        string signatureB64 = Base64UrlEncodeBytes(signature);
+
+        string proof = $"{headerB64}.{payloadB64}.{signatureB64}";
+
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            proof, DefaultMethod, DefaultUri, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+        result.Error.ShouldBe("Invalid proof signature.");
+    }
+
+    // ── Replay protection ──
+
+    [Fact]
+    public async Task ValidateAsync_ReplayProtection_MissingJti_ReturnsFailure()
+    {
+        _options.EnableReplayProtection = true;
+
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        DateTimeOffset now = _clock.Now;
+
+        string proof = CreateDPoPProof(key, DefaultMethod, DefaultUri, now,
+            modifyPayload: payload => payload.Remove("jti"));
+
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            proof, DefaultMethod, DefaultUri, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+        result.Error!.ShouldContain("Missing jti claim");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ReplayProtection_DuplicateJti_ReturnsFailure()
+    {
+        _options.EnableReplayProtection = true;
+        string jti = Guid.NewGuid().ToString();
+        string cacheKey = $"dpop:jti:{jti}";
+
+        // Simulate that this jti already exists in the cache
+        _cache.TryGetAsync<bool>(cacheKey, Arg.Any<FusionCacheEntryOptions?>(), Arg.Any<CancellationToken>())
+            .Returns(MaybeValue<bool>.FromValue(true));
+
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        DateTimeOffset now = _clock.Now;
+
+        string proof = CreateDPoPProof(key, DefaultMethod, DefaultUri, now, jti: jti);
+
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            proof, DefaultMethod, DefaultUri, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeFalse();
+        result.Error!.ShouldContain("Proof replay detected");
+    }
+
+    // ── Nonce generation ──
+
+    [Fact]
+    public async Task GenerateNonceAsync_WhenNotRequired_ReturnsNull()
+    {
+        _options.RequireNonce = false;
+
+        string? nonce = await _validator.GenerateNonceAsync(TestContext.Current.CancellationToken);
+
+        nonce.ShouldBeNull();
+    }
+
+    // ── URI normalization (query/fragment stripped, trailing slash removed) ──
+
+    [Fact]
+    public async Task ValidateAsync_HtuWithQueryString_MatchesBaseUri()
+    {
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        DateTimeOffset now = _clock.Now;
+
+        // Proof uses URI without query, request URI has query — should still match
+        string proof = CreateDPoPProof(key, DefaultMethod, DefaultUri, now);
+
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            proof, DefaultMethod, $"{DefaultUri}?page=1&size=10", TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_HtuWithTrailingSlash_MatchesWithout()
+    {
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        DateTimeOffset now = _clock.Now;
+
+        // Proof uses URI with trailing slash
+        string proof = CreateDPoPProof(key, DefaultMethod, $"{DefaultUri}/", now);
+
+        DPoPValidationResult result = await _validator.ValidateAsync(
+            proof, DefaultMethod, DefaultUri, TestContext.Current.CancellationToken);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    // ── Helper: DPoP proof JWT builder ──
+
+    private static string CreateDPoPProof(
+        ECDsa key,
+        string method,
+        string uri,
+        DateTimeOffset iat,
+        string? jti = null,
+        string? nonce = null,
+        Action<Dictionary<string, object>>? modifyHeader = null,
+        Action<Dictionary<string, object>>? modifyPayload = null)
+    {
+        ECParameters ecParams = key.ExportParameters(includePrivateParameters: false);
+        string x = Base64UrlEncodeBytes(ecParams.Q.X!);
+        string y = Base64UrlEncodeBytes(ecParams.Q.Y!);
+
+        var headerClaims = new Dictionary<string, object>
+        {
+            ["typ"] = "dpop+jwt",
+            ["alg"] = "ES256",
+            ["jwk"] = new Dictionary<string, object>
+            {
+                ["kty"] = "EC",
+                ["crv"] = "P-256",
+                ["x"] = x,
+                ["y"] = y,
+            },
+        };
+
+        var payloadClaims = new Dictionary<string, object>
+        {
+            ["htm"] = method,
+            ["htu"] = uri,
+            ["iat"] = iat.ToUnixTimeSeconds(),
+            ["jti"] = jti ?? Guid.NewGuid().ToString(),
+        };
+
+        if (nonce is not null)
+        {
+            payloadClaims["nonce"] = nonce;
+        }
+
+        modifyHeader?.Invoke(headerClaims);
+        modifyPayload?.Invoke(payloadClaims);
+
+        string headerJson = JsonSerializer.Serialize(headerClaims);
+        string payloadJson = JsonSerializer.Serialize(payloadClaims);
+        string headerB64 = Base64UrlEncode(headerJson);
+        string payloadB64 = Base64UrlEncode(payloadJson);
+
+        byte[] signingInput = Encoding.ASCII.GetBytes($"{headerB64}.{payloadB64}");
+        byte[] signature = key.SignData(signingInput, HashAlgorithmName.SHA256, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+        string signatureB64 = Base64UrlEncodeBytes(signature);
+
+        return $"{headerB64}.{payloadB64}.{signatureB64}";
+    }
+
+    // ── Base64url helpers ──
+
+    private static string Base64UrlEncode(string value) =>
+        Base64UrlEncodeBytes(Encoding.UTF8.GetBytes(value));
+
+    private static string Base64UrlEncodeBytes(byte[] bytes) =>
+        Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+}

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Validators/AdminOidcValidatorTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Validators/AdminOidcValidatorTests.cs
@@ -1,0 +1,182 @@
+using FluentValidation.TestHelper;
+using Granit.OpenIddict.Endpoints.Dtos;
+using Granit.OpenIddict.Endpoints.Validators;
+using Xunit;
+
+namespace Granit.OpenIddict.Endpoints.Tests.Validators;
+
+public sealed class AdminOidcCreateApplicationRequestValidatorTests
+{
+    private readonly AdminOidcCreateApplicationRequestValidator _validator = new();
+
+    [Fact]
+    public void Valid_request_passes()
+    {
+        AdminOidcCreateApplicationRequest request = new("my-client", "My Client", "secret", "web");
+        TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Valid_request_with_nulls_passes()
+    {
+        AdminOidcCreateApplicationRequest request = new("my-client", null, null, null);
+        TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ClientId_empty_fails(string? clientId)
+    {
+        AdminOidcCreateApplicationRequest request = new(clientId!, null, null, null);
+        TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.ClientId);
+    }
+
+    [Fact]
+    public void ClientId_exceeding_max_length_fails()
+    {
+        string clientId = new('a', 257);
+        AdminOidcCreateApplicationRequest request = new(clientId, null, null, null);
+        TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.ClientId);
+    }
+
+    [Fact]
+    public void ClientId_at_max_length_passes()
+    {
+        string clientId = new('a', 256);
+        AdminOidcCreateApplicationRequest request = new(clientId, null, null, null);
+        TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor(x => x.ClientId);
+    }
+
+    [Fact]
+    public void DisplayName_exceeding_max_length_fails()
+    {
+        string displayName = new('a', 257);
+        AdminOidcCreateApplicationRequest request = new("valid-client", displayName, null, null);
+        TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.DisplayName);
+    }
+
+    [Fact]
+    public void DisplayName_at_max_length_passes()
+    {
+        string displayName = new('a', 256);
+        AdminOidcCreateApplicationRequest request = new("valid-client", displayName, null, null);
+        TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor(x => x.DisplayName);
+    }
+
+    [Fact]
+    public void DisplayName_null_passes()
+    {
+        AdminOidcCreateApplicationRequest request = new("valid-client", null, null, null);
+        TestValidationResult<AdminOidcCreateApplicationRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor(x => x.DisplayName);
+    }
+}
+
+public sealed class AdminOidcCreateScopeRequestValidatorTests
+{
+    private readonly AdminOidcCreateScopeRequestValidator _validator = new();
+
+    [Fact]
+    public void Valid_request_passes()
+    {
+        AdminOidcCreateScopeRequest request = new("openid", "OpenID", "Standard OpenID scope");
+        TestValidationResult<AdminOidcCreateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Valid_request_with_nulls_passes()
+    {
+        AdminOidcCreateScopeRequest request = new("profile", null, null);
+        TestValidationResult<AdminOidcCreateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Name_empty_fails(string? name)
+    {
+        AdminOidcCreateScopeRequest request = new(name!, null, null);
+        TestValidationResult<AdminOidcCreateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Fact]
+    public void Name_exceeding_max_length_fails()
+    {
+        string name = new('a', 257);
+        AdminOidcCreateScopeRequest request = new(name, null, null);
+        TestValidationResult<AdminOidcCreateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Fact]
+    public void Name_at_max_length_passes()
+    {
+        string name = new('a', 256);
+        AdminOidcCreateScopeRequest request = new(name, null, null);
+        TestValidationResult<AdminOidcCreateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Fact]
+    public void DisplayName_exceeding_max_length_fails()
+    {
+        string displayName = new('a', 257);
+        AdminOidcCreateScopeRequest request = new("valid-scope", displayName, null);
+        TestValidationResult<AdminOidcCreateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.DisplayName);
+    }
+
+    [Fact]
+    public void DisplayName_at_max_length_passes()
+    {
+        string displayName = new('a', 256);
+        AdminOidcCreateScopeRequest request = new("valid-scope", displayName, null);
+        TestValidationResult<AdminOidcCreateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor(x => x.DisplayName);
+    }
+
+    [Fact]
+    public void DisplayName_null_passes()
+    {
+        AdminOidcCreateScopeRequest request = new("valid-scope", null, null);
+        TestValidationResult<AdminOidcCreateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor(x => x.DisplayName);
+    }
+
+    [Fact]
+    public void Description_exceeding_max_length_fails()
+    {
+        string description = new('a', 1025);
+        AdminOidcCreateScopeRequest request = new("valid-scope", null, description);
+        TestValidationResult<AdminOidcCreateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldHaveValidationErrorFor(x => x.Description);
+    }
+
+    [Fact]
+    public void Description_at_max_length_passes()
+    {
+        string description = new('a', 1024);
+        AdminOidcCreateScopeRequest request = new("valid-scope", null, description);
+        TestValidationResult<AdminOidcCreateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor(x => x.Description);
+    }
+
+    [Fact]
+    public void Description_null_passes()
+    {
+        AdminOidcCreateScopeRequest request = new("valid-scope", null, null);
+        TestValidationResult<AdminOidcCreateScopeRequest> result = _validator.TestValidate(request);
+        result.ShouldNotHaveValidationErrorFor(x => x.Description);
+    }
+}

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/AspNetExternalLoginServiceTests.cs
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/AspNetExternalLoginServiceTests.cs
@@ -1,0 +1,269 @@
+using System.Security.Claims;
+using Granit.Events;
+using Granit.Identity.Local.Domain;
+using Granit.Identity.Local.Events;
+using Granit.Identity.Local.Services;
+using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Granit.OpenIddict.Options;
+using Granit.OpenIddict.Services;
+using Microsoft.AspNetCore.Identity;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using GranitExternalLoginInfo = Granit.Identity.Local.Services.ExternalLoginInfo;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+
+public sealed class AspNetExternalLoginServiceTests
+{
+    private readonly UserManager<GranitUser> _userManager;
+    private readonly ExternalClaimsMapper _claimsMapper = Substitute.For<ExternalClaimsMapper>();
+    private readonly IDistributedEventBus _eventBus = Substitute.For<IDistributedEventBus>();
+    private readonly GranitOpenIddictClientOptions _clientOptions = new() { AutoRegisterExternalUsers = true };
+    private readonly AspNetExternalLoginService _sut;
+
+    public AspNetExternalLoginServiceTests()
+    {
+        IUserStore<GranitUser> store = Substitute.For<IUserStore<GranitUser>>();
+        _userManager = Substitute.For<UserManager<GranitUser>>(
+            store, null, null, null, null, null, null, null, null);
+
+        _sut = new AspNetExternalLoginService(
+            _userManager,
+            _claimsMapper,
+            _eventBus,
+            Microsoft.Extensions.Options.Options.Create(_clientOptions));
+    }
+
+    // --- GetLoginsAsync ---
+
+    [Fact]
+    public async Task GetLoginsAsync_UserExists_ReturnsLogins()
+    {
+        GranitUser user = CreateUser();
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _userManager.GetLoginsAsync(user).Returns(
+        [
+            new UserLoginInfo("Google", "g-key", "Google"),
+            new UserLoginInfo("Microsoft", "ms-key", "Microsoft"),
+        ]);
+
+        IReadOnlyList<GranitExternalLoginInfo> logins =
+            await _sut.GetLoginsAsync(user.Id.ToString(), TestContext.Current.CancellationToken);
+
+        logins.Count.ShouldBe(2);
+        logins[0].LoginProvider.ShouldBe("Google");
+        logins[1].LoginProvider.ShouldBe("Microsoft");
+    }
+
+    [Fact]
+    public async Task GetLoginsAsync_UserNotFound_ReturnsEmpty()
+    {
+        _userManager.FindByIdAsync("unknown").Returns((GranitUser?)null);
+
+        IReadOnlyList<GranitExternalLoginInfo> logins =
+            await _sut.GetLoginsAsync("unknown", TestContext.Current.CancellationToken);
+
+        logins.ShouldBeEmpty();
+    }
+
+    // --- AddLoginAsync ---
+
+    [Fact]
+    public async Task AddLoginAsync_Success()
+    {
+        GranitUser user = CreateUser();
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _userManager.AddLoginAsync(user, Arg.Any<UserLoginInfo>()).Returns(IdentityResult.Success);
+
+        await Should.NotThrowAsync(
+            () => _sut.AddLoginAsync(
+                user.Id.ToString(),
+                new GranitExternalLoginInfo("GitHub", "gh-key", "GitHub"),
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task AddLoginAsync_UserNotFound_Throws()
+    {
+        _userManager.FindByIdAsync("unknown").Returns((GranitUser?)null);
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.AddLoginAsync(
+                "unknown",
+                new GranitExternalLoginInfo("GitHub", "gh-key", "GitHub"),
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task AddLoginAsync_IdentityResultFailed_Throws()
+    {
+        GranitUser user = CreateUser();
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _userManager.AddLoginAsync(user, Arg.Any<UserLoginInfo>())
+            .Returns(IdentityResult.Failed(new IdentityError { Description = "Duplicate login" }));
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.AddLoginAsync(
+                user.Id.ToString(),
+                new GranitExternalLoginInfo("GitHub", "gh-key", "GitHub"),
+                TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("Duplicate login");
+    }
+
+    // --- RemoveLoginAsync ---
+
+    [Fact]
+    public async Task RemoveLoginAsync_HasPasswordAndMultipleLogins_Succeeds()
+    {
+        GranitUser user = CreateUser();
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _userManager.HasPasswordAsync(user).Returns(true);
+        _userManager.GetLoginsAsync(user).Returns([new UserLoginInfo("Google", "key", "Google")]);
+        _userManager.RemoveLoginAsync(user, "Google", "key").Returns(IdentityResult.Success);
+
+        await Should.NotThrowAsync(
+            () => _sut.RemoveLoginAsync(user.Id.ToString(), "Google", "key", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task RemoveLoginAsync_LastLoginWithoutPassword_Throws()
+    {
+        GranitUser user = CreateUser();
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _userManager.HasPasswordAsync(user).Returns(false);
+        _userManager.GetLoginsAsync(user).Returns([new UserLoginInfo("Google", "key", "Google")]);
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.RemoveLoginAsync(user.Id.ToString(), "Google", "key", TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("last external login");
+    }
+
+    [Fact]
+    public async Task RemoveLoginAsync_NoPasswordButMultipleLogins_Succeeds()
+    {
+        GranitUser user = CreateUser();
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _userManager.HasPasswordAsync(user).Returns(false);
+        _userManager.GetLoginsAsync(user).Returns(
+        [
+            new UserLoginInfo("Google", "g-key", "Google"),
+            new UserLoginInfo("Microsoft", "ms-key", "Microsoft"),
+        ]);
+        _userManager.RemoveLoginAsync(user, "Google", "g-key").Returns(IdentityResult.Success);
+
+        await Should.NotThrowAsync(
+            () => _sut.RemoveLoginAsync(user.Id.ToString(), "Google", "g-key", TestContext.Current.CancellationToken));
+    }
+
+    // --- ProcessCallbackAsync ---
+
+    [Fact]
+    public async Task ProcessCallbackAsync_ExistingUserByLogin_ReturnsExistingUser()
+    {
+        GranitUser user = CreateUser();
+        ClaimsPrincipal principal = CreatePrincipal("sub", "provider-key-123");
+        _userManager.FindByLoginAsync("Google", "provider-key-123").Returns(user);
+
+        ProcessCallbackResult result =
+            await _sut.ProcessCallbackAsync(principal, "Google", TestContext.Current.CancellationToken);
+
+        result.UserId.ShouldBe(user.Id);
+        result.IsNewUser.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ProcessCallbackAsync_ExistingUserByEmail_LinksAndReturnsExisting()
+    {
+        GranitUser user = CreateUser();
+        ClaimsPrincipal principal = CreatePrincipal("sub", "new-provider-key");
+        _userManager.FindByLoginAsync("Google", "new-provider-key").Returns((GranitUser?)null);
+        _claimsMapper.MapToUserProperties(principal, "Google")
+            .Returns(new ExternalUserProperties { Email = "user@test.com" });
+        _userManager.FindByEmailAsync("user@test.com").Returns(user);
+        _userManager.AddLoginAsync(user, Arg.Any<UserLoginInfo>()).Returns(IdentityResult.Success);
+
+        ProcessCallbackResult result =
+            await _sut.ProcessCallbackAsync(principal, "Google", TestContext.Current.CancellationToken);
+
+        result.UserId.ShouldBe(user.Id);
+        result.IsNewUser.ShouldBeFalse();
+        await _userManager.Received(1).AddLoginAsync(user, Arg.Any<UserLoginInfo>());
+    }
+
+    [Fact]
+    public async Task ProcessCallbackAsync_AutoRegister_CreatesUserAndPublishesEvent()
+    {
+        ClaimsPrincipal principal = CreatePrincipal("sub", "brand-new-key");
+        _userManager.FindByLoginAsync("Google", "brand-new-key").Returns((GranitUser?)null);
+        _claimsMapper.MapToUserProperties(principal, "Google")
+            .Returns(new ExternalUserProperties
+            {
+                Email = "new@example.com",
+                FirstName = "Jane",
+                LastName = "Doe",
+            });
+        _userManager.FindByEmailAsync("new@example.com").Returns((GranitUser?)null);
+        _userManager.CreateAsync(Arg.Any<GranitUser>()).Returns(IdentityResult.Success);
+        _userManager.AddLoginAsync(Arg.Any<GranitUser>(), Arg.Any<UserLoginInfo>())
+            .Returns(IdentityResult.Success);
+
+        ProcessCallbackResult result =
+            await _sut.ProcessCallbackAsync(principal, "Google", TestContext.Current.CancellationToken);
+
+        result.IsNewUser.ShouldBeTrue();
+        await _userManager.Received(1).CreateAsync(Arg.Is<GranitUser>(u =>
+            u.Email == "new@example.com" &&
+            u.FirstName == "Jane" &&
+            u.LastName == "Doe" &&
+            u.EmailConfirmed));
+        await _eventBus.Received(1).PublishAsync(
+            Arg.Any<UserRegisteredEto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessCallbackAsync_AutoRegisterDisabled_Throws()
+    {
+        _clientOptions.AutoRegisterExternalUsers = false;
+
+        ClaimsPrincipal principal = CreatePrincipal("sub", "new-key");
+        _userManager.FindByLoginAsync("Google", "new-key").Returns((GranitUser?)null);
+        _claimsMapper.MapToUserProperties(principal, "Google")
+            .Returns(new ExternalUserProperties { Email = "noone@example.com" });
+        _userManager.FindByEmailAsync("noone@example.com").Returns((GranitUser?)null);
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.ProcessCallbackAsync(principal, "Google", TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("Account not found");
+    }
+
+    [Fact]
+    public async Task ProcessCallbackAsync_MissingProviderKey_Throws()
+    {
+        var principal = new ClaimsPrincipal(new ClaimsIdentity()); // no claims
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.ProcessCallbackAsync(principal, "Google", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ProcessCallbackAsync_UsesNameIdentifierAsFallback()
+    {
+        GranitUser user = CreateUser();
+        ClaimsPrincipal principal = CreatePrincipal(ClaimTypes.NameIdentifier, "ni-key");
+        _userManager.FindByLoginAsync("Microsoft", "ni-key").Returns(user);
+
+        ProcessCallbackResult result =
+            await _sut.ProcessCallbackAsync(principal, "Microsoft", TestContext.Current.CancellationToken);
+
+        result.UserId.ShouldBe(user.Id);
+    }
+
+    private static GranitUser CreateUser() => new() { Id = Guid.NewGuid(), Email = "user@test.com" };
+
+    private static ClaimsPrincipal CreatePrincipal(string claimType, string claimValue) =>
+        new(new ClaimsIdentity([new Claim(claimType, claimValue)]));
+}

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/AspNetPasswordResetServiceTests.cs
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/AspNetPasswordResetServiceTests.cs
@@ -1,0 +1,117 @@
+using Granit.Events;
+using Granit.Identity.Local.Domain;
+using Granit.Identity.Local.Events;
+using Granit.Identity.Local.Services;
+using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Microsoft.AspNetCore.Identity;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+
+public sealed class AspNetPasswordResetServiceTests
+{
+    private readonly UserManager<GranitUser> _userManager;
+    private readonly IDistributedEventBus _eventBus = Substitute.For<IDistributedEventBus>();
+    private readonly AspNetPasswordResetService _sut;
+
+    public AspNetPasswordResetServiceTests()
+    {
+        IUserStore<GranitUser> store = Substitute.For<IUserStore<GranitUser>>();
+        _userManager = Substitute.For<UserManager<GranitUser>>(
+            store, null, null, null, null, null, null, null, null);
+
+        _sut = new AspNetPasswordResetService(_userManager, _eventBus);
+    }
+
+    [Fact]
+    public async Task RequestResetAsync_UserExists_ReturnsTrue()
+    {
+        var user = new GranitUser { Id = Guid.NewGuid(), Email = "user@example.com" };
+        _userManager.FindByEmailAsync("user@example.com").Returns(user);
+        _userManager.GeneratePasswordResetTokenAsync(user).Returns("reset-token-123");
+
+        bool result = await _sut.RequestResetAsync("user@example.com", TestContext.Current.CancellationToken);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task RequestResetAsync_UserExists_PublishesPasswordResetRequestedEto()
+    {
+        var userId = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+        var user = new GranitUser { Id = userId, Email = "user@example.com", TenantId = tenantId };
+        _userManager.FindByEmailAsync("user@example.com").Returns(user);
+        _userManager.GeneratePasswordResetTokenAsync(user).Returns("reset-token-123");
+
+        await _sut.RequestResetAsync("user@example.com", TestContext.Current.CancellationToken);
+
+        await _eventBus.Received(1).PublishAsync(
+            Arg.Is<PasswordResetRequestedEto>(e =>
+                e.UserId == userId &&
+                e.Email == "user@example.com" &&
+                e.ResetToken == "reset-token-123" &&
+                e.TenantId == tenantId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RequestResetAsync_UserNotFound_ReturnsFalse()
+    {
+        _userManager.FindByEmailAsync("unknown@example.com").Returns((GranitUser?)null);
+
+        bool result = await _sut.RequestResetAsync("unknown@example.com", TestContext.Current.CancellationToken);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task RequestResetAsync_UserNotFound_DoesNotPublishEvent()
+    {
+        _userManager.FindByEmailAsync("unknown@example.com").Returns((GranitUser?)null);
+
+        await _sut.RequestResetAsync("unknown@example.com", TestContext.Current.CancellationToken);
+
+        await _eventBus.DidNotReceive().PublishAsync(
+            Arg.Any<PasswordResetRequestedEto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResetPasswordAsync_ValidUserAndToken_Succeeds()
+    {
+        var user = new GranitUser { Id = Guid.NewGuid() };
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _userManager.ResetPasswordAsync(user, "token", "NewP@ss1").Returns(IdentityResult.Success);
+
+        await Should.NotThrowAsync(
+            () => _sut.ResetPasswordAsync(user.Id.ToString(), "token", "NewP@ss1", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ResetPasswordAsync_UserNotFound_ThrowsInvalidOperation()
+    {
+        string unknownId = Guid.NewGuid().ToString();
+        _userManager.FindByIdAsync(unknownId).Returns((GranitUser?)null);
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.ResetPasswordAsync(unknownId, "token", "NewP@ss1", TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain(unknownId);
+    }
+
+    [Fact]
+    public async Task ResetPasswordAsync_IdentityResultFailed_ThrowsWithErrors()
+    {
+        var user = new GranitUser { Id = Guid.NewGuid() };
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _userManager.ResetPasswordAsync(user, "bad-token", "NewP@ss1")
+            .Returns(IdentityResult.Failed(new IdentityError { Description = "Invalid token" }));
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.ResetPasswordAsync(user.Id.ToString(), "bad-token", "NewP@ss1", TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("Invalid token");
+    }
+}

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/AspNetTwoFactorServiceTests.cs
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/AspNetTwoFactorServiceTests.cs
@@ -1,0 +1,198 @@
+using Granit.Identity.Local.Domain;
+using Granit.Identity.Local.Services;
+using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Microsoft.AspNetCore.Identity;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+
+public sealed class AspNetTwoFactorServiceTests
+{
+    private static readonly string UserId = Guid.NewGuid().ToString();
+
+    private readonly UserManager<GranitUser> _userManager;
+    private readonly ITotpService _totpService = Substitute.For<ITotpService>();
+    private readonly AspNetTwoFactorService _sut;
+    private readonly GranitUser _user;
+
+    public AspNetTwoFactorServiceTests()
+    {
+        IUserStore<GranitUser> store = Substitute.For<IUserStore<GranitUser>>();
+        _userManager = Substitute.For<UserManager<GranitUser>>(
+            store, null, null, null, null, null, null, null, null);
+
+        _user = new GranitUser { Id = Guid.Parse(UserId), Email = "user@test.com", UserName = "testuser" };
+        _userManager.FindByIdAsync(UserId).Returns(_user);
+
+        _sut = new AspNetTwoFactorService(_userManager, _totpService);
+    }
+
+    // --- GetStatusAsync ---
+
+    [Fact]
+    public async Task GetStatusAsync_ReturnsCorrectStatus()
+    {
+        _userManager.GetTwoFactorEnabledAsync(_user).Returns(true);
+        _userManager.GetAuthenticatorKeyAsync(_user).Returns("JBSWY3DPEHPK3PXP");
+        _userManager.CountRecoveryCodesAsync(_user).Returns(5);
+
+        TwoFactorStatus status = await _sut.GetStatusAsync(UserId, TestContext.Current.CancellationToken);
+
+        status.IsEnabled.ShouldBeTrue();
+        status.HasAuthenticatorApp.ShouldBeTrue();
+        status.RecoveryCodesLeft.ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_NoAuthenticatorKey_HasAuthenticatorAppIsFalse()
+    {
+        _userManager.GetTwoFactorEnabledAsync(_user).Returns(false);
+        _userManager.GetAuthenticatorKeyAsync(_user).Returns((string?)null);
+        _userManager.CountRecoveryCodesAsync(_user).Returns(0);
+
+        TwoFactorStatus status = await _sut.GetStatusAsync(UserId, TestContext.Current.CancellationToken);
+
+        status.IsEnabled.ShouldBeFalse();
+        status.HasAuthenticatorApp.ShouldBeFalse();
+        status.RecoveryCodesLeft.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_UserNotFound_Throws()
+    {
+        _userManager.FindByIdAsync("unknown").Returns((GranitUser?)null);
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.GetStatusAsync("unknown", TestContext.Current.CancellationToken));
+    }
+
+    // --- GetAuthenticatorKeyAsync ---
+
+    [Fact]
+    public async Task GetAuthenticatorKeyAsync_KeyExists_ReturnsKeyAndQrCode()
+    {
+        _userManager.GetAuthenticatorKeyAsync(_user).Returns("EXISTINGKEY");
+        _totpService.GetQrCodeUri("user@test.com", "EXISTINGKEY").Returns("otpauth://totp/...");
+
+        AuthenticatorKeyInfo info = await _sut.GetAuthenticatorKeyAsync(UserId, TestContext.Current.CancellationToken);
+
+        info.SharedKey.ShouldBe("EXISTINGKEY");
+        info.QrCodeUri.ShouldBe("otpauth://totp/...");
+        await _userManager.DidNotReceive().ResetAuthenticatorKeyAsync(_user);
+    }
+
+    [Fact]
+    public async Task GetAuthenticatorKeyAsync_NoKey_ResetsAndReturnsNewKey()
+    {
+        _userManager.GetAuthenticatorKeyAsync(_user).Returns(
+            (string?)null,    // first call: no key
+            "NEWLYGENERATED"  // after reset
+        );
+        _totpService.GetQrCodeUri("user@test.com", "NEWLYGENERATED").Returns("otpauth://totp/new...");
+
+        AuthenticatorKeyInfo info = await _sut.GetAuthenticatorKeyAsync(UserId, TestContext.Current.CancellationToken);
+
+        info.SharedKey.ShouldBe("NEWLYGENERATED");
+        await _userManager.Received(1).ResetAuthenticatorKeyAsync(_user);
+    }
+
+    [Fact]
+    public async Task GetAuthenticatorKeyAsync_NoEmail_UsesUserNameForQrCode()
+    {
+        var user = new GranitUser { Id = Guid.NewGuid(), Email = null, UserName = "fallback-user" };
+        _userManager.FindByIdAsync(user.Id.ToString()).Returns(user);
+        _userManager.GetAuthenticatorKeyAsync(user).Returns("KEY123");
+        _totpService.GetQrCodeUri("fallback-user", "KEY123").Returns("otpauth://...");
+
+        AuthenticatorKeyInfo info = await _sut.GetAuthenticatorKeyAsync(user.Id.ToString(), TestContext.Current.CancellationToken);
+
+        info.SharedKey.ShouldBe("KEY123");
+    }
+
+    // --- EnableAsync ---
+
+    [Fact]
+    public async Task EnableAsync_ValidCode_EnablesTwoFactorAndReturnsRecoveryCodes()
+    {
+        _userManager.GetAuthenticatorKeyAsync(_user).Returns("VALIDKEY");
+        _totpService.ValidateCode("VALIDKEY", "123456").Returns(true);
+        _userManager.GenerateNewTwoFactorRecoveryCodesAsync(_user, 10)
+            .Returns(new[] { "CODE1", "CODE2", "CODE3" }.AsEnumerable());
+
+        IReadOnlyList<string> codes = await _sut.EnableAsync(UserId, "123456", TestContext.Current.CancellationToken);
+
+        codes.Count.ShouldBe(3);
+        codes.ShouldContain("CODE1");
+        await _userManager.Received(1).SetTwoFactorEnabledAsync(_user, true);
+    }
+
+    [Fact]
+    public async Task EnableAsync_InvalidCode_ThrowsInvalidOperation()
+    {
+        _userManager.GetAuthenticatorKeyAsync(_user).Returns("VALIDKEY");
+        _totpService.ValidateCode("VALIDKEY", "000000").Returns(false);
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.EnableAsync(UserId, "000000", TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("Invalid TOTP");
+        await _userManager.DidNotReceive().SetTwoFactorEnabledAsync(Arg.Any<GranitUser>(), Arg.Any<bool>());
+    }
+
+    [Fact]
+    public async Task EnableAsync_NoAuthenticatorKey_ThrowsInvalidOperation()
+    {
+        _userManager.GetAuthenticatorKeyAsync(_user).Returns((string?)null);
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.EnableAsync(UserId, "123456", TestContext.Current.CancellationToken));
+    }
+
+    // --- DisableAsync ---
+
+    [Fact]
+    public async Task DisableAsync_DisablesTwoFactorAndUpdatesSecurityStamp()
+    {
+        await _sut.DisableAsync(UserId, TestContext.Current.CancellationToken);
+
+        await _userManager.Received(1).SetTwoFactorEnabledAsync(_user, false);
+        await _userManager.Received(1).UpdateSecurityStampAsync(_user);
+    }
+
+    // --- ResetAuthenticatorAsync ---
+
+    [Fact]
+    public async Task ResetAuthenticatorAsync_ResetsKey()
+    {
+        await _sut.ResetAuthenticatorAsync(UserId, TestContext.Current.CancellationToken);
+
+        await _userManager.Received(1).ResetAuthenticatorKeyAsync(_user);
+    }
+
+    // --- GenerateRecoveryCodesAsync ---
+
+    [Fact]
+    public async Task GenerateRecoveryCodesAsync_ReturnsCodes()
+    {
+        string[] expectedCodes = ["RC1", "RC2", "RC3", "RC4", "RC5"];
+        _userManager.GenerateNewTwoFactorRecoveryCodesAsync(_user, 10)
+            .Returns(expectedCodes.AsEnumerable());
+
+        IReadOnlyList<string> codes = await _sut.GenerateRecoveryCodesAsync(UserId, TestContext.Current.CancellationToken);
+
+        codes.Count.ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task GenerateRecoveryCodesAsync_NullFromManager_ReturnsEmptyList()
+    {
+        _userManager.GenerateNewTwoFactorRecoveryCodesAsync(_user, 10)
+            .Returns((IEnumerable<string>?)null);
+
+        IReadOnlyList<string> codes = await _sut.GenerateRecoveryCodesAsync(UserId, TestContext.Current.CancellationToken);
+
+        codes.ShouldBeEmpty();
+    }
+}

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/KeyRotationServiceTests.cs
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/KeyRotationServiceTests.cs
@@ -1,0 +1,278 @@
+using Granit.Encryption;
+using Granit.OpenIddict.Domain;
+using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Granit.OpenIddict.Options;
+using Granit.OpenIddict.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+
+public sealed class KeyRotationServiceTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 3, 15, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly ISigningKeyStore _keyStore = Substitute.For<ISigningKeyStore>();
+    private readonly IStringEncryptionService _encryptionService = Substitute.For<IStringEncryptionService>();
+    private readonly TimeProvider _timeProvider = Substitute.For<TimeProvider>();
+
+    public KeyRotationServiceTests()
+    {
+        _timeProvider.GetUtcNow().Returns(Now);
+        _encryptionService.Encrypt(Arg.Any<string>()).Returns(ci => $"enc:{ci.Arg<string>()[..8]}");
+
+        // Default: no keys, no pruning
+        _keyStore.GetActiveKeyAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((SigningKey?)null);
+        _keyStore.GetKeysAsync(Arg.Any<SigningKeyStatus[]>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+        _keyStore.PruneRevokedAsync(Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(0);
+    }
+
+    private KeyRotationService CreateSut(GranitKeyRotationOptions? options = null)
+    {
+        options ??= new GranitKeyRotationOptions
+        {
+            Enabled = true,
+            KeyLifetime = TimeSpan.FromDays(90),
+            GracePeriod = TimeSpan.FromDays(7),
+            RotationLeadTime = TimeSpan.FromDays(14),
+            RsaKeySize = 2048,
+            SigningAlgorithm = "RS256",
+        };
+
+        return new KeyRotationService(
+            _keyStore,
+            _encryptionService,
+            Microsoft.Extensions.Options.Options.Create(options),
+            _timeProvider,
+            NullLogger<KeyRotationService>.Instance);
+    }
+
+    [Fact]
+    public async Task RotateAsync_WhenDisabled_ReturnsZeroResult()
+    {
+        KeyRotationService sut = CreateSut(new GranitKeyRotationOptions { Enabled = false });
+
+        KeyRotationResult result = await sut.RotateAsync(TestContext.Current.CancellationToken);
+
+        result.KeysGenerated.ShouldBe(0);
+        result.KeysRetired.ShouldBe(0);
+        result.KeysRevoked.ShouldBe(0);
+        result.KeysPruned.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task RotateAsync_WhenDisabled_DoesNotAccessKeyStore()
+    {
+        KeyRotationService sut = CreateSut(new GranitKeyRotationOptions { Enabled = false });
+
+        await sut.RotateAsync(TestContext.Current.CancellationToken);
+
+        await _keyStore.DidNotReceive().GetActiveKeyAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RotateAsync_NoActiveKeys_GeneratesBothSigningAndEncryptionKeys()
+    {
+        KeyRotationService sut = CreateSut();
+
+        KeyRotationResult result = await sut.RotateAsync(TestContext.Current.CancellationToken);
+
+        result.KeysGenerated.ShouldBe(2);
+        await _keyStore.Received(2).CreateAsync(Arg.Any<SigningKey>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RotateAsync_NoActiveKeys_GeneratesSigningKeyWithRS256()
+    {
+        SigningKey? capturedKey = null;
+        _keyStore.CreateAsync(Arg.Do<SigningKey>(k =>
+        {
+            if (k.KeyType == "signing")
+            {
+                capturedKey = k;
+            }
+        }), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+
+        KeyRotationService sut = CreateSut();
+
+        await sut.RotateAsync(TestContext.Current.CancellationToken);
+
+        capturedKey.ShouldNotBeNull();
+        capturedKey.Algorithm.ShouldBe("RS256");
+        capturedKey.KeyType.ShouldBe("signing");
+        capturedKey.KeySize.ShouldBe(2048);
+        capturedKey.Status.ShouldBe(SigningKeyStatus.Active);
+        capturedKey.ActivatedAt.ShouldBe(Now);
+        capturedKey.ExpiresAt.ShouldBe(Now.AddDays(90));
+    }
+
+    [Fact]
+    public async Task RotateAsync_NoActiveKeys_GeneratesEncryptionKeyWithRsaOaep()
+    {
+        SigningKey? capturedKey = null;
+        _keyStore.CreateAsync(Arg.Do<SigningKey>(k =>
+        {
+            if (k.KeyType == "encryption")
+            {
+                capturedKey = k;
+            }
+        }), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+
+        KeyRotationService sut = CreateSut();
+
+        await sut.RotateAsync(TestContext.Current.CancellationToken);
+
+        capturedKey.ShouldNotBeNull();
+        capturedKey.Algorithm.ShouldBe("RSA-OAEP");
+        capturedKey.KeyType.ShouldBe("encryption");
+    }
+
+    [Fact]
+    public async Task RotateAsync_NoActiveKeys_EncryptsKeyMaterial()
+    {
+        KeyRotationService sut = CreateSut();
+
+        await sut.RotateAsync(TestContext.Current.CancellationToken);
+
+        _encryptionService.Received(2).Encrypt(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task RotateAsync_ActiveKeysNotExpiring_DoesNotGenerateNewKeys()
+    {
+        SetupActiveKey("signing", Now.AddDays(30));
+        SetupActiveKey("encryption", Now.AddDays(30));
+
+        KeyRotationService sut = CreateSut();
+
+        KeyRotationResult result = await sut.RotateAsync(TestContext.Current.CancellationToken);
+
+        result.KeysGenerated.ShouldBe(0);
+        await _keyStore.DidNotReceive().CreateAsync(Arg.Any<SigningKey>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RotateAsync_SigningKeyExpiringWithinLeadTime_RotatesSigningKey()
+    {
+        // Signing key expires in 10 days (< 14 days lead time)
+        SigningKey signingKey = SetupActiveKey("signing", Now.AddDays(10));
+        SetupActiveKey("encryption", Now.AddDays(60));
+
+        KeyRotationService sut = CreateSut();
+
+        KeyRotationResult result = await sut.RotateAsync(TestContext.Current.CancellationToken);
+
+        result.KeysGenerated.ShouldBe(1);
+        await _keyStore.Received(1).CreateAsync(Arg.Any<SigningKey>(), Arg.Any<CancellationToken>());
+        await _keyStore.Received().UpdateAsync(signingKey, Arg.Any<CancellationToken>());
+        signingKey.Status.ShouldBe(SigningKeyStatus.Retired);
+        signingKey.RetiredAt.ShouldBe(Now);
+    }
+
+    [Fact]
+    public async Task RotateAsync_RetiredKeysPastGracePeriod_RevokesKeys()
+    {
+        SetupActiveKey("signing", Now.AddDays(60));
+        SetupActiveKey("encryption", Now.AddDays(60));
+
+        var retiredKey = SigningKey.Create(
+            "signing-old", "signing", "RS256", "enc:material",
+            Now.AddDays(-120), Now.AddDays(-30), 2048);
+        retiredKey.Retire(Now.AddDays(-10));
+
+        _keyStore.GetKeysAsync(Arg.Is<SigningKeyStatus[]>(s => s.Contains(SigningKeyStatus.Retired)), Arg.Any<CancellationToken>())
+            .Returns([retiredKey]);
+
+        KeyRotationService sut = CreateSut();
+
+        KeyRotationResult result = await sut.RotateAsync(TestContext.Current.CancellationToken);
+
+        result.KeysRevoked.ShouldBe(1);
+        retiredKey.Status.ShouldBe(SigningKeyStatus.Revoked);
+    }
+
+    [Fact]
+    public async Task RotateAsync_RetiredKeysWithinGracePeriod_DoesNotRevoke()
+    {
+        SetupActiveKey("signing", Now.AddDays(60));
+        SetupActiveKey("encryption", Now.AddDays(60));
+
+        var retiredKey = SigningKey.Create(
+            "signing-recent", "signing", "RS256", "enc:material",
+            Now.AddDays(-80), Now.AddDays(-1), 2048);
+        retiredKey.Retire(Now.AddDays(-3)); // Retired 3 days ago, grace = 7 days
+
+        _keyStore.GetKeysAsync(Arg.Is<SigningKeyStatus[]>(s => s.Contains(SigningKeyStatus.Retired)), Arg.Any<CancellationToken>())
+            .Returns([retiredKey]);
+
+        KeyRotationService sut = CreateSut();
+
+        KeyRotationResult result = await sut.RotateAsync(TestContext.Current.CancellationToken);
+
+        result.KeysRevoked.ShouldBe(0);
+        retiredKey.Status.ShouldBe(SigningKeyStatus.Retired);
+    }
+
+    [Fact]
+    public async Task RotateAsync_RevokedKeysOlderThan30Days_Pruned()
+    {
+        SetupActiveKey("signing", Now.AddDays(60));
+        SetupActiveKey("encryption", Now.AddDays(60));
+
+        _keyStore.PruneRevokedAsync(Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(3);
+
+        KeyRotationService sut = CreateSut();
+
+        KeyRotationResult result = await sut.RotateAsync(TestContext.Current.CancellationToken);
+
+        result.KeysPruned.ShouldBe(3);
+        await _keyStore.Received().PruneRevokedAsync(
+            Now.AddDays(-30), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RotateAsync_FullLifecycle_HandlesAllPhases()
+    {
+        // Active signing key expiring soon → rotation
+        SigningKey expiringKey = SetupActiveKey("signing", Now.AddDays(5));
+        SetupActiveKey("encryption", Now.AddDays(60));
+
+        // Retired key past grace period → revocation
+        var oldRetired = SigningKey.Create(
+            "signing-ancient", "signing", "RS256", "enc:material",
+            Now.AddDays(-200), Now.AddDays(-100), 2048);
+        oldRetired.Retire(Now.AddDays(-20));
+        _keyStore.GetKeysAsync(Arg.Is<SigningKeyStatus[]>(s => s.Contains(SigningKeyStatus.Retired)), Arg.Any<CancellationToken>())
+            .Returns([oldRetired]);
+
+        // 2 pruned keys
+        _keyStore.PruneRevokedAsync(Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(2);
+
+        KeyRotationService sut = CreateSut();
+
+        KeyRotationResult result = await sut.RotateAsync(TestContext.Current.CancellationToken);
+
+        result.KeysGenerated.ShouldBe(1);
+        result.KeysRevoked.ShouldBe(1);
+        result.KeysPruned.ShouldBe(2);
+    }
+
+    private SigningKey SetupActiveKey(string keyType, DateTimeOffset expiresAt)
+    {
+        var key = SigningKey.Create(
+            $"{keyType}-active", keyType, keyType == "signing" ? "RS256" : "RSA-OAEP",
+            "enc:material", Now.AddDays(-30), expiresAt, 2048);
+
+        _keyStore.GetActiveKeyAsync(keyType, Arg.Any<CancellationToken>())
+            .Returns(key);
+
+        return key;
+    }
+}


### PR DESCRIPTION
## Summary

- **Register `IdentityLocalMetrics` as singleton** in `GranitIdentityLocalModule.ConfigureServices` — it was defined in `Granit.Identity.Local/Diagnostics/` but never added to DI, causing `AspNetImpersonationService` activation failure at runtime
- **Add `[DependsOn(typeof(GranitIdentityLocalModule))]`** to `GranitOpenIddictEntityFrameworkCoreModule` — the project already had a `<ProjectReference>` to `Granit.Identity.Local`, so the `[DependsOn]` was missing per convention
- **Add unit tests** for DPoP proof validation, admin OIDC validators, and OpenIddict EF Core services (external login, password reset, two-factor, key rotation)

## Test plan

- [x] `dotnet build` passes for both modified projects
- [ ] CI shards pass (security shard covers both modified modules)
- [ ] Verify `AspNetImpersonationService` resolves correctly at runtime