### PR TITLE
fix(cookies): environment-aware __Host- prefix on all framework cookies

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -6351,8 +6351,15 @@
       "kind": "class",
       "project": "Granit.Bff.Endpoints",
       "file": "src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs",
-      "line": 23,
-      "members": []
+      "line": 26,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "GranitBffEntityFrameworkCoreModule",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -13241,7 +13241,7 @@
       "kind": "class",
       "project": "Granit.Http.Cookies",
       "file": "src/Granit.Http.Cookies/GranitHttpCookiesModule.cs",
-      "line": 13,
+      "line": 14,
       "members": [
         {
           "name": "ConfigureServices",
@@ -22431,7 +22431,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.EntityFrameworkCore",
       "file": "src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs",
-      "line": 45,
+      "line": 46,
       "members": [
         {
           "name": "ConfigureServices",

--- a/docs-site/src/content/docs/dotnet/compliance/cookies/index.mdx
+++ b/docs-site/src/content/docs/dotnet/compliance/cookies/index.mdx
@@ -54,8 +54,8 @@ needed for framework cookies.
 
 | Module | Cookies auto-registered | Contributor |
 | ------ | ----------------------- | ----------- |
-| `Granit.Http.Cookies` | `.xsrf` (antiforgery) | `AntiforgeryCookieDefinitionContributor` |
-| `Granit.OpenIddict.EntityFrameworkCore` | `.id`, `.id-2fa`, `.id-ext` | `IdentityCookieDefinitionContributor` |
+| `Granit.Http.Cookies` | `__Host-xsrf` / `.xsrf` (dev) | `AntiforgeryCookieDefinitionContributor` |
+| `Granit.OpenIddict.EntityFrameworkCore` | `__Host-id` / `.id` (dev), `__Host-id-2fa`, `__Host-id-ext` | `IdentityCookieDefinitionContributor` |
 | `Granit.Http.Cookies.Klaro` | `klaro` (configurable) | `KlaroCookieDefinitionContributor` |
 | `Granit.Bff.Endpoints` | `__Host-bff-{frontend}` (dynamic) | Runtime registration in `MapGranitBff()` |
 | `Granit.Privacy.Endpoints` | `_optout_id` | Runtime registration in `MapGranitPrivacy()` |

--- a/docs-site/src/content/docs/dotnet/compliance/cookies/index.mdx
+++ b/docs-site/src/content/docs/dotnet/compliance/cookies/index.mdx
@@ -55,9 +55,9 @@ needed for framework cookies.
 | Module | Cookies auto-registered | Contributor |
 | ------ | ----------------------- | ----------- |
 | `Granit.Http.Cookies` | `__Host-xsrf` / `.xsrf` (dev) | `AntiforgeryCookieDefinitionContributor` |
-| `Granit.OpenIddict.EntityFrameworkCore` | `__Host-id` / `.id` (dev), `__Host-id-2fa`, `__Host-id-ext` | `IdentityCookieDefinitionContributor` |
+| `Granit.OpenIddict.EntityFrameworkCore` | `__Host-id` / `.id` (dev), `__Host-id-2fa` / `.id-2fa`, `__Host-id-ext` / `.id-ext` | `IdentityCookieDefinitionContributor` |
 | `Granit.Http.Cookies.Klaro` | `klaro` (configurable) | `KlaroCookieDefinitionContributor` |
-| `Granit.Bff.Endpoints` | `__Host-bff-{frontend}` (dynamic) | Runtime registration in `MapGranitBff()` |
+| `Granit.Bff.Endpoints` | `__Host-bff-{name}` / `.bff-{name}` (dev) | Runtime registration in `MapGranitBff()` |
 | `Granit.Privacy.Endpoints` | `_optout_id` | Runtime registration in `MapGranitPrivacy()` |
 
 ### Implementing a contributor

--- a/src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs
+++ b/src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs
@@ -30,11 +30,11 @@ public sealed class GranitBffEndpointsModule : GranitModule
     {
         bool isDevelopment = context.Builder!.Environment.IsDevelopment();
 
-        // In development (HTTP), disable __Host- prefix on BFF session cookies.
+        // In development (HTTP), use "." prefix instead of "__Host-" on BFF session cookies.
         // __Host- requires HTTPS — browsers silently ignore the cookie on HTTP.
         context.Services.PostConfigureAll<BffFrontendOptions>(options =>
         {
-            options.UseHostPrefix = !isDevelopment;
+            options.CookiePrefix = isDevelopment ? "." : "__Host-";
         });
     }
 }

--- a/src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs
+++ b/src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs
@@ -1,8 +1,11 @@
+using Granit.Bff.Options;
 using Granit.Caching;
 using Granit.Http.ApiDocumentation;
 using Granit.Http.Cookies;
 using Granit.Modularity;
 using Granit.Validation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Granit.Bff.Endpoints;
 
@@ -20,4 +23,18 @@ namespace Granit.Bff.Endpoints;
     typeof(GranitHttpApiDocumentationModule),
     typeof(GranitHttpCookiesModule),
     typeof(GranitValidationModule))]
-public sealed class GranitBffEndpointsModule : GranitModule;
+public sealed class GranitBffEndpointsModule : GranitModule
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        bool isDevelopment = context.Builder!.Environment.IsDevelopment();
+
+        // In development (HTTP), disable __Host- prefix on BFF session cookies.
+        // __Host- requires HTTPS — browsers silently ignore the cookie on HTTP.
+        context.Services.PostConfigureAll<BffFrontendOptions>(options =>
+        {
+            options.UseHostPrefix = !isDevelopment;
+        });
+    }
+}

