### PR TITLE
refactor: harmonize Map* endpoint extension method naming

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1933,9 +1933,9 @@
       "line": 16,
       "members": [
         {
-          "name": "MapAIEndpoints",
+          "name": "MapGranitAI",
           "kind": "method",
-          "signature": "MapAIEndpoints(this IEndpointRouteBuilder endpoints, Action<AIEndpointsOptions>? configure = null)",
+          "signature": "MapGranitAI(this IEndpointRouteBuilder endpoints, Action<AIEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -3551,9 +3551,9 @@
       "line": 14,
       "members": [
         {
-          "name": "MapAuditingEndpoints",
+          "name": "MapGranitAuditing",
           "kind": "method",
-          "signature": "MapAuditingEndpoints(this IEndpointRouteBuilder endpoints, Action<AuditingEndpointsOptions>? configure = null)",
+          "signature": "MapGranitAuditing(this IEndpointRouteBuilder endpoints, Action<AuditingEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -4050,9 +4050,9 @@
       "line": 14,
       "members": [
         {
-          "name": "MapApiKeysEndpoints",
+          "name": "MapGranitApiKeys",
           "kind": "method",
-          "signature": "MapApiKeysEndpoints(this IEndpointRouteBuilder endpoints, Action<ApiKeysEndpointsOptions>? configure = null)",
+          "signature": "MapGranitApiKeys(this IEndpointRouteBuilder endpoints, Action<ApiKeysEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -4775,9 +4775,9 @@
       "line": 14,
       "members": [
         {
-          "name": "MapBackChannelLogout",
+          "name": "MapGranitBackChannelLogout",
           "kind": "method",
-          "signature": "MapBackChannelLogout(this IEndpointRouteBuilder endpoints)",
+          "signature": "MapGranitBackChannelLogout(this IEndpointRouteBuilder endpoints)",
           "returnType": "IEndpointRouteBuilder"
         }
       ]
@@ -5473,9 +5473,9 @@
       "line": 13,
       "members": [
         {
-          "name": "MapAuthorizationEndpoints",
+          "name": "MapGranitAuthorization",
           "kind": "method",
-          "signature": "MapAuthorizationEndpoints(this IEndpointRouteBuilder endpoints, Action<AuthorizationEndpointsOptions>? configure = null)",
+          "signature": "MapGranitAuthorization(this IEndpointRouteBuilder endpoints, Action<AuthorizationEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -5842,9 +5842,9 @@
       "line": 14,
       "members": [
         {
-          "name": "MapBackgroundJobsEndpoints",
+          "name": "MapGranitBackgroundJobs",
           "kind": "method",
-          "signature": "MapBackgroundJobsEndpoints(this IEndpointRouteBuilder endpoints, Action<BackgroundJobsEndpointsOptions>? configure = null)",
+          "signature": "MapGranitBackgroundJobs(this IEndpointRouteBuilder endpoints, Action<BackgroundJobsEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -6310,9 +6310,9 @@
       "line": 19,
       "members": [
         {
-          "name": "MapGranitBffEndpoints",
+          "name": "MapGranitBff",
           "kind": "method",
-          "signature": "MapGranitBffEndpoints(this IEndpointRouteBuilder endpoints)",
+          "signature": "MapGranitBff(this IEndpointRouteBuilder endpoints)",
           "returnType": "IEndpointRouteBuilder"
         }
       ]
@@ -7130,9 +7130,9 @@
       "line": 17,
       "members": [
         {
-          "name": "MapBlobStorageEndpoints",
+          "name": "MapGranitBlobStorage",
           "kind": "method",
-          "signature": "MapBlobStorageEndpoints(this IEndpointRouteBuilder endpoints, Action<BlobStorageEndpointsOptions>? configure = null)",
+          "signature": "MapGranitBlobStorage(this IEndpointRouteBuilder endpoints, Action<BlobStorageEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -7693,9 +7693,9 @@
       "line": 17,
       "members": [
         {
-          "name": "MapGranitBlobProxyEndpoints",
+          "name": "MapGranitBlobProxy",
           "kind": "method",
-          "signature": "MapGranitBlobProxyEndpoints(this IEndpointRouteBuilder endpoints)",
+          "signature": "MapGranitBlobProxy(this IEndpointRouteBuilder endpoints)",
           "returnType": "IEndpointRouteBuilder"
         }
       ]
@@ -8420,9 +8420,9 @@
       "line": 15,
       "members": [
         {
-          "name": "MapDataExchangeEndpoints",
+          "name": "MapGranitDataExchange",
           "kind": "method",
-          "signature": "MapDataExchangeEndpoints(this IEndpointRouteBuilder endpoints, Action<DataExchangeEndpointsOptions>? configure = null)",
+          "signature": "MapGranitDataExchange(this IEndpointRouteBuilder endpoints, Action<DataExchangeEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -14400,9 +14400,9 @@
       "line": 14,
       "members": [
         {
-          "name": "MapIdentityUserCacheEndpoints",
+          "name": "MapGranitIdentityUserCache",
           "kind": "method",
-          "signature": "MapIdentityUserCacheEndpoints(this IEndpointRouteBuilder endpoints, Action<IdentityEndpointsOptions>? configure = null)",
+          "signature": "MapGranitIdentityUserCache(this IEndpointRouteBuilder endpoints, Action<IdentityEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -14432,9 +14432,9 @@
       "line": 15,
       "members": [
         {
-          "name": "MapIdentityProviderEndpoints",
+          "name": "MapGranitIdentityProvider",
           "kind": "method",
-          "signature": "MapIdentityProviderEndpoints(this IEndpointRouteBuilder endpoints, Action<IdentityProviderEndpointsOptions>? configure = null)",
+          "signature": "MapGranitIdentityProvider(this IEndpointRouteBuilder endpoints, Action<IdentityProviderEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -15789,9 +15789,9 @@
       "line": 12,
       "members": [
         {
-          "name": "MapAccountEndpoints",
+          "name": "MapGranitAccount",
           "kind": "method",
-          "signature": "MapAccountEndpoints(this IEndpointRouteBuilder endpoints, Action<AccountEndpointsOptions>? configure = null)",
+          "signature": "MapGranitAccount(this IEndpointRouteBuilder endpoints, Action<AccountEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -19333,9 +19333,9 @@
       "line": 19,
       "members": [
         {
-          "name": "MapMobilePushTokenEndpoints",
+          "name": "MapGranitMobilePushTokens",
           "kind": "method",
-          "signature": "MapMobilePushTokenEndpoints(this IEndpointRouteBuilder endpoints, string prefix = \"api/notifications/mobile-push/tokens\")",
+          "signature": "MapGranitMobilePushTokens(this IEndpointRouteBuilder endpoints, string prefix = \"api/notifications/mobile-push/tokens\")",
           "returnType": "IEndpointRouteBuilder"
         }
       ]
@@ -19349,9 +19349,9 @@
       "line": 23,
       "members": [
         {
-          "name": "MapGranitNotificationEndpoints",
+          "name": "MapGranitNotifications",
           "kind": "method",
-          "signature": "MapGranitNotificationEndpoints(this IEndpointRouteBuilder endpoints, Action<NotificationEndpointsOptions>? configure = null)",
+          "signature": "MapGranitNotifications(this IEndpointRouteBuilder endpoints, Action<NotificationEndpointsOptions>? configure = null)",
           "returnType": "IEndpointRouteBuilder"
         }
       ]
@@ -20338,9 +20338,9 @@
       "line": 15,
       "members": [
         {
-          "name": "MapGranitSseNotificationEndpoints",
+          "name": "MapGranitSseNotifications",
           "kind": "method",
-          "signature": "MapGranitSseNotificationEndpoints(this IEndpointRouteBuilder endpoints)",
+          "signature": "MapGranitSseNotifications(this IEndpointRouteBuilder endpoints)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -21809,9 +21809,9 @@
       "line": 12,
       "members": [
         {
-          "name": "MapOpenIddictEndpoints",
+          "name": "MapGranitOpenIddict",
           "kind": "method",
-          "signature": "MapOpenIddictEndpoints(this IEndpointRouteBuilder endpoints, Action<OpenIddictEndpointsOptions>? configure = null)",
+          "signature": "MapGranitOpenIddict(this IEndpointRouteBuilder endpoints, Action<OpenIddictEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -27738,9 +27738,9 @@
       "line": 35,
       "members": [
         {
-          "name": "MapGranitTemplatingAdmin",
+          "name": "MapGranitTemplating",
           "kind": "method",
-          "signature": "MapGranitTemplatingAdmin(this IEndpointRouteBuilder endpoints, Action<TemplatingEndpointsOptions>? configure = null)",
+          "signature": "MapGranitTemplating(this IEndpointRouteBuilder endpoints, Action<TemplatingEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -28977,9 +28977,9 @@
       "line": 14,
       "members": [
         {
-          "name": "MapTimelineEndpoints",
+          "name": "MapGranitTimeline",
           "kind": "method",
-          "signature": "MapTimelineEndpoints(this IEndpointRouteBuilder endpoints, Action<TimelineEndpointsOptions>? configure = null)",
+          "signature": "MapGranitTimeline(this IEndpointRouteBuilder endpoints, Action<TimelineEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -31381,9 +31381,9 @@
       "line": 18,
       "members": [
         {
-          "name": "MapWebhooksEndpoints",
+          "name": "MapGranitWebhooks",
           "kind": "method",
-          "signature": "MapWebhooksEndpoints(this IEndpointRouteBuilder endpoints, Action<WebhooksEndpointsOptions>? configure = null)",
+          "signature": "MapGranitWebhooks(this IEndpointRouteBuilder endpoints, Action<WebhooksEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -32439,9 +32439,9 @@
       "line": 14,
       "members": [
         {
-          "name": "MapWorkflowEndpoints",
+          "name": "MapGranitWorkflow",
           "kind": "method",
-          "signature": "MapWorkflowEndpoints(this IEndpointRouteBuilder endpoints, Action<WorkflowEndpointsOptions>? configure = null)",
+          "signature": "MapGranitWorkflow(this IEndpointRouteBuilder endpoints, Action<WorkflowEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]

--- a/docs-site/src/content/docs/blog/why-your-react-app-should-never-touch-an-access-token.mdx
+++ b/docs-site/src/content/docs/blog/why-your-react-app-should-never-touch-an-access-token.mdx
@@ -239,7 +239,7 @@ builder.AddGranitBffYarp();
 
 var app = builder.Build();
 
-app.MapGranitBffEndpoints();
+app.MapGranitBff();
 app.UseGranitBffYarp();
 
 app.Run();

--- a/docs-site/src/content/docs/dotnet/ai/endpoints.mdx
+++ b/docs-site/src/content/docs/dotnet/ai/endpoints.mdx
@@ -43,10 +43,10 @@ builder.AddGranitAIEntityFrameworkCore(o => ...) // Persistence (workspaces + us
 builder.AddGranitAIOpenAI();                     // Provider (or AzureOpenAI, Ollama...)
 
 // Route registration
-app.MapAIEndpoints();
+app.MapGranitAI();
 
 // With custom options:
-app.MapAIEndpoints(opts =>
+app.MapGranitAI(opts =>
 {
     opts.RoutePrefix = "api/ai";
     opts.AdminRole = "platform-admin";
@@ -81,7 +81,7 @@ returns `422 Unprocessable Entity` with `AI:Workspace:SystemImmutable`.
 ### Usage tracking (Admin) via Granit.QueryEngine
 
 Instead of custom listing endpoints, usage records are exposed through
-`MapQueryEndpoints<AIUsageRecord>` — providing filtering, sorting, pagination,
+`MapGranitQuery<AIUsageRecord>` — providing filtering, sorting, pagination,
 groupBy with aggregates, saved views, and metadata out of the box.
 
 | Route | Features |

--- a/docs-site/src/content/docs/dotnet/api/blob-storage-endpoints.mdx
+++ b/docs-site/src/content/docs/dotnet/api/blob-storage-endpoints.mdx
@@ -27,10 +27,10 @@ by the `BlobStorage.Admin` authorization policy with configurable role requireme
 
 ```csharp
 // In your application startup
-app.MapBlobStorageEndpoints();
+app.MapGranitBlobStorage();
 
 // With custom options:
-app.MapBlobStorageEndpoints(opts =>
+app.MapGranitBlobStorage(opts =>
 {
     opts.RoutePrefix = "admin/blobs";
     opts.RequiredRole = "storage-admin";

--- a/docs-site/src/content/docs/dotnet/api/endpoint-registry.mdx
+++ b/docs-site/src/content/docs/dotnet/api/endpoint-registry.mdx
@@ -26,14 +26,14 @@ for request/response types — this page focuses on **routes, methods, and permi
 // Application startup (e.g., Program.cs)
 RouteGroupBuilder api = app.MapGroup("api/v{version:apiVersion}");
 
-api.MapGranitBlobStorageEndpoints();   // → /api/v1/blobs/...
-api.MapGranitTemplatingEndpoints();    // → /api/v1/templates/...
-api.MapGranitIdentityEndpoints();      // → /api/v1/identity/users/...
+api.MapGranitBlobStorage();      // → /api/v1/blobs/...
+api.MapGranitTemplating();       // → /api/v1/templates/...
+api.MapGranitIdentityUserCache();// → /api/v1/identity/users/...
 ```
 
 - **Permissions:** follow `[Group].[Resource].[Action]` (three segments)
 - **Error responses:** all endpoints return RFC 7807 Problem Details on errors
-- **Query endpoints** (`MapQueryEndpoints<T>`) are registered by the **application**,
+- **Query endpoints** (`MapGranitQuery<T>`) are registered by the **application**,
   not the framework — the route pattern is app-defined
 - **Routes below** show only the module-relative path (without the app prefix)
 
@@ -184,7 +184,7 @@ Identity uses **two separate endpoint groups** with distinct prefixes.
 
 ### User Cache (`identity/users`)
 
-**Module:** `Granit.Identity.Endpoints` — `MapGranitIdentityEndpoints()`
+**Module:** `Granit.Identity.Endpoints` — `MapGranitIdentityUserCache()`
 **Prefix:** `identity/users`
 
 | Method | Route | Operation | Permission |
@@ -201,7 +201,7 @@ Identity uses **two separate endpoint groups** with distinct prefixes.
 
 ### Identity Provider (`identity/provider`)
 
-**Module:** `Granit.Identity.Endpoints` — `MapGranitIdentityProviderEndpoints()`
+**Module:** `Granit.Identity.Endpoints` — `MapGranitIdentityProvider()`
 **Prefix:** `identity/provider`
 
 #### Users
@@ -319,7 +319,7 @@ and admin management (permission-protected).
 
 ### Account Self-Service (`account`)
 
-**Module:** `Granit.OpenIddict.Endpoints` — `MapOpenIddictEndpoints()`
+**Module:** `Granit.OpenIddict.Endpoints` — `MapGranitOpenIddict()`
 **Prefix:** `account`
 
 #### Registration & Email
@@ -385,7 +385,7 @@ and admin management (permission-protected).
 
 ### Admin Management (`admin`)
 
-**Module:** `Granit.OpenIddict.Endpoints` — `MapOpenIddictEndpoints()`
+**Module:** `Granit.OpenIddict.Endpoints` — `MapGranitOpenIddict()`
 **Prefix:** `admin`
 
 #### Users
@@ -513,11 +513,11 @@ interface OidcAuthorizationResponse {
 ## QueryEngine
 
 **Module:** `Granit.QueryEngine.Endpoints`
-**Prefix:** app-defined via `MapQueryEndpoints<T>(pattern)`
+**Prefix:** app-defined via `MapGranitQuery<T>(pattern)`
 
 <Aside type="caution">
 QueryEngine endpoints are registered by the **application**, not the framework.
-The route pattern is passed to `MapQueryEndpoints<T>()`. For consistency,
+The route pattern is passed to `MapGranitQuery<T>()`. For consistency,
 use the same prefix as the module's CRUD endpoints (e.g., `/localization/overrides`).
 </Aside>
 
@@ -730,7 +730,7 @@ use the same prefix as the module's CRUD endpoints (e.g., `/localization/overrid
 
 <Aside type="caution">
 Reference Data endpoints are registered per entity type by the **application**
-via `MapGranitReferenceDataEndpoints<T>()`. Each entity gets its own sub-group
+via `MapGranitReferenceData<T>()`. Each entity gets its own sub-group
 under the prefix.
 </Aside>
 

--- a/docs-site/src/content/docs/dotnet/api/webhooks-endpoints.mdx
+++ b/docs-site/src/content/docs/dotnet/api/webhooks-endpoints.mdx
@@ -34,10 +34,10 @@ operations (write, lifecycle, operations) additionally require
 
 ```csharp
 // In your application startup
-app.MapWebhooksEndpoints();
+app.MapGranitWebhooks();
 
 // With custom options:
-app.MapWebhooksEndpoints(opts =>
+app.MapGranitWebhooks(opts =>
 {
     opts.RoutePrefix = "admin/webhooks";
     opts.TagName = "Webhook Administration";

--- a/docs-site/src/content/docs/dotnet/architecture/patterns/specification.md
+++ b/docs-site/src/content/docs/dotnet/architecture/patterns/specification.md
@@ -157,7 +157,7 @@ public sealed class InvoiceQueryDefinition : QueryDefinition<Invoice>
 
 // --- Usage (endpoint) ---
 // GET /api/invoices?filter[amount.gte]=1000&presets[status]=Sent,Paid&sort=-issuedAt&page=1
-group.MapQueryEndpoints<Invoice>("/api/invoices",
+group.MapGranitQuery<Invoice>("/api/invoices",
     sp => sp.GetRequiredService<BillingDbContext>().Invoices.AsNoTracking());
 ```
 

--- a/docs-site/src/content/docs/dotnet/business/data-exchange.mdx
+++ b/docs-site/src/content/docs/dotnet/business/data-exchange.mdx
@@ -78,10 +78,10 @@ public class AppModule : GranitModule
 
 ```csharp
 // Map endpoints in Program.cs
-app.MapDataExchangeEndpoints();
+app.MapGranitDataExchange();
 
 // Or with custom prefix and role
-app.MapDataExchangeEndpoints(opts =>
+app.MapGranitDataExchange(opts =>
 {
     opts.RoutePrefix = "admin/data-exchange";
     opts.RequiredRole = "ops-team";
@@ -495,7 +495,7 @@ dispatchers with Wolverine's `IMessageBus` for durable outbox-backed execution:
 | Mapping | `MappingConfidence`, `ImportColumnMapping`, `ISemanticMappingService` | `Granit.DataExchange` |
 | Options | `ImportOptions`, `ExportOptions`, `ImportExecutionOptions` | `Granit.DataExchange` |
 | Permissions | `DataExchangePermissions.Imports.{Read,Execute}`, `DataExchangePermissions.Exports.{Read,Execute}` | `Granit.DataExchange.Endpoints` |
-| Extensions | `AddImportDefinition<T, TDef>()`, `AddExportDefinition<T, TDef>()`, `AddSemanticMappingService<T>()`, `MapDataExchangeEndpoints()` | --- |
+| Extensions | `AddImportDefinition<T, TDef>()`, `AddExportDefinition<T, TDef>()`, `AddSemanticMappingService<T>()`, `MapGranitDataExchange()` | --- |
 
 ## Security
 

--- a/docs-site/src/content/docs/dotnet/business/query-engine.mdx
+++ b/docs-site/src/content/docs/dotnet/business/query-engine.mdx
@@ -25,7 +25,7 @@ grid — no duplication.
 | ------- | ---- | ---------- |
 | `Granit.QueryEngine` | `IQueryEngine<T>`, `QueryDefinition<T>`, `QueryRequest`, `PagedResult<T>` | `Granit` |
 | `Granit.QueryEngine.EntityFrameworkCore` | EF Core query executor | `Granit.QueryEngine`, `Granit.Persistence` |
-| `Granit.QueryEngine.Endpoints` | `MapQueryEndpoints<T>()` generic search endpoint | `Granit.QueryEngine` |
+| `Granit.QueryEngine.Endpoints` | `MapGranitQuery<T>()` generic search endpoint | `Granit.QueryEngine` |
 | `Granit.QueryEngine.AI` | NL-to-query translation via LLM | `Granit.QueryEngine`, `Granit.AI` |
 
 ## Security hardening
@@ -34,18 +34,18 @@ The query engine applies defense-in-depth across multiple layers:
 
 ### Authentication by default
 
-All endpoints registered via `MapQueryEndpoints<T>()` require authentication by
+All endpoints registered via `MapGranitQuery<T>()` require authentication by
 default. To apply a named policy use `AuthorizationPolicy`; to opt out
 explicitly use `AllowAnonymous`:
 
 ```csharp
-endpoints.MapQueryEndpoints<Invoice>("/api/invoices", sp => ..., options =>
+endpoints.MapGranitQuery<Invoice>("/api/invoices", sp => ..., options =>
 {
     options.AuthorizationPolicy = "Invoices.Read"; // named policy
 });
 
 // Rare: anonymous access (public catalog)
-endpoints.MapQueryEndpoints<Product>("/api/products", sp => ..., options =>
+endpoints.MapGranitQuery<Product>("/api/products", sp => ..., options =>
 {
     options.AllowAnonymous = true;
 });

--- a/docs-site/src/content/docs/dotnet/business/reference-data.mdx
+++ b/docs-site/src/content/docs/dotnet/business/reference-data.mdx
@@ -95,7 +95,7 @@ public sealed class CountryConfiguration
 
 // 3. Register store + endpoints
 services.AddReferenceDataStore<Country, AppDbContext>();
-app.MapReferenceDataEndpoints<Country>();
+app.MapGranitReferenceData<Country>();
 ```
 
 </TabItem>
@@ -123,7 +123,7 @@ services.AddReferenceData<AppDbContext>(rd =>
 });
 
 // 2. Map all registered types in one call
-app.MapAllReferenceDataEndpoints();
+app.MapGranitAllReferenceData();
 ```
 
 </TabItem>
@@ -310,7 +310,7 @@ public sealed class CountrySeeder : IReferenceDataSeeder<Country>
 | Entity | `ReferenceDataEntity`, `DynamicReferenceDataEntity`, `IHasExtraProperties` | `Granit.ReferenceData`, `Granit` |
 | Store | `IReferenceDataStoreReader<T>`, `IReferenceDataStoreWriter<T>`, `IReferenceDataSeeder<T>` | `Granit.ReferenceData` |
 | Registration | `AddReferenceDataStore<T, TDb>()`, `AddReferenceData<TDb>()`, `ReferenceDataBuilder` | `Granit.ReferenceData.EntityFrameworkCore` |
-| Endpoints | `MapReferenceDataEndpoints<T>()`, `MapAllReferenceDataEndpoints()` | `Granit.ReferenceData.Endpoints` |
+| Endpoints | `MapGranitReferenceData<T>()`, `MapGranitAllReferenceData()` | `Granit.ReferenceData.Endpoints` |
 | Registry | `ReferenceDataRegistry`, `ReferenceDataTypeRegistration` | `Granit.ReferenceData` |
 | ExtraProperties | `ExtraPropertyExtensions`, `ExtraPropertyMappingOptions<T>` | `Granit`, `Granit.Persistence` |
 

--- a/docs-site/src/content/docs/dotnet/business/templating.mdx
+++ b/docs-site/src/content/docs/dotnet/business/templating.mdx
@@ -85,7 +85,7 @@ public class AppModule : GranitModule
 Map the admin endpoints in `Program.cs`:
 
 ```csharp
-app.MapGranitTemplatingAdmin(options =>
+app.MapGranitTemplating(options =>
 {
     options.RoutePrefix = "api/v1/templates";
     options.TagName = "Template Administration";
@@ -395,7 +395,7 @@ services.AddEmbeddedTemplates(typeof(AcmeTemplates).Assembly);
 
 ## Admin endpoints
 
-16 endpoints are registered via `MapGranitTemplatingAdmin()`. All require the
+16 endpoints are registered via `MapGranitTemplating()`. All require the
 `Templates.Manage` permission.
 
 ### Template endpoints
@@ -434,7 +434,7 @@ If `IDocumentTemplateStoreReader`/`IDocumentTemplateStoreWriter` is not register
 ### Endpoints
 
 ```csharp
-app.MapGranitTemplatingAdmin(options =>
+app.MapGranitTemplating(options =>
 {
     options.RoutePrefix = "api/v1/templates";  // default: "templates"
     options.TagName = "Template Administration"; // default: "Templates"
@@ -481,7 +481,7 @@ A discharge letter template stored in the EF Core store or as an embedded resour
 | Lifecycle | `TemplateLifecycleStatus`, `ITemplateTransitionHook`, `TemplateRevision` | `Granit.Templating` |
 | Permissions | `TemplatingPermissions.Manage` (`"Templates.Manage"`) | `Granit.Templating.Endpoints` |
 | Extensions | `AddGranitTemplating()`, `AddGranitTemplatingWithScriban()`, `AddEmbeddedTemplates()` | -- |
-| Extensions | `MapGranitTemplatingAdmin()` | `Granit.Templating.Endpoints` |
+| Extensions | `MapGranitTemplating()` | `Granit.Templating.Endpoints` |
 
 ## When to use — and when not to
 

--- a/docs-site/src/content/docs/dotnet/business/timeline.mdx
+++ b/docs-site/src/content/docs/dotnet/business/timeline.mdx
@@ -70,7 +70,7 @@ builder.AddGranitTimelineEntityFrameworkCore(
     opts => opts.UseNpgsql(connectionString));
 
 // Map endpoints in the app pipeline
-app.MapTimelineEndpoints();
+app.MapGranitTimeline();
 ```
 
 </TabItem>
@@ -210,7 +210,7 @@ await timeline.AddAttachmentAsync(
 | Timeline core | `ITimelined`, `ITimelineReader`, `ITimelineWriter`, `ITimelineFollowerService`, `ITimelineNotifier` | `Granit.Timeline` |
 | DTOs | `TimelineStreamEntry`, `TimelineStreamEntryType`, `TimelineAttachmentInfo`, `PostTimelineEntryRequest` | `Granit.Timeline` |
 | Permissions | `TimelinePermissions.Entries.{Read,Create,Manage}`, `.InternalNotes.Read`, `.Followers.Manage` | `Granit.Timeline.Endpoints` |
-| Extensions | `AddGranitTimeline()`, `AddGranitTimelineEntityFrameworkCore()`, `MapTimelineEndpoints()` | — |
+| Extensions | `AddGranitTimeline()`, `AddGranitTimelineEntityFrameworkCore()`, `MapGranitTimeline()` | — |
 
 ## See also
 

--- a/docs-site/src/content/docs/dotnet/business/workflow.mdx
+++ b/docs-site/src/content/docs/dotnet/business/workflow.mdx
@@ -68,7 +68,7 @@ public class AppModule : GranitModule
 
 ```csharp
 // Program.cs
-app.MapWorkflowEndpoints();
+app.MapGranitWorkflow();
 ```
 
 </TabItem>
@@ -389,7 +389,7 @@ This registers:
 
 ```csharp
 // Program.cs
-app.MapWorkflowEndpoints();
+app.MapGranitWorkflow();
 ```
 
 Query parameters: `page` (default 1), `pageSize` (default 20, max 100).
@@ -436,7 +436,7 @@ consumption (notifications, timeline).
 | Events | `WorkflowTransitionedEvent<TState>`, `WorkflowStateChangedEvent`, `WorkflowApprovalRequestedEvent` | `Granit.Workflow` |
 | EF Core | `IWorkflowDbContext`, `WorkflowTransitionInterceptor` | `Granit.Workflow.EntityFrameworkCore` |
 | Notifications | `IApproverResolver`, `WorkflowApprovalNotificationType`, `WorkflowStateChangedNotificationType` | `Granit.Workflow.Notifications` |
-| Extensions | `AddGranitWorkflow()`, `AddGranitWorkflowEntityFrameworkCore<T>()`, `AddGranitWorkflowEndpoints()`, `AddGranitWorkflowNotifications()`, `MapWorkflowEndpoints()` | -- |
+| Extensions | `AddGranitWorkflow()`, `AddGranitWorkflowEntityFrameworkCore<T>()`, `AddGranitWorkflowEndpoints()`, `AddGranitWorkflowNotifications()`, `MapGranitWorkflow()` | -- |
 
 ## When to use — and when not to
 

--- a/docs-site/src/content/docs/dotnet/compliance/audit-log.mdx
+++ b/docs-site/src/content/docs/dotnet/compliance/audit-log.mdx
@@ -59,7 +59,7 @@ services.AddDbContextFactory<AppDbContext>((sp, options) =>
 ### 4. Map endpoints (optional)
 
 ```csharp
-app.MapAuditingEndpoints();
+app.MapGranitAuditing();
 ```
 
 That's it. Every `SaveChanges` on your `AppDbContext` now produces audit entries automatically.

--- a/docs-site/src/content/docs/dotnet/concepts/security-model.mdx
+++ b/docs-site/src/content/docs/dotnet/concepts/security-model.mdx
@@ -239,7 +239,7 @@ The flow:
 
 ```csharp
 // In OnApplicationInitialization
-app.MapBackChannelLogout(); // POST /auth/back-channel-logout (anonymous)
+app.MapGranitBackChannelLogout(); // POST /auth/back-channel-logout (anonymous)
 ```
 
 :::caution[Warning]

--- a/docs-site/src/content/docs/dotnet/data/blob-storage.mdx
+++ b/docs-site/src/content/docs/dotnet/data/blob-storage.mdx
@@ -210,7 +210,7 @@ builder.AddGranitBlobStorageEntityFrameworkCore(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("BlobStorage")));
 
 var app = builder.Build();
-app.MapGranitBlobProxyEndpoints();
+app.MapGranitBlobProxy();
 ```
 
 ```json
@@ -244,7 +244,7 @@ builder.AddGranitBlobStorageEntityFrameworkCore(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("BlobStorage")));
 
 var app = builder.Build();
-app.MapGranitBlobProxyEndpoints();
+app.MapGranitBlobProxy();
 ```
 
 ```json
@@ -777,7 +777,7 @@ Verifies GCS connectivity by listing one object in the default bucket. Tagged
 | FileSystem options | `FileSystemBlobOptions` | `Granit.BlobStorage.FileSystem` |
 | DbStore options | `DbStoreBlobOptions` | `Granit.BlobStorage.DbStore` |
 | Proxy options | `ProxyBlobOptions` | `Granit.BlobStorage.Proxy` |
-| Extensions | `AddGranitBlobStorageS3()`, `AddGranitBlobStorageAzureBlob()`, `AddGranitBlobStorageGoogleCloud()`, `AddGranitBlobStorageFileSystem()`, `AddGranitBlobStorageDbStore()`, `AddGranitBlobStorageProxy()`, `AddGranitBlobStorageEntityFrameworkCore()`, `MapGranitBlobProxyEndpoints()` | -- |
+| Extensions | `AddGranitBlobStorageS3()`, `AddGranitBlobStorageAzureBlob()`, `AddGranitBlobStorageGoogleCloud()`, `AddGranitBlobStorageFileSystem()`, `AddGranitBlobStorageDbStore()`, `AddGranitBlobStorageProxy()`, `AddGranitBlobStorageEntityFrameworkCore()`, `MapGranitBlobProxy()` | -- |
 
 ## See also
 

--- a/docs-site/src/content/docs/dotnet/guides/add-background-jobs.mdx
+++ b/docs-site/src/content/docs/dotnet/guides/add-background-jobs.mdx
@@ -129,13 +129,13 @@ All occurrences are calculated in UTC. If you need tenant-local time, use
 ## 6. Map administration endpoints
 
 ```csharp
-app.MapBackgroundJobsEndpoints();
+app.MapGranitBackgroundJobs();
 ```
 
 Or with custom options:
 
 ```csharp
-app.MapBackgroundJobsEndpoints(opts =>
+app.MapGranitBackgroundJobs(opts =>
 {
     opts.RoutePrefix = "admin/jobs";
     opts.RequiredRole = "ops-team";

--- a/docs-site/src/content/docs/dotnet/guides/implement-audit-timeline.mdx
+++ b/docs-site/src/content/docs/dotnet/guides/implement-audit-timeline.mdx
@@ -231,10 +231,10 @@ automatically excluded by the EF Core global filter.
 `Granit.Timeline.Endpoints` provides a full Minimal API surface:
 
 ```csharp
-app.MapTimelineEndpoints();
+app.MapGranitTimeline();
 
 // With a custom route prefix:
-app.MapTimelineEndpoints(opts => opts.RoutePrefix = "admin/timeline");
+app.MapGranitTimeline(opts => opts.RoutePrefix = "admin/timeline");
 ```
 
 ### Available endpoints

--- a/docs-site/src/content/docs/dotnet/guides/implement-data-import.mdx
+++ b/docs-site/src/content/docs/dotnet/guides/implement-data-import.mdx
@@ -207,7 +207,7 @@ the business key.
 ## 5. Map REST endpoints
 
 ```csharp
-app.MapDataExchangeEndpoints();
+app.MapGranitDataExchange();
 ```
 
 ### Import routes

--- a/docs-site/src/content/docs/dotnet/guides/implement-workflow.mdx
+++ b/docs-site/src/content/docs/dotnet/guides/implement-workflow.mdx
@@ -179,7 +179,7 @@ builder.Services.AddGranitWorkflowNotifications();
 builder.Services.AddGranitWorkflowEndpoints();
 
 // After app.Build()
-app.MapWorkflowEndpoints();
+app.MapGranitWorkflow();
 ```
 
 ## Step 7 -- Trigger transitions

--- a/docs-site/src/content/docs/dotnet/guides/set-up-notifications.mdx
+++ b/docs-site/src/content/docs/dotnet/guides/set-up-notifications.mdx
@@ -134,7 +134,7 @@ Then set `"Provider": "Brevo"` in each channel's configuration section.
 ## 4. Map endpoints
 
 ```csharp
-app.MapGranitNotificationEndpoints();
+app.MapGranitNotifications();
 ```
 
 This registers the inbox, preferences, subscriptions, and entity follower endpoints

--- a/docs-site/src/content/docs/dotnet/guides/use-reference-data.mdx
+++ b/docs-site/src/content/docs/dotnet/guides/use-reference-data.mdx
@@ -211,8 +211,8 @@ services.AddTransient<IReferenceDataSeeder<Country>, CountrySeeder>();
 <TabItem label="Strongly-typed">
 
 ```csharp
-app.MapReferenceDataEndpoints<Country>();
-app.MapReferenceDataEndpoints<Currency>(opts =>
+app.MapGranitReferenceData<Country>();
+app.MapGranitReferenceData<Currency>(opts =>
 {
     opts.RoutePrefix = "api/ref";
     opts.TagName = "Currencies";
@@ -224,11 +224,11 @@ app.MapReferenceDataEndpoints<Currency>(opts =>
 
 ```csharp
 // Map all registered dynamic types in one call
-app.MapAllReferenceDataEndpoints();
+app.MapGranitAllReferenceData();
 
 // Or map selectively
-app.MapReferenceDataEndpoints("Countries");
-app.MapReferenceDataEndpoints("Categories", opts =>
+app.MapGranitReferenceData("Countries");
+app.MapGranitReferenceData("Categories", opts =>
     opts.TagName = "Categories");
 ```
 

--- a/docs-site/src/content/docs/dotnet/infrastructure/background-jobs.mdx
+++ b/docs-site/src/content/docs/dotnet/infrastructure/background-jobs.mdx
@@ -90,7 +90,7 @@ public class AppModule : GranitModule
 Route registration in `Program.cs`:
 
 ```csharp
-app.MapBackgroundJobsEndpoints();
+app.MapGranitBackgroundJobs();
 ```
 
 </TabItem>
@@ -380,7 +380,7 @@ operations and `BackgroundJobs.Jobs.Manage` for mutations:
 Default route prefix: `background-jobs`. Customize via `BackgroundJobsEndpointsOptions`:
 
 ```csharp
-app.MapBackgroundJobsEndpoints(opts =>
+app.MapGranitBackgroundJobs(opts =>
 {
     opts.RoutePrefix = "admin/jobs";
     opts.RequiredRole = "ops-team";
@@ -470,7 +470,7 @@ When `Granit.Observability` is loaded, the activity source is auto-discovered vi
 | Options | `BackgroundJobsOptions`, `BackgroundJobsEndpointsOptions` | -- |
 | Permissions | `BackgroundJobsPermissions.Jobs.Read`, `BackgroundJobsPermissions.Jobs.Manage` | `Granit.BackgroundJobs.Endpoints` |
 | Middleware | `RecurringJobSchedulingMiddleware` | `Granit.BackgroundJobs.Wolverine` |
-| Extensions | `AddGranitBackgroundJobs()`, `AddGranitBackgroundJobsEntityFrameworkCore()`, `MapBackgroundJobsEndpoints()` | -- |
+| Extensions | `AddGranitBackgroundJobs()`, `AddGranitBackgroundJobsEntityFrameworkCore()`, `MapGranitBackgroundJobs()` | -- |
 
 ## When to use — and when not to
 

--- a/docs-site/src/content/docs/dotnet/infrastructure/notifications.mdx
+++ b/docs-site/src/content/docs/dotnet/infrastructure/notifications.mdx
@@ -146,7 +146,7 @@ public class AppModule : GranitModule
 
     public override void OnApplicationInitialization(ApplicationInitializationContext context)
     {
-        context.App.MapGranitNotificationEndpoints();
+        context.App.MapGranitNotifications();
         context.App.MapHub<NotificationHub>("/hubs/notifications");
     }
 }
@@ -720,7 +720,7 @@ another user's notification as read or remove another user's device token.
 
 ### Mobile push tokens
 
-Mapped separately via `MapMobilePushTokenEndpoints()` under
+Mapped separately via `MapGranitMobilePushTokens()` under
 `api/notifications/mobile-push/tokens`:
 
 | Method | Route | Permission | Description |
@@ -1157,7 +1157,7 @@ Tags: `notifications.type`, `notifications.channel`, `notifications.delivery_id`
 | Zulip | `IZulipSender`, `ZulipMessage` | `Granit.Notifications.Zulip` |
 | Exceptions | `NotificationDeliveryException` | `Granit.Notifications` |
 | Endpoints | `NotificationEndpointsOptions`, `MobilePushTokenEndpoints` | `Granit.Notifications.Endpoints` |
-| Extensions | `AddGranitNotifications()`, `AddGranitNotificationsEntityFrameworkCore()`, `AddGranitNotificationsEmail()`, `AddGranitNotificationsEmailSmtp()`, `AddGranitNotificationsEmailAcs()`, `AddGranitNotificationsEmailScaleway()`, `AddGranitNotificationsEmailSendGrid()`, `AddGranitNotificationsBrevo()`, `AddGranitNotificationsSms()`, `AddGranitNotificationsSmsAcs()`, `AddGranitNotificationsSmsAwsSns()`, `AddGranitNotificationsTwilio()`, `AddGranitNotificationsWhatsApp()`, `AddGranitNotificationsMobilePush()`, `AddGranitNotificationsMobilePushGoogleFcm()`, `AddGranitNotificationsMobilePushAzureNotificationHubs()`, `AddGranitNotificationsMobilePushAwsSns()`, `AddGranitNotificationsSignalR()`, `AddGranitNotificationsPush()`, `AddGranitNotificationsSse()`, `AddGranitNotificationsZulip()`, `AddNotificationDefinitions<T>()`, `MapGranitNotificationEndpoints()`, `MapMobilePushTokenEndpoints()` | various |
+| Extensions | `AddGranitNotifications()`, `AddGranitNotificationsEntityFrameworkCore()`, `AddGranitNotificationsEmail()`, `AddGranitNotificationsEmailSmtp()`, `AddGranitNotificationsEmailAcs()`, `AddGranitNotificationsEmailScaleway()`, `AddGranitNotificationsEmailSendGrid()`, `AddGranitNotificationsBrevo()`, `AddGranitNotificationsSms()`, `AddGranitNotificationsSmsAcs()`, `AddGranitNotificationsSmsAwsSns()`, `AddGranitNotificationsTwilio()`, `AddGranitNotificationsWhatsApp()`, `AddGranitNotificationsMobilePush()`, `AddGranitNotificationsMobilePushGoogleFcm()`, `AddGranitNotificationsMobilePushAzureNotificationHubs()`, `AddGranitNotificationsMobilePushAwsSns()`, `AddGranitNotificationsSignalR()`, `AddGranitNotificationsPush()`, `AddGranitNotificationsSse()`, `AddGranitNotificationsZulip()`, `AddNotificationDefinitions<T>()`, `MapGranitNotifications()`, `MapGranitMobilePushTokens()` | various |
 
 ## Cross-module recipes
 

--- a/docs-site/src/content/docs/dotnet/security/authentication.mdx
+++ b/docs-site/src/content/docs/dotnet/security/authentication.mdx
@@ -226,7 +226,7 @@ specification. When the IdP sends a logout token, the session is revoked in dist
 
 ```csharp
 // In OnApplicationInitialization
-app.MapBackChannelLogout(); // POST /auth/back-channel-logout (anonymous)
+app.MapGranitBackChannelLogout(); // POST /auth/back-channel-logout (anonymous)
 ```
 
 The endpoint validates the logout token signature against the IdP's JWKS, extracts the `sid`
@@ -369,7 +369,7 @@ Enabling it while some clients still use plain Bearer tokens will lock those cli
 | Claims | `GoogleCloudClaimsTransformation` | `Granit.Authentication.JwtBearer.GoogleCloud` |
 | Options | `JwtBearerAuthOptions`, `KeycloakOptions`, `CognitoOptions`, `GoogleCloudOptions` | — |
 | DPoP | `IDPoPProofValidator`, `JwkThumbprintCalculator`, `DPoPValidationMiddleware` | `Granit.Authentication.DPoP` |
-| Extensions | `AddGranitJwtBearer()`, `AddGranitKeycloak()`, `AddGranitCognito()`, `MapBackChannelLogout()`, `UseGranitDPoPValidation()` | — |
+| Extensions | `AddGranitJwtBearer()`, `AddGranitKeycloak()`, `AddGranitCognito()`, `MapGranitBackChannelLogout()`, `UseGranitDPoPValidation()` | — |
 
 ## See also
 

--- a/docs-site/src/content/docs/dotnet/security/bff/getting-started.mdx
+++ b/docs-site/src/content/docs/dotnet/security/bff/getting-started.mdx
@@ -220,7 +220,7 @@ app.UseStaticFiles();
 app.UseRouting();
 
 // Map BFF endpoints (/bff/login, /bff/callback, /bff/logout, /bff/user, /bff/csrf-token)
-app.MapGranitBffEndpoints();
+app.MapGranitBff();
 
 // Map YARP reverse proxy (with token injection)
 app.UseGranitBffYarp();
@@ -244,7 +244,7 @@ flowchart LR
 ```
 
 <Aside type="caution" title="Middleware order">
-`UseGranitBffYarp()` must come **after** `MapGranitBffEndpoints()`. If reversed,
+`UseGranitBffYarp()` must come **after** `MapGranitBff()`. If reversed,
 YARP may intercept BFF endpoint routes before they are handled.
 </Aside>
 

--- a/docs-site/src/content/docs/dotnet/security/bff/index.mdx
+++ b/docs-site/src/content/docs/dotnet/security/bff/index.mdx
@@ -147,7 +147,7 @@ Granit.Bff is split into three packages following the standard Granit module ana
     - BffUserEndpoints.cs User claims for the SPA (filtered from ID token)
     - BffCsrfEndpoints.cs CSRF token generation endpoint
   - Extensions/
-    - BffEndpointRouteBuilderExtensions.cs MapGranitBffEndpoints() + security headers middleware
+    - BffEndpointRouteBuilderExtensions.cs MapGranitBff() + security headers middleware
   - GranitBffEndpointsModule.cs Module registration
 - Granit.Bff.Yarp/ YARP reverse proxy with token injection + CSRF validation
   - Internal/

--- a/docs-site/src/content/docs/dotnet/security/identity.mdx
+++ b/docs-site/src/content/docs/dotnet/security/identity.mdx
@@ -78,7 +78,7 @@ public class AppModule : GranitModule
 
     public override void OnApplicationInitialization(ApplicationInitializationContext context)
     {
-        context.App.MapIdentityUserCacheEndpoints();
+        context.App.MapGranitIdentityUserCache();
     }
 }
 ```
@@ -100,7 +100,7 @@ public class AppModule : GranitModule
 
     public override void OnApplicationInitialization(ApplicationInitializationContext context)
     {
-        context.App.MapIdentityUserCacheEndpoints();
+        context.App.MapGranitIdentityUserCache();
     }
 }
 ```
@@ -123,7 +123,7 @@ public class AppModule : GranitModule
 
     public override void OnApplicationInitialization(ApplicationInitializationContext context)
     {
-        context.App.MapIdentityUserCacheEndpoints();
+        context.App.MapGranitIdentityUserCache();
     }
 }
 ```
@@ -519,7 +519,7 @@ Both operations emit Wolverine domain events (`IdentityUserDeletedEvent`,
 | Google Cloud Auth | `GoogleCloudClaimsTransformation`, `GoogleCloudAuthenticationOptions` | `Granit.Authentication.JwtBearer.GoogleCloud` |
 | EF Core | `UserCacheEntry`, `IUserCacheDbContext`, `UserCacheOptions` | `Granit.Identity.Federated.EntityFrameworkCore` |
 | Endpoints | `IdentityEndpointsOptions`, `IdentityWebhookOptions` | `Granit.Identity.Endpoints` |
-| Extensions | `AddGranitIdentity()`, `AddIdentityProvider<T>()`, `AddGranitIdentityKeycloak()`, `AddGranitIdentityCognito()`, `AddGranitIdentityGoogleCloud()`, `AddGranitGoogleCloudAuthentication()`, `AddGranitIdentityEntityFrameworkCore<T>()`, `AddGranitIdentityEndpoints()`, `MapIdentityUserCacheEndpoints()` | — |
+| Extensions | `AddGranitIdentity()`, `AddIdentityProvider<T>()`, `AddGranitIdentityKeycloak()`, `AddGranitIdentityCognito()`, `AddGranitIdentityGoogleCloud()`, `AddGranitGoogleCloudAuthentication()`, `AddGranitIdentityEntityFrameworkCore<T>()`, `AddGranitIdentityEndpoints()`, `MapGranitIdentityUserCache()` | — |
 
 ## See also
 

--- a/docs-site/src/content/docs/dotnet/security/openiddict/account-management-api.mdx
+++ b/docs-site/src/content/docs/dotnet/security/openiddict/account-management-api.mdx
@@ -13,7 +13,7 @@ provider-agnostic module shared between OpenIddict and any future auth provider
 (e.g. Duende Identity Server). Endpoints are available at `/api/account`
 (configurable via `AccountEndpointsOptions.AccountRoutePrefix`). All endpoints
 use `MapGranitGroup()` for automatic FluentValidation. Register them by calling
-`app.MapAccountEndpoints()`.
+`app.MapGranitAccount()`.
 
 ## Endpoint summary
 
@@ -591,7 +591,7 @@ All request DTOs have corresponding FluentValidation validators auto-discovered 
 Route prefixes and OpenAPI tags are configurable:
 
 ```csharp
-app.MapAccountEndpoints(options =>
+app.MapGranitAccount(options =>
 {
     options.AccountRoutePrefix = "api/account";    // default
     options.AdminRoutePrefix = "api/admin";        // default

--- a/docs-site/src/content/docs/dotnet/security/openiddict/configuration.mdx
+++ b/docs-site/src/content/docs/dotnet/security/openiddict/configuration.mdx
@@ -291,7 +291,7 @@ environment variables. Never commit secrets to source control.
 
 ## OpenIddictEndpointsOptions
 
-**Configured in:** `MapOpenIddictEndpoints()` lambda
+**Configured in:** `MapGranitOpenIddict()` lambda
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
@@ -303,7 +303,7 @@ environment variables. Never commit secrets to source control.
 **Example:**
 
 ```csharp
-app.MapOpenIddictEndpoints(options =>
+app.MapGranitOpenIddict(options =>
 {
     options.AccountRoutePrefix = "api/v1/account";
     options.AdminRoutePrefix = "api/v1/admin";

--- a/docs-site/src/content/docs/dotnet/security/openiddict/index.mdx
+++ b/docs-site/src/content/docs/dotnet/security/openiddict/index.mdx
@@ -120,7 +120,7 @@ app.UseAuthentication();
 app.UseOpenIddict();       // MUST be between Authentication and Authorization
 app.UseAuthorization();
 
-app.MapOpenIddictEndpoints();
+app.MapGranitOpenIddict();
 ```
 
 ### 5. Run migrations

--- a/src/Granit.AI.Endpoints/Extensions/AIEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.AI.Endpoints/Extensions/AIEndpointRouteBuilderExtensions.cs
@@ -21,10 +21,10 @@ public static class AIEndpointRouteBuilderExtensions
     /// <remarks>
     /// <para>Call this from your application route registration:</para>
     /// <code>
-    /// app.MapAIEndpoints();
+    /// app.MapGranitAI();
     ///
     /// // With custom options:
-    /// app.MapAIEndpoints(opts =>
+    /// app.MapGranitAI(opts =>
     /// {
     ///     opts.RoutePrefix = "api/ai";
     /// });
@@ -33,7 +33,7 @@ public static class AIEndpointRouteBuilderExtensions
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize <see cref="AIEndpointsOptions"/>.</param>
     /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
-    public static RouteGroupBuilder MapAIEndpoints(
+    public static RouteGroupBuilder MapGranitAI(
         this IEndpointRouteBuilder endpoints,
         Action<AIEndpointsOptions>? configure = null)
     {
@@ -62,7 +62,7 @@ public static class AIEndpointRouteBuilderExtensions
             RouteGroupBuilder usageGroup = group.MapGroup("")
                 .WithTags(options.UsageTagName)
                 .RequireAuthorization(AIPermissions.Usage.Read);
-            usageGroup.MapQueryEndpoints<AIUsageRecord>(
+            usageGroup.MapGranitQuery<AIUsageRecord>(
                 "usage/query",
                 sp => sp.GetRequiredService<IAIUsageQueryableProvider>().GetUsageRecords());
         }

--- a/src/Granit.Auditing.Endpoints/Extensions/AuditingEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Auditing.Endpoints/Extensions/AuditingEndpointRouteBuilderExtensions.cs
@@ -23,10 +23,10 @@ public static class AuditingEndpointRouteBuilderExtensions
     /// <para>All endpoints are protected by the <c>Auditing.AuditEntries.Read</c> permission.</para>
     /// <para>Call from your application:</para>
     /// <code>
-    /// app.MapAuditingEndpoints();
+    /// app.MapGranitAuditing();
     /// </code>
     /// </remarks>
-    public static RouteGroupBuilder MapAuditingEndpoints(
+    public static RouteGroupBuilder MapGranitAuditing(
         this IEndpointRouteBuilder endpoints,
         Action<AuditingEndpointsOptions>? configure = null)
     {

--- a/src/Granit.Auditing.Endpoints/GranitAuditingEndpointsModule.cs
+++ b/src/Granit.Auditing.Endpoints/GranitAuditingEndpointsModule.cs
@@ -11,7 +11,7 @@ namespace Granit.Auditing.Endpoints;
 /// <remarks>
 /// <para>
 /// This module does not auto-map routes. The host application must call
-/// <c>app.MapAuditingEndpoints()</c> in the pipeline configuration.
+/// <c>app.MapGranitAuditing()</c> in the pipeline configuration.
 /// </para>
 /// </remarks>
 [DependsOn(

--- a/src/Granit.Authentication.ApiKeys.Endpoints/Extensions/ApiKeysEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Authentication.ApiKeys.Endpoints/Extensions/ApiKeysEndpointRouteBuilderExtensions.cs
@@ -29,7 +29,7 @@ public static class ApiKeysEndpointRouteBuilderExtensions
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize <see cref="ApiKeysEndpointsOptions"/>.</param>
     /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
-    public static RouteGroupBuilder MapApiKeysEndpoints(
+    public static RouteGroupBuilder MapGranitApiKeys(
         this IEndpointRouteBuilder endpoints,
         Action<ApiKeysEndpointsOptions>? configure = null)
     {

--- a/src/Granit.Authentication.JwtBearer/Extensions/JwtBearerEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Authentication.JwtBearer/Extensions/JwtBearerEndpointRouteBuilderExtensions.cs
@@ -20,7 +20,7 @@ public static class JwtBearerEndpointRouteBuilderExtensions
     /// </summary>
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <returns>The <paramref name="endpoints"/> for chaining.</returns>
-    public static IEndpointRouteBuilder MapBackChannelLogout(this IEndpointRouteBuilder endpoints)
+    public static IEndpointRouteBuilder MapGranitBackChannelLogout(this IEndpointRouteBuilder endpoints)
     {
         JwtBearerAuthOptions options = endpoints.ServiceProvider
             .GetRequiredService<IOptions<JwtBearerAuthOptions>>().Value;
@@ -37,4 +37,5 @@ public static class JwtBearerEndpointRouteBuilderExtensions
 
         return endpoints;
     }
+
 }

--- a/src/Granit.Authorization.Endpoints/Extensions/AuthorizationEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Authorization.Endpoints/Extensions/AuthorizationEndpointRouteBuilderExtensions.cs
@@ -24,10 +24,10 @@ public static class AuthorizationEndpointRouteBuilderExtensions
     /// </list>
     /// <para>Call this from your application route registration:</para>
     /// <code>
-    /// app.MapAuthorizationEndpoints();
+    /// app.MapGranitAuthorization();
     ///
     /// // With a custom prefix:
-    /// app.MapAuthorizationEndpoints(opts =>
+    /// app.MapGranitAuthorization(opts =>
     /// {
     ///     opts.ApiPrefix = "api/v1";
     ///     opts.RoutePrefix = "authorization";
@@ -37,7 +37,7 @@ public static class AuthorizationEndpointRouteBuilderExtensions
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize <see cref="AuthorizationEndpointsOptions"/>.</param>
     /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
-    public static RouteGroupBuilder MapAuthorizationEndpoints(
+    public static RouteGroupBuilder MapGranitAuthorization(
         this IEndpointRouteBuilder endpoints,
         Action<AuthorizationEndpointsOptions>? configure = null)
     {

--- a/src/Granit.Authorization.Endpoints/GranitAuthorizationEndpointsModule.cs
+++ b/src/Granit.Authorization.Endpoints/GranitAuthorizationEndpointsModule.cs
@@ -9,7 +9,7 @@ namespace Granit.Authorization.Endpoints;
 /// </summary>
 /// <remarks>
 /// Exposes permission management routes via
-/// <see cref="Extensions.AuthorizationEndpointRouteBuilderExtensions.MapAuthorizationEndpoints"/>.
+/// <see cref="Extensions.AuthorizationEndpointRouteBuilderExtensions.MapGranitAuthorization"/>.
 /// Requires <see cref="GranitAuthorizationModule"/> for permission policy enforcement.
 /// The application host must register an implementation of
 /// <see cref="Abstractions.IPermissionManagerReader"/>/<see cref="Abstractions.IPermissionManagerWriter"/>

--- a/src/Granit.Authorization.Endpoints/Options/AuthorizationEndpointsOptions.cs
+++ b/src/Granit.Authorization.Endpoints/Options/AuthorizationEndpointsOptions.cs
@@ -3,7 +3,7 @@ namespace Granit.Authorization.Endpoints.Options;
 /// <summary>
 /// Configuration options for the authorization management endpoints.
 /// Bind from <c>"AuthorizationEndpoints"</c> or pass an action to
-/// <see cref="Extensions.AuthorizationEndpointRouteBuilderExtensions.MapAuthorizationEndpoints"/>.
+/// <see cref="Extensions.AuthorizationEndpointRouteBuilderExtensions.MapGranitAuthorization"/>.
 /// </summary>
 public sealed class AuthorizationEndpointsOptions
 {

--- a/src/Granit.BackgroundJobs.Endpoints/Extensions/BackgroundJobsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.BackgroundJobs.Endpoints/Extensions/BackgroundJobsEndpointRouteBuilderExtensions.cs
@@ -23,10 +23,10 @@ public static class BackgroundJobsEndpointRouteBuilderExtensions
     /// </para>
     /// <para>Call this from your application route registration:</para>
     /// <code>
-    /// app.MapBackgroundJobsEndpoints();
+    /// app.MapGranitBackgroundJobs();
     ///
     /// // With a custom prefix:
-    /// app.MapBackgroundJobsEndpoints(opts =>
+    /// app.MapGranitBackgroundJobs(opts =>
     /// {
     ///     opts.RoutePrefix = "admin/jobs";
     /// });
@@ -40,7 +40,7 @@ public static class BackgroundJobsEndpointRouteBuilderExtensions
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize <see cref="BackgroundJobsEndpointsOptions"/>.</param>
     /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
-    public static RouteGroupBuilder MapBackgroundJobsEndpoints(
+    public static RouteGroupBuilder MapGranitBackgroundJobs(
         this IEndpointRouteBuilder endpoints,
         Action<BackgroundJobsEndpointsOptions>? configure = null)
     {

--- a/src/Granit.BackgroundJobs.Endpoints/GranitBackgroundJobsEndpointsModule.cs
+++ b/src/Granit.BackgroundJobs.Endpoints/GranitBackgroundJobsEndpointsModule.cs
@@ -10,7 +10,7 @@ namespace Granit.BackgroundJobs.Endpoints;
 /// </summary>
 /// <remarks>
 /// Exposes job management routes via
-/// <see cref="Extensions.BackgroundJobsEndpointRouteBuilderExtensions.MapBackgroundJobsEndpoints"/>.
+/// <see cref="Extensions.BackgroundJobsEndpointRouteBuilderExtensions.MapGranitBackgroundJobs"/>.
 /// Requires both <see cref="GranitBackgroundJobsModule"/> (job store and manager)
 /// and <see cref="GranitAuthorizationModule"/> (permission policy enforcement).
 /// Permission definition providers are auto-discovered by <c>GranitAuthorizationModule</c>.

--- a/src/Granit.BackgroundJobs.Endpoints/Options/BackgroundJobsEndpointsOptions.cs
+++ b/src/Granit.BackgroundJobs.Endpoints/Options/BackgroundJobsEndpointsOptions.cs
@@ -3,7 +3,7 @@ namespace Granit.BackgroundJobs.Endpoints.Options;
 /// <summary>
 /// Configuration options for the background jobs administration endpoints.
 /// Bind from <c>"BackgroundJobsEndpoints"</c> or pass an action to
-/// <see cref="Extensions.BackgroundJobsEndpointRouteBuilderExtensions.MapBackgroundJobsEndpoints"/>.
+/// <see cref="Extensions.BackgroundJobsEndpointRouteBuilderExtensions.MapGranitBackgroundJobs"/>.
 /// </summary>
 public sealed class BackgroundJobsEndpointsOptions
 {

--- a/src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs
@@ -28,7 +28,7 @@ public static class BffEndpointRouteBuilderExtensions
     /// </summary>
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <returns>The endpoint route builder for further chaining.</returns>
-    public static IEndpointRouteBuilder MapGranitBffEndpoints(this IEndpointRouteBuilder endpoints)
+    public static IEndpointRouteBuilder MapGranitBff(this IEndpointRouteBuilder endpoints)
     {
         if (s_bffEndpointsMapped)
         {

--- a/src/Granit.Bff.Endpoints/README.md
+++ b/src/Granit.Bff.Endpoints/README.md
@@ -15,7 +15,7 @@ Minimal API endpoints for BFF (Backend For Frontend) authentication.
 ## Usage
 
 ```csharp
-app.MapGranitBffEndpoints();
+app.MapGranitBff();
 ```
 
 ## Security

--- a/src/Granit.BlobStorage.Endpoints/Extensions/BlobStorageEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.Endpoints/Extensions/BlobStorageEndpointRouteBuilderExtensions.cs
@@ -22,10 +22,10 @@ public static class BlobStorageEndpointRouteBuilderExtensions
     /// <remarks>
     /// <para>Call this from your application route registration:</para>
     /// <code>
-    /// app.MapBlobStorageEndpoints();
+    /// app.MapGranitBlobStorage();
     ///
     /// // With custom options:
-    /// app.MapBlobStorageEndpoints(opts =>
+    /// app.MapGranitBlobStorage(opts =>
     /// {
     ///     opts.RoutePrefix = "admin/blobs";
     /// });
@@ -34,7 +34,7 @@ public static class BlobStorageEndpointRouteBuilderExtensions
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize <see cref="BlobStorageEndpointsOptions"/>.</param>
     /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
-    public static RouteGroupBuilder MapBlobStorageEndpoints(
+    public static RouteGroupBuilder MapGranitBlobStorage(
         this IEndpointRouteBuilder endpoints,
         Action<BlobStorageEndpointsOptions>? configure = null)
     {
@@ -59,7 +59,7 @@ public static class BlobStorageEndpointRouteBuilderExtensions
 
         if (hasQueryableProvider)
         {
-            group.RequireAuthorization(BlobStoragePermissions.Administration.Read).MapQueryEndpoints<BlobDescriptor>(
+            group.RequireAuthorization(BlobStoragePermissions.Administration.Read).MapGranitQuery<BlobDescriptor>(
                 "query",
                 sp => sp.GetRequiredService<IBlobQueryableProvider>().GetDescriptors());
         }

--- a/src/Granit.BlobStorage.FileSystem/README.md
+++ b/src/Granit.BlobStorage.FileSystem/README.md
@@ -26,7 +26,7 @@ builder.AddGranitBlobStorageFileSystem();
 builder.AddGranitBlobStorageProxy();       // required for pre-signed URLs
 
 var app = builder.Build();
-app.MapGranitBlobProxyEndpoints();
+app.MapGranitBlobProxy();
 ```
 
 ## Configuration

--- a/src/Granit.BlobStorage.Proxy/Extensions/BlobStorageProxyEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.Proxy/Extensions/BlobStorageProxyEndpointRouteBuilderExtensions.cs
@@ -30,7 +30,7 @@ public static class BlobStorageProxyEndpointRouteBuilderExtensions
     /// </remarks>
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <returns>The endpoint route builder for chaining.</returns>
-    public static IEndpointRouteBuilder MapGranitBlobProxyEndpoints(
+    public static IEndpointRouteBuilder MapGranitBlobProxy(
         this IEndpointRouteBuilder endpoints)
     {
         ProxyBlobOptions options = endpoints.ServiceProvider

--- a/src/Granit.DataExchange.Endpoints/Extensions/DataExchangeEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.DataExchange.Endpoints/Extensions/DataExchangeEndpointRouteBuilderExtensions.cs
@@ -24,10 +24,10 @@ public static class DataExchangeEndpointRouteBuilderExtensions
     /// </para>
     /// <para>Call this from your application route registration:</para>
     /// <code>
-    /// app.MapDataExchangeEndpoints();
+    /// app.MapGranitDataExchange();
     ///
     /// // With a custom prefix:
-    /// app.MapDataExchangeEndpoints(opts =>
+    /// app.MapGranitDataExchange(opts =>
     /// {
     ///     opts.RoutePrefix = "admin/imports";
     /// });
@@ -51,7 +51,7 @@ public static class DataExchangeEndpointRouteBuilderExtensions
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize <see cref="DataExchangeEndpointsOptions"/>.</param>
     /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
-    public static RouteGroupBuilder MapDataExchangeEndpoints(
+    public static RouteGroupBuilder MapGranitDataExchange(
         this IEndpointRouteBuilder endpoints,
         Action<DataExchangeEndpointsOptions>? configure = null)
     {

--- a/src/Granit.DataExchange.Endpoints/GranitDataExchangeEndpointsModule.cs
+++ b/src/Granit.DataExchange.Endpoints/GranitDataExchangeEndpointsModule.cs
@@ -9,7 +9,7 @@ namespace Granit.DataExchange.Endpoints;
 /// </summary>
 /// <remarks>
 /// Exposes import management routes via
-/// <see cref="Extensions.DataExchangeEndpointRouteBuilderExtensions.MapDataExchangeEndpoints"/>.
+/// <see cref="Extensions.DataExchangeEndpointRouteBuilderExtensions.MapGranitDataExchange"/>.
 /// Requires both <see cref="GranitDataExchangeModule"/> (pipeline infrastructure)
 /// and <see cref="GranitAuthorizationModule"/> (permission policy enforcement).
 /// Permission definition providers are auto-discovered by <c>GranitAuthorizationModule</c>.

--- a/src/Granit.DataExchange.Endpoints/Options/DataExchangeEndpointsOptions.cs
+++ b/src/Granit.DataExchange.Endpoints/Options/DataExchangeEndpointsOptions.cs
@@ -3,7 +3,7 @@ namespace Granit.DataExchange.Endpoints.Options;
 /// <summary>
 /// Configuration options for the data exchange endpoints (import + export).
 /// Bind from <c>"DataExchangeEndpoints"</c> or pass an action to
-/// <see cref="Extensions.DataExchangeEndpointRouteBuilderExtensions.MapDataExchangeEndpoints"/>.
+/// <see cref="Extensions.DataExchangeEndpointRouteBuilderExtensions.MapGranitDataExchange"/>.
 /// </summary>
 public sealed class DataExchangeEndpointsOptions
 {

--- a/src/Granit.Identity.Endpoints/Extensions/IdentityEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Identity.Endpoints/Extensions/IdentityEndpointRouteBuilderExtensions.cs
@@ -29,7 +29,7 @@ public static class IdentityEndpointRouteBuilderExtensions
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize <see cref="IdentityEndpointsOptions"/>.</param>
     /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
-    public static RouteGroupBuilder MapIdentityUserCacheEndpoints(
+    public static RouteGroupBuilder MapGranitIdentityUserCache(
         this IEndpointRouteBuilder endpoints,
         Action<IdentityEndpointsOptions>? configure = null)
     {

--- a/src/Granit.Identity.Endpoints/Extensions/IdentityProviderEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Identity.Endpoints/Extensions/IdentityProviderEndpointRouteBuilderExtensions.cs
@@ -30,7 +30,7 @@ public static class IdentityProviderEndpointRouteBuilderExtensions
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize <see cref="IdentityProviderEndpointsOptions"/>.</param>
     /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
-    public static RouteGroupBuilder MapIdentityProviderEndpoints(
+    public static RouteGroupBuilder MapGranitIdentityProvider(
         this IEndpointRouteBuilder endpoints,
         Action<IdentityProviderEndpointsOptions>? configure = null)
     {

--- a/src/Granit.Identity.Endpoints/GranitIdentityEndpointsModule.cs
+++ b/src/Granit.Identity.Endpoints/GranitIdentityEndpointsModule.cs
@@ -17,7 +17,7 @@ namespace Granit.Identity.Endpoints;
 /// </para>
 /// <para>
 /// Exposes user cache management routes via
-/// <see cref="Extensions.IdentityEndpointRouteBuilderExtensions.MapIdentityUserCacheEndpoints"/>.
+/// <see cref="Extensions.IdentityEndpointRouteBuilderExtensions.MapGranitIdentityUserCache"/>.
 /// Permission definition providers are auto-discovered by <c>GranitAuthorizationModule</c>.
 /// </para>
 /// </remarks>

--- a/src/Granit.Identity.Local.Endpoints/Extensions/AccountEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Identity.Local.Endpoints/Extensions/AccountEndpointRouteBuilderExtensions.cs
@@ -17,7 +17,7 @@ public static class AccountEndpointRouteBuilderExtensions
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize endpoint options.</param>
     /// <returns>The account <see cref="RouteGroupBuilder"/> for further chaining.</returns>
-    public static RouteGroupBuilder MapAccountEndpoints(
+    public static RouteGroupBuilder MapGranitAccount(
         this IEndpointRouteBuilder endpoints,
         Action<AccountEndpointsOptions>? configure = null)
     {

--- a/src/Granit.Identity.Local.Endpoints/README.md
+++ b/src/Granit.Identity.Local.Endpoints/README.md
@@ -13,11 +13,11 @@ provider (e.g. Duende Identity Server).
 builder.AddGranit(granit => granit.AddOpenIddict());
 
 // Map account self-service endpoints (/api/account)
-app.MapAccountEndpoints();
+app.MapGranitAccount();
 
 // Map OpenIddict OIDC endpoints (/connect/*, /api/admin/oidc)
-app.MapOpenIddictEndpoints();
-app.MapOpenIddictServerEndpoints();
+app.MapGranitOpenIddict();
+app.MapGranitOpenIddictServer();
 ```
 
 ## Key endpoints

--- a/src/Granit.Notifications.Endpoints/Endpoints/MobilePushTokenEndpoints.cs
+++ b/src/Granit.Notifications.Endpoints/Endpoints/MobilePushTokenEndpoints.cs
@@ -19,7 +19,7 @@ namespace Granit.Notifications.Endpoints.Endpoints;
 public static class MobilePushTokenEndpoints
 {
     /// <summary>Maps mobile push token management endpoints.</summary>
-    public static IEndpointRouteBuilder MapMobilePushTokenEndpoints(
+    public static IEndpointRouteBuilder MapGranitMobilePushTokens(
         this IEndpointRouteBuilder endpoints,
         string prefix = "api/notifications/mobile-push/tokens")
     {

--- a/src/Granit.Notifications.Endpoints/Extensions/NotificationEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Notifications.Endpoints/Extensions/NotificationEndpointRouteBuilderExtensions.cs
@@ -28,7 +28,7 @@ public static class NotificationEndpointRouteBuilderExtensions
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize <see cref="NotificationEndpointsOptions"/>.</param>
     /// <returns>The endpoint route builder for chaining.</returns>
-    public static IEndpointRouteBuilder MapGranitNotificationEndpoints(
+    public static IEndpointRouteBuilder MapGranitNotifications(
         this IEndpointRouteBuilder endpoints,
         Action<NotificationEndpointsOptions>? configure = null)
     {

--- a/src/Granit.Notifications.Sse/Endpoints/SseNotificationEndpoints.cs
+++ b/src/Granit.Notifications.Sse/Endpoints/SseNotificationEndpoints.cs
@@ -21,7 +21,7 @@ public static class SseNotificationEndpoints
     /// The returned <see cref="RouteGroupBuilder"/> can be further configured by the application
     /// (e.g. additional authorization policies).
     /// </summary>
-    public static RouteGroupBuilder MapGranitSseNotificationEndpoints(this IEndpointRouteBuilder endpoints)
+    public static RouteGroupBuilder MapGranitSseNotifications(this IEndpointRouteBuilder endpoints)
     {
         RouteGroupBuilder group = endpoints
             .MapGranitGroup("/notifications")

--- a/src/Granit.OpenIddict.Endpoints/Extensions/OpenIddictEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.Endpoints/Extensions/OpenIddictEndpointRouteBuilderExtensions.cs
@@ -17,14 +17,14 @@ public static class OpenIddictEndpointRouteBuilderExtensions
     /// <remarks>
     /// <para>
     /// Account self-service endpoints (login, registration, profile, etc.) have moved to
-    /// <c>Granit.Identity.Local.Endpoints</c>. Use <c>MapAccountEndpoints()</c> from that
+    /// <c>Granit.Identity.Local.Endpoints</c>. Use <c>MapGranitAccount()</c> from that
     /// module instead.
     /// </para>
     /// </remarks>
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize endpoint options.</param>
     /// <returns>The admin <see cref="RouteGroupBuilder"/> for further chaining.</returns>
-    public static RouteGroupBuilder MapOpenIddictEndpoints(
+    public static RouteGroupBuilder MapGranitOpenIddict(
         this IEndpointRouteBuilder endpoints,
         Action<OpenIddictEndpointsOptions>? configure = null)
     {
@@ -60,7 +60,7 @@ public static class OpenIddictEndpointRouteBuilderExtensions
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize <see cref="OpenIddictServerEndpointsOptions"/>.</param>
     /// <returns>The endpoint route builder for chaining.</returns>
-    public static IEndpointRouteBuilder MapOpenIddictServerEndpoints(
+    public static IEndpointRouteBuilder MapGranitOpenIddictServer(
         this IEndpointRouteBuilder endpoints,
         Action<OpenIddictServerEndpointsOptions>? configure = null)
     {

--- a/src/Granit.QueryEngine.Endpoints/Extensions/QueryEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.QueryEngine.Endpoints/Extensions/QueryEndpointRouteBuilderExtensions.cs
@@ -42,7 +42,7 @@ public static class QueryEndpointRouteBuilderExtensions
     ///   <item><c>POST /saved-views/{id}/set-default</c> — set default saved view</item>
     /// </list>
     /// </remarks>
-    public static RouteGroupBuilder MapQueryEndpoints<TEntity>(
+    public static RouteGroupBuilder MapGranitQuery<TEntity>(
         this IEndpointRouteBuilder endpoints,
         string pattern,
         Func<IServiceProvider, IQueryable<TEntity>> sourceProvider,
@@ -130,4 +130,5 @@ public static class QueryEndpointRouteBuilderExtensions
 
         return group;
     }
+
 }

--- a/src/Granit.QueryEngine.Endpoints/Granit.QueryEngine.Endpoints.csproj
+++ b/src/Granit.QueryEngine.Endpoints/Granit.QueryEngine.Endpoints.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Granit.QueryEngine.Endpoints</PackageId>
-    <Description>Minimal API endpoints for Granit.QueryEngine. MapQueryEndpoints fluent API, filter[field.op]=value query string binding, GET /meta metadata endpoint, CRUD SavedViews endpoints, and OpenAPI conventions.</Description>
+    <Description>Minimal API endpoints for Granit.QueryEngine. MapGranitQuery fluent API, filter[field.op]=value query string binding, GET /meta metadata endpoint, CRUD SavedViews endpoints, and OpenAPI conventions.</Description>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Granit.QueryEngine.Endpoints/GranitQueryEngineEndpointsModule.cs
+++ b/src/Granit.QueryEngine.Endpoints/GranitQueryEngineEndpointsModule.cs
@@ -12,7 +12,7 @@ namespace Granit.QueryEngine.Endpoints;
 /// </summary>
 /// <remarks>
 /// Exposes query list routes via
-/// <c>MapQueryEndpoints&lt;TEntity, TDto&gt;()</c>,
+/// <c>MapGranitQuery&lt;TEntity&gt;()</c>,
 /// the <c>GET /meta</c> metadata endpoint, and CRUD saved view endpoints.
 /// Requires both <see cref="GranitQueryEngineModule"/> (core infrastructure)
 /// and <see cref="GranitAuthorizationModule"/> (permission policy enforcement).

--- a/src/Granit.QueryEngine.Endpoints/Options/QueryEndpointOptions.cs
+++ b/src/Granit.QueryEngine.Endpoints/Options/QueryEndpointOptions.cs
@@ -2,7 +2,7 @@ namespace Granit.QueryEngine.Endpoints.Options;
 
 /// <summary>
 /// Configuration options for query endpoints registered via
-/// <see cref="QueryEndpointRouteBuilderExtensions.MapQueryEndpoints{TEntity}"/>.
+/// <see cref="QueryEndpointRouteBuilderExtensions.MapGranitQuery{TEntity}"/>.
 /// </summary>
 public sealed class QueryEndpointOptions
 {

--- a/src/Granit.QueryEngine.Endpoints/README.md
+++ b/src/Granit.QueryEngine.Endpoints/README.md
@@ -1,6 +1,6 @@
 # Granit.QueryEngine.Endpoints
 
-Minimal API endpoints for Granit.QueryEngine. Provides `MapQueryEndpoints<T, TDto>()`
+Minimal API endpoints for Granit.QueryEngine. Provides `MapGranitQuery<T, TDto>()`
 fluent API, `filter[field.op]=value` query string binding, `GET /meta` metadata
 endpoint, CRUD SavedViews endpoints, and OpenAPI documentation conventions.
 

--- a/src/Granit.ReferenceData.Endpoints/Extensions/ReferenceDataEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.ReferenceData.Endpoints/Extensions/ReferenceDataEndpointRouteBuilderExtensions.cs
@@ -28,16 +28,16 @@ public static class ReferenceDataEndpointRouteBuilderExtensions
     /// </para>
     /// <para>
     /// The entity type name is converted to a kebab-case segment appended to the route prefix.
-    /// For example, <c>MapReferenceDataEndpoints&lt;Country&gt;()</c> creates routes under
+    /// For example, <c>MapGranitReferenceData&lt;Country&gt;()</c> creates routes under
     /// <c>/reference-data/country</c>.
     /// </para>
     /// <para>Call from your application:</para>
     /// <code>
-    /// app.MapReferenceDataEndpoints&lt;Country&gt;();
-    /// app.MapReferenceDataEndpoints&lt;Currency&gt;(opts => opts.TagName = "Currencies");
+    /// app.MapGranitReferenceData&lt;Country&gt;();
+    /// app.MapGranitReferenceData&lt;Currency&gt;(opts => opts.TagName = "Currencies");
     /// </code>
     /// </remarks>
-    public static RouteGroupBuilder MapReferenceDataEndpoints<TEntity>(
+    public static RouteGroupBuilder MapGranitReferenceData<TEntity>(
         this IEndpointRouteBuilder endpoints,
         Action<ReferenceDataEndpointsOptions>? configure = null)
         where TEntity : ReferenceDataEntity, new()
@@ -67,7 +67,7 @@ public static class ReferenceDataEndpointRouteBuilderExtensions
     /// </param>
     /// <param name="configure">Optional delegate to customize <see cref="ReferenceDataEndpointsOptions"/>.</param>
     /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
-    public static RouteGroupBuilder MapReferenceDataEndpoints(
+    public static RouteGroupBuilder MapGranitReferenceData(
         this IEndpointRouteBuilder endpoints,
         string typeName,
         Action<ReferenceDataEndpointsOptions>? configure = null)
@@ -96,7 +96,7 @@ public static class ReferenceDataEndpointRouteBuilderExtensions
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize options for all types.</param>
     /// <returns>The endpoint route builder for chaining.</returns>
-    public static IEndpointRouteBuilder MapAllReferenceDataEndpoints(
+    public static IEndpointRouteBuilder MapGranitAllReferenceData(
         this IEndpointRouteBuilder endpoints,
         Action<ReferenceDataEndpointsOptions>? configure = null)
     {
@@ -104,7 +104,7 @@ public static class ReferenceDataEndpointRouteBuilderExtensions
 
         foreach (ReferenceDataTypeRegistration registration in registry.Types)
         {
-            endpoints.MapReferenceDataEndpoints(registration.TypeName, configure);
+            endpoints.MapGranitReferenceData(registration.TypeName, configure);
         }
 
         return endpoints;

--- a/src/Granit.ReferenceData.Endpoints/GranitReferenceDataEndpointsModule.cs
+++ b/src/Granit.ReferenceData.Endpoints/GranitReferenceDataEndpointsModule.cs
@@ -12,7 +12,7 @@ namespace Granit.ReferenceData.Endpoints;
 /// <remarks>
 /// <para>
 /// This module does not auto-map routes. The host application must call
-/// <c>app.MapReferenceDataEndpoints&lt;TEntity&gt;()</c> for each entity type.
+/// <c>app.MapGranitReferenceData&lt;TEntity&gt;()</c> for each entity type.
 /// </para>
 /// <para>Validators are auto-discovered by <c>GranitValidationModule</c>.</para>
 /// <para>Permissions are auto-discovered by <c>GranitAuthorizationModule</c>.</para>

--- a/src/Granit.ReferenceData/ReferenceDataRegistry.cs
+++ b/src/Granit.ReferenceData/ReferenceDataRegistry.cs
@@ -8,7 +8,7 @@ namespace Granit.ReferenceData;
 /// Populated at DI registration time by <c>AddReferenceData&lt;TDbContext&gt;()</c>.
 /// </summary>
 /// <remarks>
-/// The registry is read at endpoint mapping time by <c>MapAllReferenceDataEndpoints()</c>
+/// The registry is read at endpoint mapping time by <c>MapGranitAllReferenceData()</c>
 /// and at model-building time to create EF Core SharedTypeEntity configurations.
 /// </remarks>
 public sealed class ReferenceDataRegistry

--- a/src/Granit.Templating.Endpoints/Extensions/TemplatingEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Templating.Endpoints/Extensions/TemplatingEndpointRouteBuilderExtensions.cs
@@ -1,7 +1,7 @@
 // ---------------------------------------------------------------------------
 // TemplatingEndpointRouteBuilderExtensions.cs
 // Minimal API extensions for Granit template administration:
-//   - MapGranitTemplatingAdmin: CRUD endpoints for template draft management
+//   - MapGranitTemplating: CRUD endpoints for template draft management
 //     (requires Templates.Manage permission)
 // ---------------------------------------------------------------------------
 
@@ -69,7 +69,7 @@ public static class TemplatingEndpointRouteBuilderExtensions
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize <see cref="TemplatingEndpointsOptions"/>.</param>
     /// <returns>The route group builder for further chaining.</returns>
-    public static RouteGroupBuilder MapGranitTemplatingAdmin(
+    public static RouteGroupBuilder MapGranitTemplating(
         this IEndpointRouteBuilder endpoints,
         Action<TemplatingEndpointsOptions>? configure = null)
     {
@@ -1341,4 +1341,5 @@ public static class TemplatingEndpointRouteBuilderExtensions
 
         return "object";
     }
+
 }

--- a/src/Granit.Templating.Endpoints/GranitTemplatingEndpointsModule.cs
+++ b/src/Granit.Templating.Endpoints/GranitTemplatingEndpointsModule.cs
@@ -14,7 +14,7 @@ namespace Granit.Templating.Endpoints;
 /// <c>/api/v1/templates</c>, protected by the <c>Templates.Manage</c> permission.
 /// <para>
 /// The host application must call
-/// <see cref="Extensions.TemplatingEndpointRouteBuilderExtensions.MapGranitTemplatingAdmin"/>
+/// <see cref="Extensions.TemplatingEndpointRouteBuilderExtensions.MapGranitTemplating"/>
 /// to register the routes.
 /// </para>
 /// Permission definition providers are auto-discovered by <c>GranitAuthorizationModule</c>.

--- a/src/Granit.Timeline.Endpoints/Extensions/TimelineEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Timeline.Endpoints/Extensions/TimelineEndpointRouteBuilderExtensions.cs
@@ -32,10 +32,10 @@ public static class TimelineEndpointRouteBuilderExtensions
     /// </list>
     /// <para>Call this from your application route registration:</para>
     /// <code>
-    /// app.MapTimelineEndpoints();
+    /// app.MapGranitTimeline();
     ///
     /// // With a custom prefix:
-    /// app.MapTimelineEndpoints(opts =&gt;
+    /// app.MapGranitTimeline(opts =&gt;
     /// {
     ///     opts.RoutePrefix = "admin/timeline";
     /// });
@@ -44,7 +44,7 @@ public static class TimelineEndpointRouteBuilderExtensions
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize options.</param>
     /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
-    public static RouteGroupBuilder MapTimelineEndpoints(
+    public static RouteGroupBuilder MapGranitTimeline(
         this IEndpointRouteBuilder endpoints,
         Action<TimelineEndpointsOptions>? configure = null)
     {
@@ -62,4 +62,5 @@ public static class TimelineEndpointRouteBuilderExtensions
 
         return group;
     }
+
 }

--- a/src/Granit.Timeline.Endpoints/GranitTimelineEndpointsModule.cs
+++ b/src/Granit.Timeline.Endpoints/GranitTimelineEndpointsModule.cs
@@ -12,7 +12,7 @@ namespace Granit.Timeline.Endpoints;
 /// <remarks>
 /// Map endpoints in your application:
 /// <code>
-/// app.MapTimelineEndpoints();
+/// app.MapGranitTimeline();
 /// </code>
 /// Permission definition providers are auto-discovered by <c>GranitAuthorizationModule</c>.
 /// </remarks>

--- a/src/Granit.Webhooks.Endpoints/Extensions/WebhooksEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Webhooks.Endpoints/Extensions/WebhooksEndpointRouteBuilderExtensions.cs
@@ -27,10 +27,10 @@ public static class WebhooksEndpointRouteBuilderExtensions
     /// </para>
     /// <para>Call this from your application route registration:</para>
     /// <code>
-    /// app.MapWebhooksEndpoints();
+    /// app.MapGranitWebhooks();
     ///
     /// // With custom options:
-    /// app.MapWebhooksEndpoints(opts =>
+    /// app.MapGranitWebhooks(opts =>
     /// {
     ///     opts.RoutePrefix = "admin/webhooks";
     /// });
@@ -39,7 +39,7 @@ public static class WebhooksEndpointRouteBuilderExtensions
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize <see cref="WebhooksEndpointsOptions"/>.</param>
     /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
-    public static RouteGroupBuilder MapWebhooksEndpoints(
+    public static RouteGroupBuilder MapGranitWebhooks(
         this IEndpointRouteBuilder endpoints,
         Action<WebhooksEndpointsOptions>? configure = null)
     {
@@ -73,15 +73,16 @@ public static class WebhooksEndpointRouteBuilderExtensions
 
         if (hasQueryableProvider)
         {
-            group.MapQueryEndpoints<WebhookSubscription>(
+            group.MapGranitQuery<WebhookSubscription>(
                 "subscriptions/query",
                 sp => sp.GetRequiredService<IWebhookQueryableProvider>().GetSubscriptions());
 
-            group.MapQueryEndpoints<WebhookDeliveryAttempt>(
+            group.MapGranitQuery<WebhookDeliveryAttempt>(
                 "deliveries/query",
                 sp => sp.GetRequiredService<IWebhookQueryableProvider>().GetDeliveryAttempts());
         }
 
         return group;
     }
+
 }

--- a/src/Granit.Workflow.Endpoints/Extensions/WorkflowEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Workflow.Endpoints/Extensions/WorkflowEndpointRouteBuilderExtensions.cs
@@ -26,10 +26,10 @@ public static class WorkflowEndpointRouteBuilderExtensions
     /// </list>
     /// <para>Call this from your application route registration:</para>
     /// <code>
-    /// app.MapWorkflowEndpoints();
+    /// app.MapGranitWorkflow();
     ///
     /// // With a custom prefix:
-    /// app.MapWorkflowEndpoints(opts =&gt;
+    /// app.MapGranitWorkflow(opts =&gt;
     /// {
     ///     opts.RoutePrefix = "admin/workflow";
     /// });
@@ -38,7 +38,7 @@ public static class WorkflowEndpointRouteBuilderExtensions
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize options.</param>
     /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
-    public static RouteGroupBuilder MapWorkflowEndpoints(
+    public static RouteGroupBuilder MapGranitWorkflow(
         this IEndpointRouteBuilder endpoints,
         Action<WorkflowEndpointsOptions>? configure = null)
     {
@@ -78,15 +78,16 @@ public static class WorkflowEndpointRouteBuilderExtensions
     /// </para>
     /// <para>Usage:</para>
     /// <code>
-    /// var group = app.MapWorkflowEndpoints();
-    /// group.MapWorkflowTransitionEndpoints&lt;DocumentStatus&gt;();
+    /// var group = app.MapGranitWorkflow();
+    /// group.MapGranitWorkflowTransition&lt;DocumentStatus&gt;();
     /// </code>
     /// </remarks>
-    public static RouteGroupBuilder MapWorkflowTransitionEndpoints<TState>(
+    public static RouteGroupBuilder MapGranitWorkflowTransition<TState>(
         this RouteGroupBuilder group)
         where TState : struct, Enum
     {
         WorkflowTransitionEndpoints<TState>.MapTransitionEndpoints(group);
         return group;
     }
+
 }

--- a/src/Granit.Workflow.Endpoints/GranitWorkflowEndpointsModule.cs
+++ b/src/Granit.Workflow.Endpoints/GranitWorkflowEndpointsModule.cs
@@ -14,7 +14,7 @@ namespace Granit.Workflow.Endpoints;
 /// <para>
 /// Map endpoints in your application:
 /// <code>
-/// app.MapWorkflowEndpoints();
+/// app.MapGranitWorkflow();
 /// </code>
 /// </para>
 /// <para>

--- a/tests/Granit.ArchitectureTests/ApiConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/ApiConventionTests.cs
@@ -366,6 +366,65 @@ public sealed partial class ApiConventionTests
         return types.All(t => simpleTypes.Contains(t));
     }
 
+    /// <summary>
+    /// Public <c>Map*</c> extension methods on <c>IEndpointRouteBuilder</c> or
+    /// <c>RouteGroupBuilder</c> in <c>src/Granit.*</c> must follow the
+    /// <c>MapGranit{Feature}()</c> naming convention to avoid collisions
+    /// with third-party or ASP.NET extensions.
+    /// </summary>
+    /// <remarks>
+    /// Exemptions:
+    /// <list type="bullet">
+    /// <item><c>MapGranitGroup</c> — infrastructure method, not a feature endpoint registration</item>
+    /// </list>
+    /// </remarks>
+    [Fact]
+    public void Public_Map_extension_methods_should_follow_MapGranit_convention()
+    {
+        string srcDir = Path.Join(RepoRoot, "src");
+
+        HashSet<string> exemptions = new(StringComparer.Ordinal)
+        {
+            "MapGranitGroup",
+        };
+
+        List<string> violations = [];
+
+        foreach (string csFile in Directory.GetFiles(srcDir, "*.cs", SearchOption.AllDirectories))
+        {
+            if (csFile.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar)
+                || csFile.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar))
+            {
+                continue;
+            }
+
+            string content = File.ReadAllText(csFile);
+
+            foreach (Match match in PublicMapExtensionMethod().Matches(content))
+            {
+                string methodName = match.Groups[1].Value;
+
+                if (exemptions.Contains(methodName))
+                {
+                    continue;
+                }
+
+                if (!methodName.StartsWith("MapGranit", StringComparison.Ordinal))
+                {
+                    string relativePath = Path.GetRelativePath(RepoRoot, csFile);
+                    int lineNumber = content[..match.Index].Count(c => c == '\n') + 1;
+                    violations.Add($"{relativePath}:{lineNumber} ({methodName}) — expected MapGranit{{Feature}}");
+                }
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Public Map* extension methods on IEndpointRouteBuilder or RouteGroupBuilder " +
+            "must follow the MapGranit{Feature}() naming convention to avoid collisions " +
+            "and ensure discoverability. See GitHub issue #792. " +
+            $"Violators: {string.Join("; ", violations)}");
+    }
+
     private static string FindRepoRoot()
     {
         string? dir = Path.GetDirectoryName(typeof(ApiConventionTests).Assembly.Location);
@@ -404,4 +463,15 @@ public sealed partial class ApiConventionTests
     /// </summary>
     [GeneratedRegex(@"\.Map(Get|Post|Put|Delete|Patch)\s*\(", RegexOptions.Multiline)]
     private static partial Regex EndpointRegistration();
+
+    /// <summary>
+    /// Matches <c>public static</c> methods named <c>Map*</c> that extend
+    /// <c>IEndpointRouteBuilder</c>. Only top-level entry points are validated —
+    /// sub-group helpers extending <c>RouteGroupBuilder</c> are internal wiring.
+    /// Captures the method name (group 1).
+    /// </summary>
+    [GeneratedRegex(
+        @"public\s+static\s+\S+\s+(Map\w+?)(?:<[^>]+>)?\s*\(\s*this\s+IEndpointRouteBuilder",
+        RegexOptions.Multiline)]
+    private static partial Regex PublicMapExtensionMethod();
 }

--- a/tests/Granit.Authentication.ApiKeys.Endpoints.Tests/ApiKeyEndpointsIntegrationTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.Endpoints.Tests/ApiKeyEndpointsIntegrationTests.cs
@@ -71,7 +71,7 @@ public sealed class ApiKeyEndpointsIntegrationTests : IAsyncDisposable
         builder.Services.AddSingleton(_permissionChecker);
 
         _app = builder.Build();
-        _app.MapApiKeysEndpoints();
+        _app.MapGranitApiKeys();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(_app, AdminRole);

--- a/tests/Granit.Authorization.Endpoints.Tests/AuthorizationEndpointsTests.cs
+++ b/tests/Granit.Authorization.Endpoints.Tests/AuthorizationEndpointsTests.cs
@@ -85,7 +85,7 @@ public sealed class AuthorizationEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(_currentTenant);
 
         _app = builder.Build();
-        _app.MapAuthorizationEndpoints();
+        _app.MapGranitAuthorization();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient("admin");

--- a/tests/Granit.Authorization.Endpoints.Tests/MapAuthorizationEndpointsTests.cs
+++ b/tests/Granit.Authorization.Endpoints.Tests/MapAuthorizationEndpointsTests.cs
@@ -7,10 +7,10 @@ using Xunit;
 
 namespace Granit.Authorization.Endpoints.Tests;
 
-public sealed class MapAuthorizationEndpointsTests
+public sealed class MapGranitAuthorizationTests
 {
     [Fact]
-    public void MapAuthorizationEndpoints_WithDefaultOptions_ReturnsRouteGroupBuilder()
+    public void MapGranitAuthorization_WithDefaultOptions_ReturnsRouteGroupBuilder()
     {
         // Arrange
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
@@ -18,14 +18,14 @@ public sealed class MapAuthorizationEndpointsTests
         WebApplication app = builder.Build();
 
         // Act
-        RouteGroupBuilder group = app.MapAuthorizationEndpoints();
+        RouteGroupBuilder group = app.MapGranitAuthorization();
 
         // Assert
         group.ShouldNotBeNull();
     }
 
     [Fact]
-    public void MapAuthorizationEndpoints_WithCustomPrefix_ReturnsRouteGroupBuilder()
+    public void MapGranitAuthorization_WithCustomPrefix_ReturnsRouteGroupBuilder()
     {
         // Arrange
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
@@ -33,7 +33,7 @@ public sealed class MapAuthorizationEndpointsTests
         WebApplication app = builder.Build();
 
         // Act
-        RouteGroupBuilder group = app.MapAuthorizationEndpoints(
+        RouteGroupBuilder group = app.MapGranitAuthorization(
             opts => opts.RoutePrefix = "authorization");
 
         // Assert

--- a/tests/Granit.BackgroundJobs.Endpoints.Tests/BackgroundJobsEndpointsTests.cs
+++ b/tests/Granit.BackgroundJobs.Endpoints.Tests/BackgroundJobsEndpointsTests.cs
@@ -60,7 +60,7 @@ public sealed class BackgroundJobsEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(_writer);
 
         _app = builder.Build();
-        _app.MapBackgroundJobsEndpoints();
+        _app.MapGranitBackgroundJobs();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);

--- a/tests/Granit.BackgroundJobs.Endpoints.Tests/MapBackgroundJobsEndpointsTests.cs
+++ b/tests/Granit.BackgroundJobs.Endpoints.Tests/MapBackgroundJobsEndpointsTests.cs
@@ -7,10 +7,10 @@ using Xunit;
 
 namespace Granit.BackgroundJobs.Endpoints.Tests;
 
-public sealed class MapBackgroundJobsEndpointsTests
+public sealed class MapGranitBackgroundJobsTests
 {
     [Fact]
-    public void MapBackgroundJobsEndpoints_WithDefaultOptions_ReturnsRouteGroupBuilder()
+    public void MapGranitBackgroundJobs_WithDefaultOptions_ReturnsRouteGroupBuilder()
     {
         // Arrange
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
@@ -18,14 +18,14 @@ public sealed class MapBackgroundJobsEndpointsTests
         WebApplication app = builder.Build();
 
         // Act
-        RouteGroupBuilder group = app.MapBackgroundJobsEndpoints();
+        RouteGroupBuilder group = app.MapGranitBackgroundJobs();
 
         // Assert
         group.ShouldNotBeNull();
     }
 
     [Fact]
-    public void MapBackgroundJobsEndpoints_WithCustomPrefix_ReturnsRouteGroupBuilder()
+    public void MapGranitBackgroundJobs_WithCustomPrefix_ReturnsRouteGroupBuilder()
     {
         // Arrange
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
@@ -33,7 +33,7 @@ public sealed class MapBackgroundJobsEndpointsTests
         WebApplication app = builder.Build();
 
         // Act
-        RouteGroupBuilder group = app.MapBackgroundJobsEndpoints(
+        RouteGroupBuilder group = app.MapGranitBackgroundJobs(
             opts => opts.RoutePrefix = "admin/jobs");
 
         // Assert

--- a/tests/Granit.Bff.Endpoints.Tests/Extensions/BffEndpointRouteBuilderExtensionsTests.cs
+++ b/tests/Granit.Bff.Endpoints.Tests/Extensions/BffEndpointRouteBuilderExtensionsTests.cs
@@ -8,13 +8,13 @@ namespace Granit.Bff.Endpoints.Tests.Extensions;
 public sealed class BffEndpointRouteBuilderExtensionsTests
 {
     [Fact]
-    public void MapGranitBffEndpoints_IsPublicExtensionMethod()
+    public void MapGranitBff_IsPublicExtensionMethod()
     {
         // Verify the extension method exists and is publicly accessible via reflection.
         // A full integration test requires a configured WebApplication with OIDC,
         // which is out of scope for unit tests. This validates the API surface.
         MethodInfo? method = typeof(BffEndpointRouteBuilderExtensions)
-            .GetMethod(nameof(BffEndpointRouteBuilderExtensions.MapGranitBffEndpoints));
+            .GetMethod(nameof(BffEndpointRouteBuilderExtensions.MapGranitBff));
 
         method.ShouldNotBeNull();
         method.IsStatic.ShouldBeTrue();

--- a/tests/Granit.Bff.Endpoints.Tests/Integration/BffEndpointsIntegrationTests.cs
+++ b/tests/Granit.Bff.Endpoints.Tests/Integration/BffEndpointsIntegrationTests.cs
@@ -267,7 +267,7 @@ public sealed class BffEndpointsIntegrationTests : IAsyncLifetime
                 BffEndpointsTestServer.TestFrontendName,
                 "user-42",
                 Arg.Any<CancellationToken>())
-            .Returns(new List<string> { TestSessionId });
+            .Returns((IReadOnlyList<string>)[TestSessionId]);
 
         HttpResponseMessage response = await SendAnonymousWithSessionAsync(
             HttpMethod.Get, "/app/bff/sessions");
@@ -438,7 +438,7 @@ public sealed class BffEndpointsIntegrationTests : IAsyncLifetime
                 BffEndpointsTestServer.TestFrontendName,
                 "user-42",
                 Arg.Any<CancellationToken>())
-            .Returns(new List<string> { TestSessionId, otherSessionId });
+            .Returns((IReadOnlyList<string>)[TestSessionId, otherSessionId]);
 
         HttpResponseMessage response = await SendAnonymousWithSessionAsync(
             HttpMethod.Delete, "/app/bff/sessions");
@@ -486,7 +486,7 @@ public sealed class BffEndpointsIntegrationTests : IAsyncLifetime
                 BffEndpointsTestServer.TestFrontendName,
                 "user-42",
                 Arg.Any<CancellationToken>())
-            .Returns(new List<string> { "session-1", "session-2" });
+            .Returns((IReadOnlyList<string>)["session-1", "session-2"]);
 
         FormUrlEncodedContent content = new(new Dictionary<string, string>
         {
@@ -514,7 +514,7 @@ public sealed class BffEndpointsIntegrationTests : IAsyncLifetime
     public async Task PostBackChannelLogout_MissingLogoutToken_Returns400()
     {
         // Post an empty form without the logout_token parameter
-        FormUrlEncodedContent content = new(new Dictionary<string, string>());
+        FormUrlEncodedContent content = new([]);
 
         HttpResponseMessage response = await _server.AnonymousClient.PostAsync(
             "/app/bff/backchannel-logout", content, TestContext.Current.CancellationToken);

--- a/tests/Granit.Bff.Endpoints.Tests/Integration/BffEndpointsTestServer.cs
+++ b/tests/Granit.Bff.Endpoints.Tests/Integration/BffEndpointsTestServer.cs
@@ -22,7 +22,7 @@ namespace Granit.Bff.Endpoints.Tests.Integration;
 
 /// <summary>
 /// Test server that boots a minimal ASP.NET Core application with mocked services
-/// and the BFF endpoints registered via <see cref="BffEndpointRouteBuilderExtensions.MapGranitBffEndpoints"/>.
+/// and the BFF endpoints registered via <see cref="BffEndpointRouteBuilderExtensions.MapGranitBff"/>.
 /// </summary>
 internal sealed class BffEndpointsTestServer : IAsyncDisposable
 {
@@ -160,7 +160,7 @@ internal sealed class BffEndpointsTestServer : IAsyncDisposable
         builder.Services.AddHttpClient(); // default client for other uses
 
         WebApplication app = builder.Build();
-        app.MapGranitBffEndpoints();
+        app.MapGranitBff();
         await app.StartAsync().ConfigureAwait(false);
 
         TestServer testServer = app.GetTestServer();

--- a/tests/Granit.Bff.Yarp.Tests/Internal/BffTokenInjectionTransformTests.cs
+++ b/tests/Granit.Bff.Yarp.Tests/Internal/BffTokenInjectionTransformTests.cs
@@ -569,10 +569,8 @@ public sealed class BffTokenInjectionTransformTests : IDisposable
         context.HttpContext.Response.StatusCode.ShouldBe(StatusCodes.Status401Unauthorized);
     }
 
-    private static RequestTransformContext CreateTransformContext(Dictionary<string, string> metadata)
-    {
-        return CreateTransformContextWithPath(metadata, "/");
-    }
+    private static RequestTransformContext CreateTransformContext(Dictionary<string, string> metadata) =>
+        CreateTransformContextWithPath(metadata, "/");
 
     private sealed class FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
         : HttpMessageHandler

--- a/tests/Granit.DataExchange.Endpoints.Tests/Export/ExportDefinitionEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Export/ExportDefinitionEndpointsTests.cs
@@ -77,7 +77,7 @@ public sealed class ExportDefinitionEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton<IGuidGenerator>(new SimpleGuidGenerator());
 
         _app = builder.Build();
-        _app.MapDataExchangeEndpoints();
+        _app.MapGranitDataExchange();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);

--- a/tests/Granit.DataExchange.Endpoints.Tests/Export/ExportExecutionEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Export/ExportExecutionEndpointsTests.cs
@@ -77,7 +77,7 @@ public sealed class ExportExecutionEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton<IGuidGenerator>(new SimpleGuidGenerator());
 
         _app = builder.Build();
-        _app.MapDataExchangeEndpoints();
+        _app.MapGranitDataExchange();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);

--- a/tests/Granit.DataExchange.Endpoints.Tests/Export/ExportJobListEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Export/ExportJobListEndpointsTests.cs
@@ -65,7 +65,7 @@ public sealed class ExportJobListEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton<IGuidGenerator>(new SimpleGuidGenerator());
 
         _app = builder.Build();
-        _app.MapDataExchangeEndpoints();
+        _app.MapGranitDataExchange();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);

--- a/tests/Granit.DataExchange.Endpoints.Tests/Export/ExportPresetEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Export/ExportPresetEndpointsTests.cs
@@ -76,7 +76,7 @@ public sealed class ExportPresetEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton<IGuidGenerator>(new SimpleGuidGenerator());
 
         _app = builder.Build();
-        _app.MapDataExchangeEndpoints();
+        _app.MapGranitDataExchange();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);

--- a/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportExecutionEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportExecutionEndpointsTests.cs
@@ -74,7 +74,7 @@ public sealed class ImportExecutionEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(Substitute.For<IExportJobReader>());
 
         _app = builder.Build();
-        _app.MapDataExchangeEndpoints();
+        _app.MapGranitDataExchange();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);

--- a/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportJobListEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportJobListEndpointsTests.cs
@@ -64,7 +64,7 @@ public sealed class ImportJobListEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(Substitute.For<IExportJobReader>());
 
         _app = builder.Build();
-        _app.MapDataExchangeEndpoints();
+        _app.MapGranitDataExchange();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);

--- a/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportReportEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportReportEndpointsTests.cs
@@ -80,7 +80,7 @@ public sealed class ImportReportEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(Substitute.For<IExportJobReader>());
 
         _app = builder.Build();
-        _app.MapDataExchangeEndpoints();
+        _app.MapGranitDataExchange();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);

--- a/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportUploadEndpointsTests.cs
+++ b/tests/Granit.DataExchange.Endpoints.Tests/Import/ImportUploadEndpointsTests.cs
@@ -98,7 +98,7 @@ public sealed class ImportUploadEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(Substitute.For<IExportJobReader>());
 
         _app = builder.Build();
-        _app.MapDataExchangeEndpoints();
+        _app.MapGranitDataExchange();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityProviderGroupEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityProviderGroupEndpointsTests.cs
@@ -75,7 +75,7 @@ public sealed class IdentityProviderGroupEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(_capabilities);
 
         _app = builder.Build();
-        _app.MapIdentityProviderEndpoints();
+        _app.MapGranitIdentityProvider();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityProviderPasswordEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityProviderPasswordEndpointsTests.cs
@@ -72,7 +72,7 @@ public sealed class IdentityProviderPasswordEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(_capabilities);
 
         _app = builder.Build();
-        _app.MapIdentityProviderEndpoints();
+        _app.MapGranitIdentityProvider();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityProviderRoleEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityProviderRoleEndpointsTests.cs
@@ -80,7 +80,7 @@ public sealed class IdentityProviderRoleEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(_capabilities);
 
         _app = builder.Build();
-        _app.MapIdentityProviderEndpoints();
+        _app.MapGranitIdentityProvider();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityProviderSessionEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityProviderSessionEndpointsTests.cs
@@ -79,7 +79,7 @@ public sealed class IdentityProviderSessionEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(_capabilities);
 
         _app = builder.Build();
-        _app.MapIdentityProviderEndpoints();
+        _app.MapGranitIdentityProvider();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityProviderUserEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityProviderUserEndpointsTests.cs
@@ -77,7 +77,7 @@ public sealed class IdentityProviderUserEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(_capabilities);
 
         _app = builder.Build();
-        _app.MapIdentityProviderEndpoints();
+        _app.MapGranitIdentityProvider();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityUserCacheReadEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityUserCacheReadEndpointsTests.cs
@@ -52,7 +52,7 @@ public sealed class IdentityUserCacheReadEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(_cacheStats);
 
         _app = builder.Build();
-        _app.MapIdentityUserCacheEndpoints();
+        _app.MapGranitIdentityUserCache();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityUserCacheRgpdEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityUserCacheRgpdEndpointsTests.cs
@@ -48,7 +48,7 @@ public sealed class IdentityUserCacheRgpdEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(_cacheStats);
 
         _app = builder.Build();
-        _app.MapIdentityUserCacheEndpoints();
+        _app.MapGranitIdentityUserCache();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityUserCacheStatsEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityUserCacheStatsEndpointsTests.cs
@@ -49,7 +49,7 @@ public sealed class IdentityUserCacheStatsEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(_cacheStats);
 
         _app = builder.Build();
-        _app.MapIdentityUserCacheEndpoints();
+        _app.MapGranitIdentityUserCache();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityUserCacheSyncEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityUserCacheSyncEndpointsTests.cs
@@ -51,7 +51,7 @@ public sealed class IdentityUserCacheSyncEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(_cacheStats);
 
         _app = builder.Build();
-        _app.MapIdentityUserCacheEndpoints();
+        _app.MapGranitIdentityUserCache();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityWebhookEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityWebhookEndpointsTests.cs
@@ -57,7 +57,7 @@ public sealed class IdentityWebhookEndpointsTests : IAsyncDisposable
         });
 
         _app = builder.Build();
-        _app.MapIdentityUserCacheEndpoints();
+        _app.MapGranitIdentityUserCache();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _client = _app.GetTestClient();
@@ -268,7 +268,7 @@ public sealed class IdentityWebhookEndpointsNoSecretTests : IAsyncDisposable
         // No secret configured — IdentityWebhookOptions.Secret remains ""
 
         _app = builder.Build();
-        _app.MapIdentityUserCacheEndpoints();
+        _app.MapGranitIdentityUserCache();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _client = _app.GetTestClient();

--- a/tests/Granit.Identity.Local.Endpoints.Tests/IdentityLocalPermissionsTests.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/IdentityLocalPermissionsTests.cs
@@ -7,10 +7,8 @@ namespace Granit.Identity.Local.Endpoints.Tests;
 public sealed class IdentityLocalPermissionsTests
 {
     [Fact]
-    public void GroupName_IsIdentityLocal()
-    {
+    public void GroupName_IsIdentityLocal() =>
         IdentityLocalPermissions.GroupName.ShouldBe("IdentityLocal");
-    }
 
     [Fact]
     public void Impersonate_FollowsThreeSegmentFormat()
@@ -20,8 +18,6 @@ public sealed class IdentityLocalPermissionsTests
     }
 
     [Fact]
-    public void Impersonate_StartsWithGroupName()
-    {
+    public void Impersonate_StartsWithGroupName() =>
         IdentityLocalPermissions.Users.Impersonate.ShouldStartWith(IdentityLocalPermissions.GroupName + ".");
-    }
 }

--- a/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsTestServer.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsTestServer.cs
@@ -25,7 +25,7 @@ namespace Granit.Identity.Local.Endpoints.Tests.Integration;
 /// <summary>
 /// Test server that boots a minimal ASP.NET Core application with mocked services
 /// and the account endpoints registered via
-/// <see cref="AccountEndpointRouteBuilderExtensions.MapAccountEndpoints"/>.
+/// <see cref="AccountEndpointRouteBuilderExtensions.MapGranitAccount"/>.
 /// </summary>
 internal sealed class AccountEndpointsTestServer : IAsyncDisposable
 {
@@ -203,7 +203,7 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
             ServiceLifetime.Singleton, includeInternalTypes: true);
 
         WebApplication app = builder.Build();
-        app.MapAccountEndpoints();
+        app.MapGranitAccount();
         await app.StartAsync().ConfigureAwait(false);
 
         string allRoles = string.Join(",", AuthenticatedRole, ImpersonateRole);

--- a/tests/Granit.Notifications.Endpoints.Tests/MapGranitNotificationEndpointsTests.cs
+++ b/tests/Granit.Notifications.Endpoints.Tests/MapGranitNotificationEndpointsTests.cs
@@ -7,40 +7,40 @@ using Xunit;
 
 namespace Granit.Notifications.Endpoints.Tests;
 
-public sealed class MapGranitNotificationEndpointsTests
+public sealed class MapGranitNotificationsTests
 {
     [Fact]
-    public void MapGranitNotificationEndpoints_WithDefaultOptions_ReturnsEndpointRouteBuilder()
+    public void MapGranitNotifications_WithDefaultOptions_ReturnsEndpointRouteBuilder()
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
         WebApplication app = builder.Build();
 
-        IEndpointRouteBuilder result = app.MapGranitNotificationEndpoints();
+        IEndpointRouteBuilder result = app.MapGranitNotifications();
 
         result.ShouldNotBeNull();
     }
 
     [Fact]
-    public void MapGranitNotificationEndpoints_WithCustomPrefix_ReturnsEndpointRouteBuilder()
+    public void MapGranitNotifications_WithCustomPrefix_ReturnsEndpointRouteBuilder()
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
         WebApplication app = builder.Build();
 
-        IEndpointRouteBuilder result = app.MapGranitNotificationEndpoints(
+        IEndpointRouteBuilder result = app.MapGranitNotifications(
             opts => opts.RoutePrefix = "notif");
 
         result.ShouldNotBeNull();
     }
 
     [Fact]
-    public void MapGranitNotificationEndpoints_WithNullConfigure_DoesNotThrow()
+    public void MapGranitNotifications_WithNullConfigure_DoesNotThrow()
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
         WebApplication app = builder.Build();
 
-        Should.NotThrow(() => app.MapGranitNotificationEndpoints(configure: null));
+        Should.NotThrow(() => app.MapGranitNotifications(configure: null));
     }
 }

--- a/tests/Granit.Notifications.Endpoints.Tests/MobilePushTokenEndpointsTests.cs
+++ b/tests/Granit.Notifications.Endpoints.Tests/MobilePushTokenEndpointsTests.cs
@@ -54,7 +54,7 @@ public sealed class MobilePushTokenEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(_clock);
 
         _app = builder.Build();
-        _app.MapMobilePushTokenEndpoints();
+        _app.MapGranitMobilePushTokens();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _authClient = BuildClient("user-456");

--- a/tests/Granit.Notifications.Endpoints.Tests/NotificationEndpointsTests.cs
+++ b/tests/Granit.Notifications.Endpoints.Tests/NotificationEndpointsTests.cs
@@ -67,7 +67,7 @@ public sealed class NotificationEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton<IGuidGenerator>(new SimpleGuidGenerator());
 
         _app = builder.Build();
-        _app.MapGranitNotificationEndpoints();
+        _app.MapGranitNotifications();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _authClient = BuildClient("user-123");

--- a/tests/Granit.OpenIddict.Endpoints.Tests/Integration/OidcEndpointsTestServer.cs
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/Integration/OidcEndpointsTestServer.cs
@@ -17,7 +17,7 @@ namespace Granit.OpenIddict.Endpoints.Tests.Integration;
 
 /// <summary>
 /// Test server that boots a minimal ASP.NET Core application with mocked services
-/// and the OpenIddict admin endpoints registered via <see cref="OpenIddictEndpointRouteBuilderExtensions.MapOpenIddictEndpoints"/>.
+/// and the OpenIddict admin endpoints registered via <see cref="OpenIddictEndpointRouteBuilderExtensions.MapGranitOpenIddict"/>.
 /// </summary>
 internal sealed class OidcEndpointsTestServer : IAsyncDisposable
 {
@@ -109,7 +109,7 @@ internal sealed class OidcEndpointsTestServer : IAsyncDisposable
             ServiceLifetime.Singleton, includeInternalTypes: true);
 
         WebApplication app = builder.Build();
-        app.MapOpenIddictEndpoints();
+        app.MapGranitOpenIddict();
         await app.StartAsync().ConfigureAwait(false);
 
         HttpClient authenticatedClient = app.GetTestClient();

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/AspNetImpersonationServiceTests.cs
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/AspNetImpersonationServiceTests.cs
@@ -57,7 +57,7 @@ public sealed class AspNetImpersonationServiceTests
         string impersonatorId = impersonatorGuid.ToString();
 
         _userManager.FindByIdAsync(targetId).Returns(target);
-        _userManager.GetRolesAsync(target).Returns(new List<string> { "Admin", "User" });
+        _userManager.GetRolesAsync(target).Returns(["Admin", "User"]);
 
         object accessTokenEntry = new object();
         object refreshTokenEntry = new object();
@@ -91,7 +91,7 @@ public sealed class AspNetImpersonationServiceTests
         string impersonatorId = impersonatorGuid.ToString();
 
         _userManager.FindByIdAsync(targetId).Returns(target);
-        _userManager.GetRolesAsync(target).Returns(new List<string>());
+        _userManager.GetRolesAsync(target).Returns([]);
         SetupTokenCreation();
 
         await _sut.ImpersonateAsync(
@@ -113,7 +113,7 @@ public sealed class AspNetImpersonationServiceTests
         var impersonatorGuid = Guid.NewGuid();
 
         _userManager.FindByIdAsync(targetId).Returns(target);
-        _userManager.GetRolesAsync(target).Returns(new List<string>());
+        _userManager.GetRolesAsync(target).Returns([]);
         SetupTokenCreation();
 
         await _sut.ImpersonateAsync(
@@ -187,7 +187,7 @@ public sealed class AspNetImpersonationServiceTests
         string targetId = target.Id.ToString();
 
         _userManager.FindByIdAsync(targetId).Returns(target);
-        _userManager.GetRolesAsync(target).Returns(new List<string>());
+        _userManager.GetRolesAsync(target).Returns([]);
 
         object tokenEntry = new object();
         _tokenManager.CreateAsync(Arg.Any<OpenIddictTokenDescriptor>(), Arg.Any<CancellationToken>())
@@ -209,7 +209,7 @@ public sealed class AspNetImpersonationServiceTests
         string targetId = target.Id.ToString();
 
         _userManager.FindByIdAsync(targetId).Returns(target);
-        _userManager.GetRolesAsync(target).Returns(new List<string>());
+        _userManager.GetRolesAsync(target).Returns([]);
         SetupTokenCreation();
 
         ImpersonationResult result = await _sut.ImpersonateAsync(
@@ -227,7 +227,7 @@ public sealed class AspNetImpersonationServiceTests
         string adminId = admin.Id.ToString();
 
         _userManager.FindByIdAsync(adminId).Returns(admin);
-        _userManager.GetRolesAsync(admin).Returns(new List<string> { "Admin" });
+        _userManager.GetRolesAsync(admin).Returns(["Admin"]);
 
         object accessTokenEntry = new object();
         object refreshTokenEntry = new object();
@@ -257,7 +257,7 @@ public sealed class AspNetImpersonationServiceTests
         string adminId = admin.Id.ToString();
 
         _userManager.FindByIdAsync(adminId).Returns(admin);
-        _userManager.GetRolesAsync(admin).Returns(new List<string>());
+        _userManager.GetRolesAsync(admin).Returns([]);
         SetupTokenCreation();
 
         await _sut.BackToImpersonatorAsync(adminId, TestContext.Current.CancellationToken);
@@ -306,7 +306,7 @@ public sealed class AspNetImpersonationServiceTests
         string adminId = admin.Id.ToString();
 
         _userManager.FindByIdAsync(adminId).Returns(admin);
-        _userManager.GetRolesAsync(admin).Returns(new List<string>());
+        _userManager.GetRolesAsync(admin).Returns([]);
 
         object tokenEntry = new object();
         _tokenManager.CreateAsync(Arg.Any<OpenIddictTokenDescriptor>(), Arg.Any<CancellationToken>())
@@ -329,7 +329,7 @@ public sealed class AspNetImpersonationServiceTests
         string adminId = admin.Id.ToString();
 
         _userManager.FindByIdAsync(adminId).Returns(admin);
-        _userManager.GetRolesAsync(admin).Returns(new List<string>());
+        _userManager.GetRolesAsync(admin).Returns([]);
         SetupTokenCreation();
 
         ImpersonationResult result = await _sut.BackToImpersonatorAsync(
@@ -346,7 +346,7 @@ public sealed class AspNetImpersonationServiceTests
         string adminId = admin.Id.ToString();
 
         _userManager.FindByIdAsync(adminId).Returns(admin);
-        _userManager.GetRolesAsync(admin).Returns(new List<string>());
+        _userManager.GetRolesAsync(admin).Returns([]);
         SetupTokenCreation();
 
         ImpersonationResult result = await _sut.BackToImpersonatorAsync(

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/AspNetPasskeyServiceTests.cs
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/AspNetPasskeyServiceTests.cs
@@ -55,7 +55,7 @@ public sealed class AspNetPasskeyServiceTests
 
         UserPasskeyInfo passkey = CreatePasskeyInfo(credentialId);
         _userManager.FindByIdAsync(userId).Returns(user);
-        _userManager.GetPasskeysAsync(user).Returns(new List<UserPasskeyInfo> { passkey });
+        _userManager.GetPasskeysAsync(user).Returns((IList<UserPasskeyInfo>)[passkey]);
 
         IReadOnlyList<PasskeyInfo> result = await _sut.GetPasskeysAsync(
             userId, TestContext.Current.CancellationToken);
@@ -99,11 +99,11 @@ public sealed class AspNetPasskeyServiceTests
         credId2[0] = 0x02;
 
         _userManager.FindByIdAsync(userId).Returns(user);
-        _userManager.GetPasskeysAsync(user).Returns(new List<UserPasskeyInfo>
-        {
+        _userManager.GetPasskeysAsync(user).Returns((IList<UserPasskeyInfo>)
+        [
             CreatePasskeyInfo(credId1),
             CreatePasskeyInfo(credId2),
-        });
+        ]);
 
         IReadOnlyList<PasskeyInfo> result = await _sut.GetPasskeysAsync(
             userId, TestContext.Current.CancellationToken);
@@ -118,7 +118,7 @@ public sealed class AspNetPasskeyServiceTests
         string userId = user.Id.ToString();
 
         _userManager.FindByIdAsync(userId).Returns(user);
-        _userManager.GetPasskeysAsync(user).Returns(new List<UserPasskeyInfo>());
+        _userManager.GetPasskeysAsync(user).Returns((IList<UserPasskeyInfo>)[]);
 
         IReadOnlyList<PasskeyInfo> result = await _sut.GetPasskeysAsync(
             userId, TestContext.Current.CancellationToken);
@@ -324,10 +324,10 @@ public sealed class AspNetPasskeyServiceTests
 
         _userManager.FindByPasskeyIdAsync(Arg.Is<byte[]>(b => b.Length == credentialId.Length))
             .Returns(user);
-        _userManager.GetPasskeysAsync(user).Returns(new List<UserPasskeyInfo>
-        {
+        _userManager.GetPasskeysAsync(user).Returns((IList<UserPasskeyInfo>)
+        [
             CreatePasskeyInfo(credentialId),
-        });
+        ]);
 
         GranitPasskeyAssertionResult result = await _sut.CompleteAssertionAsync(
             credentialJson, TestContext.Current.CancellationToken);
@@ -378,10 +378,10 @@ public sealed class AspNetPasskeyServiceTests
 
         byte[] differentCredentialId = new byte[32];
         differentCredentialId[0] = 0xCC;
-        _userManager.GetPasskeysAsync(user).Returns(new List<UserPasskeyInfo>
-        {
+        _userManager.GetPasskeysAsync(user).Returns((IList<UserPasskeyInfo>)
+        [
             CreatePasskeyInfo(differentCredentialId),
-        });
+        ]);
 
         GranitPasskeyAssertionResult result = await _sut.CompleteAssertionAsync(
             credentialJson, TestContext.Current.CancellationToken);
@@ -434,11 +434,11 @@ public sealed class AspNetPasskeyServiceTests
 
         _userManager.FindByIdAsync(userId).Returns(user);
         _userManager.HasPasswordAsync(user).Returns(false);
-        _userManager.GetPasskeysAsync(user).Returns(new List<UserPasskeyInfo>
-        {
+        _userManager.GetPasskeysAsync(user).Returns((IList<UserPasskeyInfo>)
+        [
             CreatePasskeyInfo(new byte[32]),
             CreatePasskeyInfo(new byte[32]),
-        });
+        ]);
         _userManager.RemovePasskeyAsync(user, Arg.Any<byte[]>()).Returns(IdentityResult.Success);
 
         await Should.NotThrowAsync(
@@ -454,10 +454,10 @@ public sealed class AspNetPasskeyServiceTests
 
         _userManager.FindByIdAsync(userId).Returns(user);
         _userManager.HasPasswordAsync(user).Returns(true);
-        _userManager.GetPasskeysAsync(user).Returns(new List<UserPasskeyInfo>
-        {
+        _userManager.GetPasskeysAsync(user).Returns((IList<UserPasskeyInfo>)
+        [
             CreatePasskeyInfo(new byte[32]),
-        });
+        ]);
         _userManager.RemovePasskeyAsync(user, Arg.Any<byte[]>()).Returns(IdentityResult.Success);
 
         await Should.NotThrowAsync(
@@ -473,10 +473,10 @@ public sealed class AspNetPasskeyServiceTests
 
         _userManager.FindByIdAsync(userId).Returns(user);
         _userManager.HasPasswordAsync(user).Returns(false);
-        _userManager.GetPasskeysAsync(user).Returns(new List<UserPasskeyInfo>
-        {
+        _userManager.GetPasskeysAsync(user).Returns((IList<UserPasskeyInfo>)
+        [
             CreatePasskeyInfo(new byte[32]),
-        });
+        ]);
 
         InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
             () => _sut.DeleteAsync(userId, passkeyId, TestContext.Current.CancellationToken));
@@ -493,11 +493,11 @@ public sealed class AspNetPasskeyServiceTests
 
         _userManager.FindByIdAsync(userId).Returns(user);
         _userManager.HasPasswordAsync(user).Returns(true);
-        _userManager.GetPasskeysAsync(user).Returns(new List<UserPasskeyInfo>
-        {
+        _userManager.GetPasskeysAsync(user).Returns((IList<UserPasskeyInfo>)
+        [
             CreatePasskeyInfo(new byte[32]),
             CreatePasskeyInfo(new byte[32]),
-        });
+        ]);
         _userManager.RemovePasskeyAsync(user, Arg.Any<byte[]>())
             .Returns(IdentityResult.Failed(new IdentityError { Description = "Passkey not found" }));
 
@@ -537,7 +537,7 @@ public sealed class AspNetPasskeyServiceTests
 
         _userManager.FindByIdAsync(userId).Returns(user);
         _userManager.HasPasswordAsync(user).Returns(false);
-        _userManager.GetPasskeysAsync(user).Returns(new List<UserPasskeyInfo>());
+        _userManager.GetPasskeysAsync(user).Returns((IList<UserPasskeyInfo>)[]);
 
         InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(
             () => _sut.DeleteAsync(userId, Guid.NewGuid(), TestContext.Current.CancellationToken));

--- a/tests/Granit.OpenIddict.Tests.Integration/Fixtures/OpenIddictTestApplication.cs
+++ b/tests/Granit.OpenIddict.Tests.Integration/Fixtures/OpenIddictTestApplication.cs
@@ -123,8 +123,8 @@ public sealed class OpenIddictTestApplication : IAsyncLifetime
         // then passes through to ASP.NET Core for token issuance (client_credentials).
         _app.MapPost("/connect/token", HandleTokenAsync);
 
-        _app.MapOpenIddictEndpoints();
-        _app.MapAccountEndpoints();
+        _app.MapGranitOpenIddict();
+        _app.MapGranitAccount();
 
         // 6. EnsureCreated + seed
         await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();

--- a/tests/Granit.QueryEngine.Endpoints.Tests.Integration/QueryEndpointIntegrationTests.cs
+++ b/tests/Granit.QueryEngine.Endpoints.Tests.Integration/QueryEndpointIntegrationTests.cs
@@ -52,7 +52,7 @@ public sealed class QueryEndpointIntegrationTests : IAsyncDisposable
         _app = builder.Build();
 
         // Map query endpoints with a fake source
-        _app.MapQueryEndpoints<TestProduct>(
+        _app.MapGranitQuery<TestProduct>(
             Prefix,
             _ => Array.Empty<TestProduct>().AsQueryable());
 
@@ -353,7 +353,7 @@ public sealed class QueryEndpointIntegrationTests : IAsyncDisposable
     // ── Options ────────────────────────────────────────────────────
 
     [Fact]
-    public async Task MapQueryEndpoints_without_meta_does_not_register_meta()
+    public async Task MapGranitQuery_without_meta_does_not_register_meta()
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
@@ -377,7 +377,7 @@ public sealed class QueryEndpointIntegrationTests : IAsyncDisposable
             .Returns(new PagedResult<TestProduct>([], 0, HasMore: false));
 
         await using WebApplication customApp = builder.Build();
-        customApp.MapQueryEndpoints<TestProduct>(
+        customApp.MapGranitQuery<TestProduct>(
             "/api/items",
             _ => Array.Empty<TestProduct>().AsQueryable(),
             opts =>

--- a/tests/Granit.ReferenceData.Endpoints.Tests/ReferenceDataEndpointsTests.cs
+++ b/tests/Granit.ReferenceData.Endpoints.Tests/ReferenceDataEndpointsTests.cs
@@ -63,7 +63,7 @@ public sealed class ReferenceDataEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton<IGuidGenerator>(new SimpleGuidGenerator());
 
         _app = builder.Build();
-        _app.MapReferenceDataEndpoints<TestRefEntity>();
+        _app.MapGranitReferenceData<TestRefEntity>();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreConcurrencyTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreConcurrencyTests.cs
@@ -89,10 +89,8 @@ public sealed class EfCoreReferenceDataStoreConcurrencyTests : IAsyncLifetime
         await _keepAlive.OpenAsync();
     }
 
-    public async ValueTask DisposeAsync()
-    {
+    public async ValueTask DisposeAsync() =>
         await _keepAlive.DisposeAsync();
-    }
 
     private async Task<ServiceProvider> BuildProviderAsync(params IInterceptor[] interceptors)
     {

--- a/tests/Granit.Templating.Endpoints.Tests/TemplateCategoryEndpointsTests.cs
+++ b/tests/Granit.Templating.Endpoints.Tests/TemplateCategoryEndpointsTests.cs
@@ -74,7 +74,7 @@ public sealed class TemplateCategoryEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(userService);
 
         _app = builder.Build();
-        _app.MapGranitTemplatingAdmin();
+        _app.MapGranitTemplating();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(_app, ManageRole);
@@ -407,7 +407,7 @@ public sealed class TemplateCategoryEndpointsTests : IAsyncDisposable
                 policy => policy.RequireRole(ManageRole));
 
         WebApplication app = builder.Build();
-        app.MapGranitTemplatingAdmin();
+        app.MapGranitTemplating();
         await app.StartAsync(TestContext.Current.CancellationToken);
         return app;
     }

--- a/tests/Granit.Templating.Endpoints.Tests/TemplatingEndpointsTests.cs
+++ b/tests/Granit.Templating.Endpoints.Tests/TemplatingEndpointsTests.cs
@@ -73,7 +73,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(CreateTestUserService());
 
         _app = builder.Build();
-        _app.MapGranitTemplatingAdmin();
+        _app.MapGranitTemplating();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(ManageRole);
@@ -1061,7 +1061,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
     // =========================================================================
 
     [Fact]
-    public async Task MapGranitTemplatingAdmin_WithCustomPrefix_RespondsOnCustomRoute()
+    public async Task MapGranitTemplating_WithCustomPrefix_RespondsOnCustomRoute()
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
@@ -1087,7 +1087,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
             .Returns(new PagedTemplateResult([], 0));
 
         await using WebApplication app = builder.Build();
-        app.MapGranitTemplatingAdmin(opts =>
+        app.MapGranitTemplating(opts =>
         {
             opts.RoutePrefix = "custom-templates";
         });
@@ -1442,7 +1442,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(CreateTestUserService());
 
         WebApplication app = builder.Build();
-        app.MapGranitTemplatingAdmin();
+        app.MapGranitTemplating();
         await app.StartAsync(TestContext.Current.CancellationToken);
         return app;
     }
@@ -1498,7 +1498,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(CreateTestUserService());
 
         WebApplication app = builder.Build();
-        app.MapGranitTemplatingAdmin();
+        app.MapGranitTemplating();
         await app.StartAsync(TestContext.Current.CancellationToken);
         return app;
     }
@@ -1524,7 +1524,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
                 policy => policy.RequireRole(ManageRole));
 
         WebApplication app = builder.Build();
-        app.MapGranitTemplatingAdmin();
+        app.MapGranitTemplating();
         await app.StartAsync(TestContext.Current.CancellationToken);
         return app;
     }

--- a/tests/Granit.Timeline.Endpoints.Tests/TimelineEntryEndpointsTests.cs
+++ b/tests/Granit.Timeline.Endpoints.Tests/TimelineEntryEndpointsTests.cs
@@ -62,7 +62,7 @@ public sealed class TimelineEntryEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(_permissionChecker);
 
         _app = builder.Build();
-        _app.MapTimelineEndpoints();
+        _app.MapGranitTimeline();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _authClient = BuildClient(UserRole);

--- a/tests/Granit.Timeline.Endpoints.Tests/TimelineFollowerEndpointsTests.cs
+++ b/tests/Granit.Timeline.Endpoints.Tests/TimelineFollowerEndpointsTests.cs
@@ -55,7 +55,7 @@ public sealed class TimelineFollowerEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(Substitute.For<ITimelineNotifier>());
 
         _app = builder.Build();
-        _app.MapTimelineEndpoints();
+        _app.MapGranitTimeline();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _authClient = BuildClient(UserRole);

--- a/tests/Granit.Timeline.Endpoints.Tests/TimelineStreamEndpointsTests.cs
+++ b/tests/Granit.Timeline.Endpoints.Tests/TimelineStreamEndpointsTests.cs
@@ -57,7 +57,7 @@ public sealed class TimelineStreamEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(Substitute.For<Granit.Users.ICurrentUserService>());
 
         _app = builder.Build();
-        _app.MapTimelineEndpoints();
+        _app.MapGranitTimeline();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _authClient = BuildClient(UserRole);

--- a/tests/Granit.Workflow.Endpoints.Tests/WorkflowEndpointRouteBuilderExtensionsTests.cs
+++ b/tests/Granit.Workflow.Endpoints.Tests/WorkflowEndpointRouteBuilderExtensionsTests.cs
@@ -15,13 +15,13 @@ using Xunit;
 namespace Granit.Workflow.Endpoints.Tests;
 
 /// <summary>
-/// Verifies that <see cref="WorkflowEndpointRouteBuilderExtensions.MapWorkflowEndpoints"/>
+/// Verifies that <see cref="WorkflowEndpointRouteBuilderExtensions.MapGranitWorkflow"/>
 /// correctly applies route prefix and authorization policy.
 /// </summary>
 public sealed class WorkflowEndpointRouteBuilderExtensionsTests
 {
     [Fact]
-    public async Task MapWorkflowEndpoints_with_custom_prefix_routes_correctly()
+    public async Task MapGranitWorkflow_with_custom_prefix_routes_correctly()
     {
         // Arrange
         IWorkflowHistoryQuery historyQuery = Substitute.For<IWorkflowHistoryQuery>();
@@ -44,7 +44,7 @@ public sealed class WorkflowEndpointRouteBuilderExtensionsTests
     }
 
     [Fact]
-    public async Task MapWorkflowEndpoints_default_prefix_is_workflow()
+    public async Task MapGranitWorkflow_default_prefix_is_workflow()
     {
         // Arrange
         IWorkflowHistoryQuery historyQuery = Substitute.For<IWorkflowHistoryQuery>();
@@ -63,7 +63,7 @@ public sealed class WorkflowEndpointRouteBuilderExtensionsTests
     }
 
     [Fact]
-    public async Task MapWorkflowEndpoints_returns_group_builder_for_chaining()
+    public async Task MapGranitWorkflow_returns_group_builder_for_chaining()
     {
         // Arrange
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
@@ -79,7 +79,7 @@ public sealed class WorkflowEndpointRouteBuilderExtensionsTests
         WebApplication app = builder.Build();
 
         // Act
-        Microsoft.AspNetCore.Routing.RouteGroupBuilder group = app.MapWorkflowEndpoints();
+        Microsoft.AspNetCore.Routing.RouteGroupBuilder group = app.MapGranitWorkflow();
 
         // Assert
         group.ShouldNotBeNull();
@@ -106,7 +106,7 @@ public sealed class WorkflowEndpointRouteBuilderExtensionsTests
         builder.Services.AddSingleton(historyQuery);
 
         WebApplication app = builder.Build();
-        app.MapWorkflowEndpoints(configure);
+        app.MapGranitWorkflow(configure);
         app.StartAsync().GetAwaiter().GetResult();
 
         return app;

--- a/tests/Granit.Workflow.Endpoints.Tests/WorkflowReadEndpointsTests.cs
+++ b/tests/Granit.Workflow.Endpoints.Tests/WorkflowReadEndpointsTests.cs
@@ -43,7 +43,7 @@ public sealed class WorkflowReadEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(_historyQuery);
 
         _app = builder.Build();
-        _app.MapWorkflowEndpoints();
+        _app.MapGranitWorkflow();
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);


### PR DESCRIPTION
## Summary

Closes #792.

- **Harmonize 27 `Map*` endpoint extension methods** to follow a single `MapGranit{Feature}()` convention, eliminating 3 inconsistent patterns (`Map{Feature}Endpoints()`, `MapGranit{Feature}Endpoints()`, and mixed variants)
- **Add architecture test** (`Public_Map_extension_methods_should_follow_MapGranit_convention`) to prevent future regressions — validates all public `Map*` extension methods on `IEndpointRouteBuilder` follow the `MapGranit*` prefix
- **Fix 28 SonarQube code smells** in test files: collection expression simplifications and expression body conversions

### Rename matrix (27 methods)

| Old name | New name |
|----------|----------|
| `MapAIEndpoints` | `MapGranitAI` |
| `MapAuditingEndpoints` | `MapGranitAuditing` |
| `MapApiKeysEndpoints` | `MapGranitApiKeys` |
| `MapAuthorizationEndpoints` | `MapGranitAuthorization` |
| `MapBackgroundJobsEndpoints` | `MapGranitBackgroundJobs` |
| `MapGranitBffEndpoints` | `MapGranitBff` |
| `MapBlobStorageEndpoints` | `MapGranitBlobStorage` |
| `MapGranitBlobProxyEndpoints` | `MapGranitBlobProxy` |
| `MapDataExchangeEndpoints` | `MapGranitDataExchange` |
| `MapIdentityUserCacheEndpoints` | `MapGranitIdentityUserCache` |
| `MapIdentityProviderEndpoints` | `MapGranitIdentityProvider` |
| `MapAccountEndpoints` | `MapGranitAccount` |
| `MapGranitNotificationEndpoints` | `MapGranitNotifications` |
| `MapMobilePushTokenEndpoints` | `MapGranitMobilePushTokens` |
| `MapGranitSseNotificationEndpoints` | `MapGranitSseNotifications` |
| `MapOpenIddictEndpoints` | `MapGranitOpenIddict` |
| `MapOpenIddictServerEndpoints` | `MapGranitOpenIddictServer` |
| `MapQueryEndpoints<T>` | `MapGranitQuery<T>` |
| `MapReferenceDataEndpoints<T>` | `MapGranitReferenceData<T>` |
| `MapAllReferenceDataEndpoints` | `MapGranitAllReferenceData` |
| `MapGranitTemplatingAdmin` | `MapGranitTemplating` |
| `MapTimelineEndpoints` | `MapGranitTimeline` |
| `MapWebhooksEndpoints` | `MapGranitWebhooks` |
| `MapWorkflowEndpoints` | `MapGranitWorkflow` |
| `MapWorkflowTransitionEndpoints<T>` | `MapGranitWorkflowTransitions<T>` |
| `MapBackChannelLogout` | `MapGranitBackChannelLogout` |

### Downstream impact

Updated callers in:
- `granit-showcase-dotnet` — `Program.cs` (~18 calls)
- `granit-microservice-template` — `Program.cs` files (~3 calls)

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet format --verify-no-changes` — clean
- [x] `dotnet test tests/Granit.ArchitectureTests` — 99/99 pass (including new naming convention test)
- [ ] Full CI test suite (6 shards)
- [ ] Verify downstream repos build against updated packages
