### PR TITLE
fix: resolve 21 SonarQube code smells (round 3)

### DIFF
--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
@@ -183,6 +183,9 @@ internal static partial class AccountLoginEndpoints
         string sanitizedCode = request.Code.Replace(" ", string.Empty, StringComparison.Ordinal)
             .Replace("-", string.Empty, StringComparison.Ordinal);
 
+        string method = request.UseRecoveryCode ? "recovery_code" : "totp";
+        string failureReason = request.UseRecoveryCode ? "invalid_recovery_code" : "invalid_totp_code";
+
         Microsoft.AspNetCore.Identity.SignInResult result;
 
         if (request.UseRecoveryCode)
@@ -214,8 +217,8 @@ internal static partial class AccountLoginEndpoints
 
         if (result.Succeeded)
         {
-            LogTwoFactorSuccess(logger, request.UseRecoveryCode ? "recovery_code" : "totp");
-            metrics?.RecordAuthenticationSuccess(null, request.UseRecoveryCode ? "recovery_code" : "totp");
+            LogTwoFactorSuccess(logger, method);
+            metrics?.RecordAuthenticationSuccess(null, method);
 
             return TypedResults.Ok(new AccountLoginResponse(Succeeded: true));
         }
@@ -242,7 +245,7 @@ internal static partial class AccountLoginEndpoints
                 statusCode: StatusCodes.Status401Unauthorized);
         }
 
