### PR TITLE
feat(bff): returnUrl login flow + fix email layout regression

### DIFF
--- a/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
@@ -103,8 +103,11 @@ internal static partial class BffLoginEndpoints
         // Generate DPoP key pair if enabled (stored alongside PKCE state, used during token exchange)
         string? dpopPrivateKeyJwk = frontend.UseDPoP ? dpopService.GenerateKeyPair() : null;
 
-        // Store code_verifier + state + frontend name + DPoP key in cache (short TTL for the auth round-trip)
-        PkceState pkceData = new(codeVerifier, state, frontend.Name, dpopPrivateKeyJwk);
+        // Read and validate the caller-supplied returnUrl (open-redirect prevention)
+        string? returnUrl = ValidateReturnUrl(httpContext.Request.Query["returnUrl"], frontend);
+
+        // Store code_verifier + state + frontend name + DPoP key + returnUrl in cache (short TTL for the auth round-trip)
+        PkceState pkceData = new(codeVerifier, state, frontend.Name, dpopPrivateKeyJwk, returnUrl);
 
         await cache.SetAsync(
             $"{PkceKeyPrefix}{state}",
@@ -262,7 +265,12 @@ internal static partial class BffLoginEndpoints
         metrics.RecordLogin(null);
         LogLoginSuccess(logger, MaskSessionId(sessionId), frontend.Name);
 
-        return TypedResults.Redirect(frontend.EffectivePostLoginRedirectPath);
+        // Redirect to the original URL the user requested, or fall back to the configured post-login path
+        string redirectUrl = !string.IsNullOrEmpty(pkceState.ReturnUrl)
+            ? frontend.PrefixWithClientUrl(pkceState.ReturnUrl)
+            : frontend.EffectivePostLoginRedirectPath;
+
+        return TypedResults.Redirect(redirectUrl);
     }
 
 #pragma warning disable GRSEC003 // Method handles tokens — server-side only
@@ -545,7 +553,35 @@ internal static partial class BffLoginEndpoints
     internal static string MaskSessionId(string sessionId) =>
         sessionId.Length > 8 ? $"{sessionId[..4]}...{sessionId[^4..]}" : "****";
 
