### PR TITLE
fix(notifications): add layout wrapping to EmailNotificationChannel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -437,6 +437,13 @@ edge case, GDPR/ISO 27001 constraint, third-party workaround.
 - Remove/change interface implementations on `ValueObject`/`Entity`/`AggregateRoot` for SonarQube — mark as won't fix
 - Reduce constructor params via wrapper types that aren't real domain concepts — mark `brain-overload` as won't fix
 
+### Git — CRITICAL
+
+- **NEVER `git push` to a PR branch without verifying the PR is still open first.**
+  Run `gh pr view <number> --json state -q .state` immediately before every `git push`.
+  If result is NOT `"OPEN"`, do NOT push. Instead: fetch develop, create a new branch,
+  cherry-pick changes, create a new PR. This is a **BLOCKING** check — never skip it.
+
 ## Compliance
 
 1. **GDPR**: Minimization, right to erasure, pseudonymization

--- a/docs-site/src/content/docs/dotnet/business/templating.mdx
+++ b/docs-site/src/content/docs/dotnet/business/templating.mdx
@@ -31,18 +31,18 @@ For binary document output (PDF, Excel), see
 
 <FileTree>
 - Granit.Templating/ Core pipeline: ITextTemplateRenderer, resolvers, engines, enrichers, global contexts, template store CQRS
-  - Granit.Templating.Scriban Scriban engine (sandboxed, no I/O or reflection), template caching, built-in global contexts
+  - Granit.Templating.Scriban Scriban engine (sandboxed, no I/O or reflection), template caching, built-in global contexts, include support
   - Granit.Templating.EntityFrameworkCore EF Core persistence (TemplatingDbContext), FusionCache-backed store, StoreTemplateResolver
-  - Granit.Templating.Endpoints 16 admin endpoints (CRUD, preview, publish, categories, history, variables)
+  - Granit.Templating.Endpoints 17 admin endpoints (CRUD, preview, publish, categories, layouts, history, variables)
   - Granit.Templating.Workflow Bridge to Granit.Workflow: FSM validation, approval routing, unified audit trail
 </FileTree>
 
 | Package | Role | Depends on |
 | ------- | ---- | ---------- |
-| `Granit.Templating` | Core pipeline: rendering, resolution, enrichment, store interfaces | -- |
-| `Granit.Templating.Scriban` | Scriban template engine (sandboxed), `now.*` and `context.*` globals | `Granit.Templating` |
+| `Granit.Templating` | Core pipeline: rendering, resolution, enrichment, layout registry, store interfaces | -- |
+| `Granit.Templating.Scriban` | Scriban template engine (sandboxed), `now.*`, `context.*` and `app.*` globals, `{{ include }}` support | `Granit.Templating` |
 | `Granit.Templating.EntityFrameworkCore` | EF Core store, `StoreTemplateResolver` (Priority=100), FusionCache | `Granit.Templating`, `Granit.Persistence` |
-| `Granit.Templating.Endpoints` | 16 admin Minimal API endpoints, `Templates.Manage` permission | `Granit.Templating`, `Granit.Authorization` |
+| `Granit.Templating.Endpoints` | 17 admin Minimal API endpoints, `Templates.Manage` permission | `Granit.Templating`, `Granit.Authorization` |
 | `Granit.Templating.Workflow` | Workflow bridge: FSM validation, `IWorkflowTransitionRecorder` | `Granit.Templating`, `Granit.Workflow` |
 
 ## Dependency graph
@@ -128,7 +128,7 @@ enabling FSM-validated transitions and unified audit trail via `IWorkflowTransit
 
 ## Template rendering pipeline
 
-The text rendering pipeline executes three stages in sequence:
+The text rendering pipeline executes four stages in sequence:
 
 ```mermaid
 flowchart LR
@@ -143,10 +143,16 @@ flowchart LR
         R1 -->|hit| TD[TemplateDescriptor]
         R2 --> TD
     end
-    subgraph "3. Render"
+    subgraph "3. Layout"
+        TD -->|LayoutName?| LR["ILayoutRegistry"]
+        LR -->|resolve layout| LD[Layout Descriptor]
+        TD -->|no layout| ENG
+    end
+    subgraph "4. Render"
         TD --> ENG["ITemplateEngine<br/>(Scriban)"]
+        LD -->|"two-pass:<br/>content → {{ body | raw }}"| ENG
         ED --> ENG
