### PR TITLE
fix(bff): always prefix redirect paths with ClientUrl

### DIFF
--- a/src/Granit.Bff/Options/GranitBffOptions.cs
+++ b/src/Granit.Bff/Options/GranitBffOptions.cs
@@ -168,7 +168,7 @@ public sealed class BffFrontendOptions
     /// returns <c>{ClientUrl}/</c>.
     /// </summary>
     public string EffectivePostLoginRedirectPath =>
-        PostLoginRedirectPath ?? PrefixWithClientUrl(string.IsNullOrEmpty(PathPrefix) ? "/" : $"{PathPrefix}/");
+        PrefixWithClientUrl(PostLoginRedirectPath ?? (string.IsNullOrEmpty(PathPrefix) ? "/" : $"{PathPrefix}/"));
 
     /// <summary>
     /// Gets the effective post-logout redirect path.
@@ -176,7 +176,7 @@ public sealed class BffFrontendOptions
     /// returns <c>{ClientUrl}/</c>.
     /// </summary>
     public string EffectivePostLogoutRedirectPath =>
-        PostLogoutRedirectPath ?? PrefixWithClientUrl(string.IsNullOrEmpty(PathPrefix) ? "/" : $"{PathPrefix}/");
+        PrefixWithClientUrl(PostLogoutRedirectPath ?? (string.IsNullOrEmpty(PathPrefix) ? "/" : $"{PathPrefix}/"));
 
     /// <summary>
     /// Gets the effective error redirect path (without the <c>?error=</c> query parameter).
@@ -184,7 +184,7 @@ public sealed class BffFrontendOptions
     /// returns <c>{ClientUrl}/login</c>.
     /// </summary>
     public string EffectiveErrorRedirectPath =>
-        ErrorRedirectPath ?? PrefixWithClientUrl(string.IsNullOrEmpty(PathPrefix) ? "/login" : $"{PathPrefix}/login");
+        PrefixWithClientUrl(ErrorRedirectPath ?? (string.IsNullOrEmpty(PathPrefix) ? "/login" : $"{PathPrefix}/login"));
 
     internal string PrefixWithClientUrl(string relativePath) =>
         string.IsNullOrEmpty(ClientUrl) ? relativePath : $"{ClientUrl.TrimEnd('/')}{relativePath}";

--- a/tests/Granit.Bff.Tests/Options/GranitBffOptionsTests.cs
+++ b/tests/Granit.Bff.Tests/Options/GranitBffOptionsTests.cs
@@ -311,7 +311,7 @@ public sealed class BffFrontendOptionsTests
             PostLoginRedirectPath = "/custom/dashboard",
         };
 
-        frontend.EffectivePostLoginRedirectPath.ShouldBe("/custom/dashboard");
+        frontend.EffectivePostLoginRedirectPath.ShouldBe("http://localhost:5173/custom/dashboard");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- `EffectivePostLoginRedirectPath`, `EffectivePostLogoutRedirectPath`, and `EffectiveErrorRedirectPath` used `ExplicitPath ?? PrefixWithClientUrl(fallback)` — when an explicit path was set (e.g. `"/"`), the `??` short-circuited and `ClientUrl` was never applied
- Browser received `302 /` and resolved to backend origin (`http://localhost:5000/`) instead of frontend (`http://localhost:5174/`)
- Fix: `PrefixWithClientUrl(ExplicitPath ?? fallback)` — `ClientUrl` is always applied

## Test plan

- [x] `EffectivePostLoginRedirectPath_WithClientUrl_ExplicitValueWins` updated and passing
- [x] All 165 BFF tests + 91 BFF endpoint tests passing
- [ ] Manual: login via tenant app → verify redirect lands on `http://localhost:5174/`
