### PR TITLE
fix(openiddict): default LoginPath /account/login → /login

### DIFF
--- a/src/Granit.OpenIddict.Endpoints/Options/OpenIddictServerEndpointsOptions.cs
+++ b/src/Granit.OpenIddict.Endpoints/Options/OpenIddictServerEndpointsOptions.cs
@@ -8,9 +8,9 @@ public sealed class OpenIddictServerEndpointsOptions
     /// <summary>
     /// Default path to redirect unauthenticated users during authorization.
     /// The cookie authentication handler appends a <c>ReturnUrl</c> query parameter.
-    /// Default: <c>"/account/login"</c>.
+    /// Default: <c>"/login"</c>.
     /// </summary>
-    public string LoginPath { get; set; } = "/account/login";
+    public string LoginPath { get; set; } = "/login";
 
     /// <summary>
     /// Per-client login paths that override <see cref="LoginPath"/>.


### PR DESCRIPTION
## Summary

- Change `OpenIddictServerEndpointsOptions.LoginPath` default from `/account/login` to `/login`
- `/account/login` is an ASP.NET Core Identity Razor Pages convention, not suited for SPA/BFF setups
- `/login` is the industry standard (GitHub, Slack, Stripe, Linear, Notion, Figma)

## Test plan

- [ ] Verify that consumers without explicit `LoginPath` override now redirect to `/login`
- [ ] Verify that explicit `LoginPath` overrides (e.g. `/host/login`) still work