### PR TITLE
feat(templating): Scriban include support + Layout Registry with two-pass rendering

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18983,7 +18983,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Email",
       "file": "src/Granit.Notifications.Email/Extensions/EmailNotificationsServiceCollectionExtensions.cs",
-      "line": 10,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitNotificationsEmail",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18983,7 +18983,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Email",
       "file": "src/Granit.Notifications.Email/Extensions/EmailNotificationsServiceCollectionExtensions.cs",
-      "line": 9,
+      "line": 10,
       "members": [
         {
           "name": "AddGranitNotificationsEmail",
@@ -18999,7 +18999,7 @@
       "kind": "class",
       "project": "Granit.Notifications.Email",
       "file": "src/Granit.Notifications.Email/GranitNotificationsEmailModule.cs",
-      "line": 13,
+      "line": 17,
       "members": []
     },
     {
@@ -28113,13 +28113,47 @@
       "kind": "class",
       "project": "Granit.Templating.Scriban",
       "file": "src/Granit.Templating.Scriban/Extensions/ServiceCollectionExtensions.cs",
-      "line": 13,
+      "line": 14,
       "members": [
         {
           "name": "AddGranitTemplatingWithScriban",
           "kind": "method",
           "signature": "AddGranitTemplatingWithScriban(this IServiceCollection services)",
           "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "AppGlobalContextOptions",
+      "fqn": "Granit.Templating.Scriban.GlobalContexts.AppGlobalContextOptions",
+      "kind": "class",
+      "project": "Granit.Templating.Scriban",
+      "file": "src/Granit.Templating.Scriban/GlobalContexts/AppGlobalContextOptions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "BaseUrl",
+          "kind": "property",
+          "signature": "string BaseUrl",
+          "returnType": "string"
+        },
+        {
+          "name": "SupportEmail",
+          "kind": "property",
+          "signature": "string SupportEmail",
+          "returnType": "string"
+        },
+        {
+          "name": "LogoUrl",
+          "kind": "property",
+          "signature": "string LogoUrl",
+          "returnType": "string"
         }
       ]
     },

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -27914,12 +27914,18 @@
       "kind": "class",
       "project": "Granit.Templating",
       "file": "src/Granit.Templating/Extensions/ServiceCollectionExtensions.cs",
-      "line": 18,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitTemplating",
           "kind": "method",
           "signature": "AddGranitTemplating(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        },
+        {
+          "name": "AddTemplateLayout",
+          "kind": "method",
+          "signature": "AddTemplateLayout(this IServiceCollection services, string templatePattern, string layoutTemplateName, int priority = 0)",
           "returnType": "IServiceCollection"
         }
       ]
@@ -28003,6 +28009,37 @@
       "project": "Granit.Templating",
       "file": "src/Granit.Templating/Keys/TextTemplateType.cs",
       "line": 15,
+      "members": []
+    },
+    {
+      "name": "ILayoutRegistry",
+      "fqn": "Granit.Templating.Layouts.ILayoutRegistry",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Layouts/ILayoutRegistry.cs",
+      "line": 12,
+      "members": [
+        {
+          "name": "GetLayoutName",
+          "kind": "method",
+          "signature": "GetLayoutName(string templateName)",
+          "returnType": "string?"
+        },
+        {
+          "name": "GetAllLayoutNames",
+          "kind": "method",
+          "signature": "GetAllLayoutNames()",
+          "returnType": "IReadOnlyList<string>"
+        }
+      ]
+    },
+    {
+      "name": "LayoutRegistration",
+      "fqn": "Granit.Templating.Layouts.LayoutRegistration",
+      "kind": "record",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Layouts/LayoutRegistration.cs",
+      "line": 20,
       "members": []
     },
     {

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -27618,7 +27618,7 @@
       "kind": "record",
       "project": "Granit.Templating.Endpoints",
       "file": "src/Granit.Templating.Endpoints/Dtos/SaveTemplateRequest.cs",
-      "line": 13,
+      "line": 17,
       "members": []
     },
     {
@@ -27636,7 +27636,7 @@
       "kind": "record",
       "project": "Granit.Templating.Endpoints",
       "file": "src/Granit.Templating.Endpoints/Dtos/TemplateDetailResponse.cs",
-      "line": 10,
+      "line": 14,
       "members": []
     },
     {
@@ -27663,7 +27663,7 @@
       "kind": "record",
       "project": "Granit.Templating.Endpoints",
       "file": "src/Granit.Templating.Endpoints/Dtos/TemplateListItemResponse.cs",
-      "line": 15,
+      "line": 19,
       "members": []
     },
     {
@@ -27699,7 +27699,7 @@
       "kind": "record",
       "project": "Granit.Templating.Endpoints",
       "file": "src/Granit.Templating.Endpoints/Dtos/TemplateRevisionResponse.cs",
-      "line": 16,
+      "line": 20,
       "members": []
     },
     {
@@ -27735,7 +27735,7 @@
       "kind": "class",
       "project": "Granit.Templating.Endpoints",
       "file": "src/Granit.Templating.Endpoints/Extensions/TemplatingEndpointRouteBuilderExtensions.cs",
-      "line": 35,
+      "line": 36,
       "members": [
         {
           "name": "MapGranitTemplating",
@@ -28255,7 +28255,7 @@
         {
           "name": "SaveDraftAsync",
           "kind": "method",
-          "signature": "SaveDraftAsync(TemplateKey key, string content, string mimeType, string updatedBy, CancellationToken cancellationToken = default)",
+          "signature": "SaveDraftAsync(TemplateKey key, string content, string mimeType, string updatedBy, string? layoutName = null, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         },
         {

--- a/src/Granit.Notifications.Email/Extensions/EmailNotificationsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Email/Extensions/EmailNotificationsServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Email.Internal;
 using Granit.Notifications.Email.Options;
+using Granit.Templating.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Granit.Notifications.Email.Extensions;
@@ -23,6 +24,7 @@ public static class EmailNotificationsServiceCollectionExtensions
         }
 
         services.AddScoped<INotificationChannel, EmailNotificationChannel>();
+        services.AddEmbeddedTemplates(typeof(EmailNotificationsServiceCollectionExtensions).Assembly);
         return services;
     }
 }

--- a/src/Granit.Notifications.Email/Extensions/EmailNotificationsServiceCollectionExtensions.cs
+++ b/src/Granit.Notifications.Email/Extensions/EmailNotificationsServiceCollectionExtensions.cs
@@ -4,6 +4,8 @@ using Granit.Notifications.Email.Options;
 using Granit.Templating.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 
+using TemplatingExtensions = Granit.Templating.Extensions.ServiceCollectionExtensions;
+
 namespace Granit.Notifications.Email.Extensions;
 
 /// <summary>Extension methods for the email notification channel.</summary>
@@ -25,6 +27,7 @@ public static class EmailNotificationsServiceCollectionExtensions
 
         services.AddScoped<INotificationChannel, EmailNotificationChannel>();
         services.AddEmbeddedTemplates(typeof(EmailNotificationsServiceCollectionExtensions).Assembly);
+        services.AddTemplateLayout("Notifications.*", "Layout.Email");
         return services;
     }
 }

--- a/src/Granit.Notifications.Email/Granit.Notifications.Email.csproj
+++ b/src/Granit.Notifications.Email/Granit.Notifications.Email.csproj
@@ -12,6 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Templates/Layout.Email.html"
+        LogicalName="Granit.Notifications.Email.Templates.Layout.Email.html" />
     <EmbeddedResource Include="Templates/Notifications.Default.html"
         LogicalName="Granit.Notifications.Email.Templates.Notifications.Default.html" />
     <EmbeddedResource Include="Templates/Notifications.Default.fr.html"

--- a/src/Granit.Notifications.Email/Granit.Notifications.Email.csproj
+++ b/src/Granit.Notifications.Email/Granit.Notifications.Email.csproj
@@ -12,6 +12,56 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Templates/Notifications.Default.html"
+        LogicalName="Granit.Notifications.Email.Templates.Notifications.Default.html" />
+    <EmbeddedResource Include="Templates/Notifications.Default.fr.html"
+        LogicalName="Granit.Notifications.Email.Templates.Notifications.Default.fr.html"
+        WithCulture="false" />
+    <EmbeddedResource Include="Templates/Notifications.Default.fr-CA.html"
+        LogicalName="Granit.Notifications.Email.Templates.Notifications.Default.fr-CA.html"
+        WithCulture="false" />
+    <EmbeddedResource Include="Templates/Notifications.Default.nl.html"
+        LogicalName="Granit.Notifications.Email.Templates.Notifications.Default.nl.html"
+        WithCulture="false" />
+    <EmbeddedResource Include="Templates/Notifications.Default.de.html"
+        LogicalName="Granit.Notifications.Email.Templates.Notifications.Default.de.html"
+        WithCulture="false" />
+    <EmbeddedResource Include="Templates/Notifications.Default.es.html"
+        LogicalName="Granit.Notifications.Email.Templates.Notifications.Default.es.html"
+        WithCulture="false" />
+    <EmbeddedResource Include="Templates/Notifications.Default.it.html"
+        LogicalName="Granit.Notifications.Email.Templates.Notifications.Default.it.html"
+        WithCulture="false" />
+    <EmbeddedResource Include="Templates/Notifications.Default.pt.html"
+        LogicalName="Granit.Notifications.Email.Templates.Notifications.Default.pt.html"
+        WithCulture="false" />
+    <EmbeddedResource Include="Templates/Notifications.Default.pt-BR.html"
+        LogicalName="Granit.Notifications.Email.Templates.Notifications.Default.pt-BR.html"
+        WithCulture="false" />
+    <EmbeddedResource Include="Templates/Notifications.Default.zh.html"
+        LogicalName="Granit.Notifications.Email.Templates.Notifications.Default.zh.html"
+        WithCulture="false" />
+    <EmbeddedResource Include="Templates/Notifications.Default.ja.html"
+        LogicalName="Granit.Notifications.Email.Templates.Notifications.Default.ja.html"
+        WithCulture="false" />
+    <EmbeddedResource Include="Templates/Notifications.Default.pl.html"
+        LogicalName="Granit.Notifications.Email.Templates.Notifications.Default.pl.html"
+        WithCulture="false" />
+    <EmbeddedResource Include="Templates/Notifications.Default.tr.html"
+        LogicalName="Granit.Notifications.Email.Templates.Notifications.Default.tr.html"
+        WithCulture="false" />
+    <EmbeddedResource Include="Templates/Notifications.Default.ko.html"
+        LogicalName="Granit.Notifications.Email.Templates.Notifications.Default.ko.html"
+        WithCulture="false" />
+    <EmbeddedResource Include="Templates/Notifications.Default.sv.html"
+        LogicalName="Granit.Notifications.Email.Templates.Notifications.Default.sv.html"
+        WithCulture="false" />
+    <EmbeddedResource Include="Templates/Notifications.Default.cs.html"
+        LogicalName="Granit.Notifications.Email.Templates.Notifications.Default.cs.html"
+        WithCulture="false" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />

--- a/src/Granit.Notifications.Email/GranitNotificationsEmailModule.cs
+++ b/src/Granit.Notifications.Email/GranitNotificationsEmailModule.cs
@@ -1,4 +1,5 @@
 using Granit.Modularity;
+using Granit.Templating;
 
 namespace Granit.Notifications.Email;
 
@@ -8,6 +9,9 @@ namespace Granit.Notifications.Email;
 /// <remarks>
 /// Registration is done via <c>AddGranitNotificationsEmail()</c>.
 /// Providers (SMTP, Brevo) register keyed <c>IEmailSender</c> implementations.
+/// Embeds localized <c>Notifications.Default</c> fallback templates for when
+/// no type-specific template is registered.
 /// </remarks>
 [DependsOn(typeof(GranitNotificationsAbstractionsModule))]
+[DependsOn(typeof(GranitTemplatingModule))]
 public sealed class GranitNotificationsEmailModule : GranitModule;

--- a/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
+++ b/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
@@ -15,10 +15,15 @@ namespace Granit.Notifications.Email.Internal;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Template resolution: looks for a template named <c>{NotificationTypeName}</c>
-/// (e.g., <c>"Security.Welcome"</c>) via any registered <see cref="ITemplateResolver"/>.
-/// If found, renders with Scriban using the notification data as <c>{{ model.* }}</c>.
-/// If not found, falls back to a generic notification email.
+/// Template resolution order:
+/// <list type="number">
+///   <item>Looks for a template named <c>{NotificationTypeName}</c>
+///     (e.g., <c>"Security.Welcome"</c>) via any registered <see cref="ITemplateResolver"/>.</item>
+///   <item>Falls back to the built-in <c>Notifications.Default</c> embedded template
+///     (localized in 16 cultures) when no type-specific template exists.</item>
+/// </list>
+/// Both templates use Scriban syntax with <c>{{ model.* }}</c> for data binding.
+/// The fallback template additionally exposes <c>{{ model.notification_type }}</c>.
 /// </para>
 /// <para>
 /// Templates can be provided as embedded resources (<c>AddEmbeddedTemplates()</c>),