-        GC["Global Contexts<br/>now.*, context.*"] --> ENG
+        GC["Global Contexts<br/>now.*, context.*, app.*"] --> ENG
         ENG --> RC[RenderedTextResult]
     end
 ```
@@ -165,7 +171,12 @@ Tenant scoping is the resolver's responsibility.
 | `StoreTemplateResolver` | 100 | EF Core database (published revisions, FusionCache) |
 | `EmbeddedTemplateResolver` | -100 | Assembly embedded resources (code-level fallback) |
 
-**Stage 3 -- Engine rendering.** `ITemplateEngine` selects itself via `CanRender(descriptor)`
+**Stage 3 -- Layout wrapping.** If a layout is configured (via `TemplateDescriptor.LayoutName`
+from the database, or via `ILayoutRegistry` code-level defaults), the renderer performs
+two-pass rendering: content first, then the layout with `{{ body | raw }}` = rendered content.
+See [Layouts](#layouts) below.
+
+**Stage 4 -- Engine rendering.** `ITemplateEngine` selects itself via `CanRender(descriptor)`
 based on MIME type. Scriban handles `text/html` and `text/plain`. Global contexts are injected
 under their `ContextName` namespace.
 
@@ -261,7 +272,7 @@ from `Granit.AI` to sanitize user-controlled input (prompt injection defense).
 ## Global contexts
 
 Global contexts inject ambient data into every template under a named variable.
-Two are registered by default when using `Granit.Templating.Scriban`:
+Three are registered by default when using `Granit.Templating.Scriban`:
 
 | Namespace | Variable | Example output |
 |-----------|----------|----------------|
@@ -275,6 +286,27 @@ Two are registered by default when using `Granit.Templating.Scriban`:
 | `context` | `{{ context.culture_name }}` | `fran\u00e7ais (Belgique)` |
 | `context` | `{{ context.tenant_id }}` | `3fa85f64-...` or empty |
 | `context` | `{{ context.tenant_name }}` | `Acme Corp` or empty |
+| `app` | `{{ app.name }}` | `Guava Admin` |
+| `app` | `{{ app.base_url }}` | `https://app.example.com` |
+| `app` | `{{ app.support_email }}` | `support@example.com` |
+| `app` | `{{ app.logo_url }}` | `https://cdn.example.com/logo.png` |
+
+The `app.*` context is bound to the `Granit:Templating:App` configuration section:
+
+```json
+{
+  "Granit": {
+    "Templating": {
+      "App": {
+        "Name": "Guava Admin",
+        "BaseUrl": "https://app.example.com",
+        "SupportEmail": "support@example.com",
+        "LogoUrl": "https://cdn.example.com/logo.png"
+      }
+    }
+  }
+}
+```
 
 :::caution
 User identity is intentionally **not** exposed in global contexts. Avoid injecting PII
@@ -315,6 +347,121 @@ The Scriban engine runs in strict sandboxed mode with explicit resource limits:
 - **CancellationToken propagation** -- long-running templates can be cancelled
 - **Content size limit** -- template body is capped at 1 MB via `SaveTemplateRequestValidator`
 - **MIME type allowlist** -- only `text/html` and `text/plain` are accepted
