### PR TITLE
fix: resolve SonarQube code smells + Wolverine handler arch test

### DIFF
--- a/src/Granit.DataExchange.Wolverine/Granit.DataExchange.Wolverine.csproj
+++ b/src/Granit.DataExchange.Wolverine/Granit.DataExchange.Wolverine.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.DataExchange.Wolverine.Tests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+    <InternalsVisibleTo Include="WolverineHandlers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.Identity.Federated.EntityFrameworkCore/Granit.Identity.Federated.EntityFrameworkCore.csproj
+++ b/src/Granit.Identity.Federated.EntityFrameworkCore/Granit.Identity.Federated.EntityFrameworkCore.csproj
@@ -9,9 +9,8 @@
     <InternalsVisibleTo Include="Granit.Identity.Federated.EntityFrameworkCore.Tests" />
     <InternalsVisibleTo Include="Granit.Identity.Endpoints" />
     <InternalsVisibleTo Include="Granit.Identity.Endpoints.Tests" />
-    <!-- Required by Castle.DynamicProxy (NSubstitute) to proxy internal types in tests -->
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+    <InternalsVisibleTo Include="WolverineHandlers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.Identity.Local.Notifications/Granit.Identity.Local.Notifications.csproj
+++ b/src/Granit.Identity.Local.Notifications/Granit.Identity.Local.Notifications.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.Identity.Local.Notifications.Tests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+    <InternalsVisibleTo Include="WolverineHandlers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.Notifications.Email/Templates/Layout.Email.html
+++ b/src/Granit.Notifications.Email/Templates/Layout.Email.html
@@ -95,7 +95,7 @@
     </style>
 </head>
 <body>
-    <div class="wrapper" role="presentation">
+    <div class="wrapper">
         <div class="container">
             <header role="banner">
                 {{- if app.logo_url != "" }}
@@ -109,7 +109,7 @@
                 {{- if app.base_url != "" }}
                 <hr class="divider" aria-hidden="true">
                 <p style="text-align: center;">
-                    <a href="{{ app.base_url }}" class="btn" role="link">{{ app.name }}</a>
+                    <a href="{{ app.base_url }}" class="btn">{{ app.name }}</a>
                 </p>
                 {{- end }}
             </main>