@@ -32,6 +37,12 @@ internal sealed partial class EmailNotificationChannel(
     IRecipientResolver recipientResolver,
     ILogger<EmailNotificationChannel> logger) : INotificationChannel
 {
+    /// <summary>
+    /// Name of the built-in fallback template embedded in this assembly.
+    /// Resolved when no type-specific template exists for the notification.
+    /// </summary>
+    internal const string FallbackTemplateName = "Notifications.Default";
+
     /// <inheritdoc />
     public string Name => NotificationChannels.Email;
 
@@ -46,12 +57,15 @@ internal sealed partial class EmailNotificationChannel(
             return;
         }
 
-        // Try to render a Scriban template for this notification type
-        RenderedEmail? rendered = await TryRenderTemplateAsync(context, cancellationToken).ConfigureAwait(false);
+        // Try type-specific template first, then fall back to the built-in default template
+        RenderedEmail? rendered = await TryRenderTemplateAsync(
+                context.NotificationTypeName, context, cancellationToken).ConfigureAwait(false)
+            ?? await TryRenderTemplateAsync(
+                FallbackTemplateName, context, cancellationToken).ConfigureAwait(false);
 
         string subject = rendered?.Subject ?? context.NotificationTypeName.Replace('.', ' ');
         string htmlBody = rendered?.Html
-            ?? $"<p>You have a new notification of type <strong>{context.NotificationTypeName}</strong>.</p>";
+            ?? $"<p>{context.NotificationTypeName}</p>";
 
         await sender.SendAsync(new EmailMessage
         {
@@ -63,12 +77,12 @@ internal sealed partial class EmailNotificationChannel(
     }
 
     /// <summary>
-    /// Attempts to resolve and render a Scriban template named after the notification type.
+    /// Attempts to resolve and render a Scriban template by name.
     /// Extracts the subject from the HTML <c>&lt;title&gt;</c> tag if present.
     /// Returns <see langword="null"/> if no template is found or templating is not configured.
     /// </summary>
     private async Task<RenderedEmail?> TryRenderTemplateAsync(
-        NotificationDeliveryContext context, CancellationToken cancellationToken)
+        string templateName, NotificationDeliveryContext context, CancellationToken cancellationToken)
     {
         // Resolve ITemplateResolver chain (optional — not all apps have Granit.Templating)
         IEnumerable<ITemplateResolver>? resolvers = serviceProvider.GetService<IEnumerable<ITemplateResolver>>();
@@ -77,7 +91,7 @@ internal sealed partial class EmailNotificationChannel(
             return null;
         }
 
-        TemplateKey key = new(context.NotificationTypeName, context.Culture);
+        TemplateKey key = new(templateName, context.Culture);
 
         // Try each resolver in priority order
         TemplateDescriptor? descriptor = null;
@@ -100,12 +114,13 @@ internal sealed partial class EmailNotificationChannel(
         ITemplateEngine? engine = engines?.FirstOrDefault(e => e.CanRender(descriptor));
         if (engine is null)
         {
-            Log.NoEngineForTemplate(logger, context.NotificationTypeName);
+            Log.NoEngineForTemplate(logger, templateName);
             return null;
         }
 
         // Convert JsonElement data to Dictionary for Scriban rendering
         Dictionary<string, object?> dataDict = JsonElementToDictionary(context.Data);
+        dataDict.TryAdd("notification_type", context.NotificationTypeName);
 
         try
         {
@@ -119,14 +134,14 @@ internal sealed partial class EmailNotificationChannel(
 
             if (rendered is TextRenderedContent textResult)
             {
-                Log.TemplateRendered(logger, context.NotificationTypeName, context.Culture);
+                Log.TemplateRendered(logger, templateName, context.Culture);
                 string? subject = ExtractTitleFromHtml(textResult.Html);
                 return new RenderedEmail(textResult.Html, subject);
             }
         }
         catch (Exception ex)
         {
-            Log.TemplateRenderFailed(logger, context.NotificationTypeName, ex);
+            Log.TemplateRenderFailed(logger, templateName, ex);
         }
 
         return null;

--- a/src/Granit.Notifications.Email/Templates/Layout.Email.html
+++ b/src/Granit.Notifications.Email/Templates/Layout.Email.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="{{ context.culture }}">
+<head>
+    <meta charset="utf-8">
+    <title>{{ model.title }}</title>
+</head>
+<body>
+    {{- if app.logo_url != "" }}
+    <img src="{{ app.logo_url }}" alt="{{ app.name }}">
+    {{- end }}
+    {{ body | raw }}
+    {{- if app.base_url != "" }}
+    <p><a href="{{ app.base_url }}">{{ app.name }}</a></p>
+    {{- end }}
+</body>
+</html>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.cs.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.cs.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="cs">
+<head>
+    <meta charset="utf-8">
+    <title>{{ app.name }} — Nove oznameni</title>
+</head>
+<body>
+    <p>Obdrzeli jste nove oznameni typu <strong>{{ model.notification_type }}</strong>.</p>
+    {{- if app.base_url != "" }}
+    <p><a href="{{ app.base_url }}">Prejit do {{ app.name }}</a></p>
+    {{- end }}
+</body>
+</html>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.cs.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.cs.html
@@ -1,13 +1,1 @@
-<!DOCTYPE html>
-<html lang="cs">
-<head>
-    <meta charset="utf-8">
-    <title>{{ app.name }} — Nove oznameni</title>
-</head>
-<body>
-    <p>Obdrzeli jste nove oznameni typu <strong>{{ model.notification_type }}</strong>.</p>
-    {{- if app.base_url != "" }}
-    <p><a href="{{ app.base_url }}">Prejit do {{ app.name }}</a></p>
-    {{- end }}
-</body>
-</html>
+<p>Obdrzeli jste nove oznameni typu <strong>{{ model.notification_type }}</strong>.</p>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.de.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.de.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <title>{{ app.name }} — Neue Benachrichtigung</title>
+</head>
+<body>
+    <p>Sie haben eine neue Benachrichtigung vom Typ <strong>{{ model.notification_type }}</strong> erhalten.</p>
+    {{- if app.base_url != "" }}
+    <p><a href="{{ app.base_url }}">Zu {{ app.name }} wechseln</a></p>
+    {{- end }}
+</body>
+</html>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.de.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.de.html
@@ -1,13 +1,1 @@
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="utf-8">
-    <title>{{ app.name }} — Neue Benachrichtigung</title>
-</head>
-<body>
-    <p>Sie haben eine neue Benachrichtigung vom Typ <strong>{{ model.notification_type }}</strong> erhalten.</p>
-    {{- if app.base_url != "" }}
-    <p><a href="{{ app.base_url }}">Zu {{ app.name }} wechseln</a></p>
-    {{- end }}
-</body>
-</html>
+<p>Sie haben eine neue Benachrichtigung vom Typ <strong>{{ model.notification_type }}</strong> erhalten.</p>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.es.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.es.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="utf-8">
+    <title>{{ app.name }} — Nueva notificacion</title>
+</head>
+<body>
+    <p>Ha recibido una nueva notificacion de tipo <strong>{{ model.notification_type }}</strong>.</p>
+    {{- if app.base_url != "" }}
+    <p><a href="{{ app.base_url }}">Ir a {{ app.name }}</a></p>
+    {{- end }}
+</body>
+</html>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.es.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.es.html
@@ -1,13 +1,1 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-    <meta charset="utf-8">
-    <title>{{ app.name }} — Nueva notificacion</title>
-</head>
-<body>
-    <p>Ha recibido una nueva notificacion de tipo <strong>{{ model.notification_type }}</strong>.</p>
-    {{- if app.base_url != "" }}
-    <p><a href="{{ app.base_url }}">Ir a {{ app.name }}</a></p>
-    {{- end }}
-</body>
-</html>
+<p>Ha recibido una nueva notificacion de tipo <strong>{{ model.notification_type }}</strong>.</p>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.fr-CA.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.fr-CA.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="fr-CA">
+<head>
+    <meta charset="utf-8">
+    <title>{{ app.name }} — Nouvelle notification</title>
+</head>
+<body>
+    <p>Vous avez recu une nouvelle notification de type <strong>{{ model.notification_type }}</strong>.</p>
+    {{- if app.base_url != "" }}
+    <p><a href="{{ app.base_url }}">Acceder a {{ app.name }}</a></p>
+    {{- end }}
+</body>
+</html>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.fr-CA.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.fr-CA.html
@@ -1,13 +1,1 @@
-<!DOCTYPE html>
-<html lang="fr-CA">
-<head>
-    <meta charset="utf-8">
-    <title>{{ app.name }} — Nouvelle notification</title>
-</head>
-<body>
-    <p>Vous avez recu une nouvelle notification de type <strong>{{ model.notification_type }}</strong>.</p>
-    {{- if app.base_url != "" }}
-    <p><a href="{{ app.base_url }}">Acceder a {{ app.name }}</a></p>
-    {{- end }}
-</body>
-</html>
+<p>Vous avez recu une nouvelle notification de type <strong>{{ model.notification_type }}</strong>.</p>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.fr.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.fr.html
@@ -1,13 +1,1 @@
-<!DOCTYPE html>
-<html lang="fr">
-<head>
-    <meta charset="utf-8">
-    <title>{{ app.name }} — Nouvelle notification</title>
-</head>
-<body>
-    <p>Vous avez recu une nouvelle notification de type <strong>{{ model.notification_type }}</strong>.</p>
-    {{- if app.base_url != "" }}
-    <p><a href="{{ app.base_url }}">Acceder a {{ app.name }}</a></p>
-    {{- end }}
-</body>
-</html>
+<p>Vous avez recu une nouvelle notification de type <strong>{{ model.notification_type }}</strong>.</p>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.fr.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.fr.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="utf-8">
+    <title>{{ app.name }} — Nouvelle notification</title>
+</head>
+<body>
+    <p>Vous avez recu une nouvelle notification de type <strong>{{ model.notification_type }}</strong>.</p>
+    {{- if app.base_url != "" }}
+    <p><a href="{{ app.base_url }}">Acceder a {{ app.name }}</a></p>
+    {{- end }}
+</body>
+</html>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{{ app.name }} — New notification</title>
+</head>
+<body>
+    <p>You have received a new notification of type <strong>{{ model.notification_type }}</strong>.</p>
+    {{- if app.base_url != "" }}
+    <p><a href="{{ app.base_url }}">Go to {{ app.name }}</a></p>
+    {{- end }}
+</body>
+</html>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.html
@@ -1,13 +1,1 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>{{ app.name }} — New notification</title>
-</head>
-<body>
-    <p>You have received a new notification of type <strong>{{ model.notification_type }}</strong>.</p>
-    {{- if app.base_url != "" }}
-    <p><a href="{{ app.base_url }}">Go to {{ app.name }}</a></p>
-    {{- end }}
-</body>
-</html>
+<p>You have received a new notification of type <strong>{{ model.notification_type }}</strong>.</p>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.it.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.it.html
@@ -1,13 +1,1 @@
-<!DOCTYPE html>
-<html lang="it">
-<head>
-    <meta charset="utf-8">
-    <title>{{ app.name }} — Nuova notifica</title>
-</head>
-<body>
-    <p>Hai ricevuto una nuova notifica di tipo <strong>{{ model.notification_type }}</strong>.</p>
-    {{- if app.base_url != "" }}
-    <p><a href="{{ app.base_url }}">Vai a {{ app.name }}</a></p>
-    {{- end }}
-</body>
-</html>
+<p>Hai ricevuto una nuova notifica di tipo <strong>{{ model.notification_type }}</strong>.</p>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.it.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.it.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="utf-8">
+    <title>{{ app.name }} — Nuova notifica</title>
+</head>
+<body>
+    <p>Hai ricevuto una nuova notifica di tipo <strong>{{ model.notification_type }}</strong>.</p>
+    {{- if app.base_url != "" }}
+    <p><a href="{{ app.base_url }}">Vai a {{ app.name }}</a></p>
+    {{- end }}
+</body>
+</html>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.ja.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.ja.html
@@ -1,13 +1,1 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="utf-8">
-    <title>{{ app.name }} — 新しい通知</title>
-</head>
-<body>
-    <p>タイプ <strong>{{ model.notification_type }}</strong> の新しい通知を受信しました。</p>
-    {{- if app.base_url != "" }}
-    <p><a href="{{ app.base_url }}">{{ app.name }} を開く</a></p>
-    {{- end }}
-</body>
-</html>
+<p>タイプ <strong>{{ model.notification_type }}</strong> の新しい通知を受信しました。</p>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.ja.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.ja.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="utf-8">
+    <title>{{ app.name }} — 新しい通知</title>
+</head>
+<body>
+    <p>タイプ <strong>{{ model.notification_type }}</strong> の新しい通知を受信しました。</p>
+    {{- if app.base_url != "" }}
+    <p><a href="{{ app.base_url }}">{{ app.name }} を開く</a></p>
+    {{- end }}
+</body>
+</html>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.ko.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.ko.html
@@ -1,13 +1,1 @@
-<!DOCTYPE html>
-<html lang="ko">
-<head>
-    <meta charset="utf-8">
-    <title>{{ app.name }} — 새 알림</title>
-</head>
-<body>
-    <p><strong>{{ model.notification_type }}</strong> 유형의 새 알림을 받았습니다.</p>
-    {{- if app.base_url != "" }}
-    <p><a href="{{ app.base_url }}">{{ app.name }}(으)로 이동</a></p>
-    {{- end }}
-</body>
-</html>
+<p><strong>{{ model.notification_type }}</strong> 유형의 새 알림을 받았습니다.</p>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.ko.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.ko.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="utf-8">
+    <title>{{ app.name }} — 새 알림</title>
+</head>
+<body>
+    <p><strong>{{ model.notification_type }}</strong> 유형의 새 알림을 받았습니다.</p>
+    {{- if app.base_url != "" }}
+    <p><a href="{{ app.base_url }}">{{ app.name }}(으)로 이동</a></p>
+    {{- end }}
+</body>
+</html>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.nl.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.nl.html
@@ -1,13 +1,1 @@
-<!DOCTYPE html>
-<html lang="nl">
-<head>
-    <meta charset="utf-8">
-    <title>{{ app.name }} — Nieuwe melding</title>
-</head>
-<body>
-    <p>U heeft een nieuwe melding ontvangen van het type <strong>{{ model.notification_type }}</strong>.</p>
-    {{- if app.base_url != "" }}
-    <p><a href="{{ app.base_url }}">Ga naar {{ app.name }}</a></p>
-    {{- end }}
-</body>
-</html>
+<p>U heeft een nieuwe melding ontvangen van het type <strong>{{ model.notification_type }}</strong>.</p>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.nl.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.nl.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="utf-8">
+    <title>{{ app.name }} — Nieuwe melding</title>
+</head>
+<body>
+    <p>U heeft een nieuwe melding ontvangen van het type <strong>{{ model.notification_type }}</strong>.</p>
+    {{- if app.base_url != "" }}
+    <p><a href="{{ app.base_url }}">Ga naar {{ app.name }}</a></p>
+    {{- end }}
+</body>
+</html>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.pl.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.pl.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="utf-8">
+    <title>{{ app.name }} — Nowe powiadomienie</title>
+</head>
+<body>
+    <p>Otrzymano nowe powiadomienie typu <strong>{{ model.notification_type }}</strong>.</p>
+    {{- if app.base_url != "" }}
+    <p><a href="{{ app.base_url }}">Przejdz do {{ app.name }}</a></p>
+    {{- end }}
+</body>
+</html>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.pl.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.pl.html
@@ -1,13 +1,1 @@
-<!DOCTYPE html>
-<html lang="pl">
-<head>
-    <meta charset="utf-8">
-    <title>{{ app.name }} — Nowe powiadomienie</title>
-</head>
-<body>
-    <p>Otrzymano nowe powiadomienie typu <strong>{{ model.notification_type }}</strong>.</p>
-    {{- if app.base_url != "" }}
-    <p><a href="{{ app.base_url }}">Przejdz do {{ app.name }}</a></p>
-    {{- end }}
-</body>
-</html>
+<p>Otrzymano nowe powiadomienie typu <strong>{{ model.notification_type }}</strong>.</p>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.pt-BR.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.pt-BR.html
@@ -1,13 +1,1 @@
-<!DOCTYPE html>
-<html lang="pt-BR">
-<head>
-    <meta charset="utf-8">
-    <title>{{ app.name }} — Nova notificacao</title>
-</head>
-<body>
-    <p>Voce recebeu uma nova notificacao do tipo <strong>{{ model.notification_type }}</strong>.</p>
-    {{- if app.base_url != "" }}
-    <p><a href="{{ app.base_url }}">Ir para {{ app.name }}</a></p>
-    {{- end }}
-</body>
-</html>
+<p>Voce recebeu uma nova notificacao do tipo <strong>{{ model.notification_type }}</strong>.</p>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.pt-BR.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.pt-BR.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="utf-8">
+    <title>{{ app.name }} — Nova notificacao</title>
+</head>
+<body>
+    <p>Voce recebeu uma nova notificacao do tipo <strong>{{ model.notification_type }}</strong>.</p>
+    {{- if app.base_url != "" }}
+    <p><a href="{{ app.base_url }}">Ir para {{ app.name }}</a></p>
+    {{- end }}
+</body>
+</html>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.pt.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.pt.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+    <meta charset="utf-8">
+    <title>{{ app.name }} — Nova notificacao</title>
+</head>
+<body>
+    <p>Recebeu uma nova notificacao do tipo <strong>{{ model.notification_type }}</strong>.</p>
+    {{- if app.base_url != "" }}
+    <p><a href="{{ app.base_url }}">Ir para {{ app.name }}</a></p>
+    {{- end }}
+</body>
+</html>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.pt.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.pt.html
@@ -1,13 +1,1 @@
-<!DOCTYPE html>
-<html lang="pt">
-<head>
-    <meta charset="utf-8">
-    <title>{{ app.name }} — Nova notificacao</title>
-</head>
-<body>
-    <p>Recebeu uma nova notificacao do tipo <strong>{{ model.notification_type }}</strong>.</p>
-    {{- if app.base_url != "" }}
-    <p><a href="{{ app.base_url }}">Ir para {{ app.name }}</a></p>
-    {{- end }}
-</body>
-</html>
+<p>Recebeu uma nova notificacao do tipo <strong>{{ model.notification_type }}</strong>.</p>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.sv.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.sv.html
@@ -1,13 +1,1 @@
-<!DOCTYPE html>
-<html lang="sv">
-<head>
-    <meta charset="utf-8">
-    <title>{{ app.name }} — Nytt meddelande</title>
-</head>
-<body>
-    <p>Du har fatt ett nytt meddelande av typen <strong>{{ model.notification_type }}</strong>.</p>
-    {{- if app.base_url != "" }}
-    <p><a href="{{ app.base_url }}">Ga till {{ app.name }}</a></p>
-    {{- end }}
-</body>
-</html>
+<p>Du har fatt ett nytt meddelande av typen <strong>{{ model.notification_type }}</strong>.</p>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.sv.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.sv.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+    <meta charset="utf-8">
+    <title>{{ app.name }} — Nytt meddelande</title>
+</head>
+<body>
+    <p>Du har fatt ett nytt meddelande av typen <strong>{{ model.notification_type }}</strong>.</p>
+    {{- if app.base_url != "" }}
+    <p><a href="{{ app.base_url }}">Ga till {{ app.name }}</a></p>
+    {{- end }}
+</body>
+</html>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.tr.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.tr.html
@@ -1,13 +1,1 @@
-<!DOCTYPE html>
-<html lang="tr">
-<head>
-    <meta charset="utf-8">
-    <title>{{ app.name }} — Yeni bildirim</title>
-</head>
-<body>
-    <p><strong>{{ model.notification_type }}</strong> turunde yeni bir bildirim aldınız.</p>
-    {{- if app.base_url != "" }}
-    <p><a href="{{ app.base_url }}">{{ app.name }} uygulamasına git</a></p>
-    {{- end }}
-</body>
-</html>
+<p><strong>{{ model.notification_type }}</strong> turunde yeni bir bildirim aldınız.</p>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.tr.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.tr.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="utf-8">
+    <title>{{ app.name }} — Yeni bildirim</title>
+</head>
+<body>
+    <p><strong>{{ model.notification_type }}</strong> turunde yeni bir bildirim aldınız.</p>
+    {{- if app.base_url != "" }}
+    <p><a href="{{ app.base_url }}">{{ app.name }} uygulamasına git</a></p>
+    {{- end }}
+</body>
+</html>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.zh.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.zh.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+    <meta charset="utf-8">
+    <title>{{ app.name }} — 新通知</title>
+</head>
+<body>
+    <p>您收到了一条类型为 <strong>{{ model.notification_type }}</strong> 的新通知。</p>
+    {{- if app.base_url != "" }}
+    <p><a href="{{ app.base_url }}">前往 {{ app.name }}</a></p>
+    {{- end }}
+</body>
+</html>

--- a/src/Granit.Notifications.Email/Templates/Notifications.Default.zh.html
+++ b/src/Granit.Notifications.Email/Templates/Notifications.Default.zh.html
@@ -1,13 +1,1 @@
-<!DOCTYPE html>
-<html lang="zh">
-<head>
-    <meta charset="utf-8">
-    <title>{{ app.name }} — 新通知</title>
-</head>
-<body>
-    <p>您收到了一条类型为 <strong>{{ model.notification_type }}</strong> 的新通知。</p>
-    {{- if app.base_url != "" }}
-    <p><a href="{{ app.base_url }}">前往 {{ app.name }}</a></p>
-    {{- end }}
-</body>
-</html>
+<p>您收到了一条类型为 <strong>{{ model.notification_type }}</strong> 的新通知。</p>

--- a/src/Granit.Templating.Endpoints/Dtos/SaveTemplateRequest.cs
+++ b/src/Granit.Templating.Endpoints/Dtos/SaveTemplateRequest.cs
@@ -10,8 +10,13 @@ namespace Granit.Templating.Endpoints.Dtos;
 /// <param name="Culture">Optional BCP 47 culture tag (e.g. <c>"fr-BE"</c>). <c>null</c> for culture-neutral.</param>
 /// <param name="Content">Template source content (Scriban HTML).</param>
 /// <param name="MimeType">MIME type of the content. Default: <c>"text/html"</c>.</param>
+/// <param name="LayoutName">
+/// Layout template name assigned to this template.
+/// <c>null</c> means the code-level <c>ILayoutRegistry</c> default applies.
+/// </param>
 public sealed record SaveTemplateRequest(
     string? Name,
     string? Culture,
     string Content,
-    string MimeType = "text/html");
+    string MimeType = "text/html",
+    string? LayoutName = null);

--- a/src/Granit.Templating.Endpoints/Dtos/TemplateDetailResponse.cs
+++ b/src/Granit.Templating.Endpoints/Dtos/TemplateDetailResponse.cs
@@ -7,8 +7,13 @@ namespace Granit.Templating.Endpoints.Dtos;
 /// <param name="Culture">BCP 47 culture tag, or <c>null</c> for culture-neutral templates.</param>
 /// <param name="Draft">Current draft revision, or <c>null</c> if no draft exists.</param>
 /// <param name="Published">Currently published revision, or <c>null</c> if none is published.</param>
+/// <param name="LayoutName">
+/// Layout template name assigned to this template.
+/// <c>null</c> means the code-level <c>ILayoutRegistry</c> default applies.
+/// </param>
 public sealed record TemplateDetailResponse(
     string Name,
     string? Culture,
     TemplateRevisionResponse? Draft,
-    TemplateRevisionResponse? Published);
+    TemplateRevisionResponse? Published,
+    string? LayoutName);

--- a/src/Granit.Templating.Endpoints/Dtos/TemplateListItemResponse.cs
+++ b/src/Granit.Templating.Endpoints/Dtos/TemplateListItemResponse.cs
@@ -12,6 +12,10 @@ namespace Granit.Templating.Endpoints.Dtos;
 /// <param name="LastModifiedAt">UTC timestamp of the most recent modification.</param>
 /// <param name="LastModifiedBy">Identity of the user who last modified the template.</param>
 /// <param name="HasPublishedVersion">Whether a published version currently exists for this key.</param>
+/// <param name="LayoutName">
+/// Layout template name assigned to this template.
+/// <c>null</c> means the code-level <c>ILayoutRegistry</c> default applies.
+/// </param>
 public sealed record TemplateListItemResponse(
     string Name,
     string? Culture,
@@ -19,4 +23,5 @@ public sealed record TemplateListItemResponse(
     TemplateLifecycleStatus CurrentStatus,
     DateTimeOffset LastModifiedAt,
     string LastModifiedBy,
-    bool HasPublishedVersion);
+    bool HasPublishedVersion,
+    string? LayoutName);

--- a/src/Granit.Templating.Endpoints/Dtos/TemplateRevisionResponse.cs
+++ b/src/Granit.Templating.Endpoints/Dtos/TemplateRevisionResponse.cs
@@ -13,6 +13,10 @@ namespace Granit.Templating.Endpoints.Dtos;
 /// <param name="CreatedBy">Identity of the user who created this revision.</param>
 /// <param name="PublishedAt">UTC timestamp when this revision was published, or <c>null</c>.</param>
 /// <param name="PublishedBy">Identity of the user who published this revision, or <c>null</c>.</param>
+/// <param name="LayoutName">
+/// Layout template name assigned to this template.
+/// <c>null</c> means the code-level <c>ILayoutRegistry</c> default applies.
+/// </param>
 public sealed record TemplateRevisionResponse(
     Guid RevisionId,
     string Content,
@@ -21,4 +25,5 @@ public sealed record TemplateRevisionResponse(
     DateTimeOffset CreatedAt,
     string CreatedBy,
     DateTimeOffset? PublishedAt,
-    string? PublishedBy);
+    string? PublishedBy,
+    string? LayoutName);

--- a/src/Granit.Templating.Endpoints/Extensions/TemplatingEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Templating.Endpoints/Extensions/TemplatingEndpointRouteBuilderExtensions.cs
@@ -17,6 +17,7 @@ using Granit.Templating.Endpoints.Permissions;
 using Granit.Templating.Exceptions;
 using Granit.Templating.GlobalContext;
 using Granit.Templating.Keys;
+using Granit.Templating.Layouts;
 using Granit.Templating.Pipeline;
 using Granit.Templating.Store;
 using Granit.Users;
@@ -199,6 +200,15 @@ public static class TemplatingEndpointRouteBuilderExtensions
              .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
              .ProducesProblem(StatusCodes.Status501NotImplemented);
 
+        // ----- Layouts — Read (Templates.Read) -----
+
+        group.MapGet("/layouts", HandleListLayoutsAsync)
+             .RequireAuthorization(TemplatingPermissions.Templates.Read)
+             .WithName("ListAvailableLayouts")
+             .WithSummary("Returns all available layout template names.")
+             .WithDescription("Returns a deduplicated list of layout template names from both the code-level ILayoutRegistry and database-assigned LayoutName values. Used by the admin UI to populate layout dropdowns.")
+             .Produces<IReadOnlyList<string>>();
+
         // ----- Categories — Read (Categories.Read) -----
 
         group.MapGet("/categories", HandleListCategoriesAsync)
@@ -295,7 +305,8 @@ public static class TemplatingEndpointRouteBuilderExtensions
                 s.CurrentStatus,
                 s.LastModifiedAt,
                 s.LastModifiedBy,
-                s.HasPublishedVersion))
+                s.HasPublishedVersion,
+                s.LayoutName))
             .ToList();
 
         return TypedResults.Ok(new TemplateListResponse(items, result.TotalCount));
