### PR TITLE
feat(notifications): add RFC 8058 List-Unsubscribe headers + sender naming cleanup

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18924,9 +18924,9 @@
           "returnType": "string"
         },
         {
-          "name": "FromAddress",
+          "name": "DefaultSenderEmail",
           "kind": "property",
-          "signature": "string? FromAddress",
+          "signature": "string? DefaultSenderEmail",
           "returnType": "string?"
         }
       ]
@@ -18978,10 +18978,10 @@
           "returnType": "string?"
         },
         {
-          "name": "TimeoutSeconds",
+          "name": "DefaultSenderName",
           "kind": "property",
-          "signature": "int TimeoutSeconds",
-          "returnType": "int"
+          "signature": "string? DefaultSenderName",
+          "returnType": "string?"
         }
       ]
     },
@@ -19050,15 +19050,15 @@
           "returnType": "string"
         },
         {
-          "name": "SenderAddress",
+          "name": "DefaultSenderEmail",
           "kind": "property",
-          "signature": "string SenderAddress",
+          "signature": "string DefaultSenderEmail",
           "returnType": "string"
         },
         {
-          "name": "SenderName",
+          "name": "DefaultSenderName",
           "kind": "property",
-          "signature": "string SenderName",
+          "signature": "string DefaultSenderName",
           "returnType": "string"
         }
       ]
