### PR TITLE
feat(bff): add ClientUrl to BffFrontendOptions

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -7193,10 +7193,10 @@
           "returnType": "string"
         },
         {
-          "name": "Scopes",
+          "name": "ClientUrl",
           "kind": "property",
-          "signature": "string[] Scopes",
-          "returnType": "string[]"
+          "signature": "string? ClientUrl",
+          "returnType": "string?"
         },
         {
           "name": "PathPrefix",
@@ -7211,10 +7211,22 @@
           "returnType": "string"
         },
         {
+          "name": "LoginPath",
+          "kind": "property",
+          "signature": "string LoginPath",
+          "returnType": "string"
+        },
+        {
           "name": "PostLoginRedirectPath",
           "kind": "property",
           "signature": "string? PostLoginRedirectPath",
           "returnType": "string?"
+        },
+        {
+          "name": "PrefixWithClientUrl",
+          "kind": "method",
+          "signature": "PrefixWithClientUrl(LoginPath)",
+          "returnType": "string EffectiveLoginUrl =>"
         },
         {
           "name": "EffectivePostLoginRedirectPath",

--- a/src/Granit.Bff/Options/GranitBffOptions.cs
+++ b/src/Granit.Bff/Options/GranitBffOptions.cs
@@ -99,6 +99,15 @@ public sealed class BffFrontendOptions
     /// <summary>OIDC client secret.</summary>
     public string ClientSecret { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Base URL of the frontend application when it runs on a separate origin
+    /// (e.g., <c>"http://localhost:5173"</c> for a Vite dev server, or
+    /// <c>"https://admin.example.com"</c> for a standalone deployment).
+    /// When <see langword="null"/>, all redirect paths are relative (the frontend
+    /// is served by the BFF itself).
+    /// </summary>
+    public string? ClientUrl { get; set; }
+
     /// <summary>OIDC scopes to request.</summary>
     public string[] Scopes { get; set; } = ["openid", "profile", "email", "roles", "offline_access"];
 
@@ -116,16 +125,23 @@ public sealed class BffFrontendOptions
     /// </summary>
     public string StaticFilesPath { get; set; } = string.Empty;
 
-    /// <summary>Post-login redirect path (default: the frontend's path prefix + <c>"/"</c>).</summary>
+    /// <summary>
+    /// Login page path within the frontend (default: <c>"/login"</c>).
+    /// Combined with <see cref="ClientUrl"/> (when set) to produce the full login URL
+    /// used by the OIDC authorization server to redirect unauthenticated users.
+    /// </summary>
+    public string LoginPath { get; set; } = "/login";
+
+    /// <summary>Post-login redirect path (default: <c>"/"</c>, or <c>{ClientUrl}/</c> when set).</summary>
     public string? PostLoginRedirectPath { get; set; }
 
-    /// <summary>Post-logout redirect path (default: the frontend's path prefix + <c>"/"</c>).</summary>
+    /// <summary>Post-logout redirect path (default: <c>"/"</c>, or <c>{ClientUrl}/</c> when set).</summary>
     public string? PostLogoutRedirectPath { get; set; }
 
     /// <summary>
     /// Path to redirect to when the OIDC callback encounters an error. An <c>?error={code}</c>
     /// query parameter is appended so the SPA can display a localized error message.
-    /// Default: <c>{PathPrefix}/login</c>.
+    /// Default: <c>/login</c> (or <c>{ClientUrl}/login</c> when set).
     /// </summary>
     public string? ErrorRedirectPath { get; set; }
 
@@ -141,22 +157,37 @@ public sealed class BffFrontendOptions
     internal string CookiePrefix { get; set; } = "__Host-";
 
     /// <summary>
+    /// Gets the effective login URL. When <see cref="ClientUrl"/> is set, returns
+    /// <c>{ClientUrl}{LoginPath}</c>; otherwise returns <see cref="LoginPath"/>.
+    /// </summary>
+    public string EffectiveLoginUrl => PrefixWithClientUrl(LoginPath);
+
+    /// <summary>
     /// Gets the effective post-login redirect path.
+    /// When <see cref="ClientUrl"/> is set and no explicit path is configured,
+    /// returns <c>{ClientUrl}/</c>.
     /// </summary>
     public string EffectivePostLoginRedirectPath =>
-        PostLoginRedirectPath ?? (string.IsNullOrEmpty(PathPrefix) ? "/" : $"{PathPrefix}/");
+        PostLoginRedirectPath ?? PrefixWithClientUrl(string.IsNullOrEmpty(PathPrefix) ? "/" : $"{PathPrefix}/");
 
     /// <summary>
     /// Gets the effective post-logout redirect path.
+    /// When <see cref="ClientUrl"/> is set and no explicit path is configured,
+    /// returns <c>{ClientUrl}/</c>.
     /// </summary>
     public string EffectivePostLogoutRedirectPath =>
-        PostLogoutRedirectPath ?? (string.IsNullOrEmpty(PathPrefix) ? "/" : $"{PathPrefix}/");
+        PostLogoutRedirectPath ?? PrefixWithClientUrl(string.IsNullOrEmpty(PathPrefix) ? "/" : $"{PathPrefix}/");
 
     /// <summary>
     /// Gets the effective error redirect path (without the <c>?error=</c> query parameter).
+    /// When <see cref="ClientUrl"/> is set and no explicit path is configured,
+    /// returns <c>{ClientUrl}/login</c>.
     /// </summary>
     public string EffectiveErrorRedirectPath =>
-        ErrorRedirectPath ?? (string.IsNullOrEmpty(PathPrefix) ? "/login" : $"{PathPrefix}/login");
+        ErrorRedirectPath ?? PrefixWithClientUrl(string.IsNullOrEmpty(PathPrefix) ? "/login" : $"{PathPrefix}/login");
+
+    private string PrefixWithClientUrl(string relativePath) =>
+        string.IsNullOrEmpty(ClientUrl) ? relativePath : $"{ClientUrl.TrimEnd('/')}{relativePath}";
 
     /// <summary>
     /// Gets or sets a value indicating whether the BFF should use Pushed Authorization

--- a/src/Granit.Bff/Options/GranitBffOptionsValidator.cs
+++ b/src/Granit.Bff/Options/GranitBffOptionsValidator.cs
@@ -39,6 +39,27 @@ internal sealed class GranitBffOptionsValidator
             }
         }
 