@@ -366,7 +377,8 @@ public static class TemplatingEndpointRouteBuilderExtensions
             name,
             culture,
             draft is not null ? ToRevisionResponse(draft) : null,
-            publishedResponse));
+            publishedResponse,
+            draft?.LayoutName ?? published?.LayoutName));
     }
 
     // -------------------------------------------------------------------------
@@ -404,7 +416,7 @@ public static class TemplatingEndpointRouteBuilderExtensions
         string userId = GetCurrentUserId(context);
         TemplateKey key = new(body.Name, body.Culture);
 
-        await storeWriter.SaveDraftAsync(key, body.Content, body.MimeType, userId, cancellationToken).ConfigureAwait(false);
+        await storeWriter.SaveDraftAsync(key, body.Content, body.MimeType, userId, body.LayoutName, cancellationToken).ConfigureAwait(false);
 
         TemplateRevision? draft = await storeReader.TryGetDraftAsync(key, cancellationToken).ConfigureAwait(false);
         Pipeline.TemplateDescriptor? published = await storeReader.TryGetPublishedAsync(key, cancellationToken).ConfigureAwait(false);
@@ -426,7 +438,8 @@ public static class TemplatingEndpointRouteBuilderExtensions
             body.Name,
             body.Culture,
             draft is not null ? ToRevisionResponse(draft) : null,
-            publishedResponse);
+            publishedResponse,
+            draft?.LayoutName);
 
         return TypedResults.Created($"{body.Name}", response);
     }
@@ -460,7 +473,7 @@ public static class TemplatingEndpointRouteBuilderExtensions
         string userId = GetCurrentUserId(context);
         TemplateKey key = new(name, body.Culture);
 
-        await storeWriter.SaveDraftAsync(key, body.Content, body.MimeType, userId, cancellationToken).ConfigureAwait(false);
+        await storeWriter.SaveDraftAsync(key, body.Content, body.MimeType, userId, body.LayoutName, cancellationToken).ConfigureAwait(false);
 
         TemplateRevision? draft = await storeReader.TryGetDraftAsync(key, cancellationToken).ConfigureAwait(false);
         Pipeline.TemplateDescriptor? published = await storeReader.TryGetPublishedAsync(key, cancellationToken).ConfigureAwait(false);
@@ -482,7 +495,8 @@ public static class TemplatingEndpointRouteBuilderExtensions
             name,
             body.Culture,
             draft is not null ? ToRevisionResponse(draft) : null,
-            publishedResponse));
+            publishedResponse,
+            draft?.LayoutName));
     }
 
     // -------------------------------------------------------------------------
@@ -1135,6 +1149,25 @@ public static class TemplatingEndpointRouteBuilderExtensions
             category.SortOrder, category.TemplateCount);
 
     // -------------------------------------------------------------------------
+    // GET /layouts — List available layouts
+    // -------------------------------------------------------------------------
+
+    private static Task<Ok<IReadOnlyList<string>>> HandleListLayoutsAsync(
+        HttpContext context,
+        CancellationToken cancellationToken)
+    {
+        ILayoutRegistry? layoutRegistry = context.RequestServices.GetService<ILayoutRegistry>();
+
+        // Collect layout names from the code-level registry
+        List<string> layouts = layoutRegistry?.GetAllLayoutNames().ToList() ?? [];
+
+        // TODO: Add DISTINCT LayoutName from DB store when IDocumentTemplateStoreReader
+        // exposes a GetDistinctLayoutNamesAsync method. For now, code registry is sufficient.
+
+        return Task.FromResult(TypedResults.Ok<IReadOnlyList<string>>(layouts));
+    }
+
+    // -------------------------------------------------------------------------
     // Shared helpers
     // -------------------------------------------------------------------------
 
@@ -1155,7 +1188,8 @@ public static class TemplatingEndpointRouteBuilderExtensions
             revision.CreatedAt,
             revision.CreatedBy,
             revision.PublishedAt,
-            revision.PublishedBy);
+            revision.PublishedBy,
+            revision.LayoutName);
 
     private static async Task<TemplateDetailResponse> BuildDetailResponseAsync(
         IDocumentTemplateStoreReader storeReader,
@@ -1182,7 +1216,8 @@ public static class TemplatingEndpointRouteBuilderExtensions
             key.Name,
             key.Culture,
             draft is not null ? ToRevisionResponse(draft) : null,
-            publishedResponse);
+            publishedResponse,
+            draft?.LayoutName ?? published?.LayoutName);
     }
 
     private static ProblemHttpResult StoreNotRegistered() =>

--- a/src/Granit.Templating.Endpoints/packages.lock.json
+++ b/src/Granit.Templating.Endpoints/packages.lock.json
@@ -153,8 +153,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.13.15",
-        "contentHash": "ufSBk0vdDnrhn+YLGElUdegUkM+hb7xUoySH+oaZrNHi2fAm+oeSCr60Lqmm4OeLBhPKd2htr/DANOvjuNT6rg=="
+        "resolved": "2.13.18",
+        "contentHash": "SOe5I8KspXwmcMbey+6G4drRWhCa/ON/ZjyVKfm5FpXvcsCmb9MfiVcKAiQ8UYV+ki3fAaqcCFc5ahzx/NTXOw=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Templating.EntityFrameworkCore/Entities/TemplateRevisionEntity.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Entities/TemplateRevisionEntity.cs
@@ -52,6 +52,13 @@ internal sealed class TemplateRevisionEntity : IMultiTenant
     /// <summary>Optional category for organizing templates by domain.</summary>
     public Guid? CategoryId { get; set; }
 
+    /// <summary>
+    /// Layout template name assigned by an administrator.
+    /// Overrides the code-level <c>ILayoutRegistry</c> default.
+    /// <c>null</c> means "use the registry default".
+    /// </summary>
+    public string? LayoutName { get; set; }
+
     /// <inheritdoc/>
     public Guid? TenantId { get; set; }
 }

--- a/src/Granit.Templating.EntityFrameworkCore/Internal/EfDocumentTemplateStore.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Internal/EfDocumentTemplateStore.cs
@@ -55,7 +55,7 @@ internal sealed class EfDocumentTemplateStore(
 
                 return entity is null
                     ? TemplateCacheEntry.NotFound
-                    : TemplateCacheEntry.From(entity.Content, entity.MimeType, entity.RevisionId);
+                    : TemplateCacheEntry.From(entity.Content, entity.MimeType, entity.RevisionId, entity.LayoutName);
             },
             cancellationToken: cancellationToken);
 
