### PR TITLE
fix(multi-tenancy): security hardening — phantom tenant rejection, query string disabled by default

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1923,6 +1923,13 @@
       "framework": "net10.0"
     },
     {
+      "name": "Granit.Templating.Mjml",
+      "deps": [
+        "Granit.Templating"
+      ],
+      "framework": "net10.0"
+    },
+    {
       "name": "Granit.Templating.Scriban",
       "deps": [
         "Granit.Templating"
@@ -22217,7 +22224,7 @@
       "kind": "class",
       "project": "Granit.MultiTenancy",
       "file": "src/Granit.MultiTenancy/Middleware/TenantResolutionMiddleware.cs",
-      "line": 15,
+      "line": 21,
       "members": [
         {
           "name": "InvokeAsync",
@@ -29641,7 +29648,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/SchemaEnsurer.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "EnsureSchemasAsync",
@@ -37352,6 +37359,38 @@
       "members": []
     },
     {
+      "name": "ServiceCollectionExtensions",
+      "fqn": "Granit.Templating.Mjml.Extensions.ServiceCollectionExtensions",
+      "kind": "class",
+      "project": "Granit.Templating.Mjml",
+      "file": "src/Granit.Templating.Mjml/Extensions/ServiceCollectionExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitTemplatingWithMjml",
+          "kind": "method",
+          "signature": "AddGranitTemplatingWithMjml(this IServiceCollection services)",
+          "returnType": "IServiceCollection"
+        }
+      ]
+    },
+    {
+      "name": "GranitTemplatingMjmlModule",
+      "fqn": "Granit.Templating.Mjml.GranitTemplatingMjmlModule",
+      "kind": "class",
+      "project": "Granit.Templating.Mjml",
+      "file": "src/Granit.Templating.Mjml/GranitTemplatingMjmlModule.cs",
+      "line": 20,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
       "name": "BinaryRenderedContent",
       "fqn": "Granit.Templating.Pipeline.BinaryRenderedContent",
       "kind": "record",
@@ -37359,6 +37398,28 @@
       "file": "src/Granit.Templating/Pipeline/RenderedContent.cs",
       "line": 45,
       "members": []
+    },
+    {
+      "name": "IRenderedContentTransformer",
+      "fqn": "Granit.Templating.Pipeline.IRenderedContentTransformer",
+      "kind": "interface",
+      "project": "Granit.Templating",
+      "file": "src/Granit.Templating/Pipeline/IRenderedContentTransformer.cs",
+      "line": 39,
+      "members": [
+        {
+          "name": "CanTransform",
+          "kind": "method",
+          "signature": "CanTransform(DocumentFormat format)",
+          "returnType": "int Order { get; } bool"
+        },
+        {
+          "name": "TransformAsync",
+          "kind": "method",
+          "signature": "TransformAsync(string content, DocumentFormat format, CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
+        }
+      ]
     },
     {
       "name": "ITemplateEngine",

--- a/docs-site/src/content/docs/dotnet/guides/configure-multi-tenancy.mdx
+++ b/docs-site/src/content/docs/dotnet/guides/configure-multi-tenancy.mdx
@@ -63,7 +63,7 @@ Add the configuration to `appsettings.json`:
     "TenantIdHeaderName": "X-Tenant-Id",
     "HeaderTrustMode": "Unrestricted",
     "DomainTemplate": "{0}.myapp.com",
-    "QueryStringParamName": "__tenant"
+    "ValidateTenantExistence": true
   }
 }
 ```
@@ -74,8 +74,9 @@ Add the configuration to `appsettings.json`:
 | `TenantIdClaimType` | `"tenant_id"` | JWT claim name containing the tenant ID |
 | `TenantIdHeaderName` | `"X-Tenant-Id"` | HTTP header name for explicit tenant specification |
 | `HeaderTrustMode` | `"Unrestricted"` | `Unrestricted` (accept header as-is) or `CrossValidate` (header must match JWT claim) |
+| `ValidateTenantExistence` | `true` | Verify resolved tenant exists in tenant store (prevents phantom tenants) |
 | `DomainTemplate` | `null` | Domain template with `{0}` placeholder (e.g., `"{0}.myapp.com"`). `null` = disabled |
-| `QueryStringParamName` | `"__tenant"` | Query string parameter name for dev/debug. `null` = disabled |
+| `QueryStringParamName` | `null` | Query string param name for dev/debug (`null` = disabled). Set `"__tenant"` in `appsettings.Development.json` |
 
 :::caution[Security hardening]
 By default, the `X-Tenant-Id` header is trusted without cross-validation

--- a/docs-site/src/content/docs/dotnet/infrastructure/multi-tenancy/resolvers.mdx
+++ b/docs-site/src/content/docs/dotnet/infrastructure/multi-tenancy/resolvers.mdx
@@ -99,15 +99,20 @@ debugging — lowest priority (order 300).
 GET /api/v1/products?__tenant=3fa85f64-5694-4b5a-b7d9-c4f11f0b7f5e
 ```
 
