### PR TITLE
fix(wolverine): handle WolverineHasNotStartedException during data seeding

### DIFF
--- a/src/Granit.Events.Wolverine/GranitEventsWolverineModule.cs
+++ b/src/Granit.Events.Wolverine/GranitEventsWolverineModule.cs
@@ -29,6 +29,12 @@ public sealed class GranitEventsWolverineModule : GranitModule
     /// <inheritdoc/>
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        // Host readiness indicator — enables graceful fallback before Wolverine starts.
+        // Registered as singleton + IHostedLifecycleService so StartedAsync fires after
+        // all IHostedService.StartAsync calls (including Wolverine's) have completed.
+        context.Services.AddSingleton<WolverineHostReadiness>();
+        context.Services.AddHostedService(sp => sp.GetRequiredService<WolverineHostReadiness>());
+
         context.Services.AddScoped<ILocalEventBus, WolverineLocalEventBus>();
         context.Services.AddScoped<IDistributedEventBus, WolverineDistributedEventBus>();
         context.Services.AddScoped<IDomainEventDispatcher, WolverineDomainEventDispatcher>();

--- a/src/Granit.Events.Wolverine/Internal/WolverineDistributedEventBus.cs
+++ b/src/Granit.Events.Wolverine/Internal/WolverineDistributedEventBus.cs
@@ -1,4 +1,5 @@
 using Granit.Events;
+using Microsoft.Extensions.Logging;
 using Wolverine;
 
 namespace Granit.Events.Wolverine.Internal;
@@ -8,13 +9,38 @@ namespace Granit.Events.Wolverine.Internal;
 /// Publishes integration events via <see cref="IMessageBus"/> with outbox support
 /// for at-least-once delivery across service boundaries.
 /// </summary>
-internal sealed class WolverineDistributedEventBus(IMessageBus bus) : IDistributedEventBus
+/// <remarks>
+/// When the host has not yet started (data seeding, <c>--migrate</c> mode),
+/// distributed events are silently skipped with a warning log. Seeding creates
+/// initial state — there are no downstream consumers that need to react to it.
+/// </remarks>
+internal sealed partial class WolverineDistributedEventBus(
+    IMessageBus bus,
+    WolverineHostReadiness readiness,
+    ILogger<WolverineDistributedEventBus> logger) : IDistributedEventBus
 {
+    private int _skipWarned;
+
     /// <inheritdoc/>
     public async Task PublishAsync<TEvent>(TEvent integrationEvent, CancellationToken cancellationToken = default)
         where TEvent : class, IIntegrationEvent
     {
         ArgumentNullException.ThrowIfNull(integrationEvent);
-        await bus.PublishAsync(integrationEvent).ConfigureAwait(false);
+
+        if (readiness.IsReady)
+        {
+            await bus.PublishAsync(integrationEvent).ConfigureAwait(false);
+            return;
+        }
+
+        // Wolverine not started — skip distributed events (no consumers during seeding/migrate)
+        if (Interlocked.CompareExchange(ref _skipWarned, 1, 0) == 0)
+        {
+            LogSkippingDistributedEvents();
+        }
     }
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Wolverine host not started — distributed events will be skipped. This is expected during data seeding or --migrate mode.")]
+    private partial void LogSkippingDistributedEvents();
 }

--- a/src/Granit.Events.Wolverine/Internal/WolverineDistributedEventBus.cs
+++ b/src/Granit.Events.Wolverine/Internal/WolverineDistributedEventBus.cs
@@ -1,4 +1,5 @@
 using Granit.Events;
+using Granit.Events.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Wolverine;
 