@@ -68,6 +68,7 @@ internal sealed class EfDocumentTemplateStore(
         string content,
         string mimeType,
         string updatedBy,
+        string? layoutName = null,
         CancellationToken cancellationToken = default)
     {
         await using TemplatingDbContext ctx = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
@@ -84,6 +85,7 @@ internal sealed class EfDocumentTemplateStore(
             existing.MimeType = mimeType;
             existing.CreatedBy = updatedBy;
             existing.CreatedAt = clock.Now;
+            existing.LayoutName = layoutName;
         }
         else
         {
@@ -97,6 +99,7 @@ internal sealed class EfDocumentTemplateStore(
                 Status = TemplateLifecycleStatus.Draft,
                 CreatedAt = clock.Now,
                 CreatedBy = updatedBy,
+                LayoutName = layoutName,
                 TenantId = currentTenant is { IsAvailable: true } ? currentTenant.Id : null,
             });
         }
@@ -286,6 +289,7 @@ internal sealed class EfDocumentTemplateStore(
                 LastModifiedAt = g.Max(r => r.CreatedAt),
                 LastModifiedBy = g.OrderByDescending(r => r.CreatedAt).Select(r => r.CreatedBy).First(),
                 HasPublishedVersion = g.Any(r => r.Status == TemplateLifecycleStatus.Published),
+                LayoutName = g.OrderByDescending(r => r.CreatedAt).Select(r => r.LayoutName).First(),
             });
 
         int totalCount = await grouped.CountAsync(cancellationToken).ConfigureAwait(false);
@@ -306,6 +310,7 @@ internal sealed class EfDocumentTemplateStore(
             LastModifiedAt = g.LastModifiedAt,
             LastModifiedBy = g.LastModifiedBy,
             HasPublishedVersion = g.HasPublishedVersion,
+            LayoutName = g.LayoutName,
         });
 
         return new PagedTemplateResult(summaries, totalCount);
@@ -329,6 +334,7 @@ internal sealed class EfDocumentTemplateStore(
                 CreatedBy = r.CreatedBy,
                 PublishedAt = r.PublishedAt,
                 PublishedBy = r.PublishedBy,
+                LayoutName = r.LayoutName,
             })
             .ToListAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -344,6 +350,7 @@ internal sealed class EfDocumentTemplateStore(
             CreatedBy = entity.CreatedBy,
             PublishedAt = entity.PublishedAt,
             PublishedBy = entity.PublishedBy,
+            LayoutName = entity.LayoutName,
         };
 
     private string CacheKey(TemplateKey key)

--- a/src/Granit.Templating.EntityFrameworkCore/Internal/TemplateCacheEntry.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Internal/TemplateCacheEntry.cs
@@ -9,19 +9,21 @@ namespace Granit.Templating.EntityFrameworkCore.Internal;
 /// <param name="Content">Template content (null when <paramref name="IsFound"/> is false).</param>
 /// <param name="MimeType">Template MIME type (null when <paramref name="IsFound"/> is false).</param>
 /// <param name="RevisionId">Revision identifier for ISO 27001 traceability.</param>
+/// <param name="LayoutName">Layout template name assigned by an administrator.</param>
 internal sealed record TemplateCacheEntry(
     bool IsFound,
     string? Content,
     string? MimeType,
-    Guid? RevisionId)
+    Guid? RevisionId,
+    string? LayoutName)
 {
-    internal static TemplateCacheEntry NotFound { get; } = new(false, null, null, null);
+    internal static TemplateCacheEntry NotFound { get; } = new(false, null, null, null, null);
 
-    internal static TemplateCacheEntry From(string content, string mimeType, Guid? revisionId) =>
-        new(true, content, mimeType, revisionId);
+    internal static TemplateCacheEntry From(string content, string mimeType, Guid? revisionId, string? layoutName) =>
+        new(true, content, mimeType, revisionId, layoutName);
 
     internal TemplateDescriptor? ToDescriptor() =>
         IsFound
-            ? new TemplateDescriptor { Content = Content!, MimeType = MimeType!, RevisionId = RevisionId }
+            ? new TemplateDescriptor { Content = Content!, MimeType = MimeType!, RevisionId = RevisionId, LayoutName = LayoutName }
             : null;
 }

--- a/src/Granit.Templating.Scriban/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.Templating.Scriban/Extensions/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Granit.Templating.Scriban.GlobalContexts;
 using Granit.Templating.Scriban.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Templating.Scriban.Extensions;
 
@@ -19,8 +20,10 @@ public static class ServiceCollectionExtensions
     /// Registers the following services:
     /// <list type="bullet">
     ///   <item><see cref="ITemplateEngine"/> → <see cref="ScribanTemplateEngine"/> (singleton)</item>
+    ///   <item><see cref="GranitTemplateLoader"/> — enables <c>{{ include 'template_name' }}</c> via resolver chain</item>
     ///   <item><c>now.*</c> global context (singleton, uses <c>IClock</c>)</item>
     ///   <item><c>context.*</c> global context (singleton, soft-depends on <c>ICurrentTenant</c>)</item>
+    ///   <item><c>app.*</c> global context (singleton, bound to <c>Granit:Templating:App</c>)</item>
     /// </list>
     /// <para>
     /// Also calls <see cref="ServiceCollectionExtensions.AddGranitTemplating"/> to ensure the
@@ -34,10 +37,16 @@ public static class ServiceCollectionExtensions
     {
         services.AddGranitTemplating();
 
-        services.TryAddSingleton<ITemplateEngine, ScribanTemplateEngine>();
+        services.TryAddSingleton<GranitTemplateLoader>();
+        services.TryAddSingleton<ITemplateEngine>(sp =>
+            new ScribanTemplateEngine(sp.GetService<GranitTemplateLoader>()));
 
         services.AddTemplateGlobalContext<NowGlobalContext>();
         services.AddTemplateGlobalContext<ExecutionContextGlobalContext>();
+        services.AddTemplateGlobalContext<AppGlobalContext>();
+
+        services.AddOptions<AppGlobalContextOptions>()
+            .BindConfiguration(AppGlobalContextOptions.SectionName);
 
         return services;
     }

--- a/src/Granit.Templating.Scriban/GlobalContexts/AppGlobalContext.cs
+++ b/src/Granit.Templating.Scriban/GlobalContexts/AppGlobalContext.cs
@@ -1,0 +1,39 @@
+using Granit.Templating.GlobalContext;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Templating.Scriban.GlobalContexts;
+
+/// <summary>
+/// Injects application-level metadata into every template under the <c>app</c> namespace.
+/// </summary>
+/// <remarks>
+/// Configured via <see cref="AppGlobalContextOptions"/> (section <c>Granit:Templating:App</c>).
+/// <para>
+/// Available template variables:
+/// <list type="table">
+///   <listheader><term>Variable</term><description>Example output</description></listheader>
+///   <item><term><c>{{ app.name }}</c></term><description><c>Guava Admin</c></description></item>
+///   <item><term><c>{{ app.base_url }}</c></term><description><c>https://app.example.com</c></description></item>
+///   <item><term><c>{{ app.support_email }}</c></term><description><c>support@example.com</c></description></item>
+///   <item><term><c>{{ app.logo_url }}</c></term><description><c>https://cdn.example.com/logo.png</c></description></item>
+/// </list>
+/// </para>
+/// </remarks>
+internal sealed class AppGlobalContext(IOptions<AppGlobalContextOptions> options) : ITemplateGlobalContext
+{
+    /// <inheritdoc/>
+    public string ContextName => "app";
+
+    /// <inheritdoc/>
+    public object Resolve()
+    {
+        AppGlobalContextOptions opts = options.Value;
+        return new
+        {
+            name = opts.Name,
+            base_url = opts.BaseUrl.TrimEnd('/'),
+            support_email = opts.SupportEmail,
+            logo_url = opts.LogoUrl,
+        };
+    }
+}

--- a/src/Granit.Templating.Scriban/GlobalContexts/AppGlobalContextOptions.cs
+++ b/src/Granit.Templating.Scriban/GlobalContexts/AppGlobalContextOptions.cs
@@ -1,0 +1,39 @@
+namespace Granit.Templating.Scriban.GlobalContexts;
+
+/// <summary>
+/// Configuration options for the <c>app</c> template global context.
+/// Bind from <c>Granit:Templating:App</c> in appsettings.json.
+/// </summary>
+/// <remarks>
+/// These values are exposed in every Scriban template under <c>{{ app.* }}</c>.
+/// All properties are optional — missing values render as empty strings.
+/// </remarks>
+public sealed class AppGlobalContextOptions
+{
+    /// <summary>Configuration section path.</summary>
+    public const string SectionName = "Granit:Templating:App";
+
+    /// <summary>
+    /// The application display name (e.g., <c>"Guava Admin"</c>).
+    /// Accessible as <c>{{ app.name }}</c>.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The public base URL of the application (e.g., <c>"https://app.example.com"</c>).
+    /// No trailing slash. Accessible as <c>{{ app.base_url }}</c>.
+    /// </summary>
+    public string BaseUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The support email address (e.g., <c>"support@example.com"</c>).
+    /// Accessible as <c>{{ app.support_email }}</c>.
+    /// </summary>
+    public string SupportEmail { get; set; } = string.Empty;
+
+    /// <summary>
+    /// URL to the application logo (e.g., for email headers).
+    /// Accessible as <c>{{ app.logo_url }}</c>.
+    /// </summary>
+    public string LogoUrl { get; set; } = string.Empty;
+}

--- a/src/Granit.Templating.Scriban/Granit.Templating.Scriban.csproj
+++ b/src/Granit.Templating.Scriban/Granit.Templating.Scriban.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Granit.Templating.Scriban</PackageId>
-    <Description>Scriban implementation of the Granit templating engine. Provides ScribanTemplateEngine (sandboxed, multi-tenant safe), NowGlobalContext ({{ now.date }}) and ExecutionContextGlobalContext ({{ context.culture }}).</Description>
+    <Description>Scriban implementation of the Granit templating engine. Provides ScribanTemplateEngine (sandboxed, multi-tenant safe), NowGlobalContext ({{ now.date }}), ExecutionContextGlobalContext ({{ context.culture }}) and AppGlobalContext ({{ app.name }}, {{ app.base_url }}).</Description>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="Scriban" />
   </ItemGroup>
 

