### PR TITLE
refactor: extract domain services from Wolverine projects into base modules

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1359,6 +1359,7 @@
       "name": "Granit.Payments",
       "deps": [
         "Granit",
+        "Granit.Invoicing.Abstractions",
         "Granit.Payments.Abstractions",
         "Granit.Timing"
       ],
@@ -1738,6 +1739,7 @@
       "deps": [
         "Granit",
         "Granit.Guids",
+        "Granit.Invoicing.Abstractions",
         "Granit.Scheduling",
         "Granit.Timing",
         "Granit.Workflow"
@@ -19256,6 +19258,22 @@
       ]
     },
     {
+      "name": "IInvoiceCommandPublisher",
+      "fqn": "Granit.Invoicing.IInvoiceCommandPublisher",
+      "kind": "interface",
+      "project": "Granit.Invoicing.Abstractions",
+      "file": "src/Granit.Invoicing.Abstractions/IInvoiceCommandPublisher.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "PublishAsync",
+          "kind": "method",
+          "signature": "PublishAsync(CreateInvoiceCommand command, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "IInvoiceCreationService",
       "fqn": "Granit.Invoicing.IInvoiceCreationService",
       "kind": "interface",
@@ -19724,8 +19742,15 @@
       "kind": "class",
       "project": "Granit.Invoicing.Wolverine",
       "file": "src/Granit.Invoicing.Wolverine/GranitInvoicingWolverineModule.cs",
-      "line": 10,
-      "members": []
+      "line": 13,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "CreateInvoiceHandler",
@@ -26884,7 +26909,7 @@
       "kind": "class",
       "project": "Granit.Payments",
       "file": "src/Granit.Payments/Extensions/PaymentsHostApplicationBuilderExtensions.cs",
-      "line": 10,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitPayments",
@@ -26911,6 +26936,22 @@
       ]
     },
     {
+      "name": "IAutoChargeService",
+      "fqn": "Granit.Payments.IAutoChargeService",
+      "kind": "interface",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/IAutoChargeService.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(InvoiceFinalizedEto eto, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "ICheckoutSessionFactory",
       "fqn": "Granit.Payments.ICheckoutSessionFactory",
       "kind": "interface",
@@ -26923,6 +26964,22 @@
           "kind": "method",
           "signature": "CreateAsync(PaymentCheckoutSessionRequest request, CancellationToken cancellationToken = default)",
           "returnType": "string ProviderName { get; } Task<PaymentCheckoutSession>"
+        }
+      ]
+    },
+    {
+      "name": "IPaymentCommandDispatcher",
+      "fqn": "Granit.Payments.IPaymentCommandDispatcher",
+      "kind": "interface",
+      "project": "Granit.Payments.Abstractions",
+      "file": "src/Granit.Payments.Abstractions/IPaymentCommandDispatcher.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "SendAsync",
+          "kind": "method",
+          "signature": "SendAsync(InitiatePaymentCommand command, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
         }
       ]
     },
@@ -27160,6 +27217,22 @@
           "name": "AddAsync",
           "kind": "method",
           "signature": "AddAsync(ProviderCustomerMapping mapping, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IWebhookProcessor",
+      "fqn": "Granit.Payments.IWebhookProcessor",
+      "kind": "interface",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/IWebhookProcessor.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "ProcessAsync",
+          "kind": "method",
+          "signature": "ProcessAsync(ProcessWebhookCommand command, CancellationToken cancellationToken)",
           "returnType": "Task"
         }
       ]
@@ -27958,7 +28031,7 @@
       "kind": "class",
       "project": "Granit.Payments.Wolverine",
       "file": "src/Granit.Payments.Wolverine/GranitPaymentsWolverineModule.cs",