@@ -17,6 +18,7 @@ namespace Granit.Events.Wolverine.Internal;
 internal sealed partial class WolverineDistributedEventBus(
     IMessageBus bus,
     WolverineHostReadiness readiness,
+    EventsMetrics metrics,
     ILogger<WolverineDistributedEventBus> logger) : IDistributedEventBus
 {
     private int _skipWarned;
@@ -34,6 +36,8 @@ internal sealed partial class WolverineDistributedEventBus(
         }
 
         // Wolverine not started — skip distributed events (no consumers during seeding/migrate)
+        metrics.RecordEventPublished(null, "distributed-skipped", typeof(TEvent).Name);
+
         if (Interlocked.CompareExchange(ref _skipWarned, 1, 0) == 0)
         {
             LogSkippingDistributedEvents();

--- a/src/Granit.Events.Wolverine/Internal/WolverineDomainEventDispatcher.cs
+++ b/src/Granit.Events.Wolverine/Internal/WolverineDomainEventDispatcher.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Granit.Events;
+using Granit.Events.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Wolverine;
@@ -21,6 +22,7 @@ internal sealed partial class WolverineDomainEventDispatcher(
     IMessageBus bus,
     IServiceProvider serviceProvider,
     WolverineHostReadiness readiness,
+    EventsMetrics metrics,
     ILogger<WolverineDomainEventDispatcher> logger) : IDomainEventDispatcher
 {
     private int _fallbackWarned;
@@ -43,6 +45,10 @@ internal sealed partial class WolverineDomainEventDispatcher(
         // Wolverine not started — fall back to direct handler invocation.
         // serviceProvider is the SCOPED provider (this class is registered Scoped),
         // so handlers share the same scope as the caller (same DbContext instance).
+        //
+        // SECURITY INVARIANT: this path bypasses the Wolverine middleware pipeline.
+        // Handlers invoked here MUST NOT rely on Wolverine middleware for authorization
+        // or tenant context — they must receive all required context via the event payload.
         if (Interlocked.CompareExchange(ref _fallbackWarned, 1, 0) == 0)
         {
             LogFallbackActivated();
@@ -60,6 +66,9 @@ internal sealed partial class WolverineDomainEventDispatcher(
         // Domain events are dispatched via the non-generic IDomainEvent, so we need
         // to build the generic handler type from the concrete event type.
         Type eventType = domainEvent.GetType();
+        string eventTypeName = eventType.Name;
+        metrics.RecordEventPublished(null, "domain-fallback", eventTypeName);
+
         Type handlerType = typeof(ILocalEventHandler<>).MakeGenericType(eventType);
         IEnumerable<object?> handlers = serviceProvider.GetServices(handlerType);
 
@@ -77,14 +86,17 @@ internal sealed partial class WolverineDomainEventDispatcher(
                     .GetMethod(nameof(ILocalEventHandler<IDomainEvent>.HandleAsync))!
                     .Invoke(handler, [domainEvent, cancellationToken])!;
                 await task.ConfigureAwait(false);
+                metrics.RecordHandlerExecuted(null, eventTypeName, "success");
             }
             catch (TargetInvocationException ex) when (ex.InnerException is not null and not OperationCanceledException)
             {
                 // Unwrap reflection wrapper to log the actual handler exception
+                metrics.RecordHandlerExecuted(null, eventTypeName, "error");
                 LogFallbackHandlerFailed(eventType.Name, handler.GetType().Name, ex.InnerException);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
+                metrics.RecordHandlerExecuted(null, eventTypeName, "error");
                 LogFallbackHandlerFailed(eventType.Name, handler.GetType().Name, ex);
             }
         }

--- a/src/Granit.Events.Wolverine/Internal/WolverineDomainEventDispatcher.cs
+++ b/src/Granit.Events.Wolverine/Internal/WolverineDomainEventDispatcher.cs
@@ -1,4 +1,7 @@
+using System.Reflection;
 using Granit.Events;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Wolverine;
 
 namespace Granit.Events.Wolverine.Internal;
@@ -8,16 +11,90 @@ namespace Granit.Events.Wolverine.Internal;
 /// Publishes each domain event via <see cref="IMessageBus"/> using the non-generic
 /// overload so Wolverine routes by runtime type to locally discovered handlers.
 /// </summary>
-internal sealed class WolverineDomainEventDispatcher(IMessageBus bus) : IDomainEventDispatcher
+/// <remarks>
+/// When the host has not yet started (data seeding, <c>--migrate</c> mode),
+/// domain events are dispatched directly to <see cref="ILocalEventHandler{TEvent}"/>
+/// handlers resolved from the scoped DI container, bypassing the Wolverine pipeline.
+/// This preserves local side-effects (cache invalidation, denormalization) during seeding.
+/// </remarks>
+internal sealed partial class WolverineDomainEventDispatcher(
+    IMessageBus bus,
+    IServiceProvider serviceProvider,
+    WolverineHostReadiness readiness,
+    ILogger<WolverineDomainEventDispatcher> logger) : IDomainEventDispatcher
 {
+    private int _fallbackWarned;
+
     /// <inheritdoc/>
     public async Task DispatchAsync(
         IReadOnlyList<IDomainEvent> domainEvents,
         CancellationToken cancellationToken = default)
     {
+        if (readiness.IsReady)
+        {
+            foreach (IDomainEvent evt in domainEvents)
+            {
+                await bus.PublishAsync(evt).ConfigureAwait(false);
+            }
+
+            return;
+        }
+
+        // Wolverine not started — fall back to direct handler invocation.
+        // serviceProvider is the SCOPED provider (this class is registered Scoped),
+        // so handlers share the same scope as the caller (same DbContext instance).
+        if (Interlocked.CompareExchange(ref _fallbackWarned, 1, 0) == 0)
+        {
+            LogFallbackActivated();
+        }
+
         foreach (IDomainEvent evt in domainEvents)
         {
-            await bus.PublishAsync(evt).ConfigureAwait(false);
+            await DispatchToLocalHandlersAsync(evt, cancellationToken).ConfigureAwait(false);
         }
     }
+
+    private async Task DispatchToLocalHandlersAsync(IDomainEvent domainEvent, CancellationToken cancellationToken)
+    {
+        // Resolve ILocalEventHandler<TEvent> using the runtime type.
+        // Domain events are dispatched via the non-generic IDomainEvent, so we need
+        // to build the generic handler type from the concrete event type.
+        Type eventType = domainEvent.GetType();
+        Type handlerType = typeof(ILocalEventHandler<>).MakeGenericType(eventType);
+        IEnumerable<object?> handlers = serviceProvider.GetServices(handlerType);
+
+        foreach (object? handler in handlers)
+        {
+            if (handler is null)
+            {
+                continue;
+            }
+
+            try
+            {
+                // Invoke HandleAsync via the interface method
+                var task = (Task)handlerType
+                    .GetMethod(nameof(ILocalEventHandler<IDomainEvent>.HandleAsync))!
+                    .Invoke(handler, [domainEvent, cancellationToken])!;
+                await task.ConfigureAwait(false);
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException is not null and not OperationCanceledException)
+            {
+                // Unwrap reflection wrapper to log the actual handler exception
+                LogFallbackHandlerFailed(eventType.Name, handler.GetType().Name, ex.InnerException);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                LogFallbackHandlerFailed(eventType.Name, handler.GetType().Name, ex);
+            }
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Wolverine host not started — domain events will be dispatched directly to local handlers (bypassing Wolverine pipeline). This is expected during data seeding or --migrate mode.")]
+    private partial void LogFallbackActivated();
+
+    [LoggerMessage(Level = LogLevel.Error,
+        Message = "Domain event handler {HandlerName} failed for event {EventName} during pre-host fallback dispatch.")]
+    private partial void LogFallbackHandlerFailed(string eventName, string handlerName, Exception exception);
 }

--- a/src/Granit.Events.Wolverine/Internal/WolverineHostReadiness.cs
+++ b/src/Granit.Events.Wolverine/Internal/WolverineHostReadiness.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Events.Wolverine.Internal;
+
+/// <summary>
+/// Tracks whether the host has fully started (all <see cref="IHostedService.StartAsync"/>
+/// calls completed). Used by Wolverine event bus adapters to fall back gracefully
+/// when Wolverine is not yet ready (e.g., during data seeding or <c>--migrate</c> mode).
+/// </summary>
+/// <remarks>
+/// Registered as a singleton AND as an <see cref="IHostedLifecycleService"/>.
+/// The <see cref="IHostedLifecycleService.StartedAsync"/> callback fires after ALL
+/// hosted services (including Wolverine) have completed <c>StartAsync</c>,
+/// making it the safe point to enable Wolverine-backed event publishing.
+/// </remarks>
+internal sealed partial class WolverineHostReadiness(
+    ILogger<WolverineHostReadiness> logger) : IHostedLifecycleService
+{
+    private volatile bool _isReady;
+
+    /// <summary>
+    /// Returns <c>true</c> after all <see cref="IHostedService.StartAsync"/> calls
+    /// have completed (including Wolverine's runtime initialization).
+    /// </summary>
+    internal bool IsReady => _isReady;
+
+    Task IHostedService.StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    Task IHostedService.StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    Task IHostedLifecycleService.StartingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    Task IHostedLifecycleService.StoppingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    Task IHostedLifecycleService.StoppedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    Task IHostedLifecycleService.StartedAsync(CancellationToken cancellationToken)
+    {
+        _isReady = true;
+        LogWolverineReady();
+        return Task.CompletedTask;
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "Wolverine host readiness flag set — event bus adapters switching to Wolverine pipeline.")]
+    private partial void LogWolverineReady();
+}

--- a/src/Granit.Events.Wolverine/Internal/WolverineIntegrationEventDispatcher.cs
+++ b/src/Granit.Events.Wolverine/Internal/WolverineIntegrationEventDispatcher.cs
@@ -1,4 +1,5 @@
 using Granit.Events;
+using Microsoft.Extensions.Logging;
 using Wolverine;
 
 namespace Granit.Events.Wolverine.Internal;
@@ -8,16 +9,45 @@ namespace Granit.Events.Wolverine.Internal;
 /// Publishes each integration event via <see cref="IMessageBus"/> using the non-generic
 /// overload so Wolverine routes by runtime type and writes outbox envelopes atomically.
 /// </summary>
-internal sealed class WolverineIntegrationEventDispatcher(IMessageBus bus) : IIntegrationEventDispatcher
+/// <remarks>
+/// When the host has not yet started (data seeding, <c>--migrate</c> mode),
+/// integration events are silently skipped. Seeding creates initial state —
+/// there are no downstream consumers that need to react to it. The skip happens
+/// before any interaction with <see cref="IMessageBus"/>, preventing Wolverine
+/// from attempting outbox envelope writes.
+/// </remarks>
+internal sealed partial class WolverineIntegrationEventDispatcher(
+    IMessageBus bus,
+    WolverineHostReadiness readiness,
+    ILogger<WolverineIntegrationEventDispatcher> logger) : IIntegrationEventDispatcher
 {
+    private int _skipWarned;
+
     /// <inheritdoc/>
     public async Task DispatchAsync(
         IReadOnlyList<IIntegrationEvent> integrationEvents,
         CancellationToken cancellationToken = default)
     {
-        foreach (IIntegrationEvent evt in integrationEvents)
+        if (readiness.IsReady)
         {
-            await bus.PublishAsync(evt).ConfigureAwait(false);
+            foreach (IIntegrationEvent evt in integrationEvents)
+            {
+                await bus.PublishAsync(evt).ConfigureAwait(false);
+            }
+
+            return;
+        }
+
+        // Wolverine not started — skip integration events (no consumers during seeding/migrate).
+        // Skip before IMessageBus interaction to prevent outbox envelope writes.
+        if (integrationEvents.Count > 0
+            && Interlocked.CompareExchange(ref _skipWarned, 1, 0) == 0)
+        {
+            LogSkippingIntegrationEvents();
         }
     }
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Wolverine host not started — integration events will be skipped. This is expected during data seeding or --migrate mode.")]
+    private partial void LogSkippingIntegrationEvents();
 }

--- a/src/Granit.Events.Wolverine/Internal/WolverineIntegrationEventDispatcher.cs
+++ b/src/Granit.Events.Wolverine/Internal/WolverineIntegrationEventDispatcher.cs
@@ -1,4 +1,5 @@
 using Granit.Events;
+using Granit.Events.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Wolverine;
 
@@ -19,6 +20,7 @@ namespace Granit.Events.Wolverine.Internal;
 internal sealed partial class WolverineIntegrationEventDispatcher(
     IMessageBus bus,
     WolverineHostReadiness readiness,
+    EventsMetrics metrics,
     ILogger<WolverineIntegrationEventDispatcher> logger) : IIntegrationEventDispatcher
 {
     private int _skipWarned;
@@ -40,6 +42,11 @@ internal sealed partial class WolverineIntegrationEventDispatcher(
 
         // Wolverine not started — skip integration events (no consumers during seeding/migrate).
         // Skip before IMessageBus interaction to prevent outbox envelope writes.
+        foreach (IIntegrationEvent evt in integrationEvents)
+        {
+            metrics.RecordEventPublished(null, "integration-skipped", evt.GetType().Name);
+        }
+
         if (integrationEvents.Count > 0
             && Interlocked.CompareExchange(ref _skipWarned, 1, 0) == 0)
         {

--- a/src/Granit.Events.Wolverine/Internal/WolverineLocalEventBus.cs
+++ b/src/Granit.Events.Wolverine/Internal/WolverineLocalEventBus.cs
@@ -1,4 +1,5 @@
 using Granit.Events;
+using Granit.Events.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Wolverine;
@@ -21,6 +22,7 @@ internal sealed partial class WolverineLocalEventBus(
     IMessageBus bus,
     IServiceProvider serviceProvider,
     WolverineHostReadiness readiness,
+    EventsMetrics metrics,
     ILogger<WolverineLocalEventBus> logger) : ILocalEventBus
 {
     private int _fallbackWarned;
@@ -41,10 +43,17 @@ internal sealed partial class WolverineLocalEventBus(
         // serviceProvider is the SCOPED provider (this class is registered Scoped),
         // so handlers share the same scope as the caller — preserving transactional
         // consistency (e.g., same DbContext instance). Do NOT create a new scope here.
+        //
+        // SECURITY INVARIANT: this path bypasses the Wolverine middleware pipeline.
+        // Handlers invoked here MUST NOT rely on Wolverine middleware for authorization
+        // or tenant context — they must receive all required context via the event payload.
         if (Interlocked.CompareExchange(ref _fallbackWarned, 1, 0) == 0)
         {
             LogFallbackActivated();
         }
+
+        string eventType = typeof(TEvent).Name;
+        metrics.RecordEventPublished(null, "local-fallback", eventType);
 
         IEnumerable<ILocalEventHandler<TEvent>> handlers =
             serviceProvider.GetServices<ILocalEventHandler<TEvent>>();
@@ -54,9 +63,11 @@ internal sealed partial class WolverineLocalEventBus(
             try
             {
                 await handler.HandleAsync(localEvent, cancellationToken).ConfigureAwait(false);
+                metrics.RecordHandlerExecuted(null, eventType, "success");
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
+                metrics.RecordHandlerExecuted(null, eventType, "error");
                 LogFallbackHandlerFailed(typeof(TEvent).Name, handler.GetType().Name, ex);
             }
         }

--- a/src/Granit.Events.Wolverine/Internal/WolverineLocalEventBus.cs
+++ b/src/Granit.Events.Wolverine/Internal/WolverineLocalEventBus.cs
@@ -1,4 +1,6 @@
 using Granit.Events;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Wolverine;
 
 namespace Granit.Events.Wolverine.Internal;
@@ -8,13 +10,63 @@ namespace Granit.Events.Wolverine.Internal;
 /// Publishes events to a Wolverine local queue for in-process handler execution
 /// with Wolverine's pipeline (validation, context propagation, retry).
 /// </summary>
-internal sealed class WolverineLocalEventBus(IMessageBus bus) : ILocalEventBus
+/// <remarks>
+/// When the host has not yet started (data seeding, <c>--migrate</c> mode),
+/// Wolverine's <see cref="IMessageBus"/> throws <c>WolverineHasNotStartedException</c>.
+/// In that case, this implementation falls back to direct handler invocation —
+/// resolving <see cref="ILocalEventHandler{TEvent}"/> from DI and calling sequentially,
+/// matching <c>InProcessLocalEventBus</c> behavior.
+/// </remarks>
+internal sealed partial class WolverineLocalEventBus(
+    IMessageBus bus,
+    IServiceProvider serviceProvider,
+    WolverineHostReadiness readiness,
+    ILogger<WolverineLocalEventBus> logger) : ILocalEventBus
 {
+    private int _fallbackWarned;
+
     /// <inheritdoc/>
     public async Task PublishAsync<TEvent>(TEvent localEvent, CancellationToken cancellationToken = default)
         where TEvent : class
     {
         ArgumentNullException.ThrowIfNull(localEvent);
-        await bus.PublishAsync(localEvent).ConfigureAwait(false);
+
+        if (readiness.IsReady)
+        {
+            await bus.PublishAsync(localEvent).ConfigureAwait(false);
+            return;
+        }
+
+        // Wolverine not started — fall back to direct handler invocation.
+        // serviceProvider is the SCOPED provider (this class is registered Scoped),
+        // so handlers share the same scope as the caller — preserving transactional
+        // consistency (e.g., same DbContext instance). Do NOT create a new scope here.
+        if (Interlocked.CompareExchange(ref _fallbackWarned, 1, 0) == 0)
+        {
+            LogFallbackActivated();
+        }
+
+        IEnumerable<ILocalEventHandler<TEvent>> handlers =
+            serviceProvider.GetServices<ILocalEventHandler<TEvent>>();
+
+        foreach (ILocalEventHandler<TEvent> handler in handlers)
+        {
+            try
+            {
+                await handler.HandleAsync(localEvent, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                LogFallbackHandlerFailed(typeof(TEvent).Name, handler.GetType().Name, ex);
+            }
+        }
     }
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Wolverine host not started — local events will be dispatched directly to handlers (bypassing Wolverine pipeline). This is expected during data seeding or --migrate mode.")]
+    private partial void LogFallbackActivated();
+
+    [LoggerMessage(Level = LogLevel.Error,
+        Message = "Local event handler {HandlerName} failed for event {EventName} during pre-host fallback dispatch.")]
+    private partial void LogFallbackHandlerFailed(string eventName, string handlerName, Exception exception);
 }

--- a/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/DataSeedingHostedService.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/DataSeedingHostedService.cs
@@ -7,16 +7,33 @@ namespace Granit.Persistence.EntityFrameworkCore.DataSeeding;
 /// Hosted service that triggers data seeding at application startup.
 /// </summary>
 /// <remarks>
-/// Calls <see cref="IDataSeeder.SeedAsync"/> once during <see cref="IHostedService.StartAsync"/>
-/// with a host-level <see cref="DataSeedContext"/> (<see cref="DataSeedContext.TenantId"/> = <c>null</c>).
+/// <para>
+/// Calls <see cref="IDataSeeder.SeedAsync"/> once during
+/// <see cref="IHostedLifecycleService.StartedAsync"/> with a host-level
+/// <see cref="DataSeedContext"/> (<see cref="DataSeedContext.TenantId"/> = <c>null</c>).
 /// Exceptions are caught and logged — seeding failures never block application startup.
+/// </para>
+/// <para>
+/// Seeding runs in <c>StartedAsync</c> (not <c>StartAsync</c>) to ensure all hosted
+/// services — including messaging infrastructure like Wolverine — have fully started
+/// before seed contributors execute. This prevents <c>WolverineHasNotStartedException</c>
+/// when seed contributors use services that publish events.
+/// </para>
 /// </remarks>
 internal sealed partial class DataSeedingHostedService(
     IDataSeeder seeder,
-    ILogger<DataSeedingHostedService> logger) : IHostedService
+    ILogger<DataSeedingHostedService> logger) : IHostedLifecycleService
 {
-    /// <inheritdoc/>
-    public async Task StartAsync(CancellationToken cancellationToken)
+    Task IHostedService.StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    Task IHostedService.StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    Task IHostedLifecycleService.StartingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    Task IHostedLifecycleService.StoppingAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    Task IHostedLifecycleService.StoppedAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <summary>
+    /// Executes data seeding after all hosted services have started.
+    /// </summary>
+    async Task IHostedLifecycleService.StartedAsync(CancellationToken cancellationToken)
     {
         try
         {
@@ -28,9 +45,6 @@ internal sealed partial class DataSeedingHostedService(
             LogSeedingError(ex);
         }
     }
-
-    /// <inheritdoc/>
-    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
     [LoggerMessage(Level = LogLevel.Error,
         Message = "An error occurred during data seeding at startup. Startup continues.")]

--- a/tests/Granit.Events.Wolverine.Tests/GranitEventsWolverineModuleTests.cs
+++ b/tests/Granit.Events.Wolverine.Tests/GranitEventsWolverineModuleTests.cs
@@ -73,4 +73,29 @@ public sealed class GranitEventsWolverineModuleTests
             d.ImplementationType == typeof(WolverineDomainEventDispatcher) &&
             d.Lifetime == ServiceLifetime.Scoped);
     }
+
+    [Fact]
+    public void ConfigureServices_RegistersWolverineHostReadinessAsSingleton()
+    {
+        HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
+        ServiceConfigurationContext context = new(builder.Services, builder.Configuration, builder);
+
+        new GranitEventsWolverineModule().ConfigureServices(context);
+
+        builder.Services.ShouldContain(d =>
+            d.ServiceType == typeof(WolverineHostReadiness) &&
+            d.Lifetime == ServiceLifetime.Singleton);
+    }
+
+    [Fact]
+    public void ConfigureServices_RegistersWolverineHostReadinessAsHostedService()
+    {
+        HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
+        ServiceConfigurationContext context = new(builder.Services, builder.Configuration, builder);
+
+        new GranitEventsWolverineModule().ConfigureServices(context);
+
+        builder.Services.ShouldContain(d =>
+            d.ServiceType == typeof(IHostedService));
+    }
 }

--- a/tests/Granit.Events.Wolverine.Tests/WolverineDistributedEventBusTests.cs
+++ b/tests/Granit.Events.Wolverine.Tests/WolverineDistributedEventBusTests.cs
@@ -1,5 +1,7 @@
 using Granit.Events;
 using Granit.Events.Wolverine.Internal;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Shouldly;
 using Wolverine;
@@ -11,10 +13,23 @@ public sealed class WolverineDistributedEventBusTests
 {
     private readonly IMessageBus _bus = Substitute.For<IMessageBus>();
 
-    [Fact]
-    public async Task PublishAsync_DelegatesToMessageBus()
+    private static WolverineHostReadiness CreateReadiness(bool isReady)
     {
-        WolverineDistributedEventBus sut = new(_bus);
+        WolverineHostReadiness readiness = new(NullLogger<WolverineHostReadiness>.Instance);
+        if (isReady)
+        {
+            ((IHostedLifecycleService)readiness).StartedAsync(CancellationToken.None)
+                .GetAwaiter().GetResult();
+        }
+
+        return readiness;
+    }
+
+    [Fact]
+    public async Task PublishAsync_WhenReady_DelegatesToMessageBus()
+    {
+        WolverineDistributedEventBus sut = new(_bus, CreateReadiness(true),
+            NullLogger<WolverineDistributedEventBus>.Instance);
         TestIntegrationEvent evt = new();
 
         await sut.PublishAsync(evt, TestContext.Current.CancellationToken);
@@ -23,9 +38,22 @@ public sealed class WolverineDistributedEventBusTests
     }
 
     [Fact]
+    public async Task PublishAsync_WhenNotReady_SkipsWithoutCallingMessageBus()
+    {
+        WolverineDistributedEventBus sut = new(_bus, CreateReadiness(false),
+            NullLogger<WolverineDistributedEventBus>.Instance);
+        TestIntegrationEvent evt = new();
+
+        await sut.PublishAsync(evt, TestContext.Current.CancellationToken);
+
+        await _bus.DidNotReceive().PublishAsync(Arg.Any<TestIntegrationEvent>());
+    }
+
+    [Fact]
     public async Task PublishAsync_NullEvent_ThrowsArgumentNullException()
     {
-        WolverineDistributedEventBus sut = new(_bus);
+        WolverineDistributedEventBus sut = new(_bus, CreateReadiness(true),
+            NullLogger<WolverineDistributedEventBus>.Instance);
 
         await Should.ThrowAsync<ArgumentNullException>(
             () => sut.PublishAsync<TestIntegrationEvent>(null!, TestContext.Current.CancellationToken));

--- a/tests/Granit.Events.Wolverine.Tests/WolverineDistributedEventBusTests.cs
+++ b/tests/Granit.Events.Wolverine.Tests/WolverineDistributedEventBusTests.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics.Metrics;
 using Granit.Events;
+using Granit.Events.Diagnostics;
 using Granit.Events.Wolverine.Internal;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -25,10 +27,18 @@ public sealed class WolverineDistributedEventBusTests
         return readiness;
     }
 
+    private static EventsMetrics CreateMetrics()
+    {
+        IMeterFactory meterFactory = Substitute.For<IMeterFactory>();
+        meterFactory.Create(Arg.Any<MeterOptions>())
+            .Returns(ci => new Meter(ci.Arg<MeterOptions>().Name));
+        return new EventsMetrics(meterFactory);
+    }
+
     [Fact]
     public async Task PublishAsync_WhenReady_DelegatesToMessageBus()
     {
-        WolverineDistributedEventBus sut = new(_bus, CreateReadiness(true),
+        WolverineDistributedEventBus sut = new(_bus, CreateReadiness(true), CreateMetrics(),
             NullLogger<WolverineDistributedEventBus>.Instance);
         TestIntegrationEvent evt = new();
 
@@ -40,7 +50,7 @@ public sealed class WolverineDistributedEventBusTests
     [Fact]
     public async Task PublishAsync_WhenNotReady_SkipsWithoutCallingMessageBus()
     {
-        WolverineDistributedEventBus sut = new(_bus, CreateReadiness(false),
+        WolverineDistributedEventBus sut = new(_bus, CreateReadiness(false), CreateMetrics(),
             NullLogger<WolverineDistributedEventBus>.Instance);
         TestIntegrationEvent evt = new();
 
@@ -52,7 +62,7 @@ public sealed class WolverineDistributedEventBusTests
     [Fact]
     public async Task PublishAsync_NullEvent_ThrowsArgumentNullException()
     {
-        WolverineDistributedEventBus sut = new(_bus, CreateReadiness(true),
+        WolverineDistributedEventBus sut = new(_bus, CreateReadiness(true), CreateMetrics(),
             NullLogger<WolverineDistributedEventBus>.Instance);
 
         await Should.ThrowAsync<ArgumentNullException>(

--- a/tests/Granit.Events.Wolverine.Tests/WolverineDomainEventDispatcherTests.cs
+++ b/tests/Granit.Events.Wolverine.Tests/WolverineDomainEventDispatcherTests.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics.Metrics;
 using Granit.Events;
+using Granit.Events.Diagnostics;
 using Granit.Events.Wolverine.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -26,12 +28,20 @@ public sealed class WolverineDomainEventDispatcherTests
         return readiness;
     }
 
+    private static EventsMetrics CreateMetrics()
+    {
+        IMeterFactory meterFactory = Substitute.For<IMeterFactory>();
+        meterFactory.Create(Arg.Any<MeterOptions>())
+            .Returns(ci => new Meter(ci.Arg<MeterOptions>().Name));
+        return new EventsMetrics(meterFactory);
+    }
+
     [Fact]
     public async Task DispatchAsync_WhenReady_PublishesEachEventViaMessageBus()
     {
         ServiceCollection services = [];
         using ServiceProvider sp = services.BuildServiceProvider();
-        WolverineDomainEventDispatcher sut = new(_bus, sp, CreateReadiness(true),
+        WolverineDomainEventDispatcher sut = new(_bus, sp, CreateReadiness(true), CreateMetrics(),
             NullLogger<WolverineDomainEventDispatcher>.Instance);
         TestDomainEvent evt1 = new();
         TestDomainEvent evt2 = new();
@@ -47,7 +57,7 @@ public sealed class WolverineDomainEventDispatcherTests
     {
         ServiceCollection services = [];
         using ServiceProvider sp = services.BuildServiceProvider();
-        WolverineDomainEventDispatcher sut = new(_bus, sp, CreateReadiness(true),
+        WolverineDomainEventDispatcher sut = new(_bus, sp, CreateReadiness(true), CreateMetrics(),
             NullLogger<WolverineDomainEventDispatcher>.Instance);
 
         await sut.DispatchAsync([], TestContext.Current.CancellationToken);
@@ -60,7 +70,7 @@ public sealed class WolverineDomainEventDispatcherTests
     {
         ServiceCollection services = [];
         using ServiceProvider sp = services.BuildServiceProvider();
-        WolverineDomainEventDispatcher sut = new(_bus, sp, CreateReadiness(true),
+        WolverineDomainEventDispatcher sut = new(_bus, sp, CreateReadiness(true), CreateMetrics(),
             NullLogger<WolverineDomainEventDispatcher>.Instance);
         IReadOnlyList<IDomainEvent> events = [new TestDomainEvent(), new TestDomainEvent(), new TestDomainEvent()];
 
@@ -76,7 +86,7 @@ public sealed class WolverineDomainEventDispatcherTests
         ServiceCollection services = [];
         services.AddSingleton<ILocalEventHandler<TestDomainEvent>>(handler);
         using ServiceProvider sp = services.BuildServiceProvider();
-        WolverineDomainEventDispatcher sut = new(_bus, sp, CreateReadiness(false),
+        WolverineDomainEventDispatcher sut = new(_bus, sp, CreateReadiness(false), CreateMetrics(),
             NullLogger<WolverineDomainEventDispatcher>.Instance);
         TestDomainEvent evt = new();
 
@@ -91,7 +101,7 @@ public sealed class WolverineDomainEventDispatcherTests
     {
         ServiceCollection services = [];
         using ServiceProvider sp = services.BuildServiceProvider();
-        WolverineDomainEventDispatcher sut = new(_bus, sp, CreateReadiness(false),
+        WolverineDomainEventDispatcher sut = new(_bus, sp, CreateReadiness(false), CreateMetrics(),
             NullLogger<WolverineDomainEventDispatcher>.Instance);
 
         await Should.NotThrowAsync(

--- a/tests/Granit.Events.Wolverine.Tests/WolverineDomainEventDispatcherTests.cs
+++ b/tests/Granit.Events.Wolverine.Tests/WolverineDomainEventDispatcherTests.cs
@@ -1,6 +1,10 @@
 using Granit.Events;
 using Granit.Events.Wolverine.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using Shouldly;
 using Wolverine;
 using Xunit;
 
@@ -10,10 +14,25 @@ public sealed class WolverineDomainEventDispatcherTests
 {
     private readonly IMessageBus _bus = Substitute.For<IMessageBus>();
 
-    [Fact]
-    public async Task DispatchAsync_PublishesEachEventViaMessageBus()
+    private static WolverineHostReadiness CreateReadiness(bool isReady)
     {
-        WolverineDomainEventDispatcher sut = new(_bus);
+        WolverineHostReadiness readiness = new(NullLogger<WolverineHostReadiness>.Instance);
+        if (isReady)
+        {
+            ((IHostedLifecycleService)readiness).StartedAsync(CancellationToken.None)
+                .GetAwaiter().GetResult();
+        }
+
+        return readiness;
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenReady_PublishesEachEventViaMessageBus()
+    {
+        ServiceCollection services = [];
+        using ServiceProvider sp = services.BuildServiceProvider();
+        WolverineDomainEventDispatcher sut = new(_bus, sp, CreateReadiness(true),
+            NullLogger<WolverineDomainEventDispatcher>.Instance);
         TestDomainEvent evt1 = new();
         TestDomainEvent evt2 = new();
 
@@ -24,9 +43,12 @@ public sealed class WolverineDomainEventDispatcherTests
     }
 
     [Fact]
-    public async Task DispatchAsync_EmptyList_DoesNotCallPublish()
+    public async Task DispatchAsync_WhenReady_EmptyList_DoesNotCallPublish()
     {
-        WolverineDomainEventDispatcher sut = new(_bus);
+        ServiceCollection services = [];
+        using ServiceProvider sp = services.BuildServiceProvider();
+        WolverineDomainEventDispatcher sut = new(_bus, sp, CreateReadiness(true),
+            NullLogger<WolverineDomainEventDispatcher>.Instance);
 
         await sut.DispatchAsync([], TestContext.Current.CancellationToken);
 
@@ -34,9 +56,12 @@ public sealed class WolverineDomainEventDispatcherTests
     }
 
     [Fact]
-    public async Task DispatchAsync_PublishesExpectedCount()
+    public async Task DispatchAsync_WhenReady_PublishesExpectedCount()
     {
-        WolverineDomainEventDispatcher sut = new(_bus);
+        ServiceCollection services = [];
+        using ServiceProvider sp = services.BuildServiceProvider();
+        WolverineDomainEventDispatcher sut = new(_bus, sp, CreateReadiness(true),
+            NullLogger<WolverineDomainEventDispatcher>.Instance);
         IReadOnlyList<IDomainEvent> events = [new TestDomainEvent(), new TestDomainEvent(), new TestDomainEvent()];
 
         await sut.DispatchAsync(events, TestContext.Current.CancellationToken);
@@ -44,5 +69,45 @@ public sealed class WolverineDomainEventDispatcherTests
         await _bus.Received(3).PublishAsync(Arg.Any<IDomainEvent>());
     }
 
+    [Fact]
+    public async Task DispatchAsync_WhenNotReady_FallsBackToLocalHandlers()
+    {
+        TestDomainEventHandler handler = new();
+        ServiceCollection services = [];
+        services.AddSingleton<ILocalEventHandler<TestDomainEvent>>(handler);
+        using ServiceProvider sp = services.BuildServiceProvider();
+        WolverineDomainEventDispatcher sut = new(_bus, sp, CreateReadiness(false),
+            NullLogger<WolverineDomainEventDispatcher>.Instance);
+        TestDomainEvent evt = new();
+
+        await sut.DispatchAsync([evt], TestContext.Current.CancellationToken);
+
+        await _bus.DidNotReceive().PublishAsync(Arg.Any<IDomainEvent>());
+        handler.Received.ShouldContain(evt);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenNotReady_NoHandlers_CompletesSuccessfully()
+    {
+        ServiceCollection services = [];
+        using ServiceProvider sp = services.BuildServiceProvider();
+        WolverineDomainEventDispatcher sut = new(_bus, sp, CreateReadiness(false),
+            NullLogger<WolverineDomainEventDispatcher>.Instance);
+
+        await Should.NotThrowAsync(
+            () => sut.DispatchAsync([new TestDomainEvent()], TestContext.Current.CancellationToken));
+    }
+
     private sealed record TestDomainEvent : IDomainEvent;
+
+    private sealed class TestDomainEventHandler : ILocalEventHandler<TestDomainEvent>
+    {
+        public List<TestDomainEvent> Received { get; } = [];
+
+        public Task HandleAsync(TestDomainEvent localEvent, CancellationToken cancellationToken = default)
+        {
+            Received.Add(localEvent);
+            return Task.CompletedTask;
+        }
+    }
 }

--- a/tests/Granit.Events.Wolverine.Tests/WolverineHostReadinessTests.cs
+++ b/tests/Granit.Events.Wolverine.Tests/WolverineHostReadinessTests.cs
@@ -1,0 +1,50 @@
+using Granit.Events.Wolverine.Internal;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Events.Wolverine.Tests;
+
+public sealed class WolverineHostReadinessTests
+{
+    [Fact]
+    public void IsReady_DefaultsFalse()
+    {
+        WolverineHostReadiness sut = new(NullLogger<WolverineHostReadiness>.Instance);
+
+        sut.IsReady.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task IsReady_TrueAfterStartedAsync()
+    {
+        WolverineHostReadiness sut = new(NullLogger<WolverineHostReadiness>.Instance);
+        IHostedLifecycleService lifecycle = sut;
+
+        await lifecycle.StartedAsync(TestContext.Current.CancellationToken);
+
+        sut.IsReady.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task IsReady_RemainingFalseAfterStartAsync()
+    {
+        WolverineHostReadiness sut = new(NullLogger<WolverineHostReadiness>.Instance);
+        IHostedService hostedService = sut;
+
+        await hostedService.StartAsync(TestContext.Current.CancellationToken);
+
+        sut.IsReady.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task StopAsync_CompletesWithoutError()
+    {
+        WolverineHostReadiness sut = new(NullLogger<WolverineHostReadiness>.Instance);
+        IHostedService hostedService = sut;
+
+        await Should.NotThrowAsync(
+            () => hostedService.StopAsync(TestContext.Current.CancellationToken));
+    }
+}

--- a/tests/Granit.Events.Wolverine.Tests/WolverineIntegrationEventDispatcherTests.cs
+++ b/tests/Granit.Events.Wolverine.Tests/WolverineIntegrationEventDispatcherTests.cs
@@ -1,6 +1,9 @@
 using Granit.Events;
 using Granit.Events.Wolverine.Internal;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using Shouldly;
 using Wolverine;
 using Xunit;
 
@@ -10,24 +13,37 @@ public sealed class WolverineIntegrationEventDispatcherTests
 {
     private readonly IMessageBus _bus = Substitute.For<IMessageBus>();
 
-    [Fact]
-    public async Task DispatchAsync_PublishesEachEventViaMessageBus()
+    private static WolverineHostReadiness CreateReadiness(bool isReady)
     {
-        WolverineIntegrationEventDispatcher sut = new(_bus);
+        WolverineHostReadiness readiness = new(NullLogger<WolverineHostReadiness>.Instance);
+        if (isReady)
+        {
+            ((IHostedLifecycleService)readiness).StartedAsync(CancellationToken.None)
+                .GetAwaiter().GetResult();
+        }
+
+        return readiness;
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenReady_PublishesEachEventViaMessageBus()
+    {
+        WolverineIntegrationEventDispatcher sut = new(_bus, CreateReadiness(true),
+            NullLogger<WolverineIntegrationEventDispatcher>.Instance);
         TestIntegrationEvent evt1 = new();
         TestIntegrationEvent evt2 = new();
 
         await sut.DispatchAsync([evt1, evt2], TestContext.Current.CancellationToken);
 
-        // IIntegrationEvent generic parameter matches the implementation's T inference
         await _bus.Received(1).PublishAsync(Arg.Is<IIntegrationEvent>(e => ReferenceEquals(e, evt1)));
         await _bus.Received(1).PublishAsync(Arg.Is<IIntegrationEvent>(e => ReferenceEquals(e, evt2)));
     }
 
     [Fact]
-    public async Task DispatchAsync_EmptyList_DoesNotCallPublish()
+    public async Task DispatchAsync_WhenReady_EmptyList_DoesNotCallPublish()
     {
-        WolverineIntegrationEventDispatcher sut = new(_bus);
+        WolverineIntegrationEventDispatcher sut = new(_bus, CreateReadiness(true),
+            NullLogger<WolverineIntegrationEventDispatcher>.Instance);
 
         await sut.DispatchAsync([], TestContext.Current.CancellationToken);
 
@@ -35,14 +51,27 @@ public sealed class WolverineIntegrationEventDispatcherTests
     }
 
     [Fact]
-    public async Task DispatchAsync_PublishesExpectedCount()
+    public async Task DispatchAsync_WhenReady_PublishesExpectedCount()
     {
-        WolverineIntegrationEventDispatcher sut = new(_bus);
+        WolverineIntegrationEventDispatcher sut = new(_bus, CreateReadiness(true),
+            NullLogger<WolverineIntegrationEventDispatcher>.Instance);
         IReadOnlyList<IIntegrationEvent> events = [new TestIntegrationEvent(), new TestIntegrationEvent(), new TestIntegrationEvent()];
 
         await sut.DispatchAsync(events, TestContext.Current.CancellationToken);
 
         await _bus.Received(3).PublishAsync(Arg.Any<IIntegrationEvent>());
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenNotReady_SkipsWithoutCallingMessageBus()
+    {
+        WolverineIntegrationEventDispatcher sut = new(_bus, CreateReadiness(false),
+            NullLogger<WolverineIntegrationEventDispatcher>.Instance);
+        TestIntegrationEvent evt = new();
+
+        await sut.DispatchAsync([evt], TestContext.Current.CancellationToken);
+
+        await _bus.DidNotReceive().PublishAsync(Arg.Any<IIntegrationEvent>());
     }
 
     private sealed record TestIntegrationEvent : IIntegrationEvent;

--- a/tests/Granit.Events.Wolverine.Tests/WolverineIntegrationEventDispatcherTests.cs
+++ b/tests/Granit.Events.Wolverine.Tests/WolverineIntegrationEventDispatcherTests.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics.Metrics;
 using Granit.Events;
+using Granit.Events.Diagnostics;
 using Granit.Events.Wolverine.Internal;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -25,10 +27,18 @@ public sealed class WolverineIntegrationEventDispatcherTests
         return readiness;
     }
 
+    private static EventsMetrics CreateMetrics()
+    {
+        IMeterFactory meterFactory = Substitute.For<IMeterFactory>();
+        meterFactory.Create(Arg.Any<MeterOptions>())
+            .Returns(ci => new Meter(ci.Arg<MeterOptions>().Name));
+        return new EventsMetrics(meterFactory);
+    }
+
     [Fact]
     public async Task DispatchAsync_WhenReady_PublishesEachEventViaMessageBus()
     {
-        WolverineIntegrationEventDispatcher sut = new(_bus, CreateReadiness(true),
+        WolverineIntegrationEventDispatcher sut = new(_bus, CreateReadiness(true), CreateMetrics(),
             NullLogger<WolverineIntegrationEventDispatcher>.Instance);
         TestIntegrationEvent evt1 = new();
         TestIntegrationEvent evt2 = new();
@@ -42,7 +52,7 @@ public sealed class WolverineIntegrationEventDispatcherTests
     [Fact]
     public async Task DispatchAsync_WhenReady_EmptyList_DoesNotCallPublish()
     {
-        WolverineIntegrationEventDispatcher sut = new(_bus, CreateReadiness(true),
+        WolverineIntegrationEventDispatcher sut = new(_bus, CreateReadiness(true), CreateMetrics(),
             NullLogger<WolverineIntegrationEventDispatcher>.Instance);
 
         await sut.DispatchAsync([], TestContext.Current.CancellationToken);
@@ -53,7 +63,7 @@ public sealed class WolverineIntegrationEventDispatcherTests
     [Fact]
     public async Task DispatchAsync_WhenReady_PublishesExpectedCount()
     {
-        WolverineIntegrationEventDispatcher sut = new(_bus, CreateReadiness(true),
+        WolverineIntegrationEventDispatcher sut = new(_bus, CreateReadiness(true), CreateMetrics(),
             NullLogger<WolverineIntegrationEventDispatcher>.Instance);
         IReadOnlyList<IIntegrationEvent> events = [new TestIntegrationEvent(), new TestIntegrationEvent(), new TestIntegrationEvent()];
 
@@ -65,7 +75,7 @@ public sealed class WolverineIntegrationEventDispatcherTests
     [Fact]
     public async Task DispatchAsync_WhenNotReady_SkipsWithoutCallingMessageBus()
     {
-        WolverineIntegrationEventDispatcher sut = new(_bus, CreateReadiness(false),
+        WolverineIntegrationEventDispatcher sut = new(_bus, CreateReadiness(false), CreateMetrics(),
             NullLogger<WolverineIntegrationEventDispatcher>.Instance);
         TestIntegrationEvent evt = new();
 

--- a/tests/Granit.Events.Wolverine.Tests/WolverineLocalEventBusTests.cs
+++ b/tests/Granit.Events.Wolverine.Tests/WolverineLocalEventBusTests.cs
@@ -1,5 +1,8 @@
 using Granit.Events;
 using Granit.Events.Wolverine.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Shouldly;
 using Wolverine;
@@ -11,15 +14,93 @@ public sealed class WolverineLocalEventBusTests
 {
     private sealed record TestEvent(string Value);
 
+    private sealed class TestEventHandler : ILocalEventHandler<TestEvent>
+    {
+        public List<TestEvent> Received { get; } = [];
+
+        public Task HandleAsync(TestEvent localEvent, CancellationToken cancellationToken = default)
+        {
+            Received.Add(localEvent);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FailingTestEventHandler : ILocalEventHandler<TestEvent>
+    {
+        public Task HandleAsync(TestEvent localEvent, CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("Handler failed");
+    }
+
+    private static WolverineHostReadiness CreateReadiness(bool isReady)
+    {
+        WolverineHostReadiness readiness = new(NullLogger<WolverineHostReadiness>.Instance);
+        if (isReady)
+        {
+            ((IHostedLifecycleService)readiness).StartedAsync(CancellationToken.None)
+                .GetAwaiter().GetResult();
+        }
+
+        return readiness;
+    }
+
     [Fact]
-    public async Task PublishAsync_DelegatesToMessageBus()
+    public async Task PublishAsync_WhenReady_DelegatesToMessageBus()
     {
         IMessageBus bus = Substitute.For<IMessageBus>();
-        WolverineLocalEventBus localBus = new(bus);
+        ServiceCollection services = [];
+        using ServiceProvider sp = services.BuildServiceProvider();
+        WolverineLocalEventBus sut = new(bus, sp, CreateReadiness(true),
+            NullLogger<WolverineLocalEventBus>.Instance);
         TestEvent evt = new("test");
 
-        await localBus.PublishAsync(evt, TestContext.Current.CancellationToken);
+        await sut.PublishAsync(evt, TestContext.Current.CancellationToken);
 
         await bus.Received(1).PublishAsync(evt);
+    }
+
+    [Fact]
+    public async Task PublishAsync_WhenNotReady_FallsBackToDirectHandlers()
+    {
+        IMessageBus bus = Substitute.For<IMessageBus>();
+        TestEventHandler handler = new();
+        ServiceCollection services = [];
+        services.AddSingleton<ILocalEventHandler<TestEvent>>(handler);
+        using ServiceProvider sp = services.BuildServiceProvider();
+        WolverineLocalEventBus sut = new(bus, sp, CreateReadiness(false),
+            NullLogger<WolverineLocalEventBus>.Instance);
+        TestEvent evt = new("test");
+
+        await sut.PublishAsync(evt, TestContext.Current.CancellationToken);
+
+        await bus.DidNotReceive().PublishAsync(Arg.Any<TestEvent>());
+        handler.Received.ShouldContain(evt);
+    }
+
+    [Fact]
+    public async Task PublishAsync_WhenNotReady_HandlerThrows_DoesNotPropagate()
+    {
+        IMessageBus bus = Substitute.For<IMessageBus>();
+        ServiceCollection services = [];
+        services.AddSingleton<ILocalEventHandler<TestEvent>, FailingTestEventHandler>();
+        using ServiceProvider sp = services.BuildServiceProvider();
+        WolverineLocalEventBus sut = new(bus, sp, CreateReadiness(false),
+            NullLogger<WolverineLocalEventBus>.Instance);
+        TestEvent evt = new("test");
+
+        await Should.NotThrowAsync(
+            () => sut.PublishAsync(evt, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task PublishAsync_NullEvent_ThrowsArgumentNullException()
+    {
+        IMessageBus bus = Substitute.For<IMessageBus>();
+        ServiceCollection services = [];
+        using ServiceProvider sp = services.BuildServiceProvider();
+        WolverineLocalEventBus sut = new(bus, sp, CreateReadiness(true),
+            NullLogger<WolverineLocalEventBus>.Instance);
+
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.PublishAsync<TestEvent>(null!, TestContext.Current.CancellationToken));
     }
 }

--- a/tests/Granit.Events.Wolverine.Tests/WolverineLocalEventBusTests.cs
+++ b/tests/Granit.Events.Wolverine.Tests/WolverineLocalEventBusTests.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics.Metrics;
 using Granit.Events;
+using Granit.Events.Diagnostics;
 using Granit.Events.Wolverine.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -43,13 +45,21 @@ public sealed class WolverineLocalEventBusTests
         return readiness;
     }
 
+    private static EventsMetrics CreateMetrics()
+    {
+        IMeterFactory meterFactory = Substitute.For<IMeterFactory>();
+        meterFactory.Create(Arg.Any<MeterOptions>())
+            .Returns(ci => new Meter(ci.Arg<MeterOptions>().Name));
+        return new EventsMetrics(meterFactory);
+    }
+
     [Fact]
     public async Task PublishAsync_WhenReady_DelegatesToMessageBus()
     {
         IMessageBus bus = Substitute.For<IMessageBus>();
         ServiceCollection services = [];
         using ServiceProvider sp = services.BuildServiceProvider();
-        WolverineLocalEventBus sut = new(bus, sp, CreateReadiness(true),
+        WolverineLocalEventBus sut = new(bus, sp, CreateReadiness(true), CreateMetrics(),
             NullLogger<WolverineLocalEventBus>.Instance);
         TestEvent evt = new("test");
 
@@ -66,7 +76,7 @@ public sealed class WolverineLocalEventBusTests
         ServiceCollection services = [];
         services.AddSingleton<ILocalEventHandler<TestEvent>>(handler);
         using ServiceProvider sp = services.BuildServiceProvider();
-        WolverineLocalEventBus sut = new(bus, sp, CreateReadiness(false),
+        WolverineLocalEventBus sut = new(bus, sp, CreateReadiness(false), CreateMetrics(),
             NullLogger<WolverineLocalEventBus>.Instance);
         TestEvent evt = new("test");
 
@@ -83,7 +93,7 @@ public sealed class WolverineLocalEventBusTests
         ServiceCollection services = [];
         services.AddSingleton<ILocalEventHandler<TestEvent>, FailingTestEventHandler>();
         using ServiceProvider sp = services.BuildServiceProvider();
-        WolverineLocalEventBus sut = new(bus, sp, CreateReadiness(false),
+        WolverineLocalEventBus sut = new(bus, sp, CreateReadiness(false), CreateMetrics(),
             NullLogger<WolverineLocalEventBus>.Instance);
         TestEvent evt = new("test");
 
@@ -97,7 +107,7 @@ public sealed class WolverineLocalEventBusTests
         IMessageBus bus = Substitute.For<IMessageBus>();
         ServiceCollection services = [];
         using ServiceProvider sp = services.BuildServiceProvider();
-        WolverineLocalEventBus sut = new(bus, sp, CreateReadiness(true),
+        WolverineLocalEventBus sut = new(bus, sp, CreateReadiness(true), CreateMetrics(),
             NullLogger<WolverineLocalEventBus>.Instance);
 
         await Should.ThrowAsync<ArgumentNullException>(

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/DataSeeding/DataSeedingHostedServiceTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/DataSeeding/DataSeedingHostedServiceTests.cs
@@ -2,12 +2,14 @@
 // Tests — DataSeedingHostedService
 // =============================================================================
 // Vérifie que le hosted service :
-//   - Appelle IDataSeeder.SeedAsync au démarrage avec un contexte host-level
+//   - Appelle IDataSeeder.SeedAsync dans StartedAsync (pas StartAsync) pour
+//     garantir que tous les IHostedService ont démarré (y compris Wolverine)
 //   - Ne propage pas les exceptions (ne bloque pas le démarrage)
-//   - StopAsync complète sans effet de bord
+//   - StartAsync/StopAsync complètent sans effet de bord
 // =============================================================================
 
 using Granit.Persistence.EntityFrameworkCore.DataSeeding;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -21,47 +23,58 @@ public sealed class DataSeedingHostedServiceTests
     private readonly IDataSeeder _seeder = Substitute.For<IDataSeeder>();
 
     [Fact]
-    public async Task StartAsync_CallsSeederWithHostLevelContext()
+    public void ImplementsIHostedLifecycleService()
     {
-        // Arrange
+        typeof(DataSeedingHostedService).IsAssignableTo(typeof(IHostedLifecycleService)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task StartedAsync_CallsSeederWithHostLevelContext()
+    {
         DataSeedingHostedService service = new(_seeder, NullLogger<DataSeedingHostedService>.Instance);
+        IHostedLifecycleService lifecycle = service;
 
-        // Act
-        await service.StartAsync(TestContext.Current.CancellationToken);
+        await lifecycle.StartedAsync(TestContext.Current.CancellationToken);
 
-        // Assert
         await _seeder.Received(1).SeedAsync(
             Arg.Is<DataSeedContext>(c => c.TenantId == null),
             Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task StartAsync_SeederThrows_DoesNotPropagateException()
+    public async Task StartedAsync_SeederThrows_DoesNotPropagateException()
     {
-        // Arrange
         _seeder
             .SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Seeding failed"));
 
         DataSeedingHostedService service = new(_seeder, NullLogger<DataSeedingHostedService>.Instance);
+        IHostedLifecycleService lifecycle = service;
 
-        // Act
-        Func<Task> act = () => service.StartAsync(TestContext.Current.CancellationToken);
+        Func<Task> act = () => lifecycle.StartedAsync(TestContext.Current.CancellationToken);
 
-        // Assert
         await Should.NotThrowAsync(act);
+    }
+
+    [Fact]
+    public async Task StartAsync_DoesNotCallSeeder()
+    {
+        DataSeedingHostedService service = new(_seeder, NullLogger<DataSeedingHostedService>.Instance);
+        IHostedService hostedService = service;
+
+        await hostedService.StartAsync(TestContext.Current.CancellationToken);
+
+        await _seeder.DidNotReceive().SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task StopAsync_CompletesWithoutSideEffects()
     {
-        // Arrange
         DataSeedingHostedService service = new(_seeder, NullLogger<DataSeedingHostedService>.Instance);
+        IHostedService hostedService = service;
 
-        // Act
-        Func<Task> act = () => service.StopAsync(TestContext.Current.CancellationToken);
+        Func<Task> act = () => hostedService.StopAsync(TestContext.Current.CancellationToken);
 
-        // Assert
         await Should.NotThrowAsync(act);
         await _seeder.DidNotReceive().SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>());
     }


### PR DESCRIPTION
## Summary

- Fix `WolverineHasNotStartedException` crash during data seeding (`--migrate` mode and normal startup)
- Add host-aware guard (`WolverineHostReadiness`) to all 4 Wolverine event bus adapters with graceful fallback/skip behavior
- Move `DataSeedingHostedService` from `IHostedService.StartAsync` to `IHostedLifecycleService.StartedAsync` (defense-in-depth)

## Problem

Any `IDataSeedContributor` using framework services that publish events (`PermissionManager`, `SettingManager`, `EfCoreFeatureStore`) crashes because:

1. **`--migrate` mode**: seeding runs before `IHost.Start()` — Wolverine never starts
2. **Normal startup**: `DataSeedingHostedService.StartAsync` runs before Wolverine's `StartAsync` (DependsOn topological order: Persistence < Wolverine)

## Solution

### Change 1: Host-aware Wolverine adapters

| Adapter | Behavior when host not started |
|---------|-------------------------------|
| `WolverineLocalEventBus` | Falls back to direct `ILocalEventHandler<T>` invocation (same scope) |
| `WolverineDistributedEventBus` | Skips + warning (seeding = initial state, no consumers) |
| `WolverineDomainEventDispatcher` | Falls back to direct handler invocation via reflection |
| `WolverineIntegrationEventDispatcher` | Skips + warning (before any `IMessageBus` interaction) |

### Change 2: `DataSeedingHostedService` lifecycle

Seeding now runs in `StartedAsync` (after ALL `StartAsync` calls complete), guaranteeing Wolverine is ready during normal startup.

## Test plan

- [x] `WolverineHostReadinessTests` — flag lifecycle (default false, true after `StartedAsync`)
- [x] All Wolverine adapter tests — both "ready" (delegates to Wolverine) and "not ready" (fallback/skip) paths
- [x] `DataSeedingHostedServiceTests` — seeding in `StartedAsync`, not `StartAsync`
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 33 tests passing (28 Wolverine + 5 DataSeeding)
- [ ] Integration test on showcase with `--migrate` (manual)
