### PR TITLE
feat(subscriptions): price versioning and grandfathering

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -33053,6 +33053,12 @@
           "kind": "method",
           "signature": "Update(string name, string? description, int sortOrder)",
           "returnType": "void"
+        },
+        {
+          "name": "GetPriceHistory",
+          "kind": "method",
+          "signature": "GetPriceHistory(string currency, BillingInterval interval)",
+          "returnType": "IReadOnlyList<PlanPrice>"
         }
       ]
     },
@@ -33118,12 +33124,12 @@
       "kind": "class",
       "project": "Granit.Subscriptions",
       "file": "src/Granit.Subscriptions/Domain/PlanPrice.cs",
-      "line": 8,
+      "line": 10,
       "members": [
         {
           "name": "Create",
           "kind": "method",
-          "signature": "Create(Guid id, decimal amount, string currency, BillingInterval interval)",
+          "signature": "Create(Guid id, decimal amount, string currency, BillingInterval interval, DateTimeOffset effectiveFrom)",
           "returnType": "PlanPrice"
         },
         {
@@ -33131,6 +33137,12 @@
           "kind": "property",
           "signature": "decimal Amount",
           "returnType": "decimal"
+        },
+        {
+          "name": "Interval",
+          "kind": "property",
+          "signature": "BillingInterval Interval",
+          "returnType": "BillingInterval"
         }
       ]
     },
@@ -33154,7 +33166,7 @@
         {
           "name": "Create",
           "kind": "method",
-          "signature": "Create(SubscriptionId id, Guid tenantId, PlanId planId, string currency, DateTimeOffset periodStart, DateTimeOffset periodEnd, DateTimeOffset billingCycleAnchor, DateTimeOffset? trialEndsAt = null)",
+          "signature": "Create(SubscriptionId id, Guid tenantId, PlanId planId, string currency, DateTimeOffset periodStart, DateTimeOffset periodEnd, DateTimeOffset billingCycleAnchor, DateTimeOffset? trialEndsAt = null, Guid? planPriceId = null)",
           "returnType": "Subscription"
         },
         {
@@ -33167,7 +33179,7 @@
           "name": "AsReadOnly",
           "kind": "method",
           "signature": "AsReadOnly()",
-          "returnType": "int DunningAttempt { get; private set; } public IReadOnlyList<SubscriptionSeat> Seats => _seats."
+          "returnType": "Guid? PlanPriceId { get; private set; } public int DunningAttempt { get; private set; } public IReadOnlyList<SubscriptionSeat> Seats => _seats."
         },
         {
           "name": "AsReadOnly",
@@ -33305,6 +33317,33 @@
       ]
     },
     {
+      "name": "BulkMigratePriceRequest",
+      "fqn": "Granit.Subscriptions.Endpoints.Dtos.BulkMigratePriceRequest",
+      "kind": "record",
+      "project": "Granit.Subscriptions.Endpoints",
+      "file": "src/Granit.Subscriptions.Endpoints/Dtos/PriceVersioningDtos.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "CreatePriceVersionRequest",
+      "fqn": "Granit.Subscriptions.Endpoints.Dtos.CreatePriceVersionRequest",
+      "kind": "record",
+      "project": "Granit.Subscriptions.Endpoints",
+      "file": "src/Granit.Subscriptions.Endpoints/Dtos/PriceVersioningDtos.cs",
+      "line": 4,
+      "members": []
+    },
+    {
+      "name": "MigratePriceRequest",
+      "fqn": "Granit.Subscriptions.Endpoints.Dtos.MigratePriceRequest",
+      "kind": "record",
+      "project": "Granit.Subscriptions.Endpoints",
+      "file": "src/Granit.Subscriptions.Endpoints/Dtos/PriceVersioningDtos.cs",
+      "line": 10,
+      "members": []
+    },
+    {
       "name": "PlanCreateRequest",
       "fqn": "Granit.Subscriptions.Endpoints.Dtos.PlanCreateRequest",
       "kind": "record",
@@ -33395,6 +33434,15 @@
       "members": []
     },
     {
+      "name": "BulkMigratePriceResponse",
+      "fqn": "Granit.Subscriptions.Endpoints.Endpoints.BulkMigratePriceResponse",
+      "kind": "record",
+      "project": "Granit.Subscriptions.Endpoints",
+      "file": "src/Granit.Subscriptions.Endpoints/Endpoints/PriceVersioningEndpoints.cs",
+      "line": 211,
+      "members": []
+    },
+    {
       "name": "SubscriptionsEndpointRouteBuilderExtensions",
       "fqn": "Granit.Subscriptions.Endpoints.Extensions.SubscriptionsEndpointRouteBuilderExtensions",
       "kind": "class",
@@ -33429,12 +33477,21 @@
       "members": []
     },
     {
+      "name": "Prices",
+      "fqn": "Granit.Subscriptions.Endpoints.Permissions.Prices",
+      "kind": "class",
+      "project": "Granit.Subscriptions.Endpoints",
+      "file": "src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissions.cs",
+      "line": 30,
+      "members": []
+    },
+    {
       "name": "Seats",
       "fqn": "Granit.Subscriptions.Endpoints.Permissions.Seats",
       "kind": "class",
       "project": "Granit.Subscriptions.Endpoints",
       "file": "src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissions.cs",
-      "line": 30,
+      "line": 40,
       "members": []
     },
     {
@@ -33522,6 +33579,24 @@
       "members": []
     },
     {
+      "name": "PlanPriceCreatedEto",
+      "fqn": "Granit.Subscriptions.Events.PlanPriceCreatedEto",
+      "kind": "record",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Events/PlanPriceCreatedEto.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "PlanPriceReplacedEto",
+      "fqn": "Granit.Subscriptions.Events.PlanPriceReplacedEto",
+      "kind": "record",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Events/PlanPriceReplacedEto.cs",
+      "line": 6,
+      "members": []
+    },
+    {
       "name": "SubscriptionActivatedEto",
       "fqn": "Granit.Subscriptions.Events.SubscriptionActivatedEto",
       "kind": "record",
@@ -33572,6 +33647,15 @@
       "kind": "record",
       "project": "Granit.Subscriptions",
       "file": "src/Granit.Subscriptions/Events/SubscriptionPlanChangedEto.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "SubscriptionPriceMigratedEto",
+      "fqn": "Granit.Subscriptions.Events.SubscriptionPriceMigratedEto",
+      "kind": "record",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Events/SubscriptionPriceMigratedEto.cs",
       "line": 6,
       "members": []
     },
@@ -33697,18 +33781,18 @@
       "kind": "interface",
       "project": "Granit.Subscriptions",
       "file": "src/Granit.Subscriptions/IPricingResolver.cs",
-      "line": 9,
+      "line": 10,
       "members": [
         {
           "name": "ResolveBasePriceAsync",
           "kind": "method",
-          "signature": "ResolveBasePriceAsync(PlanId planId, string currency, BillingInterval interval, CancellationToken cancellationToken = default)",
+          "signature": "ResolveBasePriceAsync(PlanId planId, string currency, BillingInterval interval, Guid? planPriceId = null, CancellationToken cancellationToken = default)",
           "returnType": "Task<decimal>"
         },
         {
           "name": "ResolveUsageUnitPriceAsync",
           "kind": "method",
-          "signature": "ResolveUsageUnitPriceAsync(PlanId planId, string currency, BillingInterval interval, string meterId, CancellationToken cancellationToken = default)",
+          "signature": "ResolveUsageUnitPriceAsync(PlanId planId, string currency, BillingInterval interval, string meterId, Guid? planPriceId = null, CancellationToken cancellationToken = default)",
           "returnType": "Task<decimal>"
         }
       ]
@@ -33833,6 +33917,12 @@
           "name": "GetPendingCancelAtPeriodEndAsync",
           "kind": "method",
           "signature": "GetPendingCancelAtPeriodEndAsync(DateTimeOffset now, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<Subscription>>"
+        },
+        {
+          "name": "GetActiveByPlanAsync",
+          "kind": "method",
+          "signature": "GetActiveByPlanAsync(PlanId planId, CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyList<Subscription>>"
         }
       ]