+        for (int i = 0; i < options.Frontends.Count; i++)
+        {
+            BffFrontendOptions frontend = options.Frontends[i];
+
+            if (!string.IsNullOrEmpty(frontend.ClientUrl))
+            {
+                if (!Uri.TryCreate(frontend.ClientUrl, UriKind.Absolute, out Uri? uri)
+                    || (uri.Scheme != "http" && uri.Scheme != "https"))
+                {
+                    failures.Add(
+                        $"Frontends[{i}].ClientUrl '{frontend.ClientUrl}' must be an absolute HTTP(S) URL.");
+                }
+
+                if (frontend.ClientUrl.EndsWith('/'))
+                {
+                    failures.Add(
+                        $"Frontends[{i}].ClientUrl must not end with a trailing slash.");
+                }
+            }
+        }
+
         return failures.Count == 0
             ? ValidateOptionsResult.Success
             : ValidateOptionsResult.Fail(failures);

--- a/tests/Granit.Bff.Tests/Options/GranitBffOptionsTests.cs
+++ b/tests/Granit.Bff.Tests/Options/GranitBffOptionsTests.cs
@@ -1,4 +1,5 @@
 using Granit.Bff.Options;
+using Microsoft.Extensions.Options;
 using Shouldly;
 using Xunit;
 
