### PR TITLE
fix(wolverine): use non-static handler classes for attribute-free discovery

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -6836,6 +6836,38 @@
       ]
     },
     {
+      "name": "IExpiredSessionCleanupService",
+      "fqn": "Granit.Bff.BackgroundJobs.IExpiredSessionCleanupService",
+      "kind": "interface",
+      "project": "Granit.Bff.BackgroundJobs",
+      "file": "src/Granit.Bff.BackgroundJobs/IExpiredSessionCleanupService.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "ExecuteAsync",
+          "kind": "method",
+          "signature": "ExecuteAsync(CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "BffExpiredSessionCleanupHandler",
+      "fqn": "Granit.Bff.BackgroundJobs.Jobs.BffExpiredSessionCleanupHandler",
+      "kind": "class",
+      "project": "Granit.Bff.BackgroundJobs",
+      "file": "src/Granit.Bff.BackgroundJobs/Jobs/BffExpiredSessionCleanupHandler.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(BffExpiredSessionCleanupJob _, IExpiredSessionCleanupService service, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "BffExpiredSessionCleanupJob",
       "fqn": "Granit.Bff.BackgroundJobs.Jobs.BffExpiredSessionCleanupJob",
       "kind": "record",
@@ -7427,6 +7459,22 @@
       ]
     },
     {
+      "name": "OrphanBlobCleanupHandler",
+      "fqn": "Granit.BlobStorage.BackgroundJobs.Jobs.OrphanBlobCleanupHandler",
+      "kind": "class",
+      "project": "Granit.BlobStorage.BackgroundJobs",
+      "file": "src/Granit.BlobStorage.BackgroundJobs/Jobs/OrphanBlobCleanupHandler.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(OrphanBlobCleanupJob _, OrphanBlobCleanupService service, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "OrphanBlobCleanupJob",
       "fqn": "Granit.BlobStorage.BackgroundJobs.Jobs.OrphanBlobCleanupJob",
       "kind": "record",
@@ -7434,6 +7482,22 @@
       "file": "src/Granit.BlobStorage.BackgroundJobs/Jobs/OrphanBlobCleanupJob.cs",
       "line": 10,
       "members": []
+    },
+    {
+      "name": "OrphanBlobCleanupService",
+      "fqn": "Granit.BlobStorage.BackgroundJobs.Services.OrphanBlobCleanupService",
+      "kind": "class",
+      "project": "Granit.BlobStorage.BackgroundJobs",
+      "file": "src/Granit.BlobStorage.BackgroundJobs/Services/OrphanBlobCleanupService.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "ExecuteAsync",
+          "kind": "method",
+          "signature": "ExecuteAsync(CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
     },
     {
       "name": "BlobConfirmationResult",
@@ -8836,6 +8900,22 @@
       "members": []
     },
     {
+      "name": "CreditExpirationScanHandler",
+      "fqn": "Granit.CustomerBalance.BackgroundJobs.Jobs.CreditExpirationScanHandler",
+      "kind": "class",
+      "project": "Granit.CustomerBalance.BackgroundJobs",
+      "file": "src/Granit.CustomerBalance.BackgroundJobs/Jobs/CreditExpirationScanHandler.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(CreditExpirationScanJob _, ICreditExpirationService creditExpirationService, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "CreditExpirationScanJob",
       "fqn": "Granit.CustomerBalance.BackgroundJobs.Jobs.CreditExpirationScanJob",
       "kind": "record",
@@ -9303,7 +9383,7 @@
       "kind": "class",
       "project": "Granit.CustomerBalance.Wolverine",
       "file": "src/Granit.CustomerBalance.Wolverine/Handlers/OverpaymentCreditHandler.cs",
-      "line": 11,
+      "line": 10,
       "members": [
         {
           "name": "HandleAsync",
@@ -18522,6 +18602,22 @@
       ]
     },
     {
+      "name": "OverdueInvoiceDetectionHandler",
+      "fqn": "Granit.Invoicing.BackgroundJobs.Jobs.OverdueInvoiceDetectionHandler",
+      "kind": "class",
+      "project": "Granit.Invoicing.BackgroundJobs",
+      "file": "src/Granit.Invoicing.BackgroundJobs/Jobs/OverdueInvoiceDetectionHandler.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(OverdueInvoiceDetectionJob _, IOverdueInvoiceDetectionService detectionService, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "OverdueInvoiceDetectionJob",
       "fqn": "Granit.Invoicing.BackgroundJobs.Jobs.OverdueInvoiceDetectionJob",
       "kind": "record",
@@ -19621,7 +19717,7 @@
       "kind": "class",
       "project": "Granit.Invoicing.Wolverine",
       "file": "src/Granit.Invoicing.Wolverine/Handlers/CreateInvoiceHandler.cs",
-      "line": 12,
+      "line": 11,
       "members": [
         {
           "name": "HandleAsync",
@@ -20698,6 +20794,22 @@
       ]
     },
     {
+      "name": "MeteringAggregationHandler",
+      "fqn": "Granit.Metering.BackgroundJobs.Jobs.MeteringAggregationHandler",
+      "kind": "class",
+      "project": "Granit.Metering.BackgroundJobs",
+      "file": "src/Granit.Metering.BackgroundJobs/Jobs/MeteringAggregationHandler.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(MeteringAggregationJob _, MeteringAggregationScanner scanner, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "MeteringAggregationJob",
       "fqn": "Granit.Metering.BackgroundJobs.Jobs.MeteringAggregationJob",
       "kind": "record",
@@ -20707,6 +20819,22 @@
       "members": []
     },
     {
+      "name": "QuotaThresholdCheckHandler",
+      "fqn": "Granit.Metering.BackgroundJobs.Jobs.QuotaThresholdCheckHandler",
+      "kind": "class",
+      "project": "Granit.Metering.BackgroundJobs",
+      "file": "src/Granit.Metering.BackgroundJobs/Jobs/QuotaThresholdCheckHandler.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(QuotaThresholdCheckJob _, QuotaThresholdScanner scanner, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "QuotaThresholdCheckJob",
       "fqn": "Granit.Metering.BackgroundJobs.Jobs.QuotaThresholdCheckJob",
       "kind": "record",
@@ -20714,6 +20842,38 @@
       "file": "src/Granit.Metering.BackgroundJobs/Jobs/QuotaThresholdCheckJob.cs",
       "line": 10,
       "members": []
+    },
+    {
+      "name": "MeteringAggregationScanner",
+      "fqn": "Granit.Metering.BackgroundJobs.Services.MeteringAggregationScanner",
+      "kind": "class",
+      "project": "Granit.Metering.BackgroundJobs",
+      "file": "src/Granit.Metering.BackgroundJobs/Services/MeteringAggregationScanner.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "RunAsync",
+          "kind": "method",
+          "signature": "RunAsync(CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "QuotaThresholdScanner",
+      "fqn": "Granit.Metering.BackgroundJobs.Services.QuotaThresholdScanner",
+      "kind": "class",
+      "project": "Granit.Metering.BackgroundJobs",
+      "file": "src/Granit.Metering.BackgroundJobs/Services/QuotaThresholdScanner.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "ScanAsync",
+          "kind": "method",
+          "signature": "ScanAsync(CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
     },
     {
       "name": "MeteringMetrics",
@@ -25091,6 +25251,22 @@
       ]
     },
     {
+      "name": "OpenIddictIdleSessionEnforcementHandler",
+      "fqn": "Granit.OpenIddict.BackgroundJobs.Jobs.OpenIddictIdleSessionEnforcementHandler",
+      "kind": "class",
+      "project": "Granit.OpenIddict.BackgroundJobs",
+      "file": "src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictIdleSessionEnforcementHandler.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(OpenIddictIdleSessionEnforcementJob _, IdleSessionEnforcementService service, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "OpenIddictIdleSessionEnforcementJob",
       "fqn": "Granit.OpenIddict.BackgroundJobs.Jobs.OpenIddictIdleSessionEnforcementJob",
       "kind": "record",
@@ -25098,6 +25274,22 @@
       "file": "src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictIdleSessionEnforcementJob.cs",
       "line": 14,
       "members": []
+    },
+    {
+      "name": "OpenIddictKeyRotationHandler",
+      "fqn": "Granit.OpenIddict.BackgroundJobs.Jobs.OpenIddictKeyRotationHandler",
+      "kind": "class",
+      "project": "Granit.OpenIddict.BackgroundJobs",
+      "file": "src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictKeyRotationHandler.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(OpenIddictKeyRotationJob _, KeyRotationExecutionService service, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
     },
     {
       "name": "OpenIddictKeyRotationJob",
@@ -25109,6 +25301,22 @@
       "members": []
     },
     {
+      "name": "OpenIddictTokenCleanupHandler",
+      "fqn": "Granit.OpenIddict.BackgroundJobs.Jobs.OpenIddictTokenCleanupHandler",
+      "kind": "class",
+      "project": "Granit.OpenIddict.BackgroundJobs",
+      "file": "src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictTokenCleanupHandler.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(OpenIddictTokenCleanupJob _, TokenCleanupService service, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "OpenIddictTokenCleanupJob",
       "fqn": "Granit.OpenIddict.BackgroundJobs.Jobs.OpenIddictTokenCleanupJob",
       "kind": "record",
@@ -25116,6 +25324,54 @@
       "file": "src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictTokenCleanupJob.cs",
       "line": 13,
       "members": []
+    },
+    {
+      "name": "IdleSessionEnforcementService",
+      "fqn": "Granit.OpenIddict.BackgroundJobs.Services.IdleSessionEnforcementService",
+      "kind": "class",
+      "project": "Granit.OpenIddict.BackgroundJobs",
+      "file": "src/Granit.OpenIddict.BackgroundJobs/Services/IdleSessionEnforcementService.cs",
+      "line": 25,
+      "members": [
+        {
+          "name": "ExecuteAsync",
+          "kind": "method",
+          "signature": "ExecuteAsync(CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "KeyRotationExecutionService",
+      "fqn": "Granit.OpenIddict.BackgroundJobs.Services.KeyRotationExecutionService",
+      "kind": "class",
+      "project": "Granit.OpenIddict.BackgroundJobs",
+      "file": "src/Granit.OpenIddict.BackgroundJobs/Services/KeyRotationExecutionService.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "ExecuteAsync",
+          "kind": "method",
+          "signature": "ExecuteAsync(CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "TokenCleanupService",
+      "fqn": "Granit.OpenIddict.BackgroundJobs.Services.TokenCleanupService",
+      "kind": "class",
+      "project": "Granit.OpenIddict.BackgroundJobs",
+      "file": "src/Granit.OpenIddict.BackgroundJobs/Services/TokenCleanupService.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "ExecuteAsync",
+          "kind": "method",
+          "signature": "ExecuteAsync(CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
     },
     {
       "name": "OpenIddictMetrics",
@@ -27686,7 +27942,7 @@
       "kind": "class",
       "project": "Granit.Payments.Wolverine",
       "file": "src/Granit.Payments.Wolverine/GranitPaymentsWolverineModule.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "ConfigureServices",
@@ -27702,7 +27958,7 @@
       "kind": "class",
       "project": "Granit.Payments.Wolverine",
       "file": "src/Granit.Payments.Wolverine/Handlers/AutoChargeOnInvoiceHandler.cs",
-      "line": 11,
+      "line": 10,
       "members": [
         {
           "name": "HandleAsync",
@@ -27718,7 +27974,7 @@
       "kind": "class",
       "project": "Granit.Payments.Wolverine",
       "file": "src/Granit.Payments.Wolverine/Handlers/ProcessWebhookCommandHandler.cs",
-      "line": 11,
+      "line": 10,
       "members": [
         {
           "name": "HandleAsync",
@@ -27730,10 +27986,10 @@
     },
     {
       "name": "AutoChargeService",
-      "fqn": "Granit.Payments.Wolverine.Internal.AutoChargeService",
+      "fqn": "Granit.Payments.Wolverine.Services.AutoChargeService",
       "kind": "class",
       "project": "Granit.Payments.Wolverine",
-      "file": "src/Granit.Payments.Wolverine/Internal/AutoChargeService.cs",
+      "file": "src/Granit.Payments.Wolverine/Services/AutoChargeService.cs",
       "line": 18,
       "members": [
         {
@@ -27746,10 +28002,10 @@
     },
     {
       "name": "WebhookProcessor",
-      "fqn": "Granit.Payments.Wolverine.Internal.WebhookProcessor",
+      "fqn": "Granit.Payments.Wolverine.Services.WebhookProcessor",
       "kind": "class",
       "project": "Granit.Payments.Wolverine",
-      "file": "src/Granit.Payments.Wolverine/Internal/WebhookProcessor.cs",
+      "file": "src/Granit.Payments.Wolverine/Services/WebhookProcessor.cs",
       "line": 13,
       "members": [
         {
@@ -29026,6 +29282,22 @@
       ]
     },
     {
+      "name": "DeletionDeadlineEnforcerHandler",
+      "fqn": "Granit.Privacy.BackgroundJobs.Jobs.DeletionDeadlineEnforcerHandler",
+      "kind": "class",
+      "project": "Granit.Privacy.BackgroundJobs",
+      "file": "src/Granit.Privacy.BackgroundJobs/Jobs/DeletionDeadlineEnforcerHandler.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(DeletionDeadlineEnforcerJob _, DeletionDeadlineEnforcementService service, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "DeletionDeadlineEnforcerJob",
       "fqn": "Granit.Privacy.BackgroundJobs.Jobs.DeletionDeadlineEnforcerJob",
       "kind": "record",
@@ -29033,6 +29305,22 @@
       "file": "src/Granit.Privacy.BackgroundJobs/Jobs/DeletionDeadlineEnforcerJob.cs",
       "line": 11,
       "members": []
+    },
+    {
+      "name": "DeletionDeadlineEnforcementService",
+      "fqn": "Granit.Privacy.BackgroundJobs.Services.DeletionDeadlineEnforcementService",
+      "kind": "class",
+      "project": "Granit.Privacy.BackgroundJobs",
+      "file": "src/Granit.Privacy.BackgroundJobs/Services/DeletionDeadlineEnforcementService.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "ExecuteAsync",
+          "kind": "method",
+          "signature": "ExecuteAsync(CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
     },
     {
       "name": "DeletionAction",
@@ -32210,6 +32498,22 @@
       ]
     },
     {
+      "name": "SchedulingCatchUpHandler",
+      "fqn": "Granit.Scheduling.BackgroundJobs.Jobs.SchedulingCatchUpHandler",
+      "kind": "class",
+      "project": "Granit.Scheduling.BackgroundJobs",
+      "file": "src/Granit.Scheduling.BackgroundJobs/Jobs/SchedulingCatchUpHandler.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(SchedulingCatchUpJob _, CatchUpDispatcher dispatcher, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "SchedulingCatchUpJob",
       "fqn": "Granit.Scheduling.BackgroundJobs.Jobs.SchedulingCatchUpJob",
       "kind": "record",
@@ -32217,6 +32521,22 @@
       "file": "src/Granit.Scheduling.BackgroundJobs/Jobs/SchedulingCatchUpJob.cs",
       "line": 20,
       "members": []
+    },
+    {
+      "name": "CatchUpDispatcher",
+      "fqn": "Granit.Scheduling.BackgroundJobs.Services.CatchUpDispatcher",
+      "kind": "class",
+      "project": "Granit.Scheduling.BackgroundJobs",
+      "file": "src/Granit.Scheduling.BackgroundJobs/Services/CatchUpDispatcher.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "DispatchOverdueActionsAsync",
+          "kind": "method",
+          "signature": "DispatchOverdueActionsAsync(CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
     },
     {
       "name": "SchedulingMetrics",
@@ -33395,6 +33715,22 @@
       ]
     },
     {
+      "name": "CancelAtPeriodEndScanHandler",
+      "fqn": "Granit.Subscriptions.BackgroundJobs.Jobs.CancelAtPeriodEndScanHandler",
+      "kind": "class",
+      "project": "Granit.Subscriptions.BackgroundJobs",
+      "file": "src/Granit.Subscriptions.BackgroundJobs/Jobs/CancelAtPeriodEndScanHandler.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(CancelAtPeriodEndScanJob _, ICancelAtPeriodEndService cancelAtPeriodEndService, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "CancelAtPeriodEndScanJob",
       "fqn": "Granit.Subscriptions.BackgroundJobs.Jobs.CancelAtPeriodEndScanJob",
       "kind": "record",
@@ -33402,6 +33738,22 @@
       "file": "src/Granit.Subscriptions.BackgroundJobs/Jobs/CancelAtPeriodEndScanJob.cs",
       "line": 10,
       "members": []
+    },
+    {
+      "name": "PeriodEndScanHandler",
+      "fqn": "Granit.Subscriptions.BackgroundJobs.Jobs.PeriodEndScanHandler",
+      "kind": "class",
+      "project": "Granit.Subscriptions.BackgroundJobs",
+      "file": "src/Granit.Subscriptions.BackgroundJobs/Jobs/PeriodEndScanHandler.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(PeriodEndScanJob _, IPeriodAdvancementService periodAdvancementService, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
     },
     {
       "name": "PeriodEndScanJob",
@@ -33413,6 +33765,22 @@
       "members": []
     },
     {
+      "name": "TrialExpirationScanHandler",
+      "fqn": "Granit.Subscriptions.BackgroundJobs.Jobs.TrialExpirationScanHandler",
+      "kind": "class",
+      "project": "Granit.Subscriptions.BackgroundJobs",
+      "file": "src/Granit.Subscriptions.BackgroundJobs/Jobs/TrialExpirationScanHandler.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(TrialExpirationScanJob _, TrialExpirationScanner scanner, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "TrialExpirationScanJob",
       "fqn": "Granit.Subscriptions.BackgroundJobs.Jobs.TrialExpirationScanJob",
       "kind": "record",
@@ -33420,6 +33788,22 @@
       "file": "src/Granit.Subscriptions.BackgroundJobs/Jobs/TrialExpirationScanJob.cs",
       "line": 9,
       "members": []
+    },
+    {
+      "name": "TrialExpirationScanner",
+      "fqn": "Granit.Subscriptions.BackgroundJobs.Services.TrialExpirationScanner",
+      "kind": "class",
+      "project": "Granit.Subscriptions.BackgroundJobs",
+      "file": "src/Granit.Subscriptions.BackgroundJobs/Services/TrialExpirationScanner.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "ScanAsync",
+          "kind": "method",
+          "signature": "ScanAsync(CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
     },
     {
       "name": "SubscriptionWorkflows",
@@ -34768,7 +35152,7 @@
       "kind": "class",
       "project": "Granit.Subscriptions.Wolverine",
       "file": "src/Granit.Subscriptions.Wolverine/Handlers/BillingCycleCompletedHandler.cs",
-      "line": 12,
+      "line": 11,
       "members": [
         {
           "name": "HandleAsync",
@@ -34784,7 +35168,7 @@
       "kind": "class",
       "project": "Granit.Subscriptions.Wolverine",
       "file": "src/Granit.Subscriptions.Wolverine/Handlers/InvoicePaidHandler.cs",
-      "line": 11,
+      "line": 10,
       "members": [
         {
           "name": "HandleAsync",
@@ -34800,7 +35184,7 @@
       "kind": "class",
       "project": "Granit.Subscriptions.Wolverine",
       "file": "src/Granit.Subscriptions.Wolverine/Handlers/PaymentFailedHandler.cs",
-      "line": 10,
+      "line": 9,
       "members": [
         {
           "name": "HandleAsync",
@@ -34816,7 +35200,7 @@
       "kind": "class",
       "project": "Granit.Subscriptions.Wolverine",
       "file": "src/Granit.Subscriptions.Wolverine/Handlers/RetryPaymentHandler.cs",
-      "line": 12,
+      "line": 11,
       "members": [
         {
           "name": "HandleAsync",
@@ -34832,7 +35216,7 @@
       "kind": "class",
       "project": "Granit.Subscriptions.Wolverine",
       "file": "src/Granit.Subscriptions.Wolverine/Handlers/SubscriptionProviderSyncHandler.cs",
-      "line": 11,
+      "line": 10,
       "members": [
         {
           "name": "HandleAsync",
@@ -34848,7 +35232,7 @@
       "kind": "class",
       "project": "Granit.Subscriptions.Wolverine",
       "file": "src/Granit.Subscriptions.Wolverine/Handlers/UsageSummaryReadyHandler.cs",
-      "line": 12,
+      "line": 11,
       "members": [
         {
           "name": "HandleAsync",
@@ -34860,10 +35244,10 @@
     },
     {
       "name": "BillingCycleInvoiceOrchestrator",
-      "fqn": "Granit.Subscriptions.Wolverine.Internal.BillingCycleInvoiceOrchestrator",
+      "fqn": "Granit.Subscriptions.Wolverine.Services.BillingCycleInvoiceOrchestrator",
       "kind": "class",
       "project": "Granit.Subscriptions.Wolverine",
-      "file": "src/Granit.Subscriptions.Wolverine/Internal/BillingCycleInvoiceOrchestrator.cs",
+      "file": "src/Granit.Subscriptions.Wolverine/Services/BillingCycleInvoiceOrchestrator.cs",
       "line": 13,
       "members": [
         {
@@ -34876,10 +35260,10 @@
     },
     {
       "name": "PaymentRetryDispatcher",
-      "fqn": "Granit.Subscriptions.Wolverine.Internal.PaymentRetryDispatcher",
+      "fqn": "Granit.Subscriptions.Wolverine.Services.PaymentRetryDispatcher",
       "kind": "class",
       "project": "Granit.Subscriptions.Wolverine",
-      "file": "src/Granit.Subscriptions.Wolverine/Internal/PaymentRetryDispatcher.cs",
+      "file": "src/Granit.Subscriptions.Wolverine/Services/PaymentRetryDispatcher.cs",
       "line": 11,
       "members": [
         {
@@ -34892,10 +35276,10 @@
     },
     {
       "name": "UsageInvoiceOrchestrator",
-      "fqn": "Granit.Subscriptions.Wolverine.Internal.UsageInvoiceOrchestrator",
+      "fqn": "Granit.Subscriptions.Wolverine.Services.UsageInvoiceOrchestrator",
       "kind": "class",
       "project": "Granit.Subscriptions.Wolverine",
-      "file": "src/Granit.Subscriptions.Wolverine/Internal/UsageInvoiceOrchestrator.cs",
+      "file": "src/Granit.Subscriptions.Wolverine/Services/UsageInvoiceOrchestrator.cs",
       "line": 13,
       "members": [
         {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,10 +189,13 @@ Two suffixes — enforced by architecture tests:
 ### Wolverine handler visibility — CRITICAL
 
 Wolverine discovers handlers via `Assembly.ExportedTypes` (public types only).
-`InternalsVisibleTo("WolverineHandlers")` only helps code-gen **after** discovery.
+`static class` types are additionally skipped unless decorated with
+`[WolverineHandler]`, which creates an unwanted dependency on WolverineFx.
 
-- **Handlers MUST be `public static partial class`** — `internal` handlers are invisible
-  to Wolverine and silently dropped ("No routes can be determined").
+- **Handlers MUST be `public class` (non-static) with `public static` Handle methods.**
+  This ensures discovery without any attribute or WolverineFx dependency.
+- NEVER use `public static class` — requires `[WolverineHandler]` to be discovered.
+- NEVER use `internal` — invisible to `Assembly.ExportedTypes`.
 - If a handler injects an `internal` service, make the service `public` or extract an
   interface. Never make the handler `internal` to match the service visibility.
 - Background job handlers follow the same rule.

--- a/src/Granit.Authorization/Cache/PermissionCacheInvalidationHandler.cs
+++ b/src/Granit.Authorization/Cache/PermissionCacheInvalidationHandler.cs
@@ -22,7 +22,7 @@ namespace Granit.Authorization.Cache;
 /// "denied" entry is safe if the factory fails.
 /// </para>
 /// </remarks>
-public static class PermissionCacheInvalidationHandler
+public class PermissionCacheInvalidationHandler
 {
     /// <summary>
     /// Invalidates the cached permission grant entry for the changed role and tenant scope.

--- a/src/Granit.Bff.BackgroundJobs/GranitBffBackgroundJobsModule.cs
+++ b/src/Granit.Bff.BackgroundJobs/GranitBffBackgroundJobsModule.cs
@@ -18,5 +18,5 @@ public sealed class GranitBffBackgroundJobsModule : GranitModule
 {
     /// <inheritdoc/>
     public override void ConfigureServices(ServiceConfigurationContext context) =>
-        context.Services.TryAddTransient<ExpiredSessionCleanupService>();
+        context.Services.TryAddTransient<IExpiredSessionCleanupService, ExpiredSessionCleanupService>();
 }

--- a/src/Granit.Bff.BackgroundJobs/IExpiredSessionCleanupService.cs
+++ b/src/Granit.Bff.BackgroundJobs/IExpiredSessionCleanupService.cs
@@ -1,0 +1,10 @@
+namespace Granit.Bff.BackgroundJobs;
+
+/// <summary>
+/// Purges expired BFF sessions from the database.
+/// </summary>
+public interface IExpiredSessionCleanupService
+{
+    /// <summary>Deletes all sessions past their expiration time.</summary>
+    Task ExecuteAsync(CancellationToken cancellationToken);
+}

--- a/src/Granit.Bff.BackgroundJobs/Internal/ExpiredSessionCleanupService.cs
+++ b/src/Granit.Bff.BackgroundJobs/Internal/ExpiredSessionCleanupService.cs
@@ -11,7 +11,7 @@ namespace Granit.Bff.BackgroundJobs.Internal;
 internal sealed partial class ExpiredSessionCleanupService(
     IDbContextFactory<BffDbContext> dbContextFactory,
     IClock clock,
-    ILogger<ExpiredSessionCleanupService> logger)
+    ILogger<ExpiredSessionCleanupService> logger) : IExpiredSessionCleanupService
 {
     public async Task ExecuteAsync(CancellationToken cancellationToken)
     {

--- a/src/Granit.Bff.BackgroundJobs/Jobs/BffExpiredSessionCleanupHandler.cs
+++ b/src/Granit.Bff.BackgroundJobs/Jobs/BffExpiredSessionCleanupHandler.cs
@@ -1,16 +1,14 @@
-using Granit.Bff.BackgroundJobs.Internal;
-
 namespace Granit.Bff.BackgroundJobs.Jobs;
 
 /// <summary>
 /// Handler for <see cref="BffExpiredSessionCleanupJob"/>. Delegates to
-/// <see cref="ExpiredSessionCleanupService"/> for session purge logic.
+/// <see cref="IExpiredSessionCleanupService"/> for session purge logic.
 /// </summary>
-internal static class BffExpiredSessionCleanupHandler
+public class BffExpiredSessionCleanupHandler
 {
     public static Task HandleAsync(
         BffExpiredSessionCleanupJob _,
-        ExpiredSessionCleanupService service,
+        IExpiredSessionCleanupService service,
         CancellationToken cancellationToken) =>
         service.ExecuteAsync(cancellationToken);
 }

--- a/src/Granit.BlobStorage.BackgroundJobs/GranitBlobStorageBackgroundJobsModule.cs
+++ b/src/Granit.BlobStorage.BackgroundJobs/GranitBlobStorageBackgroundJobsModule.cs
@@ -1,5 +1,5 @@
 using Granit.BackgroundJobs;
-using Granit.BlobStorage.BackgroundJobs.Internal;
+using Granit.BlobStorage.BackgroundJobs.Services;
 using Granit.Modularity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/Granit.BlobStorage.BackgroundJobs/Jobs/OrphanBlobCleanupHandler.cs
+++ b/src/Granit.BlobStorage.BackgroundJobs/Jobs/OrphanBlobCleanupHandler.cs
@@ -1,4 +1,4 @@
-using Granit.BlobStorage.BackgroundJobs.Internal;
+using Granit.BlobStorage.BackgroundJobs.Services;
 
 namespace Granit.BlobStorage.BackgroundJobs.Jobs;
 
@@ -6,7 +6,7 @@ namespace Granit.BlobStorage.BackgroundJobs.Jobs;
 /// Handler for <see cref="OrphanBlobCleanupJob"/>. Delegates to
 /// <see cref="OrphanBlobCleanupService"/> for orphan blob cleanup logic.
 /// </summary>
-internal static class OrphanBlobCleanupHandler
+public class OrphanBlobCleanupHandler
 {
     public static Task HandleAsync(
         OrphanBlobCleanupJob _,

--- a/src/Granit.BlobStorage.BackgroundJobs/Services/OrphanBlobCleanupService.cs
+++ b/src/Granit.BlobStorage.BackgroundJobs/Services/OrphanBlobCleanupService.cs
@@ -1,11 +1,11 @@
 using Microsoft.Extensions.Logging;
 
-namespace Granit.BlobStorage.BackgroundJobs.Internal;
+namespace Granit.BlobStorage.BackgroundJobs.Services;
 
 /// <summary>
 /// Cleans up blobs stuck in Pending/Uploading for over 24 hours.
 /// </summary>
-internal sealed partial class OrphanBlobCleanupService(
+public sealed partial class OrphanBlobCleanupService(
     IBlobStorage blobStorage,
     ILogger<OrphanBlobCleanupService> logger)
 {

--- a/src/Granit.CustomerBalance.BackgroundJobs/Jobs/CreditExpirationScanHandler.cs
+++ b/src/Granit.CustomerBalance.BackgroundJobs/Jobs/CreditExpirationScanHandler.cs
@@ -4,7 +4,7 @@ namespace Granit.CustomerBalance.BackgroundJobs.Jobs;
 /// Handler for <see cref="CreditExpirationScanJob"/>. Delegates to
 /// <see cref="ICreditExpirationService"/> for expired promotional credit processing.
 /// </summary>
-internal static class CreditExpirationScanHandler
+public class CreditExpirationScanHandler
 {
     public static async Task HandleAsync(
         CreditExpirationScanJob _,

--- a/src/Granit.CustomerBalance.Wolverine/Handlers/OverpaymentCreditHandler.cs
+++ b/src/Granit.CustomerBalance.Wolverine/Handlers/OverpaymentCreditHandler.cs
@@ -7,8 +7,7 @@ namespace Granit.CustomerBalance.Wolverine.Handlers;
 /// Credits overpayment surplus to the tenant's balance account.
 /// Delegates to <see cref="IOverpaymentCreditService"/>.
 /// </summary>
-[global::Wolverine.Attributes.WolverineHandler]
-public static class OverpaymentCreditHandler
+public class OverpaymentCreditHandler
 {
     public static async Task HandleAsync(
         OverpaymentDetectedEto eto,

--- a/src/Granit.Features/Cache/FeatureCacheInvalidationHandler.cs
+++ b/src/Granit.Features/Cache/FeatureCacheInvalidationHandler.cs
@@ -13,7 +13,7 @@ namespace Granit.Features.Cache;
 /// Additional parameters are resolved from the application's DI container.
 /// No WolverineFx package reference is required in this project.
 /// </remarks>
-public static class FeatureCacheInvalidationHandler
+public class FeatureCacheInvalidationHandler
 {
     /// <summary>
     /// Expires the cached resolved-value entry for the changed feature and tenant scope.

--- a/src/Granit.Invoicing.BackgroundJobs/Jobs/OverdueInvoiceDetectionHandler.cs
+++ b/src/Granit.Invoicing.BackgroundJobs/Jobs/OverdueInvoiceDetectionHandler.cs
@@ -6,7 +6,7 @@ namespace Granit.Invoicing.BackgroundJobs.Jobs;
 /// Handler for <see cref="OverdueInvoiceDetectionJob"/>. Delegates to
 /// <see cref="IOverdueInvoiceDetectionService"/> for overdue invoice detection.
 /// </summary>
-internal static class OverdueInvoiceDetectionHandler
+public class OverdueInvoiceDetectionHandler
 {
     public static async Task HandleAsync(
         OverdueInvoiceDetectionJob _,

--- a/src/Granit.Invoicing.Wolverine/Handlers/CreateInvoiceHandler.cs
+++ b/src/Granit.Invoicing.Wolverine/Handlers/CreateInvoiceHandler.cs
@@ -8,8 +8,7 @@ namespace Granit.Invoicing.Wolverine.Handlers;
 /// <see cref="IInvoiceCreationService"/> for invoice creation, tax calculation,
 /// and finalization.
 /// </summary>
-[global::Wolverine.Attributes.WolverineHandler]
-public static class CreateInvoiceHandler
+public class CreateInvoiceHandler
 {
     public static async Task HandleAsync(
         CreateInvoiceCommand command,

--- a/src/Granit.Metering.BackgroundJobs/GranitMeteringBackgroundJobsModule.cs
+++ b/src/Granit.Metering.BackgroundJobs/GranitMeteringBackgroundJobsModule.cs
@@ -1,5 +1,5 @@
 using Granit.BackgroundJobs;
-using Granit.Metering.BackgroundJobs.Internal;
+using Granit.Metering.BackgroundJobs.Services;
 using Granit.Modularity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/Granit.Metering.BackgroundJobs/Jobs/MeteringAggregationHandler.cs
+++ b/src/Granit.Metering.BackgroundJobs/Jobs/MeteringAggregationHandler.cs
@@ -1,4 +1,4 @@
-using Granit.Metering.BackgroundJobs.Internal;
+using Granit.Metering.BackgroundJobs.Services;
 
 namespace Granit.Metering.BackgroundJobs.Jobs;
 
@@ -6,7 +6,7 @@ namespace Granit.Metering.BackgroundJobs.Jobs;
 /// Handler for <see cref="MeteringAggregationJob"/>. Delegates to
 /// <see cref="MeteringAggregationScanner"/> for aggregation orchestration.
 /// </summary>
-internal static class MeteringAggregationHandler
+public class MeteringAggregationHandler
 {
     public static async Task HandleAsync(
         MeteringAggregationJob _,

--- a/src/Granit.Metering.BackgroundJobs/Jobs/QuotaThresholdCheckHandler.cs
+++ b/src/Granit.Metering.BackgroundJobs/Jobs/QuotaThresholdCheckHandler.cs
@@ -1,4 +1,4 @@
-using Granit.Metering.BackgroundJobs.Internal;
+using Granit.Metering.BackgroundJobs.Services;
 
 namespace Granit.Metering.BackgroundJobs.Jobs;
 
@@ -6,7 +6,7 @@ namespace Granit.Metering.BackgroundJobs.Jobs;
 /// Handler for <see cref="QuotaThresholdCheckJob"/>. Delegates to
 /// <see cref="QuotaThresholdScanner"/> for quota detection and event publishing.
 /// </summary>
-internal static class QuotaThresholdCheckHandler
+public class QuotaThresholdCheckHandler
 {
     public static async Task HandleAsync(
         QuotaThresholdCheckJob _,

--- a/src/Granit.Metering.BackgroundJobs/Services/MeteringAggregationScanner.cs
+++ b/src/Granit.Metering.BackgroundJobs/Services/MeteringAggregationScanner.cs
@@ -1,13 +1,13 @@
 using Granit.Timing;
 using Microsoft.Extensions.Logging;
 
-namespace Granit.Metering.BackgroundJobs.Internal;
+namespace Granit.Metering.BackgroundJobs.Services;
 
 /// <summary>
 /// Orchestrates metering aggregation by delegating to <see cref="IAggregationRunner"/>
 /// with structured logging around the operation.
 /// </summary>
-internal sealed partial class MeteringAggregationScanner(
+public sealed partial class MeteringAggregationScanner(
     IAggregationRunner aggregationRunner,
     IClock clock,
     ILogger<MeteringAggregationScanner> logger)

--- a/src/Granit.Metering.BackgroundJobs/Services/QuotaThresholdScanner.cs
+++ b/src/Granit.Metering.BackgroundJobs/Services/QuotaThresholdScanner.cs
@@ -11,13 +11,13 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Wolverine;
 
-namespace Granit.Metering.BackgroundJobs.Internal;
+namespace Granit.Metering.BackgroundJobs.Services;
 
 /// <summary>
 /// Scans all active meter definitions across tenants, checks current usage
 /// against quotas, and publishes threshold or exceeded integration events.
 /// </summary>
-internal sealed partial class QuotaThresholdScanner(
+public sealed partial class QuotaThresholdScanner(
     IMeterDefinitionReader definitionReader,
     IQuotaChecker quotaChecker,
     ICurrentTenant currentTenant,

--- a/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
+++ b/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
@@ -286,6 +286,12 @@ internal sealed partial class EmailNotificationChannel(
         Dictionary<string, object?> dataDict = JsonElementToDictionary(context.Data);
         EnrichModelData(dataDict, context, enrichment);
 
+        // Inject title extracted from the rendered content template for {{ model.title }} in layout
+        if (contentEmail.Subject is not null)
+        {
+            dataDict["title"] = contentEmail.Subject;
+        }
+
         // Inject body as ExtraVariable for {{ body | raw }} in layout
         TemplateDescriptor layoutWithBody = new()
         {

--- a/src/Granit.OpenIddict.BackgroundJobs/GranitOpenIddictBackgroundJobsModule.cs
+++ b/src/Granit.OpenIddict.BackgroundJobs/GranitOpenIddictBackgroundJobsModule.cs
@@ -1,7 +1,7 @@
 using Granit.BackgroundJobs;
 using Granit.Caching;
 using Granit.Modularity;
-using Granit.OpenIddict.BackgroundJobs.Internal;
+using Granit.OpenIddict.BackgroundJobs.Services;
 using Granit.Settings;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictIdleSessionEnforcementHandler.cs
+++ b/src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictIdleSessionEnforcementHandler.cs
@@ -1,4 +1,4 @@
-using Granit.OpenIddict.BackgroundJobs.Internal;
+using Granit.OpenIddict.BackgroundJobs.Services;
 
 namespace Granit.OpenIddict.BackgroundJobs.Jobs;
 
@@ -6,7 +6,7 @@ namespace Granit.OpenIddict.BackgroundJobs.Jobs;
 /// Handler for <see cref="OpenIddictIdleSessionEnforcementJob"/>. Delegates to
 /// <see cref="IdleSessionEnforcementService"/> for idle session revocation logic.
 /// </summary>
-internal static class OpenIddictIdleSessionEnforcementHandler
+public class OpenIddictIdleSessionEnforcementHandler
 {
     public static Task HandleAsync(
         OpenIddictIdleSessionEnforcementJob _,

--- a/src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictKeyRotationHandler.cs
+++ b/src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictKeyRotationHandler.cs
@@ -1,4 +1,4 @@
-using Granit.OpenIddict.BackgroundJobs.Internal;
+using Granit.OpenIddict.BackgroundJobs.Services;
 
 namespace Granit.OpenIddict.BackgroundJobs.Jobs;
 
@@ -6,7 +6,7 @@ namespace Granit.OpenIddict.BackgroundJobs.Jobs;
 /// Handler for <see cref="OpenIddictKeyRotationJob"/>. Delegates to
 /// <see cref="KeyRotationExecutionService"/> for signing key rotation logic.
 /// </summary>
-internal static class OpenIddictKeyRotationHandler
+public class OpenIddictKeyRotationHandler
 {
     public static Task HandleAsync(
         OpenIddictKeyRotationJob _,

--- a/src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictTokenCleanupHandler.cs
+++ b/src/Granit.OpenIddict.BackgroundJobs/Jobs/OpenIddictTokenCleanupHandler.cs
@@ -1,4 +1,4 @@
-using Granit.OpenIddict.BackgroundJobs.Internal;
+using Granit.OpenIddict.BackgroundJobs.Services;
 
 namespace Granit.OpenIddict.BackgroundJobs.Jobs;
 
@@ -6,7 +6,7 @@ namespace Granit.OpenIddict.BackgroundJobs.Jobs;
 /// Handler for <see cref="OpenIddictTokenCleanupJob"/>. Delegates to
 /// <see cref="TokenCleanupService"/> for token and authorization pruning.
 /// </summary>
-internal static class OpenIddictTokenCleanupHandler
+public class OpenIddictTokenCleanupHandler
 {
     public static Task HandleAsync(
         OpenIddictTokenCleanupJob _,

--- a/src/Granit.OpenIddict.BackgroundJobs/Services/IdleSessionEnforcementService.cs
+++ b/src/Granit.OpenIddict.BackgroundJobs/Services/IdleSessionEnforcementService.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 using OpenIddict.Abstractions;
 using ZiggyCreatures.Caching.Fusion;
 
-namespace Granit.OpenIddict.BackgroundJobs.Internal;
+namespace Granit.OpenIddict.BackgroundJobs.Services;
 
 /// <summary>
 /// Scans active refresh tokens and checks whether the corresponding session cache entry
@@ -22,7 +22,7 @@ namespace Granit.OpenIddict.BackgroundJobs.Internal;
 /// Tokens with <c>remember_me = true</c> are skipped — those sessions never time out.
 /// </para>
 /// </remarks>
-internal sealed partial class IdleSessionEnforcementService(
+public sealed partial class IdleSessionEnforcementService(
     IOpenIddictTokenManager tokenManager,
     IFusionCache cache,
     ISettingProvider settingProvider,

--- a/src/Granit.OpenIddict.BackgroundJobs/Services/KeyRotationExecutionService.cs
+++ b/src/Granit.OpenIddict.BackgroundJobs/Services/KeyRotationExecutionService.cs
@@ -1,12 +1,12 @@
 using Granit.OpenIddict.Services;
 using Microsoft.Extensions.Logging;
 
-namespace Granit.OpenIddict.BackgroundJobs.Internal;
+namespace Granit.OpenIddict.BackgroundJobs.Services;
 
 /// <summary>
 /// Executes the signing key rotation lifecycle via <see cref="IKeyRotationService"/>.
 /// </summary>
-internal sealed partial class KeyRotationExecutionService(
+public sealed partial class KeyRotationExecutionService(
     IKeyRotationService keyRotationService,
     ILogger<KeyRotationExecutionService> logger)
 {

--- a/src/Granit.OpenIddict.BackgroundJobs/Services/TokenCleanupService.cs
+++ b/src/Granit.OpenIddict.BackgroundJobs/Services/TokenCleanupService.cs
@@ -1,11 +1,11 @@
 using OpenIddict.Abstractions;
 
-namespace Granit.OpenIddict.BackgroundJobs.Internal;
+namespace Granit.OpenIddict.BackgroundJobs.Services;
 
 /// <summary>
 /// Prunes expired tokens and orphaned authorizations from the OpenIddict store.
 /// </summary>
-internal sealed class TokenCleanupService(
+public sealed class TokenCleanupService(
     IOpenIddictTokenManager tokenManager,
     IOpenIddictAuthorizationManager authorizationManager,
     TimeProvider timeProvider)

--- a/src/Granit.Payments.Wolverine/GranitPaymentsWolverineModule.cs
+++ b/src/Granit.Payments.Wolverine/GranitPaymentsWolverineModule.cs
@@ -1,6 +1,7 @@
 using Granit.Invoicing;
 using Granit.Modularity;
 using Granit.Payments.Wolverine.Internal;
+using Granit.Payments.Wolverine.Services;
 using Granit.Wolverine;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/Granit.Payments.Wolverine/Handlers/AutoChargeOnInvoiceHandler.cs
+++ b/src/Granit.Payments.Wolverine/Handlers/AutoChargeOnInvoiceHandler.cs
@@ -1,5 +1,5 @@
 using Granit.Invoicing.Events;
-using Granit.Payments.Wolverine.Internal;
+using Granit.Payments.Wolverine.Services;
 
 namespace Granit.Payments.Wolverine.Handlers;
 
@@ -7,8 +7,7 @@ namespace Granit.Payments.Wolverine.Handlers;
 /// Automatically initiates payment when an invoice is finalized with auto-collection.
 /// Delegates to <see cref="AutoChargeService"/> for all charge orchestration logic.
 /// </summary>
-[global::Wolverine.Attributes.WolverineHandler]
-public static class AutoChargeOnInvoiceHandler
+public class AutoChargeOnInvoiceHandler
 {
     public static Task HandleAsync(
         InvoiceFinalizedEto eto,

--- a/src/Granit.Payments.Wolverine/Handlers/ProcessWebhookCommandHandler.cs
+++ b/src/Granit.Payments.Wolverine/Handlers/ProcessWebhookCommandHandler.cs
@@ -1,5 +1,5 @@
 using Granit.Payments.Commands;
-using Granit.Payments.Wolverine.Internal;
+using Granit.Payments.Wolverine.Services;
 
 namespace Granit.Payments.Wolverine.Handlers;
 
@@ -7,8 +7,7 @@ namespace Granit.Payments.Wolverine.Handlers;
 /// Processes inbound webhook events from payment providers.
 /// Delegates to <see cref="WebhookProcessor"/> for all reconciliation logic.
 /// </summary>
-[global::Wolverine.Attributes.WolverineHandler]
-public static class ProcessWebhookCommandHandler
+public class ProcessWebhookCommandHandler
 {
     public static Task HandleAsync(
         ProcessWebhookCommand command,

--- a/src/Granit.Payments.Wolverine/Services/AutoChargeService.cs
+++ b/src/Granit.Payments.Wolverine/Services/AutoChargeService.cs
@@ -7,7 +7,7 @@ using Granit.Payments.Domain;
 using Microsoft.Extensions.Logging;
 using Wolverine;
 
-namespace Granit.Payments.Wolverine.Internal;
+namespace Granit.Payments.Wolverine.Services;
 
 /// <summary>
 /// Automatically initiates payment when an invoice is finalized with auto-collection.

--- a/src/Granit.Payments.Wolverine/Services/WebhookProcessor.cs
+++ b/src/Granit.Payments.Wolverine/Services/WebhookProcessor.cs
@@ -4,7 +4,7 @@ using Granit.Payments.Domain;
 using Granit.Timing;
 using Microsoft.Extensions.Logging;
 
-namespace Granit.Payments.Wolverine.Internal;
+namespace Granit.Payments.Wolverine.Services;
 
 /// <summary>
 /// Processes inbound webhook events from payment providers.

--- a/src/Granit.Privacy.BackgroundJobs/GranitPrivacyBackgroundJobsModule.cs
+++ b/src/Granit.Privacy.BackgroundJobs/GranitPrivacyBackgroundJobsModule.cs
@@ -1,6 +1,6 @@
 using Granit.BackgroundJobs;
 using Granit.Modularity;
-using Granit.Privacy.BackgroundJobs.Internal;
+using Granit.Privacy.BackgroundJobs.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 

--- a/src/Granit.Privacy.BackgroundJobs/Jobs/DeletionDeadlineEnforcerHandler.cs
+++ b/src/Granit.Privacy.BackgroundJobs/Jobs/DeletionDeadlineEnforcerHandler.cs
@@ -1,4 +1,4 @@
-using Granit.Privacy.BackgroundJobs.Internal;
+using Granit.Privacy.BackgroundJobs.Services;
 
 namespace Granit.Privacy.BackgroundJobs.Jobs;
 
@@ -6,7 +6,7 @@ namespace Granit.Privacy.BackgroundJobs.Jobs;
 /// Handles <see cref="DeletionDeadlineEnforcerJob"/> by delegating to
 /// <see cref="DeletionDeadlineEnforcementService"/> for expired deferred deletion processing.
 /// </summary>
-internal static class DeletionDeadlineEnforcerHandler
+public class DeletionDeadlineEnforcerHandler
 {
     public static Task HandleAsync(
         DeletionDeadlineEnforcerJob _,

--- a/src/Granit.Privacy.BackgroundJobs/Services/DeletionDeadlineEnforcementService.cs
+++ b/src/Granit.Privacy.BackgroundJobs/Services/DeletionDeadlineEnforcementService.cs
@@ -4,14 +4,14 @@ using Granit.Privacy.DataDeletion.Events;
 using Granit.Privacy.Diagnostics;
 using Microsoft.Extensions.Logging;
 
-namespace Granit.Privacy.BackgroundJobs.Internal;
+namespace Granit.Privacy.BackgroundJobs.Services;
 
 /// <summary>
 /// Scans for expired deferred deletion requests and forces execution.
 /// Idempotent — skips requests already in
 /// <see cref="DeletionRequestState.Executed"/> or <see cref="DeletionRequestState.Cancelled"/> state.
 /// </summary>
-internal sealed partial class DeletionDeadlineEnforcementService(
+public sealed partial class DeletionDeadlineEnforcementService(
     IDeletionRequestTrackerReader trackerReader,
     IDeletionRequestTrackerWriter trackerWriter,
     IDistributedEventBus eventBus,

--- a/src/Granit.Scheduling.BackgroundJobs/GranitSchedulingBackgroundJobsModule.cs
+++ b/src/Granit.Scheduling.BackgroundJobs/GranitSchedulingBackgroundJobsModule.cs
@@ -1,6 +1,6 @@
 using Granit.BackgroundJobs;
 using Granit.Modularity;
-using Granit.Scheduling.BackgroundJobs.Internal;
+using Granit.Scheduling.BackgroundJobs.Services;
 using Granit.Scheduling.Wolverine;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/Granit.Scheduling.BackgroundJobs/Jobs/SchedulingCatchUpHandler.cs
+++ b/src/Granit.Scheduling.BackgroundJobs/Jobs/SchedulingCatchUpHandler.cs
@@ -1,4 +1,4 @@
-using Granit.Scheduling.BackgroundJobs.Internal;
+using Granit.Scheduling.BackgroundJobs.Services;
 
 namespace Granit.Scheduling.BackgroundJobs.Jobs;
 
@@ -6,7 +6,7 @@ namespace Granit.Scheduling.BackgroundJobs.Jobs;
 /// Handler for <see cref="SchedulingCatchUpJob"/>. Delegates to <see cref="CatchUpDispatcher"/>
 /// for overdue scheduled action detection and re-dispatch.
 /// </summary>
-internal static class SchedulingCatchUpHandler
+public class SchedulingCatchUpHandler
 {
     public static Task HandleAsync(
         SchedulingCatchUpJob _,

--- a/src/Granit.Scheduling.BackgroundJobs/Services/CatchUpDispatcher.cs
+++ b/src/Granit.Scheduling.BackgroundJobs/Services/CatchUpDispatcher.cs
@@ -7,13 +7,13 @@ using Granit.Timing;
 using Microsoft.Extensions.Logging;
 using Wolverine;
 
-namespace Granit.Scheduling.BackgroundJobs.Internal;
+namespace Granit.Scheduling.BackgroundJobs.Services;
 
 /// <summary>
 /// Detects overdue pending scheduled actions and re-dispatches their payloads via Wolverine.
 /// Extracted from <c>SchedulingCatchUpHandler</c> to keep the handler a thin pass-through.
 /// </summary>
-internal sealed partial class CatchUpDispatcher(
+public sealed partial class CatchUpDispatcher(
     IScheduledActionReader reader,
     IMessageBus messageBus,
     IClock clock,

--- a/src/Granit.Subscriptions.BackgroundJobs/GranitSubscriptionsBackgroundJobsModule.cs
+++ b/src/Granit.Subscriptions.BackgroundJobs/GranitSubscriptionsBackgroundJobsModule.cs
@@ -1,6 +1,6 @@
 using Granit.BackgroundJobs;
 using Granit.Modularity;
-using Granit.Subscriptions.BackgroundJobs.Internal;
+using Granit.Subscriptions.BackgroundJobs.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 

--- a/src/Granit.Subscriptions.BackgroundJobs/Jobs/CancelAtPeriodEndScanHandler.cs
+++ b/src/Granit.Subscriptions.BackgroundJobs/Jobs/CancelAtPeriodEndScanHandler.cs
@@ -4,7 +4,7 @@ namespace Granit.Subscriptions.BackgroundJobs.Jobs;
 /// Handler for <see cref="CancelAtPeriodEndScanJob"/>. Delegates to
 /// <see cref="ICancelAtPeriodEndService"/> for subscription cancellation.
 /// </summary>
-internal static class CancelAtPeriodEndScanHandler
+public class CancelAtPeriodEndScanHandler
 {
     public static async Task HandleAsync(
         CancelAtPeriodEndScanJob _,

--- a/src/Granit.Subscriptions.BackgroundJobs/Jobs/PeriodEndScanHandler.cs
+++ b/src/Granit.Subscriptions.BackgroundJobs/Jobs/PeriodEndScanHandler.cs
@@ -4,7 +4,7 @@ namespace Granit.Subscriptions.BackgroundJobs.Jobs;
 /// Handler for <see cref="PeriodEndScanJob"/>. Delegates to
 /// <see cref="IPeriodAdvancementService"/> for billing period advancement.
 /// </summary>
-internal static class PeriodEndScanHandler
+public class PeriodEndScanHandler
 {
     public static async Task HandleAsync(
         PeriodEndScanJob _,

--- a/src/Granit.Subscriptions.BackgroundJobs/Jobs/TrialExpirationScanHandler.cs
+++ b/src/Granit.Subscriptions.BackgroundJobs/Jobs/TrialExpirationScanHandler.cs
@@ -1,4 +1,4 @@
-using Granit.Subscriptions.BackgroundJobs.Internal;
+using Granit.Subscriptions.BackgroundJobs.Services;
 
 namespace Granit.Subscriptions.BackgroundJobs.Jobs;
 
@@ -6,7 +6,7 @@ namespace Granit.Subscriptions.BackgroundJobs.Jobs;
 /// Handler for <see cref="TrialExpirationScanJob"/>. Delegates to
 /// <see cref="TrialExpirationScanner"/> for trial detection and processing.
 /// </summary>
-internal static class TrialExpirationScanHandler
+public class TrialExpirationScanHandler
 {
     public static async Task HandleAsync(
         TrialExpirationScanJob _,

--- a/src/Granit.Subscriptions.BackgroundJobs/Services/TrialExpirationScanner.cs
+++ b/src/Granit.Subscriptions.BackgroundJobs/Services/TrialExpirationScanner.cs
@@ -7,12 +7,12 @@ using Granit.Timing;
 using Microsoft.Extensions.Logging;
 using Wolverine;
 
-namespace Granit.Subscriptions.BackgroundJobs.Internal;
+namespace Granit.Subscriptions.BackgroundJobs.Services;
 
 /// <summary>
 /// Scans and processes expiring and expired trials.
 /// </summary>
-internal sealed partial class TrialExpirationScanner(
+public sealed partial class TrialExpirationScanner(
     ISubscriptionReader reader,
     ISubscriptionWriter writer,
     IMessageBus messageBus,

--- a/src/Granit.Subscriptions.Wolverine/GranitSubscriptionsWolverineModule.cs
+++ b/src/Granit.Subscriptions.Wolverine/GranitSubscriptionsWolverineModule.cs
@@ -1,5 +1,5 @@
 using Granit.Modularity;
-using Granit.Subscriptions.Wolverine.Internal;
+using Granit.Subscriptions.Wolverine.Services;
 using Granit.Wolverine;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/Granit.Subscriptions.Wolverine/Handlers/BillingCycleCompletedHandler.cs
+++ b/src/Granit.Subscriptions.Wolverine/Handlers/BillingCycleCompletedHandler.cs
@@ -1,6 +1,6 @@
 using Granit.MultiTenancy;
 using Granit.Subscriptions.Events;
-using Granit.Subscriptions.Wolverine.Internal;
+using Granit.Subscriptions.Wolverine.Services;
 
 namespace Granit.Subscriptions.Wolverine.Handlers;
 
@@ -8,8 +8,7 @@ namespace Granit.Subscriptions.Wolverine.Handlers;
 /// Creates invoices for Flat/PerSeat plans when a billing cycle completes.
 /// Delegates to <see cref="BillingCycleInvoiceOrchestrator"/>.
 /// </summary>
-[global::Wolverine.Attributes.WolverineHandler]
-public static class BillingCycleCompletedHandler
+public class BillingCycleCompletedHandler
 {
     public static async Task HandleAsync(
         BillingCycleCompletedEto eto,

--- a/src/Granit.Subscriptions.Wolverine/Handlers/InvoicePaidHandler.cs
+++ b/src/Granit.Subscriptions.Wolverine/Handlers/InvoicePaidHandler.cs
@@ -7,8 +7,7 @@ namespace Granit.Subscriptions.Wolverine.Handlers;
 /// Reactivates a PastDue subscription when its invoice is paid.
 /// Delegates to <see cref="ISubscriptionReactivationService"/>.
 /// </summary>
-[global::Wolverine.Attributes.WolverineHandler]
-public static class InvoicePaidHandler
+public class InvoicePaidHandler
 {
     public static async Task HandleAsync(
         InvoicePaidEto eto,

--- a/src/Granit.Subscriptions.Wolverine/Handlers/PaymentFailedHandler.cs
+++ b/src/Granit.Subscriptions.Wolverine/Handlers/PaymentFailedHandler.cs
@@ -6,8 +6,7 @@ namespace Granit.Subscriptions.Wolverine.Handlers;
 /// <summary>
 /// Dunning entry point. Delegates to <see cref="IDunningService"/> for payment failure processing.
 /// </summary>
-[global::Wolverine.Attributes.WolverineHandler]
-public static class PaymentFailedHandler
+public class PaymentFailedHandler
 {
     public static async Task HandleAsync(
         PaymentFailedEto eto,

--- a/src/Granit.Subscriptions.Wolverine/Handlers/RetryPaymentHandler.cs
+++ b/src/Granit.Subscriptions.Wolverine/Handlers/RetryPaymentHandler.cs
@@ -1,6 +1,6 @@
 using Granit.MultiTenancy;
 using Granit.Subscriptions.Scheduling;
-using Granit.Subscriptions.Wolverine.Internal;
+using Granit.Subscriptions.Wolverine.Services;
 
 namespace Granit.Subscriptions.Wolverine.Handlers;
 
@@ -8,8 +8,7 @@ namespace Granit.Subscriptions.Wolverine.Handlers;
 /// Handles scheduled payment retries during dunning.
 /// Delegates to <see cref="PaymentRetryDispatcher"/>.
 /// </summary>
-[global::Wolverine.Attributes.WolverineHandler]
-public static class RetryPaymentHandler
+public class RetryPaymentHandler
 {
     public static async Task HandleAsync(
         RetryPaymentPayload payload,

--- a/src/Granit.Subscriptions.Wolverine/Handlers/SubscriptionProviderSyncHandler.cs
+++ b/src/Granit.Subscriptions.Wolverine/Handlers/SubscriptionProviderSyncHandler.cs
@@ -7,8 +7,7 @@ namespace Granit.Subscriptions.Wolverine.Handlers;
 /// Syncs subscription state to the external provider after FSM transitions.
 /// Delegates to <see cref="ISubscriptionProviderSyncService"/>.
 /// </summary>
-[global::Wolverine.Attributes.WolverineHandler]
-public static class SubscriptionProviderSyncHandler
+public class SubscriptionProviderSyncHandler
 {
     public static async Task HandleAsync(
         SubscriptionCancelledEto eto,

--- a/src/Granit.Subscriptions.Wolverine/Handlers/UsageSummaryReadyHandler.cs
+++ b/src/Granit.Subscriptions.Wolverine/Handlers/UsageSummaryReadyHandler.cs
@@ -1,6 +1,6 @@
 using Granit.Metering.Events;
 using Granit.MultiTenancy;
-using Granit.Subscriptions.Wolverine.Internal;
+using Granit.Subscriptions.Wolverine.Services;
 
 namespace Granit.Subscriptions.Wolverine.Handlers;
 
@@ -8,8 +8,7 @@ namespace Granit.Subscriptions.Wolverine.Handlers;
 /// Creates consolidated invoices (fixed + usage) for PerUnit/Tiered plans.
 /// Delegates to <see cref="UsageInvoiceOrchestrator"/>.
 /// </summary>
-[global::Wolverine.Attributes.WolverineHandler]
-public static class UsageSummaryReadyHandler
+public class UsageSummaryReadyHandler
 {
     public static async Task HandleAsync(
         UsageSummaryReadyEto eto,

--- a/src/Granit.Subscriptions.Wolverine/Services/BillingCycleInvoiceOrchestrator.cs
+++ b/src/Granit.Subscriptions.Wolverine/Services/BillingCycleInvoiceOrchestrator.cs
@@ -4,7 +4,7 @@ using Granit.Subscriptions.Domain;
 using Microsoft.Extensions.Logging;
 using Wolverine;
 
-namespace Granit.Subscriptions.Wolverine.Internal;
+namespace Granit.Subscriptions.Wolverine.Services;
 
 /// <summary>
 /// Creates invoices for Flat/PerSeat plans when a billing cycle completes.

--- a/src/Granit.Subscriptions.Wolverine/Services/PaymentRetryDispatcher.cs
+++ b/src/Granit.Subscriptions.Wolverine/Services/PaymentRetryDispatcher.cs
@@ -3,7 +3,7 @@ using Granit.Subscriptions.Scheduling;
 using Microsoft.Extensions.Logging;
 using Wolverine;
 
-namespace Granit.Subscriptions.Wolverine.Internal;
+namespace Granit.Subscriptions.Wolverine.Services;
 
 /// <summary>
 /// Dispatches payment retry commands during dunning.

--- a/src/Granit.Subscriptions.Wolverine/Services/UsageInvoiceOrchestrator.cs
+++ b/src/Granit.Subscriptions.Wolverine/Services/UsageInvoiceOrchestrator.cs
@@ -4,7 +4,7 @@ using Granit.Subscriptions.Domain;
 using Microsoft.Extensions.Logging;
 using Wolverine;
 
-namespace Granit.Subscriptions.Wolverine.Internal;
+namespace Granit.Subscriptions.Wolverine.Services;
 
 /// <summary>
 /// Creates consolidated invoices (fixed + usage) for PerUnit/Tiered plans.

--- a/src/Granit.Templating.Scriban/Internal/ScribanTemplateEngine.cs
+++ b/src/Granit.Templating.Scriban/Internal/ScribanTemplateEngine.cs
@@ -144,7 +144,7 @@ internal sealed class ScribanTemplateEngine(
             globals.SetValue("to_user_time", new UserTimeFunction(clock), readOnly: true);
         }
 
-        TemplateContext templateContext = new(globals)
+        TemplateContext templateContext = new()
         {
             // Sandboxing: no bypass of member visibility restrictions
             EnableRelaxedMemberAccess = false,
@@ -162,6 +162,9 @@ internal sealed class ScribanTemplateEngine(
             // Enable {{ include 'template_name' }} via the resolver chain
             TemplateLoader = templateLoader,
         };
+
+        // Push globals on top of the default BuiltinObject (which provides html, string, math, etc.)
+        templateContext.PushGlobal(globals);
 
         return templateContext;
     }

--- a/tests/Granit.BlobStorage.BackgroundJobs.Tests/Jobs/OrphanBlobCleanupHandlerTests.cs
+++ b/tests/Granit.BlobStorage.BackgroundJobs.Tests/Jobs/OrphanBlobCleanupHandlerTests.cs
@@ -1,5 +1,5 @@
-using Granit.BlobStorage.BackgroundJobs.Internal;
 using Granit.BlobStorage.BackgroundJobs.Jobs;
+using Granit.BlobStorage.BackgroundJobs.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Shouldly;

--- a/tests/Granit.OpenIddict.BackgroundJobs.Tests/Jobs/OpenIddictIdleSessionEnforcementHandlerTests.cs
+++ b/tests/Granit.OpenIddict.BackgroundJobs.Tests/Jobs/OpenIddictIdleSessionEnforcementHandlerTests.cs
@@ -1,5 +1,5 @@
 using Granit.OpenIddict;
-using Granit.OpenIddict.BackgroundJobs.Internal;
+using Granit.OpenIddict.BackgroundJobs.Services;
 using Granit.Settings.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;

--- a/tests/Granit.OpenIddict.BackgroundJobs.Tests/Jobs/OpenIddictKeyRotationHandlerTests.cs
+++ b/tests/Granit.OpenIddict.BackgroundJobs.Tests/Jobs/OpenIddictKeyRotationHandlerTests.cs
@@ -1,5 +1,5 @@
-using Granit.OpenIddict.BackgroundJobs.Internal;
 using Granit.OpenIddict.BackgroundJobs.Jobs;
+using Granit.OpenIddict.BackgroundJobs.Services;
 using Granit.OpenIddict.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;

--- a/tests/Granit.OpenIddict.BackgroundJobs.Tests/Jobs/OpenIddictTokenCleanupHandlerTests.cs
+++ b/tests/Granit.OpenIddict.BackgroundJobs.Tests/Jobs/OpenIddictTokenCleanupHandlerTests.cs
@@ -1,4 +1,4 @@
-using Granit.OpenIddict.BackgroundJobs.Internal;
+using Granit.OpenIddict.BackgroundJobs.Services;
 using NSubstitute;
 using OpenIddict.Abstractions;
 using Shouldly;

--- a/tests/Granit.Privacy.BackgroundJobs.Tests/Jobs/DeletionDeadlineEnforcerHandlerTests.cs
+++ b/tests/Granit.Privacy.BackgroundJobs.Tests/Jobs/DeletionDeadlineEnforcerHandlerTests.cs
@@ -1,5 +1,5 @@
 using Granit.Events;
-using Granit.Privacy.BackgroundJobs.Internal;
+using Granit.Privacy.BackgroundJobs.Services;
 using Granit.Privacy.DataDeletion;
 using Granit.Privacy.DataDeletion.Events;
 using Granit.Privacy.Diagnostics;


### PR DESCRIPTION
## Summary

Follows up on #884. `public static class` handlers still require `[WolverineHandler]` to be discovered, creating an unwanted dependency on WolverineFx.

- **26 handlers**: `static class` → `class` (Wolverine, Notifications, BackgroundJobs)
- **14 services**: moved from `Internal/` to `Services/` (now `public sealed`)
- **Bff special case**: extracted `IExpiredSessionCleanupService` interface (BffDbContext cascade)
- **Removed** `[WolverineHandler]` attributes from 10 handlers
- **CLAUDE.md**: updated handler visibility rules

Pattern: `public class FooHandler { public static Task HandleAsync(...) }` — Wolverine discovers via `ExportedTypes`, invokes the static methods. No attribute, no WolverineFx dependency.

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] Architecture tests — 101 passed (including `Public_types_should_not_reside_in_Internal_namespaces`)
- [ ] Full test suite in CI
- [ ] Verify forgot-password + other notification flows in showcase after package update