### PR TITLE
fix(wolverine): pass module assemblies explicitly to handler discovery

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -28812,6 +28812,22 @@
       ]
     },
     {
+      "name": "GranitDbDefaults",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.GranitDbDefaults",
+      "kind": "class",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/GranitDbDefaults.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "ResetToDefaults",
+          "kind": "method",
+          "signature": "ResetToDefaults()",
+          "returnType": "string? DbSchema { get; set; } public string? HostDbSchema { get; set; } internal void"
+        }
+      ]
+    },
+    {
       "name": "GranitFilterNames",
       "fqn": "Granit.Persistence.EntityFrameworkCore.GranitFilterNames",
       "kind": "class",
@@ -41205,7 +41221,7 @@
         {
           "name": "AddGranitWolverine",
           "kind": "method",
-          "signature": "AddGranitWolverine(this IHostApplicationBuilder builder, Action<WolverineOptions>? configure = null)",
+          "signature": "AddGranitWolverine(this IHostApplicationBuilder builder, IReadOnlyList<Assembly>? moduleAssemblies = null, Action<WolverineOptions>? configure = null)",
           "returnType": "IHostApplicationBuilder"
         }
       ]

--- a/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
@@ -43,10 +43,16 @@ public static class WolverineHostApplicationBuilderExtensions
     /// </list>
     /// </remarks>
     /// <param name="builder">The host application builder.</param>
+    /// <param name="moduleAssemblies">
+    /// Assemblies of all loaded Granit modules (from <see cref="Granit.Modularity.ServiceConfigurationContext.ModuleAssemblies"/>).
+    /// Wolverine will scan these for handler methods. When <see langword="null"/>, falls back to
+    /// <c>[assembly: WolverineHandlerModule]</c> discovery only.
+    /// </param>
     /// <param name="configure">Optional additional Wolverine configuration.</param>
     /// <returns>The builder for chaining.</returns>
     public static IHostApplicationBuilder AddGranitWolverine(
         this IHostApplicationBuilder builder,
+        IReadOnlyList<Assembly>? moduleAssemblies = null,
         Action<WolverineOptions>? configure = null)
     {
         GranitActivitySourceRegistry.Register(Diagnostics.WolverineActivitySource.Name);
@@ -88,19 +94,13 @@ public static class WolverineHostApplicationBuilderExtensions
 
         builder.UseWolverine(opts =>
         {
-            // Auto-discover handler assemblies from ALL loaded Granit modules.
-            // GranitApplication is registered as a singleton instance during AddGranit<T>()
-            // before UseWolverine() runs, so we can read it directly from the service collection.
-            // This eliminates the need for [assembly: WolverineHandlerModule] on every module.
-            var granitApp = builder.Services
-                .FirstOrDefault(d => d.ServiceType == typeof(GranitApplication))
-                ?.ImplementationInstance as GranitApplication;
-
-            if (granitApp is not null)
+            // Include all Granit module assemblies passed from the module system.
+            // This is the primary discovery path — no timing dependency on DI registration.
+            if (moduleAssemblies is not null)
             {
-                foreach (GranitModule module in granitApp.GetModuleInstances())
+                foreach (Assembly assembly in moduleAssemblies)
                 {
-                    opts.Discovery.IncludeAssembly(module.GetType().Assembly);
+                    opts.Discovery.IncludeAssembly(assembly);
                 }
             }
 

--- a/src/Granit.Wolverine/GranitWolverineModule.cs
+++ b/src/Granit.Wolverine/GranitWolverineModule.cs
@@ -24,5 +24,5 @@ public sealed class GranitWolverineModule : GranitModule
 {
     /// <inheritdoc/>
     public override void ConfigureServices(ServiceConfigurationContext context) =>
-        context.Builder.AddGranitWolverine();
+        context.Builder.AddGranitWolverine(context.ModuleAssemblies);
 }

--- a/tests/Granit.Wolverine.Tests/GranitWolverineModuleTests.cs
+++ b/tests/Granit.Wolverine.Tests/GranitWolverineModuleTests.cs
@@ -126,7 +126,7 @@ public sealed class GranitWolverineModuleTests
         HostApplicationBuilder builder = Host.CreateApplicationBuilder();
         bool callbackInvoked = false;
 
-        builder.AddGranitWolverine(opts => { callbackInvoked = true; });
+        builder.AddGranitWolverine(configure: opts => { callbackInvoked = true; });
 
         callbackInvoked.ShouldBeTrue();
     }


### PR DESCRIPTION
## Summary

- Pass `context.ModuleAssemblies` directly to `AddGranitWolverine()` instead of reading `GranitApplication` from `builder.Services` at configuration time
- Fixes a timing bug where `GranitApplication` was registered in DI **after** `ConfigureServicesAsync`, making it always `null` inside `UseWolverine()` — only `[assembly: WolverineHandlerModule]` assemblies were discovered
- Framework handlers (e.g. `AccountLockedHandler`, `PasswordResetRequestedHandler` in `Granit.Identity.Local.Notifications`) were silently never invoked

## Root cause

```
AddGranitCoreAsync():
  1. application.ConfigureServicesAsync(context)   ← UseWolverine() runs here, reads null
  2. builder.Services.AddSingleton(application)     ← too late
```

## Test plan

- [x] `Granit.Wolverine.Tests` — 154 passed
- [ ] Verify Wolverine logs show `Searching assembly Granit.Identity.Local.Notifications` at startup
- [ ] Trigger account lockout → email arrives in Mailpit