+
+## Layouts
+
+Layouts provide a shared HTML envelope (branding, header, footer) that wraps content
+templates automatically. Content templates contain only the body -- no `DOCTYPE`, no
+`<head>`, no boilerplate.
+
+### How it works
+
+The renderer performs **two-pass rendering** when a layout is configured:
+
+1. **Render content** -- the content template produces an HTML fragment
+2. **Render layout** -- the layout template receives the fragment as `{{ body | raw }}`
+   and wraps it in the full HTML structure
+
+### Layout resolution chain
+
+Layout is resolved in priority order:
+
+1. **`TemplateDescriptor.LayoutName`** (database) -- admin override per template
+2. **`ILayoutRegistry`** (code) -- pattern-based defaults registered at startup
+3. **No layout** -- template renders standalone
+
+### Registering layouts (code-level)
+
+```csharp
+// All notification emails use the email layout
+services.AddTemplateLayout("Notifications.*", "Layout.Email");
+
+// All billing templates use the document layout
+services.AddTemplateLayout("Billing.*", "Layout.Document");
+
+// Exact match takes precedence over prefix
+services.AddTemplateLayout("Billing.SpecialInvoice", "Layout.Custom");
+```
+
+Patterns support exact names (`"Billing.Invoice"`) and prefix wildcards (`"Billing.*"`).
+Exact matches always win. Among prefix matches, higher priority and longer prefix win.
+
+### Layout template example
+
+```html
+<!DOCTYPE html>
+<html lang="{{ context.culture }}">
+<head>
+    <meta charset="utf-8">
+    <title>{{ model.title }}</title>
+</head>
+<body>
+    {{- if app.logo_url != "" }}
+    <img src="{{ app.logo_url }}" alt="{{ app.name }}">
+    {{- end }}
+    {{ body | raw }}
+    {{- if app.base_url != "" }}
+    <p><a href="{{ app.base_url }}">{{ app.name }}</a></p>
+    {{- end }}
+</body>
+</html>
+```
+
+The content template is just the body:
+
+```html
+<p>You have received a new notification of type
+<strong>{{ model.notification_type }}</strong>.</p>
+```
+
+:::note[`{{ body | raw }}`]
+The `raw` filter prevents double-encoding if HTML escaping is enabled in the future.
+Today Scriban in Granit runs in raw text mode (no `HtmlEncoder`), but `raw` is a
+defensive best practice for layout templates.
+:::
+
+### Admin override
+
+An administrator can assign a specific layout to a template via the admin UI
+(`PUT /templates/{name}` with `layoutName` field). This overrides the code-level
+`ILayoutRegistry` default. Set `layoutName` to `null` to revert to the default.
+
+### Tenant override
+
+A tenant can override a layout by publishing their own version (e.g. `Layout.Email`)
+to the database template store. `StoreTemplateResolver` (priority 100) wins over the
+embedded default (priority -100). Multi-tenant query filters ensure isolation.
+
+### Safety guards
+
+- **Layout is always terminal** -- the layout render pass never resolves a layout for
+  itself, preventing infinite loops
+- **Graceful degradation** -- if the layout template cannot be resolved, a warning is
+  logged and the content renders standalone
+- **Binary skip** -- `BinaryRenderedContent` (Excel) skips layout wrapping
+
+## Template includes
+
+Templates can include other templates via `{{ include 'template_name' }}`. Included
+templates are resolved through the standard `ITemplateResolver` chain with culture
+fallback.
+
+```html
+{{ include 'Partial.EmailHeader' }}
+<p>Dear {{ model.patient_name }}, your appointment is confirmed.</p>
+{{ include 'Partial.EmailFooter' }}
+```
+
+Include support is provided by `GranitTemplateLoader`, which bridges Scriban's
+`ITemplateLoader` to Granit's resolver chain. It is registered automatically by
+`AddGranitTemplatingWithScriban()`.
+
+:::caution[Async-only]
+`GranitTemplateLoader.Load()` (sync) throws `NotSupportedException`. Always use
+`Template.RenderAsync` -- the async path calls `LoadAsync` which properly awaits
+scoped resolvers (e.g. database-backed templates). This prevents thread starvation
+under load.
+:::
 
 ## Template lifecycle
 
@@ -374,6 +521,7 @@ Templates are resolved by trying resolvers in descending priority order:
 | -100 | `EmbeddedTemplateResolver` | Assembly embedded resources | `Granit.Templating` |
 
 **Culture fallback strategy** (per resolver):
+
 1. `(Name, Culture)` -- e.g. `("Acme.Invoice", "fr-BE")`
 2. `(Name, null)` -- culture-neutral fallback
 
@@ -395,8 +543,8 @@ services.AddEmbeddedTemplates(typeof(AcmeTemplates).Assembly);
 
 ## Admin endpoints
 
-16 endpoints are registered via `MapGranitTemplating()`. All require the
-`Templates.Manage` permission.
+17 endpoints are registered via `MapGranitTemplating()`. All require the
+`Templates.Manage` permission (or `Templates.Read` for GET endpoints).
 
 ### Template endpoints
 
@@ -414,6 +562,12 @@ services.AddEmbeddedTemplates(typeof(AcmeTemplates).Assembly);
 | `GET` | `/{name}/variables` | `GetTemplateVariables` | Available variables for autocompletion |
 | `GET` | `/{name}/history` | `GetTemplateHistory` | Paginated revision history (summaries) |
 | `GET` | `/{name}/history/{revisionId}` | `GetTemplateRevisionDetail` | Full detail of a specific revision |