@@ -19271,9 +19271,9 @@
           "returnType": "bool"
         },
         {
-          "name": "Username",
+          "name": "DefaultSenderEmail",
           "kind": "property",
-          "signature": "string? Username",
+          "signature": "string? DefaultSenderEmail",
           "returnType": "string?"
         }
       ]

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19036,6 +19036,15 @@
       ]
     },
     {
+      "name": "NotificationsEmailLocalizationResource",
+      "fqn": "Granit.Notifications.Email.NotificationsEmailLocalizationResource",
+      "kind": "class",
+      "project": "Granit.Notifications.Email",
+      "file": "src/Granit.Notifications.Email/NotificationsEmailLocalizationResource.cs",
+      "line": 11,
+      "members": []
+    },
+    {
       "name": "EmailChannelOptions",
       "fqn": "Granit.Notifications.Email.Options.EmailChannelOptions",
       "kind": "class",

--- a/src/Granit.Notifications.Brevo/Internal/BrevoNotificationProvider.cs
+++ b/src/Granit.Notifications.Brevo/Internal/BrevoNotificationProvider.cs
@@ -33,17 +33,20 @@ internal sealed partial class BrevoNotificationProvider(
         BrevoOptions opts = options.CurrentValue;
         HttpClient client = httpClientFactory.CreateClient("Brevo");
 
+        var to = new { email = message.To, name = message.ToName };
+
         object payload = new
         {
             sender = new
             {
-                email = message.FromOverride ?? opts.DefaultSenderEmail,
-                name = opts.DefaultSenderName,
+                email = message.FromEmailOverride ?? opts.DefaultSenderEmail,
+                name = message.FromNameOverride ?? opts.DefaultSenderName,
             },
-            to = new[] { new { email = message.To } },
+            to = new[] { to },
             subject = message.Subject,
             htmlContent = message.HtmlBody,
             textContent = message.PlainTextBody,
+            headers = message.Headers,
         };
 
         using HttpResponseMessage response = await client.PostAsJsonAsync(

--- a/src/Granit.Notifications.Email.AwsSes/Internal/AwsSesEmailSender.cs
+++ b/src/Granit.Notifications.Email.AwsSes/Internal/AwsSesEmailSender.cs
@@ -29,7 +29,13 @@ internal sealed partial class AwsSesEmailSender(
             NotificationsEmailAwsSesActivitySource.Operations.SendEmail);
         activity?.SetTag(NotificationsEmailAwsSesActivitySource.Tags.Region, ses.Region);
 
-        string fromAddress = message.FromOverride ?? ses.FromAddress ?? "noreply@localhost";
+        string fromEmail = message.FromEmailOverride ?? ses.DefaultSenderEmail ?? "noreply@localhost";
+        string? fromName = message.FromNameOverride ?? ses.DefaultSenderName;
+
+        // SES v2 uses RFC 5322 formatted From (e.g. "Display Name <email@example.com>")
+        string fromAddress = !string.IsNullOrEmpty(fromName)
+            ? $"\"{fromName}\" <{fromEmail}>"
+            : fromEmail;
 
         EmailContent content = new()
         {
@@ -40,6 +46,7 @@ internal sealed partial class AwsSesEmailSender(
                 {
                     Html = new Content { Data = message.HtmlBody },
                 },
+                Headers = BuildMessageHeaders(message.Headers),
             },
         };
 
@@ -64,6 +71,22 @@ internal sealed partial class AwsSesEmailSender(
         await transport.SendEmailAsync(request, cancellationToken).ConfigureAwait(false);
 
         LogEmailSent(LogRedaction.Email(message.To), ses.Region);
+    }
+
+    private static List<MessageHeader>? BuildMessageHeaders(IReadOnlyDictionary<string, string>? headers)
+    {
+        if (headers is null || headers.Count == 0)
+        {
+            return null;
+        }
+
+        List<MessageHeader> result = new(headers.Count);
+        foreach (KeyValuePair<string, string> header in headers)
+        {
+            result.Add(new MessageHeader { Name = header.Key, Value = header.Value });
+        }
+
+        return result;
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "SES email sent to {RedactedRecipient} via {Region}")]

--- a/src/Granit.Notifications.Email.AwsSes/Options/AwsSesOptions.cs
+++ b/src/Granit.Notifications.Email.AwsSes/Options/AwsSesOptions.cs
@@ -13,7 +13,10 @@ public sealed class AwsSesOptions
     public string Region { get; set; } = string.Empty;
 
     /// <summary>Default sender email address (must be verified in SES).</summary>
-    public string? FromAddress { get; set; }
+    public string? DefaultSenderEmail { get; set; }
+
+    /// <summary>Default sender display name.</summary>
+    public string? DefaultSenderName { get; set; }
 
     /// <summary>Optional SES configuration set name for tracking (bounces, complaints).</summary>
     public string? ConfigurationSetName { get; set; }

--- a/src/Granit.Notifications.Email.AzureCommunicationServices/HealthChecks/AcsEmailHealthCheck.cs
+++ b/src/Granit.Notifications.Email.AzureCommunicationServices/HealthChecks/AcsEmailHealthCheck.cs
@@ -37,7 +37,7 @@ internal sealed class AcsEmailHealthCheck(IOptions<AcsEmailOptions> options) : I
             // The service will reject it, but a successful rejection proves the endpoint is reachable.
             // We catch the expected RequestFailedException to confirm connectivity.
             var testMessage = new Azure.Communication.Email.EmailMessage(
-                opts.SenderAddress,
+                opts.DefaultSenderEmail,
                 "healthcheck@localhost",
                 new EmailContent("healthcheck"));
 

--- a/src/Granit.Notifications.Email.AzureCommunicationServices/Internal/AcsEmailSender.cs
+++ b/src/Granit.Notifications.Email.AzureCommunicationServices/Internal/AcsEmailSender.cs
@@ -42,9 +42,9 @@ internal sealed partial class AcsEmailSender(
 
         string? senderName = message.FromNameOverride ?? opts.DefaultSenderName;
 
-        // ACS uses "Display Name <email>" format for sender
+        // ACS uses RFC 5322 formatted From (e.g. "Display Name <email@example.com>")
         string formattedSender = !string.IsNullOrEmpty(senderName)
-            ? $"{senderName} <{senderAddress}>"
+            ? $"\"{senderName}\" <{senderAddress}>"
             : senderAddress;
 
         var acsMessage = new Azure.Communication.Email.EmailMessage(

--- a/src/Granit.Notifications.Email.AzureCommunicationServices/Internal/AcsEmailSender.cs
+++ b/src/Granit.Notifications.Email.AzureCommunicationServices/Internal/AcsEmailSender.cs
@@ -28,7 +28,7 @@ internal sealed partial class AcsEmailSender(
             NotificationsEmailAcsActivitySource.Tags.SubjectLength,
             message.Subject.Length);
 
-        string senderAddress = message.FromOverride ?? opts.SenderAddress;
+        string senderAddress = message.FromEmailOverride ?? opts.DefaultSenderEmail;
 
         var emailContent = new Azure.Communication.Email.EmailContent(message.Subject)
         {
@@ -40,10 +40,26 @@ internal sealed partial class AcsEmailSender(
             emailContent.PlainText = message.PlainTextBody;
         }
 
+        string? senderName = message.FromNameOverride ?? opts.DefaultSenderName;
+
+        // ACS uses "Display Name <email>" format for sender
+        string formattedSender = !string.IsNullOrEmpty(senderName)
+            ? $"{senderName} <{senderAddress}>"
+            : senderAddress;
+
         var acsMessage = new Azure.Communication.Email.EmailMessage(
-            senderAddress,
+            formattedSender,
             message.To,
             emailContent);
+
+        // Custom headers (e.g. List-Unsubscribe)
+        if (message.Headers is not null)
+        {
+            foreach (KeyValuePair<string, string> header in message.Headers)
+            {
+                acsMessage.Headers.Add(header.Key, header.Value);
+            }
+        }
 
         await transport.SendAsync(acsMessage, cancellationToken).ConfigureAwait(false);
 

--- a/src/Granit.Notifications.Email.AzureCommunicationServices/Options/AcsEmailOptions.cs
+++ b/src/Granit.Notifications.Email.AzureCommunicationServices/Options/AcsEmailOptions.cs
@@ -23,7 +23,10 @@ public sealed class AcsEmailOptions
 
     /// <summary>Default sender email address (must be verified in ACS). Required.</summary>
     [Required]
-    public string SenderAddress { get; set; } = string.Empty;
+    public string DefaultSenderEmail { get; set; } = string.Empty;
+
+    /// <summary>Default sender display name.</summary>
+    public string? DefaultSenderName { get; set; }
 
     /// <summary>Send timeout in seconds. Default: 30.</summary>
     [Range(1, 300)]

--- a/src/Granit.Notifications.Email.AzureCommunicationServices/Options/AcsEmailOptionsValidator.cs
+++ b/src/Granit.Notifications.Email.AzureCommunicationServices/Options/AcsEmailOptionsValidator.cs
@@ -8,9 +8,9 @@ internal sealed class AcsEmailOptionsValidator : IValidateOptions<AcsEmailOption
     /// <inheritdoc />
     public ValidateOptionsResult Validate(string? name, AcsEmailOptions options)
     {
-        if (string.IsNullOrWhiteSpace(options.SenderAddress))
+        if (string.IsNullOrWhiteSpace(options.DefaultSenderEmail))
         {
-            return ValidateOptionsResult.Fail("AcsEmailOptions.SenderAddress is required.");
+            return ValidateOptionsResult.Fail("AcsEmailOptions.DefaultSenderEmail is required.");
         }
 
         if (string.IsNullOrWhiteSpace(options.ConnectionString) &&

--- a/src/Granit.Notifications.Email.AzureCommunicationServices/README.md
+++ b/src/Granit.Notifications.Email.AzureCommunicationServices/README.md
@@ -17,7 +17,7 @@ dotnet add package Granit.Notifications.Email.AzureCommunicationServices
   "AzureCommunicationServices": {
     "Email": {
       "ConnectionString": "endpoint=https://my-acs.communication.azure.com/;accesskey=...",
-      "SenderAddress": "noreply@example.com",
+      "DefaultSenderEmail": "noreply@example.com",
       "TimeoutSeconds": 30
     }
   }
@@ -31,7 +31,7 @@ When deployed on Azure (AKS, App Service, Container Apps), use `Endpoint` instea
   "AzureCommunicationServices": {
     "Email": {
       "Endpoint": "https://my-acs.communication.azure.com",
-      "SenderAddress": "noreply@example.com"
+      "DefaultSenderEmail": "noreply@example.com"
     }
   }
 }

--- a/src/Granit.Notifications.Email.Scaleway/Internal/ScalewayEmailSender.cs
+++ b/src/Granit.Notifications.Email.Scaleway/Internal/ScalewayEmailSender.cs
@@ -33,21 +33,24 @@ internal sealed partial class ScalewayEmailSender(
         using Activity? activity = NotificationsEmailScalewayActivitySource.Source.StartActivity(
             NotificationsEmailScalewayActivitySource.Operations.Send);
 
-        string fromEmail = message.FromOverride ?? opts.DefaultSenderEmail;
-        string fromName = opts.DefaultSenderName;
+        string fromEmail = message.FromEmailOverride ?? opts.DefaultSenderEmail;
+        string fromName = message.FromNameOverride ?? opts.DefaultSenderName;
 
         object? textField = message.PlainTextBody is not null
             ? message.PlainTextBody
             : null;
 
+        var to = new { email = message.To, name = message.ToName };
+
         object payload = new
         {
             from = new { email = fromEmail, name = fromName },
-            to = new[] { new { email = message.To } },
+            to = new[] { to },
             subject = message.Subject,
             html = message.HtmlBody,
             text = textField,
             project_id = opts.ProjectId,
+            additional_headers = message.Headers,
         };
 
         using HttpClient client = httpClientFactory.CreateClient("Scaleway");

--- a/src/Granit.Notifications.Email.SendGrid/Internal/SendGridEmailSender.cs
+++ b/src/Granit.Notifications.Email.SendGrid/Internal/SendGridEmailSender.cs
@@ -33,8 +33,8 @@ internal sealed partial class SendGridEmailSender(
         using Activity? activity = NotificationsEmailSendGridActivitySource.Source.StartActivity(
             NotificationsEmailSendGridActivitySource.Operations.Send);
 
-        string fromEmail = message.FromOverride ?? opts.DefaultSenderEmail;
-        string fromName = opts.DefaultSenderName;
+        string fromEmail = message.FromEmailOverride ?? opts.DefaultSenderEmail;
+        string fromName = message.FromNameOverride ?? opts.DefaultSenderName;
 
         List<object> content = [new { type = "text/html", value = message.HtmlBody }];
 
@@ -43,12 +43,15 @@ internal sealed partial class SendGridEmailSender(
             content.Insert(0, new { type = "text/plain", value = message.PlainTextBody });
         }
 
+        var to = new { email = message.To, name = message.ToName };
+
         object payload = new
         {
-            personalizations = new[] { new { to = new[] { new { email = message.To } } } },
+            personalizations = new[] { new { to = new[] { to } } },
             from = new { email = fromEmail, name = fromName },
             subject = message.Subject,
             content,
+            headers = message.Headers,
         };
 
         using HttpClient client = httpClientFactory.CreateClient("SendGrid");

--- a/src/Granit.Notifications.Email.Smtp/Internal/MailKitEmailSender.cs
+++ b/src/Granit.Notifications.Email.Smtp/Internal/MailKitEmailSender.cs
@@ -24,12 +24,31 @@ internal sealed partial class MailKitEmailSender(
         SmtpOptions smtp = options.CurrentValue;
         int timeoutMs = smtp.TimeoutSeconds * 1000;
 
+        string fromEmail = message.FromEmailOverride ?? smtp.DefaultSenderEmail ?? smtp.Username ?? "noreply@localhost";
+        string fromName = message.FromNameOverride ?? smtp.DefaultSenderName ?? fromEmail;
+
         MimeMessage mimeMessage = new();
-        mimeMessage.From.Add(new MailboxAddress(
-            message.FromOverride ?? smtp.Username ?? "noreply",
-            message.FromOverride ?? smtp.Username ?? "noreply@localhost"));
-        mimeMessage.To.Add(MailboxAddress.Parse(message.To));
+        mimeMessage.From.Add(new MailboxAddress(fromName, fromEmail));
+
+        if (message.ToName is not null)
+        {
+            mimeMessage.To.Add(new MailboxAddress(message.ToName, message.To));
+        }
+        else
+        {
+            mimeMessage.To.Add(MailboxAddress.Parse(message.To));
+        }
+
         mimeMessage.Subject = message.Subject;
+
+        // Custom headers (e.g. List-Unsubscribe)
+        if (message.Headers is not null)
+        {
+            foreach (KeyValuePair<string, string> header in message.Headers)
+            {
+                mimeMessage.Headers.Add(header.Key, header.Value);
+            }
+        }
 
         BodyBuilder bodyBuilder = new()
         {

--- a/src/Granit.Notifications.Email.Smtp/Options/SmtpOptions.cs
+++ b/src/Granit.Notifications.Email.Smtp/Options/SmtpOptions.cs
@@ -17,6 +17,12 @@ public sealed class SmtpOptions
     /// <summary>Whether to use SSL/TLS.</summary>
     public bool UseSsl { get; set; } = true;
 
+    /// <summary>Default sender email address. Falls back to <see cref="Username"/> if not set.</summary>
+    public string? DefaultSenderEmail { get; set; }
+
+    /// <summary>Default sender display name.</summary>
+    public string? DefaultSenderName { get; set; }
+
     /// <summary>SMTP authentication username.</summary>
     public string? Username { get; set; }
 

--- a/src/Granit.Notifications.Email/EmailMessage.cs
+++ b/src/Granit.Notifications.Email/EmailMessage.cs
@@ -1,6 +1,6 @@
 namespace Granit.Notifications.Email;
 
-/// <summary>Email message to send.</summary>
+/// <summary>Email message to send via an <see cref="IEmailSender"/> provider.</summary>
 public sealed record EmailMessage
 {
     /// <summary>Recipient email address.</summary>
@@ -15,6 +15,18 @@ public sealed record EmailMessage
     /// <summary>Optional plain text fallback body.</summary>
     public string? PlainTextBody { get; init; }
 
-    /// <summary>Optional sender address override.</summary>
-    public string? FromOverride { get; init; }
+    /// <summary>Optional recipient display name (e.g. "John Doe").</summary>
+    public string? ToName { get; init; }
+
+    /// <summary>Optional sender email address override (takes precedence over provider defaults).</summary>
+    public string? FromEmailOverride { get; init; }
+
+    /// <summary>Optional sender display name override (takes precedence over provider defaults).</summary>
+    public string? FromNameOverride { get; init; }
+
+    /// <summary>
+    /// Custom email headers (e.g. <c>List-Unsubscribe</c>, <c>List-Unsubscribe-Post</c>).
+    /// <c>null</c> means no custom headers are added.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Headers { get; init; }
 }

--- a/src/Granit.Notifications.Email/Granit.Notifications.Email.csproj
+++ b/src/Granit.Notifications.Email/Granit.Notifications.Email.csproj
@@ -12,6 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Localization\**\*.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="Templates/Layout.Email.html"
         LogicalName="Granit.Notifications.Email.Templates.Layout.Email.html" />
     <EmbeddedResource Include="Templates/Notifications.Default.html"

--- a/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
+++ b/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
@@ -4,6 +4,7 @@ using Granit.Notifications.Email.Options;
 using Granit.Templating.Keys;
 using Granit.Templating.Layouts;
 using Granit.Templating.Pipeline;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -31,11 +32,17 @@ namespace Granit.Notifications.Email.Internal;
 /// stored in the database (<c>Granit.Templating.EntityFrameworkCore</c>), or
 /// any custom <see cref="ITemplateResolver"/>.
 /// </para>
+/// <para>
+/// When <see cref="INotificationDefinitionStore"/> is available and the notification
+/// has <c>AllowUserOptOut = true</c>, RFC 2369 / RFC 8058 List-Unsubscribe headers
+/// are injected into the <see cref="EmailMessage.Headers"/>.
+/// </para>
 /// </remarks>
 internal sealed partial class EmailNotificationChannel(
     IServiceProvider serviceProvider,
     IOptions<EmailChannelOptions> options,
     IRecipientResolver recipientResolver,
+    IConfiguration configuration,
     ILogger<EmailNotificationChannel> logger) : INotificationChannel
 {
     /// <summary>
@@ -58,17 +65,41 @@ internal sealed partial class EmailNotificationChannel(
             return;
         }
 
+        // Resolve notification metadata for opt-out and group info
+        INotificationDefinitionStore? defStore = serviceProvider.GetService<INotificationDefinitionStore>();
+        NotificationDefinition? definition = defStore?.Get(context.NotificationTypeName);
+        bool allowOptOut = definition?.AllowUserOptOut ?? true;
+
+        // Build List-Unsubscribe headers (RFC 2369 + RFC 8058) when opt-out is allowed
+        Dictionary<string, string>? headers = null;
+        string unsubscribeUrl = "";
+        if (allowOptOut)
+        {
+            unsubscribeUrl = ResolveUnsubscribeUrl();
+            if (unsubscribeUrl.Length > 0)
+            {
+                headers = new()
+                {
+                    ["List-Unsubscribe"] = $"<{unsubscribeUrl}>",
+                    ["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click",
+                };
+            }
+        }
+
+        // Build enrichment context for templates
+        EmailEnrichment enrichment = new(definition, allowOptOut, unsubscribeUrl);
+
         // Try type-specific template first, then fall back to the built-in default template
         RenderedEmail? rendered = await TryRenderTemplateAsync(
-                context.NotificationTypeName, context, cancellationToken).ConfigureAwait(false)
+                context.NotificationTypeName, context, enrichment, cancellationToken).ConfigureAwait(false)
             ?? await TryRenderTemplateAsync(
-                FallbackTemplateName, context, cancellationToken).ConfigureAwait(false);
+                FallbackTemplateName, context, enrichment, cancellationToken).ConfigureAwait(false);
 
         // Apply layout wrapping (two-pass: content was rendered above, now wrap in layout)
         if (rendered is not null)
         {
             rendered = await TryApplyLayoutAsync(
-                context.NotificationTypeName, rendered, context, cancellationToken).ConfigureAwait(false)
+                context.NotificationTypeName, rendered, context, enrichment, cancellationToken).ConfigureAwait(false)
                 ?? rendered;
         }
 
@@ -76,13 +107,34 @@ internal sealed partial class EmailNotificationChannel(
         string htmlBody = rendered?.Html
             ?? $"<p>{context.NotificationTypeName}</p>";
 
+        EmailChannelOptions opts = options.Value;
+
         await sender.SendAsync(new EmailMessage
         {
             To = recipient.Email,
+            ToName = recipient.DisplayName,
             Subject = subject,
             HtmlBody = htmlBody,
-            FromOverride = options.Value.SenderAddress,
+            FromEmailOverride = opts.DefaultSenderEmail,
+            FromNameOverride = opts.DefaultSenderName,
+            Headers = headers,
         }, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Resolves the unsubscribe URL from <see cref="EmailChannelOptions.UnsubscribeUrl"/>
+    /// or falls back to <c>{BaseUrl}/notifications/preferences</c>.
+    /// </summary>
+    private string ResolveUnsubscribeUrl()
+    {
+        string? url = options.Value.UnsubscribeUrl;
+        if (!string.IsNullOrEmpty(url))
+        {
+            return url;
+        }
+
+        string? baseUrl = configuration["Granit:Templating:App:BaseUrl"];
+        return string.IsNullOrEmpty(baseUrl) ? "" : baseUrl.TrimEnd('/') + "/notifications/preferences";
     }
 
     /// <summary>
@@ -91,7 +143,7 @@ internal sealed partial class EmailNotificationChannel(
     /// Returns <see langword="null"/> if no template is found or templating is not configured.
     /// </summary>
     private async Task<RenderedEmail?> TryRenderTemplateAsync(
-        string templateName, NotificationDeliveryContext context, CancellationToken cancellationToken)
+        string templateName, NotificationDeliveryContext context, EmailEnrichment enrichment, CancellationToken cancellationToken)
     {
         // Resolve ITemplateResolver chain (optional — not all apps have Granit.Templating)
         IEnumerable<ITemplateResolver>? resolvers = serviceProvider.GetService<IEnumerable<ITemplateResolver>>();
@@ -127,9 +179,9 @@ internal sealed partial class EmailNotificationChannel(
             return null;
         }
 
-        // Convert JsonElement data to Dictionary for Scriban rendering
+        // Convert JsonElement data to Dictionary for Scriban rendering + enrich with metadata
         Dictionary<string, object?> dataDict = JsonElementToDictionary(context.Data);
-        dataDict.TryAdd("notification_type", context.NotificationTypeName);
+        EnrichModelData(dataDict, context, enrichment);
 
         try
         {
@@ -165,6 +217,7 @@ internal sealed partial class EmailNotificationChannel(
         string templateName,
         RenderedEmail contentEmail,
         NotificationDeliveryContext context,
+        EmailEnrichment enrichment,
         CancellationToken cancellationToken)
     {
         // Resolve layout name from registry (code-level defaults)
@@ -223,7 +276,7 @@ internal sealed partial class EmailNotificationChannel(
         }
 
         Dictionary<string, object?> dataDict = JsonElementToDictionary(context.Data);
-        dataDict.TryAdd("notification_type", context.NotificationTypeName);
+        EnrichModelData(dataDict, context, enrichment);
 
         // Inject body as ExtraVariable for {{ body | raw }} in layout
         TemplateDescriptor layoutWithBody = new()
@@ -257,6 +310,27 @@ internal sealed partial class EmailNotificationChannel(
 
         return null;
     }
+
+    /// <summary>
+    /// Enriches the template model data with notification metadata for the footer.
+    /// Uses defensive defaults (empty string / false) to avoid null issues in Scriban.
+    /// </summary>
+    private static void EnrichModelData(
+        Dictionary<string, object?> dataDict,
+        NotificationDeliveryContext context,
+        EmailEnrichment enrichment)
+    {
+        dataDict.TryAdd("notification_type", context.NotificationTypeName);
+        dataDict.TryAdd("notification_group", enrichment.Definition?.GroupName ?? "");
+        dataDict.TryAdd("allow_opt_out", enrichment.AllowOptOut);
+        dataDict.TryAdd("unsubscribe_url", enrichment.AllowOptOut ? enrichment.UnsubscribeUrl : "");
+    }
+
+    /// <summary>Notification metadata resolved once per send, threaded through render methods.</summary>
+    private sealed record EmailEnrichment(
+        NotificationDefinition? Definition,
+        bool AllowOptOut,
+        string UnsubscribeUrl);
 
     private static Dictionary<string, object?> JsonElementToDictionary(JsonElement element)
     {

--- a/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
+++ b/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
@@ -6,7 +6,6 @@ using Granit.Templating.Layouts;
 using Granit.Templating.Pipeline;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -316,7 +315,7 @@ internal sealed partial class EmailNotificationChannel(
     /// Enriches the template model data with notification metadata for the footer.
     /// Uses defensive defaults (empty string / false) to avoid null issues in Scriban.
     /// </summary>
-    private void EnrichModelData(
+    private static void EnrichModelData(
         Dictionary<string, object?> dataDict,
         NotificationDeliveryContext context,
         EmailEnrichment enrichment)
@@ -325,20 +324,6 @@ internal sealed partial class EmailNotificationChannel(
         dataDict.TryAdd("notification_group", enrichment.Definition?.GroupName ?? "");
         dataDict.TryAdd("allow_opt_out", enrichment.AllowOptOut);
         dataDict.TryAdd("unsubscribe_url", enrichment.AllowOptOut ? enrichment.UnsubscribeUrl : "");
-
-        // Localized footer labels for Layout.Email
-        IStringLocalizer<NotificationsEmailLocalizationResource>? localizer =
-            serviceProvider.GetService<IStringLocalizer<NotificationsEmailLocalizationResource>>();
-
-        if (localizer is not null)
-        {
-            string group = enrichment.Definition?.GroupName ?? "";
-            dataDict.TryAdd("lbl_manage_preferences", localizer["NotificationsEmail:ManagePreferences"].Value);
-            dataDict.TryAdd("lbl_subscribed_reason", string.IsNullOrEmpty(group)
-                ? ""
-                : localizer["NotificationsEmail:SubscribedReason", group].Value);
-            dataDict.TryAdd("lbl_no_reply", localizer["NotificationsEmail:NoReply"].Value);
-        }
     }
 
     /// <summary>Notification metadata resolved once per send, threaded through render methods.</summary>

--- a/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
+++ b/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
@@ -6,6 +6,7 @@ using Granit.Templating.Layouts;
 using Granit.Templating.Pipeline;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -315,7 +316,7 @@ internal sealed partial class EmailNotificationChannel(
     /// Enriches the template model data with notification metadata for the footer.
     /// Uses defensive defaults (empty string / false) to avoid null issues in Scriban.
     /// </summary>
-    private static void EnrichModelData(
+    private void EnrichModelData(
         Dictionary<string, object?> dataDict,
         NotificationDeliveryContext context,
         EmailEnrichment enrichment)
@@ -324,6 +325,20 @@ internal sealed partial class EmailNotificationChannel(
         dataDict.TryAdd("notification_group", enrichment.Definition?.GroupName ?? "");
         dataDict.TryAdd("allow_opt_out", enrichment.AllowOptOut);
         dataDict.TryAdd("unsubscribe_url", enrichment.AllowOptOut ? enrichment.UnsubscribeUrl : "");
+
+        // Localized footer labels for Layout.Email
+        IStringLocalizer<NotificationsEmailLocalizationResource>? localizer =
+            serviceProvider.GetService<IStringLocalizer<NotificationsEmailLocalizationResource>>();
+
+        if (localizer is not null)
+        {
+            string group = enrichment.Definition?.GroupName ?? "";
+            dataDict.TryAdd("lbl_manage_preferences", localizer["NotificationsEmail:ManagePreferences"].Value);
+            dataDict.TryAdd("lbl_subscribed_reason", string.IsNullOrEmpty(group)
+                ? ""
+                : localizer["NotificationsEmail:SubscribedReason", group].Value);
+            dataDict.TryAdd("lbl_no_reply", localizer["NotificationsEmail:NoReply"].Value);
+        }
     }
 
     /// <summary>Notification metadata resolved once per send, threaded through render methods.</summary>

--- a/src/Granit.Notifications.Email/Localization/NotificationsEmail/cs.json
+++ b/src/Granit.Notifications.Email/Localization/NotificationsEmail/cs.json
@@ -1,0 +1,8 @@
+{
+  "culture": "cs",
+  "texts": {
+    "NotificationsEmail:ManagePreferences": "Spravovat předvolby oznámení",
+    "NotificationsEmail:SubscribedReason": "Tento e-mail jste obdrželi, protože jste přihlášeni k odběru oznámení {0}.",
+    "NotificationsEmail:NoReply": "Na tento e-mail prosím neodpovídejte. Byl odeslán z adresy určené pouze pro oznámení."
+  }
+}

--- a/src/Granit.Notifications.Email/Localization/NotificationsEmail/de.json
+++ b/src/Granit.Notifications.Email/Localization/NotificationsEmail/de.json
@@ -1,0 +1,8 @@
+{
+  "culture": "de",
+  "texts": {
+    "NotificationsEmail:ManagePreferences": "Benachrichtigungseinstellungen verwalten",
+    "NotificationsEmail:SubscribedReason": "Sie erhalten diese E-Mail, weil Sie {0}-Benachrichtigungen abonniert haben.",
+    "NotificationsEmail:NoReply": "Bitte antworten Sie nicht auf diese E-Mail. Sie wurde von einer reinen Benachrichtigungsadresse gesendet."
+  }
+}

--- a/src/Granit.Notifications.Email/Localization/NotificationsEmail/en-GB.json
+++ b/src/Granit.Notifications.Email/Localization/NotificationsEmail/en-GB.json
@@ -1,0 +1,4 @@
+{
+  "culture": "en-GB",
+  "texts": {}
+}

--- a/src/Granit.Notifications.Email/Localization/NotificationsEmail/en.json
+++ b/src/Granit.Notifications.Email/Localization/NotificationsEmail/en.json
@@ -1,0 +1,8 @@
+{
+  "culture": "en",
+  "texts": {
+    "NotificationsEmail:ManagePreferences": "Manage notification preferences",
+    "NotificationsEmail:SubscribedReason": "You received this email because you are subscribed to {0} notifications.",
+    "NotificationsEmail:NoReply": "Please do not reply to this email. It was sent from a notification-only address."
+  }
+}

--- a/src/Granit.Notifications.Email/Localization/NotificationsEmail/es.json
+++ b/src/Granit.Notifications.Email/Localization/NotificationsEmail/es.json
@@ -1,0 +1,8 @@
+{
+  "culture": "es",
+  "texts": {
+    "NotificationsEmail:ManagePreferences": "Gestionar preferencias de notificación",
+    "NotificationsEmail:SubscribedReason": "Ha recibido este correo electrónico porque está suscrito a las notificaciones de {0}.",
+    "NotificationsEmail:NoReply": "Por favor, no responda a este correo electrónico. Fue enviado desde una dirección exclusiva para notificaciones."
+  }
+}

--- a/src/Granit.Notifications.Email/Localization/NotificationsEmail/fr-CA.json
+++ b/src/Granit.Notifications.Email/Localization/NotificationsEmail/fr-CA.json
@@ -1,0 +1,6 @@
+{
+  "culture": "fr-CA",
+  "texts": {
+    "NotificationsEmail:NoReply": "Veuillez ne pas répondre à ce courriel. Il a été envoyé depuis une adresse de notification uniquement."
+  }
+}

--- a/src/Granit.Notifications.Email/Localization/NotificationsEmail/fr.json
+++ b/src/Granit.Notifications.Email/Localization/NotificationsEmail/fr.json
@@ -1,0 +1,8 @@
+{
+  "culture": "fr",
+  "texts": {
+    "NotificationsEmail:ManagePreferences": "Gérer les préférences de notification",
+    "NotificationsEmail:SubscribedReason": "Vous recevez cet e-mail car vous êtes abonné(e) aux notifications {0}.",
+    "NotificationsEmail:NoReply": "Veuillez ne pas répondre à cet e-mail. Il a été envoyé depuis une adresse de notification uniquement."
+  }
+}

--- a/src/Granit.Notifications.Email/Localization/NotificationsEmail/it.json
+++ b/src/Granit.Notifications.Email/Localization/NotificationsEmail/it.json
@@ -1,0 +1,8 @@
+{
+  "culture": "it",
+  "texts": {
+    "NotificationsEmail:ManagePreferences": "Gestisci le preferenze di notifica",
+    "NotificationsEmail:SubscribedReason": "Hai ricevuto questa e-mail perché sei iscritto alle notifiche {0}.",
+    "NotificationsEmail:NoReply": "Si prega di non rispondere a questa e-mail. È stata inviata da un indirizzo riservato alle sole notifiche."
+  }
+}

--- a/src/Granit.Notifications.Email/Localization/NotificationsEmail/ja.json
+++ b/src/Granit.Notifications.Email/Localization/NotificationsEmail/ja.json
@@ -1,0 +1,8 @@
+{
+  "culture": "ja",
+  "texts": {
+    "NotificationsEmail:ManagePreferences": "通知設定を管理",
+    "NotificationsEmail:SubscribedReason": "このメールは、{0}の通知を購読しているために送信されました。",
+    "NotificationsEmail:NoReply": "このメールには返信しないでください。通知専用アドレスから送信されています。"
+  }
+}

--- a/src/Granit.Notifications.Email/Localization/NotificationsEmail/ko.json
+++ b/src/Granit.Notifications.Email/Localization/NotificationsEmail/ko.json
@@ -1,0 +1,8 @@
+{
+  "culture": "ko",
+  "texts": {
+    "NotificationsEmail:ManagePreferences": "알림 환경설정 관리",
+    "NotificationsEmail:SubscribedReason": "{0} 알림을 구독하고 있기 때문에 이 이메일을 받으셨습니다.",
+    "NotificationsEmail:NoReply": "이 이메일에 회신하지 마십시오. 알림 전용 주소에서 발송된 메일입니다."
+  }
+}

--- a/src/Granit.Notifications.Email/Localization/NotificationsEmail/nl.json
+++ b/src/Granit.Notifications.Email/Localization/NotificationsEmail/nl.json
@@ -1,0 +1,8 @@
+{
+  "culture": "nl",
+  "texts": {
+    "NotificationsEmail:ManagePreferences": "Meldingsvoorkeuren beheren",
+    "NotificationsEmail:SubscribedReason": "U ontvangt deze e-mail omdat u geabonneerd bent op {0}-meldingen.",
+    "NotificationsEmail:NoReply": "Gelieve niet te antwoorden op deze e-mail. Deze is verzonden vanaf een adres dat alleen voor meldingen wordt gebruikt."
+  }
+}

--- a/src/Granit.Notifications.Email/Localization/NotificationsEmail/pl.json
+++ b/src/Granit.Notifications.Email/Localization/NotificationsEmail/pl.json
@@ -1,0 +1,8 @@
+{
+  "culture": "pl",
+  "texts": {
+    "NotificationsEmail:ManagePreferences": "Zarządzaj preferencjami powiadomień",
+    "NotificationsEmail:SubscribedReason": "Otrzymujesz tę wiadomość e-mail, ponieważ subskrybujesz powiadomienia {0}.",
+    "NotificationsEmail:NoReply": "Prosimy nie odpowiadać na tę wiadomość e-mail. Została wysłana z adresu przeznaczonego wyłącznie do powiadomień."
+  }
+}

--- a/src/Granit.Notifications.Email/Localization/NotificationsEmail/pt-BR.json
+++ b/src/Granit.Notifications.Email/Localization/NotificationsEmail/pt-BR.json
@@ -1,0 +1,8 @@
+{
+  "culture": "pt-BR",
+  "texts": {
+    "NotificationsEmail:ManagePreferences": "Gerenciar preferências de notificação",
+    "NotificationsEmail:SubscribedReason": "Você recebeu este e-mail porque está inscrito nas notificações de {0}.",
+    "NotificationsEmail:NoReply": "Por favor, não responda a este e-mail. Ele foi enviado a partir de um endereço exclusivo para notificações."
+  }
+}

--- a/src/Granit.Notifications.Email/Localization/NotificationsEmail/pt.json
+++ b/src/Granit.Notifications.Email/Localization/NotificationsEmail/pt.json
@@ -1,0 +1,8 @@
+{
+  "culture": "pt",
+  "texts": {
+    "NotificationsEmail:ManagePreferences": "Gerir preferências de notificação",
+    "NotificationsEmail:SubscribedReason": "Recebeu este e-mail porque está subscrito às notificações de {0}.",
+    "NotificationsEmail:NoReply": "Por favor, não responda a este e-mail. Foi enviado a partir de um endereço exclusivo para notificações."
+  }
+}

--- a/src/Granit.Notifications.Email/Localization/NotificationsEmail/sv.json
+++ b/src/Granit.Notifications.Email/Localization/NotificationsEmail/sv.json
@@ -1,0 +1,8 @@
+{
+  "culture": "sv",
+  "texts": {
+    "NotificationsEmail:ManagePreferences": "Hantera aviseringsinställningar",
+    "NotificationsEmail:SubscribedReason": "Du fick detta e-postmeddelande eftersom du prenumererar på {0}-aviseringar.",
+    "NotificationsEmail:NoReply": "Vänligen svara inte på detta e-postmeddelande. Det skickades från en adress som endast används för aviseringar."
+  }
+}

--- a/src/Granit.Notifications.Email/Localization/NotificationsEmail/tr.json
+++ b/src/Granit.Notifications.Email/Localization/NotificationsEmail/tr.json
@@ -1,0 +1,8 @@
+{
+  "culture": "tr",
+  "texts": {
+    "NotificationsEmail:ManagePreferences": "Bildirim tercihlerini yönet",
+    "NotificationsEmail:SubscribedReason": "Bu e-postayı {0} bildirimlerine abone olduğunuz için aldınız.",
+    "NotificationsEmail:NoReply": "Lütfen bu e-postayı yanıtlamayın. Yalnızca bildirim gönderimi için kullanılan bir adresten gönderilmiştir."
+  }
+}

--- a/src/Granit.Notifications.Email/Localization/NotificationsEmail/zh.json
+++ b/src/Granit.Notifications.Email/Localization/NotificationsEmail/zh.json
@@ -1,0 +1,8 @@
+{
+  "culture": "zh",
+  "texts": {
+    "NotificationsEmail:ManagePreferences": "管理通知偏好设置",
+    "NotificationsEmail:SubscribedReason": "您收到此电子邮件是因为您订阅了{0}通知。",
+    "NotificationsEmail:NoReply": "请勿回复此电子邮件。此邮件由仅用于发送通知的地址发出。"
+  }
+}

--- a/src/Granit.Notifications.Email/NotificationsEmailLocalizationResource.cs
+++ b/src/Granit.Notifications.Email/NotificationsEmailLocalizationResource.cs
@@ -1,0 +1,11 @@
+using Granit.Localization;
+
+namespace Granit.Notifications.Email;
+
+/// <summary>
+/// Marker class for the <c>NotificationsEmail</c> localization resource.
+/// JSON files: <c>Localization/NotificationsEmail/{culture}.json</c>, embedded in this assembly.
+/// Auto-discovered by <see cref="LocalizationResourceNameAttribute"/>.
+/// </summary>
+[LocalizationResourceName("NotificationsEmail", DefaultCulture = "en")]
+public sealed class NotificationsEmailLocalizationResource;

--- a/src/Granit.Notifications.Email/Options/EmailChannelOptions.cs
+++ b/src/Granit.Notifications.Email/Options/EmailChannelOptions.cs
@@ -6,12 +6,19 @@ public sealed class EmailChannelOptions
     /// <summary>Configuration section name.</summary>
     public const string SectionName = "Notifications:Email";
 
-    /// <summary>Provider key for Keyed Services resolution (e.g. "Smtp", "Brevo").</summary>
+    /// <summary>Provider key for Keyed Services resolution (e.g. "Smtp", "SendGrid").</summary>
     public string Provider { get; set; } = "Smtp";
 
-    /// <summary>Default sender email address.</summary>
-    public string SenderAddress { get; set; } = string.Empty;
+    /// <summary>Default sender email address (e.g. "noreply@example.com").</summary>
+    public string DefaultSenderEmail { get; set; } = string.Empty;
 
-    /// <summary>Default sender display name.</summary>
-    public string SenderName { get; set; } = string.Empty;
+    /// <summary>Default sender display name (e.g. "My Application").</summary>
+    public string DefaultSenderName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// URL for the notification preferences page. Used for the <c>List-Unsubscribe</c>
+    /// header and the footer link in the email layout.
+    /// If <c>null</c>, falls back to <c>{AppGlobalContextOptions.BaseUrl}/notifications/preferences</c>.
+    /// </summary>
+    public string? UnsubscribeUrl { get; set; }
 }

--- a/src/Granit.Notifications.Email/Templates/Layout.Email.html
+++ b/src/Granit.Notifications.Email/Templates/Layout.Email.html
@@ -114,13 +114,15 @@
                 {{- end }}
             </main>
             <footer role="contentinfo">
-                {{- if model.allow_opt_out && model.unsubscribe_url != "" }}
-                <p><a href="{{ model.unsubscribe_url }}">Manage notification preferences</a></p>
+                {{- if model.allow_opt_out && model.unsubscribe_url != "" && model.lbl_manage_preferences != "" }}
+                <p><a href="{{ model.unsubscribe_url }}">{{ model.lbl_manage_preferences }}</a></p>
                 {{- end }}
-                {{- if model.notification_group != "" }}
-                <p>You received this email because you are subscribed to {{ model.notification_group }} notifications.</p>
+                {{- if model.lbl_subscribed_reason != "" }}
+                <p>{{ model.lbl_subscribed_reason }}</p>
                 {{- end }}
-                <p>Please do not reply to this email. It was sent from a notification-only address.</p>
+                {{- if model.lbl_no_reply != "" }}
+                <p>{{ model.lbl_no_reply }}</p>
+                {{- end }}
                 {{- if app.support_email != "" }}
                 <p><a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a></p>
                 {{- end }}

--- a/src/Granit.Notifications.Email/Templates/Layout.Email.html
+++ b/src/Granit.Notifications.Email/Templates/Layout.Email.html
@@ -114,15 +114,13 @@
                 {{- end }}
             </main>
             <footer role="contentinfo">
-                {{- if model.allow_opt_out && model.unsubscribe_url != "" && model.lbl_manage_preferences != "" }}
-                <p><a href="{{ model.unsubscribe_url }}">{{ model.lbl_manage_preferences }}</a></p>
+                {{- if model.allow_opt_out && model.unsubscribe_url != "" }}
+                <p><a href="{{ model.unsubscribe_url }}">{{ t "NotificationsEmail:ManagePreferences" }}</a></p>
                 {{- end }}
-                {{- if model.lbl_subscribed_reason != "" }}
-                <p>{{ model.lbl_subscribed_reason }}</p>
+                {{- if model.notification_group != "" }}
+                <p>{{ t "NotificationsEmail:SubscribedReason" model.notification_group }}</p>
                 {{- end }}
-                {{- if model.lbl_no_reply != "" }}
-                <p>{{ model.lbl_no_reply }}</p>
-                {{- end }}
+                <p>{{ t "NotificationsEmail:NoReply" }}</p>
                 {{- if app.support_email != "" }}
                 <p><a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a></p>
                 {{- end }}

--- a/src/Granit.Notifications.Email/Templates/Layout.Email.html
+++ b/src/Granit.Notifications.Email/Templates/Layout.Email.html
@@ -26,91 +26,94 @@
             box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
             overflow: hidden;
         }
-        .header {
+        header {
             background-color: #1a1a2e;
             padding: 24px 32px;
             text-align: center;
         }
-        .header img {
+        header img {
             max-height: 40px;
             width: auto;
         }
-        .header .app-name {
+        header .app-name {
             color: #ffffff;
             font-size: 20px;
             font-weight: 600;
             letter-spacing: 0.5px;
         }
-        .content {
+        main {
             padding: 32px;
         }
-        .content p {
+        main p {
             margin: 0 0 16px;
-            font-size: 15px;
+            font-size: 16px;
             color: #374151;
         }
-        .content a {
-            color: #2563eb;
-            text-decoration: none;
-        }
-        .content a:hover {
+        main a {
+            color: #1d4ed8;
             text-decoration: underline;
+        }
+        main a:hover {
+            color: #1e40af;
         }
         .divider {
             border: none;
-            border-top: 1px solid #e5e7eb;
+            border-top: 1px solid #d1d5db;
             margin: 24px 0;
         }
-        .footer {
-            background-color: #f9fafb;
+        footer {
+            background-color: #f3f4f6;
             padding: 20px 32px;
             text-align: center;
-            border-top: 1px solid #e5e7eb;
+            border-top: 1px solid #d1d5db;
         }
-        .footer p {
+        footer p {
             margin: 0 0 6px;
-            font-size: 12px;
-            color: #9ca3af;
+            font-size: 13px;
+            color: #4b5563;
         }
-        .footer a {
-            color: #6b7280;
-            text-decoration: none;
-        }
-        .footer a:hover {
+        footer a {
+            color: #374151;
             text-decoration: underline;
+        }
+        footer a:hover {
+            color: #1f2937;
         }
         .btn {
             display: inline-block;
-            padding: 10px 24px;
-            background-color: #2563eb;
+            padding: 12px 28px;
+            background-color: #1d4ed8;
             color: #ffffff !important;
             text-decoration: none;
             border-radius: 6px;
-            font-size: 14px;
-            font-weight: 500;
+            font-size: 15px;
+            font-weight: 600;
+        }
+        .btn:hover {
+            background-color: #1e40af;
         }
     </style>
 </head>
 <body>
-    <div class="wrapper">
+    <div class="wrapper" role="presentation">
         <div class="container">
-            <div class="header">
+            <header role="banner">
                 {{- if app.logo_url != "" }}
                 <img src="{{ app.logo_url }}" alt="{{ app.name }}">
                 {{- else }}
-                <span class="app-name">{{ app.name }}</span>
+                <span class="app-name" aria-label="{{ app.name }}">{{ app.name }}</span>
                 {{- end }}
-            </div>
-            <div class="content">
+            </header>
+            <main role="main">
                 {{ body | raw }}
                 {{- if app.base_url != "" }}
-                <hr class="divider">
+                <hr class="divider" aria-hidden="true">
                 <p style="text-align: center;">
-                    <a href="{{ app.base_url }}" class="btn">{{ app.name }}</a>
+                    <a href="{{ app.base_url }}" class="btn" role="link">{{ app.name }}</a>
                 </p>
                 {{- end }}
-            </div>
-            <div class="footer">
+            </main>
+            <footer role="contentinfo">
                 {{- if model.allow_opt_out && model.unsubscribe_url != "" }}
                 <p><a href="{{ model.unsubscribe_url }}">Manage notification preferences</a></p>
                 {{- end }}
@@ -122,7 +125,7 @@
                 <p><a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a></p>
                 {{- end }}
                 <p>&copy; {{ now.year }} {{ app.name }}</p>
-            </div>
+            </footer>
         </div>
     </div>
 </body>

--- a/src/Granit.Notifications.Email/Templates/Layout.Email.html
+++ b/src/Granit.Notifications.Email/Templates/Layout.Email.html
@@ -2,15 +2,128 @@
 <html lang="{{ context.culture }}">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ model.title }}</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: #f4f5f7;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+            color: #1a1a2e;
+            line-height: 1.6;
+            -webkit-text-size-adjust: 100%;
+        }
+        .wrapper {
+            width: 100%;
+            padding: 32px 0;
+        }
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            background-color: #ffffff;
+            border-radius: 8px;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+            overflow: hidden;
+        }
+        .header {
+            background-color: #1a1a2e;
+            padding: 24px 32px;
+            text-align: center;
+        }
+        .header img {
+            max-height: 40px;
+            width: auto;
+        }
+        .header .app-name {
+            color: #ffffff;
+            font-size: 20px;
+            font-weight: 600;
+            letter-spacing: 0.5px;
+        }
+        .content {
+            padding: 32px;
+        }
+        .content p {
+            margin: 0 0 16px;
+            font-size: 15px;
+            color: #374151;
+        }
+        .content a {
+            color: #2563eb;
+            text-decoration: none;
+        }
+        .content a:hover {
+            text-decoration: underline;
+        }
+        .divider {
+            border: none;
+            border-top: 1px solid #e5e7eb;
+            margin: 24px 0;
+        }
+        .footer {
+            background-color: #f9fafb;
+            padding: 20px 32px;
+            text-align: center;
+            border-top: 1px solid #e5e7eb;
+        }
+        .footer p {
+            margin: 0 0 6px;
+            font-size: 12px;
+            color: #9ca3af;
+        }
+        .footer a {
+            color: #6b7280;
+            text-decoration: none;
+        }
+        .footer a:hover {
+            text-decoration: underline;
+        }
+        .btn {
+            display: inline-block;
+            padding: 10px 24px;
+            background-color: #2563eb;
+            color: #ffffff !important;
+            text-decoration: none;
+            border-radius: 6px;
+            font-size: 14px;
+            font-weight: 500;
+        }
+    </style>
 </head>
 <body>
-    {{- if app.logo_url != "" }}
-    <img src="{{ app.logo_url }}" alt="{{ app.name }}">
-    {{- end }}
-    {{ body | raw }}
-    {{- if app.base_url != "" }}
-    <p><a href="{{ app.base_url }}">{{ app.name }}</a></p>
-    {{- end }}
+    <div class="wrapper">
+        <div class="container">
+            <div class="header">
+                {{- if app.logo_url != "" }}
+                <img src="{{ app.logo_url }}" alt="{{ app.name }}">
+                {{- else }}
+                <span class="app-name">{{ app.name }}</span>
+                {{- end }}
+            </div>
+            <div class="content">
+                {{ body | raw }}
+                {{- if app.base_url != "" }}
+                <hr class="divider">
+                <p style="text-align: center;">
+                    <a href="{{ app.base_url }}" class="btn">{{ app.name }}</a>
+                </p>
+                {{- end }}
+            </div>
+            <div class="footer">
+                {{- if model.allow_opt_out && model.unsubscribe_url != "" }}
+                <p><a href="{{ model.unsubscribe_url }}">Manage notification preferences</a></p>
+                {{- end }}
+                {{- if model.notification_group != "" }}
+                <p>You received this email because you are subscribed to {{ model.notification_group }} notifications.</p>
+                {{- end }}
+                <p>Please do not reply to this email. It was sent from a notification-only address.</p>
+                {{- if app.support_email != "" }}
+                <p><a href="mailto:{{ app.support_email }}">{{ app.support_email }}</a></p>
+                {{- end }}
+                <p>&copy; {{ now.year }} {{ app.name }}</p>
+            </div>
+        </div>
+    </div>
 </body>
 </html>

--- a/src/Granit.Templating.Scriban/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Granit.Templating.Scriban/Extensions/ServiceCollectionExtensions.cs
@@ -39,7 +39,7 @@ public static class ServiceCollectionExtensions
 
         services.TryAddSingleton<GranitTemplateLoader>();
         services.TryAddSingleton<ITemplateEngine>(sp =>
-            new ScribanTemplateEngine(sp.GetService<GranitTemplateLoader>()));
+            new ScribanTemplateEngine(sp, sp.GetService<GranitTemplateLoader>()));
 
         services.AddTemplateGlobalContext<NowGlobalContext>();
         services.AddTemplateGlobalContext<ExecutionContextGlobalContext>();

--- a/src/Granit.Templating.Scriban/Internal/ScribanTemplateEngine.cs
+++ b/src/Granit.Templating.Scriban/Internal/ScribanTemplateEngine.cs
@@ -3,6 +3,8 @@ using Granit.Templating.GlobalContext;
 using Granit.Templating.Keys;
 using Granit.Templating.Pipeline;
 using Granit.Templating.Scriban.Exceptions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using Scriban;
 using Scriban.Runtime;
 
@@ -33,7 +35,9 @@ namespace Granit.Templating.Scriban.Internal;
 /// as top-level Scriban variables (e.g. <c>{{ body }}</c> for layout rendering).
 /// </para>
 /// </remarks>
-internal sealed class ScribanTemplateEngine(GranitTemplateLoader? templateLoader = null) : ITemplateEngine
+internal sealed class ScribanTemplateEngine(
+    IServiceProvider serviceProvider,
+    GranitTemplateLoader? templateLoader = null) : ITemplateEngine
 {
     private const int MaxLoopIterations = 500;
     private const int MaxRecursionDepth = 50;
@@ -123,6 +127,13 @@ internal sealed class ScribanTemplateEngine(GranitTemplateLoader? templateLoader
             {
                 globals.SetValue(key, value, readOnly: true);
             }
+        }
+
+        // Register {{ t "Resource:Key" arg1 arg2 }} localization function
+        IStringLocalizerFactory? localizerFactory = serviceProvider.GetService<IStringLocalizerFactory>();
+        if (localizerFactory is not null)
+        {
+            globals.SetValue("t", new TemplateLocalizationFunction(localizerFactory), readOnly: true);
         }
 
         TemplateContext templateContext = new(globals)

--- a/src/Granit.Templating.Scriban/Internal/TemplateLocalizationFunction.cs
+++ b/src/Granit.Templating.Scriban/Internal/TemplateLocalizationFunction.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.Localization;
+using Scriban;
+using Scriban.Runtime;
+using Scriban.Syntax;
+
+namespace Granit.Templating.Scriban.Internal;
+
+/// <summary>
+/// Scriban custom function that resolves localized strings via <see cref="IStringLocalizerFactory"/>.
+/// Registered as <c>t</c> in the template context.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Usage in templates:
+/// <list type="bullet">
+///   <item><c>{{ t "NotificationsEmail:ManagePreferences" }}</c></item>
+///   <item><c>{{ t "NotificationsEmail:SubscribedReason" model.notification_group }}</c></item>
+/// </list>
+/// </para>
+/// <para>
+/// The key format is <c>{ResourceName}:{Key}</c>. The function resolves the localizer
+/// for the resource name and looks up the key. Format arguments are passed positionally.
+/// Returns the key itself if the resource or key is not found (Granit localizer convention).
+/// </para>
+/// </remarks>
+internal sealed class TemplateLocalizationFunction(IStringLocalizerFactory localizerFactory) : IScriptCustomFunction
+{
+    public object? Invoke(TemplateContext context, ScriptNode? callerContext, ScriptArray arguments, ScriptBlockStatement? blockStatement)
+    {
+        if (arguments.Count == 0)
+        {
+            return "";
+        }
+
+        string? key = context.ObjectToString(arguments[0]);
+        if (string.IsNullOrEmpty(key))
+        {
+            return "";
+        }
+
+        IStringLocalizer localizer = localizerFactory.Create(key, string.Empty);
+
+        if (arguments.Count == 1)
+        {
+            return localizer[key].Value;
+        }
+
+        // Collect format arguments (positional after the key)
+        object[] args = new object[arguments.Count - 1];
+        for (int i = 1; i < arguments.Count; i++)
+        {
+            args[i - 1] = arguments[i] ?? "";
+        }
+
+        return localizer[key, args].Value;
+    }
+
+    public int RequiredParameterCount => 1;
+
+    public int ParameterCount => 1;
+
+    public ScriptVarParamKind VarParamKind => ScriptVarParamKind.Direct;
+
+    public Type ReturnType => typeof(string);
+
+    public ScriptParameterInfo GetParameterInfo(int index)
+    {
+        if (index == 0)
+        {
+            return new ScriptParameterInfo(typeof(string), "key");
+        }
+
+        return new ScriptParameterInfo(typeof(object), "arg");
+    }
+
+    public ValueTask<object?> InvokeAsync(TemplateContext context, ScriptNode? callerContext, ScriptArray arguments, ScriptBlockStatement? blockStatement) =>
+        new(Invoke(context, callerContext, arguments, blockStatement));
+
+    public int GetParameterIndexByName(string name) =>
+        throw new NotImplementedException();
+}

--- a/tests/Granit.Notifications.Brevo.Tests/BrevoNotificationProviderTests.cs
+++ b/tests/Granit.Notifications.Brevo.Tests/BrevoNotificationProviderTests.cs
@@ -102,7 +102,7 @@ public sealed class BrevoNotificationProviderTests : IDisposable
     }
 
     [Fact]
-    public async Task SendEmailAsync_UsesFromOverride_WhenProvided()
+    public async Task SendEmailAsync_UsesFromEmailOverride_WhenProvided()
     {
         IEmailSender emailSender = _provider;
 
@@ -112,7 +112,7 @@ public sealed class BrevoNotificationProviderTests : IDisposable
                 To = "user@test.com",
                 Subject = "Test",
                 HtmlBody = "<p>Hi</p>",
-                FromOverride = "custom@test.com",
+                FromEmailOverride = "custom@test.com",
             },
             TestContext.Current.CancellationToken);
 

--- a/tests/Granit.Notifications.Brevo.Tests/BrevoNotificationProviderTests.cs
+++ b/tests/Granit.Notifications.Brevo.Tests/BrevoNotificationProviderTests.cs
@@ -140,6 +140,56 @@ public sealed class BrevoNotificationProviderTests : IDisposable
     }
 
     [Fact]
+    public async Task SendEmailAsync_WithHeaders_IncludesHeadersInPayload()
+    {
+        IEmailSender emailSender = _provider;
+
+        await emailSender.SendAsync(
+            new EmailMessage
+            {
+                To = "user@test.com",
+                Subject = "Test",
+                HtmlBody = "<p>Hi</p>",
+                Headers = new Dictionary<string, string>
+                {
+                    ["List-Unsubscribe"] = "<https://example.com/unsub>",
+                    ["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click",
+                },
+            },
+            TestContext.Current.CancellationToken);
+
+        _handler.Requests.Count.ShouldBe(1);
+        string body = _handler.Requests[0].Body;
+        using var doc = JsonDocument.Parse(body);
+        JsonElement root = doc.RootElement;
+        JsonElement headers = root.GetProperty("headers");
+        headers.GetProperty("List-Unsubscribe").GetString().ShouldBe("<https://example.com/unsub>");
+        headers.GetProperty("List-Unsubscribe-Post").GetString().ShouldBe("List-Unsubscribe=One-Click");
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_WithFromNameOverride_UsesOverrideName()
+    {
+        IEmailSender emailSender = _provider;
+
+        await emailSender.SendAsync(
+            new EmailMessage
+            {
+                To = "user@test.com",
+                Subject = "Test",
+                HtmlBody = "<p>Hi</p>",
+                FromNameOverride = "Override Sender",
+            },
+            TestContext.Current.CancellationToken);
+
+        _handler.Requests.Count.ShouldBe(1);
+        string body = _handler.Requests[0].Body;
+        using var doc = JsonDocument.Parse(body);
+        JsonElement root = doc.RootElement;
+        root.GetProperty("sender").GetProperty("name").GetString().ShouldBe("Override Sender");
+    }
+
+    [Fact]
     public async Task SendEmailAsync_ThrowsOnNon2xx()
     {
         _handler.ResponseStatusCode = HttpStatusCode.InternalServerError;

--- a/tests/Granit.Notifications.Email.AwsSes.Tests/AwsSesEmailSenderTests.cs
+++ b/tests/Granit.Notifications.Email.AwsSes.Tests/AwsSesEmailSenderTests.cs
@@ -28,7 +28,7 @@ public sealed class AwsSesEmailSenderTests
         AwsSesOptions opts = options ?? new AwsSesOptions
         {
             Region = "eu-west-1",
-            FromAddress = "noreply@example.com",
+            DefaultSenderEmail = "noreply@example.com",
             TimeoutSeconds = 10,
         };
         IAwsSesTransport transport = Substitute.For<IAwsSesTransport>();
@@ -49,7 +49,7 @@ public sealed class AwsSesEmailSenderTests
             To = "recipient@example.com",
             Subject = "Test subject",
             HtmlBody = "<p>Hello</p>",
-            FromOverride = fromOverride,
+            FromEmailOverride = fromOverride,
             PlainTextBody = plainText,
         };
 
@@ -109,7 +109,7 @@ public sealed class AwsSesEmailSenderTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public async Task SendAsync_WithFromOverride_UsesSenderAddressFromOverride()
+    public async Task SendAsync_WithFromEmailOverride_UsesSenderAddressFromEmailOverride()
     {
         (AwsSesEmailSender sender, IAwsSesTransport transport) = CreateSender();
         SendEmailRequest? captured = null;
@@ -126,12 +126,12 @@ public sealed class AwsSesEmailSenderTests
     }
 
     [Fact]
-    public async Task SendAsync_WithoutFromOverride_UsesFromAddress()
+    public async Task SendAsync_WithoutFromEmailOverride_UsesDefaultSenderEmail()
     {
         AwsSesOptions opts = new()
         {
             Region = "eu-west-1",
-            FromAddress = "sender@example.com",
+            DefaultSenderEmail = "sender@example.com",
             TimeoutSeconds = 5,
         };
         (AwsSesEmailSender sender, IAwsSesTransport transport) = CreateSender(opts);
@@ -147,12 +147,12 @@ public sealed class AwsSesEmailSenderTests
     }
 
     [Fact]
-    public async Task SendAsync_WithoutFromOverrideOrFromAddress_FallsBackToNoreply()
+    public async Task SendAsync_WithoutFromEmailOverrideOrDefaultSenderEmail_FallsBackToNoreply()
     {
         AwsSesOptions opts = new()
         {
             Region = "eu-west-1",
-            FromAddress = null,
+            DefaultSenderEmail = null,
             TimeoutSeconds = 5,
         };
         (AwsSesEmailSender sender, IAwsSesTransport transport) = CreateSender(opts);
@@ -215,7 +215,7 @@ public sealed class AwsSesEmailSenderTests
         AwsSesOptions opts = new()
         {
             Region = "eu-west-1",
-            FromAddress = "sender@example.com",
+            DefaultSenderEmail = "sender@example.com",
             ConfigurationSetName = "my-tracking-set",
             TimeoutSeconds = 5,
         };
@@ -237,7 +237,7 @@ public sealed class AwsSesEmailSenderTests
         AwsSesOptions opts = new()
         {
             Region = "eu-west-1",
-            FromAddress = "sender@example.com",
+            DefaultSenderEmail = "sender@example.com",
             ConfigurationSetName = null,
             TimeoutSeconds = 5,
         };
@@ -263,7 +263,7 @@ public sealed class AwsSesEmailSenderTests
         AwsSesOptions opts = new()
         {
             Region = "eu-central-1",
-            FromAddress = "sender@example.com",
+            DefaultSenderEmail = "sender@example.com",
             TimeoutSeconds = 5,
         };
         IAwsSesTransport transport = Substitute.For<IAwsSesTransport>();

--- a/tests/Granit.Notifications.Email.AwsSes.Tests/AwsSesEmailSenderTests.cs
+++ b/tests/Granit.Notifications.Email.AwsSes.Tests/AwsSesEmailSenderTests.cs
@@ -289,6 +289,113 @@ public sealed class AwsSesEmailSenderTests
     }
 
     // -------------------------------------------------------------------------
+    // Custom headers
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SendAsync_WithHeaders_BuildsMessageHeaders()
+    {
+        (AwsSesEmailSender sender, IAwsSesTransport transport) = CreateSender();
+        SendEmailRequest? captured = null;
+        await transport.SendEmailAsync(
+            Arg.Do<SendEmailRequest>(r => captured = r),
+            Arg.Any<CancellationToken>());
+
+        EmailMessage message = new()
+        {
+            To = "recipient@example.com",
+            Subject = "Test subject",
+            HtmlBody = "<p>Hello</p>",
+            Headers = new Dictionary<string, string>
+            {
+                ["List-Unsubscribe"] = "<https://example.com/unsub>",
+                ["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click",
+            },
+        };
+
+        await sender.SendAsync(message, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Content.Simple.Headers.ShouldNotBeNull();
+        captured.Content.Simple.Headers.Count.ShouldBe(2);
+        captured.Content.Simple.Headers.ShouldContain(h =>
+            h.Name == "List-Unsubscribe" && h.Value == "<https://example.com/unsub>");
+        captured.Content.Simple.Headers.ShouldContain(h =>
+            h.Name == "List-Unsubscribe-Post" && h.Value == "List-Unsubscribe=One-Click");
+    }
+
+    [Fact]
+    public async Task SendAsync_WithoutHeaders_DoesNotSetMessageHeaders()
+    {
+        (AwsSesEmailSender sender, IAwsSesTransport transport) = CreateSender();
+        SendEmailRequest? captured = null;
+        await transport.SendEmailAsync(
+            Arg.Do<SendEmailRequest>(r => captured = r),
+            Arg.Any<CancellationToken>());
+
+        await sender.SendAsync(SimpleMessage(), TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Content.Simple.Headers.ShouldBeNull();
+    }
+
+    // -------------------------------------------------------------------------
+    // Sender name formatting
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SendAsync_WithDefaultSenderName_FormatsRfc5322From()
+    {
+        AwsSesOptions opts = new()
+        {
+            Region = "eu-west-1",
+            DefaultSenderEmail = "noreply@example.com",
+            DefaultSenderName = "My App",
+            TimeoutSeconds = 5,
+        };
+        (AwsSesEmailSender sender, IAwsSesTransport transport) = CreateSender(opts);
+        SendEmailRequest? captured = null;
+        await transport.SendEmailAsync(
+            Arg.Do<SendEmailRequest>(r => captured = r),
+            Arg.Any<CancellationToken>());
+
+        await sender.SendAsync(SimpleMessage(), TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.FromEmailAddress.ShouldBe("\"My App\" <noreply@example.com>");
+    }
+
+    [Fact]
+    public async Task SendAsync_WithFromNameOverride_UsesOverrideName()
+    {
+        AwsSesOptions opts = new()
+        {
+            Region = "eu-west-1",
+            DefaultSenderEmail = "noreply@example.com",
+            DefaultSenderName = "Default",
+            TimeoutSeconds = 5,
+        };
+        (AwsSesEmailSender sender, IAwsSesTransport transport) = CreateSender(opts);
+        SendEmailRequest? captured = null;
+        await transport.SendEmailAsync(
+            Arg.Do<SendEmailRequest>(r => captured = r),
+            Arg.Any<CancellationToken>());
+
+        EmailMessage message = new()
+        {
+            To = "recipient@example.com",
+            Subject = "Test subject",
+            HtmlBody = "<p>Hello</p>",
+            FromNameOverride = "Override Name",
+        };
+
+        await sender.SendAsync(message, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.FromEmailAddress.ShouldBe("\"Override Name\" <noreply@example.com>");
+    }
+
+    // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
 

--- a/tests/Granit.Notifications.Email.AwsSes.Tests/SesEmailServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Notifications.Email.AwsSes.Tests/SesEmailServiceCollectionExtensionsTests.cs
@@ -40,14 +40,14 @@ public sealed class SesEmailServiceCollectionExtensionsTests
         services.AddGranitNotificationsEmailAwsSes(opts =>
         {
             opts.Region = "eu-central-1";
-            opts.FromAddress = "test@example.com";
+            opts.DefaultSenderEmail = "test@example.com";
         });
 
         ServiceProvider sp = services.BuildServiceProvider();
         AwsSesOptions options = sp.GetRequiredService<IOptions<AwsSesOptions>>().Value;
 
         options.Region.ShouldBe("eu-central-1");
-        options.FromAddress.ShouldBe("test@example.com");
+        options.DefaultSenderEmail.ShouldBe("test@example.com");
     }
 
     [Fact]

--- a/tests/Granit.Notifications.Email.AzureCommunicationServices.Tests/AcsEmailOptionsValidatorTests.cs
+++ b/tests/Granit.Notifications.Email.AzureCommunicationServices.Tests/AcsEmailOptionsValidatorTests.cs
@@ -15,7 +15,7 @@ public sealed class AcsEmailOptionsValidatorTests
         AcsEmailOptions options = new()
         {
             ConnectionString = "endpoint=https://test.communication.azure.com/;accesskey=dGVzdA==",
-            SenderAddress = "noreply@example.com",
+            DefaultSenderEmail = "noreply@example.com",
             TimeoutSeconds = 30,
         };
 
@@ -30,7 +30,7 @@ public sealed class AcsEmailOptionsValidatorTests
         AcsEmailOptions options = new()
         {
             Endpoint = "https://test.communication.azure.com",
-            SenderAddress = "noreply@example.com",
+            DefaultSenderEmail = "noreply@example.com",
             TimeoutSeconds = 30,
         };
 
@@ -43,19 +43,19 @@ public sealed class AcsEmailOptionsValidatorTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
-    public void Validate_EmptySenderAddress_ReturnsFail(string? senderAddress)
+    public void Validate_EmptyDefaultSenderEmail_ReturnsFail(string? defaultSenderEmail)
     {
         AcsEmailOptions options = new()
         {
             ConnectionString = "endpoint=https://test.communication.azure.com/;accesskey=dGVzdA==",
-            SenderAddress = senderAddress!,
+            DefaultSenderEmail = defaultSenderEmail!,
             TimeoutSeconds = 30,
         };
 
         ValidateOptionsResult result = _validator.Validate(null, options);
 
         result.Failed.ShouldBeTrue();
-        result.FailureMessage.ShouldContain("SenderAddress");
+        result.FailureMessage.ShouldContain("DefaultSenderEmail");
     }
 
     [Fact]
@@ -65,7 +65,7 @@ public sealed class AcsEmailOptionsValidatorTests
         {
             ConnectionString = null,
             Endpoint = null,
-            SenderAddress = "noreply@example.com",
+            DefaultSenderEmail = "noreply@example.com",
             TimeoutSeconds = 30,
         };
 
@@ -81,7 +81,7 @@ public sealed class AcsEmailOptionsValidatorTests
         AcsEmailOptions options = new()
         {
             ConnectionString = "endpoint=https://test.communication.azure.com/;accesskey=dGVzdA==",
-            SenderAddress = "noreply@example.com",
+            DefaultSenderEmail = "noreply@example.com",
             TimeoutSeconds = 0,
         };
 
@@ -98,7 +98,7 @@ public sealed class AcsEmailOptionsValidatorTests
         {
             ConnectionString = "endpoint=https://test.communication.azure.com/;accesskey=dGVzdA==",
             Endpoint = "https://test.communication.azure.com",
-            SenderAddress = "noreply@example.com",
+            DefaultSenderEmail = "noreply@example.com",
             TimeoutSeconds = 30,
         };
 

--- a/tests/Granit.Notifications.Email.AzureCommunicationServices.Tests/AcsEmailSenderTests.cs
+++ b/tests/Granit.Notifications.Email.AzureCommunicationServices.Tests/AcsEmailSenderTests.cs
@@ -21,7 +21,7 @@ public sealed class AcsEmailSenderTests
         AcsEmailOptions opts = options ?? new AcsEmailOptions
         {
             ConnectionString = "endpoint=https://test.communication.azure.com/;accesskey=dGVzdA==",
-            SenderAddress = "noreply@example.com",
+            DefaultSenderEmail = "noreply@example.com",
             TimeoutSeconds = 10,
         };
 
@@ -44,7 +44,7 @@ public sealed class AcsEmailSenderTests
             To = "recipient@example.com",
             Subject = "Test subject",
             HtmlBody = "<p>Hello</p>",
-            FromOverride = fromOverride,
+            FromEmailOverride = fromOverride,
             PlainTextBody = plainText,
         };
 
@@ -94,7 +94,7 @@ public sealed class AcsEmailSenderTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public async Task SendAsync_WithFromOverride_UsesSenderAddressFromOverride()
+    public async Task SendAsync_WithFromEmailOverride_UsesSenderAddressFromEmailOverride()
     {
         (AcsEmailSender sender, IAcsEmailTransport transport) = CreateSender();
         Azure.Communication.Email.EmailMessage? captured = null;
@@ -111,12 +111,12 @@ public sealed class AcsEmailSenderTests
     }
 
     [Fact]
-    public async Task SendAsync_WithoutFromOverride_UsesSenderAddress()
+    public async Task SendAsync_WithoutFromEmailOverride_UsesDefaultSenderEmail()
     {
         AcsEmailOptions opts = new()
         {
             ConnectionString = "endpoint=https://test.communication.azure.com/;accesskey=dGVzdA==",
-            SenderAddress = "sender@example.com",
+            DefaultSenderEmail = "sender@example.com",
             TimeoutSeconds = 5,
         };
         (AcsEmailSender sender, IAcsEmailTransport transport) = CreateSender(opts);
@@ -179,7 +179,7 @@ public sealed class AcsEmailSenderTests
         AcsEmailOptions opts = new()
         {
             ConnectionString = "endpoint=https://test.communication.azure.com/;accesskey=dGVzdA==",
-            SenderAddress = "sender@example.com",
+            DefaultSenderEmail = "sender@example.com",
             TimeoutSeconds = 5,
         };
 

--- a/tests/Granit.Notifications.Email.AzureCommunicationServices.Tests/AcsEmailSenderTests.cs
+++ b/tests/Granit.Notifications.Email.AzureCommunicationServices.Tests/AcsEmailSenderTests.cs
@@ -170,6 +170,93 @@ public sealed class AcsEmailSenderTests
     }
 
     // -------------------------------------------------------------------------
+    // Custom headers
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SendAsync_WithHeaders_AddsCustomHeaders()
+    {
+        (AcsEmailSender sender, IAcsEmailTransport transport) = CreateSender();
+        Azure.Communication.Email.EmailMessage? captured = null;
+        await transport.SendAsync(
+            Arg.Do<Azure.Communication.Email.EmailMessage>(m => captured = m),
+            Arg.Any<CancellationToken>());
+
+        EmailMessage message = new()
+        {
+            To = "recipient@example.com",
+            Subject = "Test subject",
+            HtmlBody = "<p>Hello</p>",
+            Headers = new Dictionary<string, string>
+            {
+                ["List-Unsubscribe"] = "<https://example.com/unsub>",
+            },
+        };
+
+        await sender.SendAsync(message, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Headers.ShouldContain(h =>
+            h.Key == "List-Unsubscribe" && h.Value == "<https://example.com/unsub>");
+    }
+
+    // -------------------------------------------------------------------------
+    // Sender name formatting
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SendAsync_WithDefaultSenderName_FormatsRfc5322From()
+    {
+        AcsEmailOptions opts = new()
+        {
+            ConnectionString = "endpoint=https://test.communication.azure.com/;accesskey=dGVzdA==",
+            DefaultSenderEmail = "noreply@example.com",
+            DefaultSenderName = "My App",
+            TimeoutSeconds = 5,
+        };
+        (AcsEmailSender sender, IAcsEmailTransport transport) = CreateSender(opts);
+        Azure.Communication.Email.EmailMessage? captured = null;
+        await transport.SendAsync(
+            Arg.Do<Azure.Communication.Email.EmailMessage>(m => captured = m),
+            Arg.Any<CancellationToken>());
+
+        await sender.SendAsync(SimpleMessage(), TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.SenderAddress.ShouldBe("\"My App\" <noreply@example.com>");
+    }
+
+    [Fact]
+    public async Task SendAsync_WithFromNameOverride_UsesOverrideName()
+    {
+        AcsEmailOptions opts = new()
+        {
+            ConnectionString = "endpoint=https://test.communication.azure.com/;accesskey=dGVzdA==",
+            DefaultSenderEmail = "noreply@example.com",
+            DefaultSenderName = "Default",
+            TimeoutSeconds = 5,
+        };
+        (AcsEmailSender sender, IAcsEmailTransport transport) = CreateSender(opts);
+        Azure.Communication.Email.EmailMessage? captured = null;
+        await transport.SendAsync(
+            Arg.Do<Azure.Communication.Email.EmailMessage>(m => captured = m),
+            Arg.Any<CancellationToken>());
+
+        EmailMessage message = new()
+        {
+            To = "recipient@example.com",
+            Subject = "Test subject",
+            HtmlBody = "<p>Hello</p>",
+            FromNameOverride = "Override",
+        };
+
+        await sender.SendAsync(message, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.SenderAddress.ShouldBe("\"Override\" <noreply@example.com>");
+    }
+
+    // -------------------------------------------------------------------------
     // Logger
     // -------------------------------------------------------------------------
 

--- a/tests/Granit.Notifications.Email.AzureCommunicationServices.Tests/AcsEmailServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Notifications.Email.AzureCommunicationServices.Tests/AcsEmailServiceCollectionExtensionsTests.cs
@@ -41,14 +41,14 @@ public sealed class AcsEmailServiceCollectionExtensionsTests
         services.AddGranitNotificationsEmailAcs(opts =>
         {
             opts.ConnectionString = "endpoint=https://test.communication.azure.com/;accesskey=dGVzdA==";
-            opts.SenderAddress = "test@example.com";
+            opts.DefaultSenderEmail = "test@example.com";
         });
 
         ServiceProvider sp = services.BuildServiceProvider();
         AcsEmailOptions options = sp.GetRequiredService<IOptions<AcsEmailOptions>>().Value;
 
         options.ConnectionString.ShouldNotBeNull();
-        options.SenderAddress.ShouldBe("test@example.com");
+        options.DefaultSenderEmail.ShouldBe("test@example.com");
     }
 
     [Fact]

--- a/tests/Granit.Notifications.Email.Scaleway.Tests/ScalewayEmailSenderTests.cs
+++ b/tests/Granit.Notifications.Email.Scaleway.Tests/ScalewayEmailSenderTests.cs
@@ -34,7 +34,7 @@ public sealed class ScalewayEmailSenderTests
             To = "recipient@example.com",
             Subject = "Test subject",
             HtmlBody = "<p>Hello</p>",
-            FromOverride = fromOverride,
+            FromEmailOverride = fromOverride,
             PlainTextBody = plainText,
         };
 
@@ -134,7 +134,7 @@ public sealed class ScalewayEmailSenderTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public async Task SendAsync_WithFromOverride_UsesOverrideAddress()
+    public async Task SendAsync_WithFromEmailOverride_UsesOverrideAddress()
     {
         (ScalewayEmailSender sender, MockHttpMessageHandler handler) = CreateSender();
 
@@ -148,7 +148,7 @@ public sealed class ScalewayEmailSenderTests
     }
 
     [Fact]
-    public async Task SendAsync_WithoutFromOverride_UsesDefaultSenderEmail()
+    public async Task SendAsync_WithoutFromEmailOverride_UsesDefaultSenderEmail()
     {
         (ScalewayEmailSender sender, MockHttpMessageHandler handler) = CreateSender();
 

--- a/tests/Granit.Notifications.Email.Scaleway.Tests/ScalewayEmailSenderTests.cs
+++ b/tests/Granit.Notifications.Email.Scaleway.Tests/ScalewayEmailSenderTests.cs
@@ -196,6 +196,38 @@ public sealed class ScalewayEmailSenderTests
     }
 
     // -------------------------------------------------------------------------
+    // Custom headers
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SendAsync_WithHeaders_IncludesAdditionalHeadersInPayload()
+    {
+        (ScalewayEmailSender sender, MockHttpMessageHandler handler) = CreateSender();
+
+        EmailMessage message = new()
+        {
+            To = "recipient@example.com",
+            Subject = "Test subject",
+            HtmlBody = "<p>Hello</p>",
+            Headers = new Dictionary<string, string>
+            {
+                ["List-Unsubscribe"] = "<https://example.com/unsub>",
+                ["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click",
+            },
+        };
+
+        await sender.SendAsync(message, TestContext.Current.CancellationToken);
+
+        handler.LastRequest.ShouldNotBeNull();
+        string body = await handler.LastRequest.Content!.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        using var doc = JsonDocument.Parse(body);
+        JsonElement root = doc.RootElement;
+        JsonElement headers = root.GetProperty("additional_headers");
+        headers.GetProperty("List-Unsubscribe").GetString().ShouldBe("<https://example.com/unsub>");
+        headers.GetProperty("List-Unsubscribe-Post").GetString().ShouldBe("List-Unsubscribe=One-Click");
+    }
+
+    // -------------------------------------------------------------------------
     // Error handling
     // -------------------------------------------------------------------------
 

--- a/tests/Granit.Notifications.Email.SendGrid.Tests/SendGridEmailSenderTests.cs
+++ b/tests/Granit.Notifications.Email.SendGrid.Tests/SendGridEmailSenderTests.cs
@@ -33,7 +33,7 @@ public sealed class SendGridEmailSenderTests
             To = "recipient@example.com",
             Subject = "Test subject",
             HtmlBody = "<p>Hello</p>",
-            FromOverride = fromOverride,
+            FromEmailOverride = fromOverride,
             PlainTextBody = plainText,
         };
 
@@ -118,7 +118,7 @@ public sealed class SendGridEmailSenderTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public async Task SendAsync_WithFromOverride_UsesOverrideAddress()
+    public async Task SendAsync_WithFromEmailOverride_UsesOverrideAddress()
     {
         (SendGridEmailSender sender, MockHttpMessageHandler handler) = CreateSender();
 
@@ -132,7 +132,7 @@ public sealed class SendGridEmailSenderTests
     }
 
     [Fact]
-    public async Task SendAsync_WithoutFromOverride_UsesDefaultSenderEmail()
+    public async Task SendAsync_WithoutFromEmailOverride_UsesDefaultSenderEmail()
     {
         (SendGridEmailSender sender, MockHttpMessageHandler handler) = CreateSender();
 

--- a/tests/Granit.Notifications.Email.SendGrid.Tests/SendGridEmailSenderTests.cs
+++ b/tests/Granit.Notifications.Email.SendGrid.Tests/SendGridEmailSenderTests.cs
@@ -185,6 +185,38 @@ public sealed class SendGridEmailSenderTests
     }
 
     // -------------------------------------------------------------------------
+    // Custom headers
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SendAsync_WithHeaders_IncludesHeadersInPayload()
+    {
+        (SendGridEmailSender sender, MockHttpMessageHandler handler) = CreateSender();
+
+        EmailMessage message = new()
+        {
+            To = "recipient@example.com",
+            Subject = "Test subject",
+            HtmlBody = "<p>Hello</p>",
+            Headers = new Dictionary<string, string>
+            {
+                ["List-Unsubscribe"] = "<https://example.com/unsub>",
+                ["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click",
+            },
+        };
+
+        await sender.SendAsync(message, TestContext.Current.CancellationToken);
+
+        handler.LastRequest.ShouldNotBeNull();
+        string body = await handler.LastRequest.Content!.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        using var doc = JsonDocument.Parse(body);
+        JsonElement root = doc.RootElement;
+        JsonElement headers = root.GetProperty("headers");
+        headers.GetProperty("List-Unsubscribe").GetString().ShouldBe("<https://example.com/unsub>");
+        headers.GetProperty("List-Unsubscribe-Post").GetString().ShouldBe("List-Unsubscribe=One-Click");
+    }
+
+    // -------------------------------------------------------------------------
     // Error handling
     // -------------------------------------------------------------------------
 

--- a/tests/Granit.Notifications.Email.Smtp.Tests/MailKitEmailSenderTests.cs
+++ b/tests/Granit.Notifications.Email.Smtp.Tests/MailKitEmailSenderTests.cs
@@ -327,6 +327,85 @@ public sealed class MailKitEmailSenderTests
     }
 
     // -------------------------------------------------------------------------
+    // Custom headers
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SendAsync_WithHeaders_AddsMimeHeaders()
+    {
+        (MailKitEmailSender? sender, ISmtpTransport? transport) = CreateSender();
+        MimeMessage? captured = null;
+        await transport.SendAsync(Arg.Do<MimeMessage>(m => captured = m), Arg.Any<CancellationToken>());
+
+        EmailMessage message = new()
+        {
+            To = "recipient@example.com",
+            Subject = "Test subject",
+            HtmlBody = "<p>Hello</p>",
+            Headers = new Dictionary<string, string>
+            {
+                ["List-Unsubscribe"] = "<https://example.com/unsub>",
+            },
+        };
+
+        await sender.SendAsync(message, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Headers["List-Unsubscribe"].ShouldBe("<https://example.com/unsub>");
+    }
+
+    // -------------------------------------------------------------------------
+    // ToName
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SendAsync_WithToName_UsesMailboxAddressWithName()
+    {
+        (MailKitEmailSender? sender, ISmtpTransport? transport) = CreateSender();
+        MimeMessage? captured = null;
+        await transport.SendAsync(Arg.Do<MimeMessage>(m => captured = m), Arg.Any<CancellationToken>());
+
+        EmailMessage message = new()
+        {
+            To = "recipient@example.com",
+            Subject = "Test subject",
+            HtmlBody = "<p>Hello</p>",
+            ToName = "John Doe",
+        };
+
+        await sender.SendAsync(message, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        ((MailboxAddress)captured.To[0]).Name.ShouldBe("John Doe");
+    }
+
+    // -------------------------------------------------------------------------
+    // Sender name formatting
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SendAsync_WithDefaultSenderName_UsesNameInFrom()
+    {
+        SmtpOptions opts = new()
+        {
+            Host = "mail.example.com",
+            Port = 587,
+            UseSsl = false,
+            DefaultSenderName = "My App",
+            DefaultSenderEmail = "noreply@example.com",
+            TimeoutSeconds = 5,
+        };
+        (MailKitEmailSender? sender, ISmtpTransport? transport) = CreateSender(opts);
+        MimeMessage? captured = null;
+        await transport.SendAsync(Arg.Do<MimeMessage>(m => captured = m), Arg.Any<CancellationToken>());
+
+        await sender.SendAsync(SimpleMessage(), TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        ((MailboxAddress)captured.From[0]).Name.ShouldBe("My App");
+    }
+
+    // -------------------------------------------------------------------------
     // Timeout calculation
     // -------------------------------------------------------------------------
 

--- a/tests/Granit.Notifications.Email.Smtp.Tests/MailKitEmailSenderTests.cs
+++ b/tests/Granit.Notifications.Email.Smtp.Tests/MailKitEmailSenderTests.cs
@@ -2,7 +2,7 @@
 // Tests - MailKitEmailSender
 // =============================================================================
 // Verifies the MailKit SMTP email sender: MimeMessage construction, sender
-// address resolution (FromOverride > Username > fallback), body builder,
+// address resolution (FromEmailOverride > Username > fallback), body builder,
 // authentication branching, and successful send/disconnect flow.
 // Uses ISmtpTransportFactory + ISmtpTransport substitutes to avoid real SMTP.
 // =============================================================================
@@ -53,7 +53,7 @@ public sealed class MailKitEmailSenderTests
             To = "recipient@example.com",
             Subject = "Test subject",
             HtmlBody = "<p>Hello</p>",
-            FromOverride = fromOverride,
+            FromEmailOverride = fromOverride,
             PlainTextBody = plainText,
         };
 
@@ -223,7 +223,7 @@ public sealed class MailKitEmailSenderTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public async Task SendAsync_WithFromOverride_UsesSenderAddressFromOverride()
+    public async Task SendAsync_WithFromEmailOverride_UsesSenderAddressFromEmailOverride()
     {
         (MailKitEmailSender? sender, ISmtpTransport? transport) = CreateSender();
         MimeMessage? captured = null;
@@ -236,7 +236,7 @@ public sealed class MailKitEmailSenderTests
     }
 
     [Fact]
-    public async Task SendAsync_WithoutFromOverride_UsesUsername()
+    public async Task SendAsync_WithoutFromEmailOverride_UsesUsername()
     {
         SmtpOptions opts = new()
         {
@@ -257,7 +257,7 @@ public sealed class MailKitEmailSenderTests
     }
 
     [Fact]
-    public async Task SendAsync_WithoutFromOverrideOrUsername_FallsBackToNoreply()
+    public async Task SendAsync_WithoutFromEmailOverrideOrUsername_FallsBackToNoreply()
     {
         SmtpOptions opts = new()
         {
@@ -274,7 +274,7 @@ public sealed class MailKitEmailSenderTests
         await sender.SendAsync(SimpleMessage(), TestContext.Current.CancellationToken);
 
         captured.ShouldNotBeNull();
-        ((MailboxAddress)captured.From[0]).Name.ShouldBe("noreply");
+        ((MailboxAddress)captured.From[0]).Name.ShouldBe("noreply@localhost");
         ((MailboxAddress)captured.From[0]).Address.ShouldBe("noreply@localhost");
     }
 

--- a/tests/Granit.Notifications.Email.Tests/EmailChannelOptionsTests.cs
+++ b/tests/Granit.Notifications.Email.Tests/EmailChannelOptionsTests.cs
@@ -19,19 +19,19 @@ public sealed class EmailChannelOptionsTests
     }
 
     [Fact]
-    public void Defaults_SenderAddressIsEmpty()
+    public void Defaults_DefaultSenderEmailIsEmpty()
     {
         EmailChannelOptions options = new();
 
-        options.SenderAddress.ShouldBe(string.Empty);
+        options.DefaultSenderEmail.ShouldBe(string.Empty);
     }
 
     [Fact]
-    public void Defaults_SenderNameIsEmpty()
+    public void Defaults_DefaultSenderNameIsEmpty()
     {
         EmailChannelOptions options = new();
 
-        options.SenderName.ShouldBe(string.Empty);
+        options.DefaultSenderName.ShouldBe(string.Empty);
     }
 
     [Fact]
@@ -40,12 +40,12 @@ public sealed class EmailChannelOptionsTests
         EmailChannelOptions options = new()
         {
             Provider = "Brevo",
-            SenderAddress = "no-reply@example.com",
-            SenderName = "My App",
+            DefaultSenderEmail = "no-reply@example.com",
+            DefaultSenderName = "My App",
         };
 
         options.Provider.ShouldBe("Brevo");
-        options.SenderAddress.ShouldBe("no-reply@example.com");
-        options.SenderName.ShouldBe("My App");
+        options.DefaultSenderEmail.ShouldBe("no-reply@example.com");
+        options.DefaultSenderName.ShouldBe("My App");
     }
 }

--- a/tests/Granit.Notifications.Email.Tests/EmailMessageTests.cs
+++ b/tests/Granit.Notifications.Email.Tests/EmailMessageTests.cs
@@ -8,20 +8,32 @@ public sealed class EmailMessageTests
     [Fact]
     public void Properties_SetCorrectly()
     {
+        Dictionary<string, string> headers = new()
+        {
+            ["List-Unsubscribe"] = "<mailto:unsubscribe@test.com>",
+            ["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click",
+        };
+
         EmailMessage message = new()
         {
             To = "user@test.com",
+            ToName = "Test User",
             Subject = "Test Subject",
             HtmlBody = "<p>Hello</p>",
             PlainTextBody = "Hello",
             FromEmailOverride = "sender@test.com",
+            FromNameOverride = "Custom Sender",
+            Headers = headers,
         };
 
         message.To.ShouldBe("user@test.com");
+        message.ToName.ShouldBe("Test User");
         message.Subject.ShouldBe("Test Subject");
         message.HtmlBody.ShouldBe("<p>Hello</p>");
         message.PlainTextBody.ShouldBe("Hello");
         message.FromEmailOverride.ShouldBe("sender@test.com");
+        message.FromNameOverride.ShouldBe("Custom Sender");
+        message.Headers.ShouldBe(headers);
     }
 
     [Fact]
@@ -36,6 +48,9 @@ public sealed class EmailMessageTests
 
         message.PlainTextBody.ShouldBeNull();
         message.FromEmailOverride.ShouldBeNull();
+        message.ToName.ShouldBeNull();
+        message.FromNameOverride.ShouldBeNull();
+        message.Headers.ShouldBeNull();
     }
 
     [Fact]

--- a/tests/Granit.Notifications.Email.Tests/EmailMessageTests.cs
+++ b/tests/Granit.Notifications.Email.Tests/EmailMessageTests.cs
@@ -14,14 +14,14 @@ public sealed class EmailMessageTests
             Subject = "Test Subject",
             HtmlBody = "<p>Hello</p>",
             PlainTextBody = "Hello",
-            FromOverride = "sender@test.com",
+            FromEmailOverride = "sender@test.com",
         };
 
         message.To.ShouldBe("user@test.com");
         message.Subject.ShouldBe("Test Subject");
         message.HtmlBody.ShouldBe("<p>Hello</p>");
         message.PlainTextBody.ShouldBe("Hello");
-        message.FromOverride.ShouldBe("sender@test.com");
+        message.FromEmailOverride.ShouldBe("sender@test.com");
     }
 
     [Fact]
@@ -35,7 +35,7 @@ public sealed class EmailMessageTests
         };
 
         message.PlainTextBody.ShouldBeNull();
-        message.FromOverride.ShouldBeNull();
+        message.FromEmailOverride.ShouldBeNull();
     }
 
     [Fact]

--- a/tests/Granit.Notifications.Email.Tests/EmailNotificationChannelTests.cs
+++ b/tests/Granit.Notifications.Email.Tests/EmailNotificationChannelTests.cs
@@ -585,16 +585,230 @@ public sealed class EmailNotificationChannelTests
         capturedData["notification_type"].ShouldBe("test.notification");
     }
 
+    // ──── ToName and FromNameOverride propagation tests ────
+
+    [Fact]
+    public async Task SendAsync_SetsToNameFromRecipientDisplayName()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com", displayName: "John Doe");
+        EmailMessage? captured = null;
+        _emailSender.SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                captured = callInfo.Arg<EmailMessage>();
+                return Task.CompletedTask;
+            });
+
+        await _channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.ToName.ShouldBe("John Doe");
+    }
+
+    [Fact]
+    public async Task SendAsync_SetsFromNameOverrideFromOptions()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com");
+
+        EmailNotificationChannel channel = CreateChannel(
+            opts: new EmailChannelOptions
+            {
+                Provider = "Smtp",
+                DefaultSenderEmail = "no-reply@test.com",
+                DefaultSenderName = "My App",
+            });
+
+        EmailMessage? captured = null;
+        _emailSender.SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                captured = callInfo.Arg<EmailMessage>();
+                return Task.CompletedTask;
+            });
+
+        await channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.FromNameOverride.ShouldBe("My App");
+    }
+
+    // ──── List-Unsubscribe header tests (RFC 8058) ────
+
+    [Fact]
+    public async Task SendAsync_WhenAllowUserOptOut_SetsListUnsubscribeHeaders()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com");
+
+        INotificationDefinitionStore defStore = Substitute.For<INotificationDefinitionStore>();
+        defStore.Get("test.notification").Returns(new NotificationDefinition("test.notification")
+        {
+            AllowUserOptOut = true,
+            GroupName = "Security",
+        });
+
+        EmailNotificationChannel channel = CreateChannel(
+            opts: new EmailChannelOptions
+            {
+                Provider = "Smtp",
+                DefaultSenderEmail = "no-reply@test.com",
+                UnsubscribeUrl = "https://app.test/prefs",
+            },
+            defStore: defStore);
+
+        EmailMessage? captured = null;
+        _emailSender.SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                captured = callInfo.Arg<EmailMessage>();
+                return Task.CompletedTask;
+            });
+
+        await channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Headers.ShouldNotBeNull();
+        captured.Headers["List-Unsubscribe"].ShouldBe("<https://app.test/prefs>");
+        captured.Headers["List-Unsubscribe-Post"].ShouldBe("List-Unsubscribe=One-Click");
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenAllowUserOptOutFalse_DoesNotSetHeaders()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com");
+
+        INotificationDefinitionStore defStore = Substitute.For<INotificationDefinitionStore>();
+        defStore.Get("test.notification").Returns(new NotificationDefinition("test.notification")
+        {
+            AllowUserOptOut = false,
+        });
+
+        EmailNotificationChannel channel = CreateChannel(defStore: defStore);
+
+        EmailMessage? captured = null;
+        _emailSender.SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                captured = callInfo.Arg<EmailMessage>();
+                return Task.CompletedTask;
+            });
+
+        await channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Headers.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenNoDefinitionStore_DefaultsToOptOutAllowed()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com");
+
+        EmailNotificationChannel channel = CreateChannel(
+            opts: new EmailChannelOptions
+            {
+                Provider = "Smtp",
+                DefaultSenderEmail = "no-reply@test.com",
+                UnsubscribeUrl = "https://app.test/prefs",
+            });
+
+        EmailMessage? captured = null;
+        _emailSender.SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                captured = callInfo.Arg<EmailMessage>();
+                return Task.CompletedTask;
+            });
+
+        await channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Headers.ShouldNotBeNull();
+        captured.Headers["List-Unsubscribe"].ShouldBe("<https://app.test/prefs>");
+        captured.Headers["List-Unsubscribe-Post"].ShouldBe("List-Unsubscribe=One-Click");
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenNoUnsubscribeUrlConfigured_UsesBaseUrlFallback()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com");
+
+        INotificationDefinitionStore defStore = Substitute.For<INotificationDefinitionStore>();
+        defStore.Get("test.notification").Returns(new NotificationDefinition("test.notification")
+        {
+            AllowUserOptOut = true,
+        });
+
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Granit:Templating:App:BaseUrl"] = "https://myapp.com",
+            })
+            .Build();
+
+        EmailNotificationChannel channel = CreateChannel(
+            config: config,
+            defStore: defStore);
+
+        EmailMessage? captured = null;
+        _emailSender.SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                captured = callInfo.Arg<EmailMessage>();
+                return Task.CompletedTask;
+            });
+
+        await channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Headers.ShouldNotBeNull();
+        captured.Headers["List-Unsubscribe"].ShouldBe("<https://myapp.com/notifications/preferences>");
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenNoUrlResolvable_DoesNotSetHeaders()
+    {
+        NotificationDeliveryContext context = BuildContext();
+        SetupRecipient("user-1", email: "user@test.com");
+
+        INotificationDefinitionStore defStore = Substitute.For<INotificationDefinitionStore>();
+        defStore.Get("test.notification").Returns(new NotificationDefinition("test.notification")
+        {
+            AllowUserOptOut = true,
+        });
+
+        EmailNotificationChannel channel = CreateChannel(defStore: defStore);
+
+        EmailMessage? captured = null;
+        _emailSender.SendAsync(Arg.Any<EmailMessage>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                captured = callInfo.Arg<EmailMessage>();
+                return Task.CompletedTask;
+            });
+
+        await channel.SendAsync(context, TestContext.Current.CancellationToken);
+
+        captured.ShouldNotBeNull();
+        captured.Headers.ShouldBeNull();
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 
-    private void SetupRecipient(string userId, string? email) =>
+    private void SetupRecipient(string userId, string? email, string? displayName = null) =>
         _recipientResolver.ResolveAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new RecipientInfo
             {
                 UserId = userId,
                 Email = email,
+                DisplayName = displayName,
             });
 
     private static NotificationDeliveryContext BuildContext() => new()
@@ -607,4 +821,30 @@ public sealed class EmailNotificationChannelTests
         Data = JsonSerializer.SerializeToElement(new { key = "value" }),
         OccurredAt = DateTimeOffset.UtcNow,
     };
+
+    private EmailNotificationChannel CreateChannel(
+        EmailChannelOptions? opts = null,
+        IConfiguration? config = null,
+        INotificationDefinitionStore? defStore = null)
+    {
+        opts ??= new EmailChannelOptions
+        {
+            Provider = "Smtp",
+            DefaultSenderEmail = "no-reply@test.com",
+        };
+
+        config ??= new ConfigurationBuilder().Build();
+
+        if (defStore is not null)
+        {
+            _serviceProvider.GetService(typeof(INotificationDefinitionStore)).Returns(defStore);
+        }
+
+        return new EmailNotificationChannel(
+            _serviceProvider,
+            Microsoft.Extensions.Options.Options.Create(opts),
+            _recipientResolver,
+            config,
+            Substitute.For<ILogger<EmailNotificationChannel>>());
+    }
 }

--- a/tests/Granit.Notifications.Email.Tests/EmailNotificationChannelTests.cs
+++ b/tests/Granit.Notifications.Email.Tests/EmailNotificationChannelTests.cs
@@ -11,6 +11,7 @@ using Granit.Notifications.Email;
 using Granit.Notifications.Email.Internal;
 using Granit.Notifications.Email.Options;
 using Granit.Templating.Pipeline;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -34,7 +35,7 @@ public sealed class EmailNotificationChannelTests
         _options = Microsoft.Extensions.Options.Options.Create(new EmailChannelOptions
         {
             Provider = "Smtp",
-            SenderAddress = "no-reply@test.com",
+            DefaultSenderEmail = "no-reply@test.com",
         });
 
         _serviceProvider.GetRequiredKeyedService(typeof(IEmailSender), "Smtp")
@@ -44,6 +45,7 @@ public sealed class EmailNotificationChannelTests
             _serviceProvider,
             _options,
             _recipientResolver,
+            new ConfigurationBuilder().Build(),
             Substitute.For<ILogger<EmailNotificationChannel>>());
     }
 