-        LogTwoFactorFailed(logger, request.UseRecoveryCode ? "invalid_recovery_code" : "invalid_totp_code");
+        LogTwoFactorFailed(logger, failureReason);
         metrics?.RecordAuthenticationFailure(null, "invalid_token");
 
         return TypedResults.Problem(

--- a/src/Granit.Payments.SepaDirectDebit.GoCardless/Internal/GoCardlessDirectDebitProvider.cs
+++ b/src/Granit.Payments.SepaDirectDebit.GoCardless/Internal/GoCardlessDirectDebitProvider.cs
@@ -13,6 +13,8 @@ internal sealed partial class GoCardlessDirectDebitProvider(
     GoCardlessClient client,
     ILogger<GoCardlessDirectDebitProvider> logger) : IDirectDebitProvider
 {
+    private const string DefaultRedirectUrl = "https://localhost/mandate-complete";
+
     /// <inheritdoc/>
     public string Name => "gocardless";
 
@@ -24,7 +26,7 @@ internal sealed partial class GoCardlessDirectDebitProvider(
         {
             Description = $"SEPA DD mandate for tenant {request.TenantId}",
             SessionToken = request.TenantId.ToString(),
-            SuccessRedirectUrl = request.RedirectUrl ?? "https://localhost/mandate-complete",
+            SuccessRedirectUrl = request.RedirectUrl ?? DefaultRedirectUrl,
         };
 
         RedirectFlowResponse response = await client.RedirectFlows.CreateAsync(flowRequest)

--- a/src/Granit.Payments.SepaDirectDebit.Internal/Internal/Pain008Generator.cs
+++ b/src/Granit.Payments.SepaDirectDebit.Internal/Internal/Pain008Generator.cs
@@ -34,11 +34,6 @@ internal sealed class Pain008Generator(
         SepaDirectDebitInternalOptions config = options.Value;
         DateTimeOffset now = clock.Now;
 
-        // Build mandate lookup
-        var mandateLookup = mandates
-            .Where(m => m.Collections.Count > 0)
-            .ToDictionary(m => m.Id);
-
         string msgId = $"SDD-{now:yyyyMMddHHmmss}";
 
         var doc = new XDocument(new XDeclaration("1.0", "UTF-8", null),
@@ -80,8 +75,6 @@ internal sealed class Pain008Generator(
         SepaDirectDebitInternalOptions config,
         DateTimeOffset requestedDate)
     {
-        var mandateById = mandates.ToDictionary(m => m.Id);
-
         var pmtInf = new XElement(Ns + "PmtInf",
             new XElement(Ns + "PmtInfId", $"PMT-{requestedDate:yyyyMMdd}"),
             new XElement(Ns + "PmtMtd", "DD"),

--- a/src/Granit.Payments.SepaDirectDebit.Twikey/Internal/TwikeyDirectDebitProvider.cs
+++ b/src/Granit.Payments.SepaDirectDebit.Twikey/Internal/TwikeyDirectDebitProvider.cs
@@ -6,26 +6,28 @@ namespace Granit.Payments.SepaDirectDebit.Twikey.Internal;
 /// <summary>Twikey SEPA DD provider (Phase 3 — stub implementation).</summary>
 internal sealed class TwikeyDirectDebitProvider : IDirectDebitProvider
 {
+    private const string NotImplementedMessage = "Twikey provider not yet implemented.";
+
     /// <inheritdoc/>
     public string Name => "twikey";
 
     /// <inheritdoc/>
     public Task<MandateSetupResult> SetupMandateAsync(
         MandateSetupRequest request, CancellationToken cancellationToken = default) =>
-        throw new NotSupportedException("Twikey provider not yet implemented.");
+        throw new NotSupportedException(NotImplementedMessage);
 
     /// <inheritdoc/>
     public Task CancelMandateAsync(
         string providerMandateId, CancellationToken cancellationToken = default) =>
-        throw new NotSupportedException("Twikey provider not yet implemented.");
+        throw new NotSupportedException(NotImplementedMessage);
 
     /// <inheritdoc/>
     public Task<CollectionResult> CollectAsync(
         CollectionRequest request, CancellationToken cancellationToken = default) =>
-        throw new NotSupportedException("Twikey provider not yet implemented.");
+        throw new NotSupportedException(NotImplementedMessage);
 
     /// <inheritdoc/>
     public Task<CollectionStatusResult> GetCollectionStatusAsync(
         string providerCollectionId, CancellationToken cancellationToken = default) =>
-        throw new NotSupportedException("Twikey provider not yet implemented.");
+        throw new NotSupportedException(NotImplementedMessage);
 }

--- a/src/Granit.Payments.SepaTransfer/Internal/Camt053Parser.cs
+++ b/src/Granit.Payments.SepaTransfer/Internal/Camt053Parser.cs
@@ -94,7 +94,7 @@ internal sealed class Camt053Parser : IBankStatementParser
                 ?? txDtls?.Descendants("EndToEndId").FirstOrDefault()?.Value;
 
             entries.Add(new BankStatementEntry(
-                BookingDate: DateTimeOffset.TryParse(bookingDate, out DateTimeOffset dt) ? dt : DateTimeOffset.MinValue,
+                BookingDate: DateTimeOffset.TryParse(bookingDate, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTimeOffset dt) ? dt : DateTimeOffset.MinValue,
                 Amount: amount,
                 Currency: currency ?? "EUR",
                 DebtorName: debtorName,

--- a/src/Granit.Payments.Wolverine/GranitPaymentsWolverineModule.cs
+++ b/src/Granit.Payments.Wolverine/GranitPaymentsWolverineModule.cs
@@ -13,8 +13,6 @@ namespace Granit.Payments.Wolverine;
 public sealed class GranitPaymentsWolverineModule : GranitModule
 {
     /// <inheritdoc/>
-    public override void ConfigureServices(ServiceConfigurationContext context)
-    {
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
         context.Services.TryAddScoped<IPaymentCommandDispatcher, WolverinePaymentCommandDispatcher>();
-    }
 }

--- a/src/Granit.Payments/Internal/DefaultAutoChargeService.cs
+++ b/src/Granit.Payments/Internal/DefaultAutoChargeService.cs
@@ -21,7 +21,7 @@ internal sealed partial class DefaultAutoChargeService(
     ICurrentTenant currentTenant,
     ILogger<DefaultAutoChargeService> logger) : IAutoChargeService
 {
-    public async Task HandleAsync(InvoiceFinalizedEto eto, CancellationToken cancellationToken)
+    public async Task HandleAsync(InvoiceFinalizedEto eto, CancellationToken cancellationToken = default)
     {
         using (currentTenant.Change(eto.TenantId))
         {

--- a/src/Granit.Subscriptions.Wolverine/GranitSubscriptionsWolverineModule.cs
+++ b/src/Granit.Subscriptions.Wolverine/GranitSubscriptionsWolverineModule.cs
@@ -16,8 +16,6 @@ namespace Granit.Subscriptions.Wolverine;
 public sealed class GranitSubscriptionsWolverineModule : GranitModule
 {
     /// <inheritdoc/>
-    public override void ConfigureServices(ServiceConfigurationContext context)
-    {
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
         context.Services.TryAddTransient<PaymentRetryDispatcher>();
-    }
 }

--- a/src/Granit.Subscriptions/Internal/DefaultBillingCycleInvoiceOrchestrator.cs
+++ b/src/Granit.Subscriptions/Internal/DefaultBillingCycleInvoiceOrchestrator.cs
@@ -23,7 +23,7 @@ internal sealed partial class DefaultBillingCycleInvoiceOrchestrator(
         Guid planId,
         DateTimeOffset periodStart,
         DateTimeOffset periodEnd,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken = default)
     {
         Plan? plan = await planReader.GetByIdAsync(planId, cancellationToken)
             .ConfigureAwait(false);

--- a/src/Granit.Subscriptions/Internal/DefaultUsageInvoiceOrchestrator.cs
+++ b/src/Granit.Subscriptions/Internal/DefaultUsageInvoiceOrchestrator.cs
@@ -19,7 +19,7 @@ internal sealed partial class DefaultUsageInvoiceOrchestrator(
 {
     public async Task CreateInvoiceAsync(
         CreateUsageInvoiceRequest request,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken = default)
     {
         if (request.TenantId == Guid.Empty)
         {

--- a/src/Granit.Templating.EntityFrameworkCore/Entities/TemplateRevisionEntity.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Entities/TemplateRevisionEntity.cs
@@ -81,10 +81,9 @@ internal sealed class TemplateRevisionEntity : VersionedWorkflowEntity, IMultiTe
         string content,
         string mimeType,
         string? layoutName = null,
-        Guid? categoryId = null,
-        Guid? versionId = null)
+        Guid? categoryId = null)
     {
-        var entity = new TemplateRevisionEntity
+        return new TemplateRevisionEntity
         {
             Id = id,
             TemplateName = templateName,
@@ -94,16 +93,16 @@ internal sealed class TemplateRevisionEntity : VersionedWorkflowEntity, IMultiTe
             LayoutName = layoutName,
             CategoryId = categoryId,
         };
+    }
 
-        // If a VersionId is provided (existing template group), set it so the
-        // VersioningInterceptor increments the version within the same group.
-        // If left as Guid.Empty, the interceptor generates a new VersionId.
-        if (versionId.HasValue)
-        {
-            ((IVersioned)entity).VersionId = versionId.Value;
-        }
-
-        return entity;
+    /// <summary>
+    /// Sets the version group so the <c>VersioningInterceptor</c> increments
+    /// the version within an existing group instead of creating a new one.
+    /// </summary>
+    internal TemplateRevisionEntity WithVersionId(Guid versionId)
+    {
+        ((IVersioned)this).VersionId = versionId;
+        return this;
     }
 
     /// <summary>
@@ -134,8 +133,6 @@ internal sealed class TemplateRevisionEntity : VersionedWorkflowEntity, IMultiTe
     /// <summary>
     /// Archives this revision (superseded by a newer publication).
     /// </summary>
-    public void Archive()
-    {
+    public void Archive() =>
         SetLifecycleStatus(WorkflowLifecycleStatus.Archived);
-    }
 }

--- a/src/Granit.Templating.EntityFrameworkCore/Internal/EfDocumentTemplateStore.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Internal/EfDocumentTemplateStore.cs
@@ -103,8 +103,12 @@ internal sealed class EfDocumentTemplateStore(
                 key.Culture,
                 content,
                 mimeType,
-                layoutName,
-                versionId: existingVersionId);
+                layoutName);
+
+            if (existingVersionId.HasValue)
+            {
+                entity.WithVersionId(existingVersionId.Value);
+            }
 
             entity.CreatedBy = updatedBy;
             entity.CreatedAt = clock.Now;

--- a/src/Granit.Templating.Scriban/Internal/ScribanTemplateEngine.cs
+++ b/src/Granit.Templating.Scriban/Internal/ScribanTemplateEngine.cs
@@ -109,7 +109,7 @@ internal sealed class ScribanTemplateEngine(
         ScriptObject globals = [];
 
         // Expose TData as "model" with snake_case property names (PascalCase → snake_case).
-        // Scriban's Import skips the renamer for IDictionary (upstream TODO), so we handle it manually.
+        // Scriban's Import skips the renamer for IDictionary (upstream limitation), so we handle it manually.
         ScriptObject model = [];
         if (data is IDictionary<string, object?> dict)
         {

--- a/src/Granit.Templating.Workflow/Internal/WorkflowTemplateTransitionHook.cs
+++ b/src/Granit.Templating.Workflow/Internal/WorkflowTemplateTransitionHook.cs
@@ -48,11 +48,9 @@ internal sealed class WorkflowTemplateTransitionHook(
         WorkflowLifecycleStatus from,
         WorkflowLifecycleStatus target,
         string userId,
-        CancellationToken cancellationToken = default)
-    {
+        CancellationToken cancellationToken = default) =>
         // No-op: the WorkflowTransitionInterceptor automatically creates
         // WorkflowTransitionRecord entries when the entity status changes
         // are persisted via SaveChanges.
-        return Task.CompletedTask;
-    }
+        Task.CompletedTask;
 }

--- a/tests/Granit.DataExchange.Tests/Import/ImportPreviewServiceTests.cs
+++ b/tests/Granit.DataExchange.Tests/Import/ImportPreviewServiceTests.cs
@@ -31,9 +31,9 @@ public sealed class ImportPreviewServiceTests
 
         _parser.CanParse("text/csv").Returns(true);
         _parser.ExtractHeadersAsync(Arg.Any<Stream>(), Arg.Any<FileParsingOptions>(), Arg.Any<CancellationToken>())
-            .Returns(new List<string> { "Name", "Email" });
+            .Returns(new List<string>(["Name", "Email"]));
         _parser.ReadPreviewAsync(Arg.Any<Stream>(), Arg.Any<FileParsingOptions>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(new List<string[]> { new[] { "Alice", "alice@test.com" }, new[] { "Bob", "bob@test.com" } });
+            .Returns(new List<string[]>([["Alice", "alice@test.com"], ["Bob", "bob@test.com"]]));
 
         _fileProvider.OpenAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(_ => Task.FromResult<Stream>(new MemoryStream(System.Text.Encoding.UTF8.GetBytes("Name,Email\nAlice,alice@test.com"))));

--- a/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/MultiTenancyDbPropertiesTests.cs
+++ b/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/MultiTenancyDbPropertiesTests.cs
@@ -6,14 +6,10 @@ namespace Granit.MultiTenancy.EntityFrameworkCore.Tests;
 public sealed class MultiTenancyDbPropertiesTests
 {
     [Fact]
-    public void DefaultTablePrefix_IsTenants()
-    {
+    public void DefaultTablePrefix_IsTenants() =>
         MultiTenancyDbProperties.DbTablePrefix.ShouldBe("tenants_");
-    }
 
     [Fact]
-    public void DefaultSchema_IsNull()
-    {
+    public void DefaultSchema_IsNull() =>
         MultiTenancyDbProperties.DbSchema.ShouldBeNull();
-    }
 }

--- a/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/TenantTests.cs
+++ b/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/TenantTests.cs
@@ -60,16 +60,12 @@ public sealed class TenantTests
     }
 
     [Fact]
-    public void Create_NullName_Throws()
-    {
+    public void Create_NullName_Throws() =>
         Should.Throw<ArgumentException>(() => Tenant.Create(Guid.NewGuid(), null!, "acme"));
-    }
 
     [Fact]
-    public void Create_EmptyIdentifier_Throws()
-    {
+    public void Create_EmptyIdentifier_Throws() =>
         Should.Throw<ArgumentException>(() => Tenant.Create(Guid.NewGuid(), "Acme", ""));
-    }
 
     // -------------------------------------------------------------------------
     // UpdateDetails

--- a/tests/Granit.Templating.EntityFrameworkCore.Tests/TemplateRevisionEntityTests.cs
+++ b/tests/Granit.Templating.EntityFrameworkCore.Tests/TemplateRevisionEntityTests.cs
@@ -14,15 +14,15 @@ public sealed class TemplateRevisionEntityTests
         var categoryId = Guid.NewGuid();
         var versionId = Guid.NewGuid();
 
-        var entity = TemplateRevisionEntity.Create(
+        TemplateRevisionEntity entity = TemplateRevisionEntity.Create(
             id,
             templateName: "Billing.Invoice",
             culture: "fr-BE",
             content: "<p>Facture</p>",
             mimeType: "text/html",
             layoutName: "default",
-            categoryId: categoryId,
-            versionId: versionId);
+            categoryId: categoryId)
+            .WithVersionId(versionId);
 
         entity.Id.ShouldBe(id);
         entity.RevisionId.ShouldBe(id);


### PR DESCRIPTION
## Summary

- Resolve 21 SonarQube code smells across 16 files (round 3)
- Covers Identity, Payments, Subscriptions, Templating, MultiTenancy, and DataExchange modules
- All fixes are minimal, behavior-preserving refactors

## Changes

| Issue | File(s) | Fix |
|-------|---------|-----|
| Cognitive complexity 17→15 | `AccountLoginEndpoints.cs` | Extract ternary expressions before nested `if` blocks |
| Hardcoded URI | `GoCardlessDirectDebitProvider.cs` | Extract `DefaultRedirectUrl` constant |
| Unused variables (×2) | `Pain008Generator.cs` | Remove `mandateLookup` and `mandateById` |
| Repeated literal (×4) | `TwikeyDirectDebitProvider.cs` | Extract `NotImplementedMessage` constant |
| Date parsing without format provider | `Camt053Parser.cs` | Add `CultureInfo.InvariantCulture` + `DateTimeStyles.None` |
| Expression body (×6) | Wolverine modules, `TemplateRevisionEntity`, `WorkflowTemplateTransitionHook` | Convert to `=>` |
| Missing default parameter (×3) | `DefaultAutoChargeService`, `DefaultBillingCycleInvoiceOrchestrator`, `DefaultUsageInvoiceOrchestrator` | Add `= default` matching interface |
| 8 parameters (>7 authorized) | `TemplateRevisionEntity.Create` | Extract `versionId` into fluent `WithVersionId()` method |
| TODO comment | `ScribanTemplateEngine.cs` | Reword to "upstream limitation" |
| Collection initialization (×2) | `ImportPreviewServiceTests.cs` | Simplify with collection expressions |
| Expression body (×4) | `MultiTenancyDbPropertiesTests`, `TenantTests` | Convert to `=>` |

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet format --verify-no-changes` — clean
- [x] Templating EF tests — 60/60 passed
- [x] MultiTenancy EF tests — 33/33 passed
- [x] DataExchange tests — 333/333 passed
