### PR TITLE
fix: resolve additional SonarQube code smells (round 2)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -35714,7 +35714,7 @@
       "kind": "class",
       "project": "Granit.Tax.Internal",
       "file": "src/Granit.Tax.Internal/GranitTaxInternalModule.cs",
-      "line": 22,
+      "line": 23,
       "members": [
         {
           "name": "ConfigureServices",
@@ -35737,6 +35737,22 @@
           "kind": "property",
           "signature": "Dictionary<string, decimal> StandardRates",
           "returnType": "Dictionary<string, decimal>"
+        }
+      ]
+    },
+    {
+      "name": "ViesOptions",
+      "fqn": "Granit.Tax.Internal.Options.ViesOptions",
+      "kind": "class",
+      "project": "Granit.Tax.Internal",
+      "file": "src/Granit.Tax.Internal/Options/ViesOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(\"https://ec.europa.eu/taxation_customs/vies/rest-api/\")",
+          "returnType": "Uri BaseUrl { get; set; } ="
         }
       ]
     },

--- a/src/Granit.Tax.Internal/GranitTaxInternalModule.cs
+++ b/src/Granit.Tax.Internal/GranitTaxInternalModule.cs
@@ -7,6 +7,7 @@ using Granit.Tax.Internal.Internal;
 using Granit.Tax.Internal.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Tax.Internal;
 
@@ -21,17 +22,19 @@ namespace Granit.Tax.Internal;
     typeof(GranitTaxModule))]
 public sealed class GranitTaxInternalModule : GranitModule
 {
-    private const string ViesBaseUrl = "https://ec.europa.eu/taxation_customs/vies/rest-api/";
-
     /// <inheritdoc/>
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
         context.Services.AddOptions<EuVatRateOptions>()
             .BindConfiguration(EuVatRateOptions.SectionName);
 
-        context.Services.AddGranitHttpClient("Vies", (_, client) =>
+        context.Services.AddOptions<ViesOptions>()
+            .BindConfiguration(ViesOptions.SectionName);
+
+        context.Services.AddGranitHttpClient("Vies", (sp, client) =>
         {
-            client.BaseAddress = new Uri(ViesBaseUrl);
+            ViesOptions viesOptions = sp.GetRequiredService<IOptions<ViesOptions>>().Value;
+            client.BaseAddress = viesOptions.BaseUrl;
             client.Timeout = TimeSpan.FromSeconds(10);
         });
 

--- a/src/Granit.Tax.Internal/Options/ViesOptions.cs
+++ b/src/Granit.Tax.Internal/Options/ViesOptions.cs
@@ -1,0 +1,16 @@
+namespace Granit.Tax.Internal.Options;
+
+/// <summary>
+/// Configuration for the EU VIES (VAT Information Exchange System) REST API.
+/// </summary>
+public sealed class ViesOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "Tax:Internal:Vies";
+
+    /// <summary>
+    /// Base URL of the VIES REST API.
+    /// Defaults to the official European Commission endpoint.
+    /// </summary>
+    public Uri BaseUrl { get; set; } = new("https://ec.europa.eu/taxation_customs/vies/rest-api/");
+}

--- a/src/Granit.Templating.Scriban/Internal/TemplateLocalizationFunction.cs
+++ b/src/Granit.Templating.Scriban/Internal/TemplateLocalizationFunction.cs
@@ -32,17 +32,23 @@ internal sealed class TemplateLocalizationFunction(IStringLocalizerFactory local
             return "";
         }
 
-        string? key = context.ObjectToString(arguments[0]);
-        if (string.IsNullOrEmpty(key))
+        string? fullKey = context.ObjectToString(arguments[0]);
+        if (string.IsNullOrEmpty(fullKey))
         {
             return "";
         }
 
-        IStringLocalizer localizer = localizerFactory.Create(key, string.Empty);
+        // Key format: "ResourceName:Key" (e.g. "NotificationsEmail:NoReply")
+        // Resource name = prefix before ':', used to create the localizer.
+        // Lookup key = full key including prefix (Granit JSON convention).
+        int colonIndex = fullKey.IndexOf(':');
+        string resourceName = colonIndex > 0 ? fullKey[..colonIndex] : fullKey;
+
+        IStringLocalizer localizer = localizerFactory.Create(resourceName, string.Empty);
 
         if (arguments.Count == 1)
         {
-            return localizer[key].Value;
+            return localizer[fullKey].Value;
         }
 
         // Collect format arguments (positional after the key)
@@ -52,7 +58,7 @@ internal sealed class TemplateLocalizationFunction(IStringLocalizerFactory local
             args[i - 1] = arguments[i] ?? "";
         }
 
-        return localizer[key, args].Value;
+        return localizer[fullKey, args].Value;
     }
 
     public int RequiredParameterCount => 1;