-Disable in production by setting `QueryStringParamName` to `null`:
+**Disabled by default** (`QueryStringParamName = null`). Enable in `appsettings.Development.json`:
 
 ```json
 {
   "MultiTenancy": {
-    "QueryStringParamName": null
+    "QueryStringParamName": "__tenant"
   }
 }
 ```
+
+:::danger[Never enable in production]
+The query string resolver allows unauthenticated callers to select an arbitrary
+tenant context. Only enable it in development environments.
+:::
 
 ## Custom resolver
 
@@ -141,6 +146,22 @@ services.AddScoped<ITenantResolver, CookieTenantResolver>();
 
 ## Security hardening
 
+### Tenant existence validation
+
+By default, the middleware verifies that the resolved tenant ID exists in the
+tenant store (`ITenantReader.ExistsAsync`). This prevents **phantom tenants** —
+arbitrary GUIDs from spoofed headers creating orphaned data.
+
+```json
+{
+  "MultiTenancy": {
+    "ValidateTenantExistence": true
+  }
+}
+```
+
+Disable only in test environments where no tenant store is available.
+
 ### Header trust mode
 
 The `X-Tenant-Id` header is accepted by default without cross-validation
@@ -168,8 +189,9 @@ reverse proxy. For direct API exposure, enable `CrossValidate`:
 | `TenantIdClaimType` | `"tenant_id"` | JWT claim name for tenant ID |
 | `TenantIdHeaderName` | `"X-Tenant-Id"` | HTTP header name for tenant ID |
 | `HeaderTrustMode` | `"Unrestricted"` | `Unrestricted` or `CrossValidate` |
+| `ValidateTenantExistence` | `true` | Verify resolved tenant exists in tenant store |
 | `DomainTemplate` | `null` | Domain template with `{0}` placeholder (e.g. `"{0}.monsaas.com"`) |
-| `QueryStringParamName` | `"__tenant"` | Query string parameter name (`null` to disable) |
+| `QueryStringParamName` | `null` | Query string param name (`null` = disabled, set `"__tenant"` in dev) |
 
 ## Observability
 

