### PR TITLE
fix(wolverine): auto-discover handlers from all Granit module assemblies

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -32467,7 +32467,7 @@
       "kind": "class",
       "project": "Granit.Wolverine",
       "file": "src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs",
-      "line": 25,
+      "line": 26,
       "members": [
         {
           "name": "AddGranitWolverine",

--- a/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using FluentValidation;
 using Granit.Diagnostics;
+using Granit.Modularity;
 using Granit.Users;
 using Granit.Wolverine.Behaviors;
 using Granit.Wolverine.Diagnostics;
@@ -87,12 +88,24 @@ public static class WolverineHostApplicationBuilderExtensions
 
         builder.UseWolverine(opts =>
         {
-            // Auto-discover assemblies decorated with [assembly: WolverineHandlerModule].
-            // Granit library packages use this attribute to opt in to handler scanning.
-            //
-            // NOTE: opts.Discovery.IncludeHandlerModules = true does NOT work reliably
-            // in Wolverine 5.26.x — the flag is ignored during handler compilation.
-            // Workaround: explicitly scan AppDomain and include matching assemblies.
+            // Auto-discover handler assemblies from ALL loaded Granit modules.
+            // GranitApplication is registered as a singleton instance during AddGranit<T>()
+            // before UseWolverine() runs, so we can read it directly from the service collection.
+            // This eliminates the need for [assembly: WolverineHandlerModule] on every module.
+            var granitApp = builder.Services
+                .FirstOrDefault(d => d.ServiceType == typeof(GranitApplication))
+                ?.ImplementationInstance as GranitApplication;
+
+            if (granitApp is not null)
+            {
+                foreach (GranitModule module in granitApp.GetModuleInstances())
+                {
+                    opts.Discovery.IncludeAssembly(module.GetType().Assembly);
+                }
+            }
+
+            // Also honor [assembly: WolverineHandlerModule] for non-Granit assemblies
+            // (e.g. application handler modules that don't subclass GranitModule).
             foreach (Assembly handlerAssembly in AppDomain.CurrentDomain.GetAssemblies())
             {
                 if (handlerAssembly.GetCustomAttributes(typeof(global::Wolverine.Attributes.WolverineHandlerModuleAttribute), false).Length > 0)
@@ -103,8 +116,6 @@ public static class WolverineHostApplicationBuilderExtensions
 
             // Always include the entry assembly so application handlers are discovered
             // without requiring [assembly: WolverineHandlerModule] in application code.
-            // Library packages (Granit modules) still use the attribute; this only adds
-            // the host application assembly (e.g. MyService.exe).
             var entryAssembly = Assembly.GetEntryAssembly();
             if (entryAssembly is not null)
             {


### PR DESCRIPTION
## Summary

- Scan `GranitApplication.GetModuleInstances()` to include **all loaded Granit module assemblies** in Wolverine's handler discovery
- Eliminates the need for `[assembly: WolverineHandlerModule]` on every module
- Removes the reflection-based workaround required in consumer apps (e.g. granit-fx/granit-showcase-dotnet#9)

## Problem

Wolverine handler discovery required either:
1. `[assembly: WolverineHandlerModule]` on every module (requires a WolverineFx dependency)
2. A fragile reflection workaround in the host app to manually include assemblies

This caused `Granit.Identity.Local.Notifications` handlers (password reset, welcome email, etc.) to be silently skipped — emails were never sent.

## Solution

`GranitApplication` is registered as a singleton instance during `AddGranit<T>()`, before `UseWolverine()` runs. The Wolverine setup now reads it directly from the `IServiceCollection` and includes all module assemblies automatically.

`[assembly: WolverineHandlerModule]` is still honored for non-Granit assemblies.

## Test plan

- [x] `Granit.Wolverine.Tests` — 154 tests pass
- [ ] Verify forgot password email arrives in Mailpit (showcase)
- [ ] Verify all 9 identity notification types fire