@@ -89,7 +91,7 @@ public sealed class EmailNotificationChannelTests
     }
 
     [Fact]
-    public async Task SendAsync_SetsFromOverrideFromOptions()
+    public async Task SendAsync_SetsFromEmailOverrideFromOptions()
     {
         NotificationDeliveryContext context = BuildContext();
         SetupRecipient("user-1", email: "user@test.com");
@@ -104,7 +106,7 @@ public sealed class EmailNotificationChannelTests
         await _channel.SendAsync(context, TestContext.Current.CancellationToken);
 
         captured.ShouldNotBeNull();
-        captured!.FromOverride.ShouldBe("no-reply@test.com");
+        captured!.FromEmailOverride.ShouldBe("no-reply@test.com");
     }
 
     [Fact]

--- a/tests/Granit.Notifications.Email.Tests/EmailNotificationsServiceCollectionExtensionsAdditionalTests.cs
+++ b/tests/Granit.Notifications.Email.Tests/EmailNotificationsServiceCollectionExtensionsAdditionalTests.cs
@@ -31,16 +31,16 @@ public sealed class EmailNotificationsServiceCollectionExtensionsAdditionalTests
         services.AddGranitNotificationsEmail(opts =>
         {
             opts.Provider = "Brevo";
-            opts.SenderAddress = "noreply@example.com";
-            opts.SenderName = "Test App";
+            opts.DefaultSenderEmail = "noreply@example.com";
+            opts.DefaultSenderName = "Test App";
         });
 
         using ServiceProvider sp = services.BuildServiceProvider();
         IOptions<EmailChannelOptions> options = sp.GetRequiredService<IOptions<EmailChannelOptions>>();
 
         options.Value.Provider.ShouldBe("Brevo");