--- a/docs-site/src/content/docs/blog/rfc-7807-problem-details-the-only-way-to-return-errors.mdx
+++ b/docs-site/src/content/docs/blog/rfc-7807-problem-details-the-only-way-to-return-errors.mdx
@@ -1,0 +1,345 @@
+---
+title: "RFC 7807 Problem Details: The Only Way to Return Errors"
+date: 2026-04-06
+authors:
+  - jfmeyers
+tags:
+  - best-practice
+  - api
+  - deep-dive
+description: "Stop returning bare strings from your .NET APIs. RFC 7807 Problem Details is the standard — here is why, and how Granit enforces it with zero boilerplate."
+excerpt: >
+  Stop returning bare strings from your .NET APIs. RFC 7807 Problem Details is
+  the standard for error responses — here is why it matters, what the spec
+  actually says, and how Granit enforces it with zero boilerplate.
+---
+
+import { Tabs, TabItem, Aside } from "@astrojs/starlight/components";
+
+Quick: what does this response mean?
+
+```json
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+"Product name is required"
+```
+
+Is it a validation error? A business rule violation? Should the client retry? Where is the field name for the form to highlight? What happened to the trace ID for debugging?
+
+A bare string tells the client **nothing useful**. RFC 7807 exists to fix this — and in 2026, there is no reason to return errors any other way.
+
+## What RFC 7807 actually says
+
+[RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) (updated by [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457)) defines a standard JSON shape for HTTP error responses. The content type is `application/problem+json`, and the body contains five standard members:
+
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+  "title": "Product name is required.",
+  "status": 400,
+  "detail": "The 'name' field must be between 1 and 200 characters.",
+  "instance": "/api/v1/products"
+}
+```
+
+| Member     | Required | Purpose |
+|------------|----------|---------|
+| `type`     | Yes      | URI identifying the error type (can be a documentation link) |
+| `title`    | Yes      | Short human-readable summary (same for all occurrences of this error type) |
+| `status`   | Yes      | HTTP status code (redundant with the response, but useful when responses are logged standalone) |
+| `detail`   | No       | Human-readable explanation specific to **this occurrence** |
+| `instance` | No       | URI identifying **this specific occurrence** (request path, trace ID) |
+
+The spec explicitly allows **extension members** — custom fields alongside the standard ones. This is key for real-world APIs.
+
+## Why bare strings are harmful
+
+Consider a React frontend consuming your API. With a bare string response:
+
+```typescript
+// What the frontend developer is forced to write
+try {
+  await api.post('/products', data);
+} catch (error) {
+  // Is this a validation error? A 500? A network failure?
+  // Is the message safe to display to the user?
+  // Which field failed?
+  alert(error.response?.data ?? 'Something went wrong');
+}
+```
+
+With Problem Details:
+
+```typescript
+// Structured error handling
+try {
+  await api.post('/products', data);
+} catch (error) {
+  const problem = error.response?.data;
+  if (problem.status === 422 && problem.errors) {
+    // Highlight specific fields
+    Object.entries(problem.errors).forEach(([field, codes]) => {
+      setFieldError(field, localize(codes[0]));
+    });
+  } else {
+    showToast(problem.title, 'error');
+  }
+}
+```
+
+**Structured errors enable structured handling.** The frontend can differentiate validation failures from business rule violations, map error codes to localized strings, and route specific status codes to specific UI behaviors — all without parsing strings.
+
+## The .NET 10 way: `TypedResults.Problem()`
+
+ASP.NET Core has built-in support for Problem Details. The correct way to return an error in Minimal API is:
+
+```csharp title="ProductEndpoints.cs"
+private static async Task<Results<Ok<ProductResponse>, ProblemHttpResult>>
+    GetByIdAsync(Guid id, ProductDbContext db, CancellationToken ct)
+{
+    var product = await db.Products.FindAsync([id], ct);
+
+    if (product is null)
+    {
+        return TypedResults.Problem(
+            detail: $"No product found with ID '{id}'.",
+            statusCode: StatusCodes.Status404NotFound);
+    }
+
+    return TypedResults.Ok(new ProductResponse(product.Id, product.Name, product.Price));
+}
+```
+
+This produces:
+
+```json
+HTTP/1.1 404 Not Found
+Content-Type: application/problem+json
+
+{
+  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.4",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "No product found with ID '0193a5b2-7c3d-7def-8a12-bc3456789abc'."
+}
+```
+
+<Aside type="caution" title="The anti-pattern to eliminate">
+
+Never use `TypedResults.BadRequest("message")`. It returns `application/json` with a bare string — not Problem Details. Granit's `GRAPI002` Roslyn analyzer catches this at build time and offers an automatic code fix.
+
+```csharp
+// GRAPI002 — will not compile with treat-warnings-as-errors
+return TypedResults.BadRequest("Product name is required");
+
+// Auto-fix
+return TypedResults.Problem(
+    detail: "Product name is required",
+    statusCode: StatusCodes.Status400BadRequest);
+```
+
+</Aside>
+
+## Granit's exception-to-Problem Details pipeline
+
+Returning `TypedResults.Problem()` manually works for anticipated errors. But what about exceptions? Unhandled `NullReferenceException`? Third-party library failures? Domain exceptions thrown deep in the call stack?
+
+Granit's `ExceptionHandling` module converts **every exception** into a well-formed Problem Details response through a chain of responsibility pipeline.
+
+```mermaid
+graph TD
+    A["Exception thrown"] --> B{"OperationCanceledException?"}
+    B -->|"Yes"| C["Log Info — return 499"]
+    B -->|"No"| D["IExceptionStatusCodeMapper chain"]
+    D --> E{"IUserFriendlyException?"}
+    E -->|"Yes"| F["title = exception.Message"]
+    E -->|"No"| G["title = 'An unexpected error occurred.'"]
+    F --> H["Write RFC 7807 response"]
+    G --> H
+
+    style A fill:#ffcdd2,stroke:#c62828,color:#b71c1c
+    style D fill:#e3f2fd,stroke:#1976d2,color:#0d47a1
+    style H fill:#c8e6c9,stroke:#388e3c,color:#1b5e20
+```
+
+### Setup — one line
+
+```csharp title="Program.cs"
+app.UseGranitExceptionHandling(); // Must be the FIRST middleware
+app.UseRouting();
+app.UseAuthentication();
+app.UseAuthorization();
+```
+
+### Built-in exception mappings
+
+The `DefaultExceptionStatusCodeMapper` handles common exception types out of the box:
+
+| Exception | Status | Content type |
+|-----------|--------|---|
+| `EntityNotFoundException` | 404 | `application/problem+json` |
+| `NotFoundException` | 404 | `application/problem+json` |
+| `ForbiddenException` | 403 | `application/problem+json` |
+| `ValidationException` | 422 | `application/problem+json` |
+| `ConflictException` | 409 | `application/problem+json` |
+| `BusinessRuleViolationException` | 422 | `application/problem+json` |
+| `BusinessException` | 400 | `application/problem+json` |
+| `TimeoutException` | 408 | `application/problem+json` |
+| `OperationCanceledException` | 499 | `application/problem+json` |
+| Any other | 500 | `application/problem+json` |
+
+Every response is `application/problem+json`. No exceptions. No bare strings. **Consistency by default.**
+
+### The exception hierarchy
+
+Granit provides a structured exception hierarchy designed to map cleanly to Problem Details:
+
+```csharp title="Throwing a business error"
+// BusinessException: safe to expose to clients (IUserFriendlyException)
+// Includes an error code for client-side localization
+throw new BusinessException(
+    "Appointment:SlotUnavailable",
+    "The requested time slot is no longer available.");
+```
+
+This produces:
+
+```json
+{
+  "status": 400,
+  "title": "The requested time slot is no longer available.",
+  "errorCode": "Appointment:SlotUnavailable",
+  "traceId": "abcd1234ef567890"
+}
+```
+
+The three marker interfaces control what appears in the response:
+
+| Interface | Purpose | Effect on Problem Details |
+|-----------|---------|--------------------------|
+| `IUserFriendlyException` | Message is safe for end users | `title` = exception message |
+| `IHasErrorCode` | Machine-readable error code | `errorCode` extension member added |
+| `IHasValidationErrors` | Field-level validation failures | `errors` dictionary added |
+
+Exceptions that do **not** implement `IUserFriendlyException` get their message masked to `"An unexpected error occurred."` in production. Internal details (SQL fragments, file paths, PHI) never leak to the client.
+
+<Aside type="tip" title="ISO 27001 compliance">
+
+This masking is not optional politeness — it is an ISO 27001 requirement. Internal error messages may contain schema details, connection strings, or personal data. The `ExposeInternalErrorDetails` option exists for development only. Never enable it in production.
+
+</Aside>
+
+### Validation errors: the `errors` dictionary
+
+FluentValidation failures get special treatment. The `errors` dictionary maps field names to arrays of **error codes** (not human-readable messages):
+
+```json
+{
+  "status": 422,
+  "title": "One or more validation errors occurred.",
+  "errors": {
+    "Name": ["Granit:Validation:NotEmptyValidator"],
+    "Price": ["Granit:Validation:GreaterThanValidator"]
+  }
+}
+```
+
+Why codes instead of messages? Because the **frontend resolves them to localized strings** via `GET /api/granit/localization`. A French user sees "Le nom est obligatoire.", a Dutch user sees "Naam is verplicht." — from the same error code. This is how you do i18n-friendly validation without duplicating messages between backend and frontend.
+
+### Custom mappers: extend the chain
+
+Other Granit modules register their own mappers to handle domain-specific exceptions:
+
+```csharp title="InvoiceConcurrencyMapper.cs"
+internal sealed class InvoiceConcurrencyMapper : IExceptionStatusCodeMapper
+{
+    public int? TryGetStatusCode(Exception exception) => exception switch
+    {
+        InvoiceLockedException => StatusCodes.Status423Locked,
+        _ => null
+    };
+}
+```
+
+```csharp title="InvoicingModule.cs"
+services.AddSingleton<IExceptionStatusCodeMapper, InvoiceConcurrencyMapper>();
+```
+
+Mappers are evaluated in registration order. Return `null` to pass to the next mapper. The `DefaultExceptionStatusCodeMapper` is always last as a catch-all.
+
+## The Granit extension members
+
+Standard RFC 7807 gets you `type`, `title`, `status`, `detail`, and `instance`. Granit adds two extension members that make error responses actionable:
+
+```json
+{
+  "status": 422,
+  "title": "Invoice amount must be positive.",
+  "detail": null,
+  "traceId": "abcd1234ef567890",
+  "errorCode": "Invoices:InvalidAmount",
+  "errors": {
+    "Amount": ["Granit:Validation:GreaterThanValidator"]
+  }
+}
+```
+
+| Extension | Source | When present |
+|-----------|--------|-------------|
+| `traceId` | `Activity.Current?.TraceId` or `HttpContext.TraceIdentifier` | **Always** — enables log correlation |
+| `errorCode` | `IHasErrorCode.ErrorCode` | Exception implements `IHasErrorCode` |
+| `errors` | `IHasValidationErrors.ValidationErrors` | Exception implements `IHasValidationErrors` |
+
+The `traceId` deserves emphasis: every error response carries the distributed trace ID. When a user reports "I got an error", the support team searches by trace ID and finds the exact request across all services. No guessing. No "can you reproduce it?".
+
+## OpenAPI: document your errors
+
+Problem Details are only useful if clients **know they are coming**. Every Granit endpoint declares its error responses explicitly:
+
+```csharp title="ProductEndpoints.cs"
+group.MapGet("/{id:guid}", GetByIdAsync)
+    .WithName("GetProductById")
+    .WithSummary("Returns a product by its unique identifier.")
+    .WithDescription("Fetches the full product details. Returns 404 if not found.")
+    .Produces<ProductResponse>()
+    .ProducesProblem(StatusCodes.Status404NotFound);
+```
+
+The `.ProducesProblem()` call tells OpenAPI generators that this endpoint can return `application/problem+json` with a 404 status. Generated TypeScript clients get proper type narrowing:
+
+```typescript
+// Generated client knows about the 404 case
+const result = await client.getProductById(id);
+// result is ProductResponse — 404 is thrown as a typed ProblemDetailsError
+```
+
+## The full picture: five lines of defense
+
+Here is how error handling works end-to-end in a Granit application:
+
+| Layer | Mechanism | Example |
+|-------|-----------|---------|
+| **Build time** | `GRAPI002` analyzer | Flags `TypedResults.BadRequest("string")` |
+| **Validation** | `FluentValidationEndpointFilter` | Auto-validates requests, returns 422 with `errors` dictionary |
+| **Domain** | Typed exceptions | `throw new EntityNotFoundException(typeof(Product), id)` |
+| **Pipeline** | `IExceptionStatusCodeMapper` chain | Maps exceptions to status codes |
+| **Response** | `GranitExceptionHandler` | Serializes as `application/problem+json` with extensions |
+
+No error escapes as a bare string. No status code is returned without `application/problem+json`. No internal detail leaks to the client in production.
+
+## Key takeaways
+
+- **RFC 7807 Problem Details** is the only acceptable format for HTTP error responses. Bare strings break structured error handling, localization, and OpenAPI contracts.
+- **`TypedResults.Problem()`** is the .NET 10 primitive. Use it for anticipated errors. Let Granit's exception pipeline handle everything else.
+- **`IUserFriendlyException`** controls what the client sees. Without it, the message is masked in production (ISO 27001).
+- **Error codes over messages** — the frontend resolves `Granit:Validation:NotEmptyValidator` to localized strings. Ship codes, not strings.
+- **`traceId` on every error** enables instant log correlation. No reproduction steps needed.
+
+## Further reading
+
+- [Exception Handling module reference](/dotnet/api/exception-handling/) — full pipeline documentation
+- [HTTP Conventions](/dotnet/api/http-conventions/) — status codes, DTO naming, pagination
+- [Anti-Patterns](/dotnet/architecture/patterns/anti-patterns/) — common mistakes including `TypedResults.BadRequest`
+- [Guard Clauses](/dotnet/core/guard-clauses/) — fail-fast with typed exceptions
+- [Validation](/dotnet/core/validation/) — FluentValidation with localized error codes

--- a/docs-site/src/content/docs/blog/server-sent-events-dotnet-10.mdx
+++ b/docs-site/src/content/docs/blog/server-sent-events-dotnet-10.mdx
@@ -1,0 +1,455 @@
+---
+title: "Server-Sent Events in .NET 10: Real-Time Without WebSockets"
+date: 2026-04-08
+authors:
+  - jfmeyers
+tags:
+  - real-time
+  - tutorial
+  - api
+  - deep-dive
+description: ".NET 10 makes SSE a first-class citizen with TypedResults.ServerSentEvents(). Build a full notification stream from HTTP primitives to React hooks."
+excerpt: >
+  .NET 10 makes SSE a first-class citizen with TypedResults.ServerSentEvents().
+  Build a complete real-time notification stream from HTTP primitives to React
+  hooks — no WebSocket plumbing required.
+---
+
+import { Tabs, TabItem, Aside } from "@astrojs/starlight/components";
+
+WebSockets get all the hype. But most real-time features in business applications — notification bells, live dashboards, order status trackers, activity feeds — are **one-way**: the server pushes, the client listens. For this, you do not need a bidirectional binary channel. You need **Server-Sent Events**.
+
+.NET 10 finally treats SSE as a first-class Minimal API result type. No more manual `text/event-stream` header manipulation. No more raw `Response.Body.WriteAsync()`. One method call, one `IAsyncEnumerable`, done.
+
+## What is SSE?
+
+Server-Sent Events is a **W3C standard** ([spec](https://html.spec.whatwg.org/multipage/server-sent-events.html)) that defines a simple protocol for server-to-client push over a single HTTP connection. The server holds the response open and sends newline-delimited events:
+
+```text
+event: notification
+data: {"id":"abc","title":"Invoice approved","severity":"success"}
+
+event: __heartbeat__
+data:
+
+event: notification
+data: {"id":"def","title":"New comment on PR #42","severity":"info"}
+```
+
+That's it. Plain text. Standard HTTP. The browser's built-in `EventSource` API handles reconnection, `Last-Event-ID` tracking, and event parsing — with **zero JavaScript dependencies**.
+
+### Why not WebSockets?
+
+| Concern | SSE | WebSockets |
+|---------|-----|------------|
+| Direction | Server to client | Bidirectional |
+| Protocol | Standard HTTP | `ws://` (protocol upgrade) |
+| Proxy compatibility | Works everywhere | Some corporate proxies drop upgrades |
+| Reconnection | Browser-native with `Last-Event-ID` | Manual implementation required |
+| Client library | Browser `EventSource` (0 KB) | Browser `WebSocket` (0 KB) |
+| HTTP/2 multiplexing | Yes (shares connection) | No (separate TCP socket) |
+| Binary data | No | Yes |
+
+The critical insight: **HTTP/2 multiplexing**. With HTTP/1.1, every SSE stream consumed a dedicated TCP connection (browsers limit to 6 per domain). HTTP/2 multiplexes all streams over a single TCP connection, removing this limitation entirely. In 2026, HTTP/2 is the default everywhere — the old "6 connection limit" argument against SSE is obsolete.
+
+## .NET 10: `TypedResults.ServerSentEvents()`
+
+Before .NET 10, SSE required manual plumbing:
+
+```csharp title="Before .NET 10 — manual SSE"
+app.MapGet("/stream", async (HttpContext ctx, CancellationToken ct) =>
+{
+    ctx.Response.ContentType = "text/event-stream";
+    ctx.Response.Headers.CacheControl = "no-cache";
+    ctx.Response.Headers.Connection = "keep-alive";
+
+    while (!ct.IsCancellationRequested)
+    {
+        await ctx.Response.WriteAsync($"data: {JsonSerializer.Serialize(message)}\n\n", ct);
+        await ctx.Response.Body.FlushAsync(ct);
+    }
+});
+```
+
+Manual content type. Manual headers. Manual flushing. Manual serialization with `\n\n` delimiters. Easy to get wrong.
+
+.NET 10 introduces `TypedResults.ServerSentEvents()` — a first-class result type that accepts an `IAsyncEnumerable<T>` and handles all the protocol details:
+
+```csharp title=".NET 10 — native SSE"
+app.MapGet("/stream", (CancellationToken ct) =>
+    TypedResults.ServerSentEvents(StreamEvents(ct)));
+
+static async IAsyncEnumerable<MyEvent> StreamEvents(
+    [EnumeratorCancellation] CancellationToken ct)
+{
+    while (!ct.IsCancellationRequested)
+    {
+        yield return new MyEvent("something happened");
+        await Task.Delay(1000, ct);
+    }
+}
+```
+
+**What the framework handles for you:**
+
+- Sets `Content-Type: text/event-stream` and `Cache-Control: no-cache`
+- Serializes each yielded item as a `data:` frame with JSON
+- Flushes after each event (no buffering)
+- Respects `CancellationToken` when the client disconnects
+- Integrates with OpenAPI metadata
+
+## Building a real notification stream
+
+Let's go from zero to a production-ready SSE notification endpoint. We'll build the same system that `Granit.Notifications.Sse` implements, piece by piece.
+
+### Step 1: The connection manager
+
+Each SSE client is a long-lived HTTP connection. We need to track active connections per user and route messages to all of a user's browser tabs/devices.
+
+The core data structure: a `ConcurrentDictionary` of user IDs to their active connections, where each connection wraps a bounded `Channel<T>`:
+
+```csharp title="SseConnectionManager.cs"
+internal sealed class SseConnectionManager(
+    IGuidGenerator guidGenerator,
+    IOptions<SseChannelOptions> options) : ISseConnectionManager, IDisposable
+{
+    private readonly ConcurrentDictionary<string,
+        ConcurrentDictionary<Guid, SseConnection>> _connections = new();
+
+    public SseConnection? Connect(string userId)
+    {
+        ArgumentNullException.ThrowIfNull(userId);
+
+        var userConnections = _connections
+            .GetOrAdd(userId, _ => new ConcurrentDictionary<Guid, SseConnection>());
+
+        if (userConnections.Count >= options.Value.MaxConnectionsPerUser)
+        {
+            return null; // Prevent resource exhaustion
+        }
+
+        var channel = Channel.CreateBounded<SseNotificationMessage>(
+            new BoundedChannelOptions(options.Value.MaxBufferSize)
+            {
+                FullMode = BoundedChannelFullMode.DropOldest,
+                SingleWriter = false,
+                SingleReader = true,
+            });
+
+        SseConnection connection = new(guidGenerator.Create(), userId, channel);
+        userConnections.TryAdd(connection.ConnectionId, connection);
+        return connection;
+    }
+
+    public async ValueTask SendToUserAsync(
+        string userId, SseNotificationMessage message, CancellationToken ct = default)
+    {
+        if (!_connections.TryGetValue(userId, out var userConnections))
+            return; // No active connections — InApp channel persists it
+
+        foreach (var connection in userConnections.Values)
+        {
+            connection.Channel.Writer.TryWrite(message); // Best-effort, non-blocking
+        }
+
+        await ValueTask.CompletedTask.ConfigureAwait(false);
+    }
+}
+```
+
+**Key design decisions:**
+
+- **`BoundedChannelFullMode.DropOldest`** — when a slow client falls behind, the oldest messages are dropped. The InApp channel persists all notifications, so nothing is lost permanently.
+- **`SingleReader = true`** — each connection has exactly one HTTP response reading it, enabling lock-free channel optimizations.
+- **`TryWrite` (not `WriteAsync`)** — non-blocking. If the buffer is full, the oldest item drops. We never block the notification publisher waiting on a slow client.
+- **Per-user connection limit** — prevents resource exhaustion from a user opening 50 browser tabs. Default: 10 connections.
+
+### Step 2: The SSE endpoint
+
+The endpoint authenticates the user, registers a connection, and streams events using `TypedResults.ServerSentEvents()`:
+
+```csharp title="SseNotificationEndpoints.cs"
+public static class SseNotificationEndpoints
+{
+    internal const string HeartbeatEventType = "__heartbeat__";
+
+    public static RouteGroupBuilder MapGranitSseNotifications(
+        this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGranitGroup("/notifications")
+            .RequireAuthorization();
+
+        group.MapGet("/stream", HandleStream)
+            .WithName("NotificationSseStream")
+            .WithSummary("SSE stream for real-time notifications")
+            .ExcludeFromDescription();
+
+        return group;
+    }
+
+    private static IResult HandleStream(
+        ISseConnectionManager connectionManager,
+        IOptions<SseChannelOptions> options,
+        HttpContext httpContext,
+        CancellationToken ct)
+    {
+        string? userId = httpContext.User.FindFirst("sub")?.Value
+            ?? httpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+        if (userId is null)
+            return TypedResults.Problem(
+                detail: "User identifier claim not found.",
+                statusCode: StatusCodes.Status401Unauthorized);
+
+        SseConnection? connection = connectionManager.Connect(userId);
+
+        if (connection is null)
+            return TypedResults.Problem(
+                detail: "Too many concurrent SSE connections.",
+                statusCode: StatusCodes.Status429TooManyRequests);
+
+        return TypedResults.ServerSentEvents(
+            StreamNotifications(connectionManager, connection,
+                options.Value.HeartbeatIntervalSeconds, ct));
+    }
+}
+```
+
+Two things worth noting:
+
+1. **429 Too Many Requests** when the connection limit is reached — not a silent failure, a proper RFC 7807 Problem Details response.
+2. **`ExcludeFromDescription()`** — SSE endpoints don't belong in the OpenAPI spec (clients can't call them through generated code).
+
+### Step 3: The streaming loop with heartbeats
+
+The `IAsyncEnumerable` loop is the heart of the SSE endpoint. It waits for channel data or emits a heartbeat to keep the connection alive:
+
+```csharp title="StreamNotifications (IAsyncEnumerable)"
+private static async IAsyncEnumerable<SseNotificationMessage> StreamNotifications(
+    ISseConnectionManager connectionManager,
+    SseConnection connection,
+    int heartbeatSeconds,
+    [EnumeratorCancellation] CancellationToken ct)
+{
+    try
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            bool hasData = await WaitForDataOrHeartbeatAsync(
+                connection, heartbeatSeconds, ct).ConfigureAwait(false);
+
+            if (hasData)
+            {
+                while (connection.Reader.TryRead(out var message))
+                {
+                    yield return message;
+                }
+            }
+            else
+            {
+                yield return new SseNotificationMessage
+                {
+                    NotificationTypeName = "__heartbeat__",
+                };
+            }
+        }
+    }
+    finally
+    {
+        connectionManager.Disconnect(connection);
+    }
+}
+```
+
+**Why heartbeats matter:**
+
+- Reverse proxies (Nginx, AWS ALB, Cloudflare) timeout idle connections after 60–120 seconds
+- Load balancers use heartbeats to detect dead backends
+- Clients use heartbeat absence to detect stale connections and reconnect
+
+The default heartbeat interval is **30 seconds** — well within the timeout window of any proxy.
+
+<Aside type="caution" title="Never compress SSE streams">
+
+Response compression (Brotli, gzip) **buffers data** before sending. For SSE, this means events accumulate in the compression buffer instead of streaming to the client in real time. Granit's `ResponseCompression` module hardcodes `text/event-stream` as excluded — this is not configurable, it is a safety invariant.
+
+</Aside>
+
+### Step 4: The notification channel
+
+The `SseNotificationChannel` implements `INotificationChannel` — the same interface as Email, SMS, SignalR, and every other Granit channel. This is what makes SSE a plug-and-play transport:
+
+```csharp title="SseNotificationChannel.cs"
+internal sealed class SseNotificationChannel(
+    ISseConnectionManager connectionManager) : INotificationChannel
+{
+    public string Name => NotificationChannels.Sse;
+
+    public async Task SendAsync(
+        NotificationDeliveryContext context, CancellationToken ct = default)
+    {
+        SseNotificationMessage message = new()
+        {
+            NotificationId = context.NotificationId,
+            NotificationTypeName = context.NotificationTypeName,
+            Severity = context.Severity,
+            Data = context.Data,
+            RelatedEntityType = context.RelatedEntity?.EntityType,
+            RelatedEntityId = context.RelatedEntity?.EntityId,
+            OccurredAt = context.OccurredAt,
+        };
+
+        await connectionManager
+            .SendToUserAsync(context.RecipientUserId, message, ct)
+            .ConfigureAwait(false);
+    }
+}
+```
+
+Your application code never touches this class. You call `INotificationPublisher.PublishAsync()`, the fan-out engine delivers to every registered channel, and SSE clients receive the event in their open HTTP stream.
+
+### Step 5: Wire it up
+
+<Tabs>
+<TabItem label="Backend (Program.cs)">
+
+```csharp title="Program.cs"
+var builder = WebApplication.CreateBuilder(args);
+builder.AddGranit(granit => granit.AddModule<AppModule>());
+
+builder.Services.AddGranitNotificationsSse(options =>
+{
+    options.HeartbeatIntervalSeconds = 30;
+    options.MaxConnectionsPerUser = 10;
+    options.MaxBufferSize = 100;
+});
+
+var app = builder.Build();
+app.UseGranit();
+app.MapGranitSseNotifications();
+app.Run();
+```
+
+</TabItem>
+<TabItem label="Frontend (React)">
+
+```tsx title="App.tsx"
+import { NotificationProvider } from '@granit/react-notifications';
+import { createSseTransport } from '@granit/notifications-sse';
+
+const transport = createSseTransport({
+  streamUrl: '/api/v1/notifications/stream',
+  tokenGetter: () => keycloak.token,
+  heartbeatTypeName: '__heartbeat__', // auto-filtered
+});
+
+function App() {
+  return (
+    <NotificationProvider config={{ apiClient: api }} transport={transport}>
+      <NotificationBell />
+    </NotificationProvider>
+  );
+}
+```
+
+</TabItem>
+<TabItem label="Frontend (vanilla JS)">
+
+```javascript title="sse-client.js"
+const source = new EventSource('/api/v1/notifications/stream', {
+  withCredentials: true,
+});
+
+source.onmessage = (event) => {
+  const notification = JSON.parse(event.data);
+  if (notification.notificationTypeName === '__heartbeat__') return;
+  showToast(notification);
+};
+
+source.onerror = () => {
+  // EventSource auto-reconnects — just log it
+  console.warn('SSE connection lost, reconnecting...');
+};
+```
+
+</TabItem>
+</Tabs>
+
+The vanilla JavaScript example shows the zero-dependency story: **6 lines of code**, no npm packages, browser-native reconnection.
+
+## Production checklist
+
+### Connection limits
+
+Without limits, a single user can exhaust server resources by opening tabs. `SseChannelOptions` provides three knobs:
+
+| Option | Default | Purpose |
+|--------|---------|---------|
+| `HeartbeatIntervalSeconds` | 30 | Keep-alive for proxies and load balancers |
+| `MaxConnectionsPerUser` | 10 | Prevents tab-explosion resource exhaustion |
+| `MaxBufferSize` | 100 | Bounded channel per connection (drops oldest when full) |
+
+### Scaling: single pod vs multi-pod
+
+On a **single pod**, the `SseConnectionManager` is an in-memory singleton — all connections live in the same process. This works perfectly for monoliths and small deployments.
+
+On **multiple pods** (Kubernetes), a user's SSE connection lands on one pod, but notifications may be published from another pod. You need a pub/sub layer to bridge them:
+
+```mermaid
+graph LR
+    P1["Pod 1 — publishes notification"] --> R["Redis Pub/Sub"]
+    R --> P2["Pod 2 — user's SSE connection"]
+    R --> P3["Pod 3 — user's SSE connection"]
+
+    style R fill:#fff3e0,stroke:#ef6c00,color:#e65100
+    style P1 fill:#e3f2fd,stroke:#1976d2,color:#0d47a1
+    style P2 fill:#c8e6c9,stroke:#388e3c,color:#1b5e20
+    style P3 fill:#c8e6c9,stroke:#388e3c,color:#1b5e20
+```
+
+<Aside type="tip">
+If multi-pod scaling is a day-one requirement, consider `Granit.Notifications.SignalR` with its built-in Redis backplane (`AddGranitNotificationsSignalR("redis:6379")`). Swapping transports requires changing one DI registration and one React import — see [SSE vs SignalR vs WebSockets](/blog/sse-vs-signalr-vs-websockets/).
+</Aside>
+
+### Authentication
+
+The `EventSource` browser API does **not** support custom headers. This means you cannot send a Bearer token the usual way. Two strategies:
+
+1. **Cookie-based auth** — the `EventSource` sends cookies automatically (`withCredentials: true`). This is the BFF (Backend-for-Frontend) pattern Granit recommends.
+2. **`@microsoft/fetch-event-source`** — the library Granit's `@granit/notifications-sse` uses. It wraps `fetch()` with SSE parsing, supporting custom headers and automatic reconnection with token refresh.
+
+### Reverse proxy configuration
+
+Most proxies work out of the box, but verify these settings:
+
+| Proxy | Setting | Recommended value |
+|-------|---------|-------------------|
+| **Nginx** | `proxy_buffering` | `off` (prevents event buffering) |
+| **Nginx** | `proxy_read_timeout` | `3600s` (or higher — heartbeats keep it alive) |
+| **AWS ALB** | Idle timeout | `120s` (heartbeats at 30s prevent disconnection) |
+| **Cloudflare** | — | Works by default (100s timeout, heartbeats prevent it) |
+
+## When SSE is not enough
+
+SSE is the right tool for **unidirectional server push**. It is not the right tool when:
+
+- The client needs to **send data in real time** (chat, collaborative editing) — use SignalR or WebSockets
+- You need **binary frames** (file streaming, audio) — use WebSockets
+- You need **built-in group management and Redis backplane** with zero custom code — use SignalR
+
+For most enterprise applications, notification delivery is unidirectional. SSE handles it with fewer moving parts, fewer dependencies, and a simpler mental model than the alternatives.
+
+## Key takeaways
+
+- **.NET 10's `TypedResults.ServerSentEvents()`** turns SSE from manual plumbing into a one-liner. Yield events from `IAsyncEnumerable<T>`, the framework handles the rest.
+- **`Channel<T>`** is the perfect backpressure primitive for per-connection buffering. Bounded channels with `DropOldest` prevent slow clients from blocking the publisher.
+- **Heartbeats are mandatory** — proxies kill idle connections. 30-second intervals cover all common configurations.
+- **Never compress SSE streams** — buffering breaks the real-time contract.
+- **Granit's `INotificationChannel` abstraction** means SSE is a deployment choice, not an architecture decision. Your business code calls `INotificationPublisher.PublishAsync()` regardless of transport.
+
+## Further reading
+
+- [SSE vs SignalR vs WebSockets](/blog/sse-vs-signalr-vs-websockets/) — transport comparison and decision framework
+- [Granit.Notifications module](/dotnet/infrastructure/notifications/) — full notification engine documentation
+- [Notifications React SDK](/dotnet/frontend/notifications/) — transport setup, hooks, and preferences
+- [Response Compression](/dotnet/reference/modules/response-compression/) — why SSE and compression don't mix

