### PR TITLE
fix(email): always provide title fallback for layout rendering

### DIFF
--- a/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
+++ b/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
@@ -286,11 +286,9 @@ internal sealed partial class EmailNotificationChannel(
         Dictionary<string, object?> dataDict = JsonElementToDictionary(context.Data);
         EnrichModelData(dataDict, context, enrichment);
 
-        // Inject title extracted from the rendered content template for {{ model.title }} in layout
-        if (contentEmail.Subject is not null)
-        {
-            dataDict["title"] = contentEmail.Subject;
-        }
+        // Inject title for {{ model.title }} in layout — use content <title> or humanized type name
+        dataDict["title"] = contentEmail.Subject
+            ?? context.NotificationTypeName.Replace('.', ' ');
 
         // Inject body as ExtraVariable for {{ body | raw }} in layout
         TemplateDescriptor layoutWithBody = new()


### PR DESCRIPTION
## Summary

Email layout template (`Layout.Email.html`) uses `{{ model.title }}` but content templates (e.g. `Security.PasswordReset.html`) don't include a `<title>` tag. With Scriban's `EnableRelaxedMemberAccess = false`, accessing a missing member throws an error, and the layout rendering was silently skipped — resulting in emails without header/footer/styling.

Fix: always inject `title` into the model data dictionary. Uses the extracted `<title>` from content when available, or humanized notification type name as fallback (e.g. "Security PasswordReset").

## Test plan

- [ ] Verify forgot-password email now renders with full layout (header, footer, styling)
- [ ] Verify email subject matches title