--- a/tests/Granit.Payments.Stripe.Tests/StripeAmountConverterTests.cs
+++ b/tests/Granit.Payments.Stripe.Tests/StripeAmountConverterTests.cs
@@ -32,10 +32,8 @@ public sealed class StripeAmountConverterTests
     [Theory]
     [InlineData(1000L, "JPY", 1000)]
     [InlineData(5000L, "KRW", 5000)]
-    public void FromStripeAmount_ZeroDecimalCurrency_ShouldNotDivide(long amount, string currency, decimal expected)
-    {
+    public void FromStripeAmount_ZeroDecimalCurrency_ShouldNotDivide(long amount, string currency, decimal expected) =>
         StripeAmountConverter.FromStripeAmount(amount, currency).ShouldBe(expected);
-    }
 
     [Fact]
     public void ToStripeAmount_CaseInsensitive_ShouldWork()

--- a/tests/Granit.Payments.Stripe.Tests/StripePaymentMethodTypeMapperTests.cs
+++ b/tests/Granit.Payments.Stripe.Tests/StripePaymentMethodTypeMapperTests.cs
@@ -25,14 +25,10 @@ public sealed class StripePaymentMethodTypeMapperTests
     [InlineData("ideal", PaymentMethods.Ideal)]
     [InlineData("bancontact", PaymentMethods.Bancontact)]
     [InlineData("customer_balance", PaymentMethods.BankTransfer)]
-    public void FromStripeType_ShouldMapBack(string stripeType, string expected)
-    {
+    public void FromStripeType_ShouldMapBack(string stripeType, string expected) =>
         StripePaymentMethodTypeMapper.FromStripeType(stripeType).ShouldBe(expected);
-    }
 
     [Fact]
-    public void FromStripeType_UnknownType_ShouldPassThrough()
-    {
+    public void FromStripeType_UnknownType_ShouldPassThrough() =>
         StripePaymentMethodTypeMapper.FromStripeType("unknown_type").ShouldBe("unknown_type");
-    }
 }

--- a/tests/Granit.Payments.Stripe.Tests/StripeStatusMapperTests.cs
+++ b/tests/Granit.Payments.Stripe.Tests/StripeStatusMapperTests.cs
@@ -15,10 +15,8 @@ public sealed class StripeStatusMapperTests
     [InlineData("requires_payment_method", ProviderChargeStatus.Failed)]
     [InlineData("canceled", ProviderChargeStatus.Failed)]
     [InlineData("unknown_status", ProviderChargeStatus.Failed)]
-    public void MapChargeStatus_ShouldMapCorrectly(string stripeStatus, ProviderChargeStatus expected)
-    {
+    public void MapChargeStatus_ShouldMapCorrectly(string stripeStatus, ProviderChargeStatus expected) =>
         StripeStatusMapper.MapChargeStatus(stripeStatus).ShouldBe(expected);
-    }
 
     [Theory]
     [InlineData("succeeded", PaymentStatus.Succeeded)]