-      "line": 15,
+      "line": 13,
       "members": [
         {
           "name": "ConfigureServices",
@@ -27974,12 +28047,12 @@
       "kind": "class",
       "project": "Granit.Payments.Wolverine",
       "file": "src/Granit.Payments.Wolverine/Handlers/AutoChargeOnInvoiceHandler.cs",
-      "line": 10,
+      "line": 9,
       "members": [
         {
           "name": "HandleAsync",
           "kind": "method",
-          "signature": "HandleAsync(InvoiceFinalizedEto eto, AutoChargeService autoChargeService, CancellationToken cancellationToken)",
+          "signature": "HandleAsync(InvoiceFinalizedEto eto, IAutoChargeService autoChargeService, CancellationToken cancellationToken)",
           "returnType": "Task"
         }
       ]
@@ -27990,44 +28063,12 @@
       "kind": "class",
       "project": "Granit.Payments.Wolverine",
       "file": "src/Granit.Payments.Wolverine/Handlers/ProcessWebhookCommandHandler.cs",
-      "line": 10,
+      "line": 9,
       "members": [
         {
           "name": "HandleAsync",
           "kind": "method",
-          "signature": "HandleAsync(ProcessWebhookCommand command, WebhookProcessor processor, CancellationToken cancellationToken)",
-          "returnType": "Task"
-        }
-      ]
-    },
-    {
-      "name": "AutoChargeService",
-      "fqn": "Granit.Payments.Wolverine.Services.AutoChargeService",
-      "kind": "class",
-      "project": "Granit.Payments.Wolverine",
-      "file": "src/Granit.Payments.Wolverine/Services/AutoChargeService.cs",
-      "line": 18,
-      "members": [
-        {
-          "name": "HandleAsync",
-          "kind": "method",
-          "signature": "HandleAsync(InvoiceFinalizedEto eto, CancellationToken cancellationToken)",
-          "returnType": "Task"
-        }
-      ]
-    },
-    {
-      "name": "WebhookProcessor",
-      "fqn": "Granit.Payments.Wolverine.Services.WebhookProcessor",
-      "kind": "class",
-      "project": "Granit.Payments.Wolverine",
-      "file": "src/Granit.Payments.Wolverine/Services/WebhookProcessor.cs",
-      "line": 13,
-      "members": [
-        {
-          "name": "ProcessAsync",
-          "kind": "method",
-          "signature": "ProcessAsync(ProcessWebhookCommand command, CancellationToken cancellationToken)",
+          "signature": "HandleAsync(ProcessWebhookCommand command, IWebhookProcessor processor, CancellationToken cancellationToken)",
           "returnType": "Task"
         }
       ]
@@ -33822,6 +33863,15 @@
       ]
     },
     {
+      "name": "CreateUsageInvoiceRequest",
+      "fqn": "Granit.Subscriptions.CreateUsageInvoiceRequest",
+      "kind": "record",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/IUsageInvoiceOrchestrator.cs",
+      "line": 6,
+      "members": []
+    },
+    {
       "name": "SubscriptionWorkflows",
       "fqn": "Granit.Subscriptions.Definitions.SubscriptionWorkflows",
       "kind": "class",
@@ -34592,6 +34642,22 @@
       ]
     },
     {
+      "name": "IBillingCycleInvoiceOrchestrator",
+      "fqn": "Granit.Subscriptions.IBillingCycleInvoiceOrchestrator",
+      "kind": "interface",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/IBillingCycleInvoiceOrchestrator.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "CreateInvoiceAsync",
+          "kind": "method",
+          "signature": "CreateInvoiceAsync(Guid subscriptionId, Guid tenantId, Guid planId, DateTimeOffset periodStart, DateTimeOffset periodEnd, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "ICancelAtPeriodEndService",
       "fqn": "Granit.Subscriptions.ICancelAtPeriodEndService",
       "kind": "interface",
@@ -34896,6 +34962,22 @@
       ]
     },
     {
+      "name": "IUsageInvoiceOrchestrator",
+      "fqn": "Granit.Subscriptions.IUsageInvoiceOrchestrator",
+      "kind": "interface",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/IUsageInvoiceOrchestrator.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "CreateInvoiceAsync",
+          "kind": "method",
+          "signature": "CreateInvoiceAsync(CreateUsageInvoiceRequest request, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "GranitSubscriptionsInternalModule",
       "fqn": "Granit.Subscriptions.Internal.GranitSubscriptionsInternalModule",
       "kind": "class",
@@ -35174,12 +35256,12 @@
       "kind": "class",
       "project": "Granit.Subscriptions.Wolverine",
       "file": "src/Granit.Subscriptions.Wolverine/Handlers/BillingCycleCompletedHandler.cs",
-      "line": 11,
+      "line": 10,
       "members": [
         {
           "name": "HandleAsync",
           "kind": "method",
-          "signature": "HandleAsync(BillingCycleCompletedEto eto, BillingCycleInvoiceOrchestrator orchestrator, ICurrentTenant currentTenant, CancellationToken cancellationToken)",
+          "signature": "HandleAsync(BillingCycleCompletedEto eto, IBillingCycleInvoiceOrchestrator orchestrator, ICurrentTenant currentTenant, CancellationToken cancellationToken)",
           "returnType": "Task"
         }
       ]
@@ -35254,44 +35336,12 @@
       "kind": "class",
       "project": "Granit.Subscriptions.Wolverine",
       "file": "src/Granit.Subscriptions.Wolverine/Handlers/UsageSummaryReadyHandler.cs",
-      "line": 11,
+      "line": 10,
       "members": [
         {
           "name": "HandleAsync",
           "kind": "method",
-          "signature": "HandleAsync(UsageSummaryReadyEto eto, UsageInvoiceOrchestrator orchestrator, ICurrentTenant currentTenant, CancellationToken cancellationToken)",
-          "returnType": "Task"
-        }
-      ]
-    },
-    {
-      "name": "BillingCycleInvoiceOrchestrator",
-      "fqn": "Granit.Subscriptions.Wolverine.Services.BillingCycleInvoiceOrchestrator",
-      "kind": "class",
-      "project": "Granit.Subscriptions.Wolverine",
-      "file": "src/Granit.Subscriptions.Wolverine/Services/BillingCycleInvoiceOrchestrator.cs",
-      "line": 13,
-      "members": [
-        {
-          "name": "CreateInvoiceAsync",
-          "kind": "method",
-          "signature": "CreateInvoiceAsync(Guid subscriptionId, Guid tenantId, Guid planId, DateTimeOffset periodStart, DateTimeOffset periodEnd, CancellationToken cancellationToken)",
-          "returnType": "Task"
-        }
-      ]
-    },
-    {
-      "name": "CreateUsageInvoiceRequest",
-      "fqn": "Granit.Subscriptions.Wolverine.Services.CreateUsageInvoiceRequest",
-      "kind": "record",
-      "project": "Granit.Subscriptions.Wolverine",
-      "file": "src/Granit.Subscriptions.Wolverine/Services/UsageInvoiceOrchestrator.cs",
-      "line": 12,
-      "members": [
-        {
-          "name": "CreateInvoiceAsync",
-          "kind": "method",
-          "signature": "CreateInvoiceAsync(CreateUsageInvoiceRequest request, CancellationToken cancellationToken)",
+          "signature": "HandleAsync(UsageSummaryReadyEto eto, IUsageInvoiceOrchestrator orchestrator, ICurrentTenant currentTenant, CancellationToken cancellationToken)",
           "returnType": "Task"
         }
       ]
@@ -35308,22 +35358,6 @@
           "name": "DispatchRetryAsync",
           "kind": "method",
           "signature": "DispatchRetryAsync(RetryPaymentPayload payload)",
-          "returnType": "Task"
-        }
-      ]
-    },
-    {
-      "name": "UsageInvoiceOrchestrator",
-      "fqn": "Granit.Subscriptions.Wolverine.Services.UsageInvoiceOrchestrator",
-      "kind": "class",
-      "project": "Granit.Subscriptions.Wolverine",
-      "file": "src/Granit.Subscriptions.Wolverine/Services/UsageInvoiceOrchestrator.cs",
-      "line": 25,
-      "members": [
-        {
-          "name": "CreateInvoiceAsync",
-          "kind": "method",
-          "signature": "CreateInvoiceAsync(CreateUsageInvoiceRequest request, CancellationToken cancellationToken)",
           "returnType": "Task"
         }
       ]

--- a/src/Granit.Invoicing.Abstractions/IInvoiceCommandPublisher.cs
+++ b/src/Granit.Invoicing.Abstractions/IInvoiceCommandPublisher.cs
@@ -1,0 +1,14 @@
+using Granit.Invoicing.Commands;
+
+namespace Granit.Invoicing;
+
+/// <summary>
+/// Publishes invoice commands to the messaging infrastructure.
+/// </summary>
+public interface IInvoiceCommandPublisher
+{
+    /// <summary>
+    /// Publishes a <see cref="CreateInvoiceCommand"/> for asynchronous processing.
+    /// </summary>
+    Task PublishAsync(CreateInvoiceCommand command, CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Invoicing.Wolverine/GranitInvoicingWolverineModule.cs
+++ b/src/Granit.Invoicing.Wolverine/GranitInvoicingWolverineModule.cs
@@ -1,5 +1,8 @@
+using Granit.Invoicing.Wolverine.Internal;
 using Granit.Modularity;
 using Granit.Wolverine;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Granit.Invoicing.Wolverine;
 
@@ -7,4 +10,9 @@ namespace Granit.Invoicing.Wolverine;
 [DependsOn(
     typeof(GranitInvoicingModule),
     typeof(GranitWolverineModule))]
-public sealed class GranitInvoicingWolverineModule : GranitModule;
+public sealed class GranitInvoicingWolverineModule : GranitModule
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
+        context.Services.TryAddScoped<IInvoiceCommandPublisher, WolverineInvoiceCommandPublisher>();
+}

--- a/src/Granit.Invoicing.Wolverine/Internal/WolverineInvoiceCommandPublisher.cs
+++ b/src/Granit.Invoicing.Wolverine/Internal/WolverineInvoiceCommandPublisher.cs
@@ -1,0 +1,16 @@
+using Granit.Invoicing.Commands;
+using Wolverine;
+
+namespace Granit.Invoicing.Wolverine.Internal;
+
+/// <summary>
+/// Wolverine implementation of <see cref="IInvoiceCommandPublisher"/>.
+/// </summary>
+internal sealed class WolverineInvoiceCommandPublisher(IMessageBus messageBus) : IInvoiceCommandPublisher
+{
+    public async Task PublishAsync(CreateInvoiceCommand command, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        await messageBus.PublishAsync(command).ConfigureAwait(false);
+    }
+}

--- a/src/Granit.Payments.Abstractions/IPaymentCommandDispatcher.cs
+++ b/src/Granit.Payments.Abstractions/IPaymentCommandDispatcher.cs
@@ -1,0 +1,14 @@
+using Granit.Payments.Commands;
+
+namespace Granit.Payments;
+
+/// <summary>
+/// Dispatches payment commands to the messaging infrastructure.
+/// </summary>
+public interface IPaymentCommandDispatcher
+{
+    /// <summary>
+    /// Sends an <see cref="InitiatePaymentCommand"/> for processing.
+    /// </summary>
+    Task SendAsync(InitiatePaymentCommand command, CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Payments.Endpoints/packages.lock.json
+++ b/src/Granit.Payments.Endpoints/packages.lock.json
@@ -271,6 +271,12 @@
           "Microsoft.IO.RecyclableMemoryStream": "[3.*, )"
         }
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.localization": {
         "type": "Project",
         "dependencies": {
@@ -283,6 +289,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )"
         }

--- a/src/Granit.Payments.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Payments.EntityFrameworkCore/packages.lock.json
@@ -113,10 +113,17 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.payments": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"

--- a/src/Granit.Payments.Mollie/packages.lock.json
+++ b/src/Granit.Payments.Mollie/packages.lock.json
@@ -124,10 +124,17 @@
       "granit": {
         "type": "Project"
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.payments": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"

--- a/src/Granit.Payments.Notifications/packages.lock.json
+++ b/src/Granit.Payments.Notifications/packages.lock.json
@@ -41,6 +41,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.notifications.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -52,6 +58,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"

--- a/src/Granit.Payments.Stripe/packages.lock.json
+++ b/src/Granit.Payments.Stripe/packages.lock.json
@@ -270,10 +270,17 @@
           "Microsoft.Extensions.Http.Resilience": "[10.*, )"
         }
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.payments": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"

--- a/src/Granit.Payments.Wolverine/GranitPaymentsWolverineModule.cs
+++ b/src/Granit.Payments.Wolverine/GranitPaymentsWolverineModule.cs
@@ -1,7 +1,5 @@
-using Granit.Invoicing;
 using Granit.Modularity;
 using Granit.Payments.Wolverine.Internal;
-using Granit.Payments.Wolverine.Services;
 using Granit.Wolverine;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -17,8 +15,6 @@ public sealed class GranitPaymentsWolverineModule : GranitModule
     /// <inheritdoc/>
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        context.Services.TryAddScoped<IInvoicePrePaymentProcessor, PassThroughPrePaymentProcessor>();
-        context.Services.TryAddScoped<WebhookProcessor>();
-        context.Services.TryAddScoped<AutoChargeService>();
+        context.Services.TryAddScoped<IPaymentCommandDispatcher, WolverinePaymentCommandDispatcher>();
     }
 }

