### PR TITLE
feat(cookies): ICookieDefinitionContributor for module auto-registration

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1158,6 +1158,7 @@
       "name": "Granit.OpenIddict.EntityFrameworkCore",
       "deps": [
         "Granit.Encryption",
+        "Granit.Http.Cookies",
         "Granit.Identity.Local",
         "Granit.MultiTenancy",
         "Granit.OpenIddict.Server",
@@ -6339,15 +6340,8 @@
       "kind": "class",
       "project": "Granit.Bff.Endpoints",
       "file": "src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs",
-      "line": 19,
-      "members": [
-        {
-          "name": "ConfigureServices",
-          "kind": "method",
-          "signature": "ConfigureServices(ServiceConfigurationContext context)",
-          "returnType": "void"
-        }
-      ]
+      "line": 23,
+      "members": []
     },
     {
       "name": "GranitBffEntityFrameworkCoreModule",
@@ -13236,8 +13230,15 @@
       "kind": "class",
       "project": "Granit.Http.Cookies",
       "file": "src/Granit.Http.Cookies/GranitHttpCookiesModule.cs",
-      "line": 10,
-      "members": []
+      "line": 11,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "IConsentResolver",
@@ -13268,6 +13269,22 @@
           "kind": "method",
           "signature": "GetConsentModelAsync(HttpContext httpContext)",
           "returnType": "Task<ConsentModelInfo?>"
+        }
+      ]
+    },
+    {
+      "name": "ICookieDefinitionContributor",
+      "fqn": "Granit.Http.Cookies.ICookieDefinitionContributor",
+      "kind": "interface",
+      "project": "Granit.Http.Cookies",
+      "file": "src/Granit.Http.Cookies/ICookieDefinitionContributor.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "GetCookieDefinitions",
+          "kind": "method",
+          "signature": "GetCookieDefinitions()",
+          "returnType": "IEnumerable<CookieDefinition>"
         }
       ]
     },
@@ -21966,7 +21983,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.EntityFrameworkCore",
       "file": "src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs",
