### PR TITLE
fix(identity): use PostConfigure to override Identity cookie names

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -15505,7 +15505,7 @@
       "kind": "class",
       "project": "Granit.Identity.Local.AspNetIdentity",
       "file": "src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs",
-      "line": 27,
+      "line": 28,
       "members": [
         {
           "name": "ConfigureServices",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1137,6 +1137,7 @@
     {
       "name": "Granit.OpenIddict",
       "deps": [
+        "Granit.Encryption",
         "Granit.Http.Cookies",
         "Granit.Identity.Local",
         "Granit.QueryEngine.Abstractions"
@@ -22438,7 +22439,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.EntityFrameworkCore",
       "file": "src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs",
-      "line": 37,
+      "line": 33,
       "members": [
         {
           "name": "ConfigureServices",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -15785,7 +15785,7 @@
       "kind": "record",
       "project": "Granit.Identity.Local.Endpoints",
       "file": "src/Granit.Identity.Local.Endpoints/Dtos/AccountTwoFactorLoginRequest.cs",
-      "line": 11,
+      "line": 15,
       "members": []
     },
     {
@@ -22438,7 +22438,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.EntityFrameworkCore",
       "file": "src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs",
-      "line": 44,
+      "line": 37,
       "members": [
         {
           "name": "ConfigureServices",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1137,6 +1137,7 @@
     {
       "name": "Granit.OpenIddict",
       "deps": [
+        "Granit.Http.Cookies",
         "Granit.Identity.Local",
         "Granit.QueryEngine.Abstractions"
       ],
@@ -1169,7 +1170,6 @@
       "name": "Granit.OpenIddict.EntityFrameworkCore",
       "deps": [
         "Granit.Encryption",
-        "Granit.Http.Cookies",
         "Granit.Identity.Local",
         "Granit.MultiTenancy",
         "Granit.OpenIddict.Server",
@@ -22438,7 +22438,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.EntityFrameworkCore",
       "file": "src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs",
-      "line": 46,
+      "line": 44,
       "members": [
         {
           "name": "ConfigureServices",
@@ -22470,7 +22470,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/GranitOpenIddictModule.cs",
-      "line": 23,
+      "line": 28,
       "members": [
         {
           "name": "ConfigureServices",

--- a/src/Granit.BlobStorage.S3/packages.lock.json
+++ b/src/Granit.BlobStorage.S3/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.S3": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.20.1",
-        "contentHash": "UH2ozA9bQe/dOwxClI7h1BEmpt45hk5rrzwQgDFLdt5bpP5o46gHAAHiM6dbiBLzD81Q0YQHMiJ9nWeO5AG5FQ==",
+        "resolved": "4.0.20.2",
+        "contentHash": "sMZqcVyM92oFSB4U0S3qR6+BjQzJ/xU9gjIcxQu0USVkqc6+SEdbC7N6i9DfCjHBVPof961SqoSwMtp34zSbqA==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.25, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.26, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -67,8 +67,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.25",
-        "contentHash": "ug/C6csm8/GcRrMij9EtTA6k2MtRFV9EibhWNRFTISR8AGXQnSoxUKnddMpHah6ax/Tjg1GW0zk1i0/wcvEqmg=="
+        "resolved": "4.0.3.26",
+        "contentHash": "2iVc7MZCbq2KY8vkxs+C+xbJavG9X3JvnVkQxVlxkKyCWeQuQGJCI+w+p6RXrKYMpP2AaGLIPFBR0hLDRw59bQ=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Identity.Federated.Cognito/packages.lock.json
+++ b/src/Granit.Identity.Federated.Cognito/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.6.6",
-        "contentHash": "jqKTmIw7x20SG5dYc5DnhdfM7961vZglkVn7/OUOcTS+a8mUya8I5ClmoiZpOqk6uqZxn4ZtvoNRC4vv/CnmAw==",
+        "resolved": "4.0.6.7",
+        "contentHash": "12xgG6brjfHro17L+Dxm/TrA5mFsv9Ty8o0ecESlvyNRapvcqVX/XNaFqpQkgqqG06ur/gccD0ZlmP+h8AyQJw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.25, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.26, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -32,8 +32,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.25",
-        "contentHash": "ug/C6csm8/GcRrMij9EtTA6k2MtRFV9EibhWNRFTISR8AGXQnSoxUKnddMpHah6ax/Tjg1GW0zk1i0/wcvEqmg=="
+        "resolved": "4.0.3.26",
+        "contentHash": "2iVc7MZCbq2KY8vkxs+C+xbJavG9X3JvnVkQxVlxkKyCWeQuQGJCI+w+p6RXrKYMpP2AaGLIPFBR0hLDRw59bQ=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs
@@ -2,6 +2,7 @@ using Granit.Identity;
 using Granit.Identity.Extensions;
 using Granit.Identity.Local;
 using Granit.Identity.Local.AspNetIdentity.Internal;
+using Granit.Identity.Local.Services;
 using Granit.Modularity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -34,6 +35,12 @@ public sealed partial class GranitIdentityLocalAspNetIdentityModule : GranitModu
             AspNetIdentityProviderCapabilities>());
         context.Services.Replace(ServiceDescriptor.Scoped<IUserLookupService,
             AspNetIdentityUserLookupService>());
+
+        // ASP.NET Core Identity service implementations (depend on UserManager<GranitUser>)
+        context.Services.TryAddScoped<ITotpService, TotpService>();
+        context.Services.TryAddScoped<ITwoFactorService, AspNetTwoFactorService>();
+        context.Services.TryAddScoped<IPasskeyService, AspNetPasskeyService>();
+        context.Services.TryAddScoped<IPasswordResetService, AspNetPasswordResetService>();
     }
 
     /// <inheritdoc/>

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetPasskeyService.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetPasskeyService.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Options;
 
 #pragma warning disable GRSEC003 // Passkey/credential constants, not secrets
 
-namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
+namespace Granit.Identity.Local.AspNetIdentity.Internal;
 
 /// <summary>
 /// <see cref="IPasskeyService"/> implementation using ASP.NET Core Identity's

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetPasswordResetService.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetPasswordResetService.cs
@@ -4,7 +4,7 @@ using Granit.Identity.Local.Events;
 using Granit.Identity.Local.Services;
 using Microsoft.AspNetCore.Identity;
 
-namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
+namespace Granit.Identity.Local.AspNetIdentity.Internal;
 
 /// <summary>
 /// <see cref="IPasswordResetService"/> implementation backed by ASP.NET Core Identity.

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetTwoFactorService.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetTwoFactorService.cs
@@ -2,7 +2,7 @@ using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Services;
 using Microsoft.AspNetCore.Identity;
 
-namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
+namespace Granit.Identity.Local.AspNetIdentity.Internal;
 
 /// <summary>
 /// <see cref="ITwoFactorService"/> implementation backed by <see cref="UserManager{TUser}"/>.

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/TotpService.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/TotpService.cs
@@ -5,7 +5,7 @@ using Granit.Timing;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
 
-namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
+namespace Granit.Identity.Local.AspNetIdentity.Internal;
 
 /// <summary>
 /// RFC 6238 TOTP implementation using <see cref="HMACSHA1"/> for two-factor authentication.

--- a/src/Granit.Identity.Local.Endpoints/Dtos/AccountLoginRequest.cs
+++ b/src/Granit.Identity.Local.Endpoints/Dtos/AccountLoginRequest.cs
@@ -3,4 +3,7 @@ namespace Granit.Identity.Local.Endpoints.Dtos;
 /// <summary>
 /// Request body for the headless login endpoint.
 /// </summary>
-public sealed record AccountLoginRequest(string Login, string Password);
+public sealed record AccountLoginRequest(
+    string Login,
+    string Password,
+    bool RememberMe = false);

--- a/src/Granit.Identity.Local.Endpoints/Dtos/AccountTwoFactorLoginRequest.cs
+++ b/src/Granit.Identity.Local.Endpoints/Dtos/AccountTwoFactorLoginRequest.cs
@@ -8,6 +8,11 @@ namespace Granit.Identity.Local.Endpoints.Dtos;
 /// When <see langword="true"/>, <paramref name="Code"/> is treated as a recovery code
 /// instead of a TOTP code. Default: <see langword="false"/>.
 /// </param>
+/// <param name="RememberMe">
+/// When <see langword="true"/>, the Identity session cookie is marked as persistent.
+/// Default: <see langword="false"/>.
+/// </param>
 public sealed record AccountTwoFactorLoginRequest(
     string Code,
-    bool UseRecoveryCode = false);
+    bool UseRecoveryCode = false,
+    bool RememberMe = false);

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
@@ -85,7 +85,7 @@ internal static partial class AccountLoginEndpoints
         }
 
         Microsoft.AspNetCore.Identity.SignInResult result = await signInManager
-            .PasswordSignInAsync(user, request.Password, isPersistent: false, lockoutOnFailure: true)
+            .PasswordSignInAsync(user, request.Password, isPersistent: request.RememberMe, lockoutOnFailure: true)
             .ConfigureAwait(false);
 
         if (result.Succeeded)
@@ -155,11 +155,25 @@ internal static partial class AccountLoginEndpoints
             result = await signInManager
                 .TwoFactorRecoveryCodeSignInAsync(sanitizedCode)
                 .ConfigureAwait(false);
+
+            // TwoFactorRecoveryCodeSignInAsync does not accept isPersistent,
+            // so re-sign the user with a persistent cookie when RememberMe is requested.
+            if (result.Succeeded && request.RememberMe)
+            {
+                GranitUser? user = await signInManager.UserManager
+                    .GetUserAsync(httpContext.User).ConfigureAwait(false);
+
+                if (user is not null)
+                {
+                    await signInManager.SignInAsync(user, isPersistent: true)
+                        .ConfigureAwait(false);
+                }
+            }
         }
         else
         {
             result = await signInManager
-                .TwoFactorAuthenticatorSignInAsync(sanitizedCode, isPersistent: false, rememberClient: false)
+                .TwoFactorAuthenticatorSignInAsync(sanitizedCode, isPersistent: request.RememberMe, rememberClient: false)
                 .ConfigureAwait(false);
         }
 

--- a/src/Granit.Notifications.Email.AwsSes/packages.lock.json
+++ b/src/Granit.Notifications.Email.AwsSes/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.SimpleEmailV2": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.12.6",
-        "contentHash": "mOu9MJY1uZ9geS0pRNVfAa+zLfwetfOXCe43pAvdgKrw5HhRrNykG/tCSk6Gs6Vvk6YAZTgqumOriWgtpQpksw==",
+        "resolved": "4.0.12.7",
+        "contentHash": "n/wV4Ssfh9Rc7Rjur5Z0Ykxj88pKxREvCXt0+9tpNgan8hBAkfhT/2QXGUSuG3dDKeWrck8QBt3Td2yj8hgGRQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.25, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.26, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -69,8 +69,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.25",
-        "contentHash": "ug/C6csm8/GcRrMij9EtTA6k2MtRFV9EibhWNRFTISR8AGXQnSoxUKnddMpHah6ax/Tjg1GW0zk1i0/wcvEqmg=="
+        "resolved": "4.0.3.26",
+        "contentHash": "2iVc7MZCbq2KY8vkxs+C+xbJavG9X3JvnVkQxVlxkKyCWeQuQGJCI+w+p6RXrKYMpP2AaGLIPFBR0hLDRw59bQ=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Notifications.MobilePush.AwsSns/packages.lock.json
+++ b/src/Granit.Notifications.MobilePush.AwsSns/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.23",
-        "contentHash": "KiLx1wKZ2d7QpEWfs+Bv3Zj2s4ANP0CLZucFXSS2KXXY6wdOMbml3Nv4MNfdUVwiQcHZ+2tgsWgu2JG/vsZf4g==",
+        "resolved": "4.0.2.24",
+        "contentHash": "pSjHIU+bzx4oR/0C6pn7gH9ffGDM0t7vjRsvfji1MWTLeyK9HUmbhKHXNVo5M4528Ne0kowjRJhwIMFjwmsxbQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.25, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.26, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -19,8 +19,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.25",
-        "contentHash": "ug/C6csm8/GcRrMij9EtTA6k2MtRFV9EibhWNRFTISR8AGXQnSoxUKnddMpHah6ax/Tjg1GW0zk1i0/wcvEqmg=="
+        "resolved": "4.0.3.26",
+        "contentHash": "2iVc7MZCbq2KY8vkxs+C+xbJavG9X3JvnVkQxVlxkKyCWeQuQGJCI+w+p6RXrKYMpP2AaGLIPFBR0hLDRw59bQ=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.Notifications.Sms.AwsSns/packages.lock.json
+++ b/src/Granit.Notifications.Sms.AwsSns/packages.lock.json
@@ -5,10 +5,10 @@
       "AWSSDK.SimpleNotificationService": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.23",
-        "contentHash": "KiLx1wKZ2d7QpEWfs+Bv3Zj2s4ANP0CLZucFXSS2KXXY6wdOMbml3Nv4MNfdUVwiQcHZ+2tgsWgu2JG/vsZf4g==",
+        "resolved": "4.0.2.24",
+        "contentHash": "pSjHIU+bzx4oR/0C6pn7gH9ffGDM0t7vjRsvfji1MWTLeyK9HUmbhKHXNVo5M4528Ne0kowjRJhwIMFjwmsxbQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.25, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.26, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -19,8 +19,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.25",
-        "contentHash": "ug/C6csm8/GcRrMij9EtTA6k2MtRFV9EibhWNRFTISR8AGXQnSoxUKnddMpHah6ax/Tjg1GW0zk1i0/wcvEqmg=="
+        "resolved": "4.0.3.26",
+        "contentHash": "2iVc7MZCbq2KY8vkxs+C+xbJavG9X3JvnVkQxVlxkKyCWeQuQGJCI+w+p6RXrKYMpP2AaGLIPFBR0hLDRw59bQ=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/Granit.OpenIddict.BackgroundJobs/packages.lock.json
+++ b/src/Granit.OpenIddict.BackgroundJobs/packages.lock.json
@@ -453,6 +453,12 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "granit.http.cookies": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {
@@ -473,6 +479,8 @@
       "granit.openiddict": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"

--- a/src/Granit.OpenIddict.Endpoints/packages.lock.json
+++ b/src/Granit.OpenIddict.Endpoints/packages.lock.json
@@ -283,6 +283,12 @@
           "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.events": {
         "type": "Project",
         "dependencies": {
@@ -308,6 +314,12 @@
         "dependencies": {
           "Asp.Versioning.Mvc": "[10.0.0-preview.*, )",
           "Asp.Versioning.Mvc.ApiExplorer": "[10.0.0-preview.*, )",
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.cookies": {
+        "type": "Project",
+        "dependencies": {
           "Granit": "[0.1.0-dev, )"
         }
       },
@@ -345,6 +357,8 @@
       "granit.openiddict": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Granit.OpenIddict.EntityFrameworkCore.csproj
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Granit.OpenIddict.EntityFrameworkCore.csproj
@@ -27,7 +27,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.Encryption\Granit.Encryption.csproj" />
-    <ProjectReference Include="..\Granit.Http.Cookies\Granit.Http.Cookies.csproj" />
     <ProjectReference Include="..\Granit.Identity.Local\Granit.Identity.Local.csproj" />
     <ProjectReference Include="..\Granit.MultiTenancy\Granit.MultiTenancy.csproj" />
     <ProjectReference Include="..\Granit.OpenIddict.Server\Granit.OpenIddict.Server.csproj" />

--- a/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
@@ -1,12 +1,10 @@
 using Granit.Encryption;
 using Granit.Identity.Local;
-using Granit.Identity.Local.Options;
 using Granit.Identity.Local.Services;
 using Granit.Modularity;
 using Granit.MultiTenancy;
 using Granit.OpenIddict.EntityFrameworkCore.Internal;
 using Granit.OpenIddict.EntityFrameworkCore.Seeding;
-using Granit.OpenIddict.Options;
 using Granit.OpenIddict.Server;
 using Granit.OpenIddict.Services;
 using Granit.Persistence.EntityFrameworkCore;
@@ -20,19 +18,14 @@ using OpenIddict.Server;
 namespace Granit.OpenIddict.EntityFrameworkCore;
 
 /// <summary>
-/// Granit module that registers EF Core persistence for OpenIddict.
+/// Granit module that registers EF Core persistence and ASP.NET Core Identity
+/// service implementations for OpenIddict.
 /// </summary>
 /// <remarks>
 /// <para>
-/// The host application must configure the <see cref="Internal.OpenIddictDbContext"/>
-/// connection string via <c>AddGranitOpenIddict(configure)</c>.
-/// This module registers the store implementations, OpenIddict core services,
-/// the declarative seed contributor, and passkey options.
-/// </para>
-/// <para>
-/// Depends on <see cref="GranitMultiTenancyModule"/> for GDPR-strict tenant isolation
-/// in OpenIddict stores, and <see cref="GranitEncryptionModule"/> for signing key
-/// material encryption at rest.
+/// Persistence: <see cref="Internal.OpenIddictDbContext"/>, EF stores, data seeding.
+/// Identity services: <c>AspNet*</c> implementations that depend on <c>UserManager&lt;GranitUser&gt;</c>
+/// (registered here because <c>AddIdentity()</c> is called in <c>AddGranitOpenIddict()</c>).
 /// </para>
 /// </remarks>
 [DependsOn(
@@ -46,31 +39,22 @@ public sealed class GranitOpenIddictEntityFrameworkCoreModule : GranitModule
     /// <inheritdoc/>
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        context.Services
-            .AddOptions<GranitOpenIddictSeedingOptions>()
-            .BindConfiguration(GranitOpenIddictSeedingOptions.SectionName);
-
-        context.Services
-            .AddOptions<GranitPasskeyOptions>()
-            .BindConfiguration(GranitPasskeyOptions.SectionName);
-
+        // Data seeding
         context.Services.AddTransient<IDataSeedContributor, OpenIddictSeedContributor>();
 
+        // EF Core stores
         context.Services.TryAddScoped<ILocalIdentityGroupStore, OpenIddictGroupStore>();
-        context.Services.TryAddScoped<ExternalClaimsMapper>();
+        context.Services.TryAddScoped<ISigningKeyStore, EfSigningKeyStore>();
+        context.Services.TryAddScoped<IKeyRotationService, KeyRotationService>();
+
+        // ASP.NET Core Identity service implementations (depend on UserManager<GranitUser>)
         context.Services.TryAddScoped<IExternalLoginService, AspNetExternalLoginService>();
         context.Services.TryAddScoped<ITotpService, TotpService>();
         context.Services.TryAddScoped<ITwoFactorService, AspNetTwoFactorService>();
         context.Services.TryAddScoped<IAccountDeletionService, AspNetAccountDeletionService>();
         context.Services.TryAddScoped<IPasswordResetService, AspNetPasswordResetService>();
-        context.Services.TryAddScoped<ISigningKeyStore, EfSigningKeyStore>();
-        context.Services.TryAddScoped<IKeyRotationService, KeyRotationService>();
         context.Services.TryAddScoped<IPasskeyService, AspNetPasskeyService>();
         context.Services.TryAddScoped<IImpersonationService, AspNetImpersonationService>();
-
-        context.Services
-            .AddOptions<GranitKeyRotationOptions>()
-            .BindConfiguration(GranitKeyRotationOptions.SectionName);
 
         // GranitUser implements IHasExtraProperties — apps can extend user properties
         // by calling AddExtraPropertyMappings<GranitUser> in their own module.

--- a/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
@@ -18,15 +18,11 @@ using OpenIddict.Server;
 namespace Granit.OpenIddict.EntityFrameworkCore;
 
 /// <summary>
-/// Granit module that registers EF Core persistence and ASP.NET Core Identity
-/// service implementations for OpenIddict.
+/// Granit module that registers EF Core persistence for OpenIddict.
 /// </summary>
 /// <remarks>
-/// <para>
-/// Persistence: <see cref="Internal.OpenIddictDbContext"/>, EF stores, data seeding.
-/// Identity services: <c>AspNet*</c> implementations that depend on <c>UserManager&lt;GranitUser&gt;</c>
-/// (registered here because <c>AddIdentity()</c> is called in <c>AddGranitOpenIddict()</c>).
-/// </para>
+/// Registers <see cref="Internal.OpenIddictDbContext"/>, EF stores (groups, signing keys),
+/// data seeding, extra-property infrastructure, and signing key loading at startup.
 /// </remarks>
 [DependsOn(
     typeof(GranitEncryptionModule),
@@ -45,16 +41,6 @@ public sealed class GranitOpenIddictEntityFrameworkCoreModule : GranitModule
         // EF Core stores
         context.Services.TryAddScoped<ILocalIdentityGroupStore, OpenIddictGroupStore>();
         context.Services.TryAddScoped<ISigningKeyStore, EfSigningKeyStore>();
-        context.Services.TryAddScoped<IKeyRotationService, KeyRotationService>();
-
-        // ASP.NET Core Identity service implementations (depend on UserManager<GranitUser>)
-        context.Services.TryAddScoped<IExternalLoginService, AspNetExternalLoginService>();
-        context.Services.TryAddScoped<ITotpService, TotpService>();
-        context.Services.TryAddScoped<ITwoFactorService, AspNetTwoFactorService>();
-        context.Services.TryAddScoped<IAccountDeletionService, AspNetAccountDeletionService>();
-        context.Services.TryAddScoped<IPasswordResetService, AspNetPasswordResetService>();
-        context.Services.TryAddScoped<IPasskeyService, AspNetPasskeyService>();
-        context.Services.TryAddScoped<IImpersonationService, AspNetImpersonationService>();
 
         // GranitUser implements IHasExtraProperties — apps can extend user properties
         // by calling AddExtraPropertyMappings<GranitUser> in their own module.

--- a/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
@@ -1,5 +1,4 @@
 using Granit.Encryption;
-using Granit.Http.Cookies;
 using Granit.Identity.Local;
 using Granit.Identity.Local.Options;
 using Granit.Identity.Local.Services;
@@ -15,7 +14,6 @@ using Granit.Persistence.EntityFrameworkCore.DataSeeding;
 using Granit.Persistence.EntityFrameworkCore.ExtraProperties;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using OpenIddict.Server;
 
@@ -57,27 +55,6 @@ public sealed class GranitOpenIddictEntityFrameworkCoreModule : GranitModule
             .BindConfiguration(GranitPasskeyOptions.SectionName);
 
         context.Services.AddTransient<IDataSeedContributor, OpenIddictSeedContributor>();
-        context.Services.AddSingleton<ICookieDefinitionContributor, IdentityCookieDefinitionContributor>();
-
-        // Override default ASP.NET Core Identity cookie names to avoid leaking the technology stack.
-        // Production: __Host- prefix (Secure + Path=/ + no Domain, RFC 6265bis §4.1.3.2).
-        // Development: simple names without __Host- (requires HTTPS, incompatible with HTTP dev).
-        bool isDevelopment = context.Builder!.Environment.IsDevelopment();
-
-        ConfigureIdentityCookie(context.Services, isDevelopment,
-            Microsoft.AspNetCore.Identity.IdentityConstants.ApplicationScheme,
-            IdentityCookieDefinitionContributor.DefaultApplicationCookieName,
-            IdentityCookieDefinitionContributor.DevApplicationCookieName);
-
-        ConfigureIdentityCookie(context.Services, isDevelopment,
-            Microsoft.AspNetCore.Identity.IdentityConstants.TwoFactorUserIdScheme,
-            IdentityCookieDefinitionContributor.DefaultTwoFactorCookieName,
-            IdentityCookieDefinitionContributor.DevTwoFactorCookieName);
-
-        ConfigureIdentityCookie(context.Services, isDevelopment,
-            Microsoft.AspNetCore.Identity.IdentityConstants.ExternalScheme,
-            IdentityCookieDefinitionContributor.DefaultExternalCookieName,
-            IdentityCookieDefinitionContributor.DevExternalCookieName);
 
         context.Services.TryAddScoped<ILocalIdentityGroupStore, OpenIddictGroupStore>();
         context.Services.TryAddScoped<ExternalClaimsMapper>();
@@ -103,24 +80,5 @@ public sealed class GranitOpenIddictEntityFrameworkCoreModule : GranitModule
         // Load signing/encryption keys from DB at startup (replaces ephemeral keys)
         context.Services.AddSingleton<IPostConfigureOptions<OpenIddictServerOptions>,
             DatabaseSigningKeyPostConfigure>();
-    }
-
-    private static void ConfigureIdentityCookie(
-        IServiceCollection services, bool isDevelopment, string scheme,
-        string prodCookieName, string devCookieName)
-    {
-        // MUST use PostConfigure — AddIdentity<TUser, TRole>() registers its own
-        // PostConfigure that resets cookie names to ASP.NET Core defaults.
-        // Our PostConfigure runs after Identity's because the module [DependsOn]
-        // chain ensures registration order.
-        services.PostConfigure<Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationOptions>(
-            scheme,
-            options =>
-            {
-                options.Cookie.Name = isDevelopment ? devCookieName : prodCookieName;
-                options.Cookie.SecurePolicy = isDevelopment
-                    ? Microsoft.AspNetCore.Http.CookieSecurePolicy.SameAsRequest
-                    : Microsoft.AspNetCore.Http.CookieSecurePolicy.Always;
-            });
     }
 }

--- a/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
@@ -109,7 +109,11 @@ public sealed class GranitOpenIddictEntityFrameworkCoreModule : GranitModule
         IServiceCollection services, bool isDevelopment, string scheme,
         string prodCookieName, string devCookieName)
     {
-        services.Configure<Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationOptions>(
+        // MUST use PostConfigure — AddIdentity<TUser, TRole>() registers its own
+        // PostConfigure that resets cookie names to ASP.NET Core defaults.
+        // Our PostConfigure runs after Identity's because the module [DependsOn]
+        // chain ensures registration order.
+        services.PostConfigure<Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationOptions>(
             scheme,
             options =>
             {

--- a/src/Granit.OpenIddict.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/packages.lock.json
@@ -357,6 +357,8 @@
       "granit.openiddict": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"

--- a/src/Granit.OpenIddict.Server/packages.lock.json
+++ b/src/Granit.OpenIddict.Server/packages.lock.json
@@ -280,6 +280,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.events": {
         "type": "Project",
         "dependencies": {
@@ -290,6 +296,12 @@
         "type": "Project",
         "dependencies": {
           "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.cookies": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.identity": {
@@ -312,6 +324,8 @@
       "granit.openiddict": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"

--- a/src/Granit.OpenIddict/Granit.OpenIddict.csproj
+++ b/src/Granit.OpenIddict/Granit.OpenIddict.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.Encryption\Granit.Encryption.csproj" />
     <ProjectReference Include="..\Granit.Http.Cookies\Granit.Http.Cookies.csproj" />
     <ProjectReference Include="..\Granit.Identity.Local\Granit.Identity.Local.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />

--- a/src/Granit.OpenIddict/Granit.OpenIddict.csproj
+++ b/src/Granit.OpenIddict/Granit.OpenIddict.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.Http.Cookies\Granit.Http.Cookies.csproj" />
     <ProjectReference Include="..\Granit.Identity.Local\Granit.Identity.Local.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
   </ItemGroup>

--- a/src/Granit.OpenIddict/GranitOpenIddictModule.cs
+++ b/src/Granit.OpenIddict/GranitOpenIddictModule.cs
@@ -1,23 +1,28 @@
 using Granit.Diagnostics;
+using Granit.Http.Cookies;
 using Granit.Identity.Local;
 using Granit.Identity.Local.Options;
 using Granit.Identity.Local.Services;
 using Granit.Modularity;
 using Granit.OpenIddict.Diagnostics;
+using Granit.OpenIddict.Internal;
 using Granit.OpenIddict.Options;
 using Granit.OpenIddict.Services;
 using Granit.QueryEngine;
 using Granit.Users;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 
 namespace Granit.OpenIddict;
 
 /// <summary>
 /// Granit module for the OpenIddict-based identity provider.
-/// Registers OIDC abstractions, service interfaces, and integration event types.
+/// Registers OIDC abstractions, service interfaces, integration event types,
+/// and Identity cookie configuration (neutral names, env-aware __Host- prefix).
 /// </summary>
 [DependsOn(
+    typeof(GranitHttpCookiesModule),
     typeof(GranitIdentityLocalModule),
     typeof(GranitQueryEngineAbstractionsModule))]
 public sealed class GranitOpenIddictModule : GranitModule
@@ -47,5 +52,42 @@ public sealed class GranitOpenIddictModule : GranitModule
         context.Services.TryAddScoped<IClaimsDestinationProvider, DefaultClaimsDestinationProvider>();
         context.Services.TryAddScoped<ITotpService, DefaultTotpService>();
         context.Services.TryAddSingleton<IExternalProviderRegistry, OpenIddictExternalProviderRegistry>();
+
+        // Identity cookie configuration — neutral names to avoid leaking the technology stack.
+        // PostConfigure is required because AddIdentity<TUser, TRole>() registers its own
+        // PostConfigure that resets names to ASP.NET Core defaults.
+        context.Services.AddSingleton<ICookieDefinitionContributor, IdentityCookieDefinitionContributor>();
+
+        bool isDevelopment = context.Builder!.Environment.IsDevelopment();
+
+        PostConfigureIdentityCookie(context.Services, isDevelopment,
+            Microsoft.AspNetCore.Identity.IdentityConstants.ApplicationScheme,
+            IdentityCookieDefinitionContributor.DefaultApplicationCookieName,
+            IdentityCookieDefinitionContributor.DevApplicationCookieName);
+
+        PostConfigureIdentityCookie(context.Services, isDevelopment,
+            Microsoft.AspNetCore.Identity.IdentityConstants.TwoFactorUserIdScheme,
+            IdentityCookieDefinitionContributor.DefaultTwoFactorCookieName,
+            IdentityCookieDefinitionContributor.DevTwoFactorCookieName);
+
+        PostConfigureIdentityCookie(context.Services, isDevelopment,
+            Microsoft.AspNetCore.Identity.IdentityConstants.ExternalScheme,
+            IdentityCookieDefinitionContributor.DefaultExternalCookieName,
+            IdentityCookieDefinitionContributor.DevExternalCookieName);
+    }
+
+    private static void PostConfigureIdentityCookie(
+        IServiceCollection services, bool isDevelopment, string scheme,
+        string prodCookieName, string devCookieName)
+    {
+        services.PostConfigure<Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationOptions>(
+            scheme,
+            options =>
+            {
+                options.Cookie.Name = isDevelopment ? devCookieName : prodCookieName;
+                options.Cookie.SecurePolicy = isDevelopment
+                    ? Microsoft.AspNetCore.Http.CookieSecurePolicy.SameAsRequest
+                    : Microsoft.AspNetCore.Http.CookieSecurePolicy.Always;
+            });
     }
 }

--- a/src/Granit.OpenIddict/GranitOpenIddictModule.cs
+++ b/src/Granit.OpenIddict/GranitOpenIddictModule.cs
@@ -49,8 +49,13 @@ public sealed class GranitOpenIddictModule : GranitModule
             .AddOptions<GranitOpenIddictSeedingOptions>()
             .BindConfiguration(GranitOpenIddictSeedingOptions.SectionName);
 
+        context.Services
+            .AddOptions<GranitKeyRotationOptions>()
+            .BindConfiguration(GranitKeyRotationOptions.SectionName);
+
         context.Services.TryAddScoped<IClaimsDestinationProvider, DefaultClaimsDestinationProvider>();
         context.Services.TryAddScoped<ITotpService, DefaultTotpService>();
+        context.Services.TryAddScoped<ExternalClaimsMapper>();
         context.Services.TryAddSingleton<IExternalProviderRegistry, OpenIddictExternalProviderRegistry>();
 
         // Identity cookie configuration — neutral names to avoid leaking the technology stack.

--- a/src/Granit.OpenIddict/GranitOpenIddictModule.cs
+++ b/src/Granit.OpenIddict/GranitOpenIddictModule.cs
@@ -56,6 +56,10 @@ public sealed class GranitOpenIddictModule : GranitModule
         context.Services.TryAddScoped<IClaimsDestinationProvider, DefaultClaimsDestinationProvider>();
         context.Services.TryAddScoped<ITotpService, DefaultTotpService>();
         context.Services.TryAddScoped<ExternalClaimsMapper>();
+        context.Services.TryAddScoped<IExternalLoginService, Internal.AspNetExternalLoginService>();
+        context.Services.TryAddScoped<IAccountDeletionService, Internal.AspNetAccountDeletionService>();
+        context.Services.TryAddScoped<IImpersonationService, Internal.AspNetImpersonationService>();
+        context.Services.TryAddScoped<IKeyRotationService, Internal.KeyRotationService>();
         context.Services.TryAddSingleton<IExternalProviderRegistry, OpenIddictExternalProviderRegistry>();
 
         // Identity cookie configuration — neutral names to avoid leaking the technology stack.

--- a/src/Granit.OpenIddict/Internal/AspNetAccountDeletionService.cs
+++ b/src/Granit.OpenIddict/Internal/AspNetAccountDeletionService.cs
@@ -6,7 +6,7 @@ using Granit.Timing;
 using Microsoft.AspNetCore.Identity;
 using OpenIddict.Abstractions;
 
-namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
+namespace Granit.OpenIddict.Internal;
 
 /// <summary>
 /// <see cref="IAccountDeletionService"/> implementation backed by ASP.NET Core Identity.

--- a/src/Granit.OpenIddict/Internal/AspNetExternalLoginService.cs
+++ b/src/Granit.OpenIddict/Internal/AspNetExternalLoginService.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
 using GranitExternalLoginInfo = Granit.Identity.Local.Services.ExternalLoginInfo;
 
-namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
+namespace Granit.OpenIddict.Internal;
 
 /// <summary>
 /// <see cref="IExternalLoginService"/> implementation backed by ASP.NET Core Identity's

--- a/src/Granit.OpenIddict/Internal/AspNetImpersonationService.cs
+++ b/src/Granit.OpenIddict/Internal/AspNetImpersonationService.cs
@@ -14,7 +14,7 @@ using OpenIddict.Abstractions;
 #pragma warning disable EF1001 // OpenIddictDbContext is internal but accessible via InternalsVisibleTo
 #pragma warning disable GRSEC003 // Token/claim constants, not secrets
 
-namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
+namespace Granit.OpenIddict.Internal;
 
 /// <summary>
 /// <see cref="IImpersonationService"/> implementation that issues OpenIddict tokens

--- a/src/Granit.OpenIddict/Internal/IdentityCookieDefinitionContributor.cs
+++ b/src/Granit.OpenIddict/Internal/IdentityCookieDefinitionContributor.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
 
-namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
+namespace Granit.OpenIddict.Internal;
 
 /// <summary>
 /// Contributes ASP.NET Core Identity cookie definitions to the Granit cookie registry.

--- a/src/Granit.OpenIddict/Internal/KeyRotationService.cs
+++ b/src/Granit.OpenIddict/Internal/KeyRotationService.cs
@@ -6,7 +6,7 @@ using Granit.OpenIddict.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
+namespace Granit.OpenIddict.Internal;
 
 /// <summary>
 /// <see cref="IKeyRotationService"/> implementation that manages the full signing key lifecycle.

--- a/src/Granit.OpenIddict/packages.lock.json
+++ b/src/Granit.OpenIddict/packages.lock.json
@@ -74,6 +74,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.events": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.OpenIddict/packages.lock.json
+++ b/src/Granit.OpenIddict/packages.lock.json
@@ -86,6 +86,12 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
+      "granit.http.cookies": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.Vault.Aws/packages.lock.json
+++ b/src/Granit.Vault.Aws/packages.lock.json
@@ -5,19 +5,19 @@
       "AWSSDK.KeyManagementService": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.9.7",
-        "contentHash": "oSkfkBsOw8wOhqIYlqV9Zg2m8MvRm54gEgIlFDDXxNLXE6y1IlwHFXlDA/6O3epJFjno/WyY2ESpfN2ui7I/RQ==",
+        "resolved": "4.0.9.8",
+        "contentHash": "0dyK2o+qN0CMMS76ZbbiyqqCwqSAYA5edjwC1CxbojBO9cOvENk9WxADKQTMZ5jtdpHXGgU74raSOngqf0TZkw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.25, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.26, 5.0.0)"
         }
       },
       "AWSSDK.SecretsManager": {
         "type": "Direct",
         "requested": "[4.*, )",
-        "resolved": "4.0.4.13",
-        "contentHash": "BWkSBvmn/xtwMLhEctn8Mx9Anw859LQ8HhGtIsRQRTq2YugMGEi0tBY48vQ9vnej49XipLOuZUHVxjUptlSEdg==",
+        "resolved": "4.0.4.14",
+        "contentHash": "PrdJ5228BYfdgqNSSDgZLsEIS0wdttOZGTnq5oddJsseN/zGkKrk996513JdzOkUACW2BQrkoID04lZGbHQhfg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.25, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.26, 5.0.0)"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -91,8 +91,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.25",
-        "contentHash": "ug/C6csm8/GcRrMij9EtTA6k2MtRFV9EibhWNRFTISR8AGXQnSoxUKnddMpHah6ax/Tjg1GW0zk1i0/wcvEqmg=="
+        "resolved": "4.0.3.26",
+        "contentHash": "2iVc7MZCbq2KY8vkxs+C+xbJavG9X3JvnVkQxVlxkKyCWeQuQGJCI+w+p6RXrKYMpP2AaGLIPFBR0hLDRw59bQ=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
+++ b/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
@@ -601,6 +601,8 @@
       "granit.openiddict": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"
@@ -632,7 +634,6 @@
         "type": "Project",
         "dependencies": {
           "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.OpenIddict.Server": "[0.1.0-dev, )",

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -93,8 +93,8 @@
       },
       "AWSSDK.Core": {
         "type": "Transitive",
-        "resolved": "4.0.3.25",
-        "contentHash": "ug/C6csm8/GcRrMij9EtTA6k2MtRFV9EibhWNRFTISR8AGXQnSoxUKnddMpHah6ax/Tjg1GW0zk1i0/wcvEqmg=="
+        "resolved": "4.0.3.26",
+        "contentHash": "2iVc7MZCbq2KY8vkxs+C+xbJavG9X3JvnVkQxVlxkKyCWeQuQGJCI+w+p6RXrKYMpP2AaGLIPFBR0hLDRw59bQ=="
       },
       "Azure.Core": {
         "type": "Transitive",
@@ -2446,6 +2446,8 @@
       "granit.openiddict": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"
@@ -2477,7 +2479,6 @@
         "type": "Project",
         "dependencies": {
           "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.OpenIddict.Server": "[0.1.0-dev, )",
@@ -3032,55 +3033,55 @@
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.6.6",
-        "contentHash": "jqKTmIw7x20SG5dYc5DnhdfM7961vZglkVn7/OUOcTS+a8mUya8I5ClmoiZpOqk6uqZxn4ZtvoNRC4vv/CnmAw==",
+        "resolved": "4.0.6.7",
+        "contentHash": "12xgG6brjfHro17L+Dxm/TrA5mFsv9Ty8o0ecESlvyNRapvcqVX/XNaFqpQkgqqG06ur/gccD0ZlmP+h8AyQJw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.25, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.26, 5.0.0)"
         }
       },
       "AWSSDK.KeyManagementService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.9.7",
-        "contentHash": "oSkfkBsOw8wOhqIYlqV9Zg2m8MvRm54gEgIlFDDXxNLXE6y1IlwHFXlDA/6O3epJFjno/WyY2ESpfN2ui7I/RQ==",
+        "resolved": "4.0.9.8",
+        "contentHash": "0dyK2o+qN0CMMS76ZbbiyqqCwqSAYA5edjwC1CxbojBO9cOvENk9WxADKQTMZ5jtdpHXGgU74raSOngqf0TZkw==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.25, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.26, 5.0.0)"
         }
       },
       "AWSSDK.S3": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.20.1",
-        "contentHash": "UH2ozA9bQe/dOwxClI7h1BEmpt45hk5rrzwQgDFLdt5bpP5o46gHAAHiM6dbiBLzD81Q0YQHMiJ9nWeO5AG5FQ==",
+        "resolved": "4.0.20.2",
+        "contentHash": "sMZqcVyM92oFSB4U0S3qR6+BjQzJ/xU9gjIcxQu0USVkqc6+SEdbC7N6i9DfCjHBVPof961SqoSwMtp34zSbqA==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.25, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.26, 5.0.0)"
         }
       },
       "AWSSDK.SecretsManager": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.4.13",
-        "contentHash": "BWkSBvmn/xtwMLhEctn8Mx9Anw859LQ8HhGtIsRQRTq2YugMGEi0tBY48vQ9vnej49XipLOuZUHVxjUptlSEdg==",
+        "resolved": "4.0.4.14",
+        "contentHash": "PrdJ5228BYfdgqNSSDgZLsEIS0wdttOZGTnq5oddJsseN/zGkKrk996513JdzOkUACW2BQrkoID04lZGbHQhfg==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.25, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.26, 5.0.0)"
         }
       },
       "AWSSDK.SimpleEmailV2": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.12.6",
-        "contentHash": "mOu9MJY1uZ9geS0pRNVfAa+zLfwetfOXCe43pAvdgKrw5HhRrNykG/tCSk6Gs6Vvk6YAZTgqumOriWgtpQpksw==",
+        "resolved": "4.0.12.7",
+        "contentHash": "n/wV4Ssfh9Rc7Rjur5Z0Ykxj88pKxREvCXt0+9tpNgan8hBAkfhT/2QXGUSuG3dDKeWrck8QBt3Td2yj8hgGRQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.25, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.26, 5.0.0)"
         }
       },
       "AWSSDK.SimpleNotificationService": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
-        "resolved": "4.0.2.23",
-        "contentHash": "KiLx1wKZ2d7QpEWfs+Bv3Zj2s4ANP0CLZucFXSS2KXXY6wdOMbml3Nv4MNfdUVwiQcHZ+2tgsWgu2JG/vsZf4g==",
+        "resolved": "4.0.2.24",
+        "contentHash": "pSjHIU+bzx4oR/0C6pn7gH9ffGDM0t7vjRsvfji1MWTLeyK9HUmbhKHXNVo5M4528Ne0kowjRJhwIMFjwmsxbQ==",
         "dependencies": {
-          "AWSSDK.Core": "[4.0.3.25, 5.0.0)"
+          "AWSSDK.Core": "[4.0.3.26, 5.0.0)"
         }
       },
       "Azure.AI.OpenAI": {

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/AspNetPasskeyServiceTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/AspNetPasskeyServiceTests.cs
@@ -1,8 +1,8 @@
 using System.Text.Json;
+using Granit.Identity.Local.AspNetIdentity.Internal;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Options;
 using Granit.Identity.Local.Services;
-using Granit.OpenIddict.EntityFrameworkCore.Internal;
 using Granit.Timing;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -10,7 +10,7 @@ using NSubstitute;
 using Shouldly;
 using Xunit;
 
-namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+namespace Granit.Identity.Local.AspNetIdentity.Tests;
 
 public sealed class AspNetPasskeyServiceTests
 {

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/AspNetPasswordResetServiceTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/AspNetPasswordResetServiceTests.cs
@@ -1,14 +1,14 @@
 using Granit.Events;
+using Granit.Identity.Local.AspNetIdentity.Internal;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Events;
 using Granit.Identity.Local.Services;
-using Granit.OpenIddict.EntityFrameworkCore.Internal;
 using Microsoft.AspNetCore.Identity;
 using NSubstitute;
 using Shouldly;
 using Xunit;
 
-namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+namespace Granit.Identity.Local.AspNetIdentity.Tests;
 
 public sealed class AspNetPasswordResetServiceTests
 {

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/AspNetTwoFactorServiceTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/AspNetTwoFactorServiceTests.cs
@@ -1,12 +1,12 @@
+using Granit.Identity.Local.AspNetIdentity.Internal;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Services;
-using Granit.OpenIddict.EntityFrameworkCore.Internal;
 using Microsoft.AspNetCore.Identity;
 using NSubstitute;
 using Shouldly;
 using Xunit;
 
-namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+namespace Granit.Identity.Local.AspNetIdentity.Tests;
 
 public sealed class AspNetTwoFactorServiceTests
 {

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/TotpServiceTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/TotpServiceTests.cs
@@ -1,4 +1,4 @@
-using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Granit.Identity.Local.AspNetIdentity.Internal;
 using Granit.Timing;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
@@ -6,7 +6,7 @@ using NSubstitute;
 using Shouldly;
 using Xunit;
 
-namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+namespace Granit.Identity.Local.AspNetIdentity.Tests;
 
 public sealed class TotpServiceTests
 {
@@ -195,6 +195,7 @@ public sealed class TotpServiceTests
     /// <summary>
     /// Replicates the TOTP algorithm to generate expected codes for testing.
     /// </summary>
+#pragma warning disable CA5350 // HMACSHA1 is required by RFC 6238 (TOTP standard)
     private static string GenerateCodeForKey(string base32Key, DateTimeOffset timestamp)
     {
         byte[] key = Base32Decode(base32Key);
@@ -215,6 +216,7 @@ public sealed class TotpServiceTests
         int otp = binaryCode % 1_000_000;
         return otp.ToString().PadLeft(6, '0');
     }
+#pragma warning restore CA5350
 
     private static byte[] Base32Decode(string base32)
     {

--- a/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsIntegrationTests.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsIntegrationTests.cs
@@ -1031,6 +1031,33 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Login_RememberMe_PassesPersistentFlag()
+    {
+        var fakeUser = new GranitUser { Id = AccountEndpointsTestServer.TestUserId };
+
+        _server.UserManager
+            .FindByEmailAsync("remember@example.com")
+            .Returns(fakeUser);
+
+        _server.SignInManager
+            .PasswordSignInAsync(fakeUser, "GoodP@ss1!", true, true)
+            .Returns(Microsoft.AspNetCore.Identity.SignInResult.Success);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/api/account/login",
+            new AccountLoginRequest("remember@example.com", "GoodP@ss1!", RememberMe: true),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        AccountLoginResponse? result = await response.Content
+            .ReadFromJsonAsync<AccountLoginResponse>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
     public async Task Login_Success_Returns200()
     {
         var fakeUser = new GranitUser { Id = AccountEndpointsTestServer.TestUserId };
@@ -1101,6 +1128,57 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
 
         result.ShouldNotBeNull();
         result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TwoFactorLogin_RememberMe_PassesPersistentFlag()
+    {
+        _server.SignInManager
+            .TwoFactorAuthenticatorSignInAsync("123456", true, false)
+            .Returns(Microsoft.AspNetCore.Identity.SignInResult.Success);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/api/account/login/two-factor",
+            new AccountTwoFactorLoginRequest("123456", RememberMe: true),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        AccountLoginResponse? result = await response.Content
+            .ReadFromJsonAsync<AccountLoginResponse>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TwoFactorLogin_RecoveryCode_RememberMe_ReSignsPersistent()
+    {
+        var fakeUser = new GranitUser { Id = AccountEndpointsTestServer.TestUserId };
+
+        _server.SignInManager
+            .TwoFactorRecoveryCodeSignInAsync("RECOVERY1")
+            .Returns(Microsoft.AspNetCore.Identity.SignInResult.Success);
+
+        _server.UserManager
+            .GetUserAsync(Arg.Any<System.Security.Claims.ClaimsPrincipal>())
+            .Returns(fakeUser);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/api/account/login/two-factor",
+            new AccountTwoFactorLoginRequest("RECOVERY1", UseRecoveryCode: true, RememberMe: true),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        AccountLoginResponse? result = await response.Content
+            .ReadFromJsonAsync<AccountLoginResponse>(TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.Succeeded.ShouldBeTrue();
+
+        await _server.SignInManager.Received(1)
+            .SignInAsync(fakeUser, isPersistent: true, Arg.Any<string?>());
     }
 
     [Fact]

--- a/tests/Granit.OpenIddict.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.BackgroundJobs.Tests/packages.lock.json
@@ -667,6 +667,12 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "granit.http.cookies": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {
@@ -687,6 +693,8 @@
       "granit.openiddict": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"

--- a/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
@@ -634,6 +634,8 @@
       "granit.openiddict": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"
@@ -655,7 +657,6 @@
         "type": "Project",
         "dependencies": {
           "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.OpenIddict.Server": "[0.1.0-dev, )",

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
@@ -524,6 +524,8 @@
       "granit.openiddict": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"
@@ -533,7 +535,6 @@
         "type": "Project",
         "dependencies": {
           "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.OpenIddict.Server": "[0.1.0-dev, )",

--- a/tests/Granit.OpenIddict.Server.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Server.Tests/packages.lock.json
@@ -468,6 +468,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.events": {
         "type": "Project",
         "dependencies": {
@@ -478,6 +484,12 @@
         "type": "Project",
         "dependencies": {
           "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.cookies": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.identity": {
@@ -500,6 +512,8 @@
       "granit.openiddict": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"

--- a/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
@@ -692,6 +692,8 @@
       "granit.openiddict": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"
@@ -713,7 +715,6 @@
         "type": "Project",
         "dependencies": {
           "Granit.Encryption": "[0.1.0-dev, )",
-          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.OpenIddict.Server": "[0.1.0-dev, )",

--- a/tests/Granit.OpenIddict.Tests/AspNetAccountDeletionServiceTests.cs
+++ b/tests/Granit.OpenIddict.Tests/AspNetAccountDeletionServiceTests.cs
@@ -2,7 +2,7 @@ using Granit.Events;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Events;
 using Granit.Identity.Local.Services;
-using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Granit.OpenIddict.Internal;
 using Granit.Timing;
 using Microsoft.AspNetCore.Identity;
 using NSubstitute;
@@ -10,7 +10,7 @@ using OpenIddict.Abstractions;
 using Shouldly;
 using Xunit;
 
-namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+namespace Granit.OpenIddict.Tests;
 
 public sealed class AspNetAccountDeletionServiceTests
 {

--- a/tests/Granit.OpenIddict.Tests/AspNetExternalLoginServiceTests.cs
+++ b/tests/Granit.OpenIddict.Tests/AspNetExternalLoginServiceTests.cs
@@ -3,7 +3,7 @@ using Granit.Events;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Events;
 using Granit.Identity.Local.Services;
-using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Granit.OpenIddict.Internal;
 using Granit.OpenIddict.Options;
 using Granit.OpenIddict.Services;
 using Microsoft.AspNetCore.Identity;
@@ -12,7 +12,7 @@ using Shouldly;
 using Xunit;
 using GranitExternalLoginInfo = Granit.Identity.Local.Services.ExternalLoginInfo;
 
-namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+namespace Granit.OpenIddict.Tests;
 
 public sealed class AspNetExternalLoginServiceTests
 {

--- a/tests/Granit.OpenIddict.Tests/AspNetImpersonationServiceTests.cs
+++ b/tests/Granit.OpenIddict.Tests/AspNetImpersonationServiceTests.cs
@@ -4,7 +4,7 @@ using Granit.Identity.Local.Diagnostics;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Events;
 using Granit.Identity.Local.Services;
-using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Granit.OpenIddict.Internal;
 using Granit.Timing;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
@@ -14,7 +14,7 @@ using OpenIddict.Abstractions;
 using Shouldly;
 using Xunit;
 
-namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+namespace Granit.OpenIddict.Tests;
 
 public sealed class AspNetImpersonationServiceTests
 {

--- a/tests/Granit.OpenIddict.Tests/Granit.OpenIddict.Tests.csproj
+++ b/tests/Granit.OpenIddict.Tests/Granit.OpenIddict.Tests.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Encryption\Granit.Encryption.csproj" />
     <ProjectReference Include="..\..\src\Granit.Http.Cookies\Granit.Http.Cookies.csproj" />
     <ProjectReference Include="..\..\src\Granit.OpenIddict\Granit.OpenIddict.csproj" />
   </ItemGroup>

--- a/tests/Granit.OpenIddict.Tests/Granit.OpenIddict.Tests.csproj
+++ b/tests/Granit.OpenIddict.Tests/Granit.OpenIddict.Tests.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Http.Cookies\Granit.Http.Cookies.csproj" />
     <ProjectReference Include="..\..\src\Granit.OpenIddict\Granit.OpenIddict.csproj" />
   </ItemGroup>
 

--- a/tests/Granit.OpenIddict.Tests/IdentityCookieDefinitionContributorTests.cs
+++ b/tests/Granit.OpenIddict.Tests/IdentityCookieDefinitionContributorTests.cs
@@ -1,5 +1,5 @@
 using Granit.Http.Cookies;
-using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Granit.OpenIddict.Internal;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
@@ -7,7 +7,7 @@ using NSubstitute;
 using Shouldly;
 using Xunit;
 
-namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+namespace Granit.OpenIddict.Tests;
 
 public sealed class IdentityCookieDefinitionContributorTests
 {

--- a/tests/Granit.OpenIddict.Tests/KeyRotationServiceTests.cs
+++ b/tests/Granit.OpenIddict.Tests/KeyRotationServiceTests.cs
@@ -1,6 +1,6 @@
 using Granit.Encryption;
 using Granit.OpenIddict.Domain;
-using Granit.OpenIddict.EntityFrameworkCore.Internal;
+using Granit.OpenIddict.Internal;
 using Granit.OpenIddict.Options;
 using Granit.OpenIddict.Services;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -8,7 +8,7 @@ using NSubstitute;
 using Shouldly;
 using Xunit;
 
-namespace Granit.OpenIddict.EntityFrameworkCore.Tests;
+namespace Granit.OpenIddict.Tests;
 
 public sealed class KeyRotationServiceTests
 {

--- a/tests/Granit.OpenIddict.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests/packages.lock.json
@@ -287,6 +287,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.events": {
         "type": "Project",
         "dependencies": {
@@ -325,6 +331,7 @@
       "granit.openiddict": {
         "type": "Project",
         "dependencies": {
+          "Granit.Encryption": "[0.1.0-dev, )",
           "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",

--- a/tests/Granit.OpenIddict.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests/packages.lock.json
@@ -299,6 +299,12 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
+      "granit.http.cookies": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {
@@ -319,6 +325,7 @@
       "granit.openiddict": {
         "type": "Project",
         "dependencies": {
+          "Granit.Http.Cookies": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "OpenIddict.EntityFrameworkCore": "[7.*, )"


### PR DESCRIPTION
## Summary

`AddIdentity<TUser, TRole>()` registers a `PostConfigure<CookieAuthenticationOptions>` that resets cookie names to ASP.NET Core defaults (`.AspNetCore.Identity.Application`). Our `Configure` call was silently overridden, causing `__Host-id` to appear even in development.

Switch to `PostConfigure` so our names (`.id` in dev, `__Host-id` in prod) take precedence.

## Root cause

```
Configure (our module)     → sets .id
PostConfigure (Identity)   → resets to .AspNetCore.Identity.Application  ← wins
```

Fix:
```
PostConfigure (Identity)   → sets .AspNetCore.Identity.Application
PostConfigure (our module) → overrides to .id  ← wins (registered later via DependsOn)
```

## Test plan

- [x] Granit.OpenIddict.EntityFrameworkCore.Tests — 165 pass
- [ ] Verify `.id` cookie in dev HTTP (showcase)
- [ ] Verify `__Host-id` cookie in prod HTTPS