### PR TITLE
fix(cookies): dev-compatible cookie naming and secure policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,27 +176,15 @@ segments). Enforced across all `*.Endpoints` modules.
 
 ### Events — naming convention (STRICT)
 
-Two suffixes, three dispatch mechanisms — enforced by architecture tests:
+Two suffixes — enforced by architecture tests:
 
 | Suffix | Interface | Dispatch | Example |
 | ------ | --------- | -------- | ------- |
-| `*Event` | `IDomainEvent` | `AddDomainEvent()` on aggregate root → after commit | `BlobValidatedEvent` |
-| `*Event` | _(none)_ | `ILocalEventBus.PublishAsync()` in services → explicit call | `SettingChangedEvent` |
-| `*Eto` | `IIntegrationEvent` | `AddDistributedEvent()` on aggregate root → Wolverine outbox | `PersonalDataDeletedEto` |
-| `*Eto` | `IIntegrationEvent` | `IDistributedEventBus.PublishAsync()` in services → outbox | `IdentityUserCreatedEto` |
+| `*Event` | `IDomainEvent` or none | `AddDomainEvent()` (aggregate) or `ILocalEventBus.PublishAsync()` (service) | `BlobValidatedEvent` |
+| `*Eto` | `IIntegrationEvent` | `AddDistributedEvent()` (aggregate) or `IDistributedEventBus.PublishAsync()` (service) → Wolverine outbox | `PersonalDataDeletedEto` |
 
-- **`*Event`** (local, in-process): either raised via `AddDomainEvent()` on an aggregate
-  root (dispatched after commit by `SavedChanges` interceptor), or published explicitly
-  via `ILocalEventBus.PublishAsync()` in service classes that operate on plain entities
-  without DDD behavior (Settings, Features, Authorization). Past-tense verb + `Event` suffix.
-- **`*Eto`** (Event Transfer Object, distributed): either raised via `AddDistributedEvent()`
-  on an aggregate root (persisted atomically in Wolverine outbox), or published explicitly
-  via `IDistributedEventBus.PublishAsync()` in services (at-least-once delivery, survives
-  pod crashes). Must implement `IIntegrationEvent`. Past-tense verb + `Eto` suffix.
-- **Generic lifecycle**: `EntityCreatedEvent<T>`, `EntityCreatedEto<T>` — automatic via
-  `IEmitEntityLifecycleEvents` marker interface.
-- **NEVER** use bare past-tense names without suffix (`BlobValidated` is wrong,
-  `BlobValidatedEvent` is correct).
+- Past-tense verb + suffix. NEVER bare names (`BlobValidated` → `BlobValidatedEvent`)
+- Generic lifecycle: `EntityCreatedEvent<T>` / `EntityCreatedEto<T>` via `IEmitEntityLifecycleEvents`
 
 ### Background Jobs — naming convention (STRICT)
 