-      "line": 44,
+      "line": 45,
       "members": [
         {
           "name": "ConfigureServices",

--- a/docs-site/src/content/docs/dotnet/compliance/cookies/index.mdx
+++ b/docs-site/src/content/docs/dotnet/compliance/cookies/index.mdx
@@ -46,6 +46,54 @@ public class AppModule : GranitModule
 }
 ```
 
+## Module auto-registration
+
+Granit modules that introduce cookies auto-declare them via `ICookieDefinitionContributor`.
+The cookie registry collects all contributors at first resolution — no manual declaration
+needed for framework cookies.
+
+| Module | Cookies auto-registered | Contributor |
+| ------ | ----------------------- | ----------- |
+| `Granit.OpenIddict.EntityFrameworkCore` | `.AspNetCore.Identity.Application`, `.TwoFactorUserId`, `.ExternalLogin` | `IdentityCookieDefinitionContributor` |
+| `Granit.Http.Cookies.Klaro` | `klaro` (configurable) | `KlaroCookieDefinitionContributor` |
+| `Granit.Bff.Endpoints` | `__Host-granit-bff-{frontend}` (dynamic) | Runtime registration in `MapGranitBff()` |
+| `Granit.Privacy.Endpoints` | `granit_optout_id` | Runtime registration in `MapGranitPrivacy()` |
+
+### Implementing a contributor
+
+```csharp
+internal sealed class MyCookieContributor : ICookieDefinitionContributor
+{
+    public IEnumerable<CookieDefinition> GetCookieDefinitions()
+    {
+        yield return new CookieDefinition(
+            "my_cookie", CookieCategory.StrictlyNecessary,
+            1, true, "Purpose description")
+        { IsEssential = true };
+    }
+}
+```
+
+Register it in your module's `ConfigureServices`:
+
+```csharp
+context.Services.AddSingleton<ICookieDefinitionContributor, MyCookieContributor>();
+```
+
+### Application-level cookies
+
+Cookies from optional ASP.NET Core middleware (Session, Antiforgery) are not auto-registered
+because no Granit module owns them. Declare them in the host's `AddGranitCookies()` callback:
+
+```csharp
+context.Services.AddGranitCookies(cookies =>
+{
+    cookies.RegisterCookie(new(".AspNetCore.Session",
+        CookieCategory.StrictlyNecessary, 1, true,
+        "ASP.NET Core distributed session identifier."));
+});
+```
+
 ## Cookie categories
 
 | Category | Consent required | Description |
@@ -105,6 +153,7 @@ public class SessionService(IGranitCookieManager cookieManager)
 | -------- | --------- | ------- |
 | Modules | `GranitHttpCookiesModule`, `GranitHttpCookiesKlaroModule` | -- |
 | Registry | `ICookieRegistry`, `CookieDefinition`, `CookieCategory`, `GranitCookiesBuilder` | `Granit.Http.Cookies` |
+| Contributors | `ICookieDefinitionContributor` | `Granit.Http.Cookies` |
 | Manager | `IGranitCookieManager`, `IConsentResolver` | `Granit.Http.Cookies` |
 | GPC | `IGlobalPrivacyControlSignal`, `ICookieConsentModelProvider`, `ConsentModelInfo` | `Granit.Http.Cookies` |
 | Klaro | `KlaroConsentResolver`, `KlaroOptions` | `Granit.Http.Cookies.Klaro` |

--- a/src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs
+++ b/src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs
@@ -1,7 +1,6 @@
 using Granit.Caching;
 using Granit.Http.ApiDocumentation;
 using Granit.Http.Cookies;
-using Granit.Http.Cookies.Extensions;
 using Granit.Modularity;
 using Granit.Validation;
 
@@ -10,16 +9,15 @@ namespace Granit.Bff.Endpoints;
 /// <summary>
 /// Granit module for BFF authentication HTTP endpoints (login, callback, logout, user, CSRF).
 /// </summary>
+/// <remarks>
+/// Cookie infrastructure is ensured by <see cref="GranitHttpCookiesModule"/> (dependency).
+/// BFF session cookies are registered at route-mapping time in <c>MapGranitBff()</c>
+/// because their names are configuration-driven (one per frontend).
+/// </remarks>
 [DependsOn(
     typeof(GranitBffModule),
     typeof(GranitCachingModule),
     typeof(GranitHttpApiDocumentationModule),
     typeof(GranitHttpCookiesModule),
     typeof(GranitValidationModule))]
-public sealed class GranitBffEndpointsModule : GranitModule
-{
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
-        // Ensure IGranitCookieManager + ICookieRegistry are available for BFF session cookies.
-        // No-op if AddGranitCookies() was already called by the hosting application.
-        context.Services.AddGranitCookies(_ => { });
-}
+public sealed class GranitBffEndpointsModule : GranitModule;

--- a/src/Granit.Http.Cookies.Klaro/Extensions/KlaroServiceCollectionExtensions.cs
+++ b/src/Granit.Http.Cookies.Klaro/Extensions/KlaroServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ public static class KlaroServiceCollectionExtensions
             .ValidateOnStart();
 
         services.AddScoped<IConsentResolver, KlaroConsentResolver>();
+        services.AddSingleton<ICookieDefinitionContributor, KlaroCookieDefinitionContributor>();
 
         return services;
     }

--- a/src/Granit.Http.Cookies.Klaro/Internal/KlaroCookieDefinitionContributor.cs
+++ b/src/Granit.Http.Cookies.Klaro/Internal/KlaroCookieDefinitionContributor.cs
@@ -1,0 +1,23 @@
+using Granit.Http.Cookies.Klaro.Options;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Http.Cookies.Klaro.Internal;
+
+/// <summary>
+/// Contributes the Klaro consent cookie to the Granit cookie registry.
+/// The cookie name is read from <see cref="KlaroOptions"/> to support configuration overrides.
+/// </summary>
+internal sealed class KlaroCookieDefinitionContributor(
+    IOptions<KlaroOptions> options) : ICookieDefinitionContributor
+{
+    /// <inheritdoc/>
+    public IEnumerable<CookieDefinition> GetCookieDefinitions()
+    {
+        yield return new CookieDefinition(
+            options.Value.CookieName,
+            CookieCategory.StrictlyNecessary,
+            365,
+            false,
+            "Klaro CMP consent decisions (set by client-side JavaScript).");
+    }
+}

--- a/src/Granit.Http.Cookies/Extensions/CookiesServiceCollectionExtensions.cs
+++ b/src/Granit.Http.Cookies/Extensions/CookiesServiceCollectionExtensions.cs
@@ -13,8 +13,19 @@ public static class CookiesServiceCollectionExtensions
 {
     /// <summary>
     /// Adds Granit.Http.Cookies services (ICookieRegistry, IGranitCookieManager, IThirdPartyServiceRegistry)
-    /// and registers cookie definitions declared in the builder.
+    /// and registers cookie definitions declared in the builder and contributed by modules.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This method can be called multiple times safely. Cookie definitions from each call
+    /// accumulate additively. The <see cref="ICookieRegistry"/> is built lazily at first
+    /// resolution, collecting definitions from:
+    /// </para>
+    /// <list type="number">
+    /// <item>Builder callback definitions (from every <c>AddGranitCookies()</c> call)</item>
+    /// <item><see cref="ICookieDefinitionContributor"/> implementations registered by modules</item>
+    /// </list>
+    /// </remarks>
     public static IServiceCollection AddGranitCookies(
         this IServiceCollection services,
         Action<GranitCookiesBuilder> configure)
@@ -26,16 +37,40 @@ public static class CookiesServiceCollectionExtensions
             .ValidateDataAnnotations()
             .ValidateOnStart();
 
-        CookieRegistry registry = new();
         GranitCookiesBuilder builder = new(services);
         configure(builder);
 
+        // Additive registration — each call accumulates its definitions.
+        // GetServices<CookieDefinition>() collects them all at resolution time.
         foreach (CookieDefinition definition in builder.CookieDefinitions)
         {
-            registry.Register(definition);
+            services.AddSingleton(definition);
         }
 
-        services.TryAddSingleton<ICookieRegistry>(registry);
+        // Lazy factory — collects ALL definitions + contributors after DI build.
+        // TryAddSingleton ensures only the first factory wins, but it sees everything
+        // because GetServices<T>() returns all registrations regardless of call order.
+        services.TryAddSingleton<ICookieRegistry>(sp =>
+        {
+            CookieRegistry registry = new();
+
+            foreach (CookieDefinition definition in sp.GetServices<CookieDefinition>())
+            {
+                registry.Register(definition);
+            }
+
+            foreach (ICookieDefinitionContributor contributor in
+                sp.GetServices<ICookieDefinitionContributor>())
+            {
+                foreach (CookieDefinition definition in contributor.GetCookieDefinitions())
+                {
+                    registry.Register(definition);
+                }
+            }
+
+            return registry;
+        });
+
         services.TryAddScoped<IConsentResolver, NullConsentResolver>();
         services.TryAddSingleton<IGlobalPrivacyControlSignal, GlobalPrivacyControlHeaderSignal>();
         services.TryAddScoped<ICookieConsentModelProvider, NullCookieConsentModelProvider>();

--- a/src/Granit.Http.Cookies/GranitHttpCookiesModule.cs
+++ b/src/Granit.Http.Cookies/GranitHttpCookiesModule.cs
@@ -1,10 +1,16 @@
+using Granit.Http.Cookies.Extensions;
 using Granit.Modularity;
 
 namespace Granit.Http.Cookies;
 
 /// <summary>
 /// Granit module for RGPD-compliant cookie management.
-/// Registration is done via <c>AddGranitCookies()</c> because it requires
-/// an <see cref="System.Action{GranitCookiesBuilder}"/> for cookie declarations.
+/// Ensures the cookie infrastructure (registry, manager, consent resolver) is available
+/// even if the application host does not call <c>AddGranitCookies()</c> explicitly.
 /// </summary>
-public sealed class GranitHttpCookiesModule : GranitModule;
+public sealed class GranitHttpCookiesModule : GranitModule
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.AddGranitCookies(_ => { });
+}

--- a/src/Granit.Http.Cookies/ICookieDefinitionContributor.cs
+++ b/src/Granit.Http.Cookies/ICookieDefinitionContributor.cs
@@ -1,0 +1,26 @@
+namespace Granit.Http.Cookies;
+
+/// <summary>
+/// Contributes cookie definitions to the <see cref="ICookieRegistry"/> at startup.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implement this interface in each Granit module that introduces cookies
+/// (either set directly or set by ASP.NET Core middleware the module configures).
+/// Contributors are discovered from DI and executed during registry construction.
+/// </para>
+/// <para>
+/// Implementations must be <b>idempotent</b>: the same definitions must be returned
+/// on every call. Register implementations as singletons:
+/// <code>
+/// services.AddSingleton&lt;ICookieDefinitionContributor, IdentityCookieContributor&gt;();
+/// </code>
+/// </para>
+/// </remarks>
+public interface ICookieDefinitionContributor
+{
+    /// <summary>
+    /// Returns the cookie definitions this module introduces.
+    /// </summary>
+    IEnumerable<CookieDefinition> GetCookieDefinitions();
+}

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Granit.OpenIddict.EntityFrameworkCore.csproj
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Granit.OpenIddict.EntityFrameworkCore.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.Encryption\Granit.Encryption.csproj" />
+    <ProjectReference Include="..\Granit.Http.Cookies\Granit.Http.Cookies.csproj" />
     <ProjectReference Include="..\Granit.Identity.Local\Granit.Identity.Local.csproj" />
     <ProjectReference Include="..\Granit.MultiTenancy\Granit.MultiTenancy.csproj" />
     <ProjectReference Include="..\Granit.OpenIddict.Server\Granit.OpenIddict.Server.csproj" />

--- a/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
@@ -1,4 +1,5 @@
 using Granit.Encryption;
+using Granit.Http.Cookies;
 using Granit.Identity.Local;
 using Granit.Identity.Local.Options;
 using Granit.Identity.Local.Services;
@@ -55,6 +56,7 @@ public sealed class GranitOpenIddictEntityFrameworkCoreModule : GranitModule
             .BindConfiguration(GranitPasskeyOptions.SectionName);
 
         context.Services.AddTransient<IDataSeedContributor, OpenIddictSeedContributor>();
+        context.Services.AddSingleton<ICookieDefinitionContributor, IdentityCookieDefinitionContributor>();
 
         context.Services.TryAddScoped<ILocalIdentityGroupStore, OpenIddictGroupStore>();
         context.Services.TryAddScoped<ExternalClaimsMapper>();

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/IdentityCookieDefinitionContributor.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/IdentityCookieDefinitionContributor.cs
@@ -1,0 +1,44 @@
+using Granit.Http.Cookies;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Contributes ASP.NET Core Identity cookie definitions to the Granit cookie registry.
+/// Reads actual cookie names from <see cref="CookieAuthenticationOptions"/> to support
+/// application-level overrides via <c>ConfigureApplicationCookie()</c>.
+/// </summary>
+internal sealed class IdentityCookieDefinitionContributor(
+    IOptionsMonitor<CookieAuthenticationOptions> cookieOptions) : ICookieDefinitionContributor
+{
+    /// <inheritdoc/>
+    public IEnumerable<CookieDefinition> GetCookieDefinitions()
+    {
+        yield return CreateDefinition(
+            IdentityConstants.ApplicationScheme,
+            ".AspNetCore.Identity.Application",
+            "ASP.NET Core Identity authentication session.");
+
+        yield return CreateDefinition(
+            IdentityConstants.TwoFactorUserIdScheme,
+            ".AspNetCore.Identity.TwoFactorUserId",
+            "Temporary cookie for two-factor authentication flow.");
+
+        yield return CreateDefinition(
+            IdentityConstants.ExternalScheme,
+            ".AspNetCore.Identity.ExternalLogin",
+            "Temporary cookie for external login correlation.");
+    }
+
+    private CookieDefinition CreateDefinition(string scheme, string fallbackName, string purpose)
+    {
+        string name = cookieOptions.Get(scheme).Cookie.Name ?? fallbackName;
+
+        return new CookieDefinition(name, CookieCategory.StrictlyNecessary, 1, true, purpose)
+        {
+            IsEssential = true,
+        };
+    }
+}

--- a/src/Granit.OpenIddict.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/packages.lock.json
@@ -319,6 +319,12 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
+      "granit.http.cookies": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.http.exceptionhandling": {
         "type": "Project",
         "dependencies": {

--- a/tests/Granit.Http.Cookies.Tests/CookieDefinitionContributorTests.cs
+++ b/tests/Granit.Http.Cookies.Tests/CookieDefinitionContributorTests.cs
@@ -1,0 +1,132 @@
+using Granit.Http.Cookies.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Http.Cookies.Tests;
+
+public sealed class CookieDefinitionContributorTests
+{
+    [Fact]
+    public void AddGranitCookies_WithContributor_RegistersContributorCookies()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<ICookieDefinitionContributor, TestContributor>();
+        services.AddGranitCookies(_ => { });
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        ICookieRegistry registry = provider.GetRequiredService<ICookieRegistry>();
+
+        registry.IsRegistered("contributor_cookie").ShouldBeTrue();
+        registry.GetDefinition("contributor_cookie")!.Category.ShouldBe(CookieCategory.StrictlyNecessary);
+    }
+
+    [Fact]
+    public void AddGranitCookies_ContributorAndBuilder_MergeBothSources()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<ICookieDefinitionContributor, TestContributor>();
+        services.AddGranitCookies(cookies =>
+        {
+            cookies.RegisterCookie(new("builder_cookie", CookieCategory.Analytics, 365, false, "From builder"));
+        });
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        ICookieRegistry registry = provider.GetRequiredService<ICookieRegistry>();
+
+        registry.IsRegistered("contributor_cookie").ShouldBeTrue();
+        registry.IsRegistered("builder_cookie").ShouldBeTrue();
+        registry.GetAll().Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void AddGranitCookies_MultipleContributors_RegistersAll()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<ICookieDefinitionContributor, TestContributor>();
+        services.AddSingleton<ICookieDefinitionContributor, AnotherContributor>();
+        services.AddGranitCookies(_ => { });
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        ICookieRegistry registry = provider.GetRequiredService<ICookieRegistry>();
+
+        registry.IsRegistered("contributor_cookie").ShouldBeTrue();
+        registry.IsRegistered("another_cookie").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AddGranitCookies_MultipleCalls_AccumulateDefinitions()
+    {
+        ServiceCollection services = new();
+        services.AddGranitCookies(cookies =>
+        {
+            cookies.RegisterCookie(new("first", CookieCategory.StrictlyNecessary, 1, true, "First"));
+        });
+        services.AddGranitCookies(cookies =>
+        {
+            cookies.RegisterCookie(new("second", CookieCategory.Analytics, 365, false, "Second"));
+        });
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        ICookieRegistry registry = provider.GetRequiredService<ICookieRegistry>();
+
+        registry.IsRegistered("first").ShouldBeTrue();
+        registry.IsRegistered("second").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AddGranitCookies_ContributorRegisteredAfterAddGranitCookies_StillDiscovered()
+    {
+        ServiceCollection services = new();
+        services.AddGranitCookies(_ => { });
+        services.AddSingleton<ICookieDefinitionContributor, TestContributor>();
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        ICookieRegistry registry = provider.GetRequiredService<ICookieRegistry>();
+
+        registry.IsRegistered("contributor_cookie").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AddGranitCookies_DuplicateFromContributorAndBuilder_IsIdempotent()
+    {
+        CookieDefinition shared = new("shared_cookie", CookieCategory.StrictlyNecessary, 1, true, "Shared");
+
+        ServiceCollection services = new();
+        services.AddSingleton<ICookieDefinitionContributor>(new StaticContributor(shared));
+        services.AddGranitCookies(cookies =>
+        {
+            cookies.RegisterCookie(shared);
+        });
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        ICookieRegistry registry = provider.GetRequiredService<ICookieRegistry>();
+
+        registry.IsRegistered("shared_cookie").ShouldBeTrue();
+        registry.GetAll().Count.ShouldBe(1);
+    }
+
+    private sealed class TestContributor : ICookieDefinitionContributor
+    {
+        public IEnumerable<CookieDefinition> GetCookieDefinitions()
+        {
+            yield return new("contributor_cookie", CookieCategory.StrictlyNecessary, 1, true, "From contributor");
+        }
+    }
+
+    private sealed class AnotherContributor : ICookieDefinitionContributor
+    {
+        public IEnumerable<CookieDefinition> GetCookieDefinitions()
+        {
+            yield return new("another_cookie", CookieCategory.Preferences, 180, true, "Another contributor");
+        }
+    }
+
+    private sealed class StaticContributor(CookieDefinition definition) : ICookieDefinitionContributor
+    {
+        public IEnumerable<CookieDefinition> GetCookieDefinitions()
+        {
+            yield return definition;
+        }
+    }
+}

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/Granit.OpenIddict.EntityFrameworkCore.Tests.csproj
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/Granit.OpenIddict.EntityFrameworkCore.Tests.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Http.Cookies\Granit.Http.Cookies.csproj" />
     <ProjectReference Include="..\..\src\Granit.OpenIddict.EntityFrameworkCore\Granit.OpenIddict.EntityFrameworkCore.csproj" />
   </ItemGroup>
 

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/IdentityCookieDefinitionContributorTests.cs
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/IdentityCookieDefinitionContributorTests.cs
@@ -1,0 +1,110 @@
+using Granit.Http.Cookies;
+using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+
+public sealed class IdentityCookieDefinitionContributorTests
+{
+    [Fact]
+    public void GetCookieDefinitions_ReturnsThreeIdentityCookies()
+    {
+        IOptionsMonitor<CookieAuthenticationOptions> monitor = CreateOptionsMonitor();
+        IdentityCookieDefinitionContributor sut = new(monitor);
+
+        var definitions = sut.GetCookieDefinitions().ToList();
+
+        definitions.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public void GetCookieDefinitions_AllAreStrictlyNecessary()
+    {
+        IOptionsMonitor<CookieAuthenticationOptions> monitor = CreateOptionsMonitor();
+        IdentityCookieDefinitionContributor sut = new(monitor);
+
+        var definitions = sut.GetCookieDefinitions().ToList();
+
+        definitions.ShouldAllBe(d => d.Category == CookieCategory.StrictlyNecessary);
+    }
+
+    [Fact]
+    public void GetCookieDefinitions_AllAreEssentialAndHttpOnly()
+    {
+        IOptionsMonitor<CookieAuthenticationOptions> monitor = CreateOptionsMonitor();
+        IdentityCookieDefinitionContributor sut = new(monitor);
+
+        var definitions = sut.GetCookieDefinitions().ToList();
+
+        definitions.ShouldAllBe(d => d.IsEssential && d.IsHttpOnly);
+    }
+
+    [Fact]
+    public void GetCookieDefinitions_UsesDefaultCookieNames()
+    {
+        IOptionsMonitor<CookieAuthenticationOptions> monitor = CreateOptionsMonitor();
+        IdentityCookieDefinitionContributor sut = new(monitor);
+
+        var definitions = sut.GetCookieDefinitions().ToList();
+
+        definitions.Select(d => d.Name).ShouldBe(
+        [
+            ".AspNetCore.Identity.Application",
+            ".AspNetCore.Identity.TwoFactorUserId",
+            ".AspNetCore.Identity.ExternalLogin",
+        ]);
+    }
+
+    [Fact]
+    public void GetCookieDefinitions_RespectsCustomCookieName()
+    {
+        IOptionsMonitor<CookieAuthenticationOptions> monitor = CreateOptionsMonitor(
+            applicationCookieName: "Custom.Auth.Session");
+        IdentityCookieDefinitionContributor sut = new(monitor);
+
+        var definitions = sut.GetCookieDefinitions().ToList();
+
+        definitions[0].Name.ShouldBe("Custom.Auth.Session");
+    }
+
+    [Fact]
+    public void GetCookieDefinitions_NullCookieName_UsesFallback()
+    {
+        IOptionsMonitor<CookieAuthenticationOptions> monitor = CreateOptionsMonitor(applicationCookieName: null);
+        IdentityCookieDefinitionContributor sut = new(monitor);
+
+        var definitions = sut.GetCookieDefinitions().ToList();
+
+        definitions[0].Name.ShouldBe(".AspNetCore.Identity.Application");
+    }
+
+    private static IOptionsMonitor<CookieAuthenticationOptions> CreateOptionsMonitor(
+        string? applicationCookieName = ".AspNetCore.Identity.Application",
+        string? twoFactorCookieName = ".AspNetCore.Identity.TwoFactorUserId",
+        string? externalCookieName = ".AspNetCore.Identity.ExternalLogin")
+    {
+        IOptionsMonitor<CookieAuthenticationOptions> monitor = Substitute.For<IOptionsMonitor<CookieAuthenticationOptions>>();
+
+        monitor.Get(IdentityConstants.ApplicationScheme).Returns(BuildOptions(applicationCookieName));
+        monitor.Get(IdentityConstants.TwoFactorUserIdScheme).Returns(BuildOptions(twoFactorCookieName));
+        monitor.Get(IdentityConstants.ExternalScheme).Returns(BuildOptions(externalCookieName));
+
+        return monitor;
+
+        static CookieAuthenticationOptions BuildOptions(string? cookieName)
+        {
+            CookieAuthenticationOptions options = new();
+            if (cookieName is not null)
+            {
+                options.Cookie.Name = cookieName;
+            }
+
+            return options;
+        }
+    }
+}

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
@@ -486,6 +486,12 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
+      "granit.http.cookies": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.http.exceptionhandling": {
         "type": "Project",
         "dependencies": {
@@ -527,6 +533,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.OpenIddict.Server": "[0.1.0-dev, )",


### PR DESCRIPTION
## Summary

- Introduce `ICookieDefinitionContributor` discovery pattern (modeled after `IDataSeedContributor`) so Granit modules auto-declare their cookies in `ICookieRegistry`
- Refactor `AddGranitCookies()` to use a lazy factory that collects definitions from both builder callbacks and contributors at first resolution — order-independent
- `IdentityCookieDefinitionContributor` in `Granit.OpenIddict.EntityFrameworkCore` auto-registers the 3 ASP.NET Core Identity cookies, reading actual names via `IOptionsMonitor<CookieAuthenticationOptions>` to support `ConfigureApplicationCookie()` overrides
- `KlaroCookieDefinitionContributor` in `Granit.Http.Cookies.Klaro` auto-registers the consent cookie for GDPR audit transparency

## Changes

| File | Action |
| ---- | ------ |
| `Granit.Http.Cookies/ICookieDefinitionContributor.cs` | NEW — contributor interface |
| `Granit.Http.Cookies/Extensions/CookiesServiceCollectionExtensions.cs` | Refactor — lazy factory registry |
| `Granit.Http.Cookies/GranitHttpCookiesModule.cs` | Activate `ConfigureServices` as safety net |
| `Granit.OpenIddict.EntityFrameworkCore/Internal/IdentityCookieDefinitionContributor.cs` | NEW — Identity cookies contributor |
| `Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs` | Register contributor |
| `Granit.Http.Cookies.Klaro/Internal/KlaroCookieDefinitionContributor.cs` | NEW — Klaro cookie contributor |
| `Granit.Bff.Endpoints/GranitBffEndpointsModule.cs` | Remove redundant `AddGranitCookies(_ => { })` |
| `docs-site/.../cookies/index.mdx` | Document auto-registration and contributor pattern |

## Test plan

- [x] `Granit.Http.Cookies.Tests` — 64 passed (6 new contributor discovery tests)
- [x] `Granit.Http.Cookies.Klaro.Tests` — 19 passed
- [x] `Granit.OpenIddict.EntityFrameworkCore.Tests` — 165 passed (6 new Identity contributor tests)
- [x] `Granit.Bff.Endpoints.Tests` — 82 passed
- [ ] CI shard run (security + api-data shards)