--- a/src/Granit.Notifications/Handlers/NotificationFanoutHandler.cs
+++ b/src/Granit.Notifications/Handlers/NotificationFanoutHandler.cs
@@ -48,25 +48,8 @@ public sealed class NotificationFanoutHandler(
         IReadOnlyList<string> defaultChannels = definition?.DefaultChannels ?? [NotificationChannels.InApp];
         bool allowOptOut = definition?.AllowUserOptOut ?? true;
 
-        // Resolve recipients: explicit list, or subscribers, or entity followers
-        IReadOnlyList<string> recipientUserIds = trigger.RecipientUserIds;
-
-        if (recipientUserIds.Count == 0 && trigger.RelatedEntity is not null)
-        {
-            recipientUserIds = await subscriptionReader.GetEntityFollowerIdsAsync(
-                trigger.RelatedEntity.EntityType,
-                trigger.RelatedEntity.EntityId,
-                tenantId,
-                cancellationToken).ConfigureAwait(false);
-        }
-
-        if (recipientUserIds.Count == 0)
-        {
-            recipientUserIds = await subscriptionReader.GetSubscriberIdsAsync(
-                trigger.NotificationTypeName,
-                tenantId,
-                cancellationToken).ConfigureAwait(false);
-        }
+        IReadOnlyList<string> recipientUserIds = await ResolveRecipientsAsync(
+            trigger, tenantId, cancellationToken).ConfigureAwait(false);
 
         if (recipientUserIds.Count == 0)
         {
@@ -112,6 +95,39 @@ public sealed class NotificationFanoutHandler(
             trigger.NotificationTypeName);
 
         return commands;
+    }
+
+    /// <summary>
+    /// Resolves recipients: explicit list → entity followers → topic subscribers.
+    /// </summary>
+    private async Task<IReadOnlyList<string>> ResolveRecipientsAsync(
+        NotificationTrigger trigger,
+        Guid? tenantId,
+        CancellationToken cancellationToken)
+    {
+        if (trigger.RecipientUserIds.Count > 0)
+        {
+            return trigger.RecipientUserIds;
+        }
+
+        if (trigger.RelatedEntity is not null)
+        {
+            IReadOnlyList<string> followers = await subscriptionReader.GetEntityFollowerIdsAsync(
+                trigger.RelatedEntity.EntityType,
+                trigger.RelatedEntity.EntityId,
+                tenantId,
+                cancellationToken).ConfigureAwait(false);
+
+            if (followers.Count > 0)
+            {
+                return followers;
+            }
+        }
+
+        return await subscriptionReader.GetSubscriberIdsAsync(
+            trigger.NotificationTypeName,
+            tenantId,
+            cancellationToken).ConfigureAwait(false);
     }
 
     private Task<bool> IsChannelEnabledAsync(

--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations.Wolverine/Granit.Persistence.EntityFrameworkCore.Migrations.Wolverine.csproj
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations.Wolverine/Granit.Persistence.EntityFrameworkCore.Migrations.Wolverine.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.Persistence.EntityFrameworkCore.Migrations.Wolverine.Tests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+    <InternalsVisibleTo Include="WolverineHandlers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.Templating.Scriban/Internal/TemplateLocalizationFunction.cs
+++ b/src/Granit.Templating.Scriban/Internal/TemplateLocalizationFunction.cs
@@ -76,6 +76,6 @@ internal sealed class TemplateLocalizationFunction(IStringLocalizerFactory local
     public ValueTask<object?> InvokeAsync(TemplateContext context, ScriptNode? callerContext, ScriptArray arguments, ScriptBlockStatement? blockStatement) =>
         new(Invoke(context, callerContext, arguments, blockStatement));
 
-    public int GetParameterIndexByName(string name) =>
+    public static int GetParameterIndexByName(string name) =>
         throw new NotImplementedException();
 }

--- a/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
+++ b/tests/Granit.ArchitectureTests/Granit.ArchitectureTests.csproj
@@ -38,11 +38,7 @@
     <ProjectReference Include="..\..\src\Granit.AI.Ollama\Granit.AI.Ollama.csproj" />
     <ProjectReference Include="..\..\src\Granit.AI.OpenAI\Granit.AI.OpenAI.csproj" />
     <ProjectReference Include="..\..\src\Granit.AI.VectorData\Granit.AI.VectorData.csproj" />
-    <ProjectReference Include="..\..\src\Granit.AuditLog\Granit.AuditLog.csproj" />
-    <ProjectReference Include="..\..\src\Granit.AuditLog.ConfigurationChanges\Granit.AuditLog.ConfigurationChanges.csproj" />
-    <ProjectReference Include="..\..\src\Granit.AuditLog.Endpoints\Granit.AuditLog.Endpoints.csproj" />
-    <ProjectReference Include="..\..\src\Granit.AuditLog.EntityFrameworkCore\Granit.AuditLog.EntityFrameworkCore.csproj" />
-    <ProjectReference Include="..\..\src\Granit.Auditing\Granit.Auditing.csproj" />
+<ProjectReference Include="..\..\src\Granit.Auditing\Granit.Auditing.csproj" />
     <ProjectReference Include="..\..\src\Granit.Auditing.ConfigurationChanges\Granit.Auditing.ConfigurationChanges.csproj" />
     <ProjectReference Include="..\..\src\Granit.Auditing.Endpoints\Granit.Auditing.Endpoints.csproj" />
     <ProjectReference Include="..\..\src\Granit.Auditing.EntityFrameworkCore\Granit.Auditing.EntityFrameworkCore.csproj" />


### PR DESCRIPTION
## Summary

- **Layout.Email.html**: remove redundant `role="presentation"` and `role="link"` (accessibility)
- **NotificationFanoutHandler**: extract `ResolveRecipientsAsync()` to reduce cognitive complexity (17 → 10)
- **TemplateLocalizationFunction**: make `GetParameterIndexByName` static
- **WolverineHandlerConventionTests**: new architecture test ensuring assemblies with internal Wolverine handlers declare `InternalsVisibleTo("WolverineHandlers")`
- Fix 4 modules missing `WolverineHandlers` visibility — handlers were silently skipped at runtime
- Remove obsolete `Granit.AuditLog.*` references from ArchitectureTests
- Clean up redundant `DynamicProxyGenAssembly2` PublicKey entry

## Test plan

- [x] Granit.Notifications.Tests — 249 pass
- [x] Granit.Templating.Scriban.Tests — 40 pass
- [x] WolverineHandlerConventionTests — 1 pass (catches future regressions)