### PR TITLE
test: add 250+ tests for code coverage phase 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,7 @@ jobs:
             /d:sonar.host.url="https://sonarcloud.io" \
             /d:sonar.token="${SONAR_TOKEN}" \
             /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml" \
-            /d:sonar.exclusions=".nuget/**,docs-site/**" \
+            /d:sonar.exclusions=".nuget/**,docs-site/**,scripts/**" \
             /d:sonar.coverage.exclusions="**/Tests/**,**/test/**,**/bundles/**,**/*HostApplicationBuilderExtensions.cs,**/Granit*Module.cs" \
             /d:sonar.issue.ignore.multicriteria="e1,e2,e3,e4" \
             /d:sonar.issue.ignore.multicriteria.e1.ruleKey="csharpsquid:S6608" \

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -6525,6 +6525,12 @@
           "returnType": "string"
         },
         {
+          "name": "EffectiveErrorRedirectPath",
+          "kind": "property",
+          "signature": "string EffectiveErrorRedirectPath",
+          "returnType": "string"
+        },
+        {
           "name": "UsePushedAuthorizationRequests",
           "kind": "property",
           "signature": "bool UsePushedAuthorizationRequests",

--- a/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
@@ -12,7 +12,6 @@ using Granit.Timing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -60,10 +59,10 @@ internal static partial class BffLoginEndpoints
             .ExcludeFromDescription();
 
         group.MapGet("/callback", (HttpContext httpContext,
-                [FromQuery] string? code,
-                [FromQuery] string? state,
-                [FromQuery] string? error,
-                [FromQuery] string? iss,
+                string? code,
+                string? state,
+                string? error,
+                string? iss,
                 CancellationToken cancellationToken) =>
                 HandleCallbackAsync(httpContext, frontend, code, state, error, iss, cancellationToken))
             .WithName($"BffCallback_{frontend.Name}")
@@ -71,16 +70,15 @@ internal static partial class BffLoginEndpoints
             .WithDescription(
                 "Receives the authorization code from the OIDC provider, exchanges it for tokens "
                 + "using the stored PKCE code verifier, stores the tokens server-side, sets a session "
-                + "cookie, and redirects to the configured post-login path. Returns 400 if the "
-                + "authorization code or state is missing or invalid.")
+                + "cookie, and redirects to the configured post-login path. On error, redirects to "
+                + "the frontend error page with an error code query parameter.")
             .Produces(StatusCodes.Status302Found)
-            .ProducesProblem(StatusCodes.Status400BadRequest)
             .ExcludeFromDescription();
 
         return group;
     }
 
-    private static async Task<Results<RedirectHttpResult, ProblemHttpResult>> HandleLoginAsync(
+    private static async Task<RedirectHttpResult> HandleLoginAsync(
         HttpContext httpContext,
         BffFrontendOptions frontend,
         CancellationToken cancellationToken)
@@ -140,9 +138,7 @@ internal static partial class BffLoginEndpoints
             {
                 // PAR is mandatory (FAPI 2.0 strict) — do not fall back
                 LogParFallback(logger, frontend.Name);
-                return TypedResults.Problem(
-                    detail: "Pushed Authorization Request failed and is required by configuration.",
-                    statusCode: StatusCodes.Status502BadGateway);
+                return RedirectToError(frontend, "par_failed");
             }
             else
             {
@@ -164,7 +160,7 @@ internal static partial class BffLoginEndpoints
         return TypedResults.Redirect(authorizeUrl);
     }
 
-    private static async Task<Results<RedirectHttpResult, ProblemHttpResult>> HandleCallbackAsync(
+    private static async Task<RedirectHttpResult> HandleCallbackAsync(
         HttpContext httpContext,
         BffFrontendOptions frontend,
         string? code,
@@ -188,16 +184,12 @@ internal static partial class BffLoginEndpoints
         {
             string safeError = KnownOidcErrors.Contains(error) ? error : "unknown_error";
             LogCallbackError(logger, safeError, frontend.Name);
-            return TypedResults.Problem(
-                detail: $"OIDC authorization error: {safeError}",
-                statusCode: StatusCodes.Status400BadRequest);
+            return RedirectToError(frontend, safeError);
         }
 
         if (string.IsNullOrWhiteSpace(code) || string.IsNullOrWhiteSpace(state))
         {
-            return TypedResults.Problem(
-                detail: "Missing authorization code or state parameter.",
-                statusCode: StatusCodes.Status400BadRequest);
+            return RedirectToError(frontend, "missing_code_or_state");
         }
 
         // Verify authorization response issuer (RFC 9207, FAPI 2.0 §5.3.3.2)
@@ -208,17 +200,13 @@ internal static partial class BffLoginEndpoints
             if (string.IsNullOrEmpty(iss))
             {
                 LogIssuerMissing(logger, frontend.Name);
-                return TypedResults.Problem(
-                    detail: "Missing iss parameter in authorization response (RFC 9207).",
-                    statusCode: StatusCodes.Status400BadRequest);
+                return RedirectToError(frontend, "issuer_missing");
             }
 
             if (!string.Equals(iss.TrimEnd('/'), expectedIssuer, StringComparison.OrdinalIgnoreCase))
             {
                 LogIssuerMismatch(logger, iss, expectedIssuer, frontend.Name);
-                return TypedResults.Problem(
-                    detail: "Authorization response issuer does not match expected authority.",
-                    statusCode: StatusCodes.Status400BadRequest);
+                return RedirectToError(frontend, "issuer_mismatch");
             }
         }
 
@@ -229,9 +217,7 @@ internal static partial class BffLoginEndpoints
 
         if (!maybePkce.HasValue)
         {
-            return TypedResults.Problem(
-                detail: "Invalid or expired state parameter.",
-                statusCode: StatusCodes.Status400BadRequest);
+            return RedirectToError(frontend, "invalid_state");
         }
 
         await cache.RemoveAsync(pkceKey, token: cancellationToken).ConfigureAwait(false);
@@ -249,9 +235,7 @@ internal static partial class BffLoginEndpoints
         if (tokens is null)
         {
             LogTokenExchangeFailed(logger, frontend.Name);
-            return TypedResults.Problem(
-                detail: "Failed to exchange authorization code for tokens.",
-                statusCode: StatusCodes.Status400BadRequest);
+            return RedirectToError(frontend, "token_exchange_failed");
         }
 
         // Enrich token set with user context for session management (#621)
@@ -562,6 +546,12 @@ internal static partial class BffLoginEndpoints
         sessionId.Length > 8 ? $"{sessionId[..4]}...{sessionId[^4..]}" : "****";
 
     internal sealed record PkceState(string CodeVerifier, string State, string FrontendName, string? DPoPPrivateKeyJwk = null);
+
+    /// <summary>
+    /// Builds a redirect to the frontend error page with the given error code as a query parameter.
+    /// </summary>
+    private static RedirectHttpResult RedirectToError(BffFrontendOptions frontend, string errorCode) =>
+        TypedResults.Redirect($"{frontend.EffectiveErrorRedirectPath}?error={Uri.EscapeDataString(errorCode)}");
 
     private static IClientAuthenticationStrategy ResolveClientAuth(BffFrontendOptions frontend, IClock clock) =>
         frontend.ClientAuthenticationMethod == BffClientAuthenticationMethod.PrivateKeyJwt

--- a/src/Granit.Bff/Options/GranitBffOptions.cs
+++ b/src/Granit.Bff/Options/GranitBffOptions.cs
@@ -123,6 +123,13 @@ public sealed class BffFrontendOptions
     public string? PostLogoutRedirectPath { get; set; }
 
     /// <summary>
+    /// Path to redirect to when the OIDC callback encounters an error. An <c>?error={code}</c>
+    /// query parameter is appended so the SPA can display a localized error message.
+    /// Default: <c>{PathPrefix}/login</c>.
+    /// </summary>
+    public string? ErrorRedirectPath { get; set; }
+
+    /// <summary>
     /// Gets the session cookie name for this frontend.
     /// Format: <c>__Host-granit-bff-{name}</c>.
     /// </summary>
@@ -139,6 +146,12 @@ public sealed class BffFrontendOptions
     /// </summary>
     public string EffectivePostLogoutRedirectPath =>
         PostLogoutRedirectPath ?? (string.IsNullOrEmpty(PathPrefix) ? "/" : $"{PathPrefix}/");
+
+    /// <summary>
+    /// Gets the effective error redirect path (without the <c>?error=</c> query parameter).
+    /// </summary>
+    public string EffectiveErrorRedirectPath =>
+        ErrorRedirectPath ?? (string.IsNullOrEmpty(PathPrefix) ? "/login" : $"{PathPrefix}/login");
 
     /// <summary>
     /// Gets or sets a value indicating whether the BFF should use Pushed Authorization

--- a/tests/Granit.Bff.Endpoints.Tests/Integration/BffEndpointsIntegrationTests.cs
+++ b/tests/Granit.Bff.Endpoints.Tests/Integration/BffEndpointsIntegrationTests.cs
@@ -710,7 +710,7 @@ public sealed class BffEndpointsIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task GetCallback_TokenExchangeFails_Returns400()
+    public async Task GetCallback_TokenExchangeFails_RedirectsToErrorPage()
     {
         string testState = "test-state-fail";
 
@@ -726,31 +726,34 @@ public sealed class BffEndpointsIntegrationTests : IAsyncLifetime
             new HttpRequestMessage(HttpMethod.Get, $"/app/bff/callback?code=bad-code&state={testState}"),
             TestContext.Current.CancellationToken);
 
-        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        response.Headers.Location!.ToString().ShouldBe("/app/login?error=token_exchange_failed");
     }
 
     [Fact]
-    public async Task GetCallback_MissingCode_Returns400()
+    public async Task GetCallback_MissingCode_RedirectsToErrorPage()
     {
         HttpResponseMessage response = await _server.SendWithoutRedirectAsync(
             new HttpRequestMessage(HttpMethod.Get, "/app/bff/callback?state=some-state"),
             TestContext.Current.CancellationToken);
 
-        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        response.Headers.Location!.ToString().ShouldBe("/app/login?error=missing_code_or_state");
     }
 
     [Fact]
-    public async Task GetCallback_MissingState_Returns400()
+    public async Task GetCallback_MissingState_RedirectsToErrorPage()
     {
         HttpResponseMessage response = await _server.SendWithoutRedirectAsync(
             new HttpRequestMessage(HttpMethod.Get, "/app/bff/callback?code=some-code"),
             TestContext.Current.CancellationToken);
 
-        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        response.Headers.Location!.ToString().ShouldBe("/app/login?error=missing_code_or_state");
     }
 
     [Fact]
-    public async Task GetCallback_InvalidState_Returns400()
+    public async Task GetCallback_InvalidState_RedirectsToErrorPage()
     {
         // Cache returns empty (state not found)
         _server.Cache.TryGetAsync<BffLoginEndpoints.PkceState>(
@@ -763,34 +766,32 @@ public sealed class BffEndpointsIntegrationTests : IAsyncLifetime
             new HttpRequestMessage(HttpMethod.Get, "/app/bff/callback?code=test-code&state=unknown-state"),
             TestContext.Current.CancellationToken);
 
-        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        response.Headers.Location!.ToString().ShouldBe("/app/login?error=invalid_state");
     }
 
     [Fact]
-    public async Task GetCallback_OidcError_Returns400WithSafeError()
+    public async Task GetCallback_OidcError_RedirectsWithSafeErrorCode()
     {
         HttpResponseMessage response = await _server.SendWithoutRedirectAsync(
             new HttpRequestMessage(HttpMethod.Get, "/app/bff/callback?error=access_denied"),
             TestContext.Current.CancellationToken);
 
-        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
-
-        string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        body.ShouldContain("access_denied");
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        response.Headers.Location!.ToString().ShouldBe("/app/login?error=access_denied");
     }
 
     [Fact]
-    public async Task GetCallback_UnknownOidcError_ReplacedWithUnknownError()
+    public async Task GetCallback_UnknownOidcError_RedirectsWithUnknownError()
     {
         HttpResponseMessage response = await _server.SendWithoutRedirectAsync(
             new HttpRequestMessage(HttpMethod.Get, "/app/bff/callback?error=xss_attempt"),
             TestContext.Current.CancellationToken);
 
-        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
-
-        string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        body.ShouldContain("unknown_error");
-        body.ShouldNotContain("xss_attempt");
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        string location = response.Headers.Location!.ToString();
+        location.ShouldContain("error=unknown_error");
+        location.ShouldNotContain("xss_attempt");
     }
 
     [Fact]

--- a/tests/Granit.Bff.Tests/Internal/LogoutTokenValidatorTests.cs
+++ b/tests/Granit.Bff.Tests/Internal/LogoutTokenValidatorTests.cs
@@ -252,7 +252,185 @@ public sealed class LogoutTokenValidatorTests : IDisposable
         result.ShouldBeNull();
     }
 