--- a/src/Granit.Templating.Scriban/Internal/GranitTemplateLoader.cs
+++ b/src/Granit.Templating.Scriban/Internal/GranitTemplateLoader.cs
@@ -1,0 +1,110 @@
+using System.Globalization;
+using Granit.Templating.Keys;
+using Granit.Templating.Pipeline;
+using Microsoft.Extensions.DependencyInjection;
+using Scriban;
+using Scriban.Parsing;
+using Scriban.Runtime;
+
+namespace Granit.Templating.Scriban.Internal;
+
+/// <summary>
+/// Bridges Granit's <see cref="ITemplateResolver"/> chain to Scriban's <see cref="ITemplateLoader"/>
+/// so that <c>{{ include 'template_name' }}</c> resolves templates through the standard pipeline.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registered as a singleton; creates a <see cref="IServiceScope"/> per load to access
+/// scoped resolvers (e.g. <c>StoreTemplateResolver</c> backed by EF Core).
+/// Culture is read from <see cref="CultureInfo.CurrentCulture"/> (set by ASP.NET Core
+/// request localization middleware).
+/// </para>
+/// <para>
+/// <strong>Async-only:</strong> <see cref="Load"/> throws <see cref="NotSupportedException"/>
+/// to enforce async rendering via <c>Template.RenderAsync</c>. The sync path would block threads when
+/// resolvers perform I/O (database, network), causing thread starvation under load.
+/// </para>
+/// </remarks>
+internal sealed class GranitTemplateLoader(IServiceProvider serviceProvider) : ITemplateLoader
+{
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Returns a culture-qualified cache key so that the same template name in different
+    /// cultures produces distinct cache entries in Scriban's <c>CachedTemplates</c> dictionary.
+    /// </remarks>
+    public string GetPath(TemplateContext context, SourceSpan callerSpan, string templateName)
+    {
+        string culture = CultureInfo.CurrentCulture.Name;
+        return string.IsNullOrEmpty(culture)
+            ? templateName
+            : $"{templateName}|{culture}";
+    }
+
+    /// <summary>
+    /// Not supported — Granit enforces async rendering to prevent thread starvation
+    /// with scoped DB-backed resolvers.
+    /// </summary>
+    /// <exception cref="NotSupportedException">Always thrown.</exception>
+    public string Load(TemplateContext context, SourceSpan callerSpan, string templatePath) =>
+        throw new NotSupportedException(
+            "Granit templates require async rendering via Template.RenderAsync. " +
+            "Synchronous template loading is not supported to prevent thread starvation.");
+
+    /// <inheritdoc/>
+    public async ValueTask<string?> LoadAsync(
+        TemplateContext context, SourceSpan callerSpan, string templatePath)
+    {
+        // Parse the culture-qualified cache key back into name + culture
+        (string name, string? culture) = ParseTemplatePath(templatePath);
+
+        // Create a scope to access scoped resolvers (StoreTemplateResolver needs DbContext)
+        await using AsyncServiceScope scope = serviceProvider.CreateAsyncScope();
+        IEnumerable<ITemplateResolver> resolvers = scope.ServiceProvider
+            .GetServices<ITemplateResolver>()
+            .OrderByDescending(r => r.Priority);
+
+        // Culture-specific pass
+        TemplateKey culturalKey = new(name, culture);
+        foreach (ITemplateResolver resolver in resolvers)
+        {
+            TemplateDescriptor? descriptor = await resolver
+                .TryResolveAsync(culturalKey)
+                .ConfigureAwait(false);
+
+            if (descriptor is not null)
+            {
+                return descriptor.Content;
+            }
+        }
+
+        // Culture-neutral fallback (only if we had a culture to begin with)
+        if (culture is not null)
+        {
+            TemplateKey neutralKey = new(name);
+            foreach (ITemplateResolver resolver in resolvers)
+            {
+                TemplateDescriptor? descriptor = await resolver
+                    .TryResolveAsync(neutralKey)
+                    .ConfigureAwait(false);
+
+                if (descriptor is not null)
+                {
+                    return descriptor.Content;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static (string Name, string? Culture) ParseTemplatePath(string templatePath)
+    {
+        int separator = templatePath.LastIndexOf('|');
+        if (separator < 0)
+        {
+            return (templatePath, null);
+        }
+
+        return (templatePath[..separator], templatePath[(separator + 1)..]);
+    }
+}

--- a/src/Granit.Templating.Scriban/Internal/ScribanTemplateEngine.cs
+++ b/src/Granit.Templating.Scriban/Internal/ScribanTemplateEngine.cs
@@ -23,8 +23,17 @@ namespace Granit.Templating.Scriban.Internal;
 /// (e.g. <c>{{ model.first_name }}</c>). Global contexts are injected under their
 /// <see cref="ITemplateGlobalContext.ContextName"/> (e.g. <c>{{ now.date }}</c>).
 /// </para>
+/// <para>
+/// <strong>Include support:</strong> when a <see cref="GranitTemplateLoader"/> is provided,
+/// templates can use <c>{{ include 'template_name' }}</c> to include other templates resolved
+/// through the standard <see cref="ITemplateResolver"/> chain.
+/// </para>
+/// <para>
+/// <strong>Extra variables:</strong> <see cref="TemplateDescriptor.ExtraVariables"/> are injected
+/// as top-level Scriban variables (e.g. <c>{{ body }}</c> for layout rendering).
+/// </para>
 /// </remarks>
-internal sealed class ScribanTemplateEngine : ITemplateEngine
+internal sealed class ScribanTemplateEngine(GranitTemplateLoader? templateLoader = null) : ITemplateEngine
 {
     private const int MaxLoopIterations = 500;
     private const int MaxRecursionDepth = 50;
@@ -77,7 +86,7 @@ internal sealed class ScribanTemplateEngine : ITemplateEngine
             return parsed;
         });
 
-        TemplateContext context = BuildContext(data, globalContexts, cancellationToken);
+        TemplateContext context = BuildContext(descriptor, data, globalContexts, cancellationToken);
         string rendered = await template.RenderAsync(context).ConfigureAwait(false);
 
         return new TextRenderedContent(rendered, targetFormat)
@@ -86,7 +95,8 @@ internal sealed class ScribanTemplateEngine : ITemplateEngine
         };
     }
 
-    private static TemplateContext BuildContext<TData>(
+    private TemplateContext BuildContext<TData>(
+        TemplateDescriptor descriptor,
         TData data,
         IReadOnlyList<ITemplateGlobalContext> globalContexts,
         CancellationToken cancellationToken) where TData : notnull
@@ -106,6 +116,15 @@ internal sealed class ScribanTemplateEngine : ITemplateEngine
             globals.SetValue(globalContext.ContextName, contextObj, readOnly: true);
         }
 
+        // Inject extra variables as top-level raw values (used by layout system for {{ body }})
+        if (descriptor.ExtraVariables is not null)
+        {
+            foreach ((string key, object value) in descriptor.ExtraVariables)
+            {
+                globals.SetValue(key, value, readOnly: true);
+            }
+        }
+
         TemplateContext templateContext = new(globals)
         {
             // Sandboxing: no bypass of member visibility restrictions
@@ -120,6 +139,9 @@ internal sealed class ScribanTemplateEngine : ITemplateEngine
 
             // Propagate cancellation to the Scriban render loop
             CancellationToken = cancellationToken,
+
+            // Enable {{ include 'template_name' }} via the resolver chain
+            TemplateLoader = templateLoader,
         };
 
         return templateContext;

--- a/src/Granit.Templating.Scriban/packages.lock.json
+++ b/src/Granit.Templating.Scriban/packages.lock.json
@@ -8,11 +8,41 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
       "Scriban": {
         "type": "Direct",
         "requested": "[7.*, )",
-        "resolved": "7.0.5",
-        "contentHash": "GmK0nHYvmUV7ue93eaEWwVU4NQLcW1MlBckAT6BTUIIJm9UA92pVWdcJH5BGqzgWkrA+xVt065gjP2vpQ47h6g=="
+        "resolved": "7.0.6",
+        "contentHash": "bOtHyk30sjl0y3+KYImIJv0ETZYLuFFJvlBF2ks2YLNtydhJqxRTGe4WaBDvg/3VRhhI6uf+qVfixuFROsOi+w=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
@@ -34,6 +64,16 @@
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {

--- a/src/Granit.Templating/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.Templating/Extensions/ServiceCollectionExtensions.cs
@@ -4,6 +4,8 @@ using Granit.Templating.Diagnostics;
 using Granit.Templating.Enrichment;
 using Granit.Templating.GlobalContext;
 using Granit.Templating.Internal;
+using Granit.Templating.Layouts;
+using Granit.Templating.Layouts.Internal;
 using Granit.Templating.Pipeline;
 using Granit.Templating.Resolvers;
 using Granit.Templating.Store;
@@ -44,6 +46,11 @@ public static class ServiceCollectionExtensions
 
         services.TryAddScoped<ITextTemplateRenderer, TextTemplateRenderer>();
         services.TryAddSingleton<ITemplateTransitionHook, NullTemplateTransitionHook>();
+
+        // Layout registry — built from all AddTemplateLayout() registrations
+        services.TryAddSingleton<ILayoutRegistry>(sp =>
+            new LayoutRegistry(sp.GetServices<LayoutRegistration>()));
+
         return services;
     }
 
@@ -94,4 +101,42 @@ public static class ServiceCollectionExtensions
         where TData : notnull
         where TEnricher : class, ITemplateDataEnricher<TData> =>
         services.AddTransient<ITemplateDataEnricher<TData>, TEnricher>();
+
+    /// <summary>
+    /// Registers a layout mapping: templates matching <paramref name="templatePattern"/>
+    /// are automatically wrapped in the <paramref name="layoutTemplateName"/> layout
+    /// during rendering.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Patterns support exact names (<c>"Billing.Invoice"</c>) and prefix wildcards
+    /// (<c>"Billing.*"</c>). Exact matches always take precedence over prefix matches.
+    /// </para>
+    /// <para>
+    /// The layout template is resolved through the standard <see cref="ITemplateResolver"/>
+    /// chain — embedded resources or database store. A tenant can override a layout by
+    /// publishing their own version to the store.
+    /// </para>
+    /// </remarks>
+    /// <param name="services">The service collection.</param>
+    /// <param name="templatePattern">
+    /// Exact template name (<c>"Billing.Invoice"</c>) or prefix wildcard
+    /// (<c>"Billing.*"</c>) matching all templates in that namespace.
+    /// </param>
+    /// <param name="layoutTemplateName">
+    /// Logical name of the layout template (e.g. <c>"Layout.Email"</c>).
+    /// </param>
+    /// <param name="priority">
+    /// Resolution priority when multiple prefix patterns match. Higher wins. Default: 0.
+    /// </param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddTemplateLayout(
+        this IServiceCollection services,
+        string templatePattern,
+        string layoutTemplateName,
+        int priority = 0)
+    {
+        services.AddSingleton(new LayoutRegistration(templatePattern, layoutTemplateName, priority));
+        return services;
+    }
 }

--- a/src/Granit.Templating/Internal/TextTemplateRenderer.cs
+++ b/src/Granit.Templating/Internal/TextTemplateRenderer.cs
@@ -3,21 +3,36 @@ using Granit.Templating.Enrichment;
 using Granit.Templating.Exceptions;
 using Granit.Templating.GlobalContext;
 using Granit.Templating.Keys;
+using Granit.Templating.Layouts;
 using Granit.Templating.Pipeline;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Granit.Templating.Internal;
 
 /// <summary>
 /// Internal implementation of <see cref="ITextTemplateRenderer"/>.
 /// Orchestrates the full text rendering pipeline:
-/// enrichment → resolution (with culture fallback) → engine render.
+/// enrichment → resolution (with culture fallback) → layout wrapping → engine render.
 /// </summary>
-internal sealed class TextTemplateRenderer(
+/// <remarks>
+/// <para>
+/// <strong>Layout wrapping:</strong> when a layout is configured (via
+/// <see cref="TemplateDescriptor.LayoutName"/> or <see cref="ILayoutRegistry"/>),
+/// the renderer performs two-pass rendering:
+/// <list type="number">
+///   <item>Render the content template → HTML string</item>
+///   <item>Render the layout template with <c>{{ body | raw }}</c> = content HTML</item>
+/// </list>
+/// </para>
+/// </remarks>
+internal sealed partial class TextTemplateRenderer(
     IEnumerable<ITemplateResolver> resolvers,
     IEnumerable<ITemplateEngine> engines,
     IEnumerable<ITemplateGlobalContext> globalContexts,
-    IServiceProvider serviceProvider) : ITextTemplateRenderer
+    IServiceProvider serviceProvider,
+    ILogger<TextTemplateRenderer> logger,
+    ILayoutRegistry? layoutRegistry = null) : ITextTemplateRenderer
 {
     private readonly IReadOnlyList<ITemplateResolver> _resolvers =
         [.. resolvers.OrderByDescending(r => r.Priority)];
@@ -70,7 +85,7 @@ internal sealed class TextTemplateRenderer(
             await ResolveAsync(templateType.Name, culture, cancellationToken).ConfigureAwait(false)
             ?? throw new TemplateNotFoundException(templateType.Name, culture);
 
-        // 3. Select engine by MIME type and render
+        // 3. Select engine by MIME type
         ITemplateEngine? engine = _engines.FirstOrDefault(e => e.CanRender(descriptor));
 
         if (engine is null)
@@ -80,7 +95,55 @@ internal sealed class TextTemplateRenderer(
                 "Register a compatible engine (e.g. AddGranitTemplatingWithScriban or AddGranitDocumentGenerationExcel).");
         }
 
-        return await engine.RenderAsync(descriptor, enrichedData, targetFormat, _globalContexts, cancellationToken).ConfigureAwait(false);
+        // 4. Resolve layout (DB override → code registry → no layout)
+        string? layoutName = descriptor.LayoutName
+            ?? layoutRegistry?.GetLayoutName(templateType.Name);
+
+        if (layoutName is null)
+        {
+            // No layout — render standalone (existing behavior)
+            return await engine.RenderAsync(
+                descriptor, enrichedData, targetFormat, _globalContexts, cancellationToken).ConfigureAwait(false);
+        }
+
+        TemplateDescriptor? layoutDescriptor = await ResolveAsync(
+            layoutName, culture, cancellationToken).ConfigureAwait(false);
+
+        if (layoutDescriptor is null)
+        {
+            Log.LayoutNotFound(logger, layoutName, templateType.Name);
+            return await engine.RenderAsync(
+                descriptor, enrichedData, targetFormat, _globalContexts, cancellationToken).ConfigureAwait(false);
+        }
+
+        // 5. Two-pass render: content first, then layout with body injection
+        RenderedContent contentResult = await engine.RenderAsync(
+            descriptor, enrichedData, targetFormat, _globalContexts, cancellationToken).ConfigureAwait(false);
+
+        // Binary engines (Excel) skip layout wrapping — layouts are HTML-only
+        if (contentResult is not TextRenderedContent contentText)
+        {
+            return contentResult;
+        }
+
+        // 6. Render layout with body = rendered content (pass 2 is always terminal)
+        TemplateDescriptor layoutWithBody = new()
+        {
+            Content = layoutDescriptor.Content,
+            MimeType = layoutDescriptor.MimeType,
+            RevisionId = layoutDescriptor.RevisionId,
+            ExtraVariables = new Dictionary<string, object> { ["body"] = contentText.Html },
+        };
+
+        return await engine.RenderAsync(
+            layoutWithBody, enrichedData, targetFormat, _globalContexts, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(Level = LogLevel.Warning,
+            Message = "Layout template '{LayoutName}' not found for content template '{TemplateName}'. Rendering without layout.")]
+        public static partial void LayoutNotFound(ILogger logger, string layoutName, string templateName);
     }
 
     private async Task<TData> EnrichAsync<TData>(TData data, CancellationToken cancellationToken)

--- a/src/Granit.Templating/Layouts/ILayoutRegistry.cs
+++ b/src/Granit.Templating/Layouts/ILayoutRegistry.cs
@@ -1,0 +1,29 @@
+namespace Granit.Templating.Layouts;
+
+/// <summary>
+/// Resolves the default layout template name for a given content template.
+/// </summary>
+/// <remarks>
+/// Populated at DI registration time via
+/// <see cref="Extensions.ServiceCollectionExtensions.AddTemplateLayout"/>.
+/// Code-level defaults — can be overridden per-template via <c>LayoutName</c>
+/// on <see cref="Pipeline.TemplateDescriptor"/>.
+/// </remarks>
+public interface ILayoutRegistry
+{
+    /// <summary>
+    /// Returns the layout template name for the given content template, or <c>null</c>
+    /// if no layout is registered (template renders standalone).
+    /// </summary>
+    /// <param name="templateName">The content template name (e.g. <c>"Security.Welcome"</c>).</param>
+    /// <returns>
+    /// Layout template name (e.g. <c>"Layout.Email"</c>) or <c>null</c>.
+    /// </returns>
+    string? GetLayoutName(string templateName);
+
+    /// <summary>
+    /// Returns all distinct layout template names registered in the registry.
+    /// Used by admin endpoints to populate layout dropdowns.
+    /// </summary>
+    IReadOnlyList<string> GetAllLayoutNames();
+}

--- a/src/Granit.Templating/Layouts/Internal/LayoutRegistry.cs
+++ b/src/Granit.Templating/Layouts/Internal/LayoutRegistry.cs
@@ -1,0 +1,80 @@
+using System.Collections.Frozen;
+
+namespace Granit.Templating.Layouts.Internal;
+
+/// <summary>
+/// Default implementation of <see cref="ILayoutRegistry"/>.
+/// Built once at DI resolution from all registered <see cref="LayoutRegistration"/> instances.
+/// </summary>
+/// <remarks>
+/// Uses two lookup structures:
+/// <list type="bullet">
+///   <item><see cref="FrozenDictionary{TKey,TValue}"/> for exact matches (O(1))</item>
+///   <item>Sorted list for prefix patterns (descending priority, then specificity)</item>
+/// </list>
+/// Exact matches always take precedence over prefix matches.
+/// </remarks>
+internal sealed class LayoutRegistry : ILayoutRegistry
+{
+    private readonly FrozenDictionary<string, string> _exactMatches;
+    private readonly IReadOnlyList<(string Prefix, string LayoutName)> _prefixMatches;
+    private readonly IReadOnlyList<string> _allLayoutNames;
+
+    internal LayoutRegistry(IEnumerable<LayoutRegistration> registrations)
+    {
+        Dictionary<string, string> exact = new(StringComparer.Ordinal);
+        List<(string Prefix, string LayoutName, int Priority)> prefixes = [];
+
+        foreach (LayoutRegistration reg in registrations)
+        {
+            if (reg.Pattern.EndsWith(".*", StringComparison.Ordinal))
+            {
+                string prefix = reg.Pattern[..^2]; // strip ".*"
+                prefixes.Add((prefix, reg.LayoutTemplateName, reg.Priority));
+            }
+            else
+            {
+                exact[reg.Pattern] = reg.LayoutTemplateName;
+            }
+        }
+
+        _exactMatches = exact.ToFrozenDictionary(StringComparer.Ordinal);
+
+        _prefixMatches = prefixes
+            .OrderByDescending(p => p.Priority)
+            .ThenByDescending(p => p.Prefix.Length)
+            .Select(p => (p.Prefix, p.LayoutName))
+            .ToList();
+
+        _allLayoutNames = exact.Values
+            .Concat(prefixes.Select(p => p.LayoutName))
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToList();
+    }
+
+    /// <inheritdoc/>
+    public string? GetLayoutName(string templateName)
+    {
+        // 1. Exact match always wins
+        if (_exactMatches.TryGetValue(templateName, out string? layout))
+        {
+            return layout;
+        }
+
+        // 2. Prefix match (first match wins — sorted by priority, then specificity)
+        foreach ((string prefix, string layoutName) in _prefixMatches)
+        {
+            if (templateName.StartsWith(prefix + ".", StringComparison.Ordinal)
+                || templateName.Equals(prefix, StringComparison.Ordinal))
+            {
+                return layoutName;
+            }
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<string> GetAllLayoutNames() => _allLayoutNames;
+}

--- a/src/Granit.Templating/Layouts/LayoutRegistration.cs
+++ b/src/Granit.Templating/Layouts/LayoutRegistration.cs
@@ -1,0 +1,23 @@
+namespace Granit.Templating.Layouts;
+
+/// <summary>
+/// Maps a template name or prefix pattern to a layout template name.
+/// Registered via <see cref="Extensions.ServiceCollectionExtensions.AddTemplateLayout"/>.
+/// </summary>
+/// <param name="Pattern">
+/// Either an exact template name (<c>"Billing.Invoice"</c>) or a prefix
+/// with wildcard (<c>"Billing.*"</c>) matching all templates in that namespace.
+/// </param>
+/// <param name="LayoutTemplateName">
+/// The logical template name of the layout (e.g. <c>"Layout.Email"</c>).
+/// Resolved through the standard <see cref="Pipeline.ITemplateResolver"/> chain.
+/// </param>
+/// <param name="Priority">
+/// Resolution priority when multiple prefix patterns match. Higher wins.
+/// Exact matches always beat prefix matches regardless of priority.
+/// Default: 0.
+/// </param>
+public sealed record LayoutRegistration(
+    string Pattern,
+    string LayoutTemplateName,
+    int Priority = 0);

--- a/src/Granit.Templating/Pipeline/TemplateDescriptor.cs
+++ b/src/Granit.Templating/Pipeline/TemplateDescriptor.cs
@@ -24,4 +24,17 @@ public sealed class TemplateDescriptor
     /// <c>null</c> for embedded (code-level) templates with no revision tracking.
     /// </summary>
     public Guid? RevisionId { get; init; }
+
+    /// <summary>
+    /// Layout template name assigned to this template by an administrator.
+    /// Takes precedence over <see cref="Layouts.ILayoutRegistry"/> code-level defaults.
+    /// <c>null</c> means "use the registry default" (or no layout if no match).
+    /// </summary>
+    public string? LayoutName { get; init; }
+
+    /// <summary>
+    /// Optional extra top-level variables injected into the template context.
+    /// Used by the layout system to inject <c>{{ body }}</c> with pre-rendered content.
+    /// </summary>
+    public IReadOnlyDictionary<string, object>? ExtraVariables { get; init; }
 }

--- a/src/Granit.Templating/Store/IDocumentTemplateStoreWriter.cs
+++ b/src/Granit.Templating/Store/IDocumentTemplateStoreWriter.cs
@@ -29,12 +29,17 @@ public interface IDocumentTemplateStoreWriter
     /// <param name="content">Template source (HTML).</param>
     /// <param name="mimeType">MIME type (e.g. <c>"text/html"</c>).</param>
     /// <param name="updatedBy">Identity of the user saving the draft.</param>
+    /// <param name="layoutName">
+    /// Optional layout template name. Overrides the code-level <c>ILayoutRegistry</c>
+    /// default. Pass <c>null</c> to use the registry default.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task SaveDraftAsync(
         TemplateKey key,
         string content,
         string mimeType,
         string updatedBy,
+        string? layoutName = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Granit.Templating/Store/TemplateRevision.cs
+++ b/src/Granit.Templating/Store/TemplateRevision.cs
@@ -36,4 +36,10 @@ public sealed class TemplateRevision
 
     /// <summary>Identity of the user who published this revision. <c>null</c> if not yet published.</summary>
     public string? PublishedBy { get; init; }
+
+    /// <summary>
+    /// Layout template name assigned by an administrator.
+    /// <c>null</c> means "use the <see cref="Layouts.ILayoutRegistry"/> default".
+    /// </summary>
+    public string? LayoutName { get; init; }
 }