--- a/docs-site/src/content/docs/blog/sse-vs-signalr-vs-websockets.mdx
+++ b/docs-site/src/content/docs/blog/sse-vs-signalr-vs-websockets.mdx
@@ -1,0 +1,357 @@
+---
+title: "SSE vs SignalR vs WebSockets: Choosing the Right Real-Time Transport"
+date: 2026-04-04
+authors:
+  - jfmeyers
+tags:
+  - real-time
+  - comparison
+  - architecture
+  - deep-dive
+description: "SSE, SignalR, or raw WebSockets? A practical decision framework for .NET real-time apps, with benchmarks, trade-offs, and Granit code samples."
+excerpt: >
+  SSE, SignalR, or raw WebSockets? A practical decision framework for .NET
+  real-time applications, with protocol deep-dives, trade-offs, and ready-to-use
+  Granit code samples for each transport.
+---
+
+import { Tabs, TabItem, Aside } from "@astrojs/starlight/components";
+
+Your API returns data. Your users want it **now**. Not after a polling interval. Not after a refresh. Now.
+
+Choosing the wrong real-time transport means either over-engineering a simple notification feed or under-powering a collaborative editing experience. This article breaks down the three main options — **Server-Sent Events (SSE)**, **WebSockets**, and **SignalR** — with honest trade-offs, a decision framework, and concrete Granit setup code for each.
+
+## The three contenders
+
+Before comparing, let's establish what each protocol actually does at the wire level.
+
+### Server-Sent Events (SSE)
+
+SSE is a **one-way** channel from server to client over a plain HTTP connection. The server holds the response open and pushes `text/event-stream` frames. That's it.
+
+```text
+GET /notifications/stream HTTP/1.1
+Accept: text/event-stream
+
+HTTP/1.1 200 OK
+Content-Type: text/event-stream
+
+event: notification
+data: {"id":"abc","title":"Invoice approved"}
+
+event: __heartbeat__
+data:
+
+event: notification
+data: {"id":"def","title":"New comment on PR #42"}
+```
+
+**Key characteristics:**
+
+- **HTTP-native** — works through every proxy, CDN, and load balancer without special configuration
+- **Auto-reconnect** — the browser `EventSource` API reconnects automatically with `Last-Event-ID`
+- **Text-only** — no binary frames (JSON is fine, Protobuf is not)
+- **Unidirectional** — server to client only; client-to-server uses regular HTTP requests
+- **.NET 10 native** — `TypedResults.ServerSentEvents()` is a first-class Minimal API result type
+
+### WebSockets
+
+WebSockets upgrade an HTTP connection to a **full-duplex binary channel**. Both sides can send frames at any time, with minimal overhead (2-byte header vs HTTP's multi-hundred-byte headers).
+
+```text
+GET /ws HTTP/1.1
+Upgrade: websocket
+Connection: Upgrade
+
+HTTP/1.1 101 Switching Protocols
+Upgrade: websocket
+```
+
+**Key characteristics:**
+
+- **Bidirectional** — true two-way communication with sub-millisecond latency
+- **Binary + text** — supports both frame types natively
+- **No auto-reconnect** — you implement retry logic yourself
+- **Proxy-sensitive** — some corporate proxies and older load balancers drop or mishandle WebSocket upgrades
+- **Connection management** — you own the lifecycle: heartbeats, authentication refresh, group routing
+
+### SignalR
+
+SignalR is **not a protocol** — it is an **abstraction layer** built by Microsoft on top of WebSockets, SSE, and Long Polling. It negotiates the best available transport and provides:
+
+- **Hub pattern** — RPC-style method invocation (`hub.SendAsync("ReceiveNotification", data)`)
+- **Automatic reconnection** — built-in retry with configurable backoff
+- **Transport fallback** — WebSocket → SSE → Long Polling
+- **Group management** — add/remove connections from named groups server-side
+- **Redis backplane** — horizontal scaling across multiple pods without sticky sessions
+
+## Head-to-head comparison
+
+| Criterion | SSE | WebSockets | SignalR |
+|---|---|---|---|
+| **Direction** | Server → Client | Bidirectional | Bidirectional (Hub RPC) |
+| **Protocol** | HTTP/1.1+ | ws:// / wss:// | WebSocket + SSE + LP fallback |
+| **Binary support** | No (text/JSON) | Yes | Yes (MessagePack) |
+| **Auto-reconnect** | Browser-native | Manual | Built-in |
+| **Proxy compatibility** | Excellent | Variable | Excellent (fallback) |
+| **Scaling (multi-pod)** | Sticky sessions or pub/sub | Sticky sessions or pub/sub | Redis backplane built-in |
+| **Client library size** | 0 KB (browser-native) | 0 KB (browser-native) | ~45 KB (@microsoft/signalr) |
+| **Server complexity** | Low | High | Medium |
+| **.NET 10 support** | `TypedResults.ServerSentEvents()` | `WebSocketManager` | `MapHub<T>()` |
+
+## When to use what
+
+### Choose SSE when
+
+- You need **server-to-client push only** (notifications, live feeds, dashboards)
+- Your infrastructure has strict proxy or firewall rules
+- You want **zero client dependencies** (browser `EventSource` API)
+- You value simplicity over bidirectional communication
+
+This covers **80% of real-time use cases** in business applications: notification bells, activity feeds, live status updates, dashboard tickers.
+
+### Choose raw WebSockets when
+
+- You need **low-latency bidirectional** communication (chat, collaborative editing, gaming)
+- You send **binary data** (file streaming, audio/video signaling)
+- You want **full control** over the wire protocol
+- You are building a protocol bridge (e.g., MQTT over WebSocket)
+
+### Choose SignalR when
+
+- You want **bidirectional** communication **without managing WebSocket plumbing**
+- You need **transport fallback** for hostile network environments
+- You run **multiple pods in Kubernetes** and want built-in Redis backplane scaling
+- Your team is already in the .NET ecosystem and wants the fastest path to production
+
+## Granit's approach: transport-agnostic notifications
+
+Granit's notification system decouples **what you send** from **how it arrives**. The `INotificationPublisher` fans out to every registered `INotificationChannel`. SSE and SignalR are just two of the available channels — and they are **mutually exclusive** (pick one per deployment).
+
+```mermaid
+graph LR
+    P["INotificationPublisher"] --> F["Fan-out Engine"]
+    F --> InApp["InApp"]
+    F --> Email["Email"]
+    F --> SSE["SSE"]
+    F --> SR["SignalR"]
+    F --> WP["Web Push"]
+    F --> SMS["SMS"]
+
+    style P fill:#e8eaf6,stroke:#3f51b5,color:#1a237e
+    style F fill:#fff3e0,stroke:#ef6c00,color:#e65100
+    style SSE fill:#e3f2fd,stroke:#1976d2,color:#0d47a1
+    style SR fill:#e3f2fd,stroke:#1976d2,color:#0d47a1
+```
+
+The channel interface is intentionally minimal:
+
+```csharp title="INotificationChannel.cs"
+public interface INotificationChannel
+{
+    string Name { get; }
+    Task SendAsync(NotificationDeliveryContext context, CancellationToken cancellationToken = default);
+}
+```
+
+Both transports implement the same interface. Your application code **never references SSE or SignalR directly** — you publish through `INotificationPublisher` and the registered channels handle delivery.
+
+### Setup: SSE
+
+<Tabs>
+<TabItem label="Program.cs">
+
+```csharp title="Program.cs"
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddGranitNotificationsSse(options =>
+{
+    options.HeartbeatIntervalSeconds = 30;
+    options.MaxConnectionsPerUser = 10;
+    options.MaxBufferSize = 100;
+});
+
+var app = builder.Build();
+app.MapGranitSseNotifications(); // Maps GET /notifications/stream
+app.Run();
+```
+
+</TabItem>
+<TabItem label="React client">
+
+```tsx title="App.tsx"
+import { NotificationProvider } from '@granit/react-notifications';
+import { createSseTransport } from '@granit/notifications-sse';
+
+const transport = createSseTransport({
+  streamUrl: '/api/v1/notifications/stream',
+  tokenGetter: () => keycloak.token,
+});
+
+function App() {
+  return (
+    <NotificationProvider config={{ apiClient: api }} transport={transport}>
+      <NotificationBell />
+    </NotificationProvider>
+  );
+}
+```
+
+</TabItem>
+</Tabs>
+
+Under the hood, Granit uses .NET 10's native `TypedResults.ServerSentEvents()` to stream `IAsyncEnumerable<SseNotificationMessage>` with automatic heartbeats that keep connections alive through proxies.
+
+### Setup: SignalR
+
+<Tabs>
+<TabItem label="Program.cs (single pod)">
+
+```csharp title="Program.cs"
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddGranitNotificationsSignalR();
+
+var app = builder.Build();
+app.MapHub<NotificationHub>("/hubs/notifications");
+app.Run();
+```
+
+</TabItem>
+<TabItem label="Program.cs (Kubernetes)">
+
+```csharp title="Program.cs"
+var builder = WebApplication.CreateBuilder(args);
+
+// Redis backplane for multi-pod scaling
+builder.Services.AddGranitNotificationsSignalR("redis:6379");
+
+var app = builder.Build();
+app.MapHub<NotificationHub>("/hubs/notifications");
+app.Run();
+```
+
+</TabItem>
+<TabItem label="React client">
+
+```tsx title="App.tsx"
+import { NotificationProvider } from '@granit/react-notifications';
+import { createSignalRTransport } from '@granit/notifications-signalr';
+
+const transport = createSignalRTransport({
+  hubUrl: '/hubs/notifications',
+  tokenGetter: () => keycloak.token,
+});
+
+function App() {
+  return (
+    <NotificationProvider config={{ apiClient: api }} transport={transport}>
+      <NotificationBell />
+    </NotificationProvider>
+  );
+}
+```
+
+</TabItem>
+</Tabs>
+
+<Aside type="tip">
+Notice the React code is nearly identical. The `NotificationTransport` interface means you can swap SSE for SignalR (or vice versa) by changing **one import and one factory call**. No component changes needed.
+</Aside>
+
+### Publishing: identical for both transports
+
+Regardless of which transport you register, your business code stays the same:
+
+```csharp title="InvoiceService.cs"
+public sealed class InvoiceApprovalService(INotificationPublisher notifications)
+{
+    public async Task ApproveAsync(Invoice invoice, CancellationToken ct)
+    {
+        invoice.Approve();
+
+        await notifications.PublishAsync(
+            InvoiceNotificationTypes.Approved,
+            new InvoiceApprovedData(invoice.Id, invoice.Number),
+            [invoice.CreatedByUserId],
+            new EntityReference("Invoice", invoice.Id.ToString()),
+            ct);
+    }
+}
+```
+
+The fan-out engine delivers this notification through **every registered channel** — InApp for persistence, SSE or SignalR for real-time push, Email if the user's preferences say so.
+
+## Decision framework
+
+Still unsure? Walk through these three questions:
+
+```mermaid
+graph TD
+    Q1{"Does the client<br/>send data to<br/>the server in<br/>real-time?"}
+    Q1 -- "No" --> SSE["Use SSE"]
+    Q1 -- "Yes" --> Q2{"Do you need<br/>full protocol<br/>control or<br/>binary frames?"}
+    Q2 -- "Yes" --> WS["Use WebSockets"]
+    Q2 -- "No" --> Q3{"Multi-pod<br/>deployment?"}
+    Q3 -- "Yes" --> SRR["Use SignalR<br/>+ Redis backplane"]
+    Q3 -- "No" --> SR["Use SignalR"]
+
+    style SSE fill:#c8e6c9,stroke:#388e3c,color:#1b5e20
+    style WS fill:#fff9c4,stroke:#f9a825,color:#e65100
+    style SR fill:#e3f2fd,stroke:#1976d2,color:#0d47a1
+    style SRR fill:#e3f2fd,stroke:#1976d2,color:#0d47a1
+    style Q1 fill:#fce4ec,stroke:#c62828,color:#b71c1c
+    style Q2 fill:#fce4ec,stroke:#c62828,color:#b71c1c
+    style Q3 fill:#fce4ec,stroke:#c62828,color:#b71c1c
+```
+
+**In practice**, most enterprise applications land on SSE for notification delivery. Bidirectional real-time (chat, collaboration) is a separate concern that typically warrants its own SignalR hub or a dedicated WebSocket endpoint — not the notification channel.
+
+## Performance considerations
+
+### Connection overhead
+
+**SSE** holds one HTTP connection per client. On .NET 10, this is a kept-alive `IAsyncEnumerable` stream with near-zero per-frame overhead. The `SseConnectionManager` tracks connections per user and enforces a configurable `MaxConnectionsPerUser` limit (default: 10) to prevent resource exhaustion from excessive browser tabs.
+
+**SignalR** negotiates WebSocket first, then falls back. WebSocket connections are long-lived TCP sockets with a 2-byte frame header. More efficient per message, but the negotiation handshake adds latency on first connection.
+
+### Scaling
+
+| Strategy | SSE | SignalR |
+|---|---|---|
+| **Single pod** | Works out of the box | Works out of the box |
+| **Multi-pod (sticky)** | Sticky sessions via cookie/IP | Sticky sessions via cookie |
+| **Multi-pod (stateless)** | External pub/sub (manual) | `AddStackExchangeRedis()` (one line) |
+
+SignalR's built-in Redis backplane is its strongest scaling advantage. For SSE in a multi-pod environment, you would need to build a pub/sub layer yourself or use sticky sessions.
+
+### Response compression
+
+<Aside type="caution">
+Do **not** enable response compression on SSE endpoints. Compressing a streaming response buffers events and breaks the real-time contract. WebSocket frames bypass HTTP response compression entirely (the protocol switches after the initial handshake), so no special handling is needed.
+</Aside>
+
+## The verdict
+
+There is no universally "best" transport. But there is a **best transport for your use case**:
+
+- **Notification feeds, dashboards, live status** → SSE. It is simpler, HTTP-native, and covers unidirectional push with zero client dependencies.
+- **Chat, collaboration, bidirectional RPC** → SignalR. You get transport fallback, group management, and Redis scaling without building plumbing.
+- **Custom protocols, binary streaming, maximum control** → Raw WebSockets. Accept the complexity tax only when the other options genuinely cannot do the job.
+
+Granit lets you defer this decision. Register `AddGranitNotificationsSse()` today, swap to `AddGranitNotificationsSignalR("redis:6379")` tomorrow. Your business code, your React components, and your notification types stay untouched.
+
+## Key takeaways
+
+- **SSE** is the simplest real-time transport — one HTTP connection, server-to-client, browser-native reconnection. Choose it for notifications and feeds.
+- **WebSockets** give maximum control and bidirectional binary communication. Choose them when you need full protocol ownership.
+- **SignalR** abstracts WebSocket/SSE/Long Polling behind a Hub pattern with built-in Redis scaling. Choose it for bidirectional scenarios where convenience beats control.
+- **Granit's `INotificationChannel` abstraction** means the transport is a deployment decision, not an architecture decision. Swap transports without touching business logic.
+- **Don't default to the most powerful option.** SSE handles 80% of enterprise real-time needs with 20% of the complexity.
+
+## Further reading
+
+- [Granit.Notifications module reference](/dotnet/infrastructure/notifications/) — full notification engine documentation
+- [Notifications React SDK](/dotnet/frontend/notifications/) — transport setup, hooks, and Web Push
+- [Response Compression](/dotnet/reference/modules/response-compression/) — why SSE and compression don't mix
+- [Strategy Pattern in Granit](/dotnet/architecture/patterns/strategy/) — the pattern behind pluggable transports

--- a/docs-site/src/content/docs/dotnet/saas/subscriptions.mdx
+++ b/docs-site/src/content/docs/dotnet/saas/subscriptions.mdx
@@ -47,8 +47,8 @@ var plan = Plan.Create(
     PricingModel.PerSeat, BillingInterval.Monthly,
     trialDays: 14, seatLimit: 50);
 
-plan.AddPrice(PlanPrice.Create(Guid.NewGuid(), 29.99m, "EUR", BillingInterval.Monthly));
-plan.AddPrice(PlanPrice.Create(Guid.NewGuid(), 299.99m, "EUR", BillingInterval.Yearly));
+plan.AddPrice(PlanPrice.Create(Guid.NewGuid(), 29.99m, "EUR", BillingInterval.Monthly, clock.Now));
+plan.AddPrice(PlanPrice.Create(Guid.NewGuid(), 299.99m, "EUR", BillingInterval.Yearly, clock.Now));
 ```
 
 ### Pricing models

--- a/src/Granit.Subscriptions.Endpoints/Dtos/PlanResponse.cs
+++ b/src/Granit.Subscriptions.Endpoints/Dtos/PlanResponse.cs
@@ -29,10 +29,18 @@ public sealed record PlanResponse(
         plan.Prices.Select(PlanPriceResponse.FromEntity).ToList());
 }
 
-/// <summary>Plan price entry.</summary>
+/// <summary>Plan price entry with versioning metadata.</summary>
 public sealed record PlanPriceResponse(
-    Guid Id, decimal Amount, string Currency, string Interval)
+    Guid Id,
+    decimal Amount,
+    string Currency,
+    string Interval,
+    DateTimeOffset EffectiveFrom,
+    bool IsActive,
+    Guid? ReplacedByPriceId = null,
+    DateTimeOffset? ReplacedAt = null)
 {
     internal static PlanPriceResponse FromEntity(PlanPrice price) =>
-        new(price.Id, price.Amount, price.Currency, price.Interval.ToString());
+        new(price.Id, price.Amount, price.Currency, price.Interval.ToString(),
+            price.EffectiveFrom, price.IsActive, price.ReplacedByPriceId, price.ReplacedAt);
 }

--- a/src/Granit.Subscriptions.Endpoints/Dtos/PriceVersioningDtos.cs
+++ b/src/Granit.Subscriptions.Endpoints/Dtos/PriceVersioningDtos.cs
@@ -1,0 +1,16 @@
+namespace Granit.Subscriptions.Endpoints.Dtos;
+
+/// <summary>Request to create a new price version for a plan.</summary>
+public sealed record CreatePriceVersionRequest(
+    decimal Amount,
+    string Currency,
+    string Interval);
+
+/// <summary>Request to migrate a subscription to a new price version.</summary>
+public sealed record MigratePriceRequest(Guid NewPlanPriceId);
+
+/// <summary>Request to bulk-migrate subscriptions to a new price version.</summary>
+public sealed record BulkMigratePriceRequest(
+    Guid PlanId,
+    Guid NewPlanPriceId,
+    Guid? OldPlanPriceId = null);

--- a/src/Granit.Subscriptions.Endpoints/Dtos/SubscriptionResponse.cs
+++ b/src/Granit.Subscriptions.Endpoints/Dtos/SubscriptionResponse.cs
@@ -15,7 +15,8 @@ public sealed record SubscriptionResponse(
     DateTimeOffset? CancelledAt,
     string? CancellationReason,
     int DunningAttempt,
-    int SeatCount)
+    int SeatCount,
+    Guid? PlanPriceId = null)
 {
     internal static SubscriptionResponse FromEntity(Subscription sub) => new(
         sub.Id,
@@ -29,5 +30,6 @@ public sealed record SubscriptionResponse(
         sub.CancelledAt,
         sub.CancellationReason,
         sub.DunningAttempt,
-        sub.Seats.Count);
+        sub.Seats.Count,
+        sub.PlanPriceId);
 }

--- a/src/Granit.Subscriptions.Endpoints/Endpoints/PriceVersioningEndpoints.cs
+++ b/src/Granit.Subscriptions.Endpoints/Endpoints/PriceVersioningEndpoints.cs
@@ -1,0 +1,211 @@
+using Granit.Guids;
+using Granit.Subscriptions.Domain;
+using Granit.Subscriptions.Domain.ValueObjects;
+using Granit.Subscriptions.Endpoints.Dtos;
+using Granit.Subscriptions.Endpoints.Permissions;
+using Granit.Timing;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Subscriptions.Endpoints.Endpoints;
+
+internal static class PriceVersioningEndpoints
+{
+    internal static RouteGroupBuilder MapPriceVersioningEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapPost("/plans/{planId:guid}/prices", CreatePriceVersionAsync)
+            .WithName("CreatePriceVersion")
+            .WithSummary("Creates a new price version for a plan.")
+            .WithDescription(
+                "Adds a new price for the given currency and interval. If an active price already " +
+                "exists for the same slot, it is marked as replaced. Allowed on Draft and Published " +
+                "plans. Existing subscribers keep their pinned price (grandfathering).")
+            .Produces<PlanPriceResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict)
+            .ProducesValidationProblem()
+            .RequireAuthorization(SubscriptionsPermissions.Prices.Manage);
+
+        group.MapGet("/plans/{planId:guid}/prices/history", GetPriceHistoryAsync)
+            .WithName("GetPlanPriceHistory")
+            .WithSummary("Returns the price version history for a plan.")
+            .WithDescription(
+                "Returns all price versions for the specified currency and interval, " +
+                "ordered from newest to oldest. Includes replaced prices for audit trail.")
+            .Produces<IReadOnlyList<PlanPriceResponse>>()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .RequireAuthorization(SubscriptionsPermissions.Prices.Read);
+
+        group.MapPost("/subscriptions/{id:guid}/migrate-price", MigratePriceAsync)
+            .WithName("MigrateSubscriptionPrice")
+            .WithSummary("Migrates a subscription to a new price version.")
+            .WithDescription(
+                "Updates the pinned price for a specific subscription. Only allowed for " +
+                "Active or Trial subscriptions. Publishes a SubscriptionPriceMigratedEto event.")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict)
+            .RequireAuthorization(SubscriptionsPermissions.Prices.Manage);
+
+        group.MapPost("/subscriptions/bulk-migrate-price", BulkMigratePriceAsync)
+            .WithName("BulkMigrateSubscriptionPrice")
+            .WithSummary("Bulk-migrates subscriptions to a new price version.")
+            .WithDescription(
+                "Migrates all active subscriptions on a given plan to a new price version. " +
+                "Optionally filters by old price ID. Returns the number of migrated subscriptions.")
+            .Produces<BulkMigratePriceResponse>()
+            .ProducesValidationProblem()
+            .RequireAuthorization(SubscriptionsPermissions.Prices.Manage);
+
+        return group;
+    }
+
+    private static async Task<Results<Created<PlanPriceResponse>, NotFound, ProblemHttpResult, ValidationProblem>>
+        CreatePriceVersionAsync(
+            Guid planId,
+            CreatePriceVersionRequest request,
+            [FromServices] IPlanReader planReader,
+            [FromServices] IPlanWriter planWriter,
+            [FromServices] IGuidGenerator guidGenerator,
+            [FromServices] IClock clock,
+            CancellationToken cancellationToken)
+    {
+        if (!Enum.TryParse<BillingInterval>(request.Interval, true, out BillingInterval interval))
+        {
+            return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["Interval"] = [$"Invalid billing interval: {request.Interval}"],
+            });
+        }
+
+        Plan? plan = await planReader
+            .GetByIdAsync(PlanId.Create(planId), cancellationToken).ConfigureAwait(false);
+
+        if (plan is null)
+        {
+            return TypedResults.NotFound();
+        }
+
+        DateTimeOffset now = clock.Now;
+
+        var newPrice = PlanPrice.Create(
+            guidGenerator.Create(),
+            request.Amount,
+            request.Currency.ToUpperInvariant(),
+            interval,
+            now);
+
+        try
+        {
+            plan.AddPriceVersion(newPrice, now);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return TypedResults.Problem(detail: ex.Message, statusCode: StatusCodes.Status409Conflict);
+        }
+
+        await planWriter.UpdateAsync(plan, cancellationToken).ConfigureAwait(false);
+
+        return TypedResults.Created(
+            $"/plans/{planId}/prices/{newPrice.Id}",
+            PlanPriceResponse.FromEntity(newPrice));
+    }
+
+    private static async Task<Results<Ok<IReadOnlyList<PlanPriceResponse>>, NotFound, ValidationProblem>>
+        GetPriceHistoryAsync(
+            Guid planId,
+            [FromQuery] string currency,
+            [FromQuery] string interval,
+            [FromServices] IPlanReader planReader,
+            CancellationToken cancellationToken)
+    {
+        if (!Enum.TryParse<BillingInterval>(interval, true, out BillingInterval billingInterval))
+        {
+            return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["interval"] = [$"Invalid billing interval: {interval}"],
+            });
+        }
+
+        Plan? plan = await planReader
+            .GetByIdAsync(PlanId.Create(planId), cancellationToken).ConfigureAwait(false);
+
+        if (plan is null)
+        {
+            return TypedResults.NotFound();
+        }
+
+        IReadOnlyList<PlanPrice> history = plan.GetPriceHistory(currency, billingInterval);
+
+        return TypedResults.Ok<IReadOnlyList<PlanPriceResponse>>(
+            history.Select(PlanPriceResponse.FromEntity).ToList());
+    }
+
+    private static async Task<Results<NoContent, NotFound, ProblemHttpResult>> MigratePriceAsync(
+        Guid id,
+        MigratePriceRequest request,
+        [FromServices] ISubscriptionReader reader,
+        [FromServices] ISubscriptionWriter writer,
+        CancellationToken cancellationToken)
+    {
+        Subscription? sub = await reader
+            .GetByIdAsync(SubscriptionId.Create(id), cancellationToken).ConfigureAwait(false);
+
+        if (sub is null)
+        {
+            return TypedResults.NotFound();
+        }
+
+        try
+        {
+            bool changed = sub.MigratePrice(request.NewPlanPriceId);
+            if (!changed)
+            {
+                return TypedResults.NoContent();
+            }
+        }
+        catch (InvalidOperationException ex)
+        {
+            return TypedResults.Problem(detail: ex.Message, statusCode: StatusCodes.Status409Conflict);
+        }
+
+        await writer.UpdateAsync(sub, cancellationToken).ConfigureAwait(false);
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Results<Ok<BulkMigratePriceResponse>, ValidationProblem>>
+        BulkMigratePriceAsync(
+            BulkMigratePriceRequest request,
+            [FromServices] ISubscriptionReader reader,
+            [FromServices] ISubscriptionWriter writer,
+            CancellationToken cancellationToken)
+    {
+        IReadOnlyList<Subscription> subscriptions = await reader
+            .GetActiveByPlanAsync(PlanId.Create(request.PlanId), cancellationToken)
+            .ConfigureAwait(false);
+
+        int migrated = 0;
+
+        foreach (Subscription sub in subscriptions)
+        {
+            if (request.OldPlanPriceId.HasValue && sub.PlanPriceId != request.OldPlanPriceId)
+            {
+                continue;
+            }
+
+            if (sub.MigratePrice(request.NewPlanPriceId))
+            {
+                await writer.UpdateAsync(sub, cancellationToken).ConfigureAwait(false);
+                migrated++;
+            }
+        }
+
+        return TypedResults.Ok(new BulkMigratePriceResponse(migrated));
+    }
+}
+
+/// <summary>Response for bulk price migration.</summary>
+public sealed record BulkMigratePriceResponse(int MigratedCount);

--- a/src/Granit.Subscriptions.Endpoints/Extensions/SubscriptionsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Subscriptions.Endpoints/Extensions/SubscriptionsEndpointRouteBuilderExtensions.cs
@@ -21,6 +21,7 @@ public static class SubscriptionsEndpointRouteBuilderExtensions
 
         group.MapPlanReadEndpoints();
         group.MapPlanWriteEndpoints();
+        group.MapPriceVersioningEndpoints();
         group.MapSubscriptionEndpoints();
         group.MapSeatEndpoints();
 

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/cs.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/cs.json
@@ -6,6 +6,8 @@
     "Permission:Subscriptions.Plans.Manage": "Spravovat plány předplatného (vytvořit, publikovat, archivovat)",
     "Permission:Subscriptions.Subscriptions.Read": "Zobrazit předplatná",
     "Permission:Subscriptions.Subscriptions.Manage": "Spravovat předplatná (vytvořit, zrušit, změnit plán)",
+    "Permission:Subscriptions.Prices.Read": "Zobrazit historii verzí cen",
+    "Permission:Subscriptions.Prices.Manage": "Spravovat ceny (vytvářet verze, migrovat předplatné)",
     "Permission:Subscriptions.Seats.Read": "Zobrazit přiřazení míst",
     "Permission:Subscriptions.Seats.Manage": "Spravovat přiřazení míst (přiřadit, odvolat)"
   }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/de.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/de.json
@@ -6,6 +6,8 @@
     "Permission:Subscriptions.Plans.Manage": "Abonnementpläne verwalten (erstellen, veröffentlichen, archivieren)",
     "Permission:Subscriptions.Subscriptions.Read": "Abonnements anzeigen",
     "Permission:Subscriptions.Subscriptions.Manage": "Abonnements verwalten (erstellen, kündigen, Plan wechseln)",
+    "Permission:Subscriptions.Prices.Read": "Preisversionshistorie anzeigen",
+    "Permission:Subscriptions.Prices.Manage": "Preise verwalten (Versionen erstellen, Abonnements migrieren)",
     "Permission:Subscriptions.Seats.Read": "Platzzuweisungen anzeigen",
     "Permission:Subscriptions.Seats.Manage": "Platzzuweisungen verwalten (zuweisen, widerrufen)"
   }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/en-GB.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/en-GB.json
@@ -6,6 +6,8 @@
     "Permission:Subscriptions.Plans.Manage": "Manage subscription plans (create, publish, archive)",
     "Permission:Subscriptions.Subscriptions.Read": "View subscriptions",
     "Permission:Subscriptions.Subscriptions.Manage": "Manage subscriptions (create, cancel, change plan)",
+    "Permission:Subscriptions.Prices.Read": "View price version history",
+    "Permission:Subscriptions.Prices.Manage": "Manage prices (create versions, migrate subscriptions)",
     "Permission:Subscriptions.Seats.Read": "View seat assignments",
     "Permission:Subscriptions.Seats.Manage": "Manage seat assignments (assign, revoke)"
   }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/en.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/en.json
@@ -6,6 +6,8 @@
     "Permission:Subscriptions.Plans.Manage": "Manage subscription plans (create, publish, archive)",
     "Permission:Subscriptions.Subscriptions.Read": "View subscriptions",
     "Permission:Subscriptions.Subscriptions.Manage": "Manage subscriptions (create, cancel, change plan)",
+    "Permission:Subscriptions.Prices.Read": "View price version history",
+    "Permission:Subscriptions.Prices.Manage": "Manage prices (create versions, migrate subscriptions)",
     "Permission:Subscriptions.Seats.Read": "View seat assignments",
     "Permission:Subscriptions.Seats.Manage": "Manage seat assignments (assign, revoke)"
   }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/es.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/es.json
@@ -6,6 +6,8 @@
     "Permission:Subscriptions.Plans.Manage": "Gestionar planes de suscripción (crear, publicar, archivar)",
     "Permission:Subscriptions.Subscriptions.Read": "Ver suscripciones",
     "Permission:Subscriptions.Subscriptions.Manage": "Gestionar suscripciones (crear, cancelar, cambiar de plan)",
+    "Permission:Subscriptions.Prices.Read": "Ver historial de versiones de precios",
+    "Permission:Subscriptions.Prices.Manage": "Gestionar precios (crear versiones, migrar suscripciones)",
     "Permission:Subscriptions.Seats.Read": "Ver asignaciones de puestos",
     "Permission:Subscriptions.Seats.Manage": "Gestionar asignaciones de puestos (asignar, revocar)"
   }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/fr-CA.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/fr-CA.json
@@ -6,6 +6,8 @@
     "Permission:Subscriptions.Plans.Manage": "Gérer les plans d'abonnement (créer, publier, archiver)",
     "Permission:Subscriptions.Subscriptions.Read": "Consulter les abonnements",
     "Permission:Subscriptions.Subscriptions.Manage": "Gérer les abonnements (créer, annuler, changer de plan)",
+    "Permission:Subscriptions.Prices.Read": "Consulter l'historique des versions de prix",
+    "Permission:Subscriptions.Prices.Manage": "Gérer les prix (créer des versions, migrer les abonnements)",
     "Permission:Subscriptions.Seats.Read": "Consulter les attributions de sièges",
     "Permission:Subscriptions.Seats.Manage": "Gérer les attributions de sièges (attribuer, révoquer)"
   }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/fr.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/fr.json
@@ -6,6 +6,8 @@
     "Permission:Subscriptions.Plans.Manage": "Gérer les plans d'abonnement (créer, publier, archiver)",
     "Permission:Subscriptions.Subscriptions.Read": "Consulter les abonnements",
     "Permission:Subscriptions.Subscriptions.Manage": "Gérer les abonnements (créer, annuler, changer de plan)",
+    "Permission:Subscriptions.Prices.Read": "Consulter l'historique des versions de prix",
+    "Permission:Subscriptions.Prices.Manage": "Gérer les prix (créer des versions, migrer les abonnements)",
     "Permission:Subscriptions.Seats.Read": "Consulter les attributions de sièges",
     "Permission:Subscriptions.Seats.Manage": "Gérer les attributions de sièges (attribuer, révoquer)"
   }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/it.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/it.json
@@ -6,6 +6,8 @@
     "Permission:Subscriptions.Plans.Manage": "Gestire i piani di abbonamento (creare, pubblicare, archiviare)",
     "Permission:Subscriptions.Subscriptions.Read": "Visualizzare gli abbonamenti",
     "Permission:Subscriptions.Subscriptions.Manage": "Gestire gli abbonamenti (creare, annullare, cambiare piano)",
+    "Permission:Subscriptions.Prices.Read": "Visualizzare lo storico delle versioni dei prezzi",
+    "Permission:Subscriptions.Prices.Manage": "Gestire i prezzi (creare versioni, migrare abbonamenti)",
     "Permission:Subscriptions.Seats.Read": "Visualizzare le assegnazioni dei posti",
     "Permission:Subscriptions.Seats.Manage": "Gestire le assegnazioni dei posti (assegnare, revocare)"
   }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ja.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ja.json
@@ -6,6 +6,8 @@
     "Permission:Subscriptions.Plans.Manage": "サブスクリプションプランの管理（作成、公開、アーカイブ）",
     "Permission:Subscriptions.Subscriptions.Read": "サブスクリプションの表示",
     "Permission:Subscriptions.Subscriptions.Manage": "サブスクリプションの管理（作成、キャンセル、プラン変更）",
+    "Permission:Subscriptions.Prices.Read": "価格バージョン��歴を表示",
+    "Permission:Subscriptions.Prices.Manage": "価格を管理（バージョン作成、サブスクリプション移行）",
     "Permission:Subscriptions.Seats.Read": "シート割り当ての表示",
     "Permission:Subscriptions.Seats.Manage": "シート割り当ての管理（割り当て、取り消し）"
   }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ko.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ko.json
@@ -6,6 +6,8 @@
     "Permission:Subscriptions.Plans.Manage": "구독 플랜 관리 (생성, 게시, 보관)",
     "Permission:Subscriptions.Subscriptions.Read": "구독 보기",
     "Permission:Subscriptions.Subscriptions.Manage": "구독 관리 (생성, 취소, 플랜 변경)",
+    "Permission:Subscriptions.Prices.Read": "가격 버전 이력 조회",
+    "Permission:Subscriptions.Prices.Manage": "가격 관리 (버��� 생성, 구독 마이그레이션)",
     "Permission:Subscriptions.Seats.Read": "시트 할당 보기",
     "Permission:Subscriptions.Seats.Manage": "시트 할당 관리 (할당, 철회)"
   }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/nl.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/nl.json
@@ -6,6 +6,8 @@
     "Permission:Subscriptions.Plans.Manage": "Abonnementsplannen beheren (aanmaken, publiceren, archiveren)",
     "Permission:Subscriptions.Subscriptions.Read": "Abonnementen bekijken",
     "Permission:Subscriptions.Subscriptions.Manage": "Abonnementen beheren (aanmaken, annuleren, van plan wijzigen)",
+    "Permission:Subscriptions.Prices.Read": "Prijsversiegeschiedenis bekijken",
+    "Permission:Subscriptions.Prices.Manage": "Prijzen beheren (versies aanmaken, abonnementen migreren)",
     "Permission:Subscriptions.Seats.Read": "Stoeltoewijzingen bekijken",
     "Permission:Subscriptions.Seats.Manage": "Stoeltoewijzingen beheren (toewijzen, intrekken)"
   }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pl.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pl.json
@@ -6,6 +6,8 @@
     "Permission:Subscriptions.Plans.Manage": "Zarządzanie planami subskrypcji (tworzenie, publikowanie, archiwizowanie)",
     "Permission:Subscriptions.Subscriptions.Read": "Wyświetlanie subskrypcji",
     "Permission:Subscriptions.Subscriptions.Manage": "Zarządzanie subskrypcjami (tworzenie, anulowanie, zmiana planu)",
+    "Permission:Subscriptions.Prices.Read": "Wyświetl historię wersji cen",
+    "Permission:Subscriptions.Prices.Manage": "Zarządzaj cenami (twórz wersje, migruj subskrypcje)",
     "Permission:Subscriptions.Seats.Read": "Wyświetlanie przypisań miejsc",
     "Permission:Subscriptions.Seats.Manage": "Zarządzanie przypisaniami miejsc (przypisywanie, cofanie)"
   }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt-BR.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt-BR.json
@@ -6,6 +6,8 @@
     "Permission:Subscriptions.Plans.Manage": "Gerenciar planos de assinatura (criar, publicar, arquivar)",
     "Permission:Subscriptions.Subscriptions.Read": "Visualizar assinaturas",
     "Permission:Subscriptions.Subscriptions.Manage": "Gerenciar assinaturas (criar, cancelar, alterar plano)",
+    "Permission:Subscriptions.Prices.Read": "Ver histórico de versões de preços",
+    "Permission:Subscriptions.Prices.Manage": "Gerenciar preços (criar versões, migrar assinaturas)",
     "Permission:Subscriptions.Seats.Read": "Visualizar atribuições de assentos",
     "Permission:Subscriptions.Seats.Manage": "Gerenciar atribuições de assentos (atribuir, revogar)"
   }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt.json
@@ -6,6 +6,8 @@
     "Permission:Subscriptions.Plans.Manage": "Gerir planos de subscrição (criar, publicar, arquivar)",
     "Permission:Subscriptions.Subscriptions.Read": "Ver subscrições",
     "Permission:Subscriptions.Subscriptions.Manage": "Gerir subscrições (criar, cancelar, alterar plano)",
+    "Permission:Subscriptions.Prices.Read": "Ver hist��rico de versões de preços",
+    "Permission:Subscriptions.Prices.Manage": "Gerir preços (criar versões, migrar assinaturas)",
     "Permission:Subscriptions.Seats.Read": "Ver atribuições de lugares",
     "Permission:Subscriptions.Seats.Manage": "Gerir atribuições de lugares (atribuir, revogar)"
   }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/sv.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/sv.json
@@ -6,6 +6,8 @@
     "Permission:Subscriptions.Plans.Manage": "Hantera prenumerationsplaner (skapa, publicera, arkivera)",
     "Permission:Subscriptions.Subscriptions.Read": "Visa prenumerationer",
     "Permission:Subscriptions.Subscriptions.Manage": "Hantera prenumerationer (skapa, avbryta, byta plan)",
+    "Permission:Subscriptions.Prices.Read": "Visa prisversionshistorik",
+    "Permission:Subscriptions.Prices.Manage": "Hantera priser (skapa versioner, migrera prenumerationer)",
     "Permission:Subscriptions.Seats.Read": "Visa platstilldelningar",
     "Permission:Subscriptions.Seats.Manage": "Hantera platstilldelningar (tilldela, återkalla)"
   }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/tr.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/tr.json
@@ -6,6 +6,8 @@
     "Permission:Subscriptions.Plans.Manage": "Abonelik planlarını yönet (oluştur, yayınla, arşivle)",
     "Permission:Subscriptions.Subscriptions.Read": "Abonelikleri görüntüle",
     "Permission:Subscriptions.Subscriptions.Manage": "Abonelikleri yönet (oluştur, iptal et, plan değiştir)",
+    "Permission:Subscriptions.Prices.Read": "Fiyat sürüm geçmişini görüntüle",
+    "Permission:Subscriptions.Prices.Manage": "Fiyatları yönet (sür��m oluştur, abonelikleri taşı)",
     "Permission:Subscriptions.Seats.Read": "Koltuk atamalarını görüntüle",
     "Permission:Subscriptions.Seats.Manage": "Koltuk atamalarını yönet (ata, iptal et)"
   }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/zh.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/zh.json
@@ -6,6 +6,8 @@
     "Permission:Subscriptions.Plans.Manage": "管理订阅计划（创建、发布、归档）",
     "Permission:Subscriptions.Subscriptions.Read": "查看订阅",
     "Permission:Subscriptions.Subscriptions.Manage": "管理订阅（创建、取消、更改计划）",
+    "Permission:Subscriptions.Prices.Read": "查看价格版本历史",
+    "Permission:Subscriptions.Prices.Manage": "管理价格（创建版本、迁移订阅）",
     "Permission:Subscriptions.Seats.Read": "查看席位分配",
     "Permission:Subscriptions.Seats.Manage": "管理席位分配（分配、撤销）"
   }

--- a/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissionDefinitionProvider.cs
+++ b/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissionDefinitionProvider.cs
@@ -21,6 +21,10 @@ internal sealed class SubscriptionsPermissionDefinitionProvider : IPermissionDef
             LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Subscriptions.Read"));
         group.AddPermission(SubscriptionsPermissions.Subscriptions.Manage,
             LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Subscriptions.Manage"));
+        group.AddPermission(SubscriptionsPermissions.Prices.Read,
+            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Prices.Read"));
+        group.AddPermission(SubscriptionsPermissions.Prices.Manage,
+            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Prices.Manage"));
         group.AddPermission(SubscriptionsPermissions.Seats.Read,
             LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Seats.Read"));
         group.AddPermission(SubscriptionsPermissions.Seats.Manage,

--- a/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissions.cs
+++ b/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissions.cs
@@ -26,6 +26,16 @@ public static class SubscriptionsPermissions
         public const string Manage = "Subscriptions.Subscriptions.Manage";
     }
 
+    /// <summary>Price versioning permissions.</summary>
+    public static class Prices
+    {
+        /// <summary>View price history.</summary>
+        public const string Read = "Subscriptions.Prices.Read";
+
+        /// <summary>Manage prices (create versions, migrate subscriptions).</summary>
+        public const string Manage = "Subscriptions.Prices.Manage";
+    }
+
     /// <summary>Seat resource permissions.</summary>
     public static class Seats
     {

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfPricingResolver.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfPricingResolver.cs
@@ -5,11 +5,13 @@ namespace Granit.Subscriptions.EntityFrameworkCore.Internal;
 
 /// <summary>
 /// Resolves pricing from <see cref="PlanPrice"/> entries via <see cref="IPlanReader"/>.
+/// Supports pinned price resolution for grandfathered subscriptions.
 /// </summary>
 internal sealed class EfPricingResolver(IPlanReader planReader) : IPricingResolver
 {
     public async Task<decimal> ResolveBasePriceAsync(
         PlanId planId, string currency, BillingInterval interval,
+        Guid? planPriceId = null,
         CancellationToken cancellationToken = default)
     {
         Plan? plan = await planReader.GetByIdAsync(planId, cancellationToken)
@@ -20,17 +22,14 @@ internal sealed class EfPricingResolver(IPlanReader planReader) : IPricingResolv
             return 0m;
         }
 
-        PlanPrice? price = plan.Prices
-            .FirstOrDefault(p =>
-                string.Equals(p.Currency, currency, StringComparison.OrdinalIgnoreCase)
-                && p.Interval == interval);
-
+        PlanPrice? price = ResolvePlanPrice(plan, currency, interval, planPriceId);
         return price?.Amount ?? 0m;
     }
 
     public async Task<decimal> ResolveUsageUnitPriceAsync(
         PlanId planId, string currency, BillingInterval interval,
-        string meterId, CancellationToken cancellationToken = default)
+        string meterId, Guid? planPriceId = null,
+        CancellationToken cancellationToken = default)
     {
         Plan? plan = await planReader.GetByIdAsync(planId, cancellationToken)
             .ConfigureAwait(false);
@@ -40,11 +39,20 @@ internal sealed class EfPricingResolver(IPlanReader planReader) : IPricingResolv
             return 0m;
         }
 
-        PlanPrice? price = plan.Prices
-            .FirstOrDefault(p =>
-                string.Equals(p.Currency, currency, StringComparison.OrdinalIgnoreCase)
-                && p.Interval == interval);
-
+        PlanPrice? price = ResolvePlanPrice(plan, currency, interval, planPriceId);
         return price?.Amount ?? 0m;
+    }
+
+    private static PlanPrice? ResolvePlanPrice(
+        Plan plan, string currency, BillingInterval interval, Guid? planPriceId)
+    {
+        // Pinned price: resolve by ID directly (grandfathered subscription)
+        if (planPriceId.HasValue)
+        {
+            return plan.Prices.FirstOrDefault(p => p.Id == planPriceId.Value);
+        }
+
+        // Dynamic resolution: return the current active price for (currency, interval)
+        return plan.GetActivePrice(currency, interval);
     }
 }

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfSubscriptionReader.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfSubscriptionReader.cs
@@ -50,4 +50,12 @@ internal sealed class EfSubscriptionReader(
                 s.Status == SubscriptionStatus.Active &&
                 s.CurrentPeriodEnd <= now),
             cancellationToken);
+
+    public Task<IReadOnlyList<Subscription>> GetActiveByPlanAsync(
+        PlanId planId, CancellationToken cancellationToken = default) =>
+        ListAsync(
+            Spec.For<Subscription>().Where(s =>
+                s.PlanId == planId &&
+                (s.Status == SubscriptionStatus.Active || s.Status == SubscriptionStatus.Trial)),
+            cancellationToken);
 }

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/PlanPriceConfiguration.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/PlanPriceConfiguration.cs
@@ -16,5 +16,14 @@ internal sealed class PlanPriceConfiguration : IEntityTypeConfiguration<PlanPric
         builder.Property(e => e.Amount).HasPrecision(18, 4).IsRequired();
         builder.Property(e => e.Currency).HasMaxLength(3).IsRequired();
         builder.Property(e => e.Interval).IsRequired();
+        builder.Property(e => e.EffectiveFrom).IsRequired();
+        builder.Property(e => e.ReplacedByPriceId);
+        builder.Property(e => e.ReplacedAt);
+
+        builder.HasIndex(e => new { e.ReplacedByPriceId })
+            .HasFilter("\"ReplacedByPriceId\" IS NULL")
+            .HasDatabaseName($"ix_{GranitSubscriptionsDbProperties.DbTablePrefix}plan_prices_active");
+
+        builder.Ignore(e => e.IsActive);
     }
 }

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/SubscriptionConfiguration.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/SubscriptionConfiguration.cs
@@ -24,6 +24,7 @@ internal sealed class SubscriptionConfiguration : IEntityTypeConfiguration<Subsc
         builder.Property(e => e.CancellationReason).HasMaxLength(500);
         builder.Property(e => e.Currency).HasMaxLength(3).IsRequired();
         builder.Property(e => e.DunningAttempt).IsRequired().HasDefaultValue(0);
+        builder.Property(e => e.PlanPriceId);
 
         builder.HasMany(e => e.Seats).WithOne().HasForeignKey("SubscriptionId").OnDelete(DeleteBehavior.Cascade);
         builder.HasMany(e => e.ExternalMappings).WithOne().HasForeignKey("SubscriptionId").OnDelete(DeleteBehavior.Cascade);

--- a/src/Granit.Subscriptions.Wolverine/Handlers/BillingCycleCompletedHandler.cs
+++ b/src/Granit.Subscriptions.Wolverine/Handlers/BillingCycleCompletedHandler.cs
@@ -54,7 +54,8 @@ internal static partial class BillingCycleCompletedHandler
             }
 
             decimal basePrice = await pricingResolver.ResolveBasePriceAsync(
-                subscription.PlanId, subscription.Currency, plan.DefaultInterval, cancellationToken)
+                subscription.PlanId, subscription.Currency, plan.DefaultInterval,
+                subscription.PlanPriceId, cancellationToken)
                 .ConfigureAwait(false);
 
             if (basePrice <= 0)

--- a/src/Granit.Subscriptions.Wolverine/Handlers/UsageSummaryReadyHandler.cs
+++ b/src/Granit.Subscriptions.Wolverine/Handlers/UsageSummaryReadyHandler.cs
@@ -61,9 +61,10 @@ internal static partial class UsageSummaryReadyHandler
 
             var lineItems = new List<CreateInvoiceLineItem>();
 
-            // Fixed plan charge (base price)
+            // Fixed plan charge (base price) — uses pinned price if subscription has one
             decimal basePrice = await pricingResolver.ResolveBasePriceAsync(
-                subscription.PlanId, subscription.Currency, plan.DefaultInterval, cancellationToken)
+                subscription.PlanId, subscription.Currency, plan.DefaultInterval,
+                subscription.PlanPriceId, cancellationToken)
                 .ConfigureAwait(false);
 
             if (basePrice > 0)
@@ -75,10 +76,10 @@ internal static partial class UsageSummaryReadyHandler
                     subscription.Id.ToString()));
             }
 
-            // Usage charge
+            // Usage charge — uses pinned price if subscription has one
             decimal unitPrice = await pricingResolver.ResolveUsageUnitPriceAsync(
                 subscription.PlanId, subscription.Currency, plan.DefaultInterval,
-                eto.MeterDefinitionId.ToString(), cancellationToken)
+                eto.MeterDefinitionId.ToString(), subscription.PlanPriceId, cancellationToken)
                 .ConfigureAwait(false);
 
             lineItems.Add(new CreateInvoiceLineItem(

--- a/src/Granit.Subscriptions/Domain/Plan.cs
+++ b/src/Granit.Subscriptions/Domain/Plan.cs
@@ -106,12 +106,39 @@ public sealed class Plan : AuditedAggregateRoot, IWorkflowStateful
         SortOrder = sortOrder;
     }
 
-    /// <summary>Adds a price point to this plan.</summary>
+    /// <summary>Adds a price point to this plan. Only allowed in Draft status.</summary>
     public void AddPrice(PlanPrice price)
     {
         EnsureDraft();
         ArgumentNullException.ThrowIfNull(price);
         _prices.Add(price);
+    }
+
+    /// <summary>
+    /// Adds a new price version for the same (currency, interval) slot, replacing the
+    /// current active price. Allowed on Published plans (grandfathering / price versioning).
+    /// </summary>
+    /// <returns>The previous price that was replaced, or <c>null</c> if no matching active price existed.</returns>
+    public PlanPrice? AddPriceVersion(PlanPrice newPrice, DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(newPrice);
+
+        if (LifecycleStatus == WorkflowLifecycleStatus.Archived)
+        {
+            throw new InvalidOperationException(
+                $"Plan '{Id}' is Archived. Price versions cannot be added to archived plans.");
+        }
+
+        PlanPrice? currentPrice = _prices
+            .FirstOrDefault(p =>
+                p.IsActive
+                && string.Equals(p.Currency, newPrice.Currency, StringComparison.OrdinalIgnoreCase)
+                && p.Interval == newPrice.Interval);
+
+        currentPrice?.MarkReplaced(newPrice.Id, now);
+
+        _prices.Add(newPrice);
+        return currentPrice;
     }
 
     /// <summary>Adds a feature value mapping to this plan.</summary>
@@ -158,6 +185,22 @@ public sealed class Plan : AuditedAggregateRoot, IWorkflowStateful
 
         LifecycleStatus = WorkflowLifecycleStatus.Archived;
     }
+
+    /// <summary>Returns the current active price for the given currency and interval, or <c>null</c>.</summary>
+    public PlanPrice? GetActivePrice(string currency, BillingInterval interval) =>
+        _prices.FirstOrDefault(p =>
+            p.IsActive
+            && string.Equals(p.Currency, currency, StringComparison.OrdinalIgnoreCase)
+            && p.Interval == interval);
+
+    /// <summary>Returns all price versions for the given currency and interval, newest first.</summary>
+    public IReadOnlyList<PlanPrice> GetPriceHistory(string currency, BillingInterval interval) =>
+        _prices
+            .Where(p =>
+                string.Equals(p.Currency, currency, StringComparison.OrdinalIgnoreCase)
+                && p.Interval == interval)
+            .OrderByDescending(p => p.EffectiveFrom)
+            .ToList();
 
     private void EnsureDraft()
     {

--- a/src/Granit.Subscriptions/Domain/PlanPrice.cs
+++ b/src/Granit.Subscriptions/Domain/PlanPrice.cs
@@ -4,19 +4,24 @@ namespace Granit.Subscriptions.Domain;
 
 /// <summary>
 /// A price point for a plan in a specific currency and billing interval.
+/// Supports versioning: when a price is replaced, <see cref="ReplacedByPriceId"/>
+/// points to the successor and <see cref="ReplacedAt"/> records the timestamp.
 /// </summary>
 public sealed class PlanPrice : Entity
 {
     private PlanPrice() { }
 
     /// <summary>Creates a new plan price.</summary>
-    public static PlanPrice Create(Guid id, decimal amount, string currency, BillingInterval interval) =>
+    public static PlanPrice Create(
+        Guid id, decimal amount, string currency, BillingInterval interval,
+        DateTimeOffset effectiveFrom) =>
         new()
         {
             Id = id,
             Amount = amount,
             Currency = currency,
             Interval = interval,
+            EffectiveFrom = effectiveFrom,
         };
 
     /// <summary>Price amount in the smallest currency unit (e.g., cents).</summary>
@@ -27,4 +32,29 @@ public sealed class PlanPrice : Entity
 
     /// <summary>Billing interval this price applies to.</summary>
     public BillingInterval Interval { get; private set; }
+
+    /// <summary>When this price version became effective.</summary>
+    public DateTimeOffset EffectiveFrom { get; private set; }
+
+    /// <summary>ID of the price version that replaced this one. Null if this is the current version.</summary>
+    public Guid? ReplacedByPriceId { get; private set; }
+
+    /// <summary>When this price was replaced by a newer version. Null if still current.</summary>
+    public DateTimeOffset? ReplacedAt { get; private set; }
+
+    /// <summary>Whether this price is the current active version (not replaced).</summary>
+    public bool IsActive => ReplacedByPriceId is null;
+
+    /// <summary>Marks this price as replaced by a newer version.</summary>
+    internal void MarkReplaced(Guid replacedByPriceId, DateTimeOffset replacedAt)
+    {
+        if (ReplacedByPriceId is not null)
+        {
+            throw new InvalidOperationException(
+                $"Plan price '{Id}' has already been replaced by '{ReplacedByPriceId}'.");
+        }
+
+        ReplacedByPriceId = replacedByPriceId;
+        ReplacedAt = replacedAt;
+    }
 }

--- a/src/Granit.Subscriptions/Domain/Subscription.cs
+++ b/src/Granit.Subscriptions/Domain/Subscription.cs
@@ -36,7 +36,8 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
         DateTimeOffset periodStart,
         DateTimeOffset periodEnd,
         DateTimeOffset billingCycleAnchor,
-        DateTimeOffset? trialEndsAt = null)
+        DateTimeOffset? trialEndsAt = null,
+        Guid? planPriceId = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(currency);
 
@@ -56,6 +57,7 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
             BillingCycleAnchor = billingCycleAnchor,
             TrialEndsAt = trialEndsAt,
             CancelAtPeriodEnd = false,
+            PlanPriceId = planPriceId,
         };
 
         subscription.AddDomainEvent(new SubscriptionCreatedEvent(id, planId, tenantId));
@@ -94,6 +96,13 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
 
     /// <summary>ISO 4217 currency code selected at subscription creation (e.g., "EUR").</summary>
     public string Currency { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Pinned price version. When set, billing uses this specific <see cref="PlanPrice"/>
+    /// instead of resolving dynamically from the plan's current prices (grandfathering).
+    /// Null for subscriptions created before price versioning was enabled.
+    /// </summary>
+    public Guid? PlanPriceId { get; private set; }
 
     /// <summary>Number of failed payment retry attempts (dunning). Reset on successful payment.</summary>
     public int DunningAttempt { get; private set; }
@@ -261,6 +270,30 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
         CurrentPeriodEnd = newPeriodEnd;
         AddDistributedEvent(new BillingCycleCompletedEto(
             Id, PlanId, TenantId!.Value, newPeriodStart, newPeriodEnd));
+    }
+
+    /// <summary>
+    /// Migrates this subscription to a new price version. Only allowed for Active or Trial subscriptions.
+    /// Returns <c>false</c> if already pinned to the same price.
+    /// </summary>
+    public bool MigratePrice(Guid newPlanPriceId)
+    {
+        if (Status is not (SubscriptionStatus.Active or SubscriptionStatus.Trial))
+        {
+            throw new InvalidOperationException(
+                $"Cannot migrate price for subscription '{Id}' in '{Status}' status.");
+        }
+
+        if (PlanPriceId == newPlanPriceId)
+        {
+            return false;
+        }
+
+        Guid? oldPlanPriceId = PlanPriceId;
+        PlanPriceId = newPlanPriceId;
+        AddDistributedEvent(new SubscriptionPriceMigratedEto(
+            Id, TenantId!.Value, oldPlanPriceId, newPlanPriceId));
+        return true;
     }
 
     // ── Seat management ────────────────────────────────────────────────

--- a/src/Granit.Subscriptions/Events/PlanPriceCreatedEto.cs
+++ b/src/Granit.Subscriptions/Events/PlanPriceCreatedEto.cs
@@ -1,0 +1,12 @@
+using Granit.Events;
+
+namespace Granit.Subscriptions.Events;
+
+/// <summary>Published when a new plan price version is created.</summary>
+public sealed record PlanPriceCreatedEto(
+    Guid PlanId,
+    Guid PlanPriceId,
+    decimal Amount,
+    string Currency,
+    string Interval,
+    DateTimeOffset EffectiveFrom) : IIntegrationEvent;

--- a/src/Granit.Subscriptions/Events/PlanPriceReplacedEto.cs
+++ b/src/Granit.Subscriptions/Events/PlanPriceReplacedEto.cs
@@ -1,0 +1,13 @@
+using Granit.Events;
+
+namespace Granit.Subscriptions.Events;
+
+/// <summary>Published when an existing plan price is replaced by a newer version.</summary>
+public sealed record PlanPriceReplacedEto(
+    Guid PlanId,
+    Guid OldPriceId,
+    Guid NewPriceId,
+    decimal OldAmount,
+    decimal NewAmount,
+    string Currency,
+    string Interval) : IIntegrationEvent;

--- a/src/Granit.Subscriptions/Events/SubscriptionPriceMigratedEto.cs
+++ b/src/Granit.Subscriptions/Events/SubscriptionPriceMigratedEto.cs
@@ -1,0 +1,10 @@
+using Granit.Events;
+
+namespace Granit.Subscriptions.Events;
+
+/// <summary>Published when a subscription is migrated to a new price version.</summary>
+public sealed record SubscriptionPriceMigratedEto(
+    Guid SubscriptionId,
+    Guid TenantId,
+    Guid? OldPlanPriceId,
+    Guid NewPlanPriceId) : IIntegrationEvent;

--- a/src/Granit.Subscriptions/IPricingResolver.cs
+++ b/src/Granit.Subscriptions/IPricingResolver.cs
@@ -5,16 +5,27 @@ namespace Granit.Subscriptions;
 
 /// <summary>
 /// Resolves unit pricing for invoice line items based on plan configuration.
+/// Supports pinned price resolution for grandfathered subscriptions.
 /// </summary>
 public interface IPricingResolver
 {
-    /// <summary>Resolves the base plan price for a subscription billing cycle.</summary>
+    /// <summary>
+    /// Resolves the base plan price for a subscription billing cycle.
+    /// When <paramref name="planPriceId"/> is provided, returns the pinned price amount directly.
+    /// Otherwise, resolves the current active price from the plan's price catalog.
+    /// </summary>
     Task<decimal> ResolveBasePriceAsync(
         PlanId planId, string currency, BillingInterval interval,
+        Guid? planPriceId = null,
         CancellationToken cancellationToken = default);
 
-    /// <summary>Resolves the per-unit price for usage-based billing.</summary>
+    /// <summary>
+    /// Resolves the per-unit price for usage-based billing.
+    /// When <paramref name="planPriceId"/> is provided, returns the pinned price amount directly.
+    /// Otherwise, resolves the current active price from the plan's price catalog.
+    /// </summary>
     Task<decimal> ResolveUsageUnitPriceAsync(
         PlanId planId, string currency, BillingInterval interval,
-        string meterId, CancellationToken cancellationToken = default);
+        string meterId, Guid? planPriceId = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Subscriptions/ISubscriptionReader.cs
+++ b/src/Granit.Subscriptions/ISubscriptionReader.cs
@@ -29,4 +29,9 @@ public interface ISubscriptionReader
     Task<IReadOnlyList<Subscription>> GetPendingCancelAtPeriodEndAsync(
         DateTimeOffset now,
         CancellationToken cancellationToken = default);
+
+    /// <summary>Returns all active (Active or Trial) subscriptions for a given plan.</summary>
+    Task<IReadOnlyList<Subscription>> GetActiveByPlanAsync(
+        PlanId planId,
+        CancellationToken cancellationToken = default);
 }

--- a/tests/Granit.Subscriptions.Tests/PlanTests.cs
+++ b/tests/Granit.Subscriptions.Tests/PlanTests.cs
@@ -58,7 +58,7 @@ public sealed class PlanTests
             Guid.NewGuid(), "Pro", null,
             PricingModel.Flat, BillingInterval.Monthly);
 
-        var price = PlanPrice.Create(Guid.NewGuid(), 29.99m, "EUR", BillingInterval.Monthly);
+        var price = PlanPrice.Create(Guid.NewGuid(), 29.99m, "EUR", BillingInterval.Monthly, DateTimeOffset.UtcNow);
         plan.AddPrice(price);
 
         plan.Prices.Count.ShouldBe(1);
@@ -73,5 +73,115 @@ public sealed class PlanTests
             PricingModel.Flat, BillingInterval.Monthly);
 
         plan.Prices.ShouldBeAssignableTo<IReadOnlyList<PlanPrice>>();
+    }
+
+    // ── Price versioning tests ────────────────────────────────────
+
+    [Fact]
+    public void AddPriceVersion_OnDraftPlan_ShouldAddPrice()
+    {
+        var plan = Plan.Create(
+            Guid.NewGuid(), "Pro", null,
+            PricingModel.Flat, BillingInterval.Monthly);
+
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        var price = PlanPrice.Create(Guid.NewGuid(), 29.99m, "EUR", BillingInterval.Monthly, now);
+
+        PlanPrice? replaced = plan.AddPriceVersion(price, now);
+
+        replaced.ShouldBeNull();
+        plan.Prices.Count.ShouldBe(1);
+        plan.Prices[0].Amount.ShouldBe(29.99m);
+        plan.Prices[0].IsActive.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AddPriceVersion_OnPublishedPlan_ShouldReplaceExisting()
+    {
+        Plan plan = CreatePublishedPlan("EUR", BillingInterval.Monthly, 29.99m);
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        var newPrice = PlanPrice.Create(Guid.NewGuid(), 39.99m, "EUR", BillingInterval.Monthly, now);
+        PlanPrice? replaced = plan.AddPriceVersion(newPrice, now);
+
+        replaced.ShouldNotBeNull();
+        replaced!.Amount.ShouldBe(29.99m);
+        replaced.IsActive.ShouldBeFalse();
+        replaced.ReplacedByPriceId.ShouldBe(newPrice.Id);
+        replaced.ReplacedAt.ShouldBe(now);
+
+        plan.Prices.Count.ShouldBe(2);
+        plan.GetActivePrice("EUR", BillingInterval.Monthly)!.Amount.ShouldBe(39.99m);
+    }
+
+    [Fact]
+    public void AddPriceVersion_OnArchivedPlan_ShouldThrow()
+    {
+        Plan plan = CreatePublishedPlan("EUR", BillingInterval.Monthly, 29.99m);
+        plan.Archive();
+
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        var newPrice = PlanPrice.Create(Guid.NewGuid(), 39.99m, "EUR", BillingInterval.Monthly, now);
+
+        Should.Throw<InvalidOperationException>(() => plan.AddPriceVersion(newPrice, now));
+    }
+
+    [Fact]
+    public void AddPriceVersion_DifferentCurrency_ShouldNotReplaceExisting()
+    {
+        Plan plan = CreatePublishedPlan("EUR", BillingInterval.Monthly, 29.99m);
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        var usdPrice = PlanPrice.Create(Guid.NewGuid(), 34.99m, "USD", BillingInterval.Monthly, now);
+        PlanPrice? replaced = plan.AddPriceVersion(usdPrice, now);
+
+        replaced.ShouldBeNull();
+        plan.Prices.Count.ShouldBe(2);
+        plan.GetActivePrice("EUR", BillingInterval.Monthly)!.Amount.ShouldBe(29.99m);
+        plan.GetActivePrice("USD", BillingInterval.Monthly)!.Amount.ShouldBe(34.99m);
+    }
+
+    [Fact]
+    public void GetPriceHistory_ShouldReturnNewestFirst()
+    {
+        Plan plan = CreatePublishedPlan("EUR", BillingInterval.Monthly, 29.99m);
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        var v2 = PlanPrice.Create(Guid.NewGuid(), 39.99m, "EUR", BillingInterval.Monthly, now);
+        plan.AddPriceVersion(v2, now);
+
+        DateTimeOffset later = now.AddDays(30);
+        var v3 = PlanPrice.Create(Guid.NewGuid(), 49.99m, "EUR", BillingInterval.Monthly, later);
+        plan.AddPriceVersion(v3, later);
+
+        IReadOnlyList<PlanPrice> history = plan.GetPriceHistory("EUR", BillingInterval.Monthly);
+
+        history.Count.ShouldBe(3);
+        history[0].Amount.ShouldBe(49.99m);
+        history[1].Amount.ShouldBe(39.99m);
+        history[2].Amount.ShouldBe(29.99m);
+    }
+
+    [Fact]
+    public void PlanPrice_MarkReplaced_Twice_ShouldThrow()
+    {
+        var price = PlanPrice.Create(Guid.NewGuid(), 29.99m, "EUR", BillingInterval.Monthly, DateTimeOffset.UtcNow);
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        price.MarkReplaced(Guid.NewGuid(), now);
+
+        Should.Throw<InvalidOperationException>(() => price.MarkReplaced(Guid.NewGuid(), now));
+    }
+
+    private static Plan CreatePublishedPlan(string currency, BillingInterval interval, decimal amount)
+    {
+        var plan = Plan.Create(
+            Guid.NewGuid(), "Pro", null,
+            PricingModel.Flat, interval);
+
+        var price = PlanPrice.Create(Guid.NewGuid(), amount, currency, interval, DateTimeOffset.UtcNow.AddDays(-30));
+        plan.AddPrice(price);
+        plan.Publish();
+        return plan;
     }
 }

--- a/tests/Granit.Subscriptions.Tests/SubscriptionTests.cs
+++ b/tests/Granit.Subscriptions.Tests/SubscriptionTests.cs
@@ -184,4 +184,87 @@ public sealed class SubscriptionTests
     {
         Should.Throw<ArgumentException>(() => SubscriptionId.Create(Guid.Empty));
     }
+
+    // ── Price migration tests ─────────────────────────────────────
+
+    [Fact]
+    public void Create_WithPlanPriceId_ShouldPinPrice()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        Guid priceId = Guid.NewGuid();
+
+        Subscription sub = Subscription.Create(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            PlanId.Create(Guid.NewGuid()),
+            currency: "EUR",
+            periodStart: now,
+            periodEnd: now.AddMonths(1),
+            billingCycleAnchor: now,
+            planPriceId: priceId);
+
+        sub.PlanPriceId.ShouldBe(priceId);
+    }
+
+    [Fact]
+    public void Create_WithoutPlanPriceId_ShouldLeaveNull()
+    {
+        Subscription sub = CreateActiveSubscription();
+
+        sub.PlanPriceId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void MigratePrice_WhenActive_ShouldReturnTrue()
+    {
+        Subscription sub = CreateActiveSubscription();
+        Guid newPriceId = Guid.NewGuid();
+
+        bool result = sub.MigratePrice(newPriceId);
+
+        result.ShouldBeTrue();
+        sub.PlanPriceId.ShouldBe(newPriceId);
+    }
+
+    [Fact]
+    public void MigratePrice_SamePrice_ShouldReturnFalse()
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        Guid priceId = Guid.NewGuid();
+
+        Subscription sub = Subscription.Create(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            PlanId.Create(Guid.NewGuid()),
+            currency: "EUR",
+            periodStart: now,
+            periodEnd: now.AddMonths(1),
+            billingCycleAnchor: now,
+            planPriceId: priceId);
+
+        bool result = sub.MigratePrice(priceId);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void MigratePrice_WhenCancelled_ShouldThrow()
+    {
+        Subscription sub = CreateActiveSubscription();
+        sub.Cancel("done", DateTimeOffset.UtcNow);
+
+        Should.Throw<InvalidOperationException>(() => sub.MigratePrice(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void MigratePrice_FromTrial_ShouldSucceed()
+    {
+        Subscription sub = CreateTrialSubscription();
+        Guid newPriceId = Guid.NewGuid();
+
+        bool result = sub.MigratePrice(newPriceId);
+
+        result.ShouldBeTrue();
+        sub.PlanPriceId.ShouldBe(newPriceId);
+    }
 }


### PR DESCRIPTION
## Summary

- Add price versioning on `PlanPrice` with `EffectiveFrom`, `ReplacedByPriceId`, `ReplacedAt` for full audit trail
- Pin subscriptions to a specific `PlanPriceId` at creation (grandfathering — existing subscribers keep their price when catalog prices change)
- Update `IPricingResolver` and billing handlers to resolve pinned prices with fallback to current active price
- Add 4 new endpoints: create price version, price history, individual + bulk subscription migration
- Add `Subscriptions.Prices.Read/Manage` permissions with 17-culture localization
- 11 new unit tests for plan versioning and subscription migration

Closes #879

## Test plan

- [x] `dotnet build` — full solution compiles (0 errors, 0 warnings)
- [x] `dotnet test tests/Granit.Subscriptions.Tests` — 33/33 pass
- [x] `dotnet test tests/Granit.ArchitectureTests` — 100/100 pass
- [x] `dotnet format style --verify-no-changes` — clean
- [ ] Manual: create price version on Published plan, verify old price marked replaced
- [ ] Manual: create subscription, verify PlanPriceId pinned
- [ ] Manual: bulk migrate subscriptions, verify events published