+    [Fact]
+    public async Task ValidateAsync_NullJwksFromCache_ReturnsNull()
+    {
+        string token = BuildSignedToken(
+            issuer: Authority,
+            audience: ClientId,
+            includeBackChannelEvent: true);
+
+        _cache.GetOrSetAsync<List<JsonElement>>(
+                Arg.Any<string>(),
+                Arg.Any<Func<FusionCacheFactoryExecutionContext<List<JsonElement>>, CancellationToken, Task<List<JsonElement>>>>(),
+                Arg.Any<FusionCacheEntryOptions?>(),
+                Arg.Any<CancellationToken>())
+            .ReturnsForAnyArgs((List<JsonElement>?)null!);
+
+        ValidatedLogoutToken? result = await _validator.ValidateAsync(
+            token, ClientId, TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    // ──── No kid in header (selects first sig-use key) ────
+
+    [Fact]
+    public async Task ValidateAsync_NoKidInHeader_SelectsFirstSigKey()
+    {
+        string token = BuildSignedToken(
+            issuer: Authority,
+            audience: ClientId,
+            includeBackChannelEvent: true,
+            kid: null);
+        SetupCacheWithJwks("any-kid");
+
+        ValidatedLogoutToken? result = await _validator.ValidateAsync(
+            token, ClientId, TestContext.Current.CancellationToken);
+
+        // The key should match via "use":"sig" even without kid
+        result.ShouldNotBeNull();
+    }
+
+    // ──── Audience: array with multiple values ────
+
+    [Fact]
+    public async Task ValidateAsync_AudienceArrayWithMultipleValues_Succeeds()
+    {
+        string token = BuildSignedTokenWithAudienceArray(
+            issuer: Authority,
+            audiences: ["other-client", ClientId],
+            includeBackChannelEvent: true);
+        SetupCacheWithJwks();
+
+        ValidatedLogoutToken? result = await _validator.ValidateAsync(
+            token, ClientId, TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Audiences.ShouldNotBeNull();
+        result.Audiences!.ShouldContain(ClientId);
+        result.Audiences!.ShouldContain("other-client");
+    }
+
+    // ──── Audience: null (no aud claim) — succeeds ────
+
+    [Fact]
+    public async Task ValidateAsync_NoAudienceClaim_Succeeds()
+    {
+        string token = BuildSignedTokenWithNoAudience(
+            issuer: Authority,
+            includeBackChannelEvent: true);
+        SetupCacheWithJwks();
+
+        ValidatedLogoutToken? result = await _validator.ValidateAsync(
+            token, ClientId, TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Audiences.ShouldBeNull();
+    }
+
+    // ──── Invalid base64 in payload ────
+
+    [Fact]
+    public async Task ValidateAsync_InvalidPayloadBase64_ReturnsNull()
+    {
+        string header = Base64UrlEncode(JsonSerializer.SerializeToUtf8Bytes(
+            new { alg = "RS256", kid = "test-key-1" }));
+        SetupCacheWithJwks();
+
+        // valid header + invalid payload + dummy signature
+        byte[] signingInput = System.Text.Encoding.ASCII.GetBytes($"{header}.!!!invalid!!!");
+        byte[] sig = _rsa.SignData(signingInput, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        string token = $"{header}.!!!invalid!!!.{Base64UrlEncode(sig)}";
+
+        ValidatedLogoutToken? result = await _validator.ValidateAsync(
+            token, ClientId, TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    // ──── Unsupported algorithm / key type ────
+
+    [Fact]
+    public async Task ValidateAsync_UnsupportedAlgorithm_ReturnsNull()
+    {
+        // Build token claiming HS256 (HMAC) — not supported
+        string token = BuildSignedToken(
+            issuer: Authority,
+            audience: ClientId,
+            includeBackChannelEvent: true,
+            algorithm: "HS256");
+        SetupCacheWithJwks();
+
+        ValidatedLogoutToken? result = await _validator.ValidateAsync(
+            token, ClientId, TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
     // ──── Helpers ────
+
+    private string BuildSignedTokenWithAudienceArray(
+        string issuer,
+        string[] audiences,
+        bool includeBackChannelEvent,
+        string? kid = "test-key-1")
+    {
+        var header = new Dictionary<string, object?> { ["alg"] = "RS256", ["typ"] = "JWT", ["kid"] = kid };
+        string headerB64 = Base64UrlEncode(JsonSerializer.SerializeToUtf8Bytes(header));
+
+        var payload = new Dictionary<string, object?>
+        {
+            ["iss"] = issuer,
+            ["sub"] = "user-1",
+            ["jti"] = "test-jti",
+            ["aud"] = audiences,
+        };
+
+        if (includeBackChannelEvent)
+        {
+            payload["events"] = new Dictionary<string, object>
+            {
+                ["http://schemas.openid.net/event/backchannel-logout"] = new { },
+            };
+        }
+
+        string payloadB64 = Base64UrlEncode(JsonSerializer.SerializeToUtf8Bytes(payload));
+        byte[] signingInput = System.Text.Encoding.ASCII.GetBytes($"{headerB64}.{payloadB64}");
+        byte[] signature = _rsa.SignData(signingInput, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+        return $"{headerB64}.{payloadB64}.{Base64UrlEncode(signature)}";
+    }
+
+    private string BuildSignedTokenWithNoAudience(
+        string issuer,
+        bool includeBackChannelEvent,
+        string? kid = "test-key-1")
+    {
+        var header = new Dictionary<string, object?> { ["alg"] = "RS256", ["typ"] = "JWT", ["kid"] = kid };
+        string headerB64 = Base64UrlEncode(JsonSerializer.SerializeToUtf8Bytes(header));
+
+        var payload = new Dictionary<string, object?>
+        {
+            ["iss"] = issuer,
+            ["sub"] = "user-1",
+            ["jti"] = "test-jti",
+        };
+
+        if (includeBackChannelEvent)
+        {
+            payload["events"] = new Dictionary<string, object>
+            {
+                ["http://schemas.openid.net/event/backchannel-logout"] = new { },
+            };
+        }
+
+        string payloadB64 = Base64UrlEncode(JsonSerializer.SerializeToUtf8Bytes(payload));
+        byte[] signingInput = System.Text.Encoding.ASCII.GetBytes($"{headerB64}.{payloadB64}");
+        byte[] signature = _rsa.SignData(signingInput, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+        return $"{headerB64}.{payloadB64}.{Base64UrlEncode(signature)}";
+    }
 
     private static string BuildUnsignedToken(string algorithm)
     {

--- a/tests/Granit.Bff.Tests/Options/GranitBffOptionsTests.cs
+++ b/tests/Granit.Bff.Tests/Options/GranitBffOptionsTests.cs
@@ -199,4 +199,40 @@ public sealed class BffFrontendOptionsTests
 
         frontend.PostLogoutRedirectPath.ShouldBeNull();
     }
+
+    [Fact]
+    public void DefaultErrorRedirectPath_IsNull()
+    {
+        var frontend = new BffFrontendOptions();
+
+        frontend.ErrorRedirectPath.ShouldBeNull();
+    }
+
+    [Fact]
+    public void EffectiveErrorRedirectPath_UsesExplicitValue_WhenSet()
+    {
+        var frontend = new BffFrontendOptions
+        {
+            PathPrefix = "/admin",
+            ErrorRedirectPath = "/admin/error",
+        };
+
+        frontend.EffectiveErrorRedirectPath.ShouldBe("/admin/error");
+    }
+
+    [Fact]
+    public void EffectiveErrorRedirectPath_DefaultsToPathPrefixLogin_WhenPathPrefixSet()
+    {
+        var frontend = new BffFrontendOptions { PathPrefix = "/admin" };
+
+        frontend.EffectiveErrorRedirectPath.ShouldBe("/admin/login");
+    }
+
+    [Fact]
+    public void EffectiveErrorRedirectPath_DefaultsToLogin_WhenPathPrefixEmpty()
+    {
+        var frontend = new BffFrontendOptions { PathPrefix = string.Empty };
+
+        frontend.EffectiveErrorRedirectPath.ShouldBe("/login");
+    }
 }

--- a/tests/Granit.Bff.Yarp.Tests/Internal/BffTokenInjectionTransformTests.cs
+++ b/tests/Granit.Bff.Yarp.Tests/Internal/BffTokenInjectionTransformTests.cs
@@ -186,9 +186,407 @@ public sealed class BffTokenInjectionTransformTests : IDisposable
         context.HttpContext.Response.StatusCode.ShouldBe(StatusCodes.Status401Unauthorized);
     }
 
+    // ──── Token refresh ────
+
+    [Fact]
+    public async Task ApplyAsync_TokenAboutToExpire_RefreshesAndInjectsNewToken()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        _clock.Now.Returns(now);
+
+        BffTokenSet expiringSoonTokens = new(
+            "old-access-token", "refresh-token-123", null,
+            now.AddSeconds(10)) // expires in 10s, within 30s grace period
+        {
+            SessionCreatedAt = now.AddHours(-1),
+        };
+        _tokenStore.GetAsync("main", "session-abc", Arg.Any<CancellationToken>())
+            .Returns(expiringSoonTokens);
+
+        // Setup refresh HTTP call
+        string refreshJson = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            access_token = "new-access-token",
+            refresh_token = "new-refresh-token",
+            expires_in = 3600,
+        });
+        FakeHttpMessageHandler handler = new(_ => new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK)
+        {
+            Content = new StringContent(refreshJson, System.Text.Encoding.UTF8, "application/json"),
+        });
+        HttpClient httpClient = new(handler);
+        _httpClientFactory.CreateClient("Granit.Bff").Returns(httpClient);
+
+        RequestTransformContext context = CreateTransformContext(new Dictionary<string, string>
+        {
+            ["Granit.Bff.RequireAuth"] = "true",
+            ["Granit.Bff.Frontend"] = "main",
+        });
+        context.HttpContext.Request.Cookies = CreateCookies(
+            new Dictionary<string, string> { ["__Host-granit-bff-main"] = "session-abc" });
+
+        await CreateTransform().ApplyAsync(context);
+
+        context.HttpContext.Response.StatusCode.ShouldBe(200);
+        context.ProxyRequest.Headers.Authorization?.Parameter.ShouldBe("new-access-token");
+        context.HttpContext.Response.Headers["X-Bff-Session-Refreshed"].ToString().ShouldBe("true");
+
+        // Verify the new tokens were stored
+        await _tokenStore.Received(1).StoreAsync(
+            "main", "session-abc",
+            Arg.Is<BffTokenSet>(t => t.AccessToken == "new-access-token"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ApplyAsync_RefreshFails_Returns401()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        _clock.Now.Returns(now);
+
+        BffTokenSet expiringSoonTokens = new(
+            "old-access-token", "refresh-token-123", null,
+            now.AddSeconds(10))
+        {
+            SessionCreatedAt = now.AddHours(-1),
+        };
+        _tokenStore.GetAsync("main", "session-abc", Arg.Any<CancellationToken>())
+            .Returns(expiringSoonTokens);
+
+        // Refresh fails
+        FakeHttpMessageHandler handler = new(_ =>
+            new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("{\"error\":\"invalid_grant\"}", System.Text.Encoding.UTF8, "application/json"),
+            });
+        HttpClient httpClient = new(handler);
+        _httpClientFactory.CreateClient("Granit.Bff").Returns(httpClient);
+
+        RequestTransformContext context = CreateTransformContext(new Dictionary<string, string>
+        {
+            ["Granit.Bff.RequireAuth"] = "true",
+            ["Granit.Bff.Frontend"] = "main",
+        });
+        context.HttpContext.Request.Cookies = CreateCookies(
+            new Dictionary<string, string> { ["__Host-granit-bff-main"] = "session-abc" });
+
+        await CreateTransform().ApplyAsync(context);
+
+        context.HttpContext.Response.StatusCode.ShouldBe(StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_RefreshThrowsException_Returns401()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        _clock.Now.Returns(now);
+
+        BffTokenSet expiringSoonTokens = new(
+            "old-access-token", "refresh-token-123", null,
+            now.AddSeconds(10))
+        {
+            SessionCreatedAt = now.AddHours(-1),
+        };
+        _tokenStore.GetAsync("main", "session-abc", Arg.Any<CancellationToken>())
+            .Returns(expiringSoonTokens);
+
+        // HTTP client throws
+        FakeHttpMessageHandler handler = new(_ =>
+            throw new HttpRequestException("Connection refused"));
+        HttpClient httpClient = new(handler);
+        _httpClientFactory.CreateClient("Granit.Bff").Returns(httpClient);
+
+        RequestTransformContext context = CreateTransformContext(new Dictionary<string, string>
+        {
+            ["Granit.Bff.RequireAuth"] = "true",
+            ["Granit.Bff.Frontend"] = "main",
+        });
+        context.HttpContext.Request.Cookies = CreateCookies(
+            new Dictionary<string, string> { ["__Host-granit-bff-main"] = "session-abc" });
+
+        await CreateTransform().ApplyAsync(context);
+
+        context.HttpContext.Response.StatusCode.ShouldBe(StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_TokenNotExpiring_DoesNotRefresh()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        _clock.Now.Returns(now);
+
+        // Token expires in 2 hours (well beyond 30s grace period) — no refresh needed
+        BffTokenSet tokens = new("access-token", "refresh-token", null, now.AddHours(2))
+        {
+            SessionCreatedAt = now.AddHours(-1),
+        };
+        _tokenStore.GetAsync("main", "session-abc", Arg.Any<CancellationToken>())
+            .Returns(tokens);
+
+        RequestTransformContext context = CreateTransformContext(new Dictionary<string, string>
+        {
+            ["Granit.Bff.RequireAuth"] = "true",
+            ["Granit.Bff.Frontend"] = "main",
+        });
+        context.HttpContext.Request.Cookies = CreateCookies(
+            new Dictionary<string, string> { ["__Host-granit-bff-main"] = "session-abc" });
+
+        await CreateTransform().ApplyAsync(context);
+
+        context.ProxyRequest.Headers.Authorization?.Parameter.ShouldBe("access-token");
+        // No refresh call to HTTP client
+        _httpClientFactory.DidNotReceive().CreateClient("Granit.Bff");
+    }
+
+    [Fact]
+    public async Task ApplyAsync_NoRefreshToken_DoesNotAttemptRefresh()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        _clock.Now.Returns(now);
+
+        // Token about to expire but no refresh token
+        BffTokenSet tokens = new("access-token", null, null, now.AddSeconds(10))
+        {
+            SessionCreatedAt = now.AddHours(-1),
+        };
+        _tokenStore.GetAsync("main", "session-abc", Arg.Any<CancellationToken>())
+            .Returns(tokens);
+
+        RequestTransformContext context = CreateTransformContext(new Dictionary<string, string>
+        {
+            ["Granit.Bff.RequireAuth"] = "true",
+            ["Granit.Bff.Frontend"] = "main",
+        });
+        context.HttpContext.Request.Cookies = CreateCookies(
+            new Dictionary<string, string> { ["__Host-granit-bff-main"] = "session-abc" });
+
+        await CreateTransform().ApplyAsync(context);
+
+        // Should still inject the token without refresh
+        context.ProxyRequest.Headers.Authorization?.Parameter.ShouldBe("access-token");
+        _httpClientFactory.DidNotReceive().CreateClient("Granit.Bff");
+    }
+
+    // ──── Frontend resolution ────
+
+    [Fact]
+    public async Task ApplyAsync_NoFrontendMetadata_FallsBackToSingleFrontend()
+    {
+        BffTokenSet tokens = new("access-token", null, null, DateTimeOffset.UtcNow.AddHours(1));
+        _tokenStore.GetAsync("main", "session-abc", Arg.Any<CancellationToken>())
+            .Returns(tokens);
+
+        // No Granit.Bff.Frontend metadata — should fall back to the single configured frontend
+        RequestTransformContext context = CreateTransformContext(new Dictionary<string, string>
+        {
+            ["Granit.Bff.RequireAuth"] = "true",
+        });
+        context.HttpContext.Request.Cookies = CreateCookies(
+            new Dictionary<string, string> { ["__Host-granit-bff-main"] = "session-abc" });
+
+        await CreateTransform().ApplyAsync(context);
+
+        context.ProxyRequest.Headers.Authorization?.Parameter.ShouldBe("access-token");
+    }
+
+    [Fact]
+    public async Task ApplyAsync_NoFrontendMetadata_MultipleFrontends_Returns401()
+    {
+        // Configure multiple frontends
+        _bffOptions.Frontends.Add(
+            new BffFrontendOptions { Name = "secondary", ClientId = "client2", ClientSecret = "s" });
+
+        RequestTransformContext context = CreateTransformContext(new Dictionary<string, string>
+        {
+            ["Granit.Bff.RequireAuth"] = "true",
+        });
+
+        await CreateTransform().ApplyAsync(context);
+
+        context.HttpContext.Response.StatusCode.ShouldBe(StatusCodes.Status401Unauthorized);
+
+        // Cleanup
+        _bffOptions.Frontends.RemoveAt(1);
+    }
+
+    // ──── Sliding session ────
+
+    [Fact]
+    public async Task ApplyAsync_SlidingExpiration_ExtensionPastHalfway_ReStoresTokens()
+    {
+        _bffOptions.UseSessionSlidingExpiration = true;
+        _bffOptions.SessionDuration = TimeSpan.FromHours(2);
+        _bffOptions.SessionAbsoluteMaxDuration = TimeSpan.FromHours(12);
+
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        _clock.Now.Returns(now);
+
+        BffTokenSet tokens = new("access-token", null, null, now.AddHours(1))
+        {
+            // Session created 1.5 hours ago, past halfway (1 hour) of 2-hour duration
+            SessionCreatedAt = now.AddHours(-1.5),
+        };
+        _tokenStore.GetAsync("main", "session-abc", Arg.Any<CancellationToken>())
+            .Returns(tokens);
+
+        RequestTransformContext context = CreateTransformContext(new Dictionary<string, string>
+        {
+            ["Granit.Bff.RequireAuth"] = "true",
+            ["Granit.Bff.Frontend"] = "main",
+        });
+        context.HttpContext.Request.Cookies = CreateCookies(
+            new Dictionary<string, string> { ["__Host-granit-bff-main"] = "session-abc" });
+
+        await CreateTransform().ApplyAsync(context);
+
+        // Should have stored tokens for sliding extension
+        await _tokenStore.Received().StoreAsync(
+            "main", "session-abc", tokens, Arg.Any<CancellationToken>());
+
+        _bffOptions.UseSessionSlidingExpiration = false;
+    }
+
+    [Fact]
+    public async Task ApplyAsync_SlidingExpiration_BeforeHalfway_DoesNotExtend()
+    {
+        _bffOptions.UseSessionSlidingExpiration = true;
+        _bffOptions.SessionDuration = TimeSpan.FromHours(2);
+        _bffOptions.SessionAbsoluteMaxDuration = TimeSpan.FromHours(12);
+
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        _clock.Now.Returns(now);
+
+        BffTokenSet tokens = new("access-token", null, null, now.AddHours(1))
+        {
+            // Session created 30 minutes ago, before halfway (1 hour)
+            SessionCreatedAt = now.AddMinutes(-30),
+        };
+        _tokenStore.GetAsync("main", "session-abc", Arg.Any<CancellationToken>())
+            .Returns(tokens);
+
+        RequestTransformContext context = CreateTransformContext(new Dictionary<string, string>
+        {
+            ["Granit.Bff.RequireAuth"] = "true",
+            ["Granit.Bff.Frontend"] = "main",
+        });
+        context.HttpContext.Request.Cookies = CreateCookies(
+            new Dictionary<string, string> { ["__Host-granit-bff-main"] = "session-abc" });
+
+        await CreateTransform().ApplyAsync(context);
+
+        // Should NOT have stored tokens (no sliding extension needed)
+        await _tokenStore.DidNotReceive().StoreAsync(
+            "main", "session-abc", tokens, Arg.Any<CancellationToken>());
+
+        _bffOptions.UseSessionSlidingExpiration = false;
+    }
+
+    // ──── DPoP refresh ────
+
+    [Fact]
+    public async Task ApplyAsync_DPoPTokenRefresh_AttachesDPoPProofToRefreshRequest()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        _clock.Now.Returns(now);
+
+        BffTokenSet expiringSoonTokens = new(
+            "old-access-token", "refresh-token-dpop", null,
+            now.AddSeconds(10))
+        {
+            DPoPPrivateKeyJwk = """{"kty":"EC","crv":"P-256"}""",
+            DPoPNonce = "old-nonce",
+            SessionCreatedAt = now.AddHours(-1),
+        };
+        _tokenStore.GetAsync("main", "session-abc", Arg.Any<CancellationToken>())
+            .Returns(expiringSoonTokens);
+
+        _dpopService.CreateProof(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>())
+            .Returns("dpop-proof-for-refresh");
+
+        HttpRequestMessage? capturedRefreshRequest = null;
+        FakeHttpMessageHandler handler = new(req =>
+        {
+            capturedRefreshRequest = req;
+            string json = System.Text.Json.JsonSerializer.Serialize(new
+            {
+                access_token = "new-dpop-token",
+                expires_in = 3600,
+            });
+            HttpResponseMessage resp = new(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json"),
+            };
+            resp.Headers.Add("DPoP-Nonce", "updated-nonce");
+            return resp;
+        });
+        HttpClient httpClient = new(handler);
+        _httpClientFactory.CreateClient("Granit.Bff").Returns(httpClient);
+
+        RequestTransformContext context = CreateTransformContext(new Dictionary<string, string>
+        {
+            ["Granit.Bff.RequireAuth"] = "true",
+            ["Granit.Bff.Frontend"] = "main",
+        });
+        context.HttpContext.Request.Cookies = CreateCookies(
+            new Dictionary<string, string> { ["__Host-granit-bff-main"] = "session-abc" });
+
+        await CreateTransform().ApplyAsync(context);
+
+        // DPoP proof attached to refresh request
+        capturedRefreshRequest.ShouldNotBeNull();
+        capturedRefreshRequest.Headers.TryGetValues("DPoP", out IEnumerable<string>? proofValues).ShouldBeTrue();
+        proofValues!.Single().ShouldBe("dpop-proof-for-refresh");
+
+        // Stored tokens should have updated DPoP nonce
+        await _tokenStore.Received(1).StoreAsync(
+            "main", "session-abc",
+            Arg.Is<BffTokenSet>(t =>
+                t.AccessToken == "new-dpop-token" &&
+                t.DPoPNonce == "updated-nonce"),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ──── MaskSessionId ────
+
+    [Fact]
+    public async Task ApplyAsync_ShortSessionId_MasksCorrectly()
+    {
+        // Session ID shorter than 8 chars — should be masked as "****"
+        _tokenStore.GetAsync("main", "abc", Arg.Any<CancellationToken>())
+            .Returns((BffTokenSet?)null);
+
+        RequestTransformContext context = CreateTransformContext(new Dictionary<string, string>
+        {
+            ["Granit.Bff.RequireAuth"] = "true",
+            ["Granit.Bff.Frontend"] = "main",
+        });
+        context.HttpContext.Request.Cookies = CreateCookies(
+            new Dictionary<string, string> { ["__Host-granit-bff-main"] = "abc" });
+
+        await CreateTransform().ApplyAsync(context);
+
+        // Should return 401 (session not found) — test ensures masking code path does not throw
+        context.HttpContext.Response.StatusCode.ShouldBe(StatusCodes.Status401Unauthorized);
+    }
+
     private static RequestTransformContext CreateTransformContext(Dictionary<string, string> metadata)
     {
-        DefaultHttpContext httpContext = new() { Request = { Method = "GET" } };
+        return CreateTransformContextWithPath(metadata, "/");
+    }
+
+    private sealed class FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(responseFactory(request));
+    }
+
+    private static RequestTransformContext CreateTransformContextWithPath(
+        Dictionary<string, string> metadata, string path = "/")
+    {
+        DefaultHttpContext httpContext = new() { Request = { Method = "GET", Path = path } };
 
         RouteConfig routeConfig = new()
         {

--- a/tests/Granit.Http.Resilience.Tests/HttpResilienceMetricsTests.cs
+++ b/tests/Granit.Http.Resilience.Tests/HttpResilienceMetricsTests.cs
@@ -1,0 +1,189 @@
+using System.Diagnostics.Metrics;
+using Granit.Http.Resilience.Diagnostics;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Http.Resilience.Tests;
+
+public sealed class HttpResilienceMetricsTests : IDisposable
+{
+    private readonly TestMeterFactory _meterFactory = new();
+    private readonly HttpResilienceMetrics _metrics;
+
+    public HttpResilienceMetricsTests()
+    {
+        _metrics = new HttpResilienceMetrics(_meterFactory);
+    }
+
+    public void Dispose() => _meterFactory.Dispose();
+
+    [Fact]
+    public void MeterName_IsGranitHttpResilience() =>
+        HttpResilienceMetrics.MeterName.ShouldBe("Granit.Http.Resilience");
+
+    [Fact]
+    public void RecordRetryTriggered_DoesNotThrow() =>
+        Should.NotThrow(() => _metrics.RecordRetryTriggered("tenant-1", "my-client", 2));
+
+    [Fact]
+    public void RecordRetryTriggered_WithNullTenant_DoesNotThrow() =>
+        Should.NotThrow(() => _metrics.RecordRetryTriggered(null, "my-client", 1));
+
+    [Fact]
+    public void RecordCircuitBreakerStateChanged_DoesNotThrow() =>
+        Should.NotThrow(() => _metrics.RecordCircuitBreakerStateChanged("tenant-1", "my-client", "Open"));
+
+    [Fact]
+    public void RecordCircuitBreakerStateChanged_WithNullTenant_DoesNotThrow() =>
+        Should.NotThrow(() => _metrics.RecordCircuitBreakerStateChanged(null, "my-client", "HalfOpen"));
+
+    [Fact]
+    public void RecordTimeoutOccurred_DoesNotThrow() =>
+        Should.NotThrow(() => _metrics.RecordTimeoutOccurred("tenant-1", "my-client"));
+
+    [Fact]
+    public void RecordTimeoutOccurred_WithNullTenant_DoesNotThrow() =>
+        Should.NotThrow(() => _metrics.RecordTimeoutOccurred(null, "my-client"));
+
+    [Fact]
+    public void RecordRetryTriggered_EmitsCorrectMeasurement()
+    {
+        using MeterListener listener = new();
+        long recordedValue = 0;
+        string? recordedClientName = null;
+        string? recordedTenantId = null;
+        string? recordedAttempt = null;
+
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == HttpResilienceMetrics.MeterName)
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) =>
+        {
+            if (instrument.Name == "granit.http.resilience.retry.triggered")
+            {
+                recordedValue = value;
+                foreach (KeyValuePair<string, object?> tag in tags)
+                {
+                    switch (tag.Key)
+                    {
+                        case "client_name":
+                            recordedClientName = tag.Value?.ToString();
+                            break;
+                        case "tenant_id":
+                            recordedTenantId = tag.Value?.ToString();
+                            break;
+                        case "attempt_number":
+                            recordedAttempt = tag.Value?.ToString();
+                            break;
+                    }
+                }
+            }
+        });
+        listener.Start();
+
+        _metrics.RecordRetryTriggered("t1", "test-api", 3);
+
+        recordedValue.ShouldBe(1);
+        recordedClientName.ShouldBe("test-api");
+        recordedTenantId.ShouldBe("t1");
+        recordedAttempt.ShouldBe("3");
+    }
+
+    [Fact]
+    public void RecordCircuitBreakerStateChanged_EmitsCorrectMeasurement()
+    {
+        using MeterListener listener = new();
+        long recordedValue = 0;
+        string? recordedState = null;
+
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == HttpResilienceMetrics.MeterName)
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) =>
+        {
+            if (instrument.Name == "granit.http.resilience.circuit_breaker.state_changed")
+            {
+                recordedValue = value;
+                foreach (KeyValuePair<string, object?> tag in tags)
+                {
+                    if (tag.Key == "state")
+                    {
+                        recordedState = tag.Value?.ToString();
+                    }
+                }
+            }
+        });
+        listener.Start();
+
+        _metrics.RecordCircuitBreakerStateChanged("t1", "my-client", "Open");
+
+        recordedValue.ShouldBe(1);
+        recordedState.ShouldBe("Open");
+    }
+
+    [Fact]
+    public void RecordTimeoutOccurred_EmitsCorrectMeasurement()
+    {
+        using MeterListener listener = new();
+        long recordedValue = 0;
+        string? recordedClient = null;
+
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == HttpResilienceMetrics.MeterName)
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) =>
+        {
+            if (instrument.Name == "granit.http.resilience.timeout.occurred")
+            {
+                recordedValue = value;
+                foreach (KeyValuePair<string, object?> tag in tags)
+                {
+                    if (tag.Key == "client_name")
+                    {
+                        recordedClient = tag.Value?.ToString();
+                    }
+                }
+            }
+        });
+        listener.Start();
+
+        _metrics.RecordTimeoutOccurred(null, "timeout-client");
+
+        recordedValue.ShouldBe(1);
+        recordedClient.ShouldBe("timeout-client");
+    }
+
+    private sealed class TestMeterFactory : IMeterFactory
+    {
+        private readonly List<Meter> _meters = [];
+
+        public Meter Create(MeterOptions options)
+        {
+            Meter meter = new(options);
+            _meters.Add(meter);
+            return meter;
+        }
+
+        public void Dispose()
+        {
+            foreach (Meter meter in _meters)
+            {
+                meter.Dispose();
+            }
+
+            _meters.Clear();
+        }
+    }
+}

--- a/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsIntegrationTests.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsIntegrationTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using Granit.Identity;
+using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Endpoints.Dtos;
 using Granit.Identity.Local.Services;
 using NSubstitute;
