### PR TITLE
fix(bff): support absolute URLs in PostLogoutRedirectPath

### DIFF
--- a/src/Granit.Bff.Endpoints/Endpoints/BffLogoutEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffLogoutEndpoints.cs
@@ -58,8 +58,11 @@ internal static class BffLogoutEndpoints
         IGranitCookieManager cookieManager = httpContext.RequestServices.GetRequiredService<IGranitCookieManager>();
         cookieManager.DeleteCookie(httpContext, frontend.SessionCookieName);
 
-        // Build end_session URL
-        string postLogoutRedirectUri = $"{httpContext.Request.Scheme}://{httpContext.Request.Host}{frontend.EffectivePostLogoutRedirectPath}";
+        // Build end_session URL — support absolute URLs (e.g. separate frontend origin)
+        string effectivePath = frontend.EffectivePostLogoutRedirectPath;
+        string postLogoutRedirectUri = effectivePath.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+            ? effectivePath
+            : $"{httpContext.Request.Scheme}://{httpContext.Request.Host}{effectivePath}";
         string endSessionUrl = orchestrator.BuildEndSessionUrl(frontend, postLogoutRedirectUri, idTokenHint);
 
         return TypedResults.Redirect(endSessionUrl);


### PR DESCRIPTION
## Summary

- `PostLoginRedirectPath` already supports absolute URLs (used directly in `Redirect()`)
- `PostLogoutRedirectPath` always prefixed `{scheme}://{host}`, breaking when the frontend is on a separate origin (e.g. `http://localhost:3000`)
- Now checks if the effective path starts with `http` and uses it as-is

## Test plan

- [ ] Configure `PostLogoutRedirectPath` with absolute URL, verify redirect goes to correct origin
- [ ] Verify default behavior (relative path) still works