--- a/src/Granit.Payments.Wolverine/Handlers/AutoChargeOnInvoiceHandler.cs
+++ b/src/Granit.Payments.Wolverine/Handlers/AutoChargeOnInvoiceHandler.cs
@@ -1,17 +1,16 @@
 using Granit.Invoicing.Events;
-using Granit.Payments.Wolverine.Services;
 
 namespace Granit.Payments.Wolverine.Handlers;
 
 /// <summary>
 /// Automatically initiates payment when an invoice is finalized with auto-collection.
-/// Delegates to <see cref="AutoChargeService"/> for all charge orchestration logic.
+/// Delegates to <see cref="IAutoChargeService"/> for all charge orchestration logic.
 /// </summary>
 public class AutoChargeOnInvoiceHandler
 {
     public static Task HandleAsync(
         InvoiceFinalizedEto eto,
-        AutoChargeService autoChargeService,
+        IAutoChargeService autoChargeService,
         CancellationToken cancellationToken) =>
         autoChargeService.HandleAsync(eto, cancellationToken);
 }

--- a/src/Granit.Payments.Wolverine/Handlers/ProcessWebhookCommandHandler.cs
+++ b/src/Granit.Payments.Wolverine/Handlers/ProcessWebhookCommandHandler.cs
@@ -1,17 +1,16 @@
 using Granit.Payments.Commands;
-using Granit.Payments.Wolverine.Services;
 
 namespace Granit.Payments.Wolverine.Handlers;
 
 /// <summary>
 /// Processes inbound webhook events from payment providers.
-/// Delegates to <see cref="WebhookProcessor"/> for all reconciliation logic.
+/// Delegates to <see cref="IWebhookProcessor"/> for all reconciliation logic.
 /// </summary>
 public class ProcessWebhookCommandHandler
 {
     public static Task HandleAsync(
         ProcessWebhookCommand command,
-        WebhookProcessor processor,
+        IWebhookProcessor processor,
         CancellationToken cancellationToken) =>
         processor.ProcessAsync(command, cancellationToken);
 }

