### PR TITLE
fix: regenerate ApiDocumentation test lock file for Scalar.AspNetCore 2.13.18

### DIFF
--- a/tests/Granit.Http.ApiDocumentation.Tests/packages.lock.json
+++ b/tests/Granit.Http.ApiDocumentation.Tests/packages.lock.json
@@ -616,8 +616,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.13.17",
-        "contentHash": "v44WF0m58HBwaUiZVrvuetICcoaf2ZvIYu8JxsaJRRtsrNLlCIqjCcncTTDIy7pUiC2r2EO3eCJqcqGaTKZplQ=="
+        "resolved": "2.13.18",
+        "contentHash": "SOe5I8KspXwmcMbey+6G4drRWhCa/ON/ZjyVKfm5FpXvcsCmb9MfiVcKAiQ8UYV+ki3fAaqcCFc5ahzx/NTXOw=="
       }
     }
   }


### PR DESCRIPTION
## Summary

- Regenerate `packages.lock.json` for `Granit.Http.ApiDocumentation.Tests` to resolve Scalar.AspNetCore version drift

## Problem

The source project `Granit.Http.ApiDocumentation` resolved `Scalar.AspNetCore` to `2.13.18`, but the test project lock file was pinned to `2.13.17`. This caused `FileNotFoundException` at runtime in CI (6 tests failing in the `api-data` shard).

## Test plan

- [ ] CI `api-data` shard passes (6 previously failing `ApiDocumentationApplicationBuilderExtensionsTests`)
