### PR TITLE
fix(multi-tenancy): correct namespace to match folder structure

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -22002,6 +22002,38 @@
       ]
     },
     {
+      "name": "MultiTenancyEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "fqn": "Granit.MultiTenancy.EntityFrameworkCore.Extensions.MultiTenancyEntityFrameworkCoreHostApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.MultiTenancy.EntityFrameworkCore",
+      "file": "src/Granit.MultiTenancy.EntityFrameworkCore/Extensions/MultiTenancyEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "AddGranitMultiTenancyEntityFrameworkCore",
+          "kind": "method",
+          "signature": "AddGranitMultiTenancyEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
+          "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "MultiTenancyModelBuilderExtensions",
+      "fqn": "Granit.MultiTenancy.EntityFrameworkCore.Extensions.MultiTenancyModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.MultiTenancy.EntityFrameworkCore",
+      "file": "src/Granit.MultiTenancy.EntityFrameworkCore/Extensions/MultiTenancyModelBuilderExtensions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "ConfigureMultiTenancyModule",
+          "kind": "method",
+          "signature": "ConfigureMultiTenancyModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
       "name": "GranitMultiTenancyEntityFrameworkCoreModule",
       "fqn": "Granit.MultiTenancy.EntityFrameworkCore.GranitMultiTenancyEntityFrameworkCoreModule",
       "kind": "class",
@@ -22023,38 +22055,6 @@
           "kind": "property",
           "signature": "string DbTablePrefix",
           "returnType": "string"
-        }
-      ]
-    },
-    {
-      "name": "MultiTenancyEntityFrameworkCoreHostApplicationBuilderExtensions",
-      "fqn": "Granit.MultiTenancy.EntityFrameworkCore.MultiTenancyEntityFrameworkCoreHostApplicationBuilderExtensions",
-      "kind": "class",
-      "project": "Granit.MultiTenancy.EntityFrameworkCore",
-      "file": "src/Granit.MultiTenancy.EntityFrameworkCore/Extensions/MultiTenancyEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 15,
-      "members": [
-        {
-          "name": "AddGranitMultiTenancyEntityFrameworkCore",
-          "kind": "method",
-          "signature": "AddGranitMultiTenancyEntityFrameworkCore(this IHostApplicationBuilder builder, Action<DbContextOptionsBuilder> configure)",
-          "returnType": "IHostApplicationBuilder"
-        }
-      ]
-    },
-    {
-      "name": "MultiTenancyModelBuilderExtensions",
-      "fqn": "Granit.MultiTenancy.EntityFrameworkCore.MultiTenancyModelBuilderExtensions",
-      "kind": "class",
-      "project": "Granit.MultiTenancy.EntityFrameworkCore",
-      "file": "src/Granit.MultiTenancy.EntityFrameworkCore/Extensions/MultiTenancyModelBuilderExtensions.cs",
-      "line": 9,
-      "members": [
-        {
-          "name": "ConfigureMultiTenancyModule",
-          "kind": "method",
-          "signature": "ConfigureMultiTenancyModule(this ModelBuilder modelBuilder)",
-          "returnType": "ModelBuilder"
         }
       ]
     },

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Extensions/MultiTenancyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Extensions/MultiTenancyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 
-namespace Granit.MultiTenancy.EntityFrameworkCore;
+namespace Granit.MultiTenancy.EntityFrameworkCore.Extensions;
 
 /// <summary>
 /// Extension methods for registering the multi-tenancy EF Core persistence layer.

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Extensions/MultiTenancyModelBuilderExtensions.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Extensions/MultiTenancyModelBuilderExtensions.cs
@@ -1,7 +1,7 @@
 using Granit.MultiTenancy.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;
 
-namespace Granit.MultiTenancy.EntityFrameworkCore;
+namespace Granit.MultiTenancy.EntityFrameworkCore.Extensions;
 
 /// <summary>
 /// Extension methods for applying multi-tenancy entity configurations to a <see cref="ModelBuilder"/>.

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/MultiTenancyDbContext.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/MultiTenancyDbContext.cs
@@ -1,5 +1,6 @@
 using Granit.DataFiltering;
 using Granit.MultiTenancy.EntityFrameworkCore.Entities;
+using Granit.MultiTenancy.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 

--- a/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/MultiTenancyModelBuilderExtensionsTests.cs
+++ b/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/MultiTenancyModelBuilderExtensionsTests.cs
@@ -1,4 +1,5 @@
 using Granit.MultiTenancy.EntityFrameworkCore.Entities;
+using Granit.MultiTenancy.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Shouldly;


### PR DESCRIPTION
## Summary

- Fix namespace in `Extensions/` files from `Granit.MultiTenancy.EntityFrameworkCore` to `Granit.MultiTenancy.EntityFrameworkCore.Extensions`
- Add missing `using` in `MultiTenancyDbContext.cs` and test file

Fixes architecture test `Namespace_should_match_folder_structure_in_src` failure from #898.

## Test plan

- [x] `dotnet test tests/Granit.MultiTenancy.EntityFrameworkCore.Tests` — 33 passed
- [x] Architecture test violation resolved