--- a/src/Granit.Payments.Wolverine/Internal/WolverinePaymentCommandDispatcher.cs
+++ b/src/Granit.Payments.Wolverine/Internal/WolverinePaymentCommandDispatcher.cs
@@ -1,0 +1,16 @@
+using Granit.Payments.Commands;
+using Wolverine;
+
+namespace Granit.Payments.Wolverine.Internal;
+
+/// <summary>
+/// Wolverine implementation of <see cref="IPaymentCommandDispatcher"/>.
+/// </summary>
+internal sealed class WolverinePaymentCommandDispatcher(IMessageBus messageBus) : IPaymentCommandDispatcher
+{
+    public async Task SendAsync(InitiatePaymentCommand command, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        await messageBus.SendAsync(command).ConfigureAwait(false);
+    }
+}

--- a/src/Granit.Payments.Wolverine/packages.lock.json
+++ b/src/Granit.Payments.Wolverine/packages.lock.json
@@ -535,6 +535,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"

--- a/src/Granit.Payments/Extensions/PaymentsHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Payments/Extensions/PaymentsHostApplicationBuilderExtensions.cs
@@ -1,5 +1,7 @@
 using Granit.Diagnostics;
+using Granit.Invoicing;
 using Granit.Payments.Diagnostics;
+using Granit.Payments.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -13,6 +15,9 @@ public static class PaymentsHostApplicationBuilderExtensions
     public static IHostApplicationBuilder AddGranitPayments(this IHostApplicationBuilder builder)
     {
         builder.Services.TryAddSingleton<PaymentsMetrics>();
+        builder.Services.TryAddTransient<IAutoChargeService, DefaultAutoChargeService>();
+        builder.Services.TryAddScoped<IInvoicePrePaymentProcessor, PassThroughPrePaymentProcessor>();
+        builder.Services.TryAddTransient<IWebhookProcessor, DefaultWebhookProcessor>();
         GranitActivitySourceRegistry.Register(PaymentsActivitySource.Name);
         return builder;
     }

--- a/src/Granit.Payments/Granit.Payments.csproj
+++ b/src/Granit.Payments/Granit.Payments.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.Invoicing.Abstractions\Granit.Invoicing.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Payments.Abstractions\Granit.Payments.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />
   </ItemGroup>