--- a/src/Granit.MultiTenancy/Middleware/TenantResolutionMiddleware.cs
+++ b/src/Granit.MultiTenancy/Middleware/TenantResolutionMiddleware.cs
@@ -69,6 +69,9 @@ public sealed partial class TenantResolutionMiddleware(
             {
                 _metrics.RecordResolutionFailed();
                 LogPhantomTenant(result.Tenant.Id.Value, result.ResolverType);
+                // Bare 403 without response body: intentional information-minimal
+                // rejection. Don't reveal to an attacker why the tenant was rejected.
+                // Server-side observability is provided by LogPhantomTenant.
                 context.Response.StatusCode = StatusCodes.Status403Forbidden;
                 return;
             }

--- a/src/Granit.MultiTenancy/Middleware/TenantResolutionMiddleware.cs
+++ b/src/Granit.MultiTenancy/Middleware/TenantResolutionMiddleware.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Granit.MultiTenancy.Diagnostics;
 using Granit.MultiTenancy.Options;
 using Granit.MultiTenancy.Pipeline;
+using Granit.MultiTenancy.Stores;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -12,15 +13,22 @@ namespace Granit.MultiTenancy.Middleware;
 /// Middleware for per-request HTTP tenant resolution.
 /// Uses <see cref="TenantResolverPipeline"/> and activates <see cref="ICurrentTenant"/>.
 /// </summary>
+/// <remarks>
+/// When <see cref="MultiTenancyOptions.ValidateTenantExistence"/> is enabled, the resolved
+/// tenant ID is verified against <see cref="ITenantReader"/> before activating the context.
+/// This prevents phantom tenants (arbitrary GUIDs) from creating orphaned data.
+/// </remarks>
 public sealed partial class TenantResolutionMiddleware(
     ICurrentTenant currentTenant,
     TenantResolverPipeline pipeline,
+    ITenantReader tenantReader,
     MultiTenancyMetrics metrics,
     IOptions<MultiTenancyOptions> options,
     ILogger<TenantResolutionMiddleware> logger) : IMiddleware
 {
     private readonly ICurrentTenant _currentTenant = currentTenant;
     private readonly TenantResolverPipeline _pipeline = pipeline;
+    private readonly ITenantReader _tenantReader = tenantReader;
     private readonly MultiTenancyMetrics _metrics = metrics;
     private readonly MultiTenancyOptions _options = options.Value;
     private readonly ILogger _logger = logger;
@@ -53,6 +61,18 @@ public sealed partial class TenantResolutionMiddleware(
                 }
             }
 
+            // Validate that the resolved tenant actually exists in the store.
+            // Prevents phantom tenants (arbitrary GUIDs) from creating orphaned data.
+            if (_options.ValidateTenantExistence
+                && result.Tenant.Id.HasValue
+                && !await _tenantReader.ExistsAsync(result.Tenant.Id.Value, context.RequestAborted).ConfigureAwait(false))
+            {
+                _metrics.RecordResolutionFailed();
+                LogPhantomTenant(result.Tenant.Id.Value, result.ResolverType);
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                return;
+            }
+
             _metrics.RecordResolutionSucceeded(result.Tenant.Id.ToString()!, result.ResolverType);
 
             using IDisposable _ = _currentTenant.Change(result.Tenant.Id, result.Tenant.Name);
@@ -67,4 +87,7 @@ public sealed partial class TenantResolutionMiddleware(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Tenant mismatch: resolved tenant {ResolvedTenantId} via {ResolverType} but JWT claim contains {JwtTenantId}. Request rejected.")]
     private partial void LogTenantMismatch(Guid resolvedTenantId, string resolverType, Guid jwtTenantId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Phantom tenant rejected: resolved tenant {TenantId} via {ResolverType} does not exist in the tenant store.")]
+    private partial void LogPhantomTenant(Guid tenantId, string resolverType);
 }

--- a/src/Granit.MultiTenancy/Options/MultiTenancyOptions.cs
+++ b/src/Granit.MultiTenancy/Options/MultiTenancyOptions.cs
@@ -69,8 +69,8 @@ public sealed class MultiTenancyOptions
     /// <remarks>
     /// Requires <c>Granit.MultiTenancy.EntityFrameworkCore</c> for the real
     /// <see cref="Stores.ITenantReader"/> implementation. Without it, the
-    /// <c>NullTenantReader</c> always returns <c>false</c> — all tenants
-    /// would be rejected.
+    /// <c>NullTenantReader</c> returns <c>true</c> for all IDs — validation
+    /// is effectively skipped (safe degradation to avoid denial of service).
     /// </remarks>
     public bool ValidateTenantExistence { get; set; } = true;
 

--- a/src/Granit.MultiTenancy/Options/MultiTenancyOptions.cs
+++ b/src/Granit.MultiTenancy/Options/MultiTenancyOptions.cs
@@ -61,8 +61,24 @@ public sealed class MultiTenancyOptions
     public string? DomainTemplate { get; set; }
 
     /// <summary>
-    /// Query string parameter name for tenant resolution (dev/debug).
-    /// Default: <c>"__tenant"</c>. <c>null</c> = disabled.
+    /// When <c>true</c>, the middleware verifies that the resolved tenant ID
+    /// exists in <see cref="Stores.ITenantReader"/> before activating the context.
+    /// Prevents phantom tenants (arbitrary GUIDs from spoofed headers) from creating
+    /// orphaned data. Default: <c>true</c>.
     /// </summary>
-    public string? QueryStringParamName { get; set; } = "__tenant";
+    /// <remarks>
+    /// Requires <c>Granit.MultiTenancy.EntityFrameworkCore</c> for the real
+    /// <see cref="Stores.ITenantReader"/> implementation. Without it, the
+    /// <c>NullTenantReader</c> always returns <c>false</c> — all tenants
+    /// would be rejected.
+    /// </remarks>
+    public bool ValidateTenantExistence { get; set; } = true;
+
+    /// <summary>
+    /// Query string parameter name for tenant resolution (dev/debug only).
+    /// Default: <c>null</c> (disabled). Enable in <c>appsettings.Development.json</c>
+    /// by setting to <c>"__tenant"</c>. Never enable in production — allows
+    /// unauthenticated callers to select an arbitrary tenant context.
+    /// </summary>
+    public string? QueryStringParamName { get; set; }
 }

--- a/src/Granit.MultiTenancy/Resolvers/QueryStringTenantResolver.cs
+++ b/src/Granit.MultiTenancy/Resolvers/QueryStringTenantResolver.cs
@@ -10,8 +10,8 @@ namespace Granit.MultiTenancy.Resolvers;
 /// Intended for development and debugging — lowest priority (order = 300).
 /// </summary>
 /// <remarks>
-/// Disabled when <see cref="MultiTenancyOptions.QueryStringParamName"/> is <c>null</c>.
-/// Default parameter name: <c>__tenant</c>.
+/// Disabled by default (<see cref="MultiTenancyOptions.QueryStringParamName"/> is <c>null</c>).
+/// Enable in <c>appsettings.Development.json</c> by setting to <c>"__tenant"</c>.
 /// </remarks>
 public sealed class QueryStringTenantResolver(
     IOptions<MultiTenancyOptions> options) : ITenantResolver

--- a/src/Granit.MultiTenancy/Stores/NullTenantReader.cs
+++ b/src/Granit.MultiTenancy/Stores/NullTenantReader.cs
@@ -16,6 +16,11 @@ internal sealed class NullTenantReader : ITenantReader
     public Task<IReadOnlyList<TenantData>> GetAllAsync(CancellationToken cancellationToken = default) =>
         Task.FromResult<IReadOnlyList<TenantData>>([]);
 
+    /// <summary>
+    /// Returns <c>true</c> — when no real tenant store is registered, validation
+    /// is skipped (all tenant IDs are accepted). The real <c>EfCoreTenantStore</c>
+    /// performs the actual lookup.
+    /// </summary>
     public Task<bool> ExistsAsync(Guid id, CancellationToken cancellationToken = default) =>
-        Task.FromResult(false);
+        Task.FromResult(true);
 }

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceTenantExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceTenantExtensions.cs
@@ -246,8 +246,24 @@ public static class PersistenceTenantExtensions
         // Facade — dispatches to the keyed factory resolved at runtime.
         services.TryAddScoped<IDbContextFactory<TContext>, IsolatedDbContextFactory<TContext>>();
 