-    internal sealed record PkceState(string CodeVerifier, string State, string FrontendName, string? DPoPPrivateKeyJwk = null);
+    /// <summary>
+    /// Validates a caller-supplied <c>returnUrl</c> to prevent open-redirect attacks.
+    /// Only relative paths (starting with <c>/</c>) or URLs matching the frontend's
+    /// <see cref="BffFrontendOptions.ClientUrl"/> origin are accepted.
+    /// Returns the validated relative path, or <see langword="null"/> if the URL is invalid.
+    /// </summary>
+    internal static string? ValidateReturnUrl(string? returnUrl, BffFrontendOptions frontend)
+    {
+        if (string.IsNullOrWhiteSpace(returnUrl))
+        {
+            return null;
+        }
+
+        // Must be a relative path starting with "/", reject protocol-relative URLs (//evil.com)
+        if (!returnUrl.StartsWith('/') || returnUrl.StartsWith("//", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        // Reject URLs containing a scheme (e.g. javascript:, data:, or http: after path traversal)
+        if (returnUrl.Contains(':', StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return returnUrl;
+    }
+
+    internal sealed record PkceState(string CodeVerifier, string State, string FrontendName, string? DPoPPrivateKeyJwk = null, string? ReturnUrl = null);
 
     /// <summary>
     /// Builds a redirect to the frontend error page with the given error code as a query parameter.

--- a/src/Granit.Bff/Options/GranitBffOptions.cs
+++ b/src/Granit.Bff/Options/GranitBffOptions.cs
@@ -186,7 +186,7 @@ public sealed class BffFrontendOptions
     public string EffectiveErrorRedirectPath =>
         ErrorRedirectPath ?? PrefixWithClientUrl(string.IsNullOrEmpty(PathPrefix) ? "/login" : $"{PathPrefix}/login");
 
-    private string PrefixWithClientUrl(string relativePath) =>
+    internal string PrefixWithClientUrl(string relativePath) =>
         string.IsNullOrEmpty(ClientUrl) ? relativePath : $"{ClientUrl.TrimEnd('/')}{relativePath}";
 
     /// <summary>

--- a/src/Granit.Notifications.Email/Templates/Layout.Email.html
+++ b/src/Granit.Notifications.Email/Templates/Layout.Email.html
@@ -105,7 +105,7 @@
                 {{- end }}
             </header>
             <main role="main">
-                {{ body | raw }}
+                {{ body }}
                 {{- if app.base_url != "" }}
                 <hr class="divider" aria-hidden="true">
                 <p style="text-align: center;">

--- a/tests/Granit.Bff.Endpoints.Tests/Endpoints/BffHelperMethodTests.cs
+++ b/tests/Granit.Bff.Endpoints.Tests/Endpoints/BffHelperMethodTests.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json;
 using Granit.Bff.Endpoints.Endpoints;
 using Granit.Bff.Endpoints.Extensions;
+using Granit.Bff.Options;
 using Shouldly;
 using Xunit;
 
@@ -357,6 +358,87 @@ public sealed class BffHelperMethodTests
 
         result.Length.ShouldBe(1);
         result[0].ShouldBe("contributor");
+    }
+
+    // ──── ValidateReturnUrl ────
+
+    private static BffFrontendOptions CreateFrontend(string? clientUrl = null) => new()
+    {
+        Name = "test",
+        ClientId = "test-client",
+        ClientUrl = clientUrl,
+    };
+
+    [Fact]
+    public void ValidateReturnUrl_RelativePath_ReturnsPath()
+    {
+        string? result = BffLoginEndpoints.ValidateReturnUrl("/tenants", CreateFrontend());
+
+        result.ShouldBe("/tenants");
+    }
+
+    [Fact]
+    public void ValidateReturnUrl_RelativePathWithQuery_ReturnsPath()
+    {
+        string? result = BffLoginEndpoints.ValidateReturnUrl("/tenants?page=2", CreateFrontend());
+
+        result.ShouldBe("/tenants?page=2");
+    }
+
+    [Fact]
+    public void ValidateReturnUrl_Null_ReturnsNull()
+    {
+        string? result = BffLoginEndpoints.ValidateReturnUrl(null, CreateFrontend());
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ValidateReturnUrl_Empty_ReturnsNull()
+    {
+        string? result = BffLoginEndpoints.ValidateReturnUrl("", CreateFrontend());
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ValidateReturnUrl_Whitespace_ReturnsNull()
+    {
+        string? result = BffLoginEndpoints.ValidateReturnUrl("   ", CreateFrontend());
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ValidateReturnUrl_ProtocolRelativeUrl_ReturnsNull()
+    {
+        string? result = BffLoginEndpoints.ValidateReturnUrl("//evil.com/steal", CreateFrontend());
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ValidateReturnUrl_AbsoluteExternalUrl_ReturnsNull()
+    {
+        string? result = BffLoginEndpoints.ValidateReturnUrl("https://evil.com/steal", CreateFrontend());
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ValidateReturnUrl_NoLeadingSlash_ReturnsNull()
+    {
+        string? result = BffLoginEndpoints.ValidateReturnUrl("tenants", CreateFrontend());
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ValidateReturnUrl_RootPath_ReturnsRoot()
+    {
+        string? result = BffLoginEndpoints.ValidateReturnUrl("/", CreateFrontend());
+
+        result.ShouldBe("/");
     }
 
     // ──── GetContentType ────


### PR DESCRIPTION
## Summary

- **BFF returnUrl**: store caller-supplied `returnUrl` in PKCE state during login flow and redirect to it after successful authentication, with open-redirect prevention (relative paths only, no protocol-relative or scheme-containing URLs)
- **Email layout fix**: remove invalid Liquid `| raw` filter from Scriban layout template — this filter doesn't exist in Scriban and caused silent render failure, resulting in emails sent without the HTML layout wrapper

## Test plan

- [x] `ValidateReturnUrl` unit tests cover: relative paths, null/empty, protocol-relative `//evil.com`, absolute URLs, missing leading slash
- [ ] Manual: trigger password reset email → verify HTML layout wraps the content (header, footer, styling)
- [ ] Manual: login with `?returnUrl=/tenants` → verify redirect lands on `/tenants` after auth