--- a/src/Granit.Templating/Store/TemplateSummary.cs
+++ b/src/Granit.Templating/Store/TemplateSummary.cs
@@ -29,4 +29,10 @@ public sealed class TemplateSummary
 
     /// <summary>Whether a published version currently exists for this key.</summary>
     public required bool HasPublishedVersion { get; init; }
+
+    /// <summary>
+    /// Layout template name assigned by an administrator.
+    /// <c>null</c> means "use the <see cref="Layouts.ILayoutRegistry"/> default".
+    /// </summary>
+    public string? LayoutName { get; init; }
 }

--- a/tests/Granit.Notifications.Email.Tests/EmailNotificationChannelTests.cs
+++ b/tests/Granit.Notifications.Email.Tests/EmailNotificationChannelTests.cs
@@ -467,6 +467,122 @@ public sealed class EmailNotificationChannelTests
         captured.Subject.ShouldBe("test notification");
     }
 
+    // ──── Fallback template tests ────
+
+    [Fact]
+    public async Task SendAsync_TypeSpecificNotFound_UsesFallbackTemplate()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com");
+
+        // Resolver returns null for type-specific, descriptor for fallback
+        ITemplateResolver resolver = Substitute.For<ITemplateResolver>();
+        resolver.Priority.Returns(100);
+        resolver.TryResolveAsync(
+                Arg.Is<Granit.Templating.Keys.TemplateKey>(k => k.Name == "test.notification"),
+                Arg.Any<CancellationToken>())
+            .Returns((Granit.Templating.Pipeline.TemplateDescriptor?)null);
+        resolver.TryResolveAsync(
+                Arg.Is<Granit.Templating.Keys.TemplateKey>(k => k.Name == EmailNotificationChannel.FallbackTemplateName),
+                Arg.Any<CancellationToken>())
+            .Returns(new Granit.Templating.Pipeline.TemplateDescriptor
+            {
+                Content = "<title>Fallback subject</title><p>Fallback body</p>",
+                MimeType = "text/html",
+            });
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateResolver>))
+            .Returns(new[] { resolver });
+
+        ITemplateEngine engine = Substitute.For<ITemplateEngine>();
+        engine.CanRender(Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>()).Returns(true);
+        engine.RenderAsync(
+                Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>(),
+                Arg.Any<Dictionary<string, object?>>(),
+                Arg.Any<Granit.Templating.Keys.DocumentFormat>(),
+                Arg.Any<IReadOnlyList<Granit.Templating.GlobalContext.ITemplateGlobalContext>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new Granit.Templating.Pipeline.TextRenderedContent(
+                "<title>Fallback subject</title><p>Fallback body</p>",
+                Granit.Templating.Keys.DocumentFormat.Html));
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateEngine>))
+            .Returns(new[] { engine });
+
+        _serviceProvider.GetService(typeof(IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>))
+            .Returns((IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>?)null);
+
+        EmailMessage? captured = null;
+        _emailSender.SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                captured = callInfo.Arg<EmailMessage>();
+                return Task.CompletedTask;
+            });
+
+        await _channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Subject.ShouldBe("Fallback subject");
+        captured.HtmlBody.ShouldContain("Fallback body");
+    }
+
+    [Fact]
+    public async Task SendAsync_FallbackTemplate_ReceivesNotificationType()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com");
+
+        // Resolver returns null for type-specific, descriptor for fallback
+        ITemplateResolver resolver = Substitute.For<ITemplateResolver>();
+        resolver.Priority.Returns(100);
+        resolver.TryResolveAsync(
+                Arg.Is<Granit.Templating.Keys.TemplateKey>(k => k.Name == "test.notification"),
+                Arg.Any<CancellationToken>())
+            .Returns((Granit.Templating.Pipeline.TemplateDescriptor?)null);
+        resolver.TryResolveAsync(
+                Arg.Is<Granit.Templating.Keys.TemplateKey>(k => k.Name == EmailNotificationChannel.FallbackTemplateName),
+                Arg.Any<CancellationToken>())
+            .Returns(new Granit.Templating.Pipeline.TemplateDescriptor
+            {
+                Content = "<p>{{ model.notification_type }}</p>",
+                MimeType = "text/html",
+            });
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateResolver>))
+            .Returns(new[] { resolver });
+
+        // Capture the data dict passed to the engine
+        Dictionary<string, object?>? capturedData = null;
+        ITemplateEngine engine = Substitute.For<ITemplateEngine>();
+        engine.CanRender(Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>()).Returns(true);
+        engine.RenderAsync(
+                Arg.Any<Granit.Templating.Pipeline.TemplateDescriptor>(),
+                Arg.Any<Dictionary<string, object?>>(),
+                Arg.Any<Granit.Templating.Keys.DocumentFormat>(),
+                Arg.Any<IReadOnlyList<Granit.Templating.GlobalContext.ITemplateGlobalContext>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                capturedData = callInfo.Arg<Dictionary<string, object?>>();
+                return new Granit.Templating.Pipeline.TextRenderedContent(
+                    "<p>test.notification</p>",
+                    Granit.Templating.Keys.DocumentFormat.Html);
+            });
+
+        _serviceProvider.GetService(typeof(IEnumerable<ITemplateEngine>))
+            .Returns(new[] { engine });
+
+        _serviceProvider.GetService(typeof(IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>))
+            .Returns((IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>?)null);
+
+        await _channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        capturedData.ShouldNotBeNull();
+        capturedData.ShouldContainKey("notification_type");
+        capturedData["notification_type"].ShouldBe("test.notification");
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------

--- a/tests/Granit.Notifications.Email.Tests/EmailNotificationsServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Notifications.Email.Tests/EmailNotificationsServiceCollectionExtensionsTests.cs
@@ -10,6 +10,7 @@ using Granit.Notifications.Abstractions;
 using Granit.Notifications.Email.Extensions;
 using Granit.Notifications.Email.Internal;
 using Granit.Notifications.Email.Options;
+using Granit.Templating.Pipeline;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -77,5 +78,16 @@ public sealed class EmailNotificationsServiceCollectionExtensionsTests
         ServiceCollection services = new();
 
         Should.NotThrow(() => services.AddGranitNotificationsEmail(configure: null));
+    }
+
+    [Fact]
+    public void AddGranitNotificationsEmail_RegistersEmbeddedTemplateResolver()
+    {
+        ServiceCollection services = new();
+        services.AddGranitNotificationsEmail();
+
+        services.ShouldContain(d =>
+            d.ServiceType == typeof(ITemplateResolver) &&
+            d.Lifetime == ServiceLifetime.Singleton);
     }
 }

--- a/tests/Granit.Templating.Endpoints.Tests/Dtos/TemplatingDtoTests.cs
+++ b/tests/Granit.Templating.Endpoints.Tests/Dtos/TemplatingDtoTests.cs
@@ -78,7 +78,7 @@ public sealed class TemplatingDtoTests
     [Fact]
     public void TemplateDetailResponse_WithNullDraftAndPublished_SetsCorrectly()
     {
-        TemplateDetailResponse response = new("Billing.Invoice", "fr", null, null);
+        TemplateDetailResponse response = new("Billing.Invoice", "fr", null, null, null);
 
         response.Name.ShouldBe("Billing.Invoice");
         response.Culture.ShouldBe("fr");
@@ -96,7 +96,7 @@ public sealed class TemplatingDtoTests
         TemplateListItemResponse item = new(
             "Billing.Invoice", null, "text/html",
             TemplateLifecycleStatus.Published,
-            DateTimeOffset.UtcNow, "alice", true);
+            DateTimeOffset.UtcNow, "alice", true, null);
 
         TemplateListResponse response = new([item], 1);
 
@@ -115,7 +115,7 @@ public sealed class TemplatingDtoTests
         TemplateListItemResponse item = new(
             "Billing.Invoice", "fr-BE", "text/html",
             TemplateLifecycleStatus.Draft,
-            lastModified, "bob", false);
+            lastModified, "bob", false, null);
 
         item.Name.ShouldBe("Billing.Invoice");
         item.Culture.ShouldBe("fr-BE");

--- a/tests/Granit.Templating.Endpoints.Tests/TemplatingEndpointsTests.cs
+++ b/tests/Granit.Templating.Endpoints.Tests/TemplatingEndpointsTests.cs
@@ -390,7 +390,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
             "<h1>Hello</h1>",
             "text/html",
             Arg.Any<string>(),
-            Arg.Any<CancellationToken>());
+            cancellationToken: Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -480,7 +480,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
             "<h1>Updated</h1>",
             "text/html",
             Arg.Any<string>(),
-            Arg.Any<CancellationToken>());
+            cancellationToken: Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Granit.Templating.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Templating.Endpoints.Tests/packages.lock.json
@@ -753,8 +753,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.13.15",
-        "contentHash": "ufSBk0vdDnrhn+YLGElUdegUkM+hb7xUoySH+oaZrNHi2fAm+oeSCr60Lqmm4OeLBhPKd2htr/DANOvjuNT6rg=="
+        "resolved": "2.13.18",
+        "contentHash": "SOe5I8KspXwmcMbey+6G4drRWhCa/ON/ZjyVKfm5FpXvcsCmb9MfiVcKAiQ8UYV+ki3fAaqcCFc5ahzx/NTXOw=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Templating.EntityFrameworkCore.Tests/EfDocumentTemplateStoreAdditionalTests.cs
+++ b/tests/Granit.Templating.EntityFrameworkCore.Tests/EfDocumentTemplateStoreAdditionalTests.cs
@@ -82,7 +82,7 @@ public sealed class EfDocumentTemplateStoreAdditionalTests
         TemplateKey key = new("Notifications.Welcome");
 
         await store.SaveDraftAsync(key, "<p>Draft content</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         TemplateRevision? result = await store.TryGetDraftAsync(key,
             TestContext.Current.CancellationToken);
@@ -114,7 +114,7 @@ public sealed class EfDocumentTemplateStoreAdditionalTests
         TemplateKey key = new("Billing.Invoice");
 
         await store.SaveDraftAsync(key, "<p>v1</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.PublishAsync(key, "bob",
             TestContext.Current.CancellationToken);
 
