### PR TITLE
feat: add base EF configurations for abstract entities + fix GoCardless hardcoded URI

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -28149,6 +28149,12 @@
           "kind": "property",
           "signature": "string WebhookSecret",
           "returnType": "string"
+        },
+        {
+          "name": "UseSandbox",
+          "kind": "property",
+          "signature": "bool UseSandbox",
+          "returnType": "bool"
         }
       ]
     },
@@ -30576,6 +30582,22 @@
       "file": "src/Granit.Privacy.EntityFrameworkCore/GranitPrivacyEntityFrameworkCoreModule.cs",
       "line": 10,
       "members": []
+    },
+    {
+      "name": "LegalAgreementBaseConfiguration",
+      "fqn": "Granit.Privacy.EntityFrameworkCore.LegalAgreementBaseConfiguration",
+      "kind": "class",
+      "project": "Granit.Privacy.EntityFrameworkCore",
+      "file": "src/Granit.Privacy.EntityFrameworkCore/Internal/LegalAgreementBaseConfiguration.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "Configure",
+          "kind": "method",
+          "signature": "Configure(EntityTypeBuilder<T> builder)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "PrivacyServiceCollectionExtensions",
@@ -41836,6 +41858,15 @@
           "returnType": "InterceptionResult<int>"
         }
       ]
+    },
+    {
+      "name": "VersionedWorkflowEntityBaseConfiguration",
+      "fqn": "Granit.Workflow.EntityFrameworkCore.VersionedWorkflowEntityBaseConfiguration",
+      "kind": "class",
+      "project": "Granit.Workflow.EntityFrameworkCore",
+      "file": "src/Granit.Workflow.EntityFrameworkCore/VersionedWorkflowEntityBaseConfiguration.cs",
+      "line": 36,
+      "members": []
     },
     {
       "name": "WorkflowApprovalRequestedEvent",

--- a/src/Granit.Payments.SepaDirectDebit.GoCardless/Internal/GoCardlessDirectDebitProvider.cs
+++ b/src/Granit.Payments.SepaDirectDebit.GoCardless/Internal/GoCardlessDirectDebitProvider.cs
@@ -2,7 +2,9 @@ using GoCardless;
 using GoCardless.Services;
 using Granit.Payments.SepaDirectDebit.Contracts;
 using Granit.Payments.SepaDirectDebit.Domain;
+using Granit.Payments.SepaDirectDebit.GoCardless.Options;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using GcMandateStatus = GoCardless.Resources.MandateStatus;
 using GcPaymentStatus = GoCardless.Resources.PaymentStatus;
 
@@ -11,9 +13,9 @@ namespace Granit.Payments.SepaDirectDebit.GoCardless.Internal;
 /// <summary>GoCardless implementation of <see cref="IDirectDebitProvider"/>.</summary>
 internal sealed partial class GoCardlessDirectDebitProvider(
     GoCardlessClient client,
+    IOptions<GoCardlessOptions> options,
     ILogger<GoCardlessDirectDebitProvider> logger) : IDirectDebitProvider
 {
-    private const string DefaultRedirectUrl = "https://localhost/mandate-complete";
 
     /// <inheritdoc/>
     public string Name => "gocardless";
@@ -26,7 +28,7 @@ internal sealed partial class GoCardlessDirectDebitProvider(
         {
             Description = $"SEPA DD mandate for tenant {request.TenantId}",
             SessionToken = request.TenantId.ToString(),
-            SuccessRedirectUrl = request.RedirectUrl ?? DefaultRedirectUrl,
+            SuccessRedirectUrl = request.RedirectUrl ?? options.Value.DefaultMandateRedirectUrl,
         };
 
         RedirectFlowResponse response = await client.RedirectFlows.CreateAsync(flowRequest)

--- a/src/Granit.Payments.SepaDirectDebit.GoCardless/Options/GoCardlessOptions.cs
+++ b/src/Granit.Payments.SepaDirectDebit.GoCardless/Options/GoCardlessOptions.cs
@@ -18,4 +18,12 @@ public sealed class GoCardlessOptions
 
     /// <summary>Use GoCardless sandbox environment.</summary>
     public bool UseSandbox { get; set; }
+
+    /// <summary>
+    /// Fallback redirect URL used when a mandate setup request does not provide one.
+    /// Must be an absolute HTTPS URL registered in the GoCardless dashboard.
+    /// </summary>
+    [Required]
+    [Url]
+    public string DefaultMandateRedirectUrl { get; set; } = string.Empty;
 }

--- a/src/Granit.Privacy.EntityFrameworkCore/Internal/LegalAgreementBaseConfiguration.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/Internal/LegalAgreementBaseConfiguration.cs
@@ -1,0 +1,54 @@
+using Granit.Privacy.LegalAgreements.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Privacy.EntityFrameworkCore;
+
+/// <summary>
+/// Base EF Core configuration for concrete <see cref="LegalAgreementBase"/> entities.
+/// </summary>
+/// <remarks>
+/// Inherit from this class in your application's DbContext assembly to map a concrete
+/// <c>LegalAgreement</c> entity to the standard <c>privacy_legal_agreements</c> table.
+/// Override <see cref="Configure"/> to add application-specific columns or indexes.
+/// The table can be placed in any <c>DbContext</c> the application chooses.
+/// </remarks>
+/// <example>
+/// <code>
+/// internal sealed class LegalAgreementEntityTypeConfiguration
+///     : LegalAgreementBaseConfiguration&lt;LegalAgreement&gt;;
+/// </code>
+/// </example>
+/// <typeparam name="T">Concrete entity type inheriting <see cref="LegalAgreementBase"/>.</typeparam>
+public abstract class LegalAgreementBaseConfiguration<T> : IEntityTypeConfiguration<T>
+    where T : LegalAgreementBase
+{
+    /// <inheritdoc />
+    public virtual void Configure(EntityTypeBuilder<T> builder)
+    {
+        builder.ToTable(
+            GranitPrivacyDbProperties.DbTablePrefix + "legal_agreements",
+            GranitPrivacyDbProperties.DbSchema);
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.UserId)
+            .IsRequired();
+
+        builder.Property(e => e.DocumentId)
+            .HasMaxLength(200)
+            .IsRequired();
+
+        builder.Property(e => e.Version)
+            .HasMaxLength(50)
+            .IsRequired();
+
+        builder.Property(e => e.AcceptedAt)
+            .IsRequired();
+
+        builder.Property(e => e.IpAddress)
+            .HasMaxLength(45);
+
+        builder.HasIndex(e => new { e.UserId, e.DocumentId });
+    }
+}

--- a/src/Granit.Workflow.EntityFrameworkCore/VersionedWorkflowEntityBaseConfiguration.cs
+++ b/src/Granit.Workflow.EntityFrameworkCore/VersionedWorkflowEntityBaseConfiguration.cs
@@ -1,0 +1,83 @@
+using Granit.Workflow.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Granit.Workflow.EntityFrameworkCore;
+
+/// <summary>
+/// Base EF Core configuration for concrete <see cref="VersionedWorkflowEntity"/> entities.
+/// Configures the versioning and workflow lifecycle columns common to all derived entities.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Inherit from this class in your application's DbContext assembly to map a concrete entity
+/// that extends <see cref="VersionedWorkflowEntity"/>. Pass the target table name to the
+/// base constructor. Override <see cref="ConfigureEntity"/> to add entity-specific columns
+/// or indexes.
+/// </para>
+/// <para>
+/// The table can be placed in any <c>DbContext</c> the application chooses.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// internal sealed class ContractConfiguration : VersionedWorkflowEntityBaseConfiguration&lt;Contract&gt;
+/// {
+///     public ContractConfiguration() : base("contracts") { }
+///
+///     protected override void ConfigureEntity(EntityTypeBuilder&lt;Contract&gt; builder)
+///     {
+///         builder.Property(e =&gt; e.Title).HasMaxLength(500).IsRequired();
+///     }
+/// }
+/// </code>
+/// </example>
+/// <typeparam name="T">Concrete entity type inheriting <see cref="VersionedWorkflowEntity"/>.</typeparam>
+public abstract class VersionedWorkflowEntityBaseConfiguration<T> : IEntityTypeConfiguration<T>
+    where T : VersionedWorkflowEntity
+{
+    private readonly string _tableName;
+
+    /// <summary>
+    /// Initializes a new instance with the specified table name.
+    /// </summary>
+    /// <param name="tableName">
+    /// The database table name (e.g., <c>"contracts"</c>). Use the module prefix convention:
+    /// <c>"{module}_table_name"</c> (e.g., <c>"billing_contracts"</c>).
+    /// </param>
+    protected VersionedWorkflowEntityBaseConfiguration(string tableName)
+    {
+        _tableName = tableName;
+    }
+
+    /// <inheritdoc />
+    public void Configure(EntityTypeBuilder<T> builder)
+    {
+        builder.ToTable(_tableName, GranitWorkflowDbProperties.DbSchema);
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.VersionId)
+            .IsRequired();
+
+        builder.Property(e => e.Version)
+            .IsRequired();
+
+        builder.Property(e => e.LifecycleStatus)
+            .HasConversion<string>()
+            .HasMaxLength(20)
+            .IsRequired();
+
+        builder.Property(e => e.IsPublished)
+            .IsRequired();
+
+        ConfigureEntity(builder);
+    }
+
+    /// <summary>
+    /// Override to add entity-specific column mappings and indexes after the base configuration.
+    /// </summary>
+    protected virtual void ConfigureEntity(EntityTypeBuilder<T> builder)
+    {
+    }
+}