-        services.TryAddScoped<TContext>(
-            static sp => sp.GetRequiredService<IDbContextFactory<TContext>>().CreateDbContext());
+        // Scoped TContext: tries the isolated factory first, falls back to the
+        // SharedDatabase keyed factory when no tenant is active (e.g., Wolverine
+        // startup introspection, migration orchestration, health checks).
+        services.TryAddScoped<TContext>(static sp =>
+        {
+            ICurrentTenant? tenant = sp.GetService<ICurrentTenant>();
+            if (tenant is null || !tenant.IsAvailable)
+            {
+                IDbContextFactory<TContext>? sharedFactory =
+                    sp.GetKeyedService<IDbContextFactory<TContext>>(TenantIsolationStrategy.SharedDatabase);
+                if (sharedFactory is not null)
+                {
+                    return sharedFactory.CreateDbContext();
+                }
+            }
+
+            return sp.GetRequiredService<IDbContextFactory<TContext>>().CreateDbContext();
+        });
 
         return services;
     }

--- a/tests/Granit.MultiTenancy.Tests/TenantResolutionMiddlewareTests.cs
+++ b/tests/Granit.MultiTenancy.Tests/TenantResolutionMiddlewareTests.cs
@@ -9,6 +9,7 @@ using Granit.MultiTenancy.Middleware;
 using Granit.MultiTenancy.Options;
 using Granit.MultiTenancy.Pipeline;
 using Granit.MultiTenancy.Resolvers;
+using Granit.MultiTenancy.Stores;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -31,16 +32,22 @@ public sealed class TenantResolutionMiddlewareTests
         ICurrentTenant currentTenant,
         TenantResolverPipeline pipeline,
         bool isEnabled = true,
-        TenantHeaderTrustMode headerTrustMode = TenantHeaderTrustMode.Unrestricted)
+        TenantHeaderTrustMode headerTrustMode = TenantHeaderTrustMode.Unrestricted,
+        bool validateTenantExistence = false)
     {
         IOptions<MultiTenancyOptions> options = Microsoft.Extensions.Options.Options.Create(new MultiTenancyOptions
         {
             IsEnabled = isEnabled,
             HeaderTrustMode = headerTrustMode,
+            ValidateTenantExistence = validateTenantExistence,
         });
+        ITenantReader tenantReader = Substitute.For<ITenantReader>();
+        tenantReader.ExistsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(true));
         return new TenantResolutionMiddleware(
             currentTenant,
             pipeline,
+            tenantReader,
             CreateMetrics(),
             options,
             NullLogger<TenantResolutionMiddleware>.Instance);
