### PR TITLE
fix(notifications): initialize definition store from providers

### DIFF
--- a/src/Granit.Notifications/Extensions/NotificationsHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Notifications/Extensions/NotificationsHostApplicationBuilderExtensions.cs
@@ -58,8 +58,20 @@ public static class NotificationsHostApplicationBuilderExtensions
 
         builder.Services.AddScoped<INotificationDeliveryWriter, NullNotificationDeliveryWriter>();
 
-        // Definition store (singleton)
-        builder.Services.AddSingleton<NotificationDefinitionStore>();
+        // Definition store (singleton) — initialized eagerly from all registered providers
+        builder.Services.AddSingleton<NotificationDefinitionStore>(sp =>
+        {
+            NotificationDefinitionStore store = new();
+            IEnumerable<INotificationDefinitionProvider> providers = sp.GetServices<INotificationDefinitionProvider>();
+            NotificationDefinitionContext ctx = new();
+            foreach (INotificationDefinitionProvider provider in providers)
+            {
+                provider.Define(ctx);
+            }
+
+            store.Initialize(ctx.GetDefinitions());
+            return store;
+        });
         builder.Services.AddSingleton<INotificationDefinitionStore>(sp => sp.GetRequiredService<NotificationDefinitionStore>());
 
         // Handlers (scoped — required by the Channel-based worker)


### PR DESCRIPTION
## Summary

- `NotificationDefinitionStore.Initialize()` was never called — the store remained empty at runtime
- All notifications fell back to `InApp` channel instead of using the definition's `DefaultChannels` (e.g. `Email`)
- Fix: use a factory-based singleton registration that eagerly collects all `INotificationDefinitionProvider` instances and populates the store via `NotificationDefinitionContext`

## Root cause

`AddGranitNotifications()` registered `NotificationDefinitionStore` as a plain singleton, but no code ever called `store.Initialize(definitions)`. The `internal` visibility of `Initialize()` meant only code within `Granit.Notifications` could call it — and nothing did.

## Test plan

- [ ] Trigger `POST /api/account/forgot-password` → verify delivery attempt shows `ChannelName = "Email"` (not `"InApp"`)
- [ ] Verify email arrives in Mailpit
- [ ] Run `dotnet test tests/Granit.Notifications.Tests`