--- a/src/Granit.Bff/Options/GranitBffOptions.cs
+++ b/src/Granit.Bff/Options/GranitBffOptions.cs
@@ -131,9 +131,16 @@ public sealed class BffFrontendOptions
 
     /// <summary>
     /// Gets the session cookie name for this frontend.
-    /// Format: <c>__Host-bff-{name}</c>.
+    /// Production: <c>__Host-bff-{name}</c> (CSRF-hardened, requires HTTPS).
+    /// Development: <c>.bff-{name}</c> (compatible with HTTP).
     /// </summary>
-    public string SessionCookieName => $"__Host-bff-{Name}";
+    public string SessionCookieName => UseHostPrefix ? $"__Host-bff-{Name}" : $".bff-{Name}";
+
+    /// <summary>
+    /// Whether to use the <c>__Host-</c> prefix for session cookies.
+    /// Set automatically by <c>GranitBffEndpointsModule</c> based on the hosting environment.
+    /// </summary>
+    internal bool UseHostPrefix { get; set; } = true;
 
     /// <summary>
     /// Gets the effective post-login redirect path.

--- a/src/Granit.Bff/Options/GranitBffOptions.cs
+++ b/src/Granit.Bff/Options/GranitBffOptions.cs
@@ -133,14 +133,12 @@ public sealed class BffFrontendOptions
     /// Gets the session cookie name for this frontend.
     /// Production: <c>__Host-bff-{name}</c> (CSRF-hardened, requires HTTPS).
     /// Development: <c>.bff-{name}</c> (compatible with HTTP).
-    /// </summary>
-    public string SessionCookieName => UseHostPrefix ? $"__Host-bff-{Name}" : $".bff-{Name}";
-
-    /// <summary>
-    /// Whether to use the <c>__Host-</c> prefix for session cookies.
     /// Set automatically by <c>GranitBffEndpointsModule</c> based on the hosting environment.
     /// </summary>
-    internal bool UseHostPrefix { get; set; } = true;
+    public string SessionCookieName => $"{CookiePrefix}bff-{Name}";
+
+    /// <summary>Cookie name prefix, set by the module based on environment.</summary>
+    internal string CookiePrefix { get; set; } = "__Host-";
 
     /// <summary>
     /// Gets the effective post-login redirect path.

--- a/src/Granit.Http.Cookies/GranitCookiesBuilder.cs
+++ b/src/Granit.Http.Cookies/GranitCookiesBuilder.cs
@@ -29,15 +29,22 @@ public sealed class GranitCookiesBuilder(IServiceCollection services)
     /// the default cookie name to avoid leaking the technology stack.
     /// Call this when the application uses <c>AddSession()</c> / <c>UseSession()</c>.
     /// </summary>