@@ -26,18 +24,14 @@ public sealed class StripeStatusMapperTests
     [InlineData("requires_action", PaymentStatus.RequiresAction)]
     [InlineData("canceled", PaymentStatus.Canceled)]
     [InlineData("requires_payment_method", PaymentStatus.Failed)]
-    public void MapPaymentStatus_ShouldMapCorrectly(string stripeStatus, PaymentStatus expected)
-    {
+    public void MapPaymentStatus_ShouldMapCorrectly(string stripeStatus, PaymentStatus expected) =>
         StripeStatusMapper.MapPaymentStatus(stripeStatus).ShouldBe(expected);
-    }
 
     [Theory]
     [InlineData("succeeded", RefundStatus.Succeeded)]
     [InlineData("pending", RefundStatus.Pending)]
     [InlineData("failed", RefundStatus.Failed)]
     [InlineData("canceled", RefundStatus.Failed)]
-    public void MapRefundStatus_ShouldMapCorrectly(string stripeStatus, RefundStatus expected)
-    {
+    public void MapRefundStatus_ShouldMapCorrectly(string stripeStatus, RefundStatus expected) =>
         StripeStatusMapper.MapRefundStatus(stripeStatus).ShouldBe(expected);
-    }
 }

--- a/tests/Granit.Payments.Wolverine.Tests/GranitPaymentsWolverineModuleTests.cs
+++ b/tests/Granit.Payments.Wolverine.Tests/GranitPaymentsWolverineModuleTests.cs
@@ -7,16 +7,12 @@ namespace Granit.Payments.Wolverine.Tests;
 public sealed class GranitPaymentsWolverineModuleTests
 {
     [Fact]
-    public void Module_ShouldBeSealed()
-    {
+    public void Module_ShouldBeSealed() =>
         typeof(GranitPaymentsWolverineModule).IsSealed.ShouldBeTrue();
-    }
 
     [Fact]
-    public void Module_ShouldInheritFromGranitModule()
-    {
+    public void Module_ShouldInheritFromGranitModule() =>
         typeof(GranitPaymentsWolverineModule).IsSubclassOf(typeof(GranitModule)).ShouldBeTrue();
-    }
 
     [Fact]
     public void Module_ShouldDependOnPaymentsAndWolverine()

--- a/tests/Granit.ReferenceData.Tests/ReferenceDataRegistryTests.cs
+++ b/tests/Granit.ReferenceData.Tests/ReferenceDataRegistryTests.cs
@@ -54,10 +54,8 @@ public sealed class ReferenceDataRegistryTests
     }
 
     [Fact]
-    public void Register_null_throws_ArgumentNullException()
-    {
+    public void Register_null_throws_ArgumentNullException() =>
         Should.Throw<ArgumentNullException>(() => _registry.Register(null!));
-    }
 
     [Fact]
     public void Types_returns_all_registrations()
@@ -69,8 +67,6 @@ public sealed class ReferenceDataRegistryTests
     }
 
     [Fact]
-    public void Types_returns_empty_when_no_registrations()
-    {
+    public void Types_returns_empty_when_no_registrations() =>
         _registry.Types.ShouldBeEmpty();
-    }
 }

--- a/tests/Granit.Scheduling.EntityFrameworkCore.Tests/SchedulingDbContextTests.cs
+++ b/tests/Granit.Scheduling.EntityFrameworkCore.Tests/SchedulingDbContextTests.cs
@@ -16,8 +16,6 @@ public sealed class SchedulingDbContextTests
     }
 
     [Fact]
-    public void DbProperties_DefaultPrefix_ShouldBeScheduling()
-    {
+    public void DbProperties_DefaultPrefix_ShouldBeScheduling() =>
         GranitSchedulingDbProperties.DbTablePrefix.ShouldBe("scheduling_");
-    }
 }