--- a/src/Granit.Payments/IAutoChargeService.cs
+++ b/src/Granit.Payments/IAutoChargeService.cs
@@ -1,0 +1,15 @@
+using Granit.Invoicing.Events;
+
+namespace Granit.Payments;
+
+/// <summary>
+/// Automatically initiates payment when an invoice is finalized with auto-collection.
+/// </summary>
+public interface IAutoChargeService
+{
+    /// <summary>
+    /// Processes an invoice finalization event, applying pre-payment adjustments and
+    /// initiating a charge via the default payment method when applicable.
+    /// </summary>
+    Task HandleAsync(InvoiceFinalizedEto eto, CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Payments/IWebhookProcessor.cs
+++ b/src/Granit.Payments/IWebhookProcessor.cs
@@ -1,0 +1,15 @@
+using Granit.Payments.Commands;
+
+namespace Granit.Payments;
+
+/// <summary>
+/// Processes inbound webhook events from payment providers.
+/// </summary>
+public interface IWebhookProcessor
+{
+    /// <summary>
+    /// Reconciles the provider-reported status with the local payment transaction
+    /// based on an inbound webhook event.
+    /// </summary>
+    Task ProcessAsync(ProcessWebhookCommand command, CancellationToken cancellationToken);
+}

--- a/src/Granit.Payments/Internal/DefaultAutoChargeService.cs
+++ b/src/Granit.Payments/Internal/DefaultAutoChargeService.cs
@@ -5,9 +5,8 @@ using Granit.MultiTenancy;
 using Granit.Payments.Commands;
 using Granit.Payments.Domain;
 using Microsoft.Extensions.Logging;
-using Wolverine;
 
-namespace Granit.Payments.Wolverine.Services;
+namespace Granit.Payments.Internal;
 
 /// <summary>
 /// Automatically initiates payment when an invoice is finalized with auto-collection.
@@ -15,12 +14,12 @@ namespace Granit.Payments.Wolverine.Services;
 /// pass-through returns the full total, but <c>Granit.CustomerBalance.Wolverine</c> can
 /// replace it to deduct available credit first.
 /// </summary>
-public sealed partial class AutoChargeService(
+internal sealed partial class DefaultAutoChargeService(
     IInvoicePrePaymentProcessor prePaymentProcessor,
     IPaymentMethodReader paymentMethodReader,
-    IMessageBus messageBus,
+    IPaymentCommandDispatcher paymentCommandDispatcher,
     ICurrentTenant currentTenant,
-    ILogger<AutoChargeService> logger)
+    ILogger<DefaultAutoChargeService> logger) : IAutoChargeService
 {
     public async Task HandleAsync(InvoiceFinalizedEto eto, CancellationToken cancellationToken)
     {
@@ -60,7 +59,7 @@ public sealed partial class AutoChargeService(
                 $"inv-{eto.InvoiceId:N}",
                 defaultMethod.ProviderName);
 
-            await messageBus.SendAsync(command).ConfigureAwait(false);
+            await paymentCommandDispatcher.SendAsync(command, cancellationToken).ConfigureAwait(false);
             Log.PaymentInitiated(logger, eto.InvoiceId, result.RemainingAmount, defaultMethod.Type, defaultMethod.ProviderName);
         }
     }

--- a/src/Granit.Payments/Internal/DefaultWebhookProcessor.cs
+++ b/src/Granit.Payments/Internal/DefaultWebhookProcessor.cs
@@ -4,18 +4,18 @@ using Granit.Payments.Domain;
 using Granit.Timing;
 using Microsoft.Extensions.Logging;
 
-namespace Granit.Payments.Wolverine.Services;
+namespace Granit.Payments.Internal;
 
 /// <summary>
 /// Processes inbound webhook events from payment providers.
 /// Reconciles the provider-reported status with the local <see cref="PaymentTransaction"/>.
 /// </summary>
-public sealed partial class WebhookProcessor(
+internal sealed partial class DefaultWebhookProcessor(
     IEnumerable<IPaymentProvider> providers,
     IPaymentTransactionReader transactionReader,
     IPaymentTransactionWriter transactionWriter,
     IClock clock,
-    ILogger<WebhookProcessor> logger)
+    ILogger<DefaultWebhookProcessor> logger) : IWebhookProcessor
 {
     public async Task ProcessAsync(ProcessWebhookCommand command, CancellationToken cancellationToken)
     {

--- a/src/Granit.Payments/Internal/PassThroughPrePaymentProcessor.cs
+++ b/src/Granit.Payments/Internal/PassThroughPrePaymentProcessor.cs
@@ -1,7 +1,7 @@
 using Granit.Invoicing;
 using Granit.Invoicing.Events;
 
-namespace Granit.Payments.Wolverine.Internal;
+namespace Granit.Payments.Internal;
 
 /// <summary>
 /// Default pre-payment processor that passes through the full invoice total unchanged.

--- a/src/Granit.Payments/packages.lock.json
+++ b/src/Granit.Payments/packages.lock.json
@@ -54,6 +54,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.payments.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.Subscriptions.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Subscriptions.BackgroundJobs/packages.lock.json
@@ -498,6 +498,12 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -518,6 +524,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions.Endpoints/packages.lock.json
+++ b/src/Granit.Subscriptions.Endpoints/packages.lock.json
@@ -78,6 +78,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.localization": {
         "type": "Project",
         "dependencies": {
@@ -123,6 +129,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"
@@ -202,8 +209,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.13.19",
-        "contentHash": "u6re2Vy+BZnywdyLAhzhdj4htb/WlGWaC+u0NrxDPbFTojuDMAw0INrdmzIYj7MDWJuhf3iYg5eLwH3X8MvPgA=="
+        "resolved": "2.13.20",
+        "contentHash": "KLWQcH0YisMa0nzv36S5TcKgZ5seAaTHXVcdG8S3H0UFFtAeBYwSOnzme6S9Ch1Tl9trpa0G8aiCjzF9H9khTw=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Subscriptions.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/packages.lock.json
@@ -113,6 +113,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.persistence": {
         "type": "Project",
         "dependencies": {
@@ -154,6 +160,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions.Features/packages.lock.json
+++ b/src/Granit.Subscriptions.Features/packages.lock.json
@@ -91,6 +91,12 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.localization": {
         "type": "Project",
         "dependencies": {
@@ -121,6 +127,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions.Internal/packages.lock.json
+++ b/src/Granit.Subscriptions.Internal/packages.lock.json
@@ -49,6 +49,12 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -69,6 +75,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions.Notifications/packages.lock.json
+++ b/src/Granit.Subscriptions.Notifications/packages.lock.json
@@ -49,6 +49,12 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.notifications.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -76,6 +82,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions.Wolverine/GranitSubscriptionsWolverineModule.cs
+++ b/src/Granit.Subscriptions.Wolverine/GranitSubscriptionsWolverineModule.cs
@@ -18,8 +18,6 @@ public sealed class GranitSubscriptionsWolverineModule : GranitModule
     /// <inheritdoc/>
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        context.Services.TryAddTransient<BillingCycleInvoiceOrchestrator>();
-        context.Services.TryAddTransient<UsageInvoiceOrchestrator>();
         context.Services.TryAddTransient<PaymentRetryDispatcher>();
     }
 }

--- a/src/Granit.Subscriptions.Wolverine/Handlers/BillingCycleCompletedHandler.cs
+++ b/src/Granit.Subscriptions.Wolverine/Handlers/BillingCycleCompletedHandler.cs
@@ -1,18 +1,17 @@
 using Granit.MultiTenancy;
 using Granit.Subscriptions.Events;
-using Granit.Subscriptions.Wolverine.Services;
 
 namespace Granit.Subscriptions.Wolverine.Handlers;
 
 /// <summary>
 /// Creates invoices for Flat/PerSeat plans when a billing cycle completes.
-/// Delegates to <see cref="BillingCycleInvoiceOrchestrator"/>.
+/// Delegates to <see cref="IBillingCycleInvoiceOrchestrator"/>.
 /// </summary>
 public class BillingCycleCompletedHandler
 {
     public static async Task HandleAsync(
         BillingCycleCompletedEto eto,
-        BillingCycleInvoiceOrchestrator orchestrator,
+        IBillingCycleInvoiceOrchestrator orchestrator,
         ICurrentTenant currentTenant,
         CancellationToken cancellationToken)
     {

--- a/src/Granit.Subscriptions.Wolverine/Handlers/UsageSummaryReadyHandler.cs
+++ b/src/Granit.Subscriptions.Wolverine/Handlers/UsageSummaryReadyHandler.cs
@@ -1,18 +1,17 @@
 using Granit.Metering.Events;
 using Granit.MultiTenancy;
-using Granit.Subscriptions.Wolverine.Services;
 
 namespace Granit.Subscriptions.Wolverine.Handlers;
 
 /// <summary>
 /// Creates consolidated invoices (fixed + usage) for PerUnit/Tiered plans.
-/// Delegates to <see cref="UsageInvoiceOrchestrator"/>.
+/// Delegates to <see cref="IUsageInvoiceOrchestrator"/>.
 /// </summary>
 public class UsageSummaryReadyHandler
 {
     public static async Task HandleAsync(
         UsageSummaryReadyEto eto,
-        UsageInvoiceOrchestrator orchestrator,
+        IUsageInvoiceOrchestrator orchestrator,
         ICurrentTenant currentTenant,
         CancellationToken cancellationToken)
     {

--- a/src/Granit.Subscriptions.Wolverine/packages.lock.json
+++ b/src/Granit.Subscriptions.Wolverine/packages.lock.json
@@ -571,6 +571,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions/Extensions/SubscriptionsHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Subscriptions/Extensions/SubscriptionsHostApplicationBuilderExtensions.cs
@@ -33,6 +33,8 @@ public static class SubscriptionsHostApplicationBuilderExtensions
         builder.Services.TryAddTransient<ISubscriptionReactivationService, DefaultSubscriptionReactivationService>();
         builder.Services.TryAddTransient<IDunningService, DefaultDunningService>();
         builder.Services.TryAddTransient<ISubscriptionProviderSyncService, DefaultSubscriptionProviderSyncService>();
+        builder.Services.TryAddTransient<IUsageInvoiceOrchestrator, DefaultUsageInvoiceOrchestrator>();
+        builder.Services.TryAddTransient<IBillingCycleInvoiceOrchestrator, DefaultBillingCycleInvoiceOrchestrator>();
         GranitActivitySourceRegistry.Register(SubscriptionsActivitySource.Name);
 
         return builder;

--- a/src/Granit.Subscriptions/Granit.Subscriptions.csproj
+++ b/src/Granit.Subscriptions/Granit.Subscriptions.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
+    <ProjectReference Include="..\Granit.Invoicing.Abstractions\Granit.Invoicing.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Scheduling\Granit.Scheduling.csproj" />
     <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />
     <ProjectReference Include="..\Granit.Workflow\Granit.Workflow.csproj" />

--- a/src/Granit.Subscriptions/IBillingCycleInvoiceOrchestrator.cs
+++ b/src/Granit.Subscriptions/IBillingCycleInvoiceOrchestrator.cs
@@ -1,0 +1,18 @@
+namespace Granit.Subscriptions;
+
+/// <summary>
+/// Creates invoices for Flat/PerSeat plans when a billing cycle completes.
+/// </summary>
+public interface IBillingCycleInvoiceOrchestrator
+{
+    /// <summary>
+    /// Creates an invoice for a completed billing cycle.
+    /// </summary>
+    Task CreateInvoiceAsync(
+        Guid subscriptionId,
+        Guid tenantId,
+        Guid planId,
+        DateTimeOffset periodStart,
+        DateTimeOffset periodEnd,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Subscriptions/IUsageInvoiceOrchestrator.cs
+++ b/src/Granit.Subscriptions/IUsageInvoiceOrchestrator.cs
@@ -1,0 +1,24 @@
+namespace Granit.Subscriptions;
+
+/// <summary>
+/// Groups the parameters needed to create a usage-based invoice.
+/// </summary>
+public sealed record CreateUsageInvoiceRequest(
+    Guid TenantId,
+    Guid MeterDefinitionId,
+    string MeterName,
+    decimal AggregatedValue,
+    string Unit,
+    DateTimeOffset PeriodStart,
+    DateTimeOffset PeriodEnd);
+
+/// <summary>
+/// Creates consolidated invoices (fixed + usage) for PerUnit/Tiered plans.
+/// </summary>
+public interface IUsageInvoiceOrchestrator
+{
+    /// <summary>
+    /// Creates a consolidated invoice combining fixed subscription charges and usage-based charges.
+    /// </summary>
+    Task CreateInvoiceAsync(CreateUsageInvoiceRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Subscriptions/Internal/DefaultBillingCycleInvoiceOrchestrator.cs
+++ b/src/Granit.Subscriptions/Internal/DefaultBillingCycleInvoiceOrchestrator.cs
@@ -1,21 +1,21 @@
+using Granit.Invoicing;
 using Granit.Invoicing.Commands;
 using Granit.Invoicing.Domain;
 using Granit.Subscriptions.Domain;
 using Microsoft.Extensions.Logging;
-using Wolverine;
 
-namespace Granit.Subscriptions.Wolverine.Services;
+namespace Granit.Subscriptions.Internal;
 
 /// <summary>
 /// Creates invoices for Flat/PerSeat plans when a billing cycle completes.
-/// PerUnit/Tiered plans are handled exclusively by <see cref="UsageInvoiceOrchestrator"/>.
+/// PerUnit/Tiered plans are handled exclusively by <see cref="DefaultUsageInvoiceOrchestrator"/>.
 /// </summary>
-public sealed partial class BillingCycleInvoiceOrchestrator(
+internal sealed partial class DefaultBillingCycleInvoiceOrchestrator(
     ISubscriptionReader subscriptionReader,
     IPlanReader planReader,
     IPricingResolver pricingResolver,
-    IMessageBus messageBus,
-    ILogger<BillingCycleInvoiceOrchestrator> logger)
+    IInvoiceCommandPublisher invoiceCommandPublisher,
+    ILogger<DefaultBillingCycleInvoiceOrchestrator> logger) : IBillingCycleInvoiceOrchestrator
 {
     public async Task CreateInvoiceAsync(
         Guid subscriptionId,
@@ -90,7 +90,7 @@ public sealed partial class BillingCycleInvoiceOrchestrator(
             PeriodStart: periodStart,
             PeriodEnd: periodEnd);
 
-        await messageBus.PublishAsync(command).ConfigureAwait(false);
+        await invoiceCommandPublisher.PublishAsync(command, cancellationToken).ConfigureAwait(false);
         Log.InvoiceCreated(logger, subscriptionId, basePrice, subscription.Currency);
     }
 

--- a/src/Granit.Subscriptions/Internal/DefaultUsageInvoiceOrchestrator.cs
+++ b/src/Granit.Subscriptions/Internal/DefaultUsageInvoiceOrchestrator.cs
@@ -1,33 +1,21 @@
+using Granit.Invoicing;
 using Granit.Invoicing.Commands;
 using Granit.Invoicing.Domain;
 using Granit.Subscriptions.Domain;
 using Microsoft.Extensions.Logging;
-using Wolverine;
 
-namespace Granit.Subscriptions.Wolverine.Services;
-
-/// <summary>
-/// Groups the parameters needed to create a usage-based invoice.
-/// </summary>
-public sealed record CreateUsageInvoiceRequest(
-    Guid TenantId,
-    Guid MeterDefinitionId,
-    string MeterName,
-    decimal AggregatedValue,
-    string Unit,
-    DateTimeOffset PeriodStart,
-    DateTimeOffset PeriodEnd);
+namespace Granit.Subscriptions.Internal;
 
 /// <summary>
 /// Creates consolidated invoices (fixed + usage) for PerUnit/Tiered plans.
 /// Exclusive invoice creator for plans with usage components.
 /// </summary>
-public sealed partial class UsageInvoiceOrchestrator(
+internal sealed partial class DefaultUsageInvoiceOrchestrator(
     ISubscriptionReader subscriptionReader,
     IPlanReader planReader,
     IPricingResolver pricingResolver,
-    IMessageBus messageBus,
-    ILogger<UsageInvoiceOrchestrator> logger)
+    IInvoiceCommandPublisher invoiceCommandPublisher,
+    ILogger<DefaultUsageInvoiceOrchestrator> logger) : IUsageInvoiceOrchestrator
 {
     public async Task CreateInvoiceAsync(
         CreateUsageInvoiceRequest request,
@@ -101,7 +89,7 @@ public sealed partial class UsageInvoiceOrchestrator(
             PeriodStart: request.PeriodStart,
             PeriodEnd: request.PeriodEnd);
 
-        await messageBus.PublishAsync(command).ConfigureAwait(false);
+        await invoiceCommandPublisher.PublishAsync(command, cancellationToken).ConfigureAwait(false);
         Log.UsageInvoiceCreated(logger, request.TenantId, request.MeterName, request.AggregatedValue);
     }
 

--- a/src/Granit.Subscriptions/packages.lock.json
+++ b/src/Granit.Subscriptions/packages.lock.json
@@ -62,6 +62,12 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/tests/Granit.CustomerBalance.BackgroundJobs.Tests/CreditExpirationScanTests.cs
+++ b/tests/Granit.CustomerBalance.BackgroundJobs.Tests/CreditExpirationScanTests.cs
@@ -27,13 +27,12 @@ public sealed class CreditExpirationScanTests
     }
 
     [Fact]
-    public void CreditExpirationScanHandler_ShouldBeInternalStaticPartial()
+    public void CreditExpirationScanHandler_ShouldBePublicNonStatic()
     {
         Type handlerType = typeof(CreditExpirationScanHandler);
 
-        handlerType.IsAbstract.ShouldBeTrue("static classes are abstract");
-        handlerType.IsSealed.ShouldBeTrue("static classes are sealed");
-        handlerType.IsNotPublic.ShouldBeTrue("handler should be internal");
+        handlerType.IsPublic.ShouldBeTrue("handler must be public for Wolverine discovery");
+        handlerType.IsAbstract.ShouldBeFalse("handler must not be static for Wolverine discovery");
     }
 
     [Fact]

--- a/tests/Granit.CustomerBalance.Wolverine.Tests/CustomerBalanceWolverineHandlerTests.cs
+++ b/tests/Granit.CustomerBalance.Wolverine.Tests/CustomerBalanceWolverineHandlerTests.cs
@@ -8,13 +8,12 @@ namespace Granit.CustomerBalance.Wolverine.Tests;
 public sealed class CustomerBalanceWolverineHandlerTests
 {
     [Fact]
-    public void OverpaymentCreditHandler_ShouldBeInternalStaticPartial()
+    public void OverpaymentCreditHandler_ShouldBePublicNonStatic()
     {
         Type handlerType = typeof(OverpaymentCreditHandler);
 
-        handlerType.IsAbstract.ShouldBeTrue("static classes are abstract");
-        handlerType.IsSealed.ShouldBeTrue("static classes are sealed");
-        handlerType.IsNotPublic.ShouldBeTrue("handler should be internal");
+        handlerType.IsPublic.ShouldBeTrue("handler must be public for Wolverine discovery");
+        handlerType.IsAbstract.ShouldBeFalse("handler must not be static for Wolverine discovery");
     }
 
     [Fact]

--- a/tests/Granit.Invoicing.Wolverine.Tests/InvoicingWolverineHandlerTests.cs
+++ b/tests/Granit.Invoicing.Wolverine.Tests/InvoicingWolverineHandlerTests.cs
@@ -12,13 +12,12 @@ public sealed class InvoicingWolverineHandlerTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void CreateInvoiceHandler_ShouldBeInternalStaticPartial()
+    public void CreateInvoiceHandler_ShouldBePublicNonStatic()
     {
         Type handlerType = typeof(CreateInvoiceHandler);
 
-        handlerType.IsAbstract.ShouldBeTrue("static classes are abstract");
-        handlerType.IsSealed.ShouldBeTrue("static classes are sealed");
-        handlerType.IsNotPublic.ShouldBeTrue("handler should be internal");
+        handlerType.IsPublic.ShouldBeTrue("handler must be public for Wolverine discovery");
+        handlerType.IsAbstract.ShouldBeFalse("handler must not be static for Wolverine discovery");
     }
 
     [Fact]

--- a/tests/Granit.Payments.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Payments.Endpoints.Tests/packages.lock.json
@@ -752,6 +752,12 @@
           "Microsoft.IO.RecyclableMemoryStream": "[3.*, )"
         }
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.localization": {
         "type": "Project",
         "dependencies": {
@@ -766,6 +772,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"

--- a/tests/Granit.Payments.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Payments.EntityFrameworkCore.Tests/packages.lock.json
@@ -331,10 +331,17 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.payments": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"

--- a/tests/Granit.Payments.Mollie.Tests/packages.lock.json
+++ b/tests/Granit.Payments.Mollie.Tests/packages.lock.json
@@ -333,10 +333,17 @@
       "granit": {
         "type": "Project"
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.payments": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"

--- a/tests/Granit.Payments.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Payments.Notifications.Tests/packages.lock.json
@@ -273,6 +273,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.notifications.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -284,6 +290,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"

--- a/tests/Granit.Payments.Stripe.Tests/packages.lock.json
+++ b/tests/Granit.Payments.Stripe.Tests/packages.lock.json
@@ -468,10 +468,17 @@
           "Microsoft.Extensions.Http.Resilience": "[10.*, )"
         }
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.payments": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"

--- a/tests/Granit.Payments.Wolverine.Tests/PaymentsWolverineHandlerTests.cs
+++ b/tests/Granit.Payments.Wolverine.Tests/PaymentsWolverineHandlerTests.cs
@@ -12,13 +12,12 @@ public sealed class PaymentsWolverineHandlerTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void AutoChargeOnInvoiceHandler_ShouldBeInternalStatic()
+    public void AutoChargeOnInvoiceHandler_ShouldBePublicNonStatic()
     {
         Type handlerType = typeof(AutoChargeOnInvoiceHandler);
 
-        handlerType.IsAbstract.ShouldBeTrue("static classes are abstract");
-        handlerType.IsSealed.ShouldBeTrue("static classes are sealed");
-        handlerType.IsNotPublic.ShouldBeTrue("handler should be internal");
+        handlerType.IsPublic.ShouldBeTrue("handler must be public for Wolverine discovery");
+        handlerType.IsAbstract.ShouldBeFalse("handler must not be static for Wolverine discovery");
     }
 
     [Fact]
@@ -70,13 +69,12 @@ public sealed class PaymentsWolverineHandlerTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void ProcessWebhookCommandHandler_ShouldBeInternalStatic()
+    public void ProcessWebhookCommandHandler_ShouldBePublicNonStatic()
     {
         Type handlerType = typeof(ProcessWebhookCommandHandler);
 
-        handlerType.IsAbstract.ShouldBeTrue("static classes are abstract");
-        handlerType.IsSealed.ShouldBeTrue("static classes are sealed");
-        handlerType.IsNotPublic.ShouldBeTrue("handler should be internal");
+        handlerType.IsPublic.ShouldBeTrue("handler must be public for Wolverine discovery");
+        handlerType.IsAbstract.ShouldBeFalse("handler must not be static for Wolverine discovery");
     }
 
     [Fact]

--- a/tests/Granit.Payments.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Payments.Wolverine.Tests/packages.lock.json
@@ -730,6 +730,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"

--- a/tests/Granit.Subscriptions.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.BackgroundJobs.Tests/packages.lock.json
@@ -693,6 +693,12 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -713,6 +719,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Endpoints.Tests/packages.lock.json
@@ -571,6 +571,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.localization": {
         "type": "Project",
         "dependencies": {
@@ -619,6 +625,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",
@@ -807,8 +814,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.13.19",
-        "contentHash": "u6re2Vy+BZnywdyLAhzhdj4htb/WlGWaC+u0NrxDPbFTojuDMAw0INrdmzIYj7MDWJuhf3iYg5eLwH3X8MvPgA=="
+        "resolved": "2.13.20",
+        "contentHash": "KLWQcH0YisMa0nzv36S5TcKgZ5seAaTHXVcdG8S3H0UFFtAeBYwSOnzme6S9Ch1Tl9trpa0G8aiCjzF9H9khTw=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/tests/Granit.Subscriptions.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.EntityFrameworkCore.Tests/packages.lock.json
@@ -331,6 +331,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.persistence": {
         "type": "Project",
         "dependencies": {
@@ -372,6 +378,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Features.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Features.Tests/packages.lock.json
@@ -323,6 +323,12 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.localization": {
         "type": "Project",
         "dependencies": {
@@ -353,6 +359,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Internal.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Internal.Tests/packages.lock.json
@@ -281,6 +281,12 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -301,6 +307,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Notifications.Tests/packages.lock.json
@@ -281,6 +281,12 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "granit.invoicing.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.notifications.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -308,6 +314,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Wolverine.Tests/SubscriptionsWolverineHandlerTests.cs
+++ b/tests/Granit.Subscriptions.Wolverine.Tests/SubscriptionsWolverineHandlerTests.cs
@@ -12,13 +12,12 @@ public sealed class SubscriptionsWolverineHandlerTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void SubscriptionProviderSyncHandler_ShouldBeInternalStaticPartial()
+    public void SubscriptionProviderSyncHandler_ShouldBePublicNonStatic()
     {
         Type handlerType = typeof(SubscriptionProviderSyncHandler);
 
-        handlerType.IsAbstract.ShouldBeTrue("static classes are abstract");
-        handlerType.IsSealed.ShouldBeTrue("static classes are sealed");
-        handlerType.IsNotPublic.ShouldBeTrue("handler should be internal");
+        handlerType.IsPublic.ShouldBeTrue("handler must be public for Wolverine discovery");
+        handlerType.IsAbstract.ShouldBeFalse("handler must not be static for Wolverine discovery");
     }
 
     [Fact]
@@ -59,13 +58,12 @@ public sealed class SubscriptionsWolverineHandlerTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void UsageSummaryReadyHandler_ShouldBeInternalStaticPartial()
+    public void UsageSummaryReadyHandler_ShouldBePublicNonStatic()
     {
         Type handlerType = typeof(UsageSummaryReadyHandler);
 
-        handlerType.IsAbstract.ShouldBeTrue("static classes are abstract");
-        handlerType.IsSealed.ShouldBeTrue("static classes are sealed");
-        handlerType.IsNotPublic.ShouldBeTrue("handler should be internal");
+        handlerType.IsPublic.ShouldBeTrue("handler must be public for Wolverine discovery");
+        handlerType.IsAbstract.ShouldBeFalse("handler must not be static for Wolverine discovery");
     }
 
     [Fact]

--- a/tests/Granit.Subscriptions.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Wolverine.Tests/packages.lock.json
@@ -766,6 +766,7 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",


### PR DESCRIPTION
## Summary

Extract domain services from `*.Wolverine` projects into base modules to enforce clean
layering: `.Wolverine` = thin handlers + `IMessageBus` adapters, base module = domain logic.

### New abstractions

- `IInvoiceCommandPublisher` in `Granit.Invoicing.Abstractions` — replaces direct
  `IMessageBus.PublishAsync(CreateInvoiceCommand)` usage in domain services
- `IPaymentCommandDispatcher` in `Granit.Payments.Abstractions` — replaces direct
  `IMessageBus.SendAsync(InitiatePaymentCommand)` usage
- Both implemented in their respective `.Wolverine` projects as thin `IMessageBus` wrappers

### Services relocated

| Service | From | To | IMessageBus replaced by |
|---------|------|----|------------------------|
| WebhookProcessor | `Payments.Wolverine` | `Payments/Internal/DefaultWebhookProcessor` | N/A (zero Wolverine deps) |
| AutoChargeService | `Payments.Wolverine` | `Payments/Internal/DefaultAutoChargeService` | `IPaymentCommandDispatcher` |
| PassThroughPrePaymentProcessor | `Payments.Wolverine` | `Payments/Internal/` | N/A (zero Wolverine deps) |
| UsageInvoiceOrchestrator | `Subscriptions.Wolverine` | `Subscriptions/Internal/DefaultUsageInvoiceOrchestrator` | `IInvoiceCommandPublisher` |
| BillingCycleInvoiceOrchestrator | `Subscriptions.Wolverine` | `Subscriptions/Internal/DefaultBillingCycleInvoiceOrchestrator` | `IInvoiceCommandPublisher` |

### Kept in place

- `PaymentRetryDispatcher` — pure `IMessageBus` adapter, correctly placed in `.Wolverine`
- `CustomerBalancePrePaymentProcessor` — cross-module integration (Invoicing + CustomerBalance)

### Tests updated

Handler convention tests updated from `IsAbstract/IsNotPublic` (old static/internal pattern)
to `IsPublic/!IsAbstract` (Wolverine public non-static pattern).

## Test plan

- [x] Full solution build: 0 errors, 0 warnings
- [x] All tests pass (0 failures)
- [x] `dotnet format --verify-no-changes` clean
- [ ] CI shards pass
