### PR TITLE
fix(templating): GET /layouts returns DB-assigned layout names

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -28241,6 +28241,12 @@
           "kind": "method",
           "signature": "GetHistoryAsync(TemplateKey key, CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyList<TemplateRevision>>"
+        },
+        {
+          "name": "GetDistinctLayoutNamesAsync",
+          "kind": "method",
+          "signature": "GetDistinctLayoutNamesAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<string>>"
         }
       ]
     },

--- a/src/Granit.Templating.Endpoints/Extensions/TemplatingEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Templating.Endpoints/Extensions/TemplatingEndpointRouteBuilderExtensions.cs
@@ -1152,19 +1152,29 @@ public static class TemplatingEndpointRouteBuilderExtensions
     // GET /layouts — List available layouts
     // -------------------------------------------------------------------------
 
-    private static Task<Ok<IReadOnlyList<string>>> HandleListLayoutsAsync(
+    private static async Task<Ok<IReadOnlyList<string>>> HandleListLayoutsAsync(
         HttpContext context,
         CancellationToken cancellationToken)
     {
         ILayoutRegistry? layoutRegistry = context.RequestServices.GetService<ILayoutRegistry>();
+        IDocumentTemplateStoreReader? storeReader = context.RequestServices.GetService<IDocumentTemplateStoreReader>();
 
-        // Collect layout names from the code-level registry
-        List<string> layouts = layoutRegistry?.GetAllLayoutNames().ToList() ?? [];
+        // Merge layout names from code registry + DB store, deduplicated
+        HashSet<string> layouts = new(layoutRegistry?.GetAllLayoutNames() ?? [], StringComparer.Ordinal);
 
-        // TODO: Add DISTINCT LayoutName from DB store when IDocumentTemplateStoreReader
-        // exposes a GetDistinctLayoutNamesAsync method. For now, code registry is sufficient.
+        if (storeReader is not null)
+        {
+            IReadOnlyList<string> dbLayouts = await storeReader
+                .GetDistinctLayoutNamesAsync(cancellationToken).ConfigureAwait(false);
 
-        return Task.FromResult(TypedResults.Ok<IReadOnlyList<string>>(layouts));
+            foreach (string name in dbLayouts)
+            {
+                layouts.Add(name);
+            }
+        }
+
+        IReadOnlyList<string> result = layouts.Order(StringComparer.Ordinal).ToList();
+        return TypedResults.Ok(result);
     }
 
     // -------------------------------------------------------------------------

--- a/src/Granit.Templating.EntityFrameworkCore/Internal/EfDocumentTemplateStore.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Internal/EfDocumentTemplateStore.cs
@@ -339,6 +339,19 @@ internal sealed class EfDocumentTemplateStore(
             .ToListAsync(cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<string>> GetDistinctLayoutNamesAsync(
+        CancellationToken cancellationToken = default)
+    {
+        await using TemplatingDbContext ctx = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        return await ctx.TemplateRevisions
+            .Where(r => r.LayoutName != null)
+            .Select(r => r.LayoutName!)
+            .Distinct()
+            .OrderBy(n => n)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
+
     private static TemplateRevision ToRevision(TemplateRevisionEntity entity) =>
         new()
         {

--- a/src/Granit.Templating/Store/IDocumentTemplateStoreReader.cs
+++ b/src/Granit.Templating/Store/IDocumentTemplateStoreReader.cs
@@ -43,4 +43,12 @@ public interface IDocumentTemplateStoreReader
     /// <param name="cancellationToken">Cancellation token.</param>
     Task<IReadOnlyList<TemplateRevision>> GetHistoryAsync(
         TemplateKey key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns all distinct non-null layout names assigned to templates in the store.
+    /// Used by admin endpoints to populate layout dropdowns.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IReadOnlyList<string>> GetDistinctLayoutNamesAsync(
+        CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary

- `GET /layouts` only returned code-level `ILayoutRegistry` names, ignoring admin-assigned `LayoutName` values stored in the database
- Add `GetDistinctLayoutNamesAsync()` to `IDocumentTemplateStoreReader` + EF Core implementation (`SELECT DISTINCT LayoutName WHERE NOT NULL`)
- Endpoint now merges code registry + DB results with `HashSet` deduplication
- Remove TODO comment left in production code

## Test plan

- [x] `Granit.Templating.Endpoints.Tests` — 122 passed
- [x] `Granit.Templating.EntityFrameworkCore.Tests` — 58 passed
