### PR TITLE
fix(caching): register TenantAwareFusionCache as singleton instead of scoped

### DIFF
--- a/src/Granit.Caching/Extensions/CachingServiceCollectionExtensions.cs
+++ b/src/Granit.Caching/Extensions/CachingServiceCollectionExtensions.cs
@@ -113,8 +113,12 @@ public static class CachingServiceCollectionExtensions
         services.TryAddSingleton<ICurrentTenant>(new NullCurrentTenant());
 
         // Tenant-aware cache key isolation: move the raw IFusionCache singleton to a
-        // keyed service and register a scoped decorator as the default IFusionCache.
+        // keyed service and register the decorator as the default IFusionCache.
         // All key-based operations are automatically prefixed with t:{tenantId}: or t:host:.
+        //
+        // The decorator is a SINGLETON — ICurrentTenant is backed by AsyncLocal<T>,
+        // so the tenant is read at call time (not at construction time). This avoids
+        // breaking singletons that inject IFusionCache (Localization, BFF, OIDC, etc.).
         ServiceDescriptor? rawDescriptor = services.LastOrDefault(d =>
             d.ServiceType == typeof(IFusionCache) && d.Lifetime == ServiceLifetime.Singleton);
 
@@ -137,8 +141,8 @@ public static class CachingServiceCollectionExtensions
                     rawDescriptor.ImplementationType);
             }
 
-            // Scoped decorator as the default IFusionCache
-            services.AddScoped<IFusionCache>(sp => new TenantAwareFusionCache(
+            // Singleton decorator as the default IFusionCache
+            services.AddSingleton<IFusionCache>(sp => new TenantAwareFusionCache(
                 sp.GetRequiredKeyedService<IFusionCache>(TenantAwareFusionCache.RawCacheKey),
                 sp.GetRequiredService<ICurrentTenant>()));
         }

--- a/src/Granit.Caching/MultiTenancy/TenantAwareFusionCache.cs
+++ b/src/Granit.Caching/MultiTenancy/TenantAwareFusionCache.cs
@@ -10,15 +10,18 @@ using ZiggyCreatures.Caching.Fusion.Serialization;
 namespace Granit.Caching.MultiTenancy;
 
 /// <summary>
-/// Scoped decorator around <see cref="IFusionCache"/> that automatically prefixes
+/// Singleton decorator around <see cref="IFusionCache"/> that automatically prefixes
 /// all cache keys and tags with the current tenant identifier, preventing
 /// cross-tenant cache pollution on shared Redis instances.
 /// </summary>
 /// <remarks>
 /// <para>Key format: <c>t:{tenantId:N}:{originalKey}</c> when a tenant is active,
 /// or <c>t:host:{originalKey}</c> in host context (no active tenant).</para>
-/// <para>The inner <see cref="IFusionCache"/> remains a singleton — only key
-/// prefixing is per-scope. All infrastructure operations (setup, plugins) are
+/// <para>Both the decorator and the inner cache are singletons.
+/// <see cref="ICurrentTenant"/> is backed by <c>AsyncLocal&lt;T&gt;</c>, so the
+/// tenant is resolved at call time — no scoped dependency needed. This allows
+/// singletons (Localization, BFF, OIDC) to safely inject <c>IFusionCache</c>.
+/// All infrastructure operations (setup, plugins) are
 /// delegated unchanged.</para>
 /// </remarks>
 internal sealed class TenantAwareFusionCache(


### PR DESCRIPTION
## Summary

The `TenantAwareFusionCache` decorator was registered as **scoped**, breaking all singletons that inject `IFusionCache`:

- `FusionCacheProvider` (FusionCache internal)
- `CachedLocalizationOverrideStore` (Localization)
- `DiscoveryDocumentService` (OIDC)
- `LogoutTokenValidator` (BFF)

All threw `Cannot consume scoped service 'IFusionCache' from singleton` at startup.

### Fix

Register the decorator as **singleton**. `ICurrentTenant` is backed by `AsyncLocal<T>` — the tenant is resolved at call time, not at construction time. No scoped dependency needed.

## Test plan

- [x] 64 caching tests pass
- [x] `dotnet build` — 0 errors
- [x] No more DI validation exception at startup