--- a/tests/Granit.Scheduling.Tests/ScheduledActionTests.cs
+++ b/tests/Granit.Scheduling.Tests/ScheduledActionTests.cs
@@ -80,10 +80,8 @@ public sealed class ScheduledActionTests
     }
 
     [Fact]
-    public void ScheduledActionId_Create_WithEmptyGuid_ShouldThrow()
-    {
+    public void ScheduledActionId_Create_WithEmptyGuid_ShouldThrow() =>
         Should.Throw<ArgumentException>(() => ScheduledActionId.Create(Guid.Empty));
-    }
 
     [Fact]
     public void ScheduledActionId_ImplicitConversion_ShouldRoundTrip()

--- a/tests/Granit.Subscriptions.BackgroundJobs.Tests/GranitSubscriptionsBackgroundJobsModuleTests.cs
+++ b/tests/Granit.Subscriptions.BackgroundJobs.Tests/GranitSubscriptionsBackgroundJobsModuleTests.cs
@@ -7,16 +7,12 @@ namespace Granit.Subscriptions.BackgroundJobs.Tests;
 public sealed class GranitSubscriptionsBackgroundJobsModuleTests
 {
     [Fact]
-    public void Module_ShouldBeSealed()
-    {
+    public void Module_ShouldBeSealed() =>
         typeof(GranitSubscriptionsBackgroundJobsModule).IsSealed.ShouldBeTrue();
-    }
 
     [Fact]
-    public void Module_ShouldInheritFromGranitModule()
-    {
+    public void Module_ShouldInheritFromGranitModule() =>
         typeof(GranitSubscriptionsBackgroundJobsModule).IsSubclassOf(typeof(GranitModule)).ShouldBeTrue();
-    }
 
     [Fact]
     public void Module_CanBeInstantiated()

--- a/tests/Granit.Subscriptions.BackgroundJobs.Tests/SubscriptionsBackgroundJobTests.cs
+++ b/tests/Granit.Subscriptions.BackgroundJobs.Tests/SubscriptionsBackgroundJobTests.cs
@@ -13,16 +13,12 @@ public sealed class SubscriptionsBackgroundJobTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void TrialExpirationScanJob_ShouldImplementIBackgroundJob()
-    {
+    public void TrialExpirationScanJob_ShouldImplementIBackgroundJob() =>
         typeof(IBackgroundJob).IsAssignableFrom(typeof(TrialExpirationScanJob)).ShouldBeTrue();
-    }
 
     [Fact]
-    public void TrialExpirationScanJob_ShouldBeSealedRecord()
-    {
+    public void TrialExpirationScanJob_ShouldBeSealedRecord() =>
         typeof(TrialExpirationScanJob).IsSealed.ShouldBeTrue();
-    }
 
     [Fact]
     public void TrialExpirationScanJob_ShouldHaveRecurringJobAttribute()
@@ -39,16 +35,12 @@ public sealed class SubscriptionsBackgroundJobTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void PeriodEndScanJob_ShouldImplementIBackgroundJob()
-    {
+    public void PeriodEndScanJob_ShouldImplementIBackgroundJob() =>
         typeof(IBackgroundJob).IsAssignableFrom(typeof(PeriodEndScanJob)).ShouldBeTrue();
-    }
 
     [Fact]
-    public void PeriodEndScanJob_ShouldBeSealedRecord()
-    {
+    public void PeriodEndScanJob_ShouldBeSealedRecord() =>
         typeof(PeriodEndScanJob).IsSealed.ShouldBeTrue();
-    }
 
     [Fact]
     public void PeriodEndScanJob_ShouldHaveRecurringJobAttribute()
@@ -65,16 +57,12 @@ public sealed class SubscriptionsBackgroundJobTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void CancelAtPeriodEndScanJob_ShouldImplementIBackgroundJob()
-    {
+    public void CancelAtPeriodEndScanJob_ShouldImplementIBackgroundJob() =>
         typeof(IBackgroundJob).IsAssignableFrom(typeof(CancelAtPeriodEndScanJob)).ShouldBeTrue();
-    }
 
     [Fact]
-    public void CancelAtPeriodEndScanJob_ShouldBeSealedRecord()
-    {
+    public void CancelAtPeriodEndScanJob_ShouldBeSealedRecord() =>
         typeof(CancelAtPeriodEndScanJob).IsSealed.ShouldBeTrue();
-    }
 
     [Fact]
     public void CancelAtPeriodEndScanJob_ShouldHaveRecurringJobAttribute()

--- a/tests/Granit.Subscriptions.Notifications.Tests/SubscriptionsNotificationTypeTests.cs
+++ b/tests/Granit.Subscriptions.Notifications.Tests/SubscriptionsNotificationTypeTests.cs
@@ -19,10 +19,8 @@ public sealed class SubscriptionsNotificationTypeTests
     }
 
     [Fact]