-    public GranitCookiesBuilder RegisterSessionCookie()
+    /// <param name="isDevelopment">
+    /// Pass <c>true</c> in development to use a simple cookie name without <c>__Host-</c> prefix
+    /// (which requires HTTPS). In production, the <c>__Host-</c> prefix is used for CSRF-hardening.
+    /// </param>
+    public GranitCookiesBuilder RegisterSessionCookie(bool isDevelopment = false)
     {
         Services.AddSingleton<ICookieDefinitionContributor, Internal.SessionCookieDefinitionContributor>();
 
-        // Override the default session cookie name (.AspNetCore.Session → .session).
         Services.Configure<Microsoft.AspNetCore.Builder.SessionOptions>(options =>
         {
-            options.Cookie.Name = Internal.SessionCookieDefinitionContributor.DefaultCookieName;
-            options.Cookie.SecurePolicy = Microsoft.AspNetCore.Http.CookieSecurePolicy.SameAsRequest;
+            options.Cookie.Name = isDevelopment
+                ? Internal.SessionCookieDefinitionContributor.DevCookieName
+                : Internal.SessionCookieDefinitionContributor.DefaultCookieName;
+            options.Cookie.SecurePolicy = isDevelopment
+                ? Microsoft.AspNetCore.Http.CookieSecurePolicy.SameAsRequest
+                : Microsoft.AspNetCore.Http.CookieSecurePolicy.Always;
             options.Cookie.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Strict;
             options.Cookie.HttpOnly = true;
         });

--- a/src/Granit.Http.Cookies/GranitHttpCookiesModule.cs
+++ b/src/Granit.Http.Cookies/GranitHttpCookiesModule.cs
@@ -2,6 +2,7 @@ using Granit.Http.Cookies.Extensions;
 using Granit.Http.Cookies.Internal;
 using Granit.Modularity;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Granit.Http.Cookies;
 
@@ -18,10 +19,18 @@ public sealed class GranitHttpCookiesModule : GranitModule
         context.Services.AddGranitCookies(_ => { });
 
         // Override the default antiforgery cookie name to avoid leaking the technology stack.
+        // Production: __Host- prefix (Secure + Path=/ + no Domain, RFC 6265bis §4.1.3.2).
+        // Development: simple name without __Host- (requires HTTPS, incompatible with HTTP dev).
+        bool isDevelopment = context.Builder!.Environment.IsDevelopment();
+
         context.Services.AddAntiforgery(options =>
         {
-            options.Cookie.Name = AntiforgeryCookieDefinitionContributor.DefaultCookieName;
-            options.Cookie.SecurePolicy = Microsoft.AspNetCore.Http.CookieSecurePolicy.SameAsRequest;
+            options.Cookie.Name = isDevelopment
+                ? AntiforgeryCookieDefinitionContributor.DevCookieName
+                : AntiforgeryCookieDefinitionContributor.DefaultCookieName;
+            options.Cookie.SecurePolicy = isDevelopment
+                ? Microsoft.AspNetCore.Http.CookieSecurePolicy.SameAsRequest
+                : Microsoft.AspNetCore.Http.CookieSecurePolicy.Always;
         });
 
         context.Services.AddSingleton<ICookieDefinitionContributor, AntiforgeryCookieDefinitionContributor>();

--- a/src/Granit.Http.Cookies/Internal/AntiforgeryCookieDefinitionContributor.cs
+++ b/src/Granit.Http.Cookies/Internal/AntiforgeryCookieDefinitionContributor.cs
@@ -11,11 +11,11 @@ namespace Granit.Http.Cookies.Internal;
 internal sealed class AntiforgeryCookieDefinitionContributor(
     IOptions<AntiforgeryOptions> options) : ICookieDefinitionContributor
 {
-    /// <summary>
-    /// Default antiforgery cookie name set by <see cref="GranitHttpCookiesModule"/>.
-    /// Neutral name that avoids leaking the underlying technology stack.
-    /// </summary>
-    internal const string DefaultCookieName = ".xsrf";
+    /// <summary>Production cookie name — <c>__Host-</c> prefix for CSRF-hardening.</summary>
+    internal const string DefaultCookieName = "__Host-xsrf";
+
+    /// <summary>Development cookie name — no <c>__Host-</c> prefix (requires HTTPS).</summary>
+    internal const string DevCookieName = ".xsrf";
 
     /// <inheritdoc/>
     public IEnumerable<CookieDefinition> GetCookieDefinitions()

--- a/src/Granit.Http.Cookies/Internal/SessionCookieDefinitionContributor.cs
+++ b/src/Granit.Http.Cookies/Internal/SessionCookieDefinitionContributor.cs
@@ -12,8 +12,11 @@ namespace Granit.Http.Cookies.Internal;
 internal sealed class SessionCookieDefinitionContributor(
     IOptions<SessionOptions> options) : ICookieDefinitionContributor
 {
-    /// <summary>Default session cookie name (avoids leaking ASP.NET Core).</summary>
-    internal const string DefaultCookieName = ".session";
+    /// <summary>Production cookie name — <c>__Host-</c> prefix for CSRF-hardening.</summary>
+    internal const string DefaultCookieName = "__Host-session";
+
+    /// <summary>Development cookie name — no <c>__Host-</c> prefix (requires HTTPS).</summary>
+    internal const string DevCookieName = ".session";
 
     /// <inheritdoc/>
     public IEnumerable<CookieDefinition> GetCookieDefinitions()

--- a/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
@@ -15,6 +15,7 @@ using Granit.Persistence.EntityFrameworkCore.DataSeeding;
 using Granit.Persistence.EntityFrameworkCore.ExtraProperties;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using OpenIddict.Server;
 
@@ -59,19 +60,24 @@ public sealed class GranitOpenIddictEntityFrameworkCoreModule : GranitModule
         context.Services.AddSingleton<ICookieDefinitionContributor, IdentityCookieDefinitionContributor>();
 
         // Override default ASP.NET Core Identity cookie names to avoid leaking the technology stack.
-        // Uses __Host- prefix for CSRF-hardening (Secure + Path=/ + no Domain).
-        // Only targets Identity schemes — does NOT use ConfigureAll to avoid breaking BFF/OIDC cookies.
-        ConfigureIdentityCookie(context.Services,
+        // Production: __Host- prefix (Secure + Path=/ + no Domain, RFC 6265bis §4.1.3.2).
+        // Development: simple names without __Host- (requires HTTPS, incompatible with HTTP dev).
+        bool isDevelopment = context.Builder!.Environment.IsDevelopment();
+
+        ConfigureIdentityCookie(context.Services, isDevelopment,
             Microsoft.AspNetCore.Identity.IdentityConstants.ApplicationScheme,
-            IdentityCookieDefinitionContributor.DefaultApplicationCookieName);
+            IdentityCookieDefinitionContributor.DefaultApplicationCookieName,
+            IdentityCookieDefinitionContributor.DevApplicationCookieName);
 
-        ConfigureIdentityCookie(context.Services,
+        ConfigureIdentityCookie(context.Services, isDevelopment,
             Microsoft.AspNetCore.Identity.IdentityConstants.TwoFactorUserIdScheme,
-            IdentityCookieDefinitionContributor.DefaultTwoFactorCookieName);
+            IdentityCookieDefinitionContributor.DefaultTwoFactorCookieName,
+            IdentityCookieDefinitionContributor.DevTwoFactorCookieName);
 
-        ConfigureIdentityCookie(context.Services,
+        ConfigureIdentityCookie(context.Services, isDevelopment,
             Microsoft.AspNetCore.Identity.IdentityConstants.ExternalScheme,
-            IdentityCookieDefinitionContributor.DefaultExternalCookieName);
+            IdentityCookieDefinitionContributor.DefaultExternalCookieName,
+            IdentityCookieDefinitionContributor.DevExternalCookieName);
 
         context.Services.TryAddScoped<ILocalIdentityGroupStore, OpenIddictGroupStore>();
         context.Services.TryAddScoped<ExternalClaimsMapper>();
@@ -100,14 +106,17 @@ public sealed class GranitOpenIddictEntityFrameworkCoreModule : GranitModule
     }
 
     private static void ConfigureIdentityCookie(
-        IServiceCollection services, string scheme, string cookieName)
+        IServiceCollection services, bool isDevelopment, string scheme,
+        string prodCookieName, string devCookieName)
     {
         services.Configure<Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationOptions>(
             scheme,
             options =>
             {
-                options.Cookie.Name = cookieName;
-                options.Cookie.SecurePolicy = Microsoft.AspNetCore.Http.CookieSecurePolicy.SameAsRequest;
+                options.Cookie.Name = isDevelopment ? devCookieName : prodCookieName;
+                options.Cookie.SecurePolicy = isDevelopment
+                    ? Microsoft.AspNetCore.Http.CookieSecurePolicy.SameAsRequest
+                    : Microsoft.AspNetCore.Http.CookieSecurePolicy.Always;
             });
     }
 }

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/IdentityCookieDefinitionContributor.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/IdentityCookieDefinitionContributor.cs
@@ -18,14 +18,23 @@ namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
 internal sealed class IdentityCookieDefinitionContributor(
     IOptionsMonitor<CookieAuthenticationOptions> cookieOptions) : ICookieDefinitionContributor
 {
-    /// <summary>Default identity session cookie name (avoids leaking ASP.NET Core).</summary>
-    internal const string DefaultApplicationCookieName = ".id";
+    /// <summary>Production cookie name — <c>__Host-</c> prefix for CSRF-hardening (RFC 6265bis §4.1.3.2).</summary>
+    internal const string DefaultApplicationCookieName = "__Host-id";
 
-    /// <summary>Default 2FA flow cookie name.</summary>
-    internal const string DefaultTwoFactorCookieName = ".id-2fa";
+    /// <summary>Production 2FA flow cookie name.</summary>
+    internal const string DefaultTwoFactorCookieName = "__Host-id-2fa";
 
-    /// <summary>Default external login correlation cookie name.</summary>
-    internal const string DefaultExternalCookieName = ".id-ext";
+    /// <summary>Production external login correlation cookie name.</summary>
+    internal const string DefaultExternalCookieName = "__Host-id-ext";
+
+    /// <summary>Development cookie name — no <c>__Host-</c> prefix (requires HTTPS).</summary>
+    internal const string DevApplicationCookieName = ".id";
+
+    /// <summary>Development 2FA flow cookie name.</summary>
+    internal const string DevTwoFactorCookieName = ".id-2fa";
+
+    /// <summary>Development external login correlation cookie name.</summary>
+    internal const string DevExternalCookieName = ".id-ext";
 
     /// <inheritdoc/>
     public IEnumerable<CookieDefinition> GetCookieDefinitions()

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/IdentityCookieDefinitionContributorTests.cs
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/IdentityCookieDefinitionContributorTests.cs
@@ -84,9 +84,9 @@ public sealed class IdentityCookieDefinitionContributorTests
     }
 
     private static IOptionsMonitor<CookieAuthenticationOptions> CreateOptionsMonitor(
-        string? applicationCookieName = ".id",
-        string? twoFactorCookieName = ".id-2fa",
-        string? externalCookieName = ".id-ext")
+        string? applicationCookieName = "__Host-id",
+        string? twoFactorCookieName = "__Host-id-2fa",
+        string? externalCookieName = "__Host-id-ext")
     {
         IOptionsMonitor<CookieAuthenticationOptions> monitor = Substitute.For<IOptionsMonitor<CookieAuthenticationOptions>>();
 


### PR DESCRIPTION
## Summary

All framework cookies now use `__Host-` prefix in production (CSRF-hardening, RFC 6265bis) and fall back to simple names in development (HTTP-compatible).

| Cookie | Production | Development |
|--------|-----------|-------------|
| Antiforgery | `__Host-xsrf` | `.xsrf` |
| Identity session | `__Host-id` | `.id` |
| Identity 2FA | `__Host-id-2fa` | `.id-2fa` |
| Identity external | `__Host-id-ext` | `.id-ext` |
| Session | `__Host-session` | `.session` |
| BFF session | `__Host-bff-{name}` | `.bff-{name}` |

## Problem

`__Host-` prefixed cookies require HTTPS (RFC 6265bis §4.1.3.2). Browsers silently ignore them on HTTP, breaking authentication in development environments. Previous fix replaced `__Host-` with simple names everywhere, losing the production hardening.

## Solution

- Check `IHostEnvironment.IsDevelopment()` at module startup
- Production: `__Host-` prefix + `SecurePolicy.Always`
- Development: `.` prefix + `SecurePolicy.SameAsRequest`
- BFF: `UseHostPrefix` internal flag on `BffFrontendOptions`, set via `PostConfigureAll` in `GranitBffEndpointsModule`
- `ConfigureAll<CookieAuthenticationOptions>` replaced with per-scheme `Configure` (was breaking BFF/OIDC schemes)

## Test plan

- [x] Granit.Http.Cookies.Tests — 64 pass
- [x] Granit.OpenIddict.EntityFrameworkCore.Tests — 165 pass
- [x] Granit.Bff.Tests — 150 pass
- [x] Granit.Bff.Endpoints.Tests — 82 pass
- [ ] Verify login works on HTTP dev (showcase)
- [ ] Verify `__Host-` cookies present on HTTPS prod