@@ -132,5 +139,77 @@ public sealed class TenantResolutionMiddlewareTests
         await middleware.InvokeAsync(context, _ => { nextCalled = true; return Task.CompletedTask; });
 
         nextCalled.ShouldBeTrue();
+    }
+
+    // ── Phantom tenant validation (VULN-201) ──────────────────────────
+
+    [Fact]
+    public async Task ValidateTenantExistence_Enabled_ExistingTenant_Passes()
+    {
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        IDisposable scope = Substitute.For<IDisposable>();
+        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>()).Returns(scope);
+        var tenantId = Guid.NewGuid();
+        TenantResolverPipeline pipeline = PipelineReturning(new TenantInfo(tenantId));
+        TenantResolutionMiddleware middleware = CreateMiddleware(
+            currentTenant, pipeline, validateTenantExistence: true);
+        DefaultHttpContext context = new();
+
+        await middleware.InvokeAsync(context, _ => Task.CompletedTask);
+
+        currentTenant.Received(1).Change(tenantId, Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task ValidateTenantExistence_Enabled_PhantomTenant_Returns403()
+    {
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        var phantomId = Guid.NewGuid();
+        TenantResolverPipeline pipeline = PipelineReturning(new TenantInfo(phantomId));
+        TenantResolutionMiddleware middleware = CreateMiddlewareWithPhantomRejection(
+            currentTenant, pipeline);
+        DefaultHttpContext context = new();
+
+        await middleware.InvokeAsync(context, _ => Task.CompletedTask);
+
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status403Forbidden);
+        currentTenant.DidNotReceive().Change(Arg.Any<Guid?>(), Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task ValidateTenantExistence_Disabled_PhantomTenant_Passes()
+    {
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        IDisposable scope = Substitute.For<IDisposable>();
+        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>()).Returns(scope);
+        var phantomId = Guid.NewGuid();
+        TenantResolverPipeline pipeline = PipelineReturning(new TenantInfo(phantomId));
+        TenantResolutionMiddleware middleware = CreateMiddleware(
+            currentTenant, pipeline, validateTenantExistence: false);
+        DefaultHttpContext context = new();
+
+        await middleware.InvokeAsync(context, _ => Task.CompletedTask);
+
+        currentTenant.Received(1).Change(phantomId, Arg.Any<string?>());
+    }
+
+    private static TenantResolutionMiddleware CreateMiddlewareWithPhantomRejection(
+        ICurrentTenant currentTenant,
+        TenantResolverPipeline pipeline)
+    {
+        IOptions<MultiTenancyOptions> options = Microsoft.Extensions.Options.Options.Create(new MultiTenancyOptions
+        {
+            ValidateTenantExistence = true,
+        });
+        ITenantReader tenantReader = Substitute.For<ITenantReader>();
+        tenantReader.ExistsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(false)); // Tenant does NOT exist
+        return new TenantResolutionMiddleware(
+            currentTenant,
+            pipeline,
+            tenantReader,
+            CreateMetrics(),
+            options,
+            NullLogger<TenantResolutionMiddleware>.Instance);
     }
 }


### PR DESCRIPTION
## Summary

Security hardening based on audit findings (VULN-200, VULN-201) + Wolverine startup fix.

### BREAKING CHANGE

`QueryStringParamName` default changed from `"__tenant"` to `null` (disabled). Enable in `appsettings.Development.json`:
```json
{ "MultiTenancy": { "QueryStringParamName": "__tenant" } }
```

### Security

- **ValidateTenantExistence** (default: `true`) — middleware verifies resolved tenant ID exists via `ITenantReader.ExistsAsync` before activating context. Rejects phantom tenants with 403.
- **QueryStringResolver disabled by default** — prevents unauthenticated callers from selecting arbitrary tenants in production.

### Wolverine fix

Scoped `TContext` registration falls back to `SharedDatabase` factory when no tenant is active. Fixes `InvalidOperationException` during Wolverine handler graph compilation at startup.

## Test plan

- [x] 93 MultiTenancy tests pass (3 new for phantom tenant path)
- [x] `dotnet build` — 0 errors
- [x] Phantom tenant → 403
- [x] Feature disabled → passthrough
- [x] Existing tenant → 200