-        options.Value.SenderAddress.ShouldBe("noreply@example.com");
-        options.Value.SenderName.ShouldBe("Test App");
+        options.Value.DefaultSenderEmail.ShouldBe("noreply@example.com");
+        options.Value.DefaultSenderName.ShouldBe("Test App");
     }
 
     [Fact]

--- a/tests/Granit.Notifications.Email.Tests/EmailNotificationsServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Notifications.Email.Tests/EmailNotificationsServiceCollectionExtensionsTests.cs
@@ -51,16 +51,16 @@ public sealed class EmailNotificationsServiceCollectionExtensionsTests
         services.AddGranitNotificationsEmail(opts =>
         {
             opts.Provider = "Brevo";
-            opts.SenderAddress = "noreply@example.com";
-            opts.SenderName = "Test App";
+            opts.DefaultSenderEmail = "noreply@example.com";
+            opts.DefaultSenderName = "Test App";
         });
 
         ServiceProvider sp = services.BuildServiceProvider();
         EmailChannelOptions options = sp.GetRequiredService<IOptions<EmailChannelOptions>>().Value;
 
         options.Provider.ShouldBe("Brevo");
-        options.SenderAddress.ShouldBe("noreply@example.com");
-        options.SenderName.ShouldBe("Test App");
+        options.DefaultSenderEmail.ShouldBe("noreply@example.com");
+        options.DefaultSenderName.ShouldBe("Test App");
     }
 
     [Fact]