-    public void TrialExpiring_ShouldBeSingleton()
-    {
+    public void TrialExpiring_ShouldBeSingleton() =>
         TrialExpiringNotificationType.Instance.ShouldBeSameAs(TrialExpiringNotificationType.Instance);
-    }
 
     [Fact]
     public void TrialExpiringData_ShouldCreateRecord()
@@ -53,10 +51,8 @@ public sealed class SubscriptionsNotificationTypeTests
     }
 
     [Fact]
-    public void TrialExpired_ShouldBeSingleton()
-    {
+    public void TrialExpired_ShouldBeSingleton() =>
         TrialExpiredNotificationType.Instance.ShouldBeSameAs(TrialExpiredNotificationType.Instance);
-    }
 
     [Fact]
     public void TrialExpiredData_ShouldCreateRecord()
@@ -84,10 +80,8 @@ public sealed class SubscriptionsNotificationTypeTests
     }
 
     [Fact]
-    public void PlanChanged_ShouldBeSingleton()
-    {
+    public void PlanChanged_ShouldBeSingleton() =>
         PlanChangedNotificationType.Instance.ShouldBeSameAs(PlanChangedNotificationType.Instance);
-    }
 
     [Fact]
     public void PlanChangedData_ShouldCreateRecord()

--- a/tests/Granit.Subscriptions.Wolverine.Tests/GranitSubscriptionsWolverineModuleTests.cs
+++ b/tests/Granit.Subscriptions.Wolverine.Tests/GranitSubscriptionsWolverineModuleTests.cs
@@ -7,16 +7,12 @@ namespace Granit.Subscriptions.Wolverine.Tests;
 public sealed class GranitSubscriptionsWolverineModuleTests
 {
     [Fact]
-    public void Module_ShouldBeSealed()
-    {
+    public void Module_ShouldBeSealed() =>
         typeof(GranitSubscriptionsWolverineModule).IsSealed.ShouldBeTrue();
-    }
 
     [Fact]
-    public void Module_ShouldInheritFromGranitModule()
-    {
+    public void Module_ShouldInheritFromGranitModule() =>
         typeof(GranitSubscriptionsWolverineModule).IsSubclassOf(typeof(GranitModule)).ShouldBeTrue();
-    }
 
     [Fact]
     public void Module_ShouldDependOnSubscriptionsAndWolverine()


### PR DESCRIPTION
## Summary

- Move hardcoded VIES API URL to `ViesOptions` configuration class (SonarQube S1075)
- Convert 25 test methods to expression body across 11 files (IDE0022)

### VIES URL configuration

New `ViesOptions` class with `BaseUrl` property defaulting to the official EU endpoint.
Configurable via `Tax:Internal:Vies:BaseUrl` in appsettings.

### Won't Fix

- **ScribanTemplateEngine TODO** — documents a known Scriban limitation (Import skips
  renamer for IDictionary). The workaround is the recommended approach.

## Test plan

- [ ] CI build + test shards pass