+
+### Layout endpoints
+
+| Method | Route | Name | Description |
+|--------|-------|------|-------------|
+| `GET` | `/layouts` | `ListAvailableLayouts` | Deduplicated list of layout names (code registry + DB) |
 
 ### Category endpoints
 
@@ -475,12 +629,13 @@ A discharge letter template stored in the EF Core store or as an embedded resour
 | Pipeline | `TemplateDescriptor`, `RenderedContent`, `TextRenderedContent`, `BinaryRenderedContent`, `RenderedTextResult` | `Granit.Templating` |
 | Keys | `TemplateType<TData>`, `TextTemplateType<TData>`, `TemplateKey`, `DocumentFormat` | `Granit.Templating` |
 | Enrichment | `ITemplateDataEnricher<TData>` | `Granit.Templating` |
-| Global context | `ITemplateGlobalContext` | `Granit.Templating` |
+| Layouts | `ILayoutRegistry`, `LayoutRegistration` | `Granit.Templating` |
+| Global context | `ITemplateGlobalContext`, `AppGlobalContextOptions` | `Granit.Templating`, `Granit.Templating.Scriban` |
 | Store (read) | `IDocumentTemplateStoreReader`, `ITemplateCategoryStoreReader` | `Granit.Templating` |
 | Store (write) | `IDocumentTemplateStoreWriter`, `ITemplateCategoryStoreWriter` | `Granit.Templating` |
 | Lifecycle | `TemplateLifecycleStatus`, `ITemplateTransitionHook`, `TemplateRevision` | `Granit.Templating` |
 | Permissions | `TemplatingPermissions.Manage` (`"Templates.Manage"`) | `Granit.Templating.Endpoints` |
-| Extensions | `AddGranitTemplating()`, `AddGranitTemplatingWithScriban()`, `AddEmbeddedTemplates()` | -- |
+| Extensions | `AddGranitTemplating()`, `AddGranitTemplatingWithScriban()`, `AddEmbeddedTemplates()`, `AddTemplateLayout()` | -- |
 | Extensions | `MapGranitTemplating()` | `Granit.Templating.Endpoints` |
 
 ## When to use — and when not to

--- a/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
+++ b/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Email.Options;
 using Granit.Templating.Keys;
+using Granit.Templating.Layouts;
 using Granit.Templating.Pipeline;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -62,6 +63,14 @@ internal sealed partial class EmailNotificationChannel(
                 context.NotificationTypeName, context, cancellationToken).ConfigureAwait(false)
             ?? await TryRenderTemplateAsync(
                 FallbackTemplateName, context, cancellationToken).ConfigureAwait(false);
+
+        // Apply layout wrapping (two-pass: content was rendered above, now wrap in layout)
+        if (rendered is not null)
+        {
+            rendered = await TryApplyLayoutAsync(
+                context.NotificationTypeName, rendered, context, cancellationToken).ConfigureAwait(false)
+                ?? rendered;
+        }
 
         string subject = rendered?.Subject ?? context.NotificationTypeName.Replace('.', ' ');
         string htmlBody = rendered?.Html
@@ -147,6 +156,108 @@ internal sealed partial class EmailNotificationChannel(
         return null;
     }
 