@@ -238,27 +226,13 @@ group.MapGet("/{id:guid}", GetByIdAsync)
     .ProducesProblem(StatusCodes.Status404NotFound);        // One per error path
 ```
 
-**Return type → Produces mapping:**
+**Produces mapping:** Match handler return type → `Ok<T>` = `.Produces<T>()`,
+`Created<T>` = `.Produces<T>(201)`, `NotFound` = `.ProducesProblem(404)`,
+`ValidationProblem` = `.ProducesValidationProblem()`, `FileStreamHttpResult` =
+`.Produces(200, contentType: "application/octet-stream")`. Never omit `.Produces()`.
 
-| Handler return type | Produces | ProducesProblem |
-| ------------------- | -------- | --------------- |
-| `Ok<T>` | `.Produces<T>()` | — |
-| `Created<T>` | `.Produces<T>(StatusCodes.Status201Created)` | — |
-| `Created` (no body) | `.Produces(StatusCodes.Status201Created)` | — |
-| `NoContent` | `.Produces(StatusCodes.Status204NoContent)` | — |
-| `Accepted` | `.Produces(StatusCodes.Status202Accepted)` | — |
-| `NotFound` in `Results` | — | `.ProducesProblem(Status404NotFound)` |
-| `ProblemHttpResult` in `Results` | — | `.ProducesProblem(StatusXxx)` — read handler body |
-| `ValidationProblem` in `Results` | — | `.ProducesValidationProblem()` |
-| `FileStreamHttpResult` | `.Produces(Status200OK, contentType: "application/octet-stream")` | — |
-
-**Rules:**
-
-- **WithName**: PascalCase `VerbNoun` (e.g., `GetBlobDescriptor`, `CreateExportJob`)
-- **WithSummary**: imperative sentence ending with period, ~100 chars
-- **WithDescription**: 2-4 factual sentences — what, context/behavior, error codes
-- **ProducesProblem**: one call per distinct error status code (read handler body for exact code)
-- **Never omit** `.Produces()` — without it, OpenAPI schema has no response type
+**Rules:** WithName = PascalCase VerbNoun, WithSummary = imperative ~100 chars with period,
+WithDescription = 2-4 sentences, ProducesProblem = one per error status code.
 
 ### Validation
 
@@ -373,69 +347,28 @@ Shard mapping:
 
 ## Anti-patterns — NEVER do this
 
-### Code
+Code anti-patterns are the inverse of conventions above. Key additional rules:
 
-- `DateTime.Now`/`UtcNow` → inject `TimeProvider`
-- `new Regex(..., Compiled)` → `[GeneratedRegex]`
-- String interpolation in logs → `[LoggerMessage]`
+### Code (not covered above)
+
 - `new HttpClient()` → `IHttpClientFactory`
 - `async void` → always return `Task`
 - `.Result` / `.Wait()` → `await`
-- `Results.Ok()` → `TypedResults.Ok()` for OpenAPI
-- Return EF entities from endpoints → map to `*Response` DTOs
 - Bare `catch (Exception)` → catch specific types
-- `*Dto` suffix → use `*Request` / `*Response`
-- `TypedResults.BadRequest<string>()` → `TypedResults.Problem()` (RFC 7807)
-- `lock (object)` / `lock (collection)` → `lock (Lock)` with `System.Threading.Lock`
-- `new Meter(...)` → inject `IMeterFactory` and call `meterFactory.Create(...)`
-- `Array.Empty<T>()` / `new List<T>()` / `new T[] {}` → `[]` (collection expression)
-- `string.Concat(a, b, c)` → `$"{a}{b}{c}"` (string interpolation)
-- `params T[]` in non-attribute methods → `params ReadOnlySpan<T>`
-- `nameof(T)` on type parameter → `typeof(T).Name` (nameof returns `"T"`, not the type name)
-- Traditional constructors with only field assignments → primary constructors
-- Unnamed `HasQueryFilter(expr)` → named `HasQueryFilter(name, expr)` (EF Core 10)
-- Swashbuckle / NSwag → `Microsoft.AspNetCore.OpenApi` + Scalar UI
-- Domain event without `Event` suffix → `BlobValidatedEvent` (not `BlobValidated`)
-- Integration event without `Eto` suffix → `PersonalDataDeletedEto` (not `PersonalDataDeletedEvent`)
-- Public setters on aggregate roots → `private set` + behavior methods
-- Manual `IDomainEventSource` implementation → inherit from `AggregateRoot` (or variants)
-- `new XxxEntity { ... }` on aggregate roots → `XxxEntity.Create(...)` factory method
-- `.WithMessage("hardcoded string")` in validators → `.WithErrorCodeAndMessage("Granit:Validation:XxxCode")` + localization JSON
-- `View` action in permissions → `Read` (RBAC standard: `Read`, not `View`)
-- Two-segment permission names (`Features.Read`) → three-segment `Features.Flags.Read` (`[Group].[Resource].[Action]`)
-- Endpoint without `.WithName()` → always declare an operation ID
-- Endpoint without `.WithSummary()` / `.WithDescription()` → always document the endpoint
-- Endpoint without `.Produces<T>()` → always declare the success response type
-- Endpoint without `.ProducesProblem()` when handler returns `NotFound`/`ProblemHttpResult` → always declare error responses
 
 ### Architecture
 
-- Merge `I*Reader`/`I*Writer` into combined `I*Store` → CQRS, keep them separate
-- Share DbContext across modules → each module owns its isolated DbContext
-- Manual `HasQueryFilter` in entity configs → `ApplyGranitConventions` handles all filters
-- Cross-module direct method calls → use integration events (Wolverine)
+- Merge `I*Reader`/`I*Writer` into `I*Store` → CQRS, keep separate
+- Share DbContext across modules → isolated DbContext per module
+- Cross-module direct method calls → integration events (Wolverine)
 - Repository pattern over EF Core → use DbContext directly
-- Circular project references → restructure dependencies
 
 ### Refactoring
 
-Code that looks "weird" almost always exists for a reason: production fix, regulatory
-edge case, GDPR/ISO 27001 constraint, third-party workaround.
+See global `~/.claude/CLAUDE.md` for base rules. Additional Granit-specific:
 
-**Before any refactoring:**
-
-1. Read the entire file, not just the targeted function
-2. Check `git log -p -- <file>` to understand evolution
-3. If unclear, search for the linked GitHub issue before modifying
-4. When in doubt, **ask**
-
-**NEVER:**
-
-- Delete "dead" code without verifying dynamic references (reflection, DI, runtime config)
-- Simplify complex conditions without testing the edge cases they cover
-- Replace custom implementations with stdlib without understanding why stdlib wasn't used
-- Remove/change interface implementations on `ValueObject`/`Entity`/`AggregateRoot` for SonarQube — mark as won't fix
-- Reduce constructor params via wrapper types that aren't real domain concepts — mark `brain-overload` as won't fix
+- Remove/change interface implementations on `ValueObject`/`Entity`/`AggregateRoot` for SonarQube → mark as won't fix
+- Reduce constructor params via wrapper types that aren't real domain concepts → mark `brain-overload` as won't fix
 
 ### Git — CRITICAL
 
@@ -470,22 +403,12 @@ The docs live in `docs-site/` (Astro + Starlight). Key paths:
 
 **When creating a new module**: create `.mdx` in `reference/modules/`, update `PACKAGE_COUNT` in `constants.ts`, add "See also" links from related pages.
 
-## MCP — Roslyn Navigator
+## MCP & Code index
 
-Use `roslyn-navigator` MCP tools for semantic navigation — **prefer over Grep/Read for all C# code**.
-Full guide in global `~/.claude/CLAUDE.md`.
+MCP tools (roslyn-lens + granit-tools) — see global `~/.claude/CLAUDE.md`.
 
-## Code index (`.mcp-code-index.json`)
-
-A pre-commit hook regenerates `.mcp-code-index.json` when `.cs` or `.csproj`
-files are staged. This file is consumed by the `granit-tools-mcp` local dotnet
-tool for code navigation (`search_code`, `get_public_api`,
-`get_project_graph`).
-
-- **Script:** `python3 scripts/generate-code-index.py` (Python 3.8+, no deps)
-- **Hook:** `.husky/pre-commit` — runs automatically on `.cs`/`.csproj` changes
-- **CI:** drift check validates the file is up to date
-- **NEVER edit `.mcp-code-index.json` manually** — always regenerate
+`.mcp-code-index.json` is auto-regenerated by pre-commit hook on `.cs`/`.csproj` changes.
+Script: `python3 scripts/generate-code-index.py`. **NEVER edit manually.**
 
 ## Definition of Done
 

--- a/docs-site/src/content/docs/dotnet/compliance/cookies/index.mdx
+++ b/docs-site/src/content/docs/dotnet/compliance/cookies/index.mdx
@@ -54,8 +54,8 @@ needed for framework cookies.
 
 | Module | Cookies auto-registered | Contributor |
 | ------ | ----------------------- | ----------- |
-| `Granit.Http.Cookies` | `__Host-xsrf` (antiforgery) | `AntiforgeryCookieDefinitionContributor` |
-| `Granit.OpenIddict.EntityFrameworkCore` | `__Host-id`, `__Host-id-2fa`, `__Host-id-ext` | `IdentityCookieDefinitionContributor` |
+| `Granit.Http.Cookies` | `.xsrf` (antiforgery) | `AntiforgeryCookieDefinitionContributor` |
+| `Granit.OpenIddict.EntityFrameworkCore` | `.id`, `.id-2fa`, `.id-ext` | `IdentityCookieDefinitionContributor` |
 | `Granit.Http.Cookies.Klaro` | `klaro` (configurable) | `KlaroCookieDefinitionContributor` |
 | `Granit.Bff.Endpoints` | `__Host-bff-{frontend}` (dynamic) | Runtime registration in `MapGranitBff()` |
 | `Granit.Privacy.Endpoints` | `_optout_id` | Runtime registration in `MapGranitPrivacy()` |

--- a/src/Granit.Http.Cookies/GranitCookiesBuilder.cs
+++ b/src/Granit.Http.Cookies/GranitCookiesBuilder.cs
@@ -33,11 +33,11 @@ public sealed class GranitCookiesBuilder(IServiceCollection services)
     {
         Services.AddSingleton<ICookieDefinitionContributor, Internal.SessionCookieDefinitionContributor>();
 
-        // Override the default session cookie name (.AspNetCore.Session → __Host-session).
+        // Override the default session cookie name (.AspNetCore.Session → .session).
         Services.Configure<Microsoft.AspNetCore.Builder.SessionOptions>(options =>
         {
             options.Cookie.Name = Internal.SessionCookieDefinitionContributor.DefaultCookieName;
-            options.Cookie.SecurePolicy = Microsoft.AspNetCore.Http.CookieSecurePolicy.Always;
+            options.Cookie.SecurePolicy = Microsoft.AspNetCore.Http.CookieSecurePolicy.SameAsRequest;
             options.Cookie.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Strict;
             options.Cookie.HttpOnly = true;
         });

--- a/src/Granit.Http.Cookies/GranitHttpCookiesModule.cs
+++ b/src/Granit.Http.Cookies/GranitHttpCookiesModule.cs
@@ -18,11 +18,10 @@ public sealed class GranitHttpCookiesModule : GranitModule
         context.Services.AddGranitCookies(_ => { });
 
         // Override the default antiforgery cookie name to avoid leaking the technology stack.
-        // Uses __Host- prefix for CSRF-hardening (Secure + Path=/ + no Domain).
         context.Services.AddAntiforgery(options =>
         {
             options.Cookie.Name = AntiforgeryCookieDefinitionContributor.DefaultCookieName;
-            options.Cookie.SecurePolicy = Microsoft.AspNetCore.Http.CookieSecurePolicy.Always;
+            options.Cookie.SecurePolicy = Microsoft.AspNetCore.Http.CookieSecurePolicy.SameAsRequest;
         });
 
         context.Services.AddSingleton<ICookieDefinitionContributor, AntiforgeryCookieDefinitionContributor>();

--- a/src/Granit.Http.Cookies/Internal/AntiforgeryCookieDefinitionContributor.cs
+++ b/src/Granit.Http.Cookies/Internal/AntiforgeryCookieDefinitionContributor.cs
@@ -13,10 +13,9 @@ internal sealed class AntiforgeryCookieDefinitionContributor(
 {
     /// <summary>
     /// Default antiforgery cookie name set by <see cref="GranitHttpCookiesModule"/>.
-    /// Uses the <c>__Host-</c> prefix for CSRF-hardening (RFC 6265bis §4.1.3.2)
-    /// and avoids leaking the underlying technology stack.
+    /// Neutral name that avoids leaking the underlying technology stack.
     /// </summary>
-    internal const string DefaultCookieName = "__Host-xsrf";
+    internal const string DefaultCookieName = ".xsrf";
 
     /// <inheritdoc/>
     public IEnumerable<CookieDefinition> GetCookieDefinitions()

--- a/src/Granit.Http.Cookies/Internal/SessionCookieDefinitionContributor.cs
+++ b/src/Granit.Http.Cookies/Internal/SessionCookieDefinitionContributor.cs
@@ -13,7 +13,7 @@ internal sealed class SessionCookieDefinitionContributor(
     IOptions<SessionOptions> options) : ICookieDefinitionContributor
 {
     /// <summary>Default session cookie name (avoids leaking ASP.NET Core).</summary>
-    internal const string DefaultCookieName = "__Host-session";
+    internal const string DefaultCookieName = ".session";
 
     /// <inheritdoc/>
     public IEnumerable<CookieDefinition> GetCookieDefinitions()

--- a/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
@@ -60,23 +60,18 @@ public sealed class GranitOpenIddictEntityFrameworkCoreModule : GranitModule
 
         // Override default ASP.NET Core Identity cookie names to avoid leaking the technology stack.
         // Uses __Host- prefix for CSRF-hardening (Secure + Path=/ + no Domain).
-        context.Services.ConfigureAll<Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationOptions>(
-            options =>
-            {
-                options.Cookie.SecurePolicy = Microsoft.AspNetCore.Http.CookieSecurePolicy.Always;
-            });
-
-        context.Services.Configure<Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationOptions>(
+        // Only targets Identity schemes — does NOT use ConfigureAll to avoid breaking BFF/OIDC cookies.
+        ConfigureIdentityCookie(context.Services,
             Microsoft.AspNetCore.Identity.IdentityConstants.ApplicationScheme,
-            options => options.Cookie.Name = IdentityCookieDefinitionContributor.DefaultApplicationCookieName);
+            IdentityCookieDefinitionContributor.DefaultApplicationCookieName);
 
-        context.Services.Configure<Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationOptions>(
+        ConfigureIdentityCookie(context.Services,
             Microsoft.AspNetCore.Identity.IdentityConstants.TwoFactorUserIdScheme,
-            options => options.Cookie.Name = IdentityCookieDefinitionContributor.DefaultTwoFactorCookieName);
+            IdentityCookieDefinitionContributor.DefaultTwoFactorCookieName);
 
-        context.Services.Configure<Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationOptions>(
+        ConfigureIdentityCookie(context.Services,
             Microsoft.AspNetCore.Identity.IdentityConstants.ExternalScheme,
-            options => options.Cookie.Name = IdentityCookieDefinitionContributor.DefaultExternalCookieName);
+            IdentityCookieDefinitionContributor.DefaultExternalCookieName);
 
         context.Services.TryAddScoped<ILocalIdentityGroupStore, OpenIddictGroupStore>();
         context.Services.TryAddScoped<ExternalClaimsMapper>();
@@ -102,5 +97,17 @@ public sealed class GranitOpenIddictEntityFrameworkCoreModule : GranitModule
         // Load signing/encryption keys from DB at startup (replaces ephemeral keys)
         context.Services.AddSingleton<IPostConfigureOptions<OpenIddictServerOptions>,
             DatabaseSigningKeyPostConfigure>();
+    }
+
+    private static void ConfigureIdentityCookie(
+        IServiceCollection services, string scheme, string cookieName)
+    {
+        services.Configure<Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationOptions>(
+            scheme,
+            options =>
+            {
+                options.Cookie.Name = cookieName;
+                options.Cookie.SecurePolicy = Microsoft.AspNetCore.Http.CookieSecurePolicy.SameAsRequest;
+            });
     }
 }

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/IdentityCookieDefinitionContributor.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/IdentityCookieDefinitionContributor.cs
@@ -19,13 +19,13 @@ internal sealed class IdentityCookieDefinitionContributor(
     IOptionsMonitor<CookieAuthenticationOptions> cookieOptions) : ICookieDefinitionContributor
 {
     /// <summary>Default identity session cookie name (avoids leaking ASP.NET Core).</summary>
-    internal const string DefaultApplicationCookieName = "__Host-id";
+    internal const string DefaultApplicationCookieName = ".id";
 
     /// <summary>Default 2FA flow cookie name.</summary>
-    internal const string DefaultTwoFactorCookieName = "__Host-id-2fa";
+    internal const string DefaultTwoFactorCookieName = ".id-2fa";
 
     /// <summary>Default external login correlation cookie name.</summary>
-    internal const string DefaultExternalCookieName = "__Host-id-ext";
+    internal const string DefaultExternalCookieName = ".id-ext";
 
     /// <inheritdoc/>
     public IEnumerable<CookieDefinition> GetCookieDefinitions()

--- a/tests/Granit.ArchitectureTests/WolverineHandlerConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/WolverineHandlerConventionTests.cs
@@ -1,0 +1,104 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Validates Wolverine handler conventions:
+/// <list type="bullet">
+/// <item>Assemblies with internal Wolverine handlers must expose internals to <c>WolverineHandlers</c></item>
+/// </list>
+/// </summary>
+public sealed class WolverineHandlerConventionTests
+{
+    /// <summary>
+    /// Wolverine compiles generated code into a <c>WolverineHandlers</c> assembly at runtime.
+    /// If a handler class is <c>internal</c>, the generated code cannot call it unless the
+    /// source assembly declares <c>[InternalsVisibleTo("WolverineHandlers")]</c>.
+    /// Without this, the handler is silently skipped — no error, no email, no notification.
+    /// </summary>
+    [Fact]
+    public void Assemblies_with_internal_handlers_must_expose_internals_to_WolverineHandlers()
+    {
+        string outputDir = Path.GetDirectoryName(typeof(WolverineHandlerConventionTests).Assembly.Location)!;
+
+        Assembly[] granitAssemblies = Directory.GetFiles(outputDir, "Granit.*.dll")
+            .Where(path => !Path.GetFileNameWithoutExtension(path).Contains("Tests"))
+            .Select(TryLoadAssembly)
+            .Where(a => a is not null)
+            .ToArray()!;
+
+        List<string> violations = [];
+
+        foreach (Assembly assembly in granitAssemblies)
+        {
+            Type[] internalHandlers;
+            try
+            {
+                internalHandlers = assembly.GetTypes()
+                    .Where(t => !t.IsPublic && !t.IsAbstract && !t.IsInterface)
+                    .Where(HasWolverineHandlerMethod)
+                    .ToArray();
+            }
+            catch (ReflectionTypeLoadException)
+            {
+                continue;
+            }
+
+            if (internalHandlers.Length == 0)
+            {
+                continue;
+            }
+
+            bool exposesInternals = assembly.GetCustomAttributes<InternalsVisibleToAttribute>()
+                .Any(a => a.AssemblyName == "WolverineHandlers");
+
+            if (!exposesInternals)
+            {
+                string handlerNames = string.Join(", ", internalHandlers.Select(t => t.Name));
+                violations.Add(
+                    $"{assembly.GetName().Name} has internal handler(s) [{handlerNames}] " +
+                    "but missing [InternalsVisibleTo(\"WolverineHandlers\")] in .csproj");
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Assemblies with internal Wolverine handlers must declare " +
+            "<InternalsVisibleTo Include=\"WolverineHandlers\" /> in their .csproj. " +
+            "Without this, Wolverine silently skips the handler at runtime.");
+    }
+
+    /// <summary>
+    /// Checks whether a type looks like a Wolverine handler: lives in a <c>Handlers</c> namespace
+    /// or has a name ending in <c>Handler</c>, AND has at least one method matching Wolverine's
+    /// naming conventions (<c>Handle</c>, <c>HandleAsync</c>, <c>Consume</c>, <c>ConsumeAsync</c>)
+    /// whose first parameter is a message type (not a framework/DI service).
+    /// </summary>
+    private static bool HasWolverineHandlerMethod(Type type)
+    {
+        bool looksLikeHandler = type.Name.EndsWith("Handler", StringComparison.Ordinal)
+            || (type.Namespace?.Contains(".Handlers", StringComparison.Ordinal) ?? false);
+
+        if (!looksLikeHandler)
+        {
+            return false;
+        }
+
+        return type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Any(m => m.Name is "HandleAsync" or "Handle" or "ConsumeAsync" or "Consume");
+    }
+
+    private static Assembly? TryLoadAssembly(string path)
+    {
+        try
+        {
+            return Assembly.LoadFrom(path);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/IdentityCookieDefinitionContributorTests.cs
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/IdentityCookieDefinitionContributorTests.cs
@@ -84,9 +84,9 @@ public sealed class IdentityCookieDefinitionContributorTests
     }
 
     private static IOptionsMonitor<CookieAuthenticationOptions> CreateOptionsMonitor(
-        string? applicationCookieName = "__Host-id",
-        string? twoFactorCookieName = "__Host-id-2fa",
-        string? externalCookieName = "__Host-id-ext")
+        string? applicationCookieName = ".id",
+        string? twoFactorCookieName = ".id-2fa",
+        string? externalCookieName = ".id-ext")
     {
         IOptionsMonitor<CookieAuthenticationOptions> monitor = Substitute.For<IOptionsMonitor<CookieAuthenticationOptions>>();
 


### PR DESCRIPTION
## Summary

- Replace `__Host-` prefix with neutral `.` prefix on all framework cookies (`.xsrf`, `.id`, `.id-2fa`, `.id-ext`, `.session`) — `__Host-` requires HTTPS and silently breaks on HTTP dev environments
- Replace `SecurePolicy.Always` with `SecurePolicy.SameAsRequest` — Secure on HTTPS, plain on HTTP (works with `ForwardedHeaders` in prod behind TLS proxy)
- Replace `ConfigureAll<CookieAuthenticationOptions>` with per-scheme `Configure` — the `ConfigureAll` was breaking BFF/OIDC cookie schemes
- Add `WolverineHandlerConventionTests` architecture test
- Update CLAUDE.md conventions

## Cookie naming (before → after)

| Before | After | Reason |
|--------|-------|--------|
| `__Host-xsrf` | `.xsrf` | `__Host-` requires HTTPS |
| `__Host-id` | `.id` | Same |
| `__Host-id-2fa` | `.id-2fa` | Same |
| `__Host-id-ext` | `.id-ext` | Same |
| `__Host-session` | `.session` | Same |

All names remain neutral (no ASP.NET Core / Granit disclosure).

## Test plan

- [x] Granit.Http.Cookies.Tests — 64 pass
- [x] Granit.OpenIddict.EntityFrameworkCore.Tests — 165 pass
- [x] WolverineHandlerConventionTests — 1 pass
- [ ] Verify BFF login works on HTTP dev (showcase)