@@ -150,11 +150,11 @@ public sealed class EfDocumentTemplateStoreAdditionalTests
 
         // Create draft, publish, then create a new draft and publish (archiving v1).
         await store.SaveDraftAsync(key, "<p>v1</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.PublishAsync(key, "bob",
             TestContext.Current.CancellationToken);
         await store.SaveDraftAsync(key, "<p>v2</p>", "text/html", "carol",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.PublishAsync(key, "dave",
             TestContext.Current.CancellationToken);
 
@@ -175,9 +175,9 @@ public sealed class EfDocumentTemplateStoreAdditionalTests
         EfDocumentTemplateStore store = CreateStore(db);
 
         await store.SaveDraftAsync(new TemplateKey("Billing.Invoice"), "<p>v1</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.SaveDraftAsync(new TemplateKey("Notifications.Welcome"), "<p>v1</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         PagedTemplateResult result = await store.ListTemplatesAsync(
             new TemplateListFilter(Search: "Billing"),
@@ -194,9 +194,9 @@ public sealed class EfDocumentTemplateStoreAdditionalTests
         EfDocumentTemplateStore store = CreateStore(db);
 
         await store.SaveDraftAsync(new TemplateKey("Draft.Only"), "<p>draft</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.SaveDraftAsync(new TemplateKey("Published.One"), "<p>published</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.PublishAsync(new TemplateKey("Published.One"), "bob",
             TestContext.Current.CancellationToken);
 
@@ -215,9 +215,9 @@ public sealed class EfDocumentTemplateStoreAdditionalTests
         EfDocumentTemplateStore store = CreateStore(db);
 
         await store.SaveDraftAsync(new TemplateKey("Invoice", "fr"), "<p>FR</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.SaveDraftAsync(new TemplateKey("Invoice", "en"), "<p>EN</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         PagedTemplateResult result = await store.ListTemplatesAsync(
             new TemplateListFilter(Culture: "fr"),
@@ -277,11 +277,11 @@ public sealed class EfDocumentTemplateStoreAdditionalTests
 
         // Create 3 templates.
         await store.SaveDraftAsync(new TemplateKey("A.Template"), "<p>A</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.SaveDraftAsync(new TemplateKey("B.Template"), "<p>B</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.SaveDraftAsync(new TemplateKey("C.Template"), "<p>C</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         PagedTemplateResult page1 = await store.ListTemplatesAsync(
             new TemplateListFilter(Page: 1, PageSize: 2),
@@ -313,7 +313,7 @@ public sealed class EfDocumentTemplateStoreAdditionalTests
 
         TemplateKey key = new("Billing.Invoice");
         await store.SaveDraftAsync(key, "<p>v1</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.PublishAsync(key, "bob",
             TestContext.Current.CancellationToken);
 
@@ -321,7 +321,7 @@ public sealed class EfDocumentTemplateStoreAdditionalTests
         hook.ClearReceivedCalls();
 
         await store.UnpublishAsync(key, "carol",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         await hook.Received(1).OnTransitionedAsync(
             Arg.Any<Guid>(),

--- a/tests/Granit.Templating.EntityFrameworkCore.Tests/EfDocumentTemplateStoreTests.cs
+++ b/tests/Granit.Templating.EntityFrameworkCore.Tests/EfDocumentTemplateStoreTests.cs
@@ -94,9 +94,9 @@ public sealed class EfDocumentTemplateStoreTests
         TemplateKey key = new("Billing.Invoice");
 
         await store.SaveDraftAsync(key, "<p>Hello</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.PublishAsync(key, "bob",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         TemplateDescriptor? result = await store.TryGetPublishedAsync(key,
             TestContext.Current.CancellationToken);
@@ -116,11 +116,11 @@ public sealed class EfDocumentTemplateStoreTests
         TemplateKey key = new("Billing.Invoice");
 
         await store.SaveDraftAsync(key, "<p>v1</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.PublishAsync(key, "bob",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.UnpublishAsync(key, "carol",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         TemplateDescriptor? result = await store.TryGetPublishedAsync(key,
             TestContext.Current.CancellationToken);
@@ -137,9 +137,9 @@ public sealed class EfDocumentTemplateStoreTests
         TemplateKey neutralKey = new("Billing.Invoice");
 
         await store.SaveDraftAsync(frKey, "<p>Français</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.PublishAsync(frKey, "bob",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         TemplateDescriptor? frResult = await store.TryGetPublishedAsync(frKey,
             TestContext.Current.CancellationToken);
@@ -160,16 +160,16 @@ public sealed class EfDocumentTemplateStoreTests
 
         // Publish v1 and read (populates cache)
         await store.SaveDraftAsync(key, "<p>v1</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.PublishAsync(key, "bob",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         TemplateDescriptor? v1 = await store.TryGetPublishedAsync(key,
             TestContext.Current.CancellationToken);
         v1!.Content.ShouldBe("<p>v1</p>");
 
         // Publish v2 — must invalidate the cache entry for v1
         await store.SaveDraftAsync(key, "<p>v2</p>", "text/html", "carol",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.PublishAsync(key, "dave",
             TestContext.Current.CancellationToken);
 
@@ -187,9 +187,9 @@ public sealed class EfDocumentTemplateStoreTests
         TemplateKey key = new("Cache.Unpublish");
 
         await store.SaveDraftAsync(key, "<p>v1</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.PublishAsync(key, "bob",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // Read to populate cache
         TemplateDescriptor? cached = await store.TryGetPublishedAsync(key,
@@ -198,7 +198,7 @@ public sealed class EfDocumentTemplateStoreTests
 
         // Unpublish — must invalidate the cache entry
         await store.UnpublishAsync(key, "carol",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         TemplateDescriptor? result = await store.TryGetPublishedAsync(key,
             TestContext.Current.CancellationToken);
@@ -218,9 +218,9 @@ public sealed class EfDocumentTemplateStoreTests
         TemplateKey key = new("Notifications.Welcome");
 
         await store.SaveDraftAsync(key, "<p>v1</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.SaveDraftAsync(key, "<p>v2</p>", "text/html", "bob",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // Verify only one draft exists (no duplicate rows)
         await using TemplatingDbContext ctx = new InMemoryContextFactory(db).CreateDbContext();
@@ -250,13 +250,13 @@ public sealed class EfDocumentTemplateStoreTests
 
         // First publication
         await store.SaveDraftAsync(key, "<p>v1</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.PublishAsync(key, "bob",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // Second publication
         await store.SaveDraftAsync(key, "<p>v2</p>", "text/html", "carol",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.PublishAsync(key, "dave",
             TestContext.Current.CancellationToken);
 
@@ -279,7 +279,7 @@ public sealed class EfDocumentTemplateStoreTests
         TemplateKey key = new("Ghost.Template");
 
         Func<Task> act = () => store.PublishAsync(key, "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         (await Should.ThrowAsync<NotFoundException>(act)).Message.ShouldContain("no draft");
     }
@@ -296,10 +296,10 @@ public sealed class EfDocumentTemplateStoreTests
         TemplateKey key = new("Billing.Invoice");
 
         await store.SaveDraftAsync(key, "<p>v1</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Func<Task> act = () => store.PublishAsync(key, "bob",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         TemplateTransitionDeniedException ex = await Should.ThrowAsync<TemplateTransitionDeniedException>(act);
         ex.From.ShouldBe(TemplateLifecycleStatus.Draft);
@@ -318,9 +318,9 @@ public sealed class EfDocumentTemplateStoreTests
         TemplateKey key = new("Billing.Invoice");
 
         await store.SaveDraftAsync(key, "<p>v1</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.PublishAsync(key, "bob",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         await hook.Received(1).OnTransitionedAsync(
             Arg.Any<Guid>(),
@@ -341,7 +341,7 @@ public sealed class EfDocumentTemplateStoreTests
         TemplateKey key = new("Ghost.Template");
 
         Func<Task> act = () => store.UnpublishAsync(key, "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         await Should.NotThrowAsync(act);
     }
@@ -360,12 +360,12 @@ public sealed class EfDocumentTemplateStoreTests
         TemplateKey key = new("Billing.Invoice");
 
         await store.SaveDraftAsync(key, "<p>v1</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.PublishAsync(key, "bob",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Func<Task> act = () => store.UnpublishAsync(key, "carol",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         TemplateTransitionDeniedException ex = await Should.ThrowAsync<TemplateTransitionDeniedException>(act);
         ex.From.ShouldBe(TemplateLifecycleStatus.Published);
@@ -384,9 +384,9 @@ public sealed class EfDocumentTemplateStoreTests
         TemplateKey key = new("Billing.Invoice");
 
         await store.SaveDraftAsync(key, "<p>draft</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.DeleteDraftAsync(key, "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         await using TemplatingDbContext ctx = new InMemoryContextFactory(db).CreateDbContext();
         int count = await ctx.TemplateRevisions.CountAsync(
@@ -403,7 +403,7 @@ public sealed class EfDocumentTemplateStoreTests
         TemplateKey key = new("Ghost.Template");
 
         Func<Task> act = () => store.DeleteDraftAsync(key, "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         (await Should.ThrowAsync<NotFoundException>(act)).Message.ShouldContain("no draft");
     }
@@ -418,15 +418,15 @@ public sealed class EfDocumentTemplateStoreTests
 
         // Publish v1, then create a new draft and delete it
         await store.SaveDraftAsync(key, "<p>v1</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.PublishAsync(key, "bob",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.SaveDraftAsync(key, "<p>v2-draft</p>", "text/html", "carol",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.UnpublishAsync(key, "dave",
             TestContext.Current.CancellationToken);
         await store.DeleteDraftAsync(key, "carol",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         await using TemplatingDbContext ctx = new InMemoryContextFactory(db).CreateDbContext();
         int archivedCount = await ctx.TemplateRevisions.CountAsync(
@@ -448,11 +448,11 @@ public sealed class EfDocumentTemplateStoreTests
         TemplateKey key = new("Billing.Invoice");
 
         await store.SaveDraftAsync(key, "<p>v1</p>", "text/html", "alice",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.PublishAsync(key, "bob",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
         await store.SaveDraftAsync(key, "<p>v2</p>", "text/html", "carol",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         IReadOnlyList<TemplateRevision> history = await store.GetHistoryAsync(key,
             TestContext.Current.CancellationToken);

--- a/tests/Granit.Templating.EntityFrameworkCore.Tests/TemplateCacheEntryTests.cs
+++ b/tests/Granit.Templating.EntityFrameworkCore.Tests/TemplateCacheEntryTests.cs
@@ -33,7 +33,7 @@ public sealed class TemplateCacheEntryTests
     public void From_CreatesFoundEntry()
     {
         var revisionId = Guid.NewGuid();
-        var entry = TemplateCacheEntry.From("<p>Hello</p>", "text/html", revisionId);
+        var entry = TemplateCacheEntry.From("<p>Hello</p>", "text/html", revisionId, null);
 
         entry.IsFound.ShouldBeTrue();
         entry.Content.ShouldBe("<p>Hello</p>");
@@ -45,7 +45,7 @@ public sealed class TemplateCacheEntryTests
     public void From_ToDescriptor_ReturnsDescriptorWithCorrectProperties()
     {
         var revisionId = Guid.NewGuid();
-        var entry = TemplateCacheEntry.From("<p>Content</p>", "text/html", revisionId);
+        var entry = TemplateCacheEntry.From("<p>Content</p>", "text/html", revisionId, null);
 
         TemplateDescriptor? descriptor = entry.ToDescriptor();
 
@@ -58,7 +58,7 @@ public sealed class TemplateCacheEntryTests
     [Fact]
     public void From_WithNullRevisionId_ToDescriptor_HasNullRevisionId()
     {
-        var entry = TemplateCacheEntry.From("<p>No revision</p>", "text/html", null);
+        var entry = TemplateCacheEntry.From("<p>No revision</p>", "text/html", null, null);
 
         TemplateDescriptor? descriptor = entry.ToDescriptor();
 

--- a/tests/Granit.Templating.Scriban.Tests/GlobalContexts/AppGlobalContextTests.cs
+++ b/tests/Granit.Templating.Scriban.Tests/GlobalContexts/AppGlobalContextTests.cs
@@ -1,0 +1,64 @@
+using Granit.Templating.Scriban.GlobalContexts;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Templating.Scriban.Tests.GlobalContexts;
+
+public sealed class AppGlobalContextTests
+{
+    [Fact]
+    public void ContextName_IsApp()
+    {
+        AppGlobalContext sut = new(Options.Create(new AppGlobalContextOptions()));
+
+        sut.ContextName.ShouldBe("app");
+    }
+
+    [Fact]
+    public void Resolve_ReturnsConfiguredValues()
+    {
+        AppGlobalContextOptions opts = new()
+        {
+            Name = "Guava Admin",
+            BaseUrl = "https://app.example.com",
+            SupportEmail = "support@example.com",
+            LogoUrl = "https://cdn.example.com/logo.png",
+        };
+        AppGlobalContext sut = new(Options.Create(opts));
+
+        dynamic resolved = sut.Resolve();
+        Type type = resolved.GetType();
+
+        ((string)type.GetProperty("name")!.GetValue(resolved)!).ShouldBe("Guava Admin");
+        ((string)type.GetProperty("base_url")!.GetValue(resolved)!).ShouldBe("https://app.example.com");
+        ((string)type.GetProperty("support_email")!.GetValue(resolved)!).ShouldBe("support@example.com");
+        ((string)type.GetProperty("logo_url")!.GetValue(resolved)!).ShouldBe("https://cdn.example.com/logo.png");
+    }
+
+    [Fact]
+    public void Resolve_TrimsTrailingSlashFromBaseUrl()
+    {
+        AppGlobalContextOptions opts = new() { BaseUrl = "https://app.example.com/" };
+        AppGlobalContext sut = new(Options.Create(opts));
+
+        dynamic resolved = sut.Resolve();
+
+        ((string)resolved.GetType().GetProperty("base_url")!.GetValue(resolved)!)
+            .ShouldBe("https://app.example.com");
+    }
+
+    [Fact]
+    public void Resolve_DefaultOptions_ReturnsEmptyStrings()
+    {
+        AppGlobalContext sut = new(Options.Create(new AppGlobalContextOptions()));
+
+        dynamic resolved = sut.Resolve();
+        Type type = resolved.GetType();
+
+        ((string)type.GetProperty("name")!.GetValue(resolved)!).ShouldBe(string.Empty);
+        ((string)type.GetProperty("base_url")!.GetValue(resolved)!).ShouldBe(string.Empty);
+        ((string)type.GetProperty("support_email")!.GetValue(resolved)!).ShouldBe(string.Empty);
+        ((string)type.GetProperty("logo_url")!.GetValue(resolved)!).ShouldBe(string.Empty);
+    }
+}

--- a/tests/Granit.Templating.Scriban.Tests/GranitTemplateLoaderTests.cs
+++ b/tests/Granit.Templating.Scriban.Tests/GranitTemplateLoaderTests.cs
@@ -1,0 +1,118 @@
+using System.Globalization;
+using Granit.Templating.Keys;
+using Granit.Templating.Pipeline;
+using Granit.Templating.Scriban.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Scriban;
+using Scriban.Parsing;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Templating.Scriban.Tests;
+
+public sealed class GranitTemplateLoaderTests
+{
+    [Fact]
+    public void Load_Sync_ThrowsNotSupportedException()
+    {
+        GranitTemplateLoader sut = new(new ServiceCollection().BuildServiceProvider());
+
+        Should.Throw<NotSupportedException>(() =>
+            sut.Load(new TemplateContext(), default, "Test.Template"));
+    }
+
+    [Fact]
+    public void GetPath_WithCulture_ReturnsCultureQualifiedKey()
+    {
+        GranitTemplateLoader sut = new(new ServiceCollection().BuildServiceProvider());
+
+        CultureInfo previousCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("fr-BE");
+            string path = sut.GetPath(new TemplateContext(), default, "Notifications.Layout");
+
+            path.ShouldBe("Notifications.Layout|fr-BE");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+        }
+    }
+
+    [Fact]
+    public async Task LoadAsync_ResolvesFromResolverChain()
+    {
+        ITemplateResolver resolver = Substitute.For<ITemplateResolver>();
+        resolver.Priority.Returns(100);
+        resolver.TryResolveAsync(Arg.Any<TemplateKey>(), Arg.Any<CancellationToken>())
+            .Returns(new TemplateDescriptor
+            {
+                Content = "<p>Layout content</p>",
+                MimeType = "text/html",
+            });
+
+        ServiceCollection services = new();
+        services.AddSingleton(resolver);
+        ServiceProvider sp = services.BuildServiceProvider();
+
+        GranitTemplateLoader sut = new(sp);
+        string? result = await sut.LoadAsync(
+            new TemplateContext(), default, "Notifications.Layout");
+
+        result.ShouldBe("<p>Layout content</p>");
+    }
+
+    [Fact]
+    public async Task LoadAsync_FallsBackToNeutralCulture()
+    {
+        ITemplateResolver resolver = Substitute.For<ITemplateResolver>();
+        resolver.Priority.Returns(100);
+
+        // Culture-specific returns null
+        resolver.TryResolveAsync(
+                Arg.Is<TemplateKey>(k => k.Culture == "fr"),
+                Arg.Any<CancellationToken>())
+            .Returns((TemplateDescriptor?)null);
+
+        // Neutral returns content
+        resolver.TryResolveAsync(
+                Arg.Is<TemplateKey>(k => k.Culture == null),
+                Arg.Any<CancellationToken>())
+            .Returns(new TemplateDescriptor
+            {
+                Content = "<p>Neutral fallback</p>",
+                MimeType = "text/html",
+            });
+
+        ServiceCollection services = new();
+        services.AddSingleton(resolver);
+        ServiceProvider sp = services.BuildServiceProvider();
+
+        GranitTemplateLoader sut = new(sp);
+        string? result = await sut.LoadAsync(
+            new TemplateContext(), default, "Notifications.Layout|fr");
+
+        result.ShouldBe("<p>Neutral fallback</p>");
+    }
+
+    [Fact]
+    public async Task LoadAsync_ReturnsNull_WhenNoResolverFindsTemplate()
+    {
+        ITemplateResolver resolver = Substitute.For<ITemplateResolver>();
+        resolver.Priority.Returns(100);
+        resolver.TryResolveAsync(Arg.Any<TemplateKey>(), Arg.Any<CancellationToken>())
+            .Returns((TemplateDescriptor?)null);
+
+        ServiceCollection services = new();
+        services.AddSingleton(resolver);
+        ServiceProvider sp = services.BuildServiceProvider();
+
+        GranitTemplateLoader sut = new(sp);
+        string? result = await sut.LoadAsync(
+            new TemplateContext(), default, "Missing.Template");
+
+        result.ShouldBeNull();
+    }
+}

--- a/tests/Granit.Templating.Scriban.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Templating.Scriban.Tests/ServiceCollectionExtensionsTests.cs
@@ -22,7 +22,6 @@ public sealed class ServiceCollectionExtensionsTests
 
         services.ShouldContain(d =>
             d.ServiceType == typeof(ITemplateEngine) &&
-            d.ImplementationType == typeof(ScribanTemplateEngine) &&
             d.Lifetime == ServiceLifetime.Singleton);
     }
 
@@ -38,14 +37,14 @@ public sealed class ServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddGranitTemplatingWithScriban_Registers_Two_ITemplateGlobalContexts()
+    public void AddGranitTemplatingWithScriban_Registers_Three_ITemplateGlobalContexts()
     {
         ServiceCollection services = new();
         services.AddGranitTemplatingWithScriban();
 
-        // NowGlobalContext + ExecutionContextGlobalContext
+        // NowGlobalContext + ExecutionContextGlobalContext + AppGlobalContext
         services.Count(d => d.ServiceType == typeof(ITemplateGlobalContext))
-                .ShouldBe(2, "NowGlobalContext and ExecutionContextGlobalContext must be registered");
+                .ShouldBe(3, "NowGlobalContext, ExecutionContextGlobalContext and AppGlobalContext must be registered");
     }
 
     [Fact]

--- a/tests/Granit.Templating.Scriban.Tests/packages.lock.json
+++ b/tests/Granit.Templating.Scriban.Tests/packages.lock.json
@@ -101,6 +101,23 @@
         "resolved": "18.3.0",
         "contentHash": "23BNy/vziREC20Wwhb50K7+kZe0m07KlLWDQv4qjJ9tt3QjpDpDIqJFrhYHmMEo9xDkuSp55U/8h4bMF7MiB+g=="
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
         "resolved": "10.0.5",
@@ -258,6 +275,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Templating": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
           "Scriban": "[7.*, )"
         }
       },
@@ -267,6 +285,16 @@
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -285,11 +313,24 @@
           "Microsoft.Extensions.Primitives": "10.0.5"
         }
       },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.5",
+        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
       "Scriban": {
         "type": "CentralTransitive",
         "requested": "[7.*, )",
-        "resolved": "7.0.5",
-        "contentHash": "GmK0nHYvmUV7ue93eaEWwVU4NQLcW1MlBckAT6BTUIIJm9UA92pVWdcJH5BGqzgWkrA+xVt065gjP2vpQ47h6g=="
+        "resolved": "7.0.6",
+        "contentHash": "bOtHyk30sjl0y3+KYImIJv0ETZYLuFFJvlBF2ks2YLNtydhJqxRTGe4WaBDvg/3VRhhI6uf+qVfixuFROsOi+w=="
       }
     }
   }

--- a/tests/Granit.Templating.Tests/Layouts/LayoutRegistryTests.cs
+++ b/tests/Granit.Templating.Tests/Layouts/LayoutRegistryTests.cs
@@ -1,0 +1,102 @@
+using Granit.Templating.Layouts;
+using Granit.Templating.Layouts.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Templating.Tests.Layouts;
+
+public sealed class LayoutRegistryTests
+{
+    [Fact]
+    public void GetLayoutName_ExactMatch_ReturnsLayout()
+    {
+        LayoutRegistry sut = new([new LayoutRegistration("Billing.Invoice", "Layout.Document")]);
+
+        sut.GetLayoutName("Billing.Invoice").ShouldBe("Layout.Document");
+    }
+
+    [Fact]
+    public void GetLayoutName_PrefixMatch_ReturnsLayout()
+    {
+        LayoutRegistry sut = new([new LayoutRegistration("Security.*", "Layout.Email")]);
+
+        sut.GetLayoutName("Security.Welcome").ShouldBe("Layout.Email");
+    }
+
+    [Fact]
+    public void GetLayoutName_NoMatch_ReturnsNull()
+    {
+        LayoutRegistry sut = new([new LayoutRegistration("Security.*", "Layout.Email")]);
+
+        sut.GetLayoutName("Billing.Invoice").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetLayoutName_ExactMatchTakesPrecedenceOverPrefix()
+    {
+        LayoutRegistry sut = new(
+        [
+            new LayoutRegistration("Billing.*", "Layout.Email"),
+            new LayoutRegistration("Billing.Invoice", "Layout.Document"),
+        ]);
+
+        sut.GetLayoutName("Billing.Invoice").ShouldBe("Layout.Document");
+        sut.GetLayoutName("Billing.Receipt").ShouldBe("Layout.Email");
+    }
+
+    [Fact]
+    public void GetLayoutName_HigherPriorityPrefixWins()
+    {
+        LayoutRegistry sut = new(
+        [
+            new LayoutRegistration("Notifications.*", "Layout.Generic", Priority: 0),
+            new LayoutRegistration("Notifications.*", "Layout.Email", Priority: 10),
+        ]);
+
+        sut.GetLayoutName("Notifications.Welcome").ShouldBe("Layout.Email");
+    }
+
+    [Fact]
+    public void GetLayoutName_LongerPrefixWinsAtSamePriority()
+    {
+        LayoutRegistry sut = new(
+        [
+            new LayoutRegistration("Billing.*", "Layout.Generic"),
+            new LayoutRegistration("Billing.Finance.*", "Layout.Finance"),
+        ]);
+
+        sut.GetLayoutName("Billing.Finance.Invoice").ShouldBe("Layout.Finance");
+        sut.GetLayoutName("Billing.Receipt").ShouldBe("Layout.Generic");
+    }
+
+    [Fact]
+    public void GetLayoutName_EmptyRegistry_ReturnsNull()
+    {
+        LayoutRegistry sut = new([]);
+
+        sut.GetLayoutName("Anything").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetAllLayoutNames_ReturnsDeduplicated()
+    {
+        LayoutRegistry sut = new(
+        [
+            new LayoutRegistration("Security.*", "Layout.Email"),
+            new LayoutRegistration("Notifications.*", "Layout.Email"),
+            new LayoutRegistration("Billing.*", "Layout.Document"),
+        ]);
+
+        IReadOnlyList<string> layouts = sut.GetAllLayoutNames();
+
+        layouts.ShouldBe(["Layout.Document", "Layout.Email"]); // sorted
+    }
+
+    [Fact]
+    public void GetAllLayoutNames_EmptyRegistry_ReturnsEmpty()
+    {
+        LayoutRegistry sut = new([]);
+
+        sut.GetAllLayoutNames().ShouldBeEmpty();
+    }
+}

--- a/tests/Granit.Templating.Tests/Pipeline/TextTemplateRendererAdditionalTests.cs
+++ b/tests/Granit.Templating.Tests/Pipeline/TextTemplateRendererAdditionalTests.cs
@@ -3,6 +3,7 @@ using Granit.Templating.Internal;
 using Granit.Templating.Keys;
 using Granit.Templating.Pipeline;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -47,7 +48,7 @@ public sealed class TextTemplateRendererAdditionalTests
         ServiceCollection services = new();
         IServiceProvider sp = services.BuildServiceProvider();
 
-        TextTemplateRenderer sut = new([resolver], [engine], [], sp);
+        TextTemplateRenderer sut = new([resolver], [engine], [], sp, Substitute.For<ILogger<TextTemplateRenderer>>());
 
         Func<Task> act = async () =>
             await sut.RenderAsync(DocType, new DocTestData("Test"),
@@ -71,7 +72,7 @@ public sealed class TextTemplateRendererAdditionalTests
         ServiceCollection services = new();
         IServiceProvider sp = services.BuildServiceProvider();
 
-        TextTemplateRenderer sut = new([resolver], [engine], [], sp);
+        TextTemplateRenderer sut = new([resolver], [engine], [], sp, Substitute.For<ILogger<TextTemplateRenderer>>());
 
         Func<Task> act = async () =>
             await sut.RenderAsync(DocType, new DocTestData("Test"),
@@ -103,7 +104,7 @@ public sealed class TextTemplateRendererAdditionalTests
         ServiceCollection services = new();
         IServiceProvider sp = services.BuildServiceProvider();
 
-        TextTemplateRenderer sut = new([resolver], [engine], [], sp);
+        TextTemplateRenderer sut = new([resolver], [engine], [], sp, Substitute.For<ILogger<TextTemplateRenderer>>());
 
         RenderedContent result = await sut.RenderDocumentAsync(
             DocType, new DocTestData("Test"), DocumentFormat.Pdf,
@@ -148,7 +149,7 @@ public sealed class TextTemplateRendererAdditionalTests
         ServiceCollection services = new();
         IServiceProvider sp = services.BuildServiceProvider();
 
-        TextTemplateRenderer sut = new([lowResolver, highResolver], [engine], [], sp);
+        TextTemplateRenderer sut = new([lowResolver, highResolver], [engine], [], sp, Substitute.For<ILogger<TextTemplateRenderer>>());
 
         RenderedTextResult result = await sut.RenderAsync(
             DocType, new DocTestData("Test"),
@@ -183,7 +184,7 @@ public sealed class TextTemplateRendererAdditionalTests
         ServiceCollection services = new();
         IServiceProvider sp = services.BuildServiceProvider();
 
-        TextTemplateRenderer sut = new([resolver], [engine], [globalCtx], sp);
+        TextTemplateRenderer sut = new([resolver], [engine], [globalCtx], sp, Substitute.For<ILogger<TextTemplateRenderer>>());
 
         await sut.RenderAsync(DocType, new DocTestData("Test"),
             TestContext.Current.CancellationToken);

--- a/tests/Granit.Templating.Tests/Pipeline/TextTemplateRendererTests.cs
+++ b/tests/Granit.Templating.Tests/Pipeline/TextTemplateRendererTests.cs
@@ -5,6 +5,7 @@ using Granit.Templating.Internal;
 using Granit.Templating.Keys;
 using Granit.Templating.Pipeline;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -53,7 +54,7 @@ public sealed class TextTemplateRendererTests
         IServiceProvider sp = services.BuildServiceProvider();
 
         TextTemplateRenderer sut = new(
-            [resolver], [engine], [], sp);
+            [resolver], [engine], [], sp, Substitute.For<ILogger<TextTemplateRenderer>>());
 
         // Act
         RenderedTextResult result = await sut.RenderAsync(
@@ -78,7 +79,7 @@ public sealed class TextTemplateRendererTests
         IServiceProvider sp = services.BuildServiceProvider();
 
         TextTemplateRenderer sut = new(
-            [resolver], [engine], [], sp);
+            [resolver], [engine], [], sp, Substitute.For<ILogger<TextTemplateRenderer>>());
 
         // Act
         Func<Task> act = async () =>
@@ -135,7 +136,7 @@ public sealed class TextTemplateRendererTests
         IServiceProvider sp = services.BuildServiceProvider();
 
         TextTemplateRenderer sut = new(
-            [resolver], [engine], [], sp);
+            [resolver], [engine], [], sp, Substitute.For<ILogger<TextTemplateRenderer>>());
 
         // Act
         await sut.RenderAsync(
@@ -172,7 +173,7 @@ public sealed class TextTemplateRendererTests
         IServiceProvider sp = services.BuildServiceProvider();
 
         TextTemplateRenderer sut = new(
-            [resolver], [engine], [], sp);
+            [resolver], [engine], [], sp, Substitute.For<ILogger<TextTemplateRenderer>>());
 
         // Act
         await sut.RenderAsync(TemplateType, data, TestContext.Current.CancellationToken);
@@ -210,7 +211,7 @@ public sealed class TextTemplateRendererTests
         IServiceProvider sp = services.BuildServiceProvider();
 
         TextTemplateRenderer sut = new(
-            [resolver], [engine], [], sp);
+            [resolver], [engine], [], sp, Substitute.For<ILogger<TextTemplateRenderer>>());
 
         // Act
         RenderedTextResult result = await sut.RenderAsync(


### PR DESCRIPTION
## Summary

Replaces the hardcoded email notification fallback with a full template layout system:

- **Scriban `{{ include }}` support** — `GranitTemplateLoader` bridges `ITemplateResolver` → Scriban `ITemplateLoader`, enabling template composition across all Scriban templates (#798)
- **Layout Registry** — `ILayoutRegistry` maps template patterns to layout names (`Notifications.* → Layout.Email`). `TextTemplateRenderer` performs automatic two-pass rendering: content first, then layout with `{{ body | raw }}` injection (#799)
- **Per-template admin override** — `LayoutName` column on `TemplateRevisionEntity`, exposed via DTOs and `GET /layouts` endpoint. Resolution chain: DB override → code registry → no layout (#800)
- **Email notification templates** — `Layout.Email.html` (culture-neutral branding envelope) + 16 body-only `Notifications.Default.*.html` content templates. `AppGlobalContext` exposes `{{ app.name }}`, `{{ app.base_url }}`, `{{ app.logo_url }}`, `{{ app.support_email }}` (#801)

### Architecture

```
Layout resolution: descriptor.LayoutName (DB) → ILayoutRegistry (code) → standalone
Two-pass render:   content → HTML string → inject as {{ body | raw }} → layout render
Include support:   GranitTemplateLoader (async-only, scoped resolvers, culture fallback)
Tenant override:   publish Layout.Email to DB store → StoreTemplateResolver wins (priority 100)
```

### Key design decisions

- `GranitTemplateLoader.Load()` throws `NotSupportedException` — enforces async pipeline to prevent thread starvation with DB-backed resolvers
- Layout render is always terminal (no layout-of-layout) — prevents infinite loop
- Layout not found → warning log + standalone render (graceful degradation)
- `{{ body | raw }}` — defensive against future HTML encoding activation
- `ExtraVariables` on `TemplateDescriptor` — generic mechanism, not layout-specific

## Packages modified

| Package | Changes |
|---------|---------|
| `Granit.Templating` | `ILayoutRegistry`, `LayoutRegistration`, `AddTemplateLayout()`, two-pass `TextTemplateRenderer`, `ExtraVariables` + `LayoutName` on `TemplateDescriptor` |
| `Granit.Templating.Scriban` | `GranitTemplateLoader`, `AppGlobalContext` + options, `ExtraVariables` injection in engine |
| `Granit.Templating.EntityFrameworkCore` | `LayoutName` on entity + cache entry + store |
| `Granit.Templating.Endpoints` | `LayoutName` on DTOs, `GET /layouts` endpoint |
| `Granit.Notifications.Email` | `Layout.Email.html`, 16 body-only templates, layout registration |

## Test plan

- [x] `Granit.Templating.Tests` — 103 passed (9 new: LayoutRegistry exact/prefix/priority/dedup)
- [x] `Granit.Templating.Scriban.Tests` — 40 passed (5 new: GranitTemplateLoader async/sync/culture/fallback)
- [x] `Granit.Templating.EntityFrameworkCore.Tests` — 58 passed (TemplateCacheEntry updated)
- [x] `Granit.Templating.Endpoints.Tests` — 122 passed (DTOs updated)
- [x] `Granit.Notifications.Email.Tests` — 39 passed (fallback + layout registration)
- [ ] EF Core migration for `LayoutName` column (to generate before merge)
- [ ] Integration test with real Scriban `{{ include }}` rendering