@@ -438,6 +439,811 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
     {
         HttpResponseMessage response = await _server.AnonymousClient.GetAsync(
             "/api/account/profile", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    // -------------------------------------------------------------------------
+    // Passkey endpoints
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ListPasskeys_ReturnsPasskeys()
+    {
+        List<PasskeyInfo> passkeys =
+        [
+            new(Guid.NewGuid(), "My YubiKey", DateTimeOffset.UtcNow, null),
+            new(Guid.NewGuid(), "Phone", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+        ];
+
+        _server.PasskeyService
+            .GetPasskeysAsync(AccountEndpointsTestServer.TestUserIdString, Arg.Any<CancellationToken>())
+            .Returns(passkeys);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient.GetAsync(
+            "/api/account/passkeys", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        List<PasskeyInfo>? result = await response.Content
+            .ReadFromJsonAsync<List<PasskeyInfo>>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task ListPasskeys_Anonymous_Returns401()
+    {
+        HttpResponseMessage response = await _server.AnonymousClient.GetAsync(
+            "/api/account/passkeys", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task BeginPasskeyRegistration_ReturnsOptionsJson()
+    {
+        const string optionsJson = """{"challenge":"abc123"}""";
+
+        _server.PasskeyService
+            .BeginRegistrationAsync(AccountEndpointsTestServer.TestUserIdString, Arg.Any<CancellationToken>())
+            .Returns(optionsJson);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient.PostAsync(
+            "/api/account/passkeys/register/begin", null,
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string? result = await response.Content
+            .ReadFromJsonAsync<string>(TestContext.Current.CancellationToken);
+
+        result.ShouldBe(optionsJson);
+    }
+
+    [Fact]
+    public async Task CompletePasskeyRegistration_ValidCredential_Returns201()
+    {
+        PasskeyInfo createdPasskey = new(Guid.NewGuid(), "My Key", DateTimeOffset.UtcNow, null);
+
+        _server.PasskeyService
+            .CompleteRegistrationAsync(
+                AccountEndpointsTestServer.TestUserIdString,
+                """{"id":"cred123"}""",
+                "My Key",
+                Arg.Any<CancellationToken>())
+            .Returns(createdPasskey);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient.PostAsJsonAsync(
+            "/api/account/passkeys/register/complete",
+            new PasskeyRegistrationRequest("""{"id":"cred123"}""", "My Key"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+    }
+
+    [Fact]
+    public async Task CompletePasskeyRegistration_InvalidCredential_Returns400()
+    {
+        _server.PasskeyService
+            .CompleteRegistrationAsync(
+                AccountEndpointsTestServer.TestUserIdString,
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Invalid attestation response."));
+
+        HttpResponseMessage response = await _server.AuthenticatedClient.PostAsJsonAsync(
+            "/api/account/passkeys/register/complete",
+            new PasskeyRegistrationRequest("""{"id":"bad"}""", null),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task BeginPasskeyAssertion_ReturnsOptionsJson()
+    {
+        const string optionsJson = """{"challenge":"xyz789"}""";
+
+        _server.PasskeyService
+            .BeginAssertionAsync(Arg.Any<CancellationToken>())
+            .Returns(optionsJson);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsync(
+            "/api/account/passkeys/assertion/begin", null,
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string? result = await response.Content
+            .ReadFromJsonAsync<string>(TestContext.Current.CancellationToken);
+
+        result.ShouldBe(optionsJson);
+    }
+
+    [Fact]
+    public async Task CompletePasskeyAssertion_ValidCredential_Returns200()
+    {
+        var fakeUser = new GranitUser { Id = AccountEndpointsTestServer.TestUserId };
+
+        _server.PasskeyService
+            .CompleteAssertionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new GranitPasskeyAssertionResult(true, AccountEndpointsTestServer.TestUserIdString));
+
+        _server.UserManager
+            .FindByIdAsync(AccountEndpointsTestServer.TestUserIdString)
+            .Returns(fakeUser);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/api/account/passkeys/assertion/complete",
+            new AccountPasskeyLoginRequest("""{"id":"cred123","response":{}}"""),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        AccountLoginResponse? result = await response.Content
+            .ReadFromJsonAsync<AccountLoginResponse>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task CompletePasskeyAssertion_InvalidCredential_Returns401()
+    {
+        _server.PasskeyService
+            .CompleteAssertionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new GranitPasskeyAssertionResult(false, null));
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/api/account/passkeys/assertion/complete",
+            new AccountPasskeyLoginRequest("""{"id":"bad"}"""),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task CompletePasskeyAssertion_UserNotFound_Returns401()
+    {
+        _server.PasskeyService
+            .CompleteAssertionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new GranitPasskeyAssertionResult(true, "nonexistent-user-id"));
+
+        _server.UserManager
+            .FindByIdAsync("nonexistent-user-id")
+            .Returns((GranitUser?)null);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/api/account/passkeys/assertion/complete",
+            new AccountPasskeyLoginRequest("""{"id":"cred123"}"""),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task RenamePasskey_Returns204()
+    {
+        var passkeyId = Guid.NewGuid();
+
+        HttpResponseMessage response = await _server.AuthenticatedClient.PatchAsJsonAsync(
+            $"/api/account/passkeys/{passkeyId}",
+            new PasskeyRenameRequest("Renamed Key"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        await _server.PasskeyService.Received(1).RenameAsync(
+            AccountEndpointsTestServer.TestUserIdString,
+            passkeyId,
+            "Renamed Key",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeletePasskey_Returns204()
+    {
+        var passkeyId = Guid.NewGuid();
+
+        HttpResponseMessage response = await _server.AuthenticatedClient.DeleteAsync(
+            $"/api/account/passkeys/{passkeyId}",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        await _server.PasskeyService.Received(1).DeleteAsync(
+            AccountEndpointsTestServer.TestUserIdString,
+            passkeyId,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeletePasskey_LastCredential_Returns400()
+    {
+        var passkeyId = Guid.NewGuid();
+
+        _server.PasskeyService
+            .DeleteAsync(
+                AccountEndpointsTestServer.TestUserIdString,
+                passkeyId,
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Cannot delete the last credential."));
+
+        HttpResponseMessage response = await _server.AuthenticatedClient.DeleteAsync(
+            $"/api/account/passkeys/{passkeyId}",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    // -------------------------------------------------------------------------
+    // External login endpoints
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ListExternalLogins_ReturnsLogins()
+    {
+        List<ExternalLoginInfo> logins =
+        [
+            new("Google", "google-key-123", "Google"),
+            new("Microsoft", "ms-key-456", "Microsoft"),
+        ];
+
+        _server.ExternalLoginService
+            .GetLoginsAsync(AccountEndpointsTestServer.TestUserIdString, Arg.Any<CancellationToken>())
+            .Returns(logins);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient.GetAsync(
+            "/api/account/external-logins", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        List<ExternalLoginInfo>? result = await response.Content
+            .ReadFromJsonAsync<List<ExternalLoginInfo>>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task ListExternalLogins_Anonymous_Returns401()
+    {
+        HttpResponseMessage response = await _server.AnonymousClient.GetAsync(
+            "/api/account/external-logins", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ChallengeExternalLogin_ConfiguredProvider_Returns200()
+    {
+        _server.ExternalProviderRegistry
+            .IsProviderConfigured("Google")
+            .Returns(true);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsync(
+            "/api/account/external-logins/challenge/Google", null,
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task ChallengeExternalLogin_UnconfiguredProvider_Returns400()
+    {
+        _server.ExternalProviderRegistry
+            .IsProviderConfigured("NotConfigured")
+            .Returns(false);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsync(
+            "/api/account/external-logins/challenge/NotConfigured", null,
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task UnlinkExternalLogin_ValidProvider_Returns204()
+    {
+        List<ExternalLoginInfo> logins =
+        [
+            new("Google", "google-key-123", "Google"),
+        ];
+
+        _server.ExternalLoginService
+            .GetLoginsAsync(AccountEndpointsTestServer.TestUserIdString, Arg.Any<CancellationToken>())
+            .Returns(logins);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient.DeleteAsync(
+            "/api/account/external-logins/Google",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        await _server.ExternalLoginService.Received(1).RemoveLoginAsync(
+            AccountEndpointsTestServer.TestUserIdString,
+            "Google",
+            "google-key-123",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UnlinkExternalLogin_NotLinked_Returns400()
+    {
+        _server.ExternalLoginService
+            .GetLoginsAsync(AccountEndpointsTestServer.TestUserIdString, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<ExternalLoginInfo>());
+
+        HttpResponseMessage response = await _server.AuthenticatedClient.DeleteAsync(
+            "/api/account/external-logins/GitHub",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task UnlinkExternalLogin_LastCredential_Returns400()
+    {
+        List<ExternalLoginInfo> logins = [new("Google", "google-key-123", "Google")];
+
+        _server.ExternalLoginService
+            .GetLoginsAsync(AccountEndpointsTestServer.TestUserIdString, Arg.Any<CancellationToken>())
+            .Returns(logins);
+
+        _server.ExternalLoginService
+            .RemoveLoginAsync(
+                AccountEndpointsTestServer.TestUserIdString,
+                "Google",
+                "google-key-123",
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Cannot remove last login method."));
+
+        HttpResponseMessage response = await _server.AuthenticatedClient.DeleteAsync(
+            "/api/account/external-logins/Google",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ExternalLoginCallback_MissingProvider_Returns400()
+    {
+        HttpResponseMessage response = await _server.AnonymousClient.GetAsync(
+            "/api/account/external-logins/callback",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ExternalLoginCallback_ValidProvider_Returns200()
+    {
+        _server.ExternalLoginService
+            .ProcessCallbackAsync(Arg.Any<System.Security.Claims.ClaimsPrincipal>(), "Google", Arg.Any<CancellationToken>())
+            .Returns(new ProcessCallbackResult(AccountEndpointsTestServer.TestUserId, false));
+
+        HttpResponseMessage response = await _server.AuthenticatedClient.GetAsync(
+            "/api/account/external-logins/callback?provider=Google",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task ExternalLoginCallback_DuplicateEmail_Returns409()
+    {
+        _server.ExternalLoginService
+            .ProcessCallbackAsync(Arg.Any<System.Security.Claims.ClaimsPrincipal>(), "Google", Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("DuplicateEmail: email already in use."));
+
+        HttpResponseMessage response = await _server.AuthenticatedClient.GetAsync(
+            "/api/account/external-logins/callback?provider=Google",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task ExternalLoginCallback_UserNotFound_Returns403()
+    {
+        _server.ExternalLoginService
+            .ProcessCallbackAsync(Arg.Any<System.Security.Claims.ClaimsPrincipal>(), "GitHub", Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("User not found for external login."));
+
+        HttpResponseMessage response = await _server.AuthenticatedClient.GetAsync(
+            "/api/account/external-logins/callback?provider=GitHub",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    // -------------------------------------------------------------------------
+    // Admin impersonation endpoints
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Impersonate_Success_Returns200()
+    {
+        var targetUserId = Guid.NewGuid();
+        var fakeResult = new ImpersonationResult("access-token", "refresh-token", 3600);
+
+        _server.ImpersonationService
+            .ImpersonateAsync(
+                targetUserId.ToString(),
+                AccountEndpointsTestServer.TestUserIdString,
+                "test@example.com",
+                Arg.Any<CancellationToken>())
+            .Returns(fakeResult);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient.PostAsync(
+            $"/api/admin/users/{targetUserId}/impersonate", null,
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        ImpersonationResult? result = await response.Content
+            .ReadFromJsonAsync<ImpersonationResult>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.AccessToken.ShouldBe("access-token");
+        result.ExpiresIn.ShouldBe(3600);
+    }
+
+    [Fact]
+    public async Task Impersonate_Anonymous_Returns401()
+    {
+        var targetUserId = Guid.NewGuid();
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsync(
+            $"/api/admin/users/{targetUserId}/impersonate", null,
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Impersonate_ChainImpersonation_Returns403()
+    {
+        var targetUserId = Guid.NewGuid();
+
+        HttpResponseMessage response = await _server.ImpersonatedClient.PostAsync(
+            $"/api/admin/users/{targetUserId}/impersonate", null,
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    // -------------------------------------------------------------------------
+    // Login error paths
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Login_InvalidCredentials_Returns401()
+    {
+        _server.UserManager
+            .FindByEmailAsync("unknown@example.com")
+            .Returns((GranitUser?)null);
+
+        _server.UserManager
+            .FindByNameAsync("unknown@example.com")
+            .Returns((GranitUser?)null);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/api/account/login",
+            new AccountLoginRequest("unknown@example.com", "SomeP@ss1!"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Login_LockedOut_Returns423()
+    {
+        var fakeUser = new GranitUser { Id = AccountEndpointsTestServer.TestUserId };
+
+        _server.UserManager
+            .FindByEmailAsync("locked@example.com")
+            .Returns(fakeUser);
+
+        _server.SignInManager
+            .PasswordSignInAsync(fakeUser, "MyP@ss1!", false, true)
+            .Returns(Microsoft.AspNetCore.Identity.SignInResult.LockedOut);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/api/account/login",
+            new AccountLoginRequest("locked@example.com", "MyP@ss1!"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Locked);
+    }
+
+    [Fact]
+    public async Task Login_RequiresTwoFactor_Returns200WithFlag()
+    {
+        var fakeUser = new GranitUser { Id = AccountEndpointsTestServer.TestUserId };
+
+        _server.UserManager
+            .FindByEmailAsync("2fa@example.com")
+            .Returns(fakeUser);
+
+        _server.SignInManager
+            .PasswordSignInAsync(fakeUser, "MyP@ss1!", false, true)
+            .Returns(Microsoft.AspNetCore.Identity.SignInResult.TwoFactorRequired);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/api/account/login",
+            new AccountLoginRequest("2fa@example.com", "MyP@ss1!"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        AccountLoginResponse? result = await response.Content
+            .ReadFromJsonAsync<AccountLoginResponse>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Succeeded.ShouldBeFalse();
+        result.RequiresTwoFactor.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Login_NotAllowed_Returns401()
+    {
+        var fakeUser = new GranitUser { Id = AccountEndpointsTestServer.TestUserId };
+
+        _server.UserManager
+            .FindByEmailAsync("unconfirmed@example.com")
+            .Returns(fakeUser);
+
+        _server.SignInManager
+            .PasswordSignInAsync(fakeUser, "MyP@ss1!", false, true)
+            .Returns(Microsoft.AspNetCore.Identity.SignInResult.NotAllowed);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/api/account/login",
+            new AccountLoginRequest("unconfirmed@example.com", "MyP@ss1!"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Login_WrongPassword_Returns401()
+    {
+        var fakeUser = new GranitUser { Id = AccountEndpointsTestServer.TestUserId };
+
+        _server.UserManager
+            .FindByEmailAsync("user@example.com")
+            .Returns(fakeUser);
+
+        _server.SignInManager
+            .PasswordSignInAsync(fakeUser, "WrongP@ss!", false, true)
+            .Returns(Microsoft.AspNetCore.Identity.SignInResult.Failed);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/api/account/login",
+            new AccountLoginRequest("user@example.com", "WrongP@ss!"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Login_Success_Returns200()
+    {
+        var fakeUser = new GranitUser { Id = AccountEndpointsTestServer.TestUserId };
+
+        _server.UserManager
+            .FindByEmailAsync("success@example.com")
+            .Returns(fakeUser);
+
+        _server.SignInManager
+            .PasswordSignInAsync(fakeUser, "GoodP@ss1!", false, true)
+            .Returns(Microsoft.AspNetCore.Identity.SignInResult.Success);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/api/account/login",
+            new AccountLoginRequest("success@example.com", "GoodP@ss1!"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        AccountLoginResponse? result = await response.Content
+            .ReadFromJsonAsync<AccountLoginResponse>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    // -------------------------------------------------------------------------
+    // Two-factor login
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task TwoFactorLogin_ValidTotpCode_Returns200()
+    {
+        _server.SignInManager
+            .TwoFactorAuthenticatorSignInAsync("123456", false, false)
+            .Returns(Microsoft.AspNetCore.Identity.SignInResult.Success);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/api/account/login/two-factor",
+            new AccountTwoFactorLoginRequest("123456"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        AccountLoginResponse? result = await response.Content
+            .ReadFromJsonAsync<AccountLoginResponse>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TwoFactorLogin_RecoveryCode_Returns200()
+    {
+        _server.SignInManager
+            .TwoFactorRecoveryCodeSignInAsync("RECOVERY1")
+            .Returns(Microsoft.AspNetCore.Identity.SignInResult.Success);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/api/account/login/two-factor",
+            new AccountTwoFactorLoginRequest("RECOVERY1", UseRecoveryCode: true),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        AccountLoginResponse? result = await response.Content
+            .ReadFromJsonAsync<AccountLoginResponse>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TwoFactorLogin_InvalidCode_Returns401()
+    {
+        _server.SignInManager
+            .TwoFactorAuthenticatorSignInAsync("000000", false, false)
+            .Returns(Microsoft.AspNetCore.Identity.SignInResult.Failed);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/api/account/login/two-factor",
+            new AccountTwoFactorLoginRequest("000000"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task TwoFactorLogin_LockedOut_Returns423()
+    {
+        _server.SignInManager
+            .TwoFactorAuthenticatorSignInAsync("123456", false, false)
+            .Returns(Microsoft.AspNetCore.Identity.SignInResult.LockedOut);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/api/account/login/two-factor",
+            new AccountTwoFactorLoginRequest("123456"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Locked);
+    }
+
+    // -------------------------------------------------------------------------
+    // Two-factor additional paths
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetAuthenticatorKey_ReturnsKeyAndUri()
+    {
+        _server.TwoFactorService
+            .GetAuthenticatorKeyAsync(AccountEndpointsTestServer.TestUserIdString, Arg.Any<CancellationToken>())
+            .Returns(new AuthenticatorKeyInfo("JBSWY3DPEHPK3PXP", "otpauth://totp/Granit:test@example.com?secret=JBSWY3DPEHPK3PXP&issuer=Granit"));
+
+        HttpResponseMessage response = await _server.AuthenticatedClient.GetAsync(
+            "/api/account/two-factor/authenticator-key",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        AccountAuthenticatorKeyResponse? result = await response.Content
+            .ReadFromJsonAsync<AccountAuthenticatorKeyResponse>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.SharedKey.ShouldBe("JBSWY3DPEHPK3PXP");
+        result.QrCodeUri.ShouldStartWith("otpauth://");
+    }
+
+    [Fact]
+    public async Task GenerateRecoveryCodes_ValidPassword_ReturnsCodes()
+    {
+        _server.CredentialVerifier
+            .VerifyUserCredentialsAsync("test-user", "MyP@ss1!", Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        List<string> codes = ["CODE-A", "CODE-B", "CODE-C", "CODE-D", "CODE-E"];
+        _server.TwoFactorService
+            .GenerateRecoveryCodesAsync(AccountEndpointsTestServer.TestUserIdString, Arg.Any<CancellationToken>())
+            .Returns(codes);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient.PostAsJsonAsync(
+            "/api/account/two-factor/recovery-codes",
+            new AccountGenerateRecoveryCodesRequest("MyP@ss1!"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        AccountRecoveryCodesResponse? result = await response.Content
+            .ReadFromJsonAsync<AccountRecoveryCodesResponse>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.RecoveryCodes.Count.ShouldBe(5);
+        result.RecoveryCodes.ShouldContain("CODE-A");
+    }
+
+    [Fact]
+    public async Task GenerateRecoveryCodes_WrongPassword_Returns400()
+    {
+        _server.CredentialVerifier
+            .VerifyUserCredentialsAsync("test-user", "WrongP@ss!", Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient.PostAsJsonAsync(
+            "/api/account/two-factor/recovery-codes",
+            new AccountGenerateRecoveryCodesRequest("WrongP@ss!"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    // -------------------------------------------------------------------------
+    // Session — back to impersonator
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task BackToImpersonator_ImpersonatedSession_Returns200()
+    {
+        var fakeResult = new ImpersonationResult("admin-access-token", "admin-refresh-token", 3600);
+
+        _server.ImpersonationService
+            .BackToImpersonatorAsync(
+                AccountEndpointsTestServer.ImpersonatorUserIdString,
+                Arg.Any<CancellationToken>())
+            .Returns(fakeResult);
+
+        HttpResponseMessage response = await _server.ImpersonatedClient.PostAsync(
+            "/api/account/session/back-to-impersonator", null,
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        ImpersonationResult? result = await response.Content
+            .ReadFromJsonAsync<ImpersonationResult>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.AccessToken.ShouldBe("admin-access-token");
+    }
+
+    [Fact]
+    public async Task BackToImpersonator_NotImpersonated_Returns400()
+    {
+        HttpResponseMessage response = await _server.AuthenticatedClient.PostAsync(
+            "/api/account/session/back-to-impersonator", null,
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task BackToImpersonator_Anonymous_Returns401()
+    {
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsync(
+            "/api/account/session/back-to-impersonator", null,
+            TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
     }

--- a/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsTestServer.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsTestServer.cs
@@ -31,6 +31,8 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
 {
     public static readonly Guid TestUserId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
     public static readonly string TestUserIdString = TestUserId.ToString();
+    public static readonly Guid ImpersonatorUserId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+    public static readonly string ImpersonatorUserIdString = ImpersonatorUserId.ToString();
     public static readonly DateTimeOffset FixedNow = new(2026, 1, 15, 10, 0, 0, TimeSpan.Zero);
 
     private const string AuthenticatedRole = "authenticated";
@@ -40,6 +42,11 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
 
     public HttpClient AuthenticatedClient { get; }
     public HttpClient AnonymousClient { get; }
+
+    /// <summary>
+    /// Client that simulates an impersonation session (has <c>impersonator_id</c> claim).
+    /// </summary>
+    public HttpClient ImpersonatedClient { get; }
 
     public IIdentityProvider IdentityProvider { get; }
     public IIdentityCredentialVerifier CredentialVerifier { get; }
@@ -64,6 +71,7 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
         WebApplication app,
         HttpClient authenticatedClient,
         HttpClient anonymousClient,
+        HttpClient impersonatedClient,
         IIdentityProvider identityProvider,
         IIdentityCredentialVerifier credentialVerifier,
         IIdentityUserReader userReader,
@@ -86,6 +94,7 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
         _app = app;
         AuthenticatedClient = authenticatedClient;
         AnonymousClient = anonymousClient;
+        ImpersonatedClient = impersonatedClient;
         IdentityProvider = identityProvider;
         CredentialVerifier = credentialVerifier;
         UserReader = userReader;
@@ -204,8 +213,13 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
 
         HttpClient anonymousClient = app.GetTestClient();
 
+        HttpClient impersonatedClient = app.GetTestClient();
+        impersonatedClient.DefaultRequestHeaders.Add(TestAuthHandler.RolesHeader, allRoles);
+        impersonatedClient.DefaultRequestHeaders.Add(
+            TestAuthHandler.ImpersonatorIdHeader, ImpersonatorUserIdString);
+
         return new AccountEndpointsTestServer(
-            app, authenticatedClient, anonymousClient,
+            app, authenticatedClient, anonymousClient, impersonatedClient,
             identityProvider, credentialVerifier, userReader, userWriter, passwordManager,
             emailConfirmation, passwordResetService, twoFactorService,
             externalLoginService, externalProviderRegistry,
@@ -218,6 +232,7 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
     {
         AuthenticatedClient.Dispose();
         AnonymousClient.Dispose();
+        ImpersonatedClient.Dispose();
         await _app.DisposeAsync().ConfigureAwait(false);
     }
 }
@@ -234,6 +249,7 @@ internal sealed class TestAuthHandler(
 {
     public const string SchemeName = "Test";
     public const string RolesHeader = "X-Test-Roles";
+    public const string ImpersonatorIdHeader = "X-Test-Impersonator-Id";
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
@@ -243,7 +259,7 @@ internal sealed class TestAuthHandler(
         }
 
         string[] roles = rolesHeader.ToString().Split(',', StringSplitOptions.RemoveEmptyEntries);
-        Claim[] claims =
+        List<Claim> claims =
         [
             new("sub", AccountEndpointsTestServer.TestUserIdString),
             new(ClaimTypes.NameIdentifier, AccountEndpointsTestServer.TestUserIdString),
@@ -255,6 +271,14 @@ internal sealed class TestAuthHandler(
             new("jti", Guid.NewGuid().ToString()),
             .. roles.Select(r => new Claim(ClaimTypes.Role, r.Trim())),
         ];
+
+        // Support impersonation testing via X-Test-Impersonator-Id header
+        if (Request.Headers.TryGetValue(ImpersonatorIdHeader, out Microsoft.Extensions.Primitives.StringValues impersonatorId)
+            && !string.IsNullOrEmpty(impersonatorId.ToString()))
+        {
+            claims.Add(new Claim("impersonator_id", impersonatorId.ToString()));
+            claims.Add(new Claim("impersonator_name", "admin@example.com"));
+        }
 
         ClaimsIdentity identity = new(claims, SchemeName);
         ClaimsPrincipal principal = new(identity);

--- a/tests/Granit.Notifications.Email.Tests/EmailNotificationChannelTests.cs
+++ b/tests/Granit.Notifications.Email.Tests/EmailNotificationChannelTests.cs
@@ -10,10 +10,12 @@ using Granit.Notifications.Abstractions;
 using Granit.Notifications.Email;
 using Granit.Notifications.Email.Internal;
 using Granit.Notifications.Email.Options;
+using Granit.Templating.Pipeline;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Shouldly;
 using Xunit;
 
@@ -108,6 +110,362 @@ public sealed class EmailNotificationChannelTests
     [Fact]
     public void Name_ReturnsEmail() =>
         _channel.Name.ShouldBe(NotificationChannels.Email);
+
+    // ──── Template rendering branch tests ────
+
+    [Fact]
+    public async Task SendAsync_WithTemplateRendered_UsesRenderedHtmlAndSubject()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com");
+
+        // Setup template resolver
+        ITemplateResolver resolver = Substitute.For<ITemplateResolver>();
+        resolver.Priority.Returns(100);
+        resolver.TryResolveAsync(Arg.Any<Granit.Templating.Keys.TemplateKey>(), Arg.Any<CancellationToken>())
+            .Returns(new Granit.Templating.Pipeline.TemplateDescriptor
+            {
+                Content = "<html><title>Welcome</title><body>Hello {{ model.key }}</body></html>",
+                MimeType = "text/html",
+            });
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateResolver>))
+            .Returns(new[] { resolver });
+
+        // Setup template engine
+        ITemplateEngine engine = Substitute.For<ITemplateEngine>();
+        engine.CanRender(Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>()).Returns(true);
+        engine.RenderAsync(
+                Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>(),
+                Arg.Any<Dictionary<string, object?>>(),
+                Arg.Any<Granit.Templating.Keys.DocumentFormat>(),
+                Arg.Any<IReadOnlyList<Granit.Templating.GlobalContext.ITemplateGlobalContext>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new Granit.Templating.Pipeline.TextRenderedContent(
+                "<html><title>Welcome</title><body>Hello world</body></html>",
+                Granit.Templating.Keys.DocumentFormat.Html));
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateEngine>))
+            .Returns(new[] { engine });
+
+        _serviceProvider.GetService(typeof(IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>))
+            .Returns((IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>?)null);
+
+        EmailMessage? captured = null;
+        _emailSender.SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                captured = callInfo.Arg<EmailMessage>();
+                return Task.CompletedTask;
+            });
+
+        await _channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Subject.ShouldBe("Welcome");
+        captured.HtmlBody.ShouldContain("Hello world");
+    }
+
+    [Fact]
+    public async Task SendAsync_NoResolversRegistered_UsesFallbackSubjectAndBody()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com");
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateResolver>))
+            .Returns((IEnumerable<ITemplateResolver>?)null);
+
+        EmailMessage? captured = null;
+        _emailSender.SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                captured = callInfo.Arg<EmailMessage>();
+                return Task.CompletedTask;
+            });
+
+        await _channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        // Fallback subject replaces dots with spaces
+        captured.Subject.ShouldBe("test notification");
+        captured.HtmlBody.ShouldContain("test.notification");
+    }
+
+    [Fact]
+    public async Task SendAsync_ResolverReturnsNull_UsesFallback()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com");
+
+        ITemplateResolver resolver = Substitute.For<ITemplateResolver>();
+        resolver.Priority.Returns(100);
+        resolver.TryResolveAsync(Arg.Any<Granit.Templating.Keys.TemplateKey>(), Arg.Any<CancellationToken>())
+            .Returns((Granit.Templating.Pipeline.TemplateDescriptor?)null);
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateResolver>))
+            .Returns(new[] { resolver });
+
+        EmailMessage? captured = null;
+        _emailSender.SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                captured = callInfo.Arg<EmailMessage>();
+                return Task.CompletedTask;
+            });
+
+        await _channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Subject.ShouldBe("test notification");
+    }
+
+    [Fact]
+    public async Task SendAsync_NoMatchingEngine_UsesFallback()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com");
+
+        ITemplateResolver resolver = Substitute.For<ITemplateResolver>();
+        resolver.Priority.Returns(100);
+        resolver.TryResolveAsync(Arg.Any<Granit.Templating.Keys.TemplateKey>(), Arg.Any<CancellationToken>())
+            .Returns(new Granit.Templating.Pipeline.TemplateDescriptor
+            {
+                Content = "template content",
+                MimeType = "text/html",
+            });
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateResolver>))
+            .Returns(new[] { resolver });
+
+        // No engines registered
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateEngine>))
+            .Returns((IEnumerable<ITemplateEngine>?)null);
+
+        EmailMessage? captured = null;
+        _emailSender.SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                captured = callInfo.Arg<EmailMessage>();
+                return Task.CompletedTask;
+            });
+
+        await _channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Subject.ShouldBe("test notification");
+    }
+
+    [Fact]
+    public async Task SendAsync_EngineCannotRender_UsesFallback()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com");
+
+        ITemplateResolver resolver = Substitute.For<ITemplateResolver>();
+        resolver.Priority.Returns(100);
+        resolver.TryResolveAsync(Arg.Any<Granit.Templating.Keys.TemplateKey>(), Arg.Any<CancellationToken>())
+            .Returns(new Granit.Templating.Pipeline.TemplateDescriptor
+            {
+                Content = "template content",
+                MimeType = "application/xml",
+            });
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateResolver>))
+            .Returns(new[] { resolver });
+
+        ITemplateEngine engine = Substitute.For<ITemplateEngine>();
+        engine.CanRender(Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>()).Returns(false);
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateEngine>))
+            .Returns(new[] { engine });
+
+        EmailMessage? captured = null;
+        _emailSender.SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                captured = callInfo.Arg<EmailMessage>();
+                return Task.CompletedTask;
+            });
+
+        await _channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Subject.ShouldBe("test notification");
+    }
+
+    [Fact]
+    public async Task SendAsync_EngineThrows_UsesFallback()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com");
+
+        ITemplateResolver resolver = Substitute.For<ITemplateResolver>();
+        resolver.Priority.Returns(100);
+        resolver.TryResolveAsync(Arg.Any<Granit.Templating.Keys.TemplateKey>(), Arg.Any<CancellationToken>())
+            .Returns(new Granit.Templating.Pipeline.TemplateDescriptor
+            {
+                Content = "template content",
+                MimeType = "text/html",
+            });
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateResolver>))
+            .Returns(new[] { resolver });
+
+        ITemplateEngine engine = Substitute.For<ITemplateEngine>();
+        engine.CanRender(Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>()).Returns(true);
+        engine.RenderAsync(
+                Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>(),
+                Arg.Any<Dictionary<string, object?>>(),
+                Arg.Any<Granit.Templating.Keys.DocumentFormat>(),
+                Arg.Any<IReadOnlyList<Granit.Templating.GlobalContext.ITemplateGlobalContext>>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Scriban parse error"));
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateEngine>))
+            .Returns(new[] { engine });
+
+        _serviceProvider.GetService(typeof(IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>))
+            .Returns((IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>?)null);
+
+        EmailMessage? captured = null;
+        _emailSender.SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                captured = callInfo.Arg<EmailMessage>();
+                return Task.CompletedTask;
+            });
+
+        await _channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Subject.ShouldBe("test notification");
+    }
+
+    [Fact]
+    public async Task SendAsync_RenderedHtmlWithoutTitle_UsesRenderedHtmlWithFallbackSubject()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com");
+
+        ITemplateResolver resolver = Substitute.For<ITemplateResolver>();
+        resolver.Priority.Returns(100);
+        resolver.TryResolveAsync(Arg.Any<Granit.Templating.Keys.TemplateKey>(), Arg.Any<CancellationToken>())
+            .Returns(new Granit.Templating.Pipeline.TemplateDescriptor
+            {
+                Content = "<html><body>No title here</body></html>",
+                MimeType = "text/html",
+            });
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateResolver>))
+            .Returns(new[] { resolver });
+
+        ITemplateEngine engine = Substitute.For<ITemplateEngine>();
+        engine.CanRender(Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>()).Returns(true);
+        engine.RenderAsync(
+                Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>(),
+                Arg.Any<Dictionary<string, object?>>(),
+                Arg.Any<Granit.Templating.Keys.DocumentFormat>(),
+                Arg.Any<IReadOnlyList<Granit.Templating.GlobalContext.ITemplateGlobalContext>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new Granit.Templating.Pipeline.TextRenderedContent(
+                "<html><body>No title here</body></html>",
+                Granit.Templating.Keys.DocumentFormat.Html));
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateEngine>))
+            .Returns(new[] { engine });
+
+        _serviceProvider.GetService(typeof(IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>))
+            .Returns((IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>?)null);
+
+        EmailMessage? captured = null;
+        _emailSender.SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                captured = callInfo.Arg<EmailMessage>();
+                return Task.CompletedTask;
+            });
+
+        await _channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        // No <title> in rendered HTML => falls back to notification type name
+        captured.Subject.ShouldBe("test notification");
+        captured.HtmlBody.ShouldContain("No title here");
+    }
+
+    [Fact]
+    public async Task SendAsync_EmptyTitleTag_UsesFallbackSubject()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com");
+
+        ITemplateResolver resolver = Substitute.For<ITemplateResolver>();
+        resolver.Priority.Returns(100);
+        resolver.TryResolveAsync(Arg.Any<Granit.Templating.Keys.TemplateKey>(), Arg.Any<CancellationToken>())
+            .Returns(new Granit.Templating.Pipeline.TemplateDescriptor
+            {
+                Content = "<html><title>   </title><body>Body</body></html>",
+                MimeType = "text/html",
+            });
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateResolver>))
+            .Returns(new[] { resolver });
+
+        ITemplateEngine engine = Substitute.For<ITemplateEngine>();
+        engine.CanRender(Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>()).Returns(true);
+        engine.RenderAsync(
+                Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>(),
+                Arg.Any<Dictionary<string, object?>>(),
+                Arg.Any<Granit.Templating.Keys.DocumentFormat>(),
+                Arg.Any<IReadOnlyList<Granit.Templating.GlobalContext.ITemplateGlobalContext>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new Granit.Templating.Pipeline.TextRenderedContent(
+                "<html><title>   </title><body>Body</body></html>",
+                Granit.Templating.Keys.DocumentFormat.Html));
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateEngine>))
+            .Returns(new[] { engine });
+
+        _serviceProvider.GetService(typeof(IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>))
+            .Returns((IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>?)null);
+
+        EmailMessage? captured = null;
+        _emailSender.SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                captured = callInfo.Arg<EmailMessage>();
+                return Task.CompletedTask;
+            });
+
+        await _channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        // Empty <title> after trim => null => fallback
+        captured.Subject.ShouldBe("test notification");
+    }
+
+    [Fact]
+    public async Task SendAsync_EmptyResolverList_UsesFallback()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com");
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateResolver>))
+            .Returns(Array.Empty<ITemplateResolver>());
+
+        EmailMessage? captured = null;
+        _emailSender.SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                captured = callInfo.Arg<EmailMessage>();
+                return Task.CompletedTask;
+            });
+
+        await _channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Subject.ShouldBe("test notification");
+    }
 
     // -------------------------------------------------------------------------
     // Helpers

--- a/tests/Granit.Oidc.TokenManagement.Tests/TokenEndpointServiceTests.cs
+++ b/tests/Granit.Oidc.TokenManagement.Tests/TokenEndpointServiceTests.cs
@@ -1,6 +1,11 @@
 using System.Diagnostics.Metrics;
+using System.Net;
+using System.Text.Json;
+using Granit.Oidc.ClientAuthentication;
 using Granit.Oidc.Discovery;
 using Granit.Oidc.DPoP;
+using Granit.Oidc.Requests;
+using Granit.Oidc.Responses;
 using Granit.Oidc.TokenManagement.Diagnostics;
 using Granit.Oidc.TokenManagement.Services;
 using Granit.Oidc.TokenManagement.Services.Internal;
@@ -11,26 +16,46 @@ using Xunit;
 
 namespace Granit.Oidc.TokenManagement.Tests;
 
-public sealed class TokenEndpointServiceTests
+public sealed class TokenEndpointServiceTests : IDisposable
 {
+    private const string Authority = "https://auth.example.com";
+    private const string TokenEndpoint = "https://auth.example.com/connect/token";
+
+    private readonly IDiscoveryDocumentService _discoveryService = Substitute.For<IDiscoveryDocumentService>();
+    private readonly IHttpClientFactory _httpClientFactory = Substitute.For<IHttpClientFactory>();
+    private readonly IDPoPProofService _dpopProofService = Substitute.For<IDPoPProofService>();
+    private readonly TestMeterFactory _meterFactory = new();
+    private readonly TokenManagementMetrics _metrics;
+    private readonly TokenEndpointService _sut;
+
+    public TokenEndpointServiceTests()
+    {
+        _metrics = new TokenManagementMetrics(_meterFactory);
+        _sut = new TokenEndpointService(
+            _discoveryService,
+            _httpClientFactory,
+            _dpopProofService,
+            _metrics,
+            NullLogger<TokenEndpointService>.Instance);
+
+        OidcDiscoveryDocument disco = new()
+        {
+            Issuer = Authority,
+            AuthorizationEndpoint = $"{Authority}/connect/authorize",
+            TokenEndpoint = TokenEndpoint,
+        };
+
+        _discoveryService.GetAsync(Authority, Arg.Any<CancellationToken>())
+            .Returns(disco);
+    }
+
+    public void Dispose() => _meterFactory.Dispose();
+
     [Fact]
     public void TokenEndpointService_CanBeConstructed()
     {
-        IDiscoveryDocumentService discoveryDocumentService = Substitute.For<IDiscoveryDocumentService>();
-        IHttpClientFactory httpClientFactory = Substitute.For<IHttpClientFactory>();
-        IDPoPProofService dpopProofService = Substitute.For<IDPoPProofService>();
-        TestMeterFactory meterFactory = new();
-        TokenManagementMetrics metrics = new(meterFactory);
-
-        TokenEndpointService sut = new(
-            discoveryDocumentService,
-            httpClientFactory,
-            dpopProofService,
-            metrics,
-            NullLogger<TokenEndpointService>.Instance);
-
-        sut.ShouldNotBeNull();
-        sut.ShouldBeAssignableTo<ITokenEndpointService>();
+        _sut.ShouldNotBeNull();
+        _sut.ShouldBeAssignableTo<ITokenEndpointService>();
     }
 
     [Fact]
@@ -51,6 +76,214 @@ public sealed class TokenEndpointServiceTests
         updated.PrivateKeyJwk.ShouldBe("key-1");
         updated.Nonce.ShouldBe("new-nonce");
         original.Nonce.ShouldBeNull();
+    }
+
+    // ──── Argument validation ────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task RequestTokenAsync_NullOrEmptyAuthority_Throws(string? authority) =>
+        await Should.ThrowAsync<ArgumentException>(() =>
+            _sut.RequestTokenAsync(authority!, CreateClientCredentialsRequest()));
+
+    [Fact]
+    public async Task RequestTokenAsync_NullRequest_Throws() =>
+        await Should.ThrowAsync<ArgumentNullException>(() =>
+            _sut.RequestTokenAsync(Authority, null!));
+
+    // ──── Successful token request ────
+
+    [Fact]
+    public async Task RequestTokenAsync_SuccessfulResponse_ReturnsTokenResponse()
+    {
+        SetupHttpClient(CreateSuccessResponse());
+
+        TokenResponse result = await _sut.RequestTokenAsync(
+            Authority, CreateClientCredentialsRequest(), cancellationToken: TestContext.Current.CancellationToken);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.AccessToken.ShouldBe("test-access-token");
+    }
+
+    // ──── Error response ────
+
+    [Fact]
+    public async Task RequestTokenAsync_ErrorResponse_ReturnsErrorTokenResponse()
+    {
+        string errorJson = JsonSerializer.Serialize(new
+        {
+            error = "invalid_client",
+            error_description = "Client authentication failed",
+        });
+        HttpResponseMessage response = new(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent(errorJson, System.Text.Encoding.UTF8, "application/json"),
+        };
+        SetupHttpClient(response);
+
+        TokenResponse result = await _sut.RequestTokenAsync(
+            Authority, CreateClientCredentialsRequest(), cancellationToken: TestContext.Current.CancellationToken);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.Error.ShouldBe("invalid_client");
+        result.Error.ErrorDescription.ShouldBe("Client authentication failed");
+    }
+
+    // ──── HTTP error (network failure) ────
+
+    [Fact]
+    public async Task RequestTokenAsync_HttpRequestException_ReturnsHttpError()
+    {
+        FakeHttpMessageHandler handler = new(_ => throw new HttpRequestException("Connection refused"));
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri(Authority) };
+        _httpClientFactory.CreateClient("Granit.TokenManagement").Returns(httpClient);
+
+        TokenResponse result = await _sut.RequestTokenAsync(
+            Authority, CreateClientCredentialsRequest(), cancellationToken: TestContext.Current.CancellationToken);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.Error.ShouldBe("http_error");
+        result.Error.ErrorDescription!.ShouldContain("Connection refused");
+    }
+
+    // ──── Client authentication strategy applied ────
+
+    [Fact]
+    public async Task RequestTokenAsync_WithClientAuth_AppliesStrategy()
+    {
+        SetupHttpClient(CreateSuccessResponse());
+        IClientAuthenticationStrategy clientAuth = Substitute.For<IClientAuthenticationStrategy>();
+
+        TokenResponse result = await _sut.RequestTokenAsync(
+            Authority, CreateClientCredentialsRequest(), clientAuth, cancellationToken: TestContext.Current.CancellationToken);
+
+        result.IsSuccess.ShouldBeTrue();
+        clientAuth.Received(1).Apply(
+            Arg.Any<Dictionary<string, string>>(),
+            "test-client",
+            TokenEndpoint);
+    }
+
+    // ──── DPoP proof injection ────
+
+    [Fact]
+    public async Task RequestTokenAsync_WithDPoP_AttachesDPoPHeader()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        FakeHttpMessageHandler handler = new(req =>
+        {
+            capturedRequest = req;
+            return CreateSuccessResponse();
+        });
+        HttpClient httpClient = new(handler);
+        _httpClientFactory.CreateClient("Granit.TokenManagement").Returns(httpClient);
+
+        _dpopProofService.CreateProof("my-key-jwk", "POST", TokenEndpoint, "nonce-1")
+            .Returns("dpop-proof-abc");
+
+        DPoPOptions dpop = new("my-key-jwk", "nonce-1");
+
+        TokenResponse result = await _sut.RequestTokenAsync(
+            Authority, CreateClientCredentialsRequest(), dpop: dpop, cancellationToken: TestContext.Current.CancellationToken);
+
+        result.IsSuccess.ShouldBeTrue();
+        capturedRequest.ShouldNotBeNull();
+        capturedRequest.Headers.TryGetValues("DPoP", out IEnumerable<string>? values).ShouldBeTrue();
+        values!.Single().ShouldBe("dpop-proof-abc");
+    }
+
+    // ──── DPoP nonce retry ────
+
+    [Fact]
+    public async Task RequestTokenAsync_DPoPNonceRetry_RetriesWithNewNonce()
+    {
+        int callCount = 0;
+        FakeHttpMessageHandler handler = new(_ =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                // First call: use_dpop_nonce error with new nonce in header
+                string errorJson = JsonSerializer.Serialize(new { error = "use_dpop_nonce" });
+                HttpResponseMessage errorResp = new(HttpStatusCode.BadRequest)
+                {
+                    Content = new StringContent(errorJson, System.Text.Encoding.UTF8, "application/json"),
+                };
+                errorResp.Headers.Add("DPoP-Nonce", "server-nonce-42");
+                return errorResp;
+            }
+
+            // Second call: success
+            return CreateSuccessResponse();
+        });
+        HttpClient httpClient = new(handler);
+        _httpClientFactory.CreateClient("Granit.TokenManagement").Returns(httpClient);
+
+        _dpopProofService.CreateProof(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>())
+            .Returns("dpop-proof");
+
+        DPoPOptions dpop = new("key-jwk");
+
+        TokenResponse result = await _sut.RequestTokenAsync(
+            Authority, CreateClientCredentialsRequest(), dpop: dpop, cancellationToken: TestContext.Current.CancellationToken);
+
+        result.IsSuccess.ShouldBeTrue();
+        callCount.ShouldBe(2);
+
+        // Verify the second call used the server nonce
+        _dpopProofService.Received(1).CreateProof("key-jwk", "POST", TokenEndpoint, "server-nonce-42");
+    }
+
+    // ──── DPoP nonce in success response ────
+
+    [Fact]
+    public async Task RequestTokenAsync_DPoPNonceInSuccessResponse_PropagatesNonce()
+    {
+        HttpResponseMessage response = CreateSuccessResponse();
+        response.Headers.Add("DPoP-Nonce", "fresh-nonce");
+        SetupHttpClient(response);
+
+        TokenResponse result = await _sut.RequestTokenAsync(
+            Authority, CreateClientCredentialsRequest(), cancellationToken: TestContext.Current.CancellationToken);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.DPoPNonce.ShouldBe("fresh-nonce");
+    }
+
+    // ──── Helpers ────
+
+    private static ClientCredentialsTokenRequest CreateClientCredentialsRequest() =>
+        new() { ClientId = "test-client", Scope = "api" };
+
+    private static HttpResponseMessage CreateSuccessResponse()
+    {
+        string json = JsonSerializer.Serialize(new
+        {
+            access_token = "test-access-token",
+            token_type = "Bearer",
+            expires_in = 3600,
+        });
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json"),
+        };
+    }
+
+    private void SetupHttpClient(HttpResponseMessage response)
+    {
+        FakeHttpMessageHandler handler = new(_ => response);
+        HttpClient httpClient = new(handler);
+        _httpClientFactory.CreateClient("Granit.TokenManagement").Returns(httpClient);
+    }
+
+    private sealed class FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(responseFactory(request));
     }
 
     private sealed class TestMeterFactory : IMeterFactory

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Granit.OpenIddict.Endpoints.Tests.csproj
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Granit.OpenIddict.Endpoints.Tests.csproj
@@ -16,10 +16,14 @@
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
+    <PackageReference Include="OpenIddict" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Granit.OpenIddict.Endpoints\Granit.OpenIddict.Endpoints.csproj" />
+    <ProjectReference Include="..\..\src\Granit.OpenIddict.EntityFrameworkCore\Granit.OpenIddict.EntityFrameworkCore.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/AdminOidcEndpointsIntegrationTests.cs
@@ -1,0 +1,594 @@
+using System.Net;
+using System.Net.Http.Json;
+using Granit.OpenIddict.Endpoints.Dtos;
+using Granit.OpenIddict.Entities.OpenIddict;
+using NSubstitute;
+using OpenIddict.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.Endpoints.Tests.Integration;
+
+public sealed class AdminOidcEndpointsIntegrationTests : IAsyncLifetime
+{
+    private OidcEndpointsTestServer _server = null!;
+
+    public async ValueTask InitializeAsync() =>
+        _server = await OidcEndpointsTestServer.CreateAsync().ConfigureAwait(false);
+
+    public async ValueTask DisposeAsync() =>
+        await _server.DisposeAsync().ConfigureAwait(false);
+
+    // -------------------------------------------------------------------------
+    // Application endpoints
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ListApplications_ReturnsEmptyList()
+    {
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .GetAsync("/api/admin/oidc/applications", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        List<AdminOidcApplicationResponse>? result = await response.Content
+            .ReadFromJsonAsync<List<AdminOidcApplicationResponse>>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ListApplications_ReturnsApplications()
+    {
+        GranitOpenIddictApplication app1 = new() { TenantId = null };
+        GranitOpenIddictApplication app2 = new() { TenantId = Guid.NewGuid() };
+
+        _server.ApplicationManager.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable<object>(app1, app2));
+
+        _server.ApplicationManager.GetClientIdAsync(app1, Arg.Any<CancellationToken>())
+            .Returns("client-1");
+        _server.ApplicationManager.GetDisplayNameAsync(app1, Arg.Any<CancellationToken>())
+            .Returns("App One");
+        _server.ApplicationManager.GetApplicationTypeAsync(app1, Arg.Any<CancellationToken>())
+            .Returns("web");
+
+        _server.ApplicationManager.GetClientIdAsync(app2, Arg.Any<CancellationToken>())
+            .Returns("client-2");
+        _server.ApplicationManager.GetDisplayNameAsync(app2, Arg.Any<CancellationToken>())
+            .Returns("App Two");
+        _server.ApplicationManager.GetApplicationTypeAsync(app2, Arg.Any<CancellationToken>())
+            .Returns("native");
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .GetAsync("/api/admin/oidc/applications", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        List<AdminOidcApplicationResponse>? result = await response.Content
+            .ReadFromJsonAsync<List<AdminOidcApplicationResponse>>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(2);
+
+        result[0].ClientId.ShouldBe("client-1");
+        result[0].DisplayName.ShouldBe("App One");
+        result[0].Type.ShouldBe("web");
+        result[0].TenantId.ShouldBeNull();
+
+        result[1].ClientId.ShouldBe("client-2");
+        result[1].DisplayName.ShouldBe("App Two");
+        result[1].Type.ShouldBe("native");
+        result[1].TenantId.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task ListApplications_Anonymous_Returns401()
+    {
+        HttpResponseMessage response = await _server.AnonymousClient
+            .GetAsync("/api/admin/oidc/applications", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task CreateApplication_ReturnsCreated()
+    {
+        GranitOpenIddictApplication createdApp = new() { TenantId = null };
+
+        _server.ApplicationManager.CreateAsync(
+            Arg.Any<OpenIddictApplicationDescriptor>(),
+            Arg.Any<CancellationToken>())
+            .Returns(createdApp);
+        _server.ApplicationManager.GetClientIdAsync(createdApp, Arg.Any<CancellationToken>())
+            .Returns("new-client");
+        _server.ApplicationManager.GetDisplayNameAsync(createdApp, Arg.Any<CancellationToken>())
+            .Returns("New App");
+        _server.ApplicationManager.GetApplicationTypeAsync(createdApp, Arg.Any<CancellationToken>())
+            .Returns("web");
+
+        AdminOidcCreateApplicationRequest request = new("new-client", "New App", null, "web");
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PostAsJsonAsync("/api/admin/oidc/applications", request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+        response.Headers.Location?.ToString().ShouldBe("/api/admin/oidc/applications/new-client");
+
+        AdminOidcApplicationResponse? result = await response.Content
+            .ReadFromJsonAsync<AdminOidcApplicationResponse>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.ClientId.ShouldBe("new-client");
+        result.DisplayName.ShouldBe("New App");
+        result.Type.ShouldBe("web");
+        result.TenantId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CreateApplication_WithSecret_SetsConfidentialType()
+    {
+        GranitOpenIddictApplication createdApp = new() { TenantId = null };
+
+        _server.ApplicationManager.CreateAsync(
+            Arg.Any<OpenIddictApplicationDescriptor>(),
+            Arg.Any<CancellationToken>())
+            .Returns(createdApp);
+        _server.ApplicationManager.GetClientIdAsync(createdApp, Arg.Any<CancellationToken>())
+            .Returns("confidential-client");
+        _server.ApplicationManager.GetDisplayNameAsync(createdApp, Arg.Any<CancellationToken>())
+            .Returns("Confidential App");
+        _server.ApplicationManager.GetApplicationTypeAsync(createdApp, Arg.Any<CancellationToken>())
+            .Returns("web");
+
+        AdminOidcCreateApplicationRequest request = new("confidential-client", "Confidential App", "my-secret", "web");
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PostAsJsonAsync("/api/admin/oidc/applications", request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+
+        await _server.ApplicationManager.Received(1)
+            .CreateAsync(
+                Arg.Is<OpenIddictApplicationDescriptor>(d =>
+                    d.ClientSecret == "my-secret" &&
+                    d.ClientType == OpenIddictConstants.ClientTypes.Confidential),
+                Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateApplication_WithoutSecret_SetsPublicType()
+    {
+        GranitOpenIddictApplication createdApp = new() { TenantId = null };
+
+        _server.ApplicationManager.CreateAsync(
+            Arg.Any<OpenIddictApplicationDescriptor>(),
+            Arg.Any<CancellationToken>())
+            .Returns(createdApp);
+        _server.ApplicationManager.GetClientIdAsync(createdApp, Arg.Any<CancellationToken>())
+            .Returns("public-client");
+        _server.ApplicationManager.GetDisplayNameAsync(createdApp, Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        _server.ApplicationManager.GetApplicationTypeAsync(createdApp, Arg.Any<CancellationToken>())
+            .Returns("web");
+
+        AdminOidcCreateApplicationRequest request = new("public-client", null, null, null);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PostAsJsonAsync("/api/admin/oidc/applications", request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+
+        await _server.ApplicationManager.Received(1)
+            .CreateAsync(
+                Arg.Is<OpenIddictApplicationDescriptor>(d =>
+                    d.ClientSecret == null &&
+                    d.ClientType == OpenIddictConstants.ClientTypes.Public),
+                Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateApplication_EmptyClientId_ReturnsValidationError()
+    {
+        AdminOidcCreateApplicationRequest request = new("", "Name", null, null);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PostAsJsonAsync("/api/admin/oidc/applications", request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task CreateApplication_Anonymous_Returns401()
+    {
+        AdminOidcCreateApplicationRequest request = new("client", "Name", null, null);
+
+        HttpResponseMessage response = await _server.AnonymousClient
+            .PostAsJsonAsync("/api/admin/oidc/applications", request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task DeleteApplication_ExistingApp_Returns204()
+    {
+        object existingApp = new GranitOpenIddictApplication();
+
+        _server.ApplicationManager.FindByClientIdAsync("client-to-delete", Arg.Any<CancellationToken>())
+            .Returns(existingApp);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .DeleteAsync("/api/admin/oidc/applications/client-to-delete", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        await _server.ApplicationManager.Received(1)
+            .DeleteAsync(existingApp, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteApplication_NotFound_Returns404()
+    {
+        _server.ApplicationManager.FindByClientIdAsync("nonexistent", Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .DeleteAsync("/api/admin/oidc/applications/nonexistent", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task RotateSecret_ExistingApp_ReturnsNewSecret()
+    {
+        GranitOpenIddictApplication existingApp = new();
+
+        _server.ApplicationManager.FindByClientIdAsync("rotate-client", Arg.Any<CancellationToken>())
+            .Returns(existingApp);
+        _server.ApplicationManager.GetDisplayNameAsync(existingApp, Arg.Any<CancellationToken>())
+            .Returns("Rotate App");
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PostAsync("/api/admin/oidc/applications/rotate-client/rotate-secret", null,
+                TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        AdminOidcRotateSecretResponse? result = await response.Content
+            .ReadFromJsonAsync<AdminOidcRotateSecretResponse>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.ClientId.ShouldBe("rotate-client");
+        result.DisplayName.ShouldBe("Rotate App");
+        result.NewClientSecret.ShouldNotBeNullOrWhiteSpace();
+
+        // Verify the manager was called with confidential type and a secret
+        await _server.ApplicationManager.Received(1)
+            .UpdateAsync(
+                existingApp,
+                Arg.Is<OpenIddictApplicationDescriptor>(d =>
+                    d.ClientType == OpenIddictConstants.ClientTypes.Confidential &&
+                    !string.IsNullOrEmpty(d.ClientSecret)),
+                Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RotateSecret_NotFound_Returns404()
+    {
+        _server.ApplicationManager.FindByClientIdAsync("nonexistent", Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PostAsync("/api/admin/oidc/applications/nonexistent/rotate-secret", null,
+                TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    // -------------------------------------------------------------------------
+    // Scope endpoints
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ListScopes_ReturnsEmptyList()
+    {
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .GetAsync("/api/admin/oidc/scopes", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        List<AdminOidcScopeResponse>? result = await response.Content
+            .ReadFromJsonAsync<List<AdminOidcScopeResponse>>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ListScopes_ReturnsScopes()
+    {
+        object scope1 = new();
+        object scope2 = new();
+
+        _server.ScopeManager.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable<object>(scope1, scope2));
+
+        _server.ScopeManager.GetNameAsync(scope1, Arg.Any<CancellationToken>())
+            .Returns("openid");
+        _server.ScopeManager.GetDisplayNameAsync(scope1, Arg.Any<CancellationToken>())
+            .Returns("OpenID");
+        _server.ScopeManager.GetDescriptionAsync(scope1, Arg.Any<CancellationToken>())
+            .Returns("OpenID Connect scope");
+
+        _server.ScopeManager.GetNameAsync(scope2, Arg.Any<CancellationToken>())
+            .Returns("profile");
+        _server.ScopeManager.GetDisplayNameAsync(scope2, Arg.Any<CancellationToken>())
+            .Returns("Profile");
+        _server.ScopeManager.GetDescriptionAsync(scope2, Arg.Any<CancellationToken>())
+            .Returns("User profile scope");
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .GetAsync("/api/admin/oidc/scopes", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        List<AdminOidcScopeResponse>? result = await response.Content
+            .ReadFromJsonAsync<List<AdminOidcScopeResponse>>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(2);
+
+        result[0].Name.ShouldBe("openid");
+        result[0].DisplayName.ShouldBe("OpenID");
+        result[0].Description.ShouldBe("OpenID Connect scope");
+
+        result[1].Name.ShouldBe("profile");
+        result[1].DisplayName.ShouldBe("Profile");
+        result[1].Description.ShouldBe("User profile scope");
+    }
+
+    [Fact]
+    public async Task ListScopes_Anonymous_Returns401()
+    {
+        HttpResponseMessage response = await _server.AnonymousClient
+            .GetAsync("/api/admin/oidc/scopes", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task CreateScope_ReturnsCreated()
+    {
+        object createdScope = new();
+
+        _server.ScopeManager.CreateAsync(
+            Arg.Any<OpenIddictScopeDescriptor>(),
+            Arg.Any<CancellationToken>())
+            .Returns(createdScope);
+        _server.ScopeManager.GetNameAsync(createdScope, Arg.Any<CancellationToken>())
+            .Returns("custom_scope");
+        _server.ScopeManager.GetDisplayNameAsync(createdScope, Arg.Any<CancellationToken>())
+            .Returns("Custom Scope");
+        _server.ScopeManager.GetDescriptionAsync(createdScope, Arg.Any<CancellationToken>())
+            .Returns("A custom OIDC scope");
+
+        AdminOidcCreateScopeRequest request = new("custom_scope", "Custom Scope", "A custom OIDC scope");
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PostAsJsonAsync("/api/admin/oidc/scopes", request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+        response.Headers.Location?.ToString().ShouldBe("/api/admin/oidc/scopes/custom_scope");
+
+        AdminOidcScopeResponse? result = await response.Content
+            .ReadFromJsonAsync<AdminOidcScopeResponse>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Name.ShouldBe("custom_scope");
+        result.DisplayName.ShouldBe("Custom Scope");
+        result.Description.ShouldBe("A custom OIDC scope");
+    }
+
+    [Fact]
+    public async Task CreateScope_EmptyName_ReturnsValidationError()
+    {
+        AdminOidcCreateScopeRequest request = new("", "Display", null);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .PostAsJsonAsync("/api/admin/oidc/scopes", request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task DeleteScope_ExistingScope_Returns204()
+    {
+        object existingScope = new();
+
+        _server.ScopeManager.FindByNameAsync("scope-to-delete", Arg.Any<CancellationToken>())
+            .Returns(existingScope);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .DeleteAsync("/api/admin/oidc/scopes/scope-to-delete", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        await _server.ScopeManager.Received(1)
+            .DeleteAsync(existingScope, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteScope_NotFound_Returns404()
+    {
+        _server.ScopeManager.FindByNameAsync("nonexistent", Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .DeleteAsync("/api/admin/oidc/scopes/nonexistent", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    // -------------------------------------------------------------------------
+    // Authorization endpoints
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ListAuthorizations_ReturnsEmptyList()
+    {
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .GetAsync("/api/admin/oidc/authorizations", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        List<AdminOidcAuthorizationResponse>? result = await response.Content
+            .ReadFromJsonAsync<List<AdminOidcAuthorizationResponse>>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ListAuthorizations_ReturnsAuthorizations()
+    {
+        var authId = Guid.NewGuid();
+        object auth1 = new();
+
+        _server.AuthorizationManager.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable<object>(auth1));
+
+        _server.AuthorizationManager.GetIdAsync(auth1, Arg.Any<CancellationToken>())
+            .Returns(authId.ToString());
+        _server.AuthorizationManager.GetSubjectAsync(auth1, Arg.Any<CancellationToken>())
+            .Returns("user-123");
+        _server.AuthorizationManager.GetStatusAsync(auth1, Arg.Any<CancellationToken>())
+            .Returns("valid");
+        _server.AuthorizationManager.GetTypeAsync(auth1, Arg.Any<CancellationToken>())
+            .Returns("permanent");
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .GetAsync("/api/admin/oidc/authorizations", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        List<AdminOidcAuthorizationResponse>? result = await response.Content
+            .ReadFromJsonAsync<List<AdminOidcAuthorizationResponse>>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(1);
+        result[0].Id.ShouldBe(authId);
+        result[0].Subject.ShouldBe("user-123");
+        result[0].Status.ShouldBe("valid");
+        result[0].Type.ShouldBe("permanent");
+    }
+
+    [Fact]
+    public async Task ListAuthorizations_Anonymous_Returns401()
+    {
+        HttpResponseMessage response = await _server.AnonymousClient
+            .GetAsync("/api/admin/oidc/authorizations", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task RevokeAuthorization_ExistingAuth_Returns204()
+    {
+        var authId = Guid.NewGuid();
+        object existingAuth = new();
+        object token1 = new();
+
+        _server.AuthorizationManager.FindByIdAsync(authId.ToString(), Arg.Any<CancellationToken>())
+            .Returns(existingAuth);
+
+        _server.TokenManager.FindByAuthorizationIdAsync(authId.ToString(), Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable<object>(token1));
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .DeleteAsync($"/api/admin/oidc/authorizations/{authId}", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        await _server.TokenManager.Received(1)
+            .TryRevokeAsync(token1, Arg.Any<CancellationToken>());
+
+        await _server.AuthorizationManager.Received(1)
+            .DeleteAsync(existingAuth, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RevokeAuthorization_NotFound_Returns404()
+    {
+        var authId = Guid.NewGuid();
+
+        _server.AuthorizationManager.FindByIdAsync(authId.ToString(), Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .DeleteAsync($"/api/admin/oidc/authorizations/{authId}", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task RevokeUserAuthorizations_RevokesAllTokensAndAuthorizations()
+    {
+        var userId = Guid.NewGuid();
+        string subject = userId.ToString();
+
+        object token1 = new();
+        object token2 = new();
+        object auth1 = new();
+
+        _server.TokenManager.FindBySubjectAsync(subject, Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable<object>(token1, token2));
+
+        _server.AuthorizationManager.FindBySubjectAsync(subject, Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable<object>(auth1));
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .DeleteAsync($"/api/admin/oidc/authorizations/user/{userId}", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        await _server.TokenManager.Received(1)
+            .TryRevokeAsync(token1, Arg.Any<CancellationToken>());
+        await _server.TokenManager.Received(1)
+            .TryRevokeAsync(token2, Arg.Any<CancellationToken>());
+        await _server.AuthorizationManager.Received(1)
+            .DeleteAsync(auth1, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RevokeUserAuthorizations_NoTokensOrAuths_Returns204()
+    {
+        var userId = Guid.NewGuid();
+        string subject = userId.ToString();
+
+        _server.TokenManager.FindBySubjectAsync(subject, Arg.Any<CancellationToken>())
+            .Returns(AsyncEnumerable.Empty<object>());
+
+        _server.AuthorizationManager.FindBySubjectAsync(subject, Arg.Any<CancellationToken>())
+            .Returns(AsyncEnumerable.Empty<object>());
+
+        HttpResponseMessage response = await _server.AuthenticatedClient
+            .DeleteAsync($"/api/admin/oidc/authorizations/user/{userId}", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(params T[] items)
+    {
+        foreach (T item in items)
+        {
+            yield return item;
+        }
+
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+}

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/OidcEndpointsTestServer.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/OidcEndpointsTestServer.cs
@@ -1,0 +1,168 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using FluentValidation;
+using Granit.OpenIddict.Endpoints.Extensions;
+using Granit.OpenIddict.Endpoints.Options;
+using Granit.OpenIddict.Permissions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using OpenIddict.Abstractions;
+
+namespace Granit.OpenIddict.Endpoints.Tests.Integration;
+
+/// <summary>
+/// Test server that boots a minimal ASP.NET Core application with mocked services
+/// and the OpenIddict admin endpoints registered via <see cref="OpenIddictEndpointRouteBuilderExtensions.MapOpenIddictEndpoints"/>.
+/// </summary>
+internal sealed class OidcEndpointsTestServer : IAsyncDisposable
+{
+    public static readonly Guid TestUserId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+
+    private const string AdminRole = "admin";
+
+    private readonly WebApplication _app;
+
+    public HttpClient AuthenticatedClient { get; }
+    public HttpClient AnonymousClient { get; }
+
+    public IOpenIddictApplicationManager ApplicationManager { get; }
+    public IOpenIddictScopeManager ScopeManager { get; }
+    public IOpenIddictAuthorizationManager AuthorizationManager { get; }
+    public IOpenIddictTokenManager TokenManager { get; }
+
+    private OidcEndpointsTestServer(
+        WebApplication app,
+        HttpClient authenticatedClient,
+        HttpClient anonymousClient,
+        IOpenIddictApplicationManager applicationManager,
+        IOpenIddictScopeManager scopeManager,
+        IOpenIddictAuthorizationManager authorizationManager,
+        IOpenIddictTokenManager tokenManager)
+    {
+        _app = app;
+        AuthenticatedClient = authenticatedClient;
+        AnonymousClient = anonymousClient;
+        ApplicationManager = applicationManager;
+        ScopeManager = scopeManager;
+        AuthorizationManager = authorizationManager;
+        TokenManager = tokenManager;
+    }
+
+    public static async Task<OidcEndpointsTestServer> CreateAsync()
+    {
+        IOpenIddictApplicationManager applicationManager = Substitute.For<IOpenIddictApplicationManager>();
+        IOpenIddictScopeManager scopeManager = Substitute.For<IOpenIddictScopeManager>();
+        IOpenIddictAuthorizationManager authorizationManager = Substitute.For<IOpenIddictAuthorizationManager>();
+        IOpenIddictTokenManager tokenManager = Substitute.For<IOpenIddictTokenManager>();
+
+        // Default: empty async enumerables
+        applicationManager.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(AsyncEnumerable.Empty<object>());
+        scopeManager.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(AsyncEnumerable.Empty<object>());
+        authorizationManager.ListAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(AsyncEnumerable.Empty<object>());
+
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+
+        // Authentication
+        builder.Services
+            .AddAuthentication(TestAuthHandler.SchemeName)
+            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                TestAuthHandler.SchemeName, _ => { });
+
+        // Authorization policies matching the permission names used by the endpoints
+        builder.Services.AddAuthorizationBuilder()
+            .AddPolicy(OpenIddictPermissions.Applications.Read,
+                policy => policy.RequireRole(AdminRole))
+            .AddPolicy(OpenIddictPermissions.Applications.Manage,
+                policy => policy.RequireRole(AdminRole))
+            .AddPolicy(OpenIddictPermissions.Applications.Rotate,
+                policy => policy.RequireRole(AdminRole))
+            .AddPolicy(OpenIddictPermissions.Scopes.Read,
+                policy => policy.RequireRole(AdminRole))
+            .AddPolicy(OpenIddictPermissions.Scopes.Manage,
+                policy => policy.RequireRole(AdminRole))
+            .AddPolicy(OpenIddictPermissions.Authorizations.Read,
+                policy => policy.RequireRole(AdminRole))
+            .AddPolicy(OpenIddictPermissions.Authorizations.Revoke,
+                policy => policy.RequireRole(AdminRole));
+
+        // Service mocks
+        builder.Services.AddSingleton(applicationManager);
+        builder.Services.AddSingleton(scopeManager);
+        builder.Services.AddSingleton(authorizationManager);
+        builder.Services.AddSingleton(tokenManager);
+
+        // Options
+        builder.Services.AddSingleton(Microsoft.Extensions.Options.Options.Create(new OpenIddictEndpointsOptions()));
+
+        // Validators from the OpenIddict.Endpoints assembly
+        builder.Services.AddValidatorsFromAssemblyContaining<OpenIddictEndpointsOptions>(
+            ServiceLifetime.Singleton, includeInternalTypes: true);
+
+        WebApplication app = builder.Build();
+        app.MapOpenIddictEndpoints();
+        await app.StartAsync().ConfigureAwait(false);
+
+        HttpClient authenticatedClient = app.GetTestClient();
+        authenticatedClient.DefaultRequestHeaders.Add(TestAuthHandler.RolesHeader, AdminRole);
+
+        HttpClient anonymousClient = app.GetTestClient();
+
+        return new OidcEndpointsTestServer(
+            app, authenticatedClient, anonymousClient,
+            applicationManager, scopeManager, authorizationManager, tokenManager);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        AuthenticatedClient.Dispose();
+        AnonymousClient.Dispose();
+        await _app.DisposeAsync().ConfigureAwait(false);
+    }
+}
+
+/// <summary>
+/// Fake authentication handler that authenticates when the <c>X-Test-Roles</c> header
+/// is present. The authenticated user has a fixed <c>sub</c> claim set to
+/// <see cref="OidcEndpointsTestServer.TestUserId"/>.
+/// </summary>
+internal sealed class TestAuthHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    public const string SchemeName = "Test";
+    public const string RolesHeader = "X-Test-Roles";
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue(RolesHeader, out Microsoft.Extensions.Primitives.StringValues rolesHeader))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        string[] roles = rolesHeader.ToString().Split(',', StringSplitOptions.RemoveEmptyEntries);
+        Claim[] claims =
+        [
+            new("sub", OidcEndpointsTestServer.TestUserId.ToString()),
+            new(ClaimTypes.NameIdentifier, OidcEndpointsTestServer.TestUserId.ToString()),
+            new(ClaimTypes.Name, "test-admin"),
+            .. roles.Select(r => new Claim(ClaimTypes.Role, r.Trim())),
+        ];
+
+        ClaimsIdentity identity = new(claims, SchemeName);
+        ClaimsPrincipal principal = new(identity);
+        AuthenticationTicket ticket = new(principal, SchemeName);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/OidcPrincipalFactoryTests.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/OidcPrincipalFactoryTests.cs
@@ -1,0 +1,300 @@
+using System.Collections.Immutable;
+using System.Security.Claims;
+using Granit.Identity.Local.Domain;
+using Granit.OpenIddict.Endpoints.Internal;
+using Granit.OpenIddict.Services;
+using Microsoft.AspNetCore.Identity;
+using NSubstitute;
+using OpenIddict.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.Endpoints.Tests.Integration;
+
+public sealed class OidcPrincipalFactoryTests
+{
+    private readonly UserManager<GranitUser> _userManager;
+    private readonly IClaimsDestinationProvider _destinationProvider;
+    private readonly OidcPrincipalFactory _factory;
+
+    public OidcPrincipalFactoryTests()
+    {
+        IUserStore<GranitUser> userStore = Substitute.For<IUserStore<GranitUser>>();
+        _userManager = Substitute.For<UserManager<GranitUser>>(
+            userStore, null, null, null, null, null, null, null, null);
+
+        _destinationProvider = Substitute.For<IClaimsDestinationProvider>();
+        _destinationProvider.GetDestinations(Arg.Any<Claim>(), Arg.Any<ClaimsPrincipal>())
+            .Returns([OpenIddictConstants.Destinations.AccessToken]);
+
+        _factory = new OidcPrincipalFactory(_userManager, _destinationProvider);
+    }
+
+    [Fact]
+    public async Task CreateUserPrincipal_SetsSubjectClaim()
+    {
+        GranitUser user = CreateTestUser();
+        SetupUserManager(user);
+
+        ClaimsPrincipal principal = await _factory.CreateUserPrincipalAsync(
+            user, [], "TestScheme", TestContext.Current.CancellationToken);
+
+        ClaimsIdentity identity = principal.Identity.ShouldBeOfType<ClaimsIdentity>();
+        identity.FindFirst(OpenIddictConstants.Claims.Subject)?.Value
+            .ShouldBe(user.Id.ToString());
+    }
+
+    [Fact]
+    public async Task CreateUserPrincipal_SetsPreferredUsername()
+    {
+        GranitUser user = CreateTestUser();
+        user.UserName = "jdoe";
+        SetupUserManager(user);
+
+        ClaimsPrincipal principal = await _factory.CreateUserPrincipalAsync(
+            user, [], "TestScheme", TestContext.Current.CancellationToken);
+
+        ClaimsIdentity identity = principal.Identity.ShouldBeOfType<ClaimsIdentity>();
+        identity.FindFirst(OpenIddictConstants.Claims.PreferredUsername)?.Value
+            .ShouldBe("jdoe");
+    }
+
+    [Fact]
+    public async Task CreateUserPrincipal_SetsNameFromFirstAndLast()
+    {
+        GranitUser user = CreateTestUser();
+        user.FirstName = "John";
+        user.LastName = "Doe";
+        SetupUserManager(user);
+
+        ClaimsPrincipal principal = await _factory.CreateUserPrincipalAsync(
+            user, [], "TestScheme", TestContext.Current.CancellationToken);
+
+        ClaimsIdentity identity = principal.Identity.ShouldBeOfType<ClaimsIdentity>();
+        identity.FindFirst(OpenIddictConstants.Claims.Name)?.Value.ShouldBe("John Doe");
+        identity.FindFirst(OpenIddictConstants.Claims.GivenName)?.Value.ShouldBe("John");
+        identity.FindFirst(OpenIddictConstants.Claims.FamilyName)?.Value.ShouldBe("Doe");
+    }
+
+    [Fact]
+    public async Task CreateUserPrincipal_OnlyFirstName_SetsNameWithoutTrailingSpace()
+    {
+        GranitUser user = CreateTestUser();
+        user.FirstName = "John";
+        user.LastName = null;
+        SetupUserManager(user);
+
+        ClaimsPrincipal principal = await _factory.CreateUserPrincipalAsync(
+            user, [], "TestScheme", TestContext.Current.CancellationToken);
+
+        ClaimsIdentity identity = principal.Identity.ShouldBeOfType<ClaimsIdentity>();
+        identity.FindFirst(OpenIddictConstants.Claims.Name)?.Value.ShouldBe("John");
+        identity.FindFirst(OpenIddictConstants.Claims.GivenName)?.Value.ShouldBe("John");
+        identity.FindFirst(OpenIddictConstants.Claims.FamilyName).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CreateUserPrincipal_NullNames_NoNameClaim()
+    {
+        GranitUser user = CreateTestUser();
+        user.FirstName = null;
+        user.LastName = null;
+        SetupUserManager(user);
+
+        ClaimsPrincipal principal = await _factory.CreateUserPrincipalAsync(
+            user, [], "TestScheme", TestContext.Current.CancellationToken);
+
+        ClaimsIdentity identity = principal.Identity.ShouldBeOfType<ClaimsIdentity>();
+        identity.FindFirst(OpenIddictConstants.Claims.Name).ShouldBeNull();
+        identity.FindFirst(OpenIddictConstants.Claims.GivenName).ShouldBeNull();
+        identity.FindFirst(OpenIddictConstants.Claims.FamilyName).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CreateUserPrincipal_SetsEmailClaims()
+    {
+        GranitUser user = CreateTestUser();
+        user.Email = "john@example.com";
+        user.EmailConfirmed = true;
+        SetupUserManager(user);
+
+        ClaimsPrincipal principal = await _factory.CreateUserPrincipalAsync(
+            user, [], "TestScheme", TestContext.Current.CancellationToken);
+
+        ClaimsIdentity identity = principal.Identity.ShouldBeOfType<ClaimsIdentity>();
+        identity.FindFirst(OpenIddictConstants.Claims.Email)?.Value.ShouldBe("john@example.com");
+        identity.FindFirst(OpenIddictConstants.Claims.EmailVerified)?.Value.ShouldBe("true");
+    }
+
+    [Fact]
+    public async Task CreateUserPrincipal_UnconfirmedEmail_SetsVerifiedFalse()
+    {
+        GranitUser user = CreateTestUser();
+        user.Email = "john@example.com";
+        user.EmailConfirmed = false;
+        SetupUserManager(user);
+
+        ClaimsPrincipal principal = await _factory.CreateUserPrincipalAsync(
+            user, [], "TestScheme", TestContext.Current.CancellationToken);
+
+        ClaimsIdentity identity = principal.Identity.ShouldBeOfType<ClaimsIdentity>();
+        identity.FindFirst(OpenIddictConstants.Claims.EmailVerified)?.Value.ShouldBe("false");
+    }
+
+    [Fact]
+    public async Task CreateUserPrincipal_NullEmail_NoEmailClaim()
+    {
+        GranitUser user = CreateTestUser();
+        user.Email = null;
+        SetupUserManager(user);
+
+        ClaimsPrincipal principal = await _factory.CreateUserPrincipalAsync(
+            user, [], "TestScheme", TestContext.Current.CancellationToken);
+
+        ClaimsIdentity identity = principal.Identity.ShouldBeOfType<ClaimsIdentity>();
+        identity.FindFirst(OpenIddictConstants.Claims.Email).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CreateUserPrincipal_SetsPhoneClaims()
+    {
+        GranitUser user = CreateTestUser();
+        user.PhoneNumber = "+32471000000";
+        user.PhoneNumberConfirmed = true;
+        SetupUserManager(user);
+
+        ClaimsPrincipal principal = await _factory.CreateUserPrincipalAsync(
+            user, [], "TestScheme", TestContext.Current.CancellationToken);
+
+        ClaimsIdentity identity = principal.Identity.ShouldBeOfType<ClaimsIdentity>();
+        identity.FindFirst(OpenIddictConstants.Claims.PhoneNumber)?.Value.ShouldBe("+32471000000");
+        identity.FindFirst(OpenIddictConstants.Claims.PhoneNumberVerified)?.Value.ShouldBe("true");
+    }
+
+    [Fact]
+    public async Task CreateUserPrincipal_NullPhone_NoPhoneClaim()
+    {
+        GranitUser user = CreateTestUser();
+        user.PhoneNumber = null;
+        SetupUserManager(user);
+
+        ClaimsPrincipal principal = await _factory.CreateUserPrincipalAsync(
+            user, [], "TestScheme", TestContext.Current.CancellationToken);
+
+        ClaimsIdentity identity = principal.Identity.ShouldBeOfType<ClaimsIdentity>();
+        identity.FindFirst(OpenIddictConstants.Claims.PhoneNumber).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CreateUserPrincipal_IncludesRoles()
+    {
+        GranitUser user = CreateTestUser();
+        SetupUserManager(user, roles: ["admin", "editor"]);
+
+        ClaimsPrincipal principal = await _factory.CreateUserPrincipalAsync(
+            user, [], "TestScheme", TestContext.Current.CancellationToken);
+
+        ClaimsIdentity identity = principal.Identity.ShouldBeOfType<ClaimsIdentity>();
+        IEnumerable<string> roleClaims = identity.FindAll(OpenIddictConstants.Claims.Role)
+            .Select(c => c.Value);
+        roleClaims.ShouldContain("admin");
+        roleClaims.ShouldContain("editor");
+    }
+
+    [Fact]
+    public async Task CreateUserPrincipal_IncludesCustomClaims()
+    {
+        GranitUser user = CreateTestUser();
+        List<Claim> customClaims = [new Claim("tenant_id", "abc-123")];
+        SetupUserManager(user, customClaims: customClaims);
+
+        ClaimsPrincipal principal = await _factory.CreateUserPrincipalAsync(
+            user, [], "TestScheme", TestContext.Current.CancellationToken);
+
+        ClaimsIdentity identity = principal.Identity.ShouldBeOfType<ClaimsIdentity>();
+        identity.FindFirst("tenant_id")?.Value.ShouldBe("abc-123");
+    }
+
+    [Fact]
+    public async Task CreateUserPrincipal_SetsScopes()
+    {
+        GranitUser user = CreateTestUser();
+        SetupUserManager(user);
+
+        ImmutableArray<string> scopes = ["openid", "profile", "email"];
+
+        ClaimsPrincipal principal = await _factory.CreateUserPrincipalAsync(
+            user, scopes, "TestScheme", TestContext.Current.CancellationToken);
+
+        // Scopes are set via OpenIddict extension methods on the identity
+        principal.ShouldNotBeNull();
+        principal.Identity.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task CreateUserPrincipal_CallsDestinationProvider()
+    {
+        GranitUser user = CreateTestUser();
+        SetupUserManager(user);
+
+        await _factory.CreateUserPrincipalAsync(
+            user, [], "TestScheme", TestContext.Current.CancellationToken);
+
+        _destinationProvider.Received().GetDestinations(Arg.Any<Claim>(), Arg.Any<ClaimsPrincipal>());
+    }
+
+    [Fact]
+    public void CreateClientPrincipal_SetsSubjectToClientId()
+    {
+        ClaimsPrincipal principal = OidcPrincipalFactory.CreateClientPrincipal(
+            "my-client", [], "TestScheme");
+
+        ClaimsIdentity identity = principal.Identity.ShouldBeOfType<ClaimsIdentity>();
+        identity.FindFirst(OpenIddictConstants.Claims.Subject)?.Value.ShouldBe("my-client");
+    }
+
+    [Fact]
+    public void CreateClientPrincipal_SetsAuthenticationScheme()
+    {
+        ClaimsPrincipal principal = OidcPrincipalFactory.CreateClientPrincipal(
+            "my-client", [], "CustomScheme");
+
+        ClaimsIdentity identity = principal.Identity.ShouldBeOfType<ClaimsIdentity>();
+        identity.AuthenticationType.ShouldBe("CustomScheme");
+    }
+
+    [Fact]
+    public void CreateClientPrincipal_SetsScopes()
+    {
+        ImmutableArray<string> scopes = ["api", "openid"];
+
+        ClaimsPrincipal principal = OidcPrincipalFactory.CreateClientPrincipal(
+            "my-client", scopes, "TestScheme");
+
+        principal.ShouldNotBeNull();
+        principal.Identity.ShouldNotBeNull();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static GranitUser CreateTestUser() => new()
+    {
+        Id = Guid.NewGuid(),
+        UserName = "testuser",
+        FirstName = null,
+        LastName = null,
+        Email = null,
+        PhoneNumber = null,
+    };
+
+    private void SetupUserManager(
+        GranitUser user,
+        IList<string>? roles = null,
+        IList<Claim>? customClaims = null)
+    {
+        _userManager.GetRolesAsync(user).Returns(roles ?? Array.Empty<string>());
+        _userManager.GetClaimsAsync(user).Returns(customClaims ?? Array.Empty<Claim>());
+    }
+}

--- a/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
@@ -8,11 +8,30 @@
         "resolved": "8.0.1",
         "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
       },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "Direct",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1"
+        }
+      },
       "JunitXml.TestLogger": {
         "type": "Direct",
         "requested": "[7.*, )",
         "resolved": "7.1.0",
         "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "MfacYQ7jNzj6073YobyoFfXpNmGqrV1UCywTM339DOcYpfalcM4K4heFjV5k3dDkKkWOGWO/DV3hdmVRqFkIxA==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.5",
+          "Microsoft.Extensions.DependencyModel": "10.0.5"
+        }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",
@@ -37,6 +56,24 @@
         "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
         "dependencies": {
           "Castle.Core": "5.1.1"
+        }
+      },
+      "OpenIddict": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.4.0",
+        "contentHash": "oum61BkFI5tEPZ96L23QE4kX51neQbTd2sbpHvgOTkCDc+r0oBI8VYwR3EBYrVdt3fqKvtCt8bKJVn73PBbtyQ==",
+        "dependencies": {
+          "OpenIddict.Abstractions": "7.4.0",
+          "OpenIddict.Client": "7.4.0",
+          "OpenIddict.Client.SystemIntegration": "7.4.0",
+          "OpenIddict.Client.SystemNetHttp": "7.4.0",
+          "OpenIddict.Client.WebIntegration": "7.4.0",
+          "OpenIddict.Core": "7.4.0",
+          "OpenIddict.Server": "7.4.0",
+          "OpenIddict.Validation": "7.4.0",
+          "OpenIddict.Validation.ServerIntegration": "7.4.0",
+          "OpenIddict.Validation.SystemNetHttp": "7.4.0"
         }
       },
       "Shouldly": {
@@ -101,6 +138,11 @@
         "resolved": "2.23.0",
         "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
       },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "PJEdrZnnhvxIEXzDdvdZ38GvpdaiUfKkZ99kudS8riJwhowFb/Qh26Wjk9smrCWcYdMFQmpN5epGiL4o1s8LYA=="
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -113,13 +155,13 @@
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "c7Uoz381xnMHNBRB8eHRhGgzUtXbgddlbODhwZRrTSzZWDharp3RkJsFwhxyESbeXhCqmML7VdvjMQ7uu+HreA=="
+        "resolved": "10.0.5",
+        "contentHash": "32c58Rnm47Qvhimawf67KO9PytgPz3QoWye7Abapt0Yocw/JnzMiSNj/pRoIKyn8Jxypkv86zxKD4Q/zNTc0Ag=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "lVABgJTyTUNE7Bi0bSu4dWHiCHIXEGzTh/kLh0N07IgU/tIKwTeBPp8tgV4x2iKj4h7iPLo8oXzyHmLDGtAE1g=="
+        "resolved": "10.0.5",
+        "contentHash": "ipC4u1VojgEfoIZhtbS2Sx5IluJTP/Jf1hz3yGsxGBgSukYY/CquI6rAjxn5H58CZgVn36qcuPPtNMwZ0AUzMg=="
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
@@ -135,6 +177,11 @@
         "type": "Transitive",
         "resolved": "10.3.0",
         "contentHash": "g6/S5rhP1XNBqeDa9zKXri/uDKe6gjzSqGsocuySb1OdVm8fz/M9YcWTJsCw5RHF8xIb/B3NgsfBPQF9Emjk3Q=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "xA4kkL+QS6KCAOKz/O0oquHs44Ob8J7zpBCNt3wjkBWDg5aCqfwG8rWWLsg5V86AM0sB849g9JjPjIdksTCIKg=="
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",
@@ -507,6 +554,12 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.events": {
         "type": "Project",
         "dependencies": {
@@ -566,6 +619,12 @@
           "SmartFormat": "[3.*, )"
         }
       },
+      "granit.multitenancy": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.openiddict": {
         "type": "Project",
         "dependencies": {
@@ -586,6 +645,21 @@
           "Granit.Validation": "[0.1.0-dev, )"
         }
       },
+      "granit.openiddict.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Identity.Local": "[0.1.0-dev, )",
+          "Granit.MultiTenancy": "[0.1.0-dev, )",
+          "Granit.OpenIddict.Server": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "OpenIddict": "[7.*, )",
+          "OpenIddict.EntityFrameworkCore": "[7.*, )"
+        }
+      },
       "granit.openiddict.server": {
         "type": "Project",
         "dependencies": {
@@ -593,6 +667,25 @@
           "OpenIddict": "[7.*, )",
           "OpenIddict.Server.AspNetCore": "[7.*, )",
           "OpenIddict.Validation.AspNetCore": "[7.*, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -641,13 +734,13 @@
         "resolved": "12.1.1",
         "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
       },
-      "FluentValidation.DependencyInjectionExtensions": {
+      "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
         "type": "CentralTransitive",
-        "requested": "[12.*, )",
-        "resolved": "12.1.1",
-        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "oo1uauTwgcnhYgituZ2nI3wJ8XN9z76ggu2zkOJu1BCfOOsqr+g08Kr4MOiMuXEhwySkpIV+MVoC25hC1288NA==",
         "dependencies": {
-          "FluentValidation": "12.1.1"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.5"
         }
       },
       "Microsoft.AspNetCore.OpenApi": {
@@ -662,20 +755,29 @@
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.3",
-        "contentHash": "CDEImwD4A7BseABJMCpLZnhfFjmPY/bHwhhS70elc6gLI/bYUEOhxWt7PmaNGYGhIEzOnStlCy5QcVb+8dod5Q==",
+        "resolved": "10.0.5",
+        "contentHash": "9tNBmK3EpYVGRQLiqP+bqK2m+TD0Gv//4vCzR7ZOgl4FWzCFyOpYdIVka13M4kcBdPdSJcs3wbHr3rmzOqbIMA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.3",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.3"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.5",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.5"
         }
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.3",
-        "contentHash": "Pmh60OK9neVr/M0FJwm9hlzm2bD4Kd65SID8E6SP5c90tExNgXwORrlEWl0oGU/ig9ifpNN4PSpIrnHNozlT5w==",
+        "resolved": "10.0.5",
+        "contentHash": "uxmFjZEAB/KbsgWFSS4lLqkEHCfXxB2x0UcbiO4e5fCRpFFeTMSx/me6009nYJLu5IKlDwO1POh++P6RilFTDw==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.3"
+          "Microsoft.EntityFrameworkCore": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "RtNhAwrnZcUZgi3SUMvaDVF405ZtKVR7l/6OHcqFj6JY5nT7QOdBxxULnby9dUQ6Jhnfl7cdDlMjsexfASNyjg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.5"
         }
       },
       "Microsoft.Extensions.Http.Resilience": {
@@ -686,24 +788,6 @@
         "dependencies": {
           "Microsoft.Extensions.Http.Diagnostics": "10.3.0",
           "Microsoft.Extensions.Resilience": "10.3.0"
-        }
-      },
-      "OpenIddict": {
-        "type": "CentralTransitive",
-        "requested": "[7.*, )",
-        "resolved": "7.4.0",
-        "contentHash": "oum61BkFI5tEPZ96L23QE4kX51neQbTd2sbpHvgOTkCDc+r0oBI8VYwR3EBYrVdt3fqKvtCt8bKJVn73PBbtyQ==",
-        "dependencies": {
-          "OpenIddict.Abstractions": "7.4.0",
-          "OpenIddict.Client": "7.4.0",
-          "OpenIddict.Client.SystemIntegration": "7.4.0",
-          "OpenIddict.Client.SystemNetHttp": "7.4.0",
-          "OpenIddict.Client.WebIntegration": "7.4.0",
-          "OpenIddict.Core": "7.4.0",
-          "OpenIddict.Server": "7.4.0",
-          "OpenIddict.Validation": "7.4.0",
-          "OpenIddict.Validation.ServerIntegration": "7.4.0",
-          "OpenIddict.Validation.SystemNetHttp": "7.4.0"
         }
       },
       "OpenIddict.EntityFrameworkCore": {
@@ -755,8 +839,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.13.17",
-        "contentHash": "v44WF0m58HBwaUiZVrvuetICcoaf2ZvIYu8JxsaJRRtsrNLlCIqjCcncTTDIy7pUiC2r2EO3eCJqcqGaTKZplQ=="
+        "resolved": "2.13.18",
+        "contentHash": "SOe5I8KspXwmcMbey+6G4drRWhCa/ON/ZjyVKfm5FpXvcsCmb9MfiVcKAiQ8UYV+ki3fAaqcCFc5ahzx/NTXOw=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/AspNetAccountDeletionServiceTests.cs
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/AspNetAccountDeletionServiceTests.cs
@@ -1,0 +1,254 @@
+using Granit.Events;
+using Granit.Identity.Local.Domain;
+using Granit.Identity.Local.Events;
+using Granit.Identity.Local.Services;
+using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Granit.Timing;
+using Microsoft.AspNetCore.Identity;
+using NSubstitute;
+using OpenIddict.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+
+public sealed class AspNetAccountDeletionServiceTests
+{
+    private static readonly DateTimeOffset FixedNow = new(2025, 6, 15, 10, 0, 0, TimeSpan.Zero);
+
+    private readonly UserManager<GranitUser> _userManager;
+    private readonly IOpenIddictTokenManager _tokenManager = Substitute.For<IOpenIddictTokenManager>();
+    private readonly IDistributedEventBus _eventBus = Substitute.For<IDistributedEventBus>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly AspNetAccountDeletionService _sut;
+
+    public AspNetAccountDeletionServiceTests()
+    {
+        IUserStore<GranitUser> store = Substitute.For<IUserStore<GranitUser>>();
+        _userManager = Substitute.For<UserManager<GranitUser>>(
+            store, null, null, null, null, null, null, null, null);
+
+        _clock.Now.Returns(FixedNow);
+
+        _sut = new AspNetAccountDeletionService(
+            _userManager,
+            _tokenManager,
+            _eventBus,
+            _clock);
+    }
+
+    // ────────────────────── InitiateAsync — happy path ──────────────────────
+
+    [Fact]
+    public async Task InitiateAsync_UserExists_SoftDeletesUser()
+    {
+        GranitUser user = CreateUser();
+        string userId = user.Id.ToString();
+
+        _userManager.FindByIdAsync(userId).Returns(user);
+        _userManager.UpdateAsync(user).Returns(IdentityResult.Success);
+        _userManager.SetLockoutEndDateAsync(user, DateTimeOffset.MaxValue).Returns(IdentityResult.Success);
+        _userManager.UpdateSecurityStampAsync(user).Returns(IdentityResult.Success);
+        SetupEmptyTokenStream(userId);
+
+        await _sut.InitiateAsync(userId, TestContext.Current.CancellationToken);
+
+        user.IsDeleted.ShouldBeTrue();
+        user.DeletedAt.ShouldBe(FixedNow);
+        user.DeletedBy.ShouldBe(userId);
+    }
+
+    [Fact]
+    public async Task InitiateAsync_UserExists_LocksAccount()
+    {
+        GranitUser user = CreateUser();
+        string userId = user.Id.ToString();
+
+        _userManager.FindByIdAsync(userId).Returns(user);
+        _userManager.UpdateAsync(user).Returns(IdentityResult.Success);
+        _userManager.SetLockoutEndDateAsync(user, Arg.Any<DateTimeOffset>()).Returns(IdentityResult.Success);
+        _userManager.UpdateSecurityStampAsync(user).Returns(IdentityResult.Success);
+        SetupEmptyTokenStream(userId);
+
+        await _sut.InitiateAsync(userId, TestContext.Current.CancellationToken);
+
+        await _userManager.Received(1).SetLockoutEndDateAsync(user, DateTimeOffset.MaxValue);
+    }
+
+    [Fact]
+    public async Task InitiateAsync_UserExists_UpdatesSecurityStamp()
+    {
+        GranitUser user = CreateUser();
+        string userId = user.Id.ToString();
+
+        _userManager.FindByIdAsync(userId).Returns(user);
+        _userManager.UpdateAsync(user).Returns(IdentityResult.Success);
+        _userManager.SetLockoutEndDateAsync(user, Arg.Any<DateTimeOffset>()).Returns(IdentityResult.Success);
+        _userManager.UpdateSecurityStampAsync(user).Returns(IdentityResult.Success);
+        SetupEmptyTokenStream(userId);
+
+        await _sut.InitiateAsync(userId, TestContext.Current.CancellationToken);
+
+        await _userManager.Received(1).UpdateSecurityStampAsync(user);
+    }
+
+    [Fact]
+    public async Task InitiateAsync_UserExists_PublishesAccountDeletedEto()
+    {
+        GranitUser user = CreateUser();
+        var tenantId = Guid.NewGuid();
+        user.TenantId = tenantId;
+        string userId = user.Id.ToString();
+
+        _userManager.FindByIdAsync(userId).Returns(user);
+        _userManager.UpdateAsync(user).Returns(IdentityResult.Success);
+        _userManager.SetLockoutEndDateAsync(user, Arg.Any<DateTimeOffset>()).Returns(IdentityResult.Success);
+        _userManager.UpdateSecurityStampAsync(user).Returns(IdentityResult.Success);
+        SetupEmptyTokenStream(userId);
+
+        await _sut.InitiateAsync(userId, TestContext.Current.CancellationToken);
+
+        await _eventBus.Received(1).PublishAsync(
+            Arg.Is<AccountDeletedEto>(e =>
+                e.UserId == user.Id &&
+                e.TenantId == tenantId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InitiateAsync_UserWithNoTenant_PublishesEventWithNullTenant()
+    {
+        GranitUser user = CreateUser();
+        user.TenantId = null;
+        string userId = user.Id.ToString();
+
+        _userManager.FindByIdAsync(userId).Returns(user);
+        _userManager.UpdateAsync(user).Returns(IdentityResult.Success);
+        _userManager.SetLockoutEndDateAsync(user, Arg.Any<DateTimeOffset>()).Returns(IdentityResult.Success);
+        _userManager.UpdateSecurityStampAsync(user).Returns(IdentityResult.Success);
+        SetupEmptyTokenStream(userId);
+
+        await _sut.InitiateAsync(userId, TestContext.Current.CancellationToken);
+
+        await _eventBus.Received(1).PublishAsync(
+            Arg.Is<AccountDeletedEto>(e =>
+                e.UserId == user.Id &&
+                e.TenantId == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ────────────────────── InitiateAsync — token revocation ──────────────────────
+
+    [Fact]
+    public async Task InitiateAsync_UserHasTokens_RevokesAllTokens()
+    {
+        GranitUser user = CreateUser();
+        string userId = user.Id.ToString();
+
+        _userManager.FindByIdAsync(userId).Returns(user);
+        _userManager.UpdateAsync(user).Returns(IdentityResult.Success);
+        _userManager.SetLockoutEndDateAsync(user, Arg.Any<DateTimeOffset>()).Returns(IdentityResult.Success);
+        _userManager.UpdateSecurityStampAsync(user).Returns(IdentityResult.Success);
+
+        object token1 = new object();
+        object token2 = new object();
+        _tokenManager.FindBySubjectAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable(token1, token2));
+        _tokenManager.TryRevokeAsync(Arg.Any<object>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        await _sut.InitiateAsync(userId, TestContext.Current.CancellationToken);
+
+        await _tokenManager.Received(1).TryRevokeAsync(token1, Arg.Any<CancellationToken>());
+        await _tokenManager.Received(1).TryRevokeAsync(token2, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InitiateAsync_NoTokens_StillSucceeds()
+    {
+        GranitUser user = CreateUser();
+        string userId = user.Id.ToString();
+
+        _userManager.FindByIdAsync(userId).Returns(user);
+        _userManager.UpdateAsync(user).Returns(IdentityResult.Success);
+        _userManager.SetLockoutEndDateAsync(user, Arg.Any<DateTimeOffset>()).Returns(IdentityResult.Success);
+        _userManager.UpdateSecurityStampAsync(user).Returns(IdentityResult.Success);
+        SetupEmptyTokenStream(userId);
+
+        await Should.NotThrowAsync(
+            () => _sut.InitiateAsync(userId, TestContext.Current.CancellationToken));
+    }
+
+    // ────────────────────── InitiateAsync — error paths ──────────────────────
+
+    [Fact]
+    public async Task InitiateAsync_UserNotFound_ThrowsInvalidOperation()
+    {
+        string unknownId = Guid.NewGuid().ToString();
+        _userManager.FindByIdAsync(unknownId).Returns((GranitUser?)null);
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.InitiateAsync(unknownId, TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain(unknownId);
+    }
+
+    [Fact]
+    public async Task InitiateAsync_UpdateFails_ThrowsInvalidOperation()
+    {
+        GranitUser user = CreateUser();
+        string userId = user.Id.ToString();
+
+        _userManager.FindByIdAsync(userId).Returns(user);
+        _userManager.UpdateAsync(user)
+            .Returns(IdentityResult.Failed(new IdentityError { Description = "Update failed" }));
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.InitiateAsync(userId, TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("Update failed");
+    }
+
+    [Fact]
+    public async Task InitiateAsync_UpdateFails_DoesNotLockAccountOrRevokeTokens()
+    {
+        GranitUser user = CreateUser();
+        string userId = user.Id.ToString();
+
+        _userManager.FindByIdAsync(userId).Returns(user);
+        _userManager.UpdateAsync(user)
+            .Returns(IdentityResult.Failed(new IdentityError { Description = "Conflict" }));
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.InitiateAsync(userId, TestContext.Current.CancellationToken));
+
+        await _userManager.DidNotReceive().SetLockoutEndDateAsync(Arg.Any<GranitUser>(), Arg.Any<DateTimeOffset>());
+        await _userManager.DidNotReceive().UpdateSecurityStampAsync(Arg.Any<GranitUser>());
+        await _eventBus.DidNotReceive().PublishAsync(Arg.Any<AccountDeletedEto>(), Arg.Any<CancellationToken>());
+    }
+
+    // ────────────────────── Helpers ──────────────────────
+
+    private static GranitUser CreateUser() => new()
+    {
+        Id = Guid.NewGuid(),
+        UserName = "testuser",
+        Email = "test@example.com",
+    };
+
+    private void SetupEmptyTokenStream(string userId)
+    {
+        _tokenManager.FindBySubjectAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable<object>());
+    }
+
+    private static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(params T[] items)
+    {
+        foreach (T item in items)
+        {
+            yield return item;
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/AspNetImpersonationServiceTests.cs
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/AspNetImpersonationServiceTests.cs
@@ -1,0 +1,385 @@
+using System.Diagnostics.Metrics;
+using Granit.Events;
+using Granit.Identity.Local.Diagnostics;
+using Granit.Identity.Local.Domain;
+using Granit.Identity.Local.Events;
+using Granit.Identity.Local.Services;
+using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Granit.Timing;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using OpenIddict.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+
+public sealed class AspNetImpersonationServiceTests
+{
+    private static readonly DateTimeOffset FixedNow = new(2025, 6, 15, 10, 0, 0, TimeSpan.Zero);
+
+    private readonly UserManager<GranitUser> _userManager;
+    private readonly IOpenIddictTokenManager _tokenManager = Substitute.For<IOpenIddictTokenManager>();
+    private readonly IDistributedEventBus _eventBus = Substitute.For<IDistributedEventBus>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly AspNetImpersonationService _sut;
+
+    public AspNetImpersonationServiceTests()
+    {
+        IUserStore<GranitUser> store = Substitute.For<IUserStore<GranitUser>>();
+        _userManager = Substitute.For<UserManager<GranitUser>>(
+            store, null, null, null, null, null, null, null, null);
+
+        _clock.Now.Returns(FixedNow);
+
+        IMeterFactory meterFactory = new TestMeterFactory();
+        IdentityLocalMetrics metrics = new(meterFactory);
+
+        _sut = new AspNetImpersonationService(
+            _userManager,
+            _tokenManager,
+            _eventBus,
+            metrics,
+            _clock,
+            NullLogger<AspNetImpersonationService>.Instance);
+    }
+
+    // ────────────────────── ImpersonateAsync ──────────────────────
+
+    [Fact]
+    public async Task ImpersonateAsync_ValidInputs_ReturnsTokenResult()
+    {
+        GranitUser target = CreateUser();
+        string targetId = target.Id.ToString();
+        var impersonatorGuid = Guid.NewGuid();
+        string impersonatorId = impersonatorGuid.ToString();
+
+        _userManager.FindByIdAsync(targetId).Returns(target);
+        _userManager.GetRolesAsync(target).Returns(new List<string> { "Admin", "User" });
+
+        object accessTokenEntry = new object();
+        object refreshTokenEntry = new object();
+        _tokenManager.CreateAsync(Arg.Is<OpenIddictTokenDescriptor>(d =>
+                d.Type == OpenIddictConstants.TokenTypeHints.AccessToken), Arg.Any<CancellationToken>())
+            .Returns(accessTokenEntry);
+        _tokenManager.CreateAsync(Arg.Is<OpenIddictTokenDescriptor>(d =>
+                d.Type == OpenIddictConstants.TokenTypeHints.RefreshToken), Arg.Any<CancellationToken>())
+            .Returns(refreshTokenEntry);
+        _tokenManager.GetPayloadAsync(accessTokenEntry, Arg.Any<CancellationToken>())
+            .Returns("access-token-value");
+        _tokenManager.GetPayloadAsync(refreshTokenEntry, Arg.Any<CancellationToken>())
+            .Returns("refresh-token-value");
+
+        ImpersonationResult result = await _sut.ImpersonateAsync(
+            targetId, impersonatorId, "Admin User", TestContext.Current.CancellationToken);
+
+        result.AccessToken.ShouldBe("access-token-value");
+        result.RefreshToken.ShouldBe("refresh-token-value");
+        result.ExpiresIn.ShouldBe(3600);
+    }
+
+    [Fact]
+    public async Task ImpersonateAsync_PublishesUserImpersonatedEto()
+    {
+        GranitUser target = CreateUser();
+        var tenantId = Guid.NewGuid();
+        target.TenantId = tenantId;
+        string targetId = target.Id.ToString();
+        var impersonatorGuid = Guid.NewGuid();
+        string impersonatorId = impersonatorGuid.ToString();
+
+        _userManager.FindByIdAsync(targetId).Returns(target);
+        _userManager.GetRolesAsync(target).Returns(new List<string>());
+        SetupTokenCreation();
+
+        await _sut.ImpersonateAsync(
+            targetId, impersonatorId, "Admin User", TestContext.Current.CancellationToken);
+
+        await _eventBus.Received(1).PublishAsync(
+            Arg.Is<UserImpersonatedEto>(e =>
+                e.TargetUserId == target.Id &&
+                e.ImpersonatorId == impersonatorGuid &&
+                e.TenantId == tenantId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ImpersonateAsync_CreatesAccessAndRefreshTokens()
+    {
+        GranitUser target = CreateUser();
+        string targetId = target.Id.ToString();
+        var impersonatorGuid = Guid.NewGuid();
+
+        _userManager.FindByIdAsync(targetId).Returns(target);
+        _userManager.GetRolesAsync(target).Returns(new List<string>());
+        SetupTokenCreation();
+
+        await _sut.ImpersonateAsync(
+            targetId, impersonatorGuid.ToString(), "Admin", TestContext.Current.CancellationToken);
+
+        await _tokenManager.Received(1).CreateAsync(
+            Arg.Is<OpenIddictTokenDescriptor>(d =>
+                d.Type == OpenIddictConstants.TokenTypeHints.AccessToken &&
+                d.Subject == targetId &&
+                d.CreationDate == FixedNow &&
+                d.ExpirationDate == FixedNow + TimeSpan.FromHours(1)),
+            Arg.Any<CancellationToken>());
+
+        await _tokenManager.Received(1).CreateAsync(
+            Arg.Is<OpenIddictTokenDescriptor>(d =>
+                d.Type == OpenIddictConstants.TokenTypeHints.RefreshToken &&
+                d.Subject == targetId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ImpersonateAsync_UserNotFound_ThrowsInvalidOperation()
+    {
+        string unknownId = Guid.NewGuid().ToString();
+        _userManager.FindByIdAsync(unknownId).Returns((GranitUser?)null);
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.ImpersonateAsync(
+                unknownId, Guid.NewGuid().ToString(), "Admin", TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain(unknownId);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task ImpersonateAsync_NullOrWhiteSpaceTargetUserId_ThrowsArgument(string? targetUserId)
+    {
+        await Should.ThrowAsync<ArgumentException>(
+            () => _sut.ImpersonateAsync(
+                targetUserId!, Guid.NewGuid().ToString(), "Admin", TestContext.Current.CancellationToken));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task ImpersonateAsync_NullOrWhiteSpaceImpersonatorId_ThrowsArgument(string? impersonatorId)
+    {
+        await Should.ThrowAsync<ArgumentException>(
+            () => _sut.ImpersonateAsync(
+                Guid.NewGuid().ToString(), impersonatorId!, "Admin", TestContext.Current.CancellationToken));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task ImpersonateAsync_NullOrWhiteSpaceImpersonatorName_ThrowsArgument(string? impersonatorName)
+    {
+        await Should.ThrowAsync<ArgumentException>(
+            () => _sut.ImpersonateAsync(
+                Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), impersonatorName!, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ImpersonateAsync_NullPayload_ReturnsEmptyToken()
+    {
+        GranitUser target = CreateUser();
+        string targetId = target.Id.ToString();
+
+        _userManager.FindByIdAsync(targetId).Returns(target);
+        _userManager.GetRolesAsync(target).Returns(new List<string>());
+
+        object tokenEntry = new object();
+        _tokenManager.CreateAsync(Arg.Any<OpenIddictTokenDescriptor>(), Arg.Any<CancellationToken>())
+            .Returns(tokenEntry);
+        _tokenManager.GetPayloadAsync(tokenEntry, Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+
+        ImpersonationResult result = await _sut.ImpersonateAsync(
+            targetId, Guid.NewGuid().ToString(), "Admin", TestContext.Current.CancellationToken);
+
+        result.AccessToken.ShouldBe(string.Empty);
+        result.RefreshToken.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public async Task ImpersonateAsync_UserWithNoRoles_SucceedsWithoutRoleClaims()
+    {
+        GranitUser target = CreateUser();
+        string targetId = target.Id.ToString();
+
+        _userManager.FindByIdAsync(targetId).Returns(target);
+        _userManager.GetRolesAsync(target).Returns(new List<string>());
+        SetupTokenCreation();
+
+        ImpersonationResult result = await _sut.ImpersonateAsync(
+            targetId, Guid.NewGuid().ToString(), "Admin", TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+    }
+
+    // ────────────────────── BackToImpersonatorAsync ──────────────────────
+
+    [Fact]
+    public async Task BackToImpersonatorAsync_ValidId_ReturnsTokenResult()
+    {
+        GranitUser admin = CreateUser();
+        string adminId = admin.Id.ToString();
+
+        _userManager.FindByIdAsync(adminId).Returns(admin);
+        _userManager.GetRolesAsync(admin).Returns(new List<string> { "Admin" });
+
+        object accessTokenEntry = new object();
+        object refreshTokenEntry = new object();
+        _tokenManager.CreateAsync(Arg.Is<OpenIddictTokenDescriptor>(d =>
+                d.Type == OpenIddictConstants.TokenTypeHints.AccessToken), Arg.Any<CancellationToken>())
+            .Returns(accessTokenEntry);
+        _tokenManager.CreateAsync(Arg.Is<OpenIddictTokenDescriptor>(d =>
+                d.Type == OpenIddictConstants.TokenTypeHints.RefreshToken), Arg.Any<CancellationToken>())
+            .Returns(refreshTokenEntry);
+        _tokenManager.GetPayloadAsync(accessTokenEntry, Arg.Any<CancellationToken>())
+            .Returns("admin-access-token");
+        _tokenManager.GetPayloadAsync(refreshTokenEntry, Arg.Any<CancellationToken>())
+            .Returns("admin-refresh-token");
+
+        ImpersonationResult result = await _sut.BackToImpersonatorAsync(
+            adminId, TestContext.Current.CancellationToken);
+
+        result.AccessToken.ShouldBe("admin-access-token");
+        result.RefreshToken.ShouldBe("admin-refresh-token");
+        result.ExpiresIn.ShouldBe(3600);
+    }
+
+    [Fact]
+    public async Task BackToImpersonatorAsync_CreatesTokensWithCorrectExpiry()
+    {
+        GranitUser admin = CreateUser();
+        string adminId = admin.Id.ToString();
+
+        _userManager.FindByIdAsync(adminId).Returns(admin);
+        _userManager.GetRolesAsync(admin).Returns(new List<string>());
+        SetupTokenCreation();
+
+        await _sut.BackToImpersonatorAsync(adminId, TestContext.Current.CancellationToken);
+
+        await _tokenManager.Received(1).CreateAsync(
+            Arg.Is<OpenIddictTokenDescriptor>(d =>
+                d.Type == OpenIddictConstants.TokenTypeHints.AccessToken &&
+                d.Subject == adminId &&
+                d.ExpirationDate == FixedNow + TimeSpan.FromHours(1)),
+            Arg.Any<CancellationToken>());
+
+        await _tokenManager.Received(1).CreateAsync(
+            Arg.Is<OpenIddictTokenDescriptor>(d =>
+                d.Type == OpenIddictConstants.TokenTypeHints.RefreshToken &&
+                d.Subject == adminId &&
+                d.ExpirationDate == FixedNow + TimeSpan.FromDays(14)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BackToImpersonatorAsync_UserNotFound_ThrowsInvalidOperation()
+    {
+        string unknownId = Guid.NewGuid().ToString();
+        _userManager.FindByIdAsync(unknownId).Returns((GranitUser?)null);
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.BackToImpersonatorAsync(unknownId, TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain(unknownId);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task BackToImpersonatorAsync_NullOrWhiteSpaceId_ThrowsArgument(string? impersonatorId)
+    {
+        await Should.ThrowAsync<ArgumentException>(
+            () => _sut.BackToImpersonatorAsync(impersonatorId!, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task BackToImpersonatorAsync_NullPayload_ReturnsEmptyToken()
+    {
+        GranitUser admin = CreateUser();
+        string adminId = admin.Id.ToString();
+
+        _userManager.FindByIdAsync(adminId).Returns(admin);
+        _userManager.GetRolesAsync(admin).Returns(new List<string>());
+
+        object tokenEntry = new object();
+        _tokenManager.CreateAsync(Arg.Any<OpenIddictTokenDescriptor>(), Arg.Any<CancellationToken>())
+            .Returns(tokenEntry);
+        _tokenManager.GetPayloadAsync(tokenEntry, Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+
+        ImpersonationResult result = await _sut.BackToImpersonatorAsync(
+            adminId, TestContext.Current.CancellationToken);
+
+        result.AccessToken.ShouldBe(string.Empty);
+        result.RefreshToken.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public async Task BackToImpersonatorAsync_UserWithNullUserName_UsesEmptyString()
+    {
+        GranitUser admin = CreateUser();
+        admin.UserName = null;
+        string adminId = admin.Id.ToString();
+
+        _userManager.FindByIdAsync(adminId).Returns(admin);
+        _userManager.GetRolesAsync(admin).Returns(new List<string>());
+        SetupTokenCreation();
+
+        ImpersonationResult result = await _sut.BackToImpersonatorAsync(
+            adminId, TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task BackToImpersonatorAsync_UserWithNullEmail_UsesEmptyString()
+    {
+        GranitUser admin = CreateUser();
+        admin.Email = null;
+        string adminId = admin.Id.ToString();
+
+        _userManager.FindByIdAsync(adminId).Returns(admin);
+        _userManager.GetRolesAsync(admin).Returns(new List<string>());
+        SetupTokenCreation();
+
+        ImpersonationResult result = await _sut.BackToImpersonatorAsync(
+            adminId, TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+    }
+
+    // ────────────────────── Helpers ──────────────────────
+
+    private static GranitUser CreateUser() => new()
+    {
+        Id = Guid.NewGuid(),
+        UserName = "testuser",
+        Email = "test@example.com",
+    };
+
+    private void SetupTokenCreation()
+    {
+        object tokenEntry = new object();
+        _tokenManager.CreateAsync(Arg.Any<OpenIddictTokenDescriptor>(), Arg.Any<CancellationToken>())
+            .Returns(tokenEntry);
+        _tokenManager.GetPayloadAsync(tokenEntry, Arg.Any<CancellationToken>())
+            .Returns("mock-token");
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IMeterFactory"/> for unit tests — returns a fresh <see cref="Meter"/>
+    /// per call without registration.
+    /// </summary>
+    private sealed class TestMeterFactory : IMeterFactory
+    {
+        public Meter Create(MeterOptions options) => new(options);
+        public void Dispose() { }
+    }
+}

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/AspNetPasskeyServiceTests.cs
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/AspNetPasskeyServiceTests.cs
@@ -1,0 +1,569 @@
+using System.Text.Json;
+using Granit.Identity.Local.Domain;
+using Granit.Identity.Local.Options;
+using Granit.Identity.Local.Services;
+using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Granit.Timing;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+
+public sealed class AspNetPasskeyServiceTests
+{
+    private static readonly DateTimeOffset FixedNow = new(2025, 6, 15, 10, 0, 0, TimeSpan.Zero);
+
+    private readonly UserManager<GranitUser> _userManager;
+    private readonly IClock _clock = Substitute.For<IClock>();
+    private readonly GranitPasskeyOptions _passkeyOptions;
+    private readonly AspNetPasskeyService _sut;
+
+    public AspNetPasskeyServiceTests()
+    {
+        IUserStore<GranitUser> store = Substitute.For<IUserStore<GranitUser>>();
+        _userManager = Substitute.For<UserManager<GranitUser>>(
+            store, null, null, null, null, null, null, null, null);
+
+        _clock.Now.Returns(FixedNow);
+
+        _passkeyOptions = new GranitPasskeyOptions
+        {
+            ServerDomain = "example.com",
+            AuthenticatorTimeout = TimeSpan.FromMinutes(5),
+            ChallengeSize = 32,
+        };
+
+        _sut = new AspNetPasskeyService(
+            _userManager,
+            Microsoft.Extensions.Options.Options.Create(_passkeyOptions),
+            _clock,
+            NullLogger<AspNetPasskeyService>.Instance);
+    }
+
+    // ────────────────────── GetPasskeysAsync ──────────────────────
+
+    [Fact]
+    public async Task GetPasskeysAsync_UserExists_ReturnsMappedPasskeys()
+    {
+        GranitUser user = CreateUser();
+        string userId = user.Id.ToString();
+        byte[] credentialId = new byte[32];
+        credentialId[0] = 0x01;
+
+        UserPasskeyInfo passkey = CreatePasskeyInfo(credentialId);
+        _userManager.FindByIdAsync(userId).Returns(user);
+        _userManager.GetPasskeysAsync(user).Returns(new List<UserPasskeyInfo> { passkey });
+
+        IReadOnlyList<PasskeyInfo> result = await _sut.GetPasskeysAsync(
+            userId, TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(1);
+        result[0].CreatedAt.ShouldBe(FixedNow);
+        result[0].LastUsedAt.ShouldBeNull();
+        result[0].Name.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetPasskeysAsync_UserNotFound_ThrowsInvalidOperation()
+    {
+        string unknownId = Guid.NewGuid().ToString();
+        _userManager.FindByIdAsync(unknownId).Returns((GranitUser?)null);
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.GetPasskeysAsync(unknownId, TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain(unknownId);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task GetPasskeysAsync_NullOrWhiteSpaceUserId_ThrowsArgument(string? userId)
+    {
+        await Should.ThrowAsync<ArgumentException>(
+            () => _sut.GetPasskeysAsync(userId!, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task GetPasskeysAsync_MultiplePasskeys_ReturnsAll()
+    {
+        GranitUser user = CreateUser();
+        string userId = user.Id.ToString();
+        byte[] credId1 = new byte[32];
+        byte[] credId2 = new byte[32];
+        credId1[0] = 0x01;
+        credId2[0] = 0x02;
+
+        _userManager.FindByIdAsync(userId).Returns(user);
+        _userManager.GetPasskeysAsync(user).Returns(new List<UserPasskeyInfo>
+        {
+            CreatePasskeyInfo(credId1),
+            CreatePasskeyInfo(credId2),
+        });
+
+        IReadOnlyList<PasskeyInfo> result = await _sut.GetPasskeysAsync(
+            userId, TestContext.Current.CancellationToken);
+
+        result.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GetPasskeysAsync_EmptyList_ReturnsEmpty()
+    {
+        GranitUser user = CreateUser();
+        string userId = user.Id.ToString();
+
+        _userManager.FindByIdAsync(userId).Returns(user);
+        _userManager.GetPasskeysAsync(user).Returns(new List<UserPasskeyInfo>());
+
+        IReadOnlyList<PasskeyInfo> result = await _sut.GetPasskeysAsync(
+            userId, TestContext.Current.CancellationToken);
+
+        result.ShouldBeEmpty();
+    }
+
+    // ────────────────────── BeginRegistrationAsync ──────────────────────
+
+    [Fact]
+    public async Task BeginRegistrationAsync_ReturnsValidJson()
+    {
+        var userId = Guid.NewGuid();
+
+        string json = await _sut.BeginRegistrationAsync(
+            userId.ToString(), TestContext.Current.CancellationToken);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("challenge").GetString().ShouldNotBeNullOrWhiteSpace();
+        doc.RootElement.GetProperty("rp").GetProperty("name").GetString().ShouldBe("Granit");
+        doc.RootElement.GetProperty("rp").GetProperty("id").GetString().ShouldBe("example.com");
+        doc.RootElement.GetProperty("attestation").GetString().ShouldBe("none");
+        doc.RootElement.GetProperty("mediation").GetString().ShouldBe("conditional");
+    }
+
+    [Fact]
+    public async Task BeginRegistrationAsync_ContainsUserInfo()
+    {
+        var userId = Guid.NewGuid();
+
+        string json = await _sut.BeginRegistrationAsync(
+            userId.ToString(), TestContext.Current.CancellationToken);
+
+        using var doc = JsonDocument.Parse(json);
+        JsonElement userElement = doc.RootElement.GetProperty("user");
+        userElement.GetProperty("name").GetString().ShouldBe(userId.ToString());
+        userElement.GetProperty("displayName").GetString().ShouldBe(userId.ToString());
+    }
+
+    [Fact]
+    public async Task BeginRegistrationAsync_ContainsPubKeyCredParams()
+    {
+        string json = await _sut.BeginRegistrationAsync(
+            Guid.NewGuid().ToString(), TestContext.Current.CancellationToken);
+
+        using var doc = JsonDocument.Parse(json);
+        JsonElement paramsArray = doc.RootElement.GetProperty("pubKeyCredParams");
+        paramsArray.GetArrayLength().ShouldBe(2);
+        paramsArray[0].GetProperty("alg").GetInt32().ShouldBe(-7);
+        paramsArray[1].GetProperty("alg").GetInt32().ShouldBe(-257);
+    }
+
+    [Fact]
+    public async Task BeginRegistrationAsync_UsesConfiguredTimeout()
+    {
+        _passkeyOptions.AuthenticatorTimeout = TimeSpan.FromMinutes(3);
+
+        string json = await _sut.BeginRegistrationAsync(
+            Guid.NewGuid().ToString(), TestContext.Current.CancellationToken);
+
+        using var doc = JsonDocument.Parse(json);
+        long timeout = doc.RootElement.GetProperty("timeout").GetInt64();
+        timeout.ShouldBe((long)TimeSpan.FromMinutes(3).TotalMilliseconds);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task BeginRegistrationAsync_NullOrWhiteSpaceUserId_ThrowsArgument(string? userId)
+    {
+        await Should.ThrowAsync<ArgumentException>(
+            () => _sut.BeginRegistrationAsync(userId!, TestContext.Current.CancellationToken));
+    }
+
+    // ────────────────────── CompleteRegistrationAsync ──────────────────────
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_ValidInput_ReturnsPasskeyInfo()
+    {
+        GranitUser user = CreateUser();
+        string userId = user.Id.ToString();
+
+        _userManager.FindByIdAsync(userId).Returns(user);
+
+        PasskeyInfo result = await _sut.CompleteRegistrationAsync(
+            userId, "{\"type\":\"public-key\"}", "My Key", TestContext.Current.CancellationToken);
+
+        result.Name.ShouldBe("My Key");
+        result.CreatedAt.ShouldBe(FixedNow);
+        result.LastUsedAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_CallsAddOrUpdatePasskey()
+    {
+        GranitUser user = CreateUser();
+        string userId = user.Id.ToString();
+
+        _userManager.FindByIdAsync(userId).Returns(user);
+
+        await _sut.CompleteRegistrationAsync(
+            userId, "{\"type\":\"public-key\"}", null, TestContext.Current.CancellationToken);
+
+        await _userManager.Received(1).AddOrUpdatePasskeyAsync(user, Arg.Any<UserPasskeyInfo>());
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_NullName_ReturnsNullName()
+    {
+        GranitUser user = CreateUser();
+        string userId = user.Id.ToString();
+
+        _userManager.FindByIdAsync(userId).Returns(user);
+
+        PasskeyInfo result = await _sut.CompleteRegistrationAsync(
+            userId, "{\"type\":\"public-key\"}", null, TestContext.Current.CancellationToken);
+
+        result.Name.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CompleteRegistrationAsync_UserNotFound_ThrowsInvalidOperation()
+    {
+        string unknownId = Guid.NewGuid().ToString();
+        _userManager.FindByIdAsync(unknownId).Returns((GranitUser?)null);
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.CompleteRegistrationAsync(
+                unknownId, "{\"type\":\"public-key\"}", null, TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain(unknownId);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task CompleteRegistrationAsync_NullOrWhiteSpaceUserId_ThrowsArgument(string? userId)
+    {
+        await Should.ThrowAsync<ArgumentException>(
+            () => _sut.CompleteRegistrationAsync(
+                userId!, "{}", null, TestContext.Current.CancellationToken));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task CompleteRegistrationAsync_NullOrWhiteSpaceCredentialJson_ThrowsArgument(string? credentialJson)
+    {
+        await Should.ThrowAsync<ArgumentException>(
+            () => _sut.CompleteRegistrationAsync(
+                Guid.NewGuid().ToString(), credentialJson!, null, TestContext.Current.CancellationToken));
+    }
+
+    // ────────────────────── BeginAssertionAsync ──────────────────────
+
+    [Fact]
+    public async Task BeginAssertionAsync_ReturnsValidJson()
+    {
+        string json = await _sut.BeginAssertionAsync(TestContext.Current.CancellationToken);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("challenge").GetString().ShouldNotBeNullOrWhiteSpace();
+        doc.RootElement.GetProperty("rpId").GetString().ShouldBe("example.com");
+        doc.RootElement.GetProperty("userVerification").GetString().ShouldBe("preferred");
+        doc.RootElement.GetProperty("mediation").GetString().ShouldBe("conditional");
+    }
+
+    [Fact]
+    public async Task BeginAssertionAsync_HasEmptyAllowCredentials()
+    {
+        string json = await _sut.BeginAssertionAsync(TestContext.Current.CancellationToken);
+
+        using var doc = JsonDocument.Parse(json);
+        JsonElement allowCredentials = doc.RootElement.GetProperty("allowCredentials");
+        allowCredentials.GetArrayLength().ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task BeginAssertionAsync_UsesConfiguredTimeout()
+    {
+        _passkeyOptions.AuthenticatorTimeout = TimeSpan.FromMinutes(2);
+
+        string json = await _sut.BeginAssertionAsync(TestContext.Current.CancellationToken);
+
+        using var doc = JsonDocument.Parse(json);
+        long timeout = doc.RootElement.GetProperty("timeout").GetInt64();
+        timeout.ShouldBe((long)TimeSpan.FromMinutes(2).TotalMilliseconds);
+    }
+
+    // ────────────────────── CompleteAssertionAsync ──────────────────────
+
+    [Fact]
+    public async Task CompleteAssertionAsync_ValidCredential_ReturnsSuccess()
+    {
+        GranitUser user = CreateUser();
+        byte[] credentialId = new byte[32];
+        credentialId[0] = 0xAA;
+        string credentialIdBase64 = Convert.ToBase64String(credentialId);
+        string credentialJson = $"{{\"id\":\"{credentialIdBase64}\"}}";
+
+        _userManager.FindByPasskeyIdAsync(Arg.Is<byte[]>(b => b.Length == credentialId.Length))
+            .Returns(user);
+        _userManager.GetPasskeysAsync(user).Returns(new List<UserPasskeyInfo>
+        {
+            CreatePasskeyInfo(credentialId),
+        });
+
+        GranitPasskeyAssertionResult result = await _sut.CompleteAssertionAsync(
+            credentialJson, TestContext.Current.CancellationToken);
+
+        result.Succeeded.ShouldBeTrue();
+        result.UserId.ShouldBe(user.Id.ToString());
+    }
+
+    [Fact]
+    public async Task CompleteAssertionAsync_MissingIdProperty_ReturnsFailed()
+    {
+        string credentialJson = "{\"type\":\"public-key\"}";
+
+        GranitPasskeyAssertionResult result = await _sut.CompleteAssertionAsync(
+            credentialJson, TestContext.Current.CancellationToken);
+
+        result.Succeeded.ShouldBeFalse();
+        result.UserId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CompleteAssertionAsync_UserNotFoundForCredential_ReturnsFailed()
+    {
+        byte[] credentialId = new byte[32];
+        string credentialIdBase64 = Convert.ToBase64String(credentialId);
+        string credentialJson = $"{{\"id\":\"{credentialIdBase64}\"}}";
+
+        _userManager.FindByPasskeyIdAsync(Arg.Any<byte[]>()).Returns((GranitUser?)null);
+
+        GranitPasskeyAssertionResult result = await _sut.CompleteAssertionAsync(
+            credentialJson, TestContext.Current.CancellationToken);
+
+        result.Succeeded.ShouldBeFalse();
+        result.UserId.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CompleteAssertionAsync_CredentialNotInUserPasskeys_ReturnsFailed()
+    {
+        GranitUser user = CreateUser();
+        byte[] credentialId = new byte[32];
+        credentialId[0] = 0xBB;
+        string credentialIdBase64 = Convert.ToBase64String(credentialId);
+        string credentialJson = $"{{\"id\":\"{credentialIdBase64}\"}}";
+
+        // User is found by passkey lookup but the credential doesn't match stored ones
+        _userManager.FindByPasskeyIdAsync(Arg.Any<byte[]>()).Returns(user);
+
+        byte[] differentCredentialId = new byte[32];
+        differentCredentialId[0] = 0xCC;
+        _userManager.GetPasskeysAsync(user).Returns(new List<UserPasskeyInfo>
+        {
+            CreatePasskeyInfo(differentCredentialId),
+        });
+
+        GranitPasskeyAssertionResult result = await _sut.CompleteAssertionAsync(
+            credentialJson, TestContext.Current.CancellationToken);
+
+        result.Succeeded.ShouldBeFalse();
+        result.UserId.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task CompleteAssertionAsync_NullOrWhiteSpaceCredentialJson_ThrowsArgument(string? credentialJson)
+    {
+        await Should.ThrowAsync<ArgumentException>(
+            () => _sut.CompleteAssertionAsync(credentialJson!, TestContext.Current.CancellationToken));
+    }
+
+    // ────────────────────── RenameAsync ──────────────────────
+
+    [Fact]
+    public async Task RenameAsync_ValidInput_CompletesWithoutException()
+    {
+        var passkeyId = Guid.NewGuid();
+
+        await Should.NotThrowAsync(
+            () => _sut.RenameAsync(
+                Guid.NewGuid().ToString(), passkeyId, "New Name", TestContext.Current.CancellationToken));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task RenameAsync_NullOrWhiteSpaceNewName_ThrowsArgument(string? newName)
+    {
+        await Should.ThrowAsync<ArgumentException>(
+            () => _sut.RenameAsync(
+                Guid.NewGuid().ToString(), Guid.NewGuid(), newName!, TestContext.Current.CancellationToken));
+    }
+
+    // ────────────────────── DeleteAsync ──────────────────────
+
+    [Fact]
+    public async Task DeleteAsync_MultiplePasskeysAndNoPassword_Succeeds()
+    {
+        GranitUser user = CreateUser();
+        string userId = user.Id.ToString();
+        var passkeyId = Guid.NewGuid();
+
+        _userManager.FindByIdAsync(userId).Returns(user);
+        _userManager.HasPasswordAsync(user).Returns(false);
+        _userManager.GetPasskeysAsync(user).Returns(new List<UserPasskeyInfo>
+        {
+            CreatePasskeyInfo(new byte[32]),
+            CreatePasskeyInfo(new byte[32]),
+        });
+        _userManager.RemovePasskeyAsync(user, Arg.Any<byte[]>()).Returns(IdentityResult.Success);
+
+        await Should.NotThrowAsync(
+            () => _sut.DeleteAsync(userId, passkeyId, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_LastPasskeyWithPassword_Succeeds()
+    {
+        GranitUser user = CreateUser();
+        string userId = user.Id.ToString();
+        var passkeyId = Guid.NewGuid();
+
+        _userManager.FindByIdAsync(userId).Returns(user);
+        _userManager.HasPasswordAsync(user).Returns(true);
+        _userManager.GetPasskeysAsync(user).Returns(new List<UserPasskeyInfo>
+        {
+            CreatePasskeyInfo(new byte[32]),
+        });
+        _userManager.RemovePasskeyAsync(user, Arg.Any<byte[]>()).Returns(IdentityResult.Success);
+
+        await Should.NotThrowAsync(
+            () => _sut.DeleteAsync(userId, passkeyId, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_LastPasskeyWithoutPassword_ThrowsInvalidOperation()
+    {
+        GranitUser user = CreateUser();
+        string userId = user.Id.ToString();
+        var passkeyId = Guid.NewGuid();
+
+        _userManager.FindByIdAsync(userId).Returns(user);
+        _userManager.HasPasswordAsync(user).Returns(false);
+        _userManager.GetPasskeysAsync(user).Returns(new List<UserPasskeyInfo>
+        {
+            CreatePasskeyInfo(new byte[32]),
+        });
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.DeleteAsync(userId, passkeyId, TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("last passkey");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovePasskeyFails_ThrowsInvalidOperation()
+    {
+        GranitUser user = CreateUser();
+        string userId = user.Id.ToString();
+        var passkeyId = Guid.NewGuid();
+
+        _userManager.FindByIdAsync(userId).Returns(user);
+        _userManager.HasPasswordAsync(user).Returns(true);
+        _userManager.GetPasskeysAsync(user).Returns(new List<UserPasskeyInfo>
+        {
+            CreatePasskeyInfo(new byte[32]),
+            CreatePasskeyInfo(new byte[32]),
+        });
+        _userManager.RemovePasskeyAsync(user, Arg.Any<byte[]>())
+            .Returns(IdentityResult.Failed(new IdentityError { Description = "Passkey not found" }));
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.DeleteAsync(userId, passkeyId, TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("Passkey not found");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_UserNotFound_ThrowsInvalidOperation()
+    {
+        string unknownId = Guid.NewGuid().ToString();
+        _userManager.FindByIdAsync(unknownId).Returns((GranitUser?)null);
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.DeleteAsync(unknownId, Guid.NewGuid(), TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain(unknownId);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task DeleteAsync_NullOrWhiteSpaceUserId_ThrowsArgument(string? userId)
+    {
+        await Should.ThrowAsync<ArgumentException>(
+            () => _sut.DeleteAsync(userId!, Guid.NewGuid(), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ZeroPasskeysWithoutPassword_ThrowsInvalidOperation()
+    {
+        GranitUser user = CreateUser();
+        string userId = user.Id.ToString();
+
+        _userManager.FindByIdAsync(userId).Returns(user);
+        _userManager.HasPasswordAsync(user).Returns(false);
+        _userManager.GetPasskeysAsync(user).Returns(new List<UserPasskeyInfo>());
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => _sut.DeleteAsync(userId, Guid.NewGuid(), TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("last passkey");
+    }
+
+    // ────────────────────── Helpers ──────────────────────
+
+    private static GranitUser CreateUser() => new()
+    {
+        Id = Guid.NewGuid(),
+        UserName = "testuser",
+        Email = "test@example.com",
+    };
+
+    private static UserPasskeyInfo CreatePasskeyInfo(byte[] credentialId) =>
+        new(
+            credentialId: credentialId,
+            publicKey: new byte[65],
+            createdAt: FixedNow,
+            signCount: 0,
+            transports: ["internal"],
+            isUserVerified: true,
+            isBackupEligible: true,
+            isBackedUp: false,
+            attestationObject: [],
+            clientDataJson: []);
+}


### PR DESCRIPTION
## Summary

- Add **250+ new tests** (unit + integration) — phase 2 of coverage improvement
- Targets the 8 modules with the most uncovered lines identified via SonarCloud

## Test breakdown

| Module | Type | Tests added | Target files |
|--------|------|-------------|-------------|
| OpenIddict.EntityFrameworkCore | Unit | +62 | ImpersonationService, PasskeyService, AccountDeletionService |
| OpenIddict.Endpoints | Integration | +43 | Admin CRUD, OidcPrincipalFactory, connect endpoints |
| Identity.Local.Endpoints | Integration | +42 | Passkey, external login, impersonation, login errors, 2FA |
| Notifications.Email | Unit | +20 | EmailNotificationChannel edge cases |
| Bff.Yarp | Unit | +16 | BffTokenInjectionTransform |
| Bff | Unit | +15 | LogoutTokenValidator |
| Oidc.TokenManagement | Unit | +14 | TokenEndpointService |
| Http.Resilience | Unit | +12 | HttpResilienceMetrics |

## Expected coverage impact

Phase 1 (#786) brought coverage from 73.2% to 76.8%. This phase targets ~2 000 additional
lines across the 8 modules with the largest uncovered blocks, aiming for ~80%.

## Test plan

- [x] All 8 modified test projects build and pass (626 tests total)
- [ ] CI pipeline passes
- [ ] SonarCloud quality gate passes
