### PR TITLE
fix(templating): inject Scriban builtins and fix dictionary key renaming

### DIFF
--- a/src/Granit.Templating.Scriban/Internal/ScribanTemplateEngine.cs
+++ b/src/Granit.Templating.Scriban/Internal/ScribanTemplateEngine.cs
@@ -108,9 +108,21 @@ internal sealed class ScribanTemplateEngine(
     {
         ScriptObject globals = [];
 
-        // Expose TData as "model" with snake_case property names (PascalCase → snake_case)
+        // Expose TData as "model" with snake_case property names (PascalCase → snake_case).
+        // Scriban's Import skips the renamer for IDictionary (upstream TODO), so we handle it manually.
         ScriptObject model = [];
-        model.Import(data, renamer: StandardMemberRenamer.Default);
+        if (data is IDictionary<string, object?> dict)
+        {
+            foreach ((string key, object? value) in dict)
+            {
+                model.SetValue(StandardMemberRenamer.Rename(key), value, readOnly: false);
+            }
+        }
+        else
+        {
+            model.Import(data, renamer: StandardMemberRenamer.Default);
+        }
+
         globals.SetValue("model", model, readOnly: true);
 
         // Inject each global context under its ContextName


### PR DESCRIPTION
## Summary

Fixes two Scriban template rendering bugs that caused email notifications (e.g. forgot-password) to fall back to plaintext:

- **Builtins missing**: `new TemplateContext(globals)` replaced the default `BuiltinObject` (containing `html`, `string`, `math`, etc.) instead of pushing globals on top. Templates using `{{ html.escape }}` got "Object 'html' is null". Fix: `new TemplateContext()` + `PushGlobal(globals)`.
- **Dictionary keys not renamed**: Scriban's `ScriptObject.Import(IDictionary)` skips the `MemberRenamerDelegate` (upstream TODO). Dictionary keys like `"Email"` stayed PascalCase instead of being converted to `"email"`. Fix: manually iterate dictionary entries and apply `StandardMemberRenamer.Rename()`.

## Test plan

- [x] `dotnet build` — 0 errors
- [x] Scriban tests — 40 passed
- [ ] Verify forgot-password email renders with proper content in showcase