--- a/tests/Granit.Templating.Scriban.Tests/ScribanTemplateEngineCachingTests.cs
+++ b/tests/Granit.Templating.Scriban.Tests/ScribanTemplateEngineCachingTests.cs
@@ -2,6 +2,7 @@ using Granit.Templating.GlobalContext;
 using Granit.Templating.Keys;
 using Granit.Templating.Pipeline;
 using Granit.Templating.Scriban.Internal;
+using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using Xunit;
 
@@ -14,7 +15,7 @@ public sealed class ScribanTemplateEngineCachingTests
     [Fact]
     public async Task RenderAsync_SameRevisionId_UsesCachedTemplate()
     {
-        ScribanTemplateEngine sut = new();
+        ScribanTemplateEngine sut = new(new ServiceCollection().BuildServiceProvider());
         var revisionId = Guid.NewGuid();
 
         TemplateDescriptor descriptor = new()
@@ -39,7 +40,7 @@ public sealed class ScribanTemplateEngineCachingTests
     [Fact]
     public async Task RenderAsync_NullRevisionId_CachesByContent()
     {
-        ScribanTemplateEngine sut = new();
+        ScribanTemplateEngine sut = new(new ServiceCollection().BuildServiceProvider());
 
         TemplateDescriptor descriptor = new()
         {
@@ -63,7 +64,7 @@ public sealed class ScribanTemplateEngineCachingTests
     [Fact]
     public async Task RenderAsync_PropagatesTargetFormat()
     {
-        ScribanTemplateEngine sut = new();
+        ScribanTemplateEngine sut = new(new ServiceCollection().BuildServiceProvider());
 
         TemplateDescriptor descriptor = new()
         {
@@ -82,7 +83,7 @@ public sealed class ScribanTemplateEngineCachingTests
     [Fact]
     public async Task RenderAsync_MultipleGlobalContexts_AllInjected()
     {
-        ScribanTemplateEngine sut = new();
+        ScribanTemplateEngine sut = new(new ServiceCollection().BuildServiceProvider());
 
         TemplateDescriptor descriptor = new()
         {

--- a/tests/Granit.Templating.Scriban.Tests/ScribanTemplateEngineTests.cs
+++ b/tests/Granit.Templating.Scriban.Tests/ScribanTemplateEngineTests.cs
@@ -4,6 +4,7 @@ using Granit.Templating.Pipeline;
 using Granit.Templating.Scriban;
 using Granit.Templating.Scriban.Exceptions;
 using Granit.Templating.Scriban.Internal;
+using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -15,7 +16,7 @@ internal sealed record PersonModel(string FirstName, string LastName, int? Age =
 
 public sealed class ScribanTemplateEngineTests
 {
-    private static readonly ScribanTemplateEngine Sut = new();
+    private static readonly ScribanTemplateEngine Sut = new(new ServiceCollection().BuildServiceProvider());
 
     // ---- CanRender -------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **RFC 2369 / RFC 8058 List-Unsubscribe headers** — Gmail/Outlook native unsubscribe button, required by Google/Yahoo since 2024 for bulk senders
- **Conditional on `AllowUserOptOut`** — password reset, security alerts, GDPR breach notifications skip the header
- **Generic `EmailMessage.Headers`** — `IReadOnlyDictionary<string, string>?` extensible for future headers (Reply-To, X-*, tracking)
- **Professional email footer** — conditional unsubscribe link, notification group reason text, no-reply disclaimer
- **Sender naming harmonization** — `DefaultSenderEmail` + `DefaultSenderName` across all options (was `SenderAddress`, `FromAddress`, etc.)
- **All 6 providers** map headers to their transport (SMTP, SendGrid, Scaleway, AWS SES V2, Azure ACS, Brevo)

### Unsubscribe URL resolution

```
EmailChannelOptions.UnsubscribeUrl (explicit)
  ↓ null
AppGlobalContextOptions.BaseUrl + "/notifications/preferences" (fallback)
  ↓ null
No header (graceful)
```

### Breaking changes (config only)

| Package | Old | New |
|---------|-----|-----|
| `EmailChannelOptions` | `SenderAddress` / `SenderName` | `DefaultSenderEmail` / `DefaultSenderName` |
| `AcsEmailOptions` | `SenderAddress` | `DefaultSenderEmail` |
| `SmtpOptions` | _(auth only)_ | + `DefaultSenderEmail` / `DefaultSenderName` |
| `EmailMessage` | `FromOverride` | `FromEmailOverride` + `FromNameOverride` + `ToName` |

Showcase `appsettings.json` updated accordingly.

## Test plan

- [x] `Granit.Notifications.Email.Tests` — 39 passed
- [x] `Granit.Notifications.Email.Smtp.Tests` — 31 passed
- [x] `Granit.Notifications.Email.SendGrid.Tests` — 26 passed
- [x] `Granit.Notifications.Email.Scaleway.Tests` — 28 passed
- [x] `Granit.Notifications.Email.AwsSes.Tests` — 35 passed
- [x] `Granit.Notifications.Email.AzureCommunicationServices.Tests` — 28 passed
- [x] `Granit.Notifications.Brevo.Tests` — 49 passed
- [ ] Showcase appsettings.json config rename