+    /// <summary>
+    /// Wraps rendered content in a layout template if one is registered for this notification type.
+    /// Uses the same two-pass pattern as <c>TextTemplateRenderer</c>: render layout with
+    /// <c>{{ body }}</c> = pre-rendered content HTML.
+    /// </summary>
+    private async Task<RenderedEmail?> TryApplyLayoutAsync(
+        string templateName,
+        RenderedEmail contentEmail,
+        NotificationDeliveryContext context,
+        CancellationToken cancellationToken)
+    {
+        // Resolve layout name from registry (code-level defaults)
+        ILayoutRegistry? layoutRegistry = serviceProvider.GetService<ILayoutRegistry>();
+        string? layoutName = layoutRegistry?.GetLayoutName(templateName);
+
+        if (layoutName is null)
+        {
+            return null;
+        }
+
+        // Resolve the layout template
+        IEnumerable<ITemplateResolver>? resolvers = serviceProvider.GetService<IEnumerable<ITemplateResolver>>();
+        if (resolvers is null)
+        {
+            return null;
+        }
+
+        TemplateKey layoutKey = new(layoutName, context.Culture);
+        TemplateDescriptor? layoutDescriptor = null;
+        foreach (ITemplateResolver resolver in resolvers.OrderByDescending(r => r.Priority))
+        {
+            layoutDescriptor = await resolver.TryResolveAsync(layoutKey, cancellationToken).ConfigureAwait(false);
+            if (layoutDescriptor is not null)
+            {
+                break;
+            }
+        }
+
+        // Culture-neutral fallback for layout
+        if (layoutDescriptor is null)
+        {
+            TemplateKey neutralKey = new(layoutName);
+            foreach (ITemplateResolver resolver in resolvers.OrderByDescending(r => r.Priority))
+            {
+                layoutDescriptor = await resolver.TryResolveAsync(neutralKey, cancellationToken).ConfigureAwait(false);
+                if (layoutDescriptor is not null)
+                {
+                    break;
+                }
+            }
+        }
+
+        if (layoutDescriptor is null)
+        {
+            Log.LayoutNotFound(logger, layoutName, templateName);
+            return null;
+        }
+
+        // Render layout with body injection
+        IEnumerable<ITemplateEngine>? engines = serviceProvider.GetService<IEnumerable<ITemplateEngine>>();
+        ITemplateEngine? engine = engines?.FirstOrDefault(e => e.CanRender(layoutDescriptor));
+        if (engine is null)
+        {
+            return null;
+        }
+
+        Dictionary<string, object?> dataDict = JsonElementToDictionary(context.Data);
+        dataDict.TryAdd("notification_type", context.NotificationTypeName);
+
+        // Inject body as ExtraVariable for {{ body | raw }} in layout
+        TemplateDescriptor layoutWithBody = new()
+        {
+            Content = layoutDescriptor.Content,
+            MimeType = layoutDescriptor.MimeType,
+            RevisionId = layoutDescriptor.RevisionId,
+            ExtraVariables = new Dictionary<string, object> { ["body"] = contentEmail.Html },
+        };
+
+        try
+        {
+            IReadOnlyList<Granit.Templating.GlobalContext.ITemplateGlobalContext> globalContexts =
+                serviceProvider.GetService<IEnumerable<Granit.Templating.GlobalContext.ITemplateGlobalContext>>()?.ToList()
+                ?? [];
+
+            RenderedContent rendered = await engine
+                .RenderAsync(layoutWithBody, dataDict, DocumentFormat.Html, globalContexts, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (rendered is TextRenderedContent textResult)
+            {
+                string? subject = ExtractTitleFromHtml(textResult.Html);
+                return new RenderedEmail(textResult.Html, subject);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.TemplateRenderFailed(logger, layoutName, ex);
+        }
+
+        return null;
+    }
+
     private static Dictionary<string, object?> JsonElementToDictionary(JsonElement element)
     {
         Dictionary<string, object?> dict = [];
@@ -210,5 +321,9 @@ internal sealed partial class EmailNotificationChannel(
         [LoggerMessage(Level = LogLevel.Warning,
             Message = "Failed to render email template for notification '{NotificationType}'.")]
         public static partial void TemplateRenderFailed(ILogger logger, string notificationType, Exception exception);
+
+        [LoggerMessage(Level = LogLevel.Warning,
+            Message = "Layout template '{LayoutName}' not found for notification '{NotificationType}'. Sending without layout.")]
+        public static partial void LayoutNotFound(ILogger logger, string layoutName, string notificationType);
     }
 }

--- a/src/bundles/Granit.Bundle.Documents/packages.lock.json
+++ b/src/bundles/Granit.Bundle.Documents/packages.lock.json
@@ -217,6 +217,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Templating": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
           "Scriban": "[7.*, )"
         }
       },


### PR DESCRIPTION
## Summary

- `EmailNotificationChannel` bypasses `TextTemplateRenderer` and renders templates directly via `ITemplateResolver` + `ITemplateEngine`. After #802 refactored templates to body-only, the channel needs its own layout wrapping
- Add `TryApplyLayoutAsync`: resolves layout via `ILayoutRegistry`, renders with `ExtraVariables { body = contentHtml }`, extracts subject from layout's `<title>`
- Graceful degradation: layout not found → warning log + send without layout
- Also moves the PR-state-check rule from memory to `CLAUDE.md` anti-patterns

## Test plan

- [x] `Granit.Notifications.Email.Tests` — 39 passed
- [ ] Manual: verify email HTML output includes layout envelope
