### PR TITLE
fix(bff): prevent TCP loopback deadlock in self-hosted mode

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -6371,7 +6371,7 @@
       "kind": "class",
       "project": "Granit.Bff",
       "file": "src/Granit.Bff/GranitBffModule.cs",
-      "line": 30,
+      "line": 31,
       "members": [
         {
           "name": "ConfigureServices",
@@ -18983,7 +18983,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Email",
       "file": "src/Granit.Notifications.Email/Extensions/EmailNotificationsServiceCollectionExtensions.cs",
-      "line": 9,
+      "line": 10,
       "members": [
         {
           "name": "AddGranitNotificationsEmail",
@@ -18999,7 +18999,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Email",
       "file": "src/Granit.Notifications.Email/GranitNotificationsEmailModule.cs",
-      "line": 13,
+      "line": 17,
       "members": []
     },
     {
@@ -28113,13 +28113,47 @@
       "kind": "class",
       "project": "Granit.Templating.Scriban",
       "file": "src/Granit.Templating.Scriban/Extensions/ServiceCollectionExtensions.cs",
-      "line": 13,
+      "line": 14,
       "members": [
         {
           "name": "AddGranitTemplatingWithScriban",
           "kind": "method",
           "signature": "AddGranitTemplatingWithScriban(this IServiceCollection services)",
           "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "AppGlobalContextOptions",
+      "fqn": "Granit.Templating.Scriban.GlobalContexts.AppGlobalContextOptions",
+      "kind": "class",
+      "project": "Granit.Templating.Scriban",
+      "file": "src/Granit.Templating.Scriban/GlobalContexts/AppGlobalContextOptions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "BaseUrl",
+          "kind": "property",
+          "signature": "string BaseUrl",
+          "returnType": "string"
+        },
+        {
+          "name": "SupportEmail",
+          "kind": "property",
+          "signature": "string SupportEmail",
+          "returnType": "string"
+        },
+        {
+          "name": "LogoUrl",
+          "kind": "property",
+          "signature": "string LogoUrl",
+          "returnType": "string"
         }
       ]
     },

--- a/src/Granit.Bff/GranitBffModule.cs
+++ b/src/Granit.Bff/GranitBffModule.cs
@@ -7,6 +7,7 @@ using Granit.Modularity;
 using Granit.Oidc;
 using Granit.Timing;
 using Granit.Users;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -36,6 +37,16 @@ public sealed class GranitBffModule : GranitModule
         context.Services.TryAddScoped<IBffTokenStore, DistributedCacheBffTokenStore>();
         context.Services.TryAddSingleton<IBffCsrfTokenGenerator, HmacBffCsrfTokenGenerator>();
         context.Services.TryAddSingleton<ILogoutTokenValidator, LogoutTokenValidator>();
+
+        // Internal loopback handler — routes HTTP calls through the ASP.NET Core pipeline
+        // in-memory when the BFF authority is the same process (BFF + OpenIddict self-hosted).
+        // Auto-detects via IServer addresses; no-op when authority is a remote server.
+        BffLoopbackPipelineCapture pipelineCapture = new();
+        context.Services.AddSingleton(pipelineCapture);
+        context.Services.AddSingleton<IStartupFilter>(pipelineCapture);
+        context.Services.AddTransient<InternalLoopbackHandler>();
+        context.Services.AddHttpClient("Granit.Bff")
+            .AddHttpMessageHandler<InternalLoopbackHandler>();
 
         GranitActivitySourceRegistry.Register(BffActivitySource.Name);
     }

--- a/src/Granit.Bff/Internal/BffLoopbackPipelineCapture.cs
+++ b/src/Granit.Bff/Internal/BffLoopbackPipelineCapture.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+
+namespace Granit.Bff.Internal;
+
+/// <summary>
+/// Captures the ASP.NET Core request pipeline at startup by registering a transparent
+/// middleware as the first component in the chain. The captured <see cref="Pipeline"/>
+/// is used by <see cref="InternalLoopbackHandler"/> to invoke the pipeline in-memory,
+/// avoiding TCP loopback deadlocks when BFF and OpenIddict run in the same process.
+/// </summary>
+internal sealed class BffLoopbackPipelineCapture : IStartupFilter
+{
+    /// <summary>
+    /// The full ASP.NET Core middleware pipeline, captured after startup completes.
+    /// <c>null</c> until the host finishes building the pipeline.
+    /// </summary>
+    internal RequestDelegate? Pipeline { get; set; }
+
+    public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next) =>
+        app =>
+        {
+            app.Use(pipeline =>
+            {
+                Pipeline = pipeline;
+                return pipeline;
+            });
+            next(app);
+        };
+}

--- a/src/Granit.Bff/Internal/InternalLoopbackHandler.cs
+++ b/src/Granit.Bff/Internal/InternalLoopbackHandler.cs
@@ -1,0 +1,277 @@
+using System.Net;
+using Granit.Bff.Options;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+
+namespace Granit.Bff.Internal;
+
+/// <summary>
+/// HTTP message handler that routes requests through the ASP.NET Core middleware
+/// pipeline in-memory when the BFF authority is hosted in the same process.
+/// Prevents TCP loopback deadlocks in self-hosted (BFF + OpenIddict) scenarios.
+/// </summary>
+/// <remarks>
+/// <para>
+/// When the configured <see cref="GranitBffOptions.Authority"/> matches one of the
+/// addresses reported by <see cref="IServer"/>, the handler builds an
+/// <see cref="HttpContext"/> from the outgoing <see cref="HttpRequestMessage"/> and
+/// invokes the request pipeline directly (similar to <c>TestServer.CreateHandler()</c>),
+/// bypassing TCP entirely.
+/// </para>
+/// <para>
+/// When the authority does not match (separate OIDC server), the handler delegates
+/// to the inner <see cref="HttpMessageHandler"/> which performs a normal network call.
+/// </para>
+/// </remarks>
+internal sealed partial class InternalLoopbackHandler(
+    BffLoopbackPipelineCapture pipelineCapture,
+    IServer server,
+    IOptions<GranitBffOptions> bffOptions,
+    IServiceScopeFactory scopeFactory,
+    ILogger<InternalLoopbackHandler> logger) : DelegatingHandler
+{
+    private bool? _isLoopback;
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        if (!ShouldShortCircuit(request))
+        {
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        LogLoopbackRequest(logger, request.RequestUri!);
+        return await InvokeInMemoryAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private bool ShouldShortCircuit(HttpRequestMessage request)
+    {
+        if (pipelineCapture.Pipeline is null || request.RequestUri is null)
+        {
+            return false;
+        }
+
+        if (!IsAuthorityLocal())
+        {
+            return false;
+        }
+
+        // Verify this specific request targets the authority (safety net — all BFF
+        // calls go to the authority, but guard against unexpected use of the client).
+        Uri authority = bffOptions.Value.Authority;
+        return string.Equals(request.RequestUri.Host, authority.Host, StringComparison.OrdinalIgnoreCase)
+            && request.RequestUri.Port == authority.Port;
+    }
+
+    /// <summary>
+    /// Determines whether the configured BFF authority is served by this process
+    /// by comparing it against <see cref="IServerAddressesFeature.Addresses"/>.
+    /// The result is cached after the first successful evaluation.
+    /// </summary>
+    private bool IsAuthorityLocal()
+    {
+        if (_isLoopback.HasValue)
+        {
+            return _isLoopback.Value;
+        }
+
+        IServerAddressesFeature? feature = server.Features.Get<IServerAddressesFeature>();
+        if (feature is null)
+        {
+            return false;
+        }
+
+        ICollection<string> addresses = feature.Addresses;
+        if (addresses.Count == 0)
+        {
+            return false; // Server hasn't bound yet — retry on next request
+        }
+
+        Uri authority = bffOptions.Value.Authority;
+
+        foreach (string address in addresses)
+        {
+            if (!TryParseServerAddress(address, out string scheme, out string host, out int port))
+            {
+                continue;
+            }
+
+            if (!string.Equals(scheme, authority.Scheme, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (port != authority.Port)
+            {
+                continue;
+            }
+
+            if (IsWildcardHost(host)
+                || string.Equals(host, authority.Host, StringComparison.OrdinalIgnoreCase))
+            {
+                _isLoopback = true;
+                LogLoopbackActive(logger, authority);
+                return true;
+            }
+        }
+
+        _isLoopback = false;
+        return false;
+    }
+
+    /// <summary>
+    /// Parses a Kestrel server address (e.g. <c>https://+:5001</c>, <c>http://[::]:80</c>).
+    /// <see cref="Uri.TryCreate(string, UriKind, out Uri?)"/> rejects wildcard hosts
+    /// (<c>+</c>, <c>*</c>) that Kestrel accepts, so we parse manually.
+    /// </summary>
+    private static bool TryParseServerAddress(
+        string address, out string scheme, out string host, out int port)
+    {
+        scheme = host = "";
+        port = 0;
+
+        int schemeEnd = address.IndexOf("://", StringComparison.Ordinal);
+        if (schemeEnd < 0)
+        {
+            return false;
+        }
+
+        scheme = address[..schemeEnd];
+        string remaining = address[(schemeEnd + 3)..];
+        int defaultPort = string.Equals(scheme, "https", StringComparison.OrdinalIgnoreCase) ? 443 : 80;
+
+        // IPv6: [::]:port
+        if (remaining.StartsWith('['))
+        {
+            int bracketEnd = remaining.IndexOf(']');
+            if (bracketEnd < 0)
+            {
+                return false;
+            }
+
+            host = remaining[1..bracketEnd];
+            string afterBracket = remaining[(bracketEnd + 1)..];
+            port = afterBracket.StartsWith(':') && int.TryParse(afterBracket[1..], out int ipv6Port)
+                ? ipv6Port
+                : defaultPort;
+            return true;
+        }
+
+        // host:port or host
+        int colonIndex = remaining.LastIndexOf(':');
+        if (colonIndex >= 0 && int.TryParse(remaining[(colonIndex + 1)..], out int parsedPort))
+        {
+            host = remaining[..colonIndex];
+            port = parsedPort;
+            return true;
+        }
+
+        host = remaining;
+        port = defaultPort;
+        return true;
+    }
+
+    private static bool IsWildcardHost(string host) =>
+        host is "+" or "*" or "0.0.0.0" or "::" or "";
+
+    /// <summary>
+    /// Invokes the ASP.NET Core middleware pipeline in-memory by building
+    /// an <see cref="HttpContext"/> from the outgoing request and converting
+    /// the response back to an <see cref="HttpResponseMessage"/>.
+    /// </summary>
+    private async Task<HttpResponseMessage> InvokeInMemoryAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        await using AsyncServiceScope scope = scopeFactory.CreateAsyncScope();
+
+        DefaultHttpContext context = new()
+        {
+            RequestServices = scope.ServiceProvider,
+            RequestAborted = cancellationToken,
+        };
+
+        await MapRequestAsync(request, context.Request, cancellationToken).ConfigureAwait(false);
+
+        MemoryStream responseBody = new();
+        context.Response.Body = responseBody;
+
+        await pipelineCapture.Pipeline!(context).ConfigureAwait(false);
+
+        return BuildResponse(context.Response, request);
+    }
+
+    private static async Task MapRequestAsync(
+        HttpRequestMessage source, HttpRequest target, CancellationToken ct)
+    {
+        target.Method = source.Method.Method;
+        target.Protocol = "HTTP/1.1";
+        target.Scheme = source.RequestUri!.Scheme;
+        target.Host = source.RequestUri.IsDefaultPort
+            ? new HostString(source.RequestUri.Host)
+            : new HostString(source.RequestUri.Host, source.RequestUri.Port);
+        target.Path = source.RequestUri.AbsolutePath;
+        target.QueryString = new QueryString(source.RequestUri.Query);
+
+        foreach (KeyValuePair<string, IEnumerable<string>> header in source.Headers)
+        {
+            target.Headers.Append(header.Key, new StringValues([.. header.Value]));
+        }
+
+        if (source.Content is null)
+        {
+            return;
+        }
+
+        foreach (KeyValuePair<string, IEnumerable<string>> header in source.Content.Headers)
+        {
+            target.Headers.Append(header.Key, new StringValues([.. header.Value]));
+        }
+
+        MemoryStream body = new();
+        await source.Content.CopyToAsync(body, ct).ConfigureAwait(false);
+        body.Position = 0;
+        target.Body = body;
+
+        if (source.Content.Headers.ContentType is not null)
+        {
+            target.ContentType = source.Content.Headers.ContentType.ToString();
+        }
+
+        if (source.Content.Headers.ContentLength.HasValue)
+        {
+            target.ContentLength = source.Content.Headers.ContentLength;
+        }
+    }
+
+    private static HttpResponseMessage BuildResponse(HttpResponse source, HttpRequestMessage request)
+    {
+        source.Body.Position = 0;
+
+        HttpResponseMessage response = new((HttpStatusCode)source.StatusCode)
+        {
+            Content = new StreamContent(source.Body),
+            RequestMessage = request,
+        };
+
+        foreach (KeyValuePair<string, StringValues> header in source.Headers)
+        {
+            if (!response.Headers.TryAddWithoutValidation(header.Key, (IEnumerable<string>)header.Value!))
+            {
+                response.Content.Headers.TryAddWithoutValidation(header.Key, (IEnumerable<string>)header.Value!);
+            }
+        }
+
+        return response;
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "BFF loopback — routing {RequestUri} through in-memory pipeline")]
+    private static partial void LogLoopbackRequest(ILogger logger, Uri requestUri);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "BFF self-loopback active — authority {Authority} matches server address, HTTP calls bypass TCP")]
+    private static partial void LogLoopbackActive(ILogger logger, Uri authority);
+}