### PR DESCRIPTION
## Summary

- **`LegalAgreementBaseConfiguration<T>`** (`Granit.Privacy.EntityFrameworkCore`): classe de base `public abstract` pour configurer les entités concrètes héritant de `LegalAgreementBase` — mappe `privacy_legal_agreements`, l'app n'a plus qu'à hériter sans redéclarer les colonnes
- **`VersionedWorkflowEntityBaseConfiguration<T>`** (`Granit.Workflow.EntityFrameworkCore`): même pattern que `ReferenceDataEntityTypeConfiguration<T>` — constructeur `(tableName)` + hook `ConfigureEntity`, configure `VersionId`, `Version`, `LifecycleStatus`, `IsPublished`
- **GoCardless S1075 fix**: `DefaultRedirectUrl` constante hardcodée (`https://localhost/mandate-complete`) déplacée dans `GoCardlessOptions.DefaultMandateRedirectUrl` avec `[Required]` + `[Url]` — `ValidateOnStart()` bloque au démarrage si absent

## Test plan

- [ ] Vérifier que `LegalAgreementBaseConfiguration<T>` est bien `public` et accessible depuis un projet applicatif
- [ ] Vérifier que `VersionedWorkflowEntityBaseConfiguration<T>` configure correctement les colonnes workflow (LifecycleStatus as string, IsPublished)
- [ ] Vérifier que l'app qui n'a pas `DefaultMandateRedirectUrl` dans sa config échoue au démarrage avec un message clair