### PR TITLE
fix: resolve SonarQube smells, boost test coverage, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,29 +21,47 @@
 
 Granit is a rock-solid, production-ready modular framework for .NET and React.
 Built as a Modular Monolith with zero compromises on Developer Experience.
-It provides **100 NuGet packages** organized as independent modules,
+It provides **217 NuGet packages** organized as independent modules,
 compliant with **GDPR/ISO 27001** requirements.
+
+**📖 Full documentation: [granit-fx.dev](https://granit-fx.dev)**
 
 ## Features
 
 | Domain | What Granit provides |
 | --- | --- |
 | **Core & Modularity** | Self-configuring module system, topological dependency sorting, timing, GUID generation |
-| **Security** | JWT Bearer authentication, RBAC, Vault Transit encryption, dynamic credentials |
+| **Security** | JWT Bearer authentication (Keycloak, EntraID, Cognito, Google), API keys, DPoP, OpenIddict |
+| **Authorization** | Fine-grained RBAC, permission definition providers, AI-assisted policy evaluation |
 | **Identity** | Identity provider abstractions, user cache (cache-aside, login-time sync, GDPR) |
+| **BFF** | Backend for Frontend with YARP reverse proxy, session management, OpenID Connect |
 | **Persistence** | EF Core interceptors: audit trail (3 years), GDPR soft delete, multi-tenancy, settings, features |
 | **Multi-tenancy** | Schema or database isolation, automatic resolution, transparent filtering |
 | **Caching** | FusionCache (L1+L2+backplane, fail-safe, eager refresh), Redis, AES-256 encryption |
-| **Observability** | Structured logging + distributed tracing → OTLP, health checks, metrics |
-| **Messaging** | Transactional outbox, HMAC-SHA256 webhooks, notifications (6 channels), cron jobs |
-| **API** | Versioning, OpenAPI Scalar, Stripe-style idempotency, ProblemDetails, CORS |
+| **Query Engine** | Dynamic filtering, sorting, pagination over EF Core with OpenAPI schema generation |
+| **Reference Data** | Versioned lookup tables, import/export, tenant-scoped overrides |
+| **Observability** | Structured logging + distributed tracing → OTLP, health checks, per-module metrics |
+| **Diagnostics** | `ActivitySource` per module, `IMeterFactory`-based metrics, `GranitActivitySourceRegistry` |
+| **Messaging** | Wolverine transactional outbox, domain events, integration events (ETO) |
+| **Background Jobs** | Recurring cron jobs (Wolverine scheduling), dashboard endpoints, history tracking |
+| **Notifications** | 6 channels (email, SMS, push, in-app, Teams, Slack), templated content |
+| **Webhooks** | HMAC-SHA256 signed delivery, retry policies, subscription management |
+| **API** | Versioning, OpenAPI 3.1 Scalar, Stripe-style idempotency, ProblemDetails, CORS |
+| **Rate Limiting** | Per-endpoint and per-tenant rate limiting with sliding window policies |
 | **Storage & Imaging** | S3-compatible blob storage, pre-signed URLs, Crypto-Shredding, image processing |
 | **Documents** | Template engine (Scriban), HTML→PDF rendering, Excel generation |
 | **Data Exchange** | Import (Extract→Map→Validate→Execute), Export (tabular Excel/CSV with presets) |
 | **Workflow** | FSM engine, publication lifecycle, approval routing |
+| **Timeline** | Activity stream, audit-friendly event history, per-entity timeline |
 | **Localization** | i18n (17 cultures), override store, source-generated keys |
+| **Settings** | Dynamic key-value settings, tenant-scoped, typed access, change auditing |
 | **SaaS** | Feature flags per commercial plan, quotas, Default → Plan → Tenant resolution |
-| **Quality** | Embedded Roslyn analyzers, Architecture Tests (ArchUnitNET), FluentValidation (VAT, SIREN, NISS) |
+| **Privacy & Encryption** | GDPR pseudonymization, right to erasure, Vault Transit encryption, key rotation |
+| **Auditing** | Configuration change tracking, entity-level audit log, 3-year retention |
+| **AI** | Provider-agnostic LLM (OpenAI, Azure, Anthropic, Ollama), NLQ, semantic search, extraction |
+| **MCP** | Model Context Protocol server integration, SDK-native auth and filters |
+| **Testing** | xUnit helpers, Testcontainers, Bogus fakers, architecture tests (ArchUnitNET) |
+| **Quality** | Embedded Roslyn analyzers, FluentValidation (VAT, SIREN, NISS), OpenAPI schema enrichment |
 
 ## Quick start
 
@@ -87,14 +105,22 @@ public sealed class MyAppModule : GranitModule
 
 | Section | Content |
 | --- | --- |
-| [Getting Started](docs/guide/getting-started.md) | Build a working Granit API in under 5 minutes |
-| [Framework](docs/framework/index.md) | Architecture, modules, security, data, API, messaging, storage |
-| [Tests](docs/testing/index.md) | xUnit conventions, mocking, assertions, EF Core integration |
-| [Package catalogue](docs/index.md) | Complete list of 100 packages with their roles |
+| [Getting Started](https://granit-fx.dev/dotnet/getting-started/) | Build a working Granit API in under 5 minutes |
+| [Architecture](https://granit-fx.dev/dotnet/architecture/) | ADRs, patterns, module system, DDD |
+| [Core](https://granit-fx.dev/dotnet/core/) | Module system, validation, diagnostics, analyzers |
+| [Security](https://granit-fx.dev/dotnet/security/) | Authentication, authorization, encryption, Vault |
+| [Data](https://granit-fx.dev/dotnet/data/) | Persistence, caching, blob storage, multi-tenancy |
+| [API](https://granit-fx.dev/dotnet/api/) | Endpoints, OpenAPI, versioning, idempotency |
+| [Infrastructure](https://granit-fx.dev/dotnet/infrastructure/) | Messaging, background jobs, notifications, webhooks |
+| [Business](https://granit-fx.dev/dotnet/business/) | Workflow, data exchange, templating, document generation |
+| [AI](https://granit-fx.dev/dotnet/ai/) | AI abstractions, MCP, vector data, extraction |
+| [Compliance](https://granit-fx.dev/dotnet/compliance/) | GDPR, ISO 27001, audit trail |
+| [Guides](https://granit-fx.dev/dotnet/guides/) | Step-by-step tutorials and recipes |
+| [Contributing](https://granit-fx.dev/contributing/) | Conventions and contribution workflow |
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for conventions and contribution workflow.
+See [CONTRIBUTING.md](CONTRIBUTING.md) and the [contribution guide](https://granit-fx.dev/contributing/) for conventions and workflow.
 
 ## Changelog
 

--- a/src/Granit.Auditing/Diagnostics/AuditingMetrics.cs
+++ b/src/Granit.Auditing/Diagnostics/AuditingMetrics.cs
@@ -13,6 +13,9 @@ public sealed class AuditingMetrics
 {
     public const string MeterName = "Granit.Auditing";
 
+    private const string TenantIdTag = "tenant_id";
+    private const string GlobalTenant = "global";
+
     private readonly Counter<long> _entriesPersisted;
     private readonly Counter<long> _entriesPurged;
     private readonly Counter<long> _entriesPseudonymized;
@@ -65,13 +68,13 @@ public sealed class AuditingMetrics
     public void RecordPersisted(long count, string? tenantId) =>
         _entriesPersisted.Add(count, new TagList
         {
-            { "tenant_id", tenantId ?? "global" },
+            { TenantIdTag, tenantId ?? GlobalTenant },
         });
 
     public void RecordPurged(long count, string category, string? tenantId) =>
         _entriesPurged.Add(count, new TagList
         {
-            { "tenant_id", tenantId ?? "global" },
+            { TenantIdTag, tenantId ?? GlobalTenant },
             { "category", category },
         });
 
@@ -84,7 +87,7 @@ public sealed class AuditingMetrics
     public void RecordCaptureError(string? tenantId) =>
         _captureErrors.Add(1, new TagList
         {
-            { "tenant_id", tenantId ?? "global" },
+            { TenantIdTag, tenantId ?? GlobalTenant },
         });
 
     public void RecordPersistenceDuration(double elapsedMs, string? tenantId) =>

--- a/src/Granit.DataExchange/Import/Internal/ImportOrchestrator.cs
+++ b/src/Granit.DataExchange/Import/Internal/ImportOrchestrator.cs
@@ -167,8 +167,8 @@ internal sealed class ImportOrchestrator(
         // Try to resolve ImportDefinition<T> for known entity types
         // The definitions are registered as singletons — enumerate them
         IEnumerable<object> definitions = serviceProvider.GetServices<object>()
-            .Where(s => s?.GetType().BaseType?.IsGenericType == true
-                        && s?.GetType().BaseType?.GetGenericTypeDefinition() == typeof(ImportDefinition<>));
+            .Where(s => s.GetType().BaseType?.IsGenericType == true
+                        && s.GetType().BaseType?.GetGenericTypeDefinition() == typeof(ImportDefinition<>));
 
         foreach (object definition in definitions)
         {

--- a/tests/Granit.Analyzers.CodeFixes.Tests/CrossModuleReferenceCodeFixProviderTests.cs
+++ b/tests/Granit.Analyzers.CodeFixes.Tests/CrossModuleReferenceCodeFixProviderTests.cs
@@ -1,0 +1,120 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Granit.Analyzers.CodeFixes.Tests;
+
+public sealed class CrossModuleReferenceCodeFixProviderTests
+{
+    private const string ContractsTypeStub = """
+        namespace MyApp.Modules.Orders.Contracts
+        {
+            public interface IOrderSummary { }
+        }
+        """;
+
+    private const string InternalTypeStub = """
+        namespace MyApp.Modules.Orders.Internal
+        {
+            public class IOrderSummary { }
+        }
+        """;
+
+    [Fact]
+    public async Task Replaces_internal_using_with_contracts_using()
+    {
+        string source = """
+            using MyApp.Modules.Orders.Internal;
+
+            namespace MyApp.Modules.Billing
+            {
+                public class InvoiceService
+                {
+                    public IOrderSummary Get() => null;
+                }
+            }
+            """;
+
+        string expected = """
+            using MyApp.Modules.Orders.Contracts;
+
+            namespace MyApp.Modules.Billing
+            {
+                public class InvoiceService
+                {
+                    public IOrderSummary Get() => null;
+                }
+            }
+            """;
+
+        await CodeFixTestHelpers.VerifyCodeFixAsync<CrossModuleReferenceAnalyzer, CrossModuleReferenceCodeFixProvider>(
+            source, expected, [InternalTypeStub, ContractsTypeStub]);
+    }
+
+    [Fact]
+    public async Task No_diagnostic_when_both_usings_present_and_contracts_type_resolves()
+    {
+        // When both usings are present, the compiler resolves the Contracts interface type
+        // (not the Internal class) because IOrderSummary is an interface in Contracts.
+        // No cross-module diagnostic should fire.
+        string source = """
+            using MyApp.Modules.Orders.Contracts;
+            using MyApp.Modules.Orders.Internal;
+
+            namespace MyApp.Modules.Billing
+            {
+                public class InvoiceService
+                {
+                    public IOrderSummary Get() => null;
+                }
+            }
+            """;
+
+        await CodeFixTestHelpers.VerifyNoCodeFixAsync<CrossModuleReferenceAnalyzer, CrossModuleReferenceCodeFixProvider>(
+            source, [InternalTypeStub, ContractsTypeStub]);
+    }
+
+    [Fact]
+    public async Task No_diagnostic_for_same_module_reference()
+    {
+        string source = """
+            using MyApp.Modules.Orders.Internal;
+
+            namespace MyApp.Modules.Orders.Services
+            {
+                public class OrderProcessor
+                {
+                    public IOrderSummary Get() => null;
+                }
+            }
+            """;
+
+        await CodeFixTestHelpers.VerifyNoCodeFixAsync<CrossModuleReferenceAnalyzer, CrossModuleReferenceCodeFixProvider>(
+            source, [InternalTypeStub, ContractsTypeStub]);
+    }
+
+    [Fact]
+    public async Task No_diagnostic_when_using_contracts_namespace()
+    {
+        string contractsUsageStub = """
+            namespace MyApp.Modules.Orders.Contracts
+            {
+                public class OrderSummaryDto { }
+            }
+            """;
+
+        string source = """
+            using MyApp.Modules.Orders.Contracts;
+
+            namespace MyApp.Modules.Billing
+            {
+                public class InvoiceService
+                {
+                    public OrderSummaryDto Get() => null;
+                }
+            }
+            """;
+
+        await CodeFixTestHelpers.VerifyNoCodeFixAsync<CrossModuleReferenceAnalyzer, CrossModuleReferenceCodeFixProvider>(
+            source, [contractsUsageStub]);
+    }
+}

--- a/tests/Granit.Analyzers.CodeFixes.Tests/DirectCookieAccessCodeFixProviderTests.cs
+++ b/tests/Granit.Analyzers.CodeFixes.Tests/DirectCookieAccessCodeFixProviderTests.cs
@@ -1,0 +1,124 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Granit.Analyzers.CodeFixes.Tests;
+
+public sealed class DirectCookieAccessCodeFixProviderTests
+{
+    private static readonly string[] CookieStubs =
+    [
+        Analyzers.Tests.AnalyzerTestHelpers.ResponseCookiesStub,
+        Analyzers.Tests.AnalyzerTestHelpers.GranitCookieManagerStub,
+    ];
+
+    [Fact]
+    public async Task Replaces_Append_with_SetCookieAsync_and_injects_IGranitCookieManager()
+    {
+        string source = """
+            using Microsoft.AspNetCore.Http;
+            public class MyMiddleware
+            {
+                public MyMiddleware() { }
+                public void Handle(HttpContext httpContext)
+                {
+                    httpContext.Response.Cookies.Append("token", "abc");
+                }
+            }
+            """;
+
+        string expected = """
+            using Microsoft.AspNetCore.Http;
+            using Granit.Http.Cookies;
+
+            public class MyMiddleware
+            {
+                private readonly IGranitCookieManager _cookieManager;
+
+                public MyMiddleware(IGranitCookieManager cookieManager)
+                {
+                    _cookieManager = cookieManager;
+                }
+                public void Handle(HttpContext httpContext)
+                {
+                    await _cookieManager.SetCookieAsync(httpContext, "token", "abc");
+                }
+            }
+            """;
+
+        await CodeFixTestHelpers.VerifyCodeFixAsync<DirectCookieAccessAnalyzer, DirectCookieAccessCodeFixProvider>(
+            source, expected, CookieStubs);
+    }
+
+    [Fact]
+    public async Task Replaces_Delete_with_DeleteCookie_and_injects_IGranitCookieManager()
+    {
+        string source = """
+            using Microsoft.AspNetCore.Http;
+            public class MyMiddleware
+            {
+                public MyMiddleware() { }
+                public void Handle(HttpContext httpContext)
+                {
+                    httpContext.Response.Cookies.Delete("token");
+                }
+            }
+            """;
+
+        string expected = """
+            using Microsoft.AspNetCore.Http;
+            using Granit.Http.Cookies;
+
+            public class MyMiddleware
+            {
+                private readonly IGranitCookieManager _cookieManager;
+
+                public MyMiddleware(IGranitCookieManager cookieManager)
+                {
+                    _cookieManager = cookieManager;
+                }
+                public void Handle(HttpContext httpContext)
+                {
+                    _cookieManager.DeleteCookie(httpContext, "token");
+                }
+            }
+            """;
+
+        await CodeFixTestHelpers.VerifyCodeFixAsync<DirectCookieAccessAnalyzer, DirectCookieAccessCodeFixProvider>(
+            source, expected, CookieStubs);
+    }
+
+    [Fact]
+    public async Task Does_not_duplicate_field_when_cookieManager_already_exists()
+    {
+        string source = """
+            using Microsoft.AspNetCore.Http;
+            public class MyMiddleware
+            {
+                private readonly IGranitCookieManager _cookieManager;
+                public MyMiddleware(IGranitCookieManager cookieManager) { _cookieManager = cookieManager; }
+                public void Handle(HttpContext httpContext)
+                {
+                    httpContext.Response.Cookies.Append("token", "abc");
+                }
+            }
+            """;
+
+        string expected = """
+            using Microsoft.AspNetCore.Http;
+            using Granit.Http.Cookies;
+
+            public class MyMiddleware
+            {
+                private readonly IGranitCookieManager _cookieManager;
+                public MyMiddleware(IGranitCookieManager cookieManager) { _cookieManager = cookieManager; }
+                public void Handle(HttpContext httpContext)
+                {
+                    await _cookieManager.SetCookieAsync(httpContext, "token", "abc");
+                }
+            }
+            """;
+
+        await CodeFixTestHelpers.VerifyCodeFixAsync<DirectCookieAccessAnalyzer, DirectCookieAccessCodeFixProvider>(
+            source, expected, CookieStubs);
+    }
+}

--- a/tests/Granit.Analyzers.CodeFixes.Tests/MinimalApiServiceParameterCodeFixProviderTests.cs
+++ b/tests/Granit.Analyzers.CodeFixes.Tests/MinimalApiServiceParameterCodeFixProviderTests.cs
@@ -1,0 +1,146 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Granit.Analyzers.CodeFixes.Tests;
+
+public sealed class MinimalApiServiceParameterCodeFixProviderTests
+{
+    private static readonly string[] ApiStubs =
+    [
+        Analyzers.Tests.AnalyzerTestHelpers.MinimalApiResultsStub,
+        Analyzers.Tests.AnalyzerTestHelpers.MinimalApiBindingStub,
+    ];
+
+    [Fact]
+    public async Task Adds_FromServices_to_interface_parameter()
+    {
+        string source = """
+            using Microsoft.AspNetCore.Http;
+            public interface IMyService { }
+            public static class Endpoint
+            {
+                public static Ok Handle(IMyService service) => null;
+            }
+            """;
+
+        string expected = """
+            using Microsoft.AspNetCore.Http;
+            using Microsoft.AspNetCore.Mvc;
+
+            public interface IMyService { }
+            public static class Endpoint
+            {
+                public static Ok Handle([FromServices] IMyService service) => null;
+            }
+            """;
+
+        await CodeFixTestHelpers.VerifyCodeFixAsync<MinimalApiServiceParameterAnalyzer, MinimalApiServiceParameterCodeFixProvider>(
+            source, expected, ApiStubs);
+    }
+
+    [Fact]
+    public async Task Adds_FromServices_with_async_Task_return_type()
+    {
+        string source = """
+            using System.Threading.Tasks;
+            using Microsoft.AspNetCore.Http;
+            public interface IMyService { }
+            public static class Endpoint
+            {
+                public static Task<Ok> HandleAsync(IMyService service) => null;
+            }
+            """;
+
+        string expected = """
+            using System.Threading.Tasks;
+            using Microsoft.AspNetCore.Http;
+            using Microsoft.AspNetCore.Mvc;
+
+            public interface IMyService { }
+            public static class Endpoint
+            {
+                public static Task<Ok> HandleAsync([FromServices] IMyService service) => null;
+            }
+            """;
+
+        await CodeFixTestHelpers.VerifyCodeFixAsync<MinimalApiServiceParameterAnalyzer, MinimalApiServiceParameterCodeFixProvider>(
+            source, expected, ApiStubs);
+    }
+
+    [Fact]
+    public async Task No_diagnostic_when_FromServices_already_present()
+    {
+        string source = """
+            using Microsoft.AspNetCore.Http;
+            using Microsoft.AspNetCore.Mvc;
+            public interface IMyService { }
+            public static class Endpoint
+            {
+                public static Ok Handle([FromServices] IMyService service) => null;
+            }
+            """;
+
+        await CodeFixTestHelpers.VerifyNoCodeFixAsync<MinimalApiServiceParameterAnalyzer, MinimalApiServiceParameterCodeFixProvider>(
+            source, ApiStubs);
+    }
+
+    [Fact]
+    public async Task No_diagnostic_for_non_static_method()
+    {
+        string source = """
+            using Microsoft.AspNetCore.Http;
+            public interface IMyService { }
+            public class Endpoint
+            {
+                public Ok Handle(IMyService service) => null;
+            }
+            """;
+
+        await CodeFixTestHelpers.VerifyNoCodeFixAsync<MinimalApiServiceParameterAnalyzer, MinimalApiServiceParameterCodeFixProvider>(
+            source, ApiStubs);
+    }
+
+    [Fact]
+    public async Task No_diagnostic_for_exempt_IFormFile_parameter()
+    {
+        string source = """
+            using Microsoft.AspNetCore.Http;
+            public static class Endpoint
+            {
+                public static Ok Handle(IFormFile file) => null;
+            }
+            """;
+
+        await CodeFixTestHelpers.VerifyNoCodeFixAsync<MinimalApiServiceParameterAnalyzer, MinimalApiServiceParameterCodeFixProvider>(
+            source, ApiStubs);
+    }
+
+    [Fact]
+    public async Task Does_not_duplicate_using_when_Mvc_already_imported()
+    {
+        string source = """
+            using Microsoft.AspNetCore.Http;
+            using Microsoft.AspNetCore.Mvc;
+            public interface IMyService { }
+            public interface IOtherService { }
+            public static class Endpoint
+            {
+                public static Ok Handle([FromServices] IMyService svc, IOtherService other) => null;
+            }
+            """;
+
+        string expected = """
+            using Microsoft.AspNetCore.Http;
+            using Microsoft.AspNetCore.Mvc;
+            public interface IMyService { }
+            public interface IOtherService { }
+            public static class Endpoint
+            {
+                public static Ok Handle([FromServices] IMyService svc, [FromServices] IOtherService other) => null;
+            }
+            """;
+
+        await CodeFixTestHelpers.VerifyCodeFixAsync<MinimalApiServiceParameterAnalyzer, MinimalApiServiceParameterCodeFixProvider>(
+            source, expected, ApiStubs);
+    }
+}

--- a/tests/Granit.ReferenceData.Endpoints.Tests/Internal/ReferenceDataMapperTests.cs
+++ b/tests/Granit.ReferenceData.Endpoints.Tests/Internal/ReferenceDataMapperTests.cs
@@ -1,0 +1,132 @@
+using Granit.ReferenceData.Domain;
+using Granit.ReferenceData.Endpoints.Dtos;
+using Granit.ReferenceData.Endpoints.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ReferenceData.Endpoints.Tests.Internal;
+
+public sealed class ReferenceDataMapperTests
+{
+    private sealed class TestEntity : ReferenceDataEntity;
+
+    [Fact]
+    public void ToResponse_maps_all_fields()
+    {
+        var id = Guid.NewGuid();
+        DateTimeOffset validFrom = DateTimeOffset.UtcNow;
+        DateTimeOffset validTo = validFrom.AddYears(1);
+
+        TestEntity entity = new()
+        {
+            Id = id,
+            Code = "BE",
+            LabelEn = "Belgium",
+            LabelFr = "Belgique",
+            LabelNl = "België",
+            LabelDe = "Belgien",
+            LabelEs = "Bélgica",
+            LabelIt = "Belgio",
+            LabelPt = "Bélgica",
+            LabelZh = "比利时",
+            LabelJa = "ベルギー",
+            LabelPl = "Belgia",
+            LabelTr = "Belçika",
+            LabelKo = "벨기에",
+            LabelSv = "Belgien",
+            LabelCs = "Belgie",
+            IsActive = true,
+            SortOrder = 5,
+            ValidFrom = validFrom,
+            ValidTo = validTo,
+            ParentCode = "EU",
+        };
+
+        ReferenceDataResponse response = ReferenceDataMapper.ToResponse(entity);
+
+        response.Id.ShouldBe(id);
+        response.Code.ShouldBe("BE");
+        response.LabelEn.ShouldBe("Belgium");
+        response.LabelFr.ShouldBe("Belgique");
+        response.LabelNl.ShouldBe("België");
+        response.LabelDe.ShouldBe("Belgien");
+        response.LabelEs.ShouldBe("Bélgica");
+        response.LabelIt.ShouldBe("Belgio");
+        response.LabelPt.ShouldBe("Bélgica");
+        response.LabelZh.ShouldBe("比利时");
+        response.LabelJa.ShouldBe("ベルギー");
+        response.LabelPl.ShouldBe("Belgia");
+        response.LabelTr.ShouldBe("Belçika");
+        response.LabelKo.ShouldBe("벨기에");
+        response.LabelSv.ShouldBe("Belgien");
+        response.LabelCs.ShouldBe("Belgie");
+        response.IsActive.ShouldBeTrue();
+        response.SortOrder.ShouldBe(5);
+        response.ValidFrom.ShouldBe(validFrom);
+        response.ValidTo.ShouldBe(validTo);
+        response.ParentCode.ShouldBe("EU");
+    }
+
+    [Fact]
+    public void ToResponse_with_no_extra_properties_sets_null()
+    {
+        TestEntity entity = new()
+        {
+            Code = "BE",
+            LabelEn = "Belgium",
+        };
+
+        ReferenceDataResponse response = ReferenceDataMapper.ToResponse(entity);
+
+        response.ExtraProperties.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ToResponse_with_extra_properties_returns_dictionary()
+    {
+        TestEntity entity = new()
+        {
+            Code = "BE",
+            LabelEn = "Belgium",
+            ExtraPropertiesJson = """{"Alpha3Code":"BEL","Population":"11000000"}""",
+        };
+
+        ReferenceDataResponse response = ReferenceDataMapper.ToResponse(entity);
+
+        response.ExtraProperties.ShouldNotBeNull();
+        response.ExtraProperties!.Count.ShouldBe(2);
+        response.ExtraProperties["Alpha3Code"].ShouldBe("BEL");
+        response.ExtraProperties["Population"].ShouldBe("11000000");
+    }
+
+    [Fact]
+    public void ToResponse_with_empty_json_bag_sets_null()
+    {
+        TestEntity entity = new()
+        {
+            Code = "BE",
+            LabelEn = "Belgium",
+            ExtraPropertiesJson = "{}",
+        };
+
+        ReferenceDataResponse response = ReferenceDataMapper.ToResponse(entity);
+
+        response.ExtraProperties.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ToResponse_nullable_fields_default_to_null()
+    {
+        TestEntity entity = new()
+        {
+            Code = "XX",
+            LabelEn = "Test",
+        };
+
+        ReferenceDataResponse response = ReferenceDataMapper.ToResponse(entity);
+
+        response.ValidFrom.ShouldBeNull();
+        response.ValidTo.ShouldBeNull();
+        response.ParentCode.ShouldBeNull();
+    }
+}

--- a/tests/Granit.ReferenceData.Tests/Internal/ReferenceDataRegistryInitializerTests.cs
+++ b/tests/Granit.ReferenceData.Tests/Internal/ReferenceDataRegistryInitializerTests.cs
@@ -1,0 +1,54 @@
+using Granit.ReferenceData.Internal;
+using Granit.ReferenceData.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ReferenceData.Tests.Internal;
+
+public sealed class ReferenceDataRegistryInitializerTests
+{
+    [Fact]
+    public async Task StartAsync_calls_all_contributors()
+    {
+        ReferenceDataRegistry registry = new();
+        ReferenceDataTypeRegistration reg1 = new("Countries", new ReferenceDataExtensionOptions());
+        ReferenceDataTypeRegistration reg2 = new("Currencies", new ReferenceDataExtensionOptions());
+
+        IReferenceDataRegistryContributor[] contributors =
+        [
+            new ReferenceDataRegistryContributor(reg1),
+            new ReferenceDataRegistryContributor(reg2),
+        ];
+
+        ReferenceDataRegistryInitializer initializer = new(registry, contributors);
+
+        await initializer.StartAsync(CancellationToken.None);
+
+        registry.Types.Count.ShouldBe(2);
+        registry.TryGet("Countries", out _).ShouldBeTrue();
+        registry.TryGet("Currencies", out _).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task StartAsync_with_no_contributors_does_not_throw()
+    {
+        ReferenceDataRegistry registry = new();
+        ReferenceDataRegistryInitializer initializer = new(registry, []);
+
+        await initializer.StartAsync(CancellationToken.None);
+
+        registry.Types.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task StopAsync_completes_immediately()
+    {
+        ReferenceDataRegistry registry = new();
+        ReferenceDataRegistryInitializer initializer = new(registry, []);
+
+        Task result = initializer.StopAsync(CancellationToken.None);
+
+        result.IsCompletedSuccessfully.ShouldBeTrue();
+        await result;
+    }
+}

--- a/tests/Granit.ReferenceData.Tests/ReferenceDataBuilderTests.cs
+++ b/tests/Granit.ReferenceData.Tests/ReferenceDataBuilderTests.cs
@@ -1,0 +1,68 @@
+using Shouldly;
+using Xunit;
+
+namespace Granit.ReferenceData.Tests;
+
+public sealed class ReferenceDataBuilderTests
+{
+    [Fact]
+    public void Add_registers_type_with_default_options()
+    {
+        ReferenceDataBuilder builder = new();
+
+        builder.Add("Countries");
+
+        builder.Registrations.ShouldHaveSingleItem();
+        builder.Registrations[0].TypeName.ShouldBe("Countries");
+        builder.Registrations[0].Options.TableName.ShouldBe("ref_data");
+    }
+
+    [Fact]
+    public void Add_with_configure_applies_options()
+    {
+        ReferenceDataBuilder builder = new();
+
+        builder.Add("Countries", opts => opts.Table("ref_countries").Hierarchical());
+
+        builder.Registrations.ShouldHaveSingleItem();
+        builder.Registrations[0].Options.TableName.ShouldBe("ref_countries");
+        builder.Registrations[0].Options.IsHierarchical.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Add_returns_builder_for_chaining()
+    {
+        ReferenceDataBuilder builder = new();
+
+        ReferenceDataBuilder result = builder
+            .Add("Countries")
+            .Add("Currencies");
+
+        result.ShouldBeSameAs(builder);
+        builder.Registrations.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void Add_null_typeName_throws()
+    {
+        ReferenceDataBuilder builder = new();
+
+        Should.Throw<ArgumentException>(() => builder.Add(null!));
+    }
+
+    [Fact]
+    public void Add_empty_typeName_throws()
+    {
+        ReferenceDataBuilder builder = new();
+
+        Should.Throw<ArgumentException>(() => builder.Add(""));
+    }
+
+    [Fact]
+    public void Add_whitespace_typeName_throws()
+    {
+        ReferenceDataBuilder builder = new();
+
+        Should.Throw<ArgumentException>(() => builder.Add("   "));
+    }
+}

--- a/tests/Granit.ReferenceData.Tests/ReferenceDataExtensionOptionsTests.cs
+++ b/tests/Granit.ReferenceData.Tests/ReferenceDataExtensionOptionsTests.cs
@@ -1,0 +1,145 @@
+using Granit.ReferenceData.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ReferenceData.Tests;
+
+public sealed class ReferenceDataExtensionOptionsTests
+{
+    [Fact]
+    public void Default_TableName_is_ref_data()
+    {
+        ReferenceDataExtensionOptions options = new();
+
+        options.TableName.ShouldBe("ref_data");
+    }
+
+    [Fact]
+    public void Default_IsHierarchical_is_false()
+    {
+        ReferenceDataExtensionOptions options = new();
+
+        options.IsHierarchical.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Default_PropertyMappings_is_empty()
+    {
+        ReferenceDataExtensionOptions options = new();
+
+        options.PropertyMappings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Table_sets_TableName_and_returns_self()
+    {
+        ReferenceDataExtensionOptions options = new();
+
+        ReferenceDataExtensionOptions result = options.Table("ref_countries");
+
+        result.ShouldBeSameAs(options);
+        options.TableName.ShouldBe("ref_countries");
+    }
+
+    [Fact]
+    public void Table_null_throws()
+    {
+        ReferenceDataExtensionOptions options = new();
+
+        Should.Throw<ArgumentException>(() => options.Table(null!));
+    }
+
+    [Fact]
+    public void Table_empty_throws()
+    {
+        ReferenceDataExtensionOptions options = new();
+
+        Should.Throw<ArgumentException>(() => options.Table(""));
+    }
+
+    [Fact]
+    public void Hierarchical_sets_IsHierarchical_and_returns_self()
+    {
+        ReferenceDataExtensionOptions options = new();
+
+        ReferenceDataExtensionOptions result = options.Hierarchical();
+
+        result.ShouldBeSameAs(options);
+        options.IsHierarchical.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void MapProperty_adds_mapping_with_all_parameters()
+    {
+        ReferenceDataExtensionOptions options = new();
+
+        ReferenceDataExtensionOptions result = options.MapProperty<string>(
+            "Alpha3Code",
+            maxLength: 3,
+            isRequired: true,
+            isFilterable: true,
+            isSortable: true);
+
+        result.ShouldBeSameAs(options);
+        options.PropertyMappings.ShouldHaveSingleItem();
+
+        ReferenceDataPropertyMapping mapping = options.PropertyMappings[0];
+        mapping.Name.ShouldBe("Alpha3Code");
+        mapping.ClrType.ShouldBe(typeof(string));
+        mapping.MaxLength.ShouldBe(3);
+        mapping.IsRequired.ShouldBeTrue();
+        mapping.IsFilterable.ShouldBeTrue();
+        mapping.IsSortable.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void MapProperty_defaults_to_optional_non_filterable_non_sortable()
+    {
+        ReferenceDataExtensionOptions options = new();
+
+        options.MapProperty<int>("Population");
+
+        ReferenceDataPropertyMapping mapping = options.PropertyMappings[0];
+        mapping.ClrType.ShouldBe(typeof(int));
+        mapping.MaxLength.ShouldBeNull();
+        mapping.IsRequired.ShouldBeFalse();
+        mapping.IsFilterable.ShouldBeFalse();
+        mapping.IsSortable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void MapProperty_null_name_throws()
+    {
+        ReferenceDataExtensionOptions options = new();
+
+        Should.Throw<ArgumentException>(() => options.MapProperty<string>(null!));
+    }
+
+    [Fact]
+    public void MapProperty_multiple_adds_all()
+    {
+        ReferenceDataExtensionOptions options = new();
+
+        options
+            .MapProperty<string>("Alpha3Code", maxLength: 3)
+            .MapProperty<int>("Population")
+            .MapProperty<bool>("IsMember");
+
+        options.PropertyMappings.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public void Fluent_chain_combines_all_options()
+    {
+        ReferenceDataExtensionOptions options = new();
+
+        options
+            .Table("ref_countries")
+            .Hierarchical()
+            .MapProperty<string>("Alpha3Code", maxLength: 3, isFilterable: true);
+
+        options.TableName.ShouldBe("ref_countries");
+        options.IsHierarchical.ShouldBeTrue();
+        options.PropertyMappings.ShouldHaveSingleItem();
+    }
+}

--- a/tests/Granit.ReferenceData.Tests/ReferenceDataRegistryTests.cs
+++ b/tests/Granit.ReferenceData.Tests/ReferenceDataRegistryTests.cs
@@ -1,0 +1,76 @@
+using Granit.ReferenceData.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ReferenceData.Tests;
+
+public sealed class ReferenceDataRegistryTests
+{
+    private readonly ReferenceDataRegistry _registry = new();
+
+    [Fact]
+    public void Register_and_TryGet_returns_registration()
+    {
+        ReferenceDataTypeRegistration registration = new("Countries", new ReferenceDataExtensionOptions());
+
+        _registry.Register(registration);
+
+        _registry.TryGet("Countries", out ReferenceDataTypeRegistration? result).ShouldBeTrue();
+        result.ShouldBe(registration);
+    }
+
+    [Fact]
+    public void TryGet_is_case_insensitive()
+    {
+        _registry.Register(new ReferenceDataTypeRegistration("Countries", new ReferenceDataExtensionOptions()));
+
+        _registry.TryGet("countries", out ReferenceDataTypeRegistration? result).ShouldBeTrue();
+        result!.TypeName.ShouldBe("Countries");
+    }
+
+    [Fact]
+    public void TryGet_returns_false_for_unknown_type()
+    {
+        _registry.TryGet("Unknown", out ReferenceDataTypeRegistration? result).ShouldBeFalse();
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Register_duplicate_throws_InvalidOperationException()
+    {
+        _registry.Register(new ReferenceDataTypeRegistration("Countries", new ReferenceDataExtensionOptions()));
+
+        Should.Throw<InvalidOperationException>(
+            () => _registry.Register(new ReferenceDataTypeRegistration("Countries", new ReferenceDataExtensionOptions())));
+    }
+
+    [Fact]
+    public void Register_duplicate_case_insensitive_throws()
+    {
+        _registry.Register(new ReferenceDataTypeRegistration("Countries", new ReferenceDataExtensionOptions()));
+
+        Should.Throw<InvalidOperationException>(
+            () => _registry.Register(new ReferenceDataTypeRegistration("countries", new ReferenceDataExtensionOptions())));
+    }
+
+    [Fact]
+    public void Register_null_throws_ArgumentNullException()
+    {
+        Should.Throw<ArgumentNullException>(() => _registry.Register(null!));
+    }
+
+    [Fact]
+    public void Types_returns_all_registrations()
+    {
+        _registry.Register(new ReferenceDataTypeRegistration("Countries", new ReferenceDataExtensionOptions()));
+        _registry.Register(new ReferenceDataTypeRegistration("Currencies", new ReferenceDataExtensionOptions()));
+
+        _registry.Types.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void Types_returns_empty_when_no_registrations()
+    {
+        _registry.Types.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- **README overhaul**: updated package count to 217, expanded features table from 16 to 32 domains, replaced local doc links with [granit-fx.dev](https://granit-fx.dev) URLs
- **SonarQube code smells**: extracted `tenant_id`/`global` string literals to constants in `AuditingMetrics`, removed unnecessary null-conditional in `ImportOrchestrator`
- **Analyzers.CodeFixes coverage**: added 13 tests for 3 previously untested providers (CrossModuleReference, DirectCookieAccess, MinimalApiServiceParameter)
- **ReferenceData coverage**: added 33 tests covering Registry, Builder, ExtensionOptions, RegistryInitializer, and Mapper — all previously at 0%

## Test plan

- [x] `dotnet test tests/Granit.Analyzers.CodeFixes.Tests` — 32/32 passed
- [x] `dotnet test tests/Granit.ReferenceData.Tests` — 85/85 passed
- [x] `dotnet test tests/Granit.ReferenceData.Endpoints.Tests` — 106/106 passed
- [ ] CI green on all 6 test shards
- [ ] SonarQube quality gate passes with improved coverage