--- a/tests/Granit.Bff.Tests/Internal/InternalLoopbackHandlerTests.cs
+++ b/tests/Granit.Bff.Tests/Internal/InternalLoopbackHandlerTests.cs
@@ -1,0 +1,280 @@
+using System.Net;
+using Granit.Bff.Internal;
+using Granit.Bff.Options;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Bff.Tests.Internal;
+
+public sealed class InternalLoopbackHandlerTests
+{
+    private const string Authority = "https://localhost:5001";
+
+    private readonly BffLoopbackPipelineCapture _pipelineCapture = new();
+    private readonly IServer _server = Substitute.For<IServer>();
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public InternalLoopbackHandlerTests()
+    {
+        ServiceCollection services = new();
+        ServiceProvider provider = services.BuildServiceProvider();
+        _scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+    }
+
+    private InternalLoopbackHandler CreateHandler(
+        string authority = Authority,
+        IReadOnlyList<string>? serverAddresses = null)
+    {
+        ServerAddressesFeature addressesFeature = new();
+        foreach (string address in serverAddresses ?? [authority])
+        {
+            addressesFeature.Addresses.Add(address);
+        }
+
+        FeatureCollection features = new();
+        features.Set<IServerAddressesFeature>(addressesFeature);
+        _server.Features.Returns(features);
+
+        Microsoft.Extensions.Options.IOptions<GranitBffOptions> options = Microsoft.Extensions.Options.Options.Create(new GranitBffOptions
+        {
+            Authority = new Uri(authority),
+        });
+
+        InternalLoopbackHandler handler = new(
+            _pipelineCapture,
+            _server,
+            options,
+            _scopeFactory,
+            NullLogger<InternalLoopbackHandler>.Instance)
+        {
+            InnerHandler = new StubInnerHandler(),
+        };
+
+        return handler;
+    }
+
+    // --- Loopback detection ---
+
+    [Fact]
+    public async Task SendAsync_DelegatesToInnerHandler_WhenPipelineNotCaptured()
+    {
+        using InternalLoopbackHandler handler = CreateHandler();
+        // pipelineCapture.Pipeline is null (no IStartupFilter ran)
+        using HttpMessageInvoker invoker = new(handler);
+
+        using HttpRequestMessage request = new(HttpMethod.Post, $"{Authority}/connect/token");
+        using HttpResponseMessage response = await invoker.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent); // StubInnerHandler returns 204
+    }
+
+    [Fact]
+    public async Task SendAsync_DelegatesToInnerHandler_WhenAuthorityDoesNotMatchServer()
+    {
+        using InternalLoopbackHandler handler = CreateHandler(
+            authority: "https://auth.external.com",
+            serverAddresses: ["https://localhost:5001"]);
+        CapturePipeline(context => { context.Response.StatusCode = 200; return Task.CompletedTask; });
+        using HttpMessageInvoker invoker = new(handler);
+
+        using HttpRequestMessage request = new(HttpMethod.Post, "https://auth.external.com/connect/token");
+        using HttpResponseMessage response = await invoker.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent); // StubInnerHandler, not pipeline
+    }
+
+    [Fact]
+    public async Task SendAsync_InvokesPipeline_WhenAuthorityMatchesServerAddress()
+    {
+        using InternalLoopbackHandler handler = CreateHandler();
+        CapturePipeline(context =>
+        {
+            context.Response.StatusCode = 200;
+            return context.Response.WriteAsync("""{"access_token":"in-memory"}""");
+        });
+        using HttpMessageInvoker invoker = new(handler);
+
+        using HttpRequestMessage request = new(HttpMethod.Post, $"{Authority}/connect/token");
+        using HttpResponseMessage response = await invoker.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.ShouldContain("in-memory");
+    }
+
+    [Fact]
+    public async Task SendAsync_InvokesPipeline_WhenServerUsesWildcardHost()
+    {
+        using InternalLoopbackHandler handler = CreateHandler(
+            authority: "https://localhost:5001",
+            serverAddresses: ["https://+:5001"]);
+        CapturePipeline(context => { context.Response.StatusCode = 200; return Task.CompletedTask; });
+        using HttpMessageInvoker invoker = new(handler);
+
+        using HttpRequestMessage request = new(HttpMethod.Post, $"{Authority}/connect/token");
+        using HttpResponseMessage response = await invoker.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Theory]
+    [InlineData("https://0.0.0.0:5001")]
+    [InlineData("https://[::]:5001")]
+    [InlineData("https://*:5001")]
+    public async Task SendAsync_InvokesPipeline_ForAllWildcardFormats(string serverAddress)
+    {
+        using InternalLoopbackHandler handler = CreateHandler(
+            authority: Authority,
+            serverAddresses: [serverAddress]);
+        CapturePipeline(context => { context.Response.StatusCode = 200; return Task.CompletedTask; });
+        using HttpMessageInvoker invoker = new(handler);
+
+        using HttpRequestMessage request = new(HttpMethod.Post, $"{Authority}/connect/token");
+        using HttpResponseMessage response = await invoker.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task SendAsync_DelegatesToInnerHandler_WhenPortMismatch()
+    {
+        using InternalLoopbackHandler handler = CreateHandler(
+            authority: "https://localhost:5001",
+            serverAddresses: ["https://localhost:5002"]);
+        CapturePipeline(context => { context.Response.StatusCode = 200; return Task.CompletedTask; });
+        using HttpMessageInvoker invoker = new(handler);
+
+        using HttpRequestMessage request = new(HttpMethod.Post, "https://localhost:5001/connect/token");
+        using HttpResponseMessage response = await invoker.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent); // Inner handler
+    }
+
+    [Fact]
+    public async Task SendAsync_DelegatesToInnerHandler_WhenSchemeMismatch()
+    {
+        using InternalLoopbackHandler handler = CreateHandler(
+            authority: "https://localhost:5001",
+            serverAddresses: ["http://localhost:5001"]);
+        CapturePipeline(context => { context.Response.StatusCode = 200; return Task.CompletedTask; });
+        using HttpMessageInvoker invoker = new(handler);
+
+        using HttpRequestMessage request = new(HttpMethod.Post, "https://localhost:5001/connect/token");
+        using HttpResponseMessage response = await invoker.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+    }
+
+    // --- Request/response mapping ---
+
+    [Fact]
+    public async Task SendAsync_MapsRequestHeadersToPipeline()
+    {
+        string? capturedAuth = null;
+        using InternalLoopbackHandler handler = CreateHandler();
+        CapturePipeline(context =>
+        {
+            capturedAuth = context.Request.Headers.Authorization;
+            context.Response.StatusCode = 200;
+            return Task.CompletedTask;
+        });
+        using HttpMessageInvoker invoker = new(handler);
+
+        using HttpRequestMessage request = new(HttpMethod.Post, $"{Authority}/connect/token");
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", "Y2xpZW50OnNlY3JldA==");
+        using HttpResponseMessage _ = await invoker.SendAsync(request, TestContext.Current.CancellationToken);
+
+        capturedAuth.ShouldNotBeNull();
+        capturedAuth.ShouldContain("Basic");
+    }
+
+    [Fact]
+    public async Task SendAsync_MapsFormBodyToPipeline()
+    {
+        string? capturedBody = null;
+        using InternalLoopbackHandler handler = CreateHandler();
+        CapturePipeline(async context =>
+        {
+            using StreamReader reader = new(context.Request.Body);
+            capturedBody = await reader.ReadToEndAsync(TestContext.Current.CancellationToken);
+            context.Response.StatusCode = 200;
+        });
+        using HttpMessageInvoker invoker = new(handler);
+
+        using HttpRequestMessage request = new(HttpMethod.Post, $"{Authority}/connect/token")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["grant_type"] = "authorization_code",
+                ["code"] = "test-code",
+            }),
+        };
+        using HttpResponseMessage _ = await invoker.SendAsync(request, TestContext.Current.CancellationToken);
+
+        capturedBody.ShouldNotBeNull();
+        capturedBody.ShouldContain("grant_type=authorization_code");
+        capturedBody.ShouldContain("code=test-code");
+    }
+
+    [Fact]
+    public async Task SendAsync_MapsResponseHeaders()
+    {
+        using InternalLoopbackHandler handler = CreateHandler();
+        CapturePipeline(context =>
+        {
+            context.Response.StatusCode = 200;
+            context.Response.Headers["DPoP-Nonce"] = "server-nonce-42";
+            return Task.CompletedTask;
+        });
+        using HttpMessageInvoker invoker = new(handler);
+
+        using HttpRequestMessage request = new(HttpMethod.Post, $"{Authority}/connect/token");
+        using HttpResponseMessage response = await invoker.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.Headers.TryGetValues("DPoP-Nonce", out IEnumerable<string>? values).ShouldBeTrue();
+        values!.ShouldContain("server-nonce-42");
+    }
+
+    [Fact]
+    public async Task SendAsync_PropagatesErrorStatusFromPipeline()
+    {
+        using InternalLoopbackHandler handler = CreateHandler();
+        CapturePipeline(context =>
+        {
+            context.Response.StatusCode = 400;
+            return context.Response.WriteAsync("""{"error":"invalid_grant"}""");
+        });
+        using HttpMessageInvoker invoker = new(handler);
+
+        using HttpRequestMessage request = new(HttpMethod.Post, $"{Authority}/connect/token");
+        using HttpResponseMessage response = await invoker.SendAsync(request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.ShouldContain("invalid_grant");
+    }
+
+    // --- Helpers ---
+
+    private void CapturePipeline(RequestDelegate pipeline) =>
+        _pipelineCapture.Pipeline = pipeline;
+
+    /// <summary>
+    /// Minimal handler that returns 204 No Content — used to verify that
+    /// the loopback handler correctly delegates to the inner handler
+    /// when the request should not be short-circuited.
+    /// </summary>
+    private sealed class StubInnerHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `InternalLoopbackHandler` (`DelegatingHandler`) that routes BFF HTTP calls (`/connect/token`, `/connect/par`, `/connect/revoke`, `/.well-known/*`) through the ASP.NET Core middleware pipeline in-memory when the authority is co-hosted
- Auto-detects self-hosting by comparing `GranitBffOptions.Authority` against `IServer` addresses (supports Kestrel wildcards `+`, `*`, `0.0.0.0`, `[::]`)
- No configuration change needed — falls back to normal TCP when authority is a remote server

## Problem

When BFF and OpenIddict Server run in the same process, HTTP calls to the authority (e.g. `http://localhost:5000/connect/token`) loop back through TCP to the same Kestrel instance, causing a deadlock.

## Solution

`BffLoopbackPipelineCapture` (an `IStartupFilter`) captures the `RequestDelegate` at startup. `InternalLoopbackHandler` checks at request time whether the target matches a local server address and, if so, builds a `DefaultHttpContext` and invokes the pipeline directly — zero TCP, zero deadlock.

## Test plan

- [x] 12 new unit tests covering loopback detection (exact match, all wildcard formats, port/scheme mismatch, pipeline not captured) and request/response mapping (headers, form body, error status, DPoP-Nonce)
- [x] All 150 `Granit.Bff.Tests` pass
- [x] `dotnet format --verify-no-changes` clean
- [ ] Integration test with showcase self-hosted BFF + OpenIddict