@@ -234,5 +235,183 @@ public sealed class BffFrontendOptionsTests
         var frontend = new BffFrontendOptions { PathPrefix = string.Empty };
 
         frontend.EffectiveErrorRedirectPath.ShouldBe("/login");
+    }
+
+    // ──── ClientUrl ────
+
+    [Fact]
+    public void DefaultClientUrl_IsNull()
+    {
+        var frontend = new BffFrontendOptions();
+
+        frontend.ClientUrl.ShouldBeNull();
+    }
+
+    [Fact]
+    public void DefaultLoginPath_IsLogin()
+    {
+        var frontend = new BffFrontendOptions();
+
+        frontend.LoginPath.ShouldBe("/login");
+    }
+
+    // ──── EffectiveLoginUrl ────
+
+    [Fact]
+    public void EffectiveLoginUrl_WithoutClientUrl_ReturnsLoginPath()
+    {
+        var frontend = new BffFrontendOptions { LoginPath = "/login" };
+
+        frontend.EffectiveLoginUrl.ShouldBe("/login");
+    }
+
+    [Fact]
+    public void EffectiveLoginUrl_WithClientUrl_ReturnsCombined()
+    {
+        var frontend = new BffFrontendOptions
+        {
+            ClientUrl = "http://localhost:5173",
+            LoginPath = "/login",
+        };
+
+        frontend.EffectiveLoginUrl.ShouldBe("http://localhost:5173/login");
+    }
+
+    [Fact]
+    public void EffectiveLoginUrl_WithClientUrlTrailingSlash_TrimsSlash()
+    {
+        var frontend = new BffFrontendOptions
+        {
+            ClientUrl = "http://localhost:5173/",
+            LoginPath = "/login",
+        };
+
+        frontend.EffectiveLoginUrl.ShouldBe("http://localhost:5173/login");
+    }
+
+    // ──── Effective*Path with ClientUrl ────
+
+    [Fact]
+    public void EffectivePostLoginRedirectPath_WithClientUrl_PrefixesUrl()
+    {
+        var frontend = new BffFrontendOptions
+        {
+            ClientUrl = "http://localhost:5173",
+        };
+
+        frontend.EffectivePostLoginRedirectPath.ShouldBe("http://localhost:5173/");
+    }
+
+    [Fact]
+    public void EffectivePostLoginRedirectPath_WithClientUrl_ExplicitValueWins()
+    {
+        var frontend = new BffFrontendOptions
+        {
+            ClientUrl = "http://localhost:5173",
+            PostLoginRedirectPath = "/custom/dashboard",
+        };
+
+        frontend.EffectivePostLoginRedirectPath.ShouldBe("/custom/dashboard");
+    }
+
+    [Fact]
+    public void EffectivePostLogoutRedirectPath_WithClientUrl_PrefixesUrl()
+    {
+        var frontend = new BffFrontendOptions
+        {
+            ClientUrl = "http://localhost:5174",
+        };
+
+        frontend.EffectivePostLogoutRedirectPath.ShouldBe("http://localhost:5174/");
+    }
+
+    [Fact]
+    public void EffectiveErrorRedirectPath_WithClientUrl_PrefixesUrl()
+    {
+        var frontend = new BffFrontendOptions
+        {
+            ClientUrl = "http://localhost:5174",
+        };
+
+        frontend.EffectiveErrorRedirectPath.ShouldBe("http://localhost:5174/login");
+    }
+}
+
+public sealed class GranitBffOptionsValidatorTests
+{
+    private readonly GranitBffOptionsValidator _validator = new();
+
+    private static GranitBffOptions CreateValidOptions() => new()
+    {
+        Authority = new Uri("https://auth.example.com"),
+    };
+
+    [Fact]
+    public void ClientUrl_ValidHttps_Succeeds()
+    {
+        GranitBffOptions options = CreateValidOptions();
+        options.Frontends.Add(new BffFrontendOptions { ClientUrl = "https://admin.example.com" });
+
+        ValidateOptionsResult result = _validator.Validate(null, options);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ClientUrl_ValidHttpLocalhost_Succeeds()
+    {
+        GranitBffOptions options = CreateValidOptions();
+        options.Frontends.Add(new BffFrontendOptions { ClientUrl = "http://localhost:5173" });
+
+        ValidateOptionsResult result = _validator.Validate(null, options);
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ClientUrl_WithTrailingSlash_Fails()
+    {
+        GranitBffOptions options = CreateValidOptions();
+        options.Frontends.Add(new BffFrontendOptions { ClientUrl = "http://localhost:5173/" });
+
+        ValidateOptionsResult result = _validator.Validate(null, options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("trailing slash");
+    }
+
+    [Fact]
+    public void ClientUrl_NotAbsoluteUri_Fails()
+    {
+        GranitBffOptions options = CreateValidOptions();
+        options.Frontends.Add(new BffFrontendOptions { ClientUrl = "/relative/path" });
+
+        ValidateOptionsResult result = _validator.Validate(null, options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("absolute HTTP(S) URL");
+    }
+
+    [Fact]
+    public void ClientUrl_FtpScheme_Fails()
+    {
+        GranitBffOptions options = CreateValidOptions();
+        options.Frontends.Add(new BffFrontendOptions { ClientUrl = "ftp://files.example.com" });
+
+        ValidateOptionsResult result = _validator.Validate(null, options);
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("absolute HTTP(S) URL");
+    }
+
+    [Fact]
+    public void ClientUrl_Null_Succeeds()
+    {
+        GranitBffOptions options = CreateValidOptions();
+        options.Frontends.Add(new BffFrontendOptions { ClientUrl = null });
+
+        ValidateOptionsResult result = _validator.Validate(null, options);
+
+        result.Succeeded.ShouldBeTrue();
     }
 }


### PR DESCRIPTION
## Summary

- Add `ClientUrl` (nullable) and `LoginPath` (default `/login`) properties to `BffFrontendOptions`
- Add `EffectiveLoginUrl` computed property that combines `ClientUrl + LoginPath`
- Update all `Effective*` properties (`PostLoginRedirectPath`, `PostLogoutRedirectPath`, `ErrorRedirectPath`) to prefix with `ClientUrl` when set
- Add `ClientUrl` validation in `GranitBffOptionsValidator` (absolute HTTP(S) URL, no trailing slash)
- Add 13 new unit tests covering defaults, effective URLs, and validation

### How it works

In **dev** (separate Vite ports), set `ClientUrl` per frontend:

```json
"Bff": {
  "Frontends": [
    { "Name": "host", "ClientUrl": "http://localhost:5173" },
    { "Name": "app",  "ClientUrl": "http://localhost:5174" }
  ]
}
```

The host wires OpenIddict `ClientLoginPaths` from BFF config:

```csharp
app.MapGranitOpenIddictServer(opts =>
{
    foreach (var frontend in bffOptions.Frontends)
        if (!string.IsNullOrEmpty(frontend.ClientId))
            opts.ClientLoginPaths[frontend.ClientId] = frontend.EffectiveLoginUrl;
});
```

In **production** (`ClientUrl` null), all paths stay relative — zero config needed.

## Test plan

- [ ] Verify `EffectiveLoginUrl` returns `/login` when `ClientUrl` is null
- [ ] Verify `EffectiveLoginUrl` returns `http://localhost:5173/login` when `ClientUrl` is set
- [ ] Verify `EffectivePostLoginRedirectPath` prefixes with `ClientUrl` when set
- [ ] Verify explicit `PostLoginRedirectPath` overrides `ClientUrl` prefix
- [ ] Verify validator rejects non-HTTP(S) URLs and trailing slashes
- [ ] Verify showcase dev flow: host (:5173) and tenant (:5174) each redirect to their own `/login`