### PR TITLE
refactor(notifications): migrate email templates to MJML layout with inline styles

### DIFF
--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.cs.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.cs.html
@@ -3,10 +3,10 @@
 <p>Jedná se o bezpečnostní opatření k ochraně vašeho účtu. Uzamčení vyprší <strong>{{ model.lockout_expires_at | date.to_string '%d.%m.%Y v %H:%M UTC' }}</strong>.</p>
 <p>Pokud tyto pokusy o přihlášení nebyly provedeny vámi, můžete si obnovit heslo a okamžitě odemknout svůj účet:</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Obnovit moje heslo</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Obnovit moje heslo</a>
 </p>
 <p>Pokud jste tyto pokusy neprovedli a nechcete podnikat žádné kroky, uzamčení vyprší automaticky.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Pokud tlačítko nefunguje, zkopírujte a vložte následující odkaz do svého prohlížeče:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.de.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.de.html
@@ -3,10 +3,10 @@
 <p>Dies ist eine Sicherheitsmaßnahme zum Schutz Ihres Kontos. Die Sperre wird am <strong>{{ model.lockout_expires_at | date.to_string '%d.%m.%Y um %H:%M UTC' }}</strong> aufgehoben.</p>
 <p>Wenn diese Anmeldeversuche nicht von Ihnen stammten, können Sie Ihr Passwort zurücksetzen, um Ihr Konto sofort zu entsperren:</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Passwort zurücksetzen</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Passwort zurücksetzen</a>
 </p>
 <p>Wenn Sie diese Versuche nicht unternommen haben und keine Maßnahmen ergreifen möchten, wird die Sperre automatisch aufgehoben.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Falls die Schaltfläche nicht funktioniert, kopieren Sie den folgenden Link und fügen Sie ihn in Ihren Browser ein:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.es.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.es.html
@@ -3,10 +3,10 @@
 <p>Esta es una medida de seguridad para proteger su cuenta. El bloqueo expirará el <strong>{{ model.lockout_expires_at | date.to_string '%d/%m/%Y a las %H:%M UTC' }}</strong>.</p>
 <p>Si estos intentos de inicio de sesión no fueron realizados por usted, puede restablecer su contraseña para desbloquear su cuenta de inmediato:</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Restablecer mi contraseña</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Restablecer mi contraseña</a>
 </p>
 <p>Si no realizó estos intentos y prefiere no tomar medidas, el bloqueo expirará automáticamente.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Si el botón no funciona, copie y pegue el siguiente enlace en su navegador:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.fr.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.fr.html
@@ -3,10 +3,10 @@
 <p>Il s'agit d'une mesure de sécurité pour protéger votre compte. Le verrouillage expirera le <strong>{{ model.lockout_expires_at | date.to_string '%d/%m/%Y à %H:%M UTC' }}</strong>.</p>
 <p>Si ces tentatives de connexion n'ont pas été effectuées par vous, vous pouvez réinitialiser votre mot de passe pour déverrouiller immédiatement votre compte :</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Réinitialiser mon mot de passe</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Réinitialiser mon mot de passe</a>
 </p>
 <p>Si vous n'avez pas effectué ces tentatives et préférez ne pas agir, le verrouillage expirera automatiquement.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Si le bouton ne fonctionne pas, copiez et collez le lien suivant dans votre navigateur :<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.hi.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.hi.html
@@ -3,10 +3,10 @@
 <p>यह आपके खाते की सुरक्षा के लिए एक सुरक्षा उपाय है। लॉकआउट <strong>{{ model.lockout_expires_at | date.to_string '%d/%m/%Y को %H:%M UTC' }}</strong> पर समाप्त होगा।</p>
 <p>यदि ये लॉगिन प्रयास आपने नहीं किए थे, तो आप अपना पासवर्ड रीसेट करके अपने खाते को तुरंत अनलॉक कर सकते हैं:</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">मेरा पासवर्ड रीसेट करें</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">मेरा पासवर्ड रीसेट करें</a>
 </p>
 <p>यदि आपने ये प्रयास नहीं किए और कोई कार्रवाई नहीं करना चाहते, तो लॉकआउट स्वचालित रूप से समाप्त हो जाएगा।</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   यदि बटन काम नहीं करता है, तो निम्नलिखित लिंक को कॉपी करके अपने ब्राउज़र में पेस्ट करें:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.html
@@ -3,10 +3,10 @@
 <p>This is a security measure to protect your account. The lockout will expire on <strong>{{ model.lockout_expires_at | date.to_string '%B %d, %Y at %H:%M UTC' }}</strong>.</p>
 <p>If these login attempts were not made by you, you can reset your password to immediately unlock your account:</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Reset my password</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Reset my password</a>
 </p>
 <p>If you didn't make these attempts and prefer not to take action, the lockout will expire automatically.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   If the button doesn't work, copy and paste the following link into your browser:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.it.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.it.html
@@ -3,10 +3,10 @@
 <p>Questa è una misura di sicurezza per proteggere il tuo account. Il blocco scadrà il <strong>{{ model.lockout_expires_at | date.to_string '%d/%m/%Y alle %H:%M UTC' }}</strong>.</p>
 <p>Se questi tentativi di accesso non sono stati effettuati da te, puoi reimpostare la password per sbloccare immediatamente il tuo account:</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Reimposta la mia password</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Reimposta la mia password</a>
 </p>
 <p>Se non hai effettuato questi tentativi e preferisci non agire, il blocco scadrà automaticamente.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Se il pulsante non funziona, copia e incolla il seguente link nel tuo browser:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.ja.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.ja.html
@@ -3,10 +3,10 @@
 <p>これはアカウントを保護するためのセキュリティ対策です。ロックは <strong>{{ model.lockout_expires_at | date.to_string '%Y年%m月%d日 %H:%M UTC' }}</strong> に解除されます。</p>
 <p>これらのログイン試行が身に覚えのないものである場合は、パスワードをリセットしてアカウントを即座にロック解除できます：</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">パスワードをリセット</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">パスワードをリセット</a>
 </p>
 <p>これらの試行を行っておらず、対応を希望しない場合、ロックは自動的に解除されます。</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   ボタンが機能しない場合は、以下のリンクをコピーしてブラウザに貼り付けてください：<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.ko.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.ko.html
@@ -3,10 +3,10 @@
 <p>이는 계정을 보호하기 위한 보안 조치입니다. 잠금은 <strong>{{ model.lockout_expires_at | date.to_string '%Y년 %m월 %d일 %H:%M UTC' }}</strong>에 해제됩니다.</p>
 <p>이러한 로그인 시도가 본인의 것이 아닌 경우, 비밀번호를 재설정하여 계정을 즉시 잠금 해제할 수 있습니다:</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">비밀번호 재설정</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">비밀번호 재설정</a>
 </p>
 <p>이러한 시도를 하지 않았으며 조치를 취하지 않으려면 잠금이 자동으로 해제됩니다.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   버튼이 작동하지 않으면 다음 링크를 복사하여 브라우저에 붙여넣으세요:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.nl.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.nl.html
@@ -3,10 +3,10 @@
 <p>Dit is een beveiligingsmaatregel om uw account te beschermen. De vergrendeling verloopt op <strong>{{ model.lockout_expires_at | date.to_string '%d-%m-%Y om %H:%M UTC' }}</strong>.</p>
 <p>Als deze aanmeldpogingen niet door u zijn gedaan, kunt u uw wachtwoord opnieuw instellen om uw account onmiddellijk te ontgrendelen:</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Wachtwoord opnieuw instellen</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Wachtwoord opnieuw instellen</a>
 </p>
 <p>Als u deze pogingen niet hebt gedaan en liever geen actie onderneemt, verloopt de vergrendeling automatisch.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Als de knop niet werkt, kopieer en plak de volgende link in uw browser:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.pl.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.pl.html
@@ -3,10 +3,10 @@
 <p>Jest to środek bezpieczeństwa mający na celu ochronę Twojego konta. Blokada wygaśnie <strong>{{ model.lockout_expires_at | date.to_string '%d.%m.%Y o %H:%M UTC' }}</strong>.</p>
 <p>Jeśli te próby logowania nie zostały wykonane przez Ciebie, możesz zresetować hasło, aby natychmiast odblokować swoje konto:</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Zresetuj moje hasło</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Zresetuj moje hasło</a>
 </p>
 <p>Jeśli nie wykonałeś tych prób i wolisz nie podejmować działań, blokada wygaśnie automatycznie.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Jeśli przycisk nie działa, skopiuj i wklej poniższy link do przeglądarki:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.pt-BR.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.pt-BR.html
@@ -3,10 +3,10 @@
 <p>Esta é uma medida de segurança para proteger sua conta. O bloqueio expirará em <strong>{{ model.lockout_expires_at | date.to_string '%d/%m/%Y às %H:%M UTC' }}</strong>.</p>
 <p>Se essas tentativas de login não foram feitas por você, você pode redefinir sua senha para desbloquear sua conta imediatamente:</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Redefinir minha senha</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Redefinir minha senha</a>
 </p>
 <p>Se você não fez essas tentativas e prefere não agir, o bloqueio expirará automaticamente.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.pt.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.pt.html
@@ -3,10 +3,10 @@
 <p>Esta é uma medida de segurança para proteger a sua conta. O bloqueio expirará em <strong>{{ model.lockout_expires_at | date.to_string '%d/%m/%Y às %H:%M UTC' }}</strong>.</p>
 <p>Se estas tentativas de início de sessão não foram feitas por si, pode repor a sua palavra-passe para desbloquear imediatamente a sua conta:</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Repor a minha palavra-passe</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Repor a minha palavra-passe</a>
 </p>
 <p>Se não fez estas tentativas e prefere não agir, o bloqueio expirará automaticamente.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.sv.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.sv.html
@@ -3,10 +3,10 @@
 <p>Detta är en säkerhetsåtgärd för att skydda ditt konto. Låsningen upphör <strong>{{ model.lockout_expires_at | date.to_string '%Y-%m-%d kl. %H:%M UTC' }}</strong>.</p>
 <p>Om dessa inloggningsförsök inte gjordes av dig kan du återställa ditt lösenord för att omedelbart låsa upp ditt konto:</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Återställ mitt lösenord</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Återställ mitt lösenord</a>
 </p>
 <p>Om du inte gjorde dessa försök och föredrar att inte vidta åtgärder kommer låsningen att upphöra automatiskt.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Om knappen inte fungerar, kopiera och klistra in följande länk i din webbläsare:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.tr.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.tr.html
@@ -3,10 +3,10 @@
 <p>Bu, hesabınızı korumaya yönelik bir güvenlik önlemidir. Kilitleme <strong>{{ model.lockout_expires_at | date.to_string '%d.%m.%Y saat %H:%M UTC' }}</strong> tarihinde sona erecektir.</p>
 <p>Bu giriş denemeleri sizin tarafınızdan yapılmadıysa, hesabınızı hemen açmak için parolanızı sıfırlayabilirsiniz:</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Parolamı sıfırla</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Parolamı sıfırla</a>
 </p>
 <p>Bu denemeleri yapmadıysanız ve işlem yapmak istemiyorsanız, kilitleme otomatik olarak sona erecektir.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Düğme çalışmıyorsa, aşağıdaki bağlantıyı kopyalayıp tarayıcınıza yapıştırın:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.zh.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.AccountLocked.zh.html
@@ -3,10 +3,10 @@
 <p>这是保护您账户的安全措施。锁定将于 <strong>{{ model.lockout_expires_at | date.to_string '%Y年%m月%d日 %H:%M UTC' }}</strong> 解除。</p>
 <p>如果这些登录尝试不是您本人所为，您可以重置密码以立即解锁您的账户：</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">重置我的密码</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">重置我的密码</a>
 </p>
 <p>如果您未进行这些尝试且不想采取措施，锁定将自动解除。</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   如果按钮无法使用，请将以下链接复制并粘贴到您的浏览器中：<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.cs.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.cs.html
@@ -1,10 +1,10 @@
 <p>Dobrý den,</p>
 <p>Potvrďte prosím, že <strong>{{ model.new_email | html.escape }}</strong> je vaše nová e-mailová adresa.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Potvrdit nový e-mail</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Potvrdit nový e-mail</a>
 </p>
 <p>Platnost tohoto odkazu vyprší za <strong>24 hodin</strong>. Pokud jste o tuto změnu nežádali, můžete tento e-mail ignorovat.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Pokud tlačítko nefunguje, zkopírujte a vložte následující odkaz do prohlížeče:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.de.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.de.html
@@ -1,10 +1,10 @@
 <p>Hallo,</p>
 <p>Bitte bestätigen Sie, dass <strong>{{ model.new_email | html.escape }}</strong> Ihre neue E-Mail-Adresse ist.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Neue E-Mail bestätigen</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Neue E-Mail bestätigen</a>
 </p>
 <p>Dieser Link läuft in <strong>24 Stunden</strong> ab. Wenn Sie diese Änderung nicht angefordert haben, können Sie diese E-Mail ignorieren.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Wenn die Schaltfläche nicht funktioniert, kopieren Sie den folgenden Link und fügen Sie ihn in Ihren Browser ein:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.es.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.es.html
@@ -1,10 +1,10 @@
 <p>Hola,</p>
 <p>Confirme que <strong>{{ model.new_email | html.escape }}</strong> es su nueva dirección de correo electrónico.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Confirmar nuevo correo electrónico</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirmar nuevo correo electrónico</a>
 </p>
 <p>Este enlace caduca en <strong>24 horas</strong>. Si no solicitó este cambio, puede ignorar este correo electrónico.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Si el botón no funciona, copie y pegue el siguiente enlace en su navegador:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.fr.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.fr.html
@@ -1,10 +1,10 @@
 <p>Bonjour,</p>
 <p>Veuillez confirmer que <strong>{{ model.new_email | html.escape }}</strong> est votre nouvelle adresse e-mail.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Confirmer le nouvel e-mail</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirmer le nouvel e-mail</a>
 </p>
 <p>Ce lien expire dans <strong>24 heures</strong>. Si vous n'avez pas demandé cette modification, vous pouvez ignorer cet e-mail en toute sécurité.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Si le bouton ne fonctionne pas, copiez et collez le lien suivant dans votre navigateur :<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.hi.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.hi.html
@@ -1,10 +1,10 @@
 <p>नमस्ते,</p>
 <p>कृपया पुष्टि करें कि <strong>{{ model.new_email | html.escape }}</strong> आपका नया ईमेल पता है।</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">नया ईमेल पुष्टि करें</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">नया ईमेल पुष्टि करें</a>
 </p>
 <p>यह लिंक <strong>24 घंटे</strong> में समाप्त हो जाएगा। यदि आपने यह परिवर्तन नहीं किया, तो आप इस ईमेल को सुरक्षित रूप से अनदेखा कर सकते हैं।</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   यदि बटन काम नहीं करता, तो निम्नलिखित लिंक को अपने ब्राउज़र में कॉपी और पेस्ट करें:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.html
@@ -1,10 +1,10 @@
 <p>Hi,</p>
 <p>Please confirm that <strong>{{ model.new_email | html.escape }}</strong> is your new email address.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Confirm new email</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirm new email</a>
 </p>
 <p>This link expires in <strong>24 hours</strong>. If you did not request this change, you can safely ignore this email.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   If the button doesn't work, copy and paste the following link into your browser:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.it.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.it.html
@@ -1,10 +1,10 @@
 <p>Ciao,</p>
 <p>Conferma che <strong>{{ model.new_email | html.escape }}</strong> è il tuo nuovo indirizzo e-mail.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Conferma nuovo e-mail</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Conferma nuovo e-mail</a>
 </p>
 <p>Questo link scade tra <strong>24 ore</strong>. Se non hai richiesto questa modifica, puoi ignorare questa e-mail.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Se il pulsante non funziona, copia e incolla il seguente link nel tuo browser:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.ja.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.ja.html
@@ -1,10 +1,10 @@
 <p>こんにちは、</p>
 <p><strong>{{ model.new_email | html.escape }}</strong> が新しいメールアドレスであることを確認してください。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">新しいメールを確認</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">新しいメールを確認</a>
 </p>
 <p>このリンクは <strong>24 時間</strong>で有効期限が切れます。この変更をリクエストしていない場合は、このメールを無視してください。</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   ボタンが機能しない場合は、以下のリンクをコピーしてブラウザに貼り付けてください：<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.ko.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.ko.html
@@ -1,10 +1,10 @@
 <p>안녕하세요,</p>
 <p><strong>{{ model.new_email | html.escape }}</strong>이(가) 새 이메일 주소임을 확인해 주세요.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">새 이메일 확인</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">새 이메일 확인</a>
 </p>
 <p>이 링크는 <strong>24시간</strong> 후에 만료됩니다. 이 변경을 요청하지 않으셨다면 이 이메일을 무시하셔도 됩니다.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   버튼이 작동하지 않는 경우 아래 링크를 복사하여 브라우저에 붙여넣으세요:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.nl.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.nl.html
@@ -1,10 +1,10 @@
 <p>Hallo,</p>
 <p>Bevestig dat <strong>{{ model.new_email | html.escape }}</strong> uw nieuwe e-mailadres is.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Nieuw e-mailadres bevestigen</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Nieuw e-mailadres bevestigen</a>
 </p>
 <p>Deze link vervalt over <strong>24 uur</strong>. Als u deze wijziging niet heeft aangevraagd, kunt u deze e-mail veilig negeren.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Als de knop niet werkt, kopieer en plak de volgende link in uw browser:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.pl.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.pl.html
@@ -1,10 +1,10 @@
 <p>Witaj,</p>
 <p>Potwierdź, że <strong>{{ model.new_email | html.escape }}</strong> to Twój nowy adres e-mail.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Potwierdź nowy e-mail</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Potwierdź nowy e-mail</a>
 </p>
 <p>Ten link wygasa za <strong>24 godziny</strong>. Jeśli nie prosiłeś o tę zmianę, możesz zignorować tę wiadomość.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Jeśli przycisk nie działa, skopiuj i wklej poniższy link do przeglądarki:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.pt-BR.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.pt-BR.html
@@ -1,10 +1,10 @@
 <p>Olá,</p>
 <p>Confirme que <strong>{{ model.new_email | html.escape }}</strong> é seu novo endereço de e-mail.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Confirmar novo e-mail</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirmar novo e-mail</a>
 </p>
 <p>Este link expira em <strong>24 horas</strong>. Se você não solicitou essa alteração, pode ignorar este e-mail com segurança.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.pt.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.pt.html
@@ -1,10 +1,10 @@
 <p>Olá,</p>
 <p>Confirme que <strong>{{ model.new_email | html.escape }}</strong> é o seu novo endereço de e-mail.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Confirmar novo e-mail</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirmar novo e-mail</a>
 </p>
 <p>Este link expira em <strong>24 horas</strong>. Se não solicitou esta alteração, pode ignorar este e-mail com segurança.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.sv.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.sv.html
@@ -1,10 +1,10 @@
 <p>Hej,</p>
 <p>Vänligen bekräfta att <strong>{{ model.new_email | html.escape }}</strong> är din nya e-postadress.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Bekräfta ny e-post</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Bekräfta ny e-post</a>
 </p>
 <p>Denna länk upphör att gälla om <strong>24 timmar</strong>. Om du inte begärde denna ändring kan du ignorera detta e-postmeddelande.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Om knappen inte fungerar, kopiera och klistra in följande länk i din webbläsare:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.tr.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.tr.html
@@ -1,10 +1,10 @@
 <p>Merhaba,</p>
 <p>Lütfen <strong>{{ model.new_email | html.escape }}</strong> adresinin yeni e-posta adresiniz olduğunu doğrulayın.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Yeni e-postayı doğrula</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Yeni e-postayı doğrula</a>
 </p>
 <p>Bu bağlantı <strong>24 saat</strong> içinde geçerliliğini yitirecektir. Bu değişikliği talep etmediyseniz bu e-postayı güvenle yok sayabilirsiniz.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Düğme çalışmıyorsa aşağıdaki bağlantıyı kopyalayıp tarayıcınıza yapıştırın:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.zh.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailChangeConfirmation.zh.html
@@ -1,10 +1,10 @@
 <p>您好，</p>
 <p>请确认 <strong>{{ model.new_email | html.escape }}</strong> 是您的新电子邮件地址。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">确认新邮箱</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">确认新邮箱</a>
 </p>
 <p>此链接将在 <strong>24 小时</strong>后过期。如果您未请求此更改，可以放心忽略此邮件。</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   如果按钮无法使用，请复制以下链接并粘贴到您的浏览器中：<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.cs.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.cs.html
@@ -1,10 +1,10 @@
 <p>Dobrý den,</p>
 <p>Potvrďte prosím svou e-mailovou adresu <strong>{{ model.email | html.escape }}</strong> pro aktivaci účtu.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Potvrdit můj e-mail</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Potvrdit můj e-mail</a>
 </p>
 <p>Platnost tohoto odkazu vyprší za <strong>24 hodin</strong>.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Pokud tlačítko nefunguje, zkopírujte a vložte následující odkaz do prohlížeče:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.de.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.de.html
@@ -1,10 +1,10 @@
 <p>Hallo,</p>
 <p>Bitte bestätigen Sie Ihre E-Mail-Adresse <strong>{{ model.email | html.escape }}</strong>, um Ihr Konto zu aktivieren.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Meine E-Mail bestätigen</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Meine E-Mail bestätigen</a>
 </p>
 <p>Dieser Link läuft in <strong>24 Stunden</strong> ab.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Wenn die Schaltfläche nicht funktioniert, kopieren Sie den folgenden Link und fügen Sie ihn in Ihren Browser ein:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.es.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.es.html
@@ -1,10 +1,10 @@
 <p>Hola,</p>
 <p>Confirme su dirección de correo electrónico <strong>{{ model.email | html.escape }}</strong> para activar su cuenta.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Confirmar mi correo electrónico</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirmar mi correo electrónico</a>
 </p>
 <p>Este enlace caduca en <strong>24 horas</strong>.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Si el botón no funciona, copie y pegue el siguiente enlace en su navegador:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.fr.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.fr.html
@@ -1,10 +1,10 @@
 <p>Bonjour,</p>
 <p>Veuillez confirmer votre adresse e-mail <strong>{{ model.email | html.escape }}</strong> pour activer votre compte.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Confirmer mon e-mail</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirmer mon e-mail</a>
 </p>
 <p>Ce lien expire dans <strong>24 heures</strong>.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Si le bouton ne fonctionne pas, copiez et collez le lien suivant dans votre navigateur :<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.hi.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.hi.html
@@ -1,10 +1,10 @@
 <p>नमस्ते,</p>
 <p>कृपया अपना खाता सक्रिय करने के लिए अपना ईमेल पता <strong>{{ model.email | html.escape }}</strong> पुष्टि करें।</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">मेरा ईमेल पुष्टि करें</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">मेरा ईमेल पुष्टि करें</a>
 </p>
 <p>यह लिंक <strong>24 घंटे</strong> में समाप्त हो जाएगा।</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   यदि बटन काम नहीं करता, तो निम्नलिखित लिंक को अपने ब्राउज़र में कॉपी और पेस्ट करें:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.html
@@ -1,10 +1,10 @@
 <p>Hi,</p>
 <p>Please confirm your email address <strong>{{ model.email | html.escape }}</strong> to activate your account.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Confirm my email</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirm my email</a>
 </p>
 <p>This link expires in <strong>24 hours</strong>.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   If the button doesn't work, copy and paste the following link into your browser:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.it.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.it.html
@@ -1,10 +1,10 @@
 <p>Ciao,</p>
 <p>Conferma il tuo indirizzo e-mail <strong>{{ model.email | html.escape }}</strong> per attivare il tuo account.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Conferma la mia e-mail</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Conferma la mia e-mail</a>
 </p>
 <p>Questo link scade tra <strong>24 ore</strong>.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Se il pulsante non funziona, copia e incolla il seguente link nel tuo browser:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.ja.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.ja.html
@@ -1,10 +1,10 @@
 <p>こんにちは、</p>
 <p>アカウントを有効にするために、メールアドレス <strong>{{ model.email | html.escape }}</strong> を確認してください。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">メールを確認</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">メールを確認</a>
 </p>
 <p>このリンクは <strong>24 時間</strong>で有効期限が切れます。</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   ボタンが機能しない場合は、以下のリンクをコピーしてブラウザに貼り付けてください：<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.ko.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.ko.html
@@ -1,10 +1,10 @@
 <p>안녕하세요,</p>
 <p>계정을 활성화하려면 이메일 주소 <strong>{{ model.email | html.escape }}</strong>을(를) 확인해 주세요.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">이메일 확인</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">이메일 확인</a>
 </p>
 <p>이 링크는 <strong>24시간</strong> 후에 만료됩니다.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   버튼이 작동하지 않는 경우 아래 링크를 복사하여 브라우저에 붙여넣으세요:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.nl.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.nl.html
@@ -1,10 +1,10 @@
 <p>Hallo,</p>
 <p>Bevestig uw e-mailadres <strong>{{ model.email | html.escape }}</strong> om uw account te activeren.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Mijn e-mail bevestigen</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Mijn e-mail bevestigen</a>
 </p>
 <p>Deze link vervalt over <strong>24 uur</strong>.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Als de knop niet werkt, kopieer en plak de volgende link in uw browser:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.pl.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.pl.html
@@ -1,10 +1,10 @@
 <p>Witaj,</p>
 <p>Potwierdź swój adres e-mail <strong>{{ model.email | html.escape }}</strong>, aby aktywować swoje konto.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Potwierdź mój e-mail</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Potwierdź mój e-mail</a>
 </p>
 <p>Ten link wygasa za <strong>24 godziny</strong>.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Jeśli przycisk nie działa, skopiuj i wklej poniższy link do przeglądarki:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.pt-BR.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.pt-BR.html
@@ -1,10 +1,10 @@
 <p>Olá,</p>
 <p>Confirme seu endereço de e-mail <strong>{{ model.email | html.escape }}</strong> para ativar sua conta.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Confirmar meu e-mail</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirmar meu e-mail</a>
 </p>
 <p>Este link expira em <strong>24 horas</strong>.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.pt.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.pt.html
@@ -1,10 +1,10 @@
 <p>Olá,</p>
 <p>Confirme o seu endereço de e-mail <strong>{{ model.email | html.escape }}</strong> para ativar a sua conta.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Confirmar o meu e-mail</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Confirmar o meu e-mail</a>
 </p>
 <p>Este link expira em <strong>24 horas</strong>.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.sv.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.sv.html
@@ -1,10 +1,10 @@
 <p>Hej,</p>
 <p>Vänligen bekräfta din e-postadress <strong>{{ model.email | html.escape }}</strong> för att aktivera ditt konto.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">Bekräfta min e-post</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Bekräfta min e-post</a>
 </p>
 <p>Denna länk upphör att gälla om <strong>24 timmar</strong>.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Om knappen inte fungerar, kopiera och klistra in följande länk i din webbläsare:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.tr.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.tr.html
@@ -1,10 +1,10 @@
 <p>Merhaba,</p>
 <p>Hesabınızı etkinleştirmek için lütfen <strong>{{ model.email | html.escape }}</strong> e-posta adresinizi doğrulayın.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">E-postamı doğrula</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">E-postamı doğrula</a>
 </p>
 <p>Bu bağlantı <strong>24 saat</strong> içinde geçerliliğini yitirecektir.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Düğme çalışmıyorsa aşağıdaki bağlantıyı kopyalayıp tarayıcınıza yapıştırın:<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.zh.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.EmailConfirmation.zh.html
@@ -1,10 +1,10 @@
 <p>您好，</p>
 <p>请确认您的电子邮件地址 <strong>{{ model.email | html.escape }}</strong> 以激活您的账户。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.confirm_link }}" class="btn">确认我的电子邮件</a>
+  <a href="{{ model.confirm_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">确认我的电子邮件</a>
 </p>
 <p>此链接将在 <strong>24 小时</strong>后过期。</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   如果按钮无法使用，请复制以下链接并粘贴到您的浏览器中：<br>
   <a href="{{ model.confirm_link }}">{{ model.confirm_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.cs.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.cs.html
@@ -1,11 +1,11 @@
 <p>Dobrý den,</p>
 <p>Obdrželi jsme žádost o obnovení hesla k účtu spojenému s adresou <strong>{{ model.email | html.escape }}</strong>.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Obnovit mé heslo</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Obnovit mé heslo</a>
 </p>
 <p>Platnost tohoto odkazu vyprší za <strong>15 minut</strong>.</p>
 <p>Pokud jste o obnovení hesla nežádali, můžete tento e-mail ignorovat. Vaše heslo nebude změněno.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Pokud tlačítko nefunguje, zkopírujte a vložte následující odkaz do prohlížeče:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.de.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.de.html
@@ -1,11 +1,11 @@
 <p>Hallo,</p>
 <p>Wir haben eine Anfrage erhalten, das Passwort für das Konto zu zurücksetzen, das mit <strong>{{ model.email | html.escape }}</strong> verknüpft ist.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Mein Passwort zurücksetzen</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Mein Passwort zurücksetzen</a>
 </p>
 <p>Dieser Link läuft in <strong>15 Minuten</strong> ab.</p>
 <p>Wenn Sie keine Passwortzurücksetzung angefordert haben, können Sie diese E-Mail ignorieren. Ihr Passwort wird nicht geändert.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Wenn die Schaltfläche nicht funktioniert, kopieren Sie den folgenden Link und fügen Sie ihn in Ihren Browser ein:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.es.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.es.html
@@ -1,11 +1,11 @@
 <p>Hola,</p>
 <p>Hemos recibido una solicitud para restablecer la contraseña de la cuenta asociada a <strong>{{ model.email | html.escape }}</strong>.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Restablecer mi contraseña</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Restablecer mi contraseña</a>
 </p>
 <p>Este enlace caduca en <strong>15 minutos</strong>.</p>
 <p>Si no solicitó un restablecimiento de contraseña, puede ignorar este correo electrónico. Su contraseña no será modificada.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Si el botón no funciona, copie y pegue el siguiente enlace en su navegador:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.fr.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.fr.html
@@ -1,11 +1,11 @@
 <p>Bonjour,</p>
 <p>Nous avons reçu une demande de réinitialisation du mot de passe pour le compte associé à <strong>{{ model.email | html.escape }}</strong>.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Réinitialiser mon mot de passe</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Réinitialiser mon mot de passe</a>
 </p>
 <p>Ce lien expire dans <strong>15 minutes</strong>.</p>
 <p>Si vous n'avez pas demandé de réinitialisation de mot de passe, vous pouvez ignorer cet e-mail en toute sécurité. Votre mot de passe ne sera pas modifié.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Si le bouton ne fonctionne pas, copiez et collez le lien suivant dans votre navigateur :<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.hi.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.hi.html
@@ -1,11 +1,11 @@
 <p>नमस्ते,</p>
 <p>हमें <strong>{{ model.email | html.escape }}</strong> से जुड़े खाते का पासवर्ड रीसेट करने का अनुरोध प्राप्त हुआ है।</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">मेरा पासवर्ड रीसेट करें</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">मेरा पासवर्ड रीसेट करें</a>
 </p>
 <p>यह लिंक <strong>15 मिनट</strong> में समाप्त हो जाएगा।</p>
 <p>यदि आपने पासवर्ड रीसेट का अनुरोध नहीं किया, तो आप इस ईमेल को सुरक्षित रूप से अनदेखा कर सकते हैं। आपका पासवर्ड नहीं बदला जाएगा।</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   यदि बटन काम नहीं करता, तो निम्नलिखित लिंक को अपने ब्राउज़र में कॉपी और पेस्ट करें:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.html
@@ -1,11 +1,11 @@
 <p>Hi,</p>
 <p>We received a request to reset the password for the account associated with <strong>{{ model.email | html.escape }}</strong>.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Reset my password</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Reset my password</a>
 </p>
 <p>This link expires in <strong>15 minutes</strong>.</p>
 <p>If you didn't request a password reset, you can safely ignore this email. Your password will not be changed.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   If the button doesn't work, copy and paste the following link into your browser:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.it.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.it.html
@@ -1,11 +1,11 @@
 <p>Ciao,</p>
 <p>Abbiamo ricevuto una richiesta di reimpostazione della password per l'account associato a <strong>{{ model.email | html.escape }}</strong>.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Reimposta la mia password</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Reimposta la mia password</a>
 </p>
 <p>Questo link scade tra <strong>15 minuti</strong>.</p>
 <p>Se non hai richiesto la reimpostazione della password, puoi ignorare questa e-mail. La tua password non verrà modificata.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Se il pulsante non funziona, copia e incolla il seguente link nel tuo browser:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.ja.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.ja.html
@@ -1,11 +1,11 @@
 <p>こんにちは、</p>
 <p><strong>{{ model.email | html.escape }}</strong> に関連付けられたアカウントのパスワードリセットリクエストを受け取りました。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">パスワードをリセット</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">パスワードをリセット</a>
 </p>
 <p>このリンクは <strong>15 分</strong>で有効期限が切れます。</p>
 <p>パスワードリセットをリクエストしていない場合は、このメールを無視してください。パスワードは変更されません。</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   ボタンが機能しない場合は、以下のリンクをコピーしてブラウザに貼り付けてください：<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.ko.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.ko.html
@@ -1,11 +1,11 @@
 <p>안녕하세요,</p>
 <p><strong>{{ model.email | html.escape }}</strong>과(와) 연결된 계정의 비밀번호 재설정 요청을 받았습니다.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">비밀번호 재설정</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">비밀번호 재설정</a>
 </p>
 <p>이 링크는 <strong>15분</strong> 후에 만료됩니다.</p>
 <p>비밀번호 재설정을 요청하지 않으셨다면 이 이메일을 무시하셔도 됩니다. 비밀번호는 변경되지 않습니다.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   버튼이 작동하지 않는 경우 아래 링크를 복사하여 브라우저에 붙여넣으세요:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.nl.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.nl.html
@@ -1,11 +1,11 @@
 <p>Hallo,</p>
 <p>We hebben een verzoek ontvangen om het wachtwoord opnieuw in te stellen voor het account gekoppeld aan <strong>{{ model.email | html.escape }}</strong>.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Mijn wachtwoord opnieuw instellen</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Mijn wachtwoord opnieuw instellen</a>
 </p>
 <p>Deze link vervalt over <strong>15 minuten</strong>.</p>
 <p>Als u geen wachtwoordherstel heeft aangevraagd, kunt u deze e-mail veilig negeren. Uw wachtwoord wordt niet gewijzigd.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Als de knop niet werkt, kopieer en plak de volgende link in uw browser:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.pl.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.pl.html
@@ -1,11 +1,11 @@
 <p>Witaj,</p>
 <p>Otrzymaliśmy prośbę o zresetowanie hasła do konta powiązanego z adresem <strong>{{ model.email | html.escape }}</strong>.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Zresetuj moje hasło</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Zresetuj moje hasło</a>
 </p>
 <p>Ten link wygasa za <strong>15 minut</strong>.</p>
 <p>Jeśli nie prosiłeś o zresetowanie hasła, możesz zignorować tę wiadomość. Twoje hasło nie zostanie zmienione.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Jeśli przycisk nie działa, skopiuj i wklej poniższy link do przeglądarki:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.pt-BR.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.pt-BR.html
@@ -1,11 +1,11 @@
 <p>Olá,</p>
 <p>Recebemos uma solicitação para redefinir a senha da conta associada a <strong>{{ model.email | html.escape }}</strong>.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Redefinir minha senha</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Redefinir minha senha</a>
 </p>
 <p>Este link expira em <strong>15 minutos</strong>.</p>
 <p>Se você não solicitou a redefinição de senha, pode ignorar este e-mail com segurança. Sua senha não será alterada.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.pt.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.pt.html
@@ -1,11 +1,11 @@
 <p>Olá,</p>
 <p>Recebemos um pedido para repor a palavra-passe da conta associada a <strong>{{ model.email | html.escape }}</strong>.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Repor a minha palavra-passe</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Repor a minha palavra-passe</a>
 </p>
 <p>Este link expira em <strong>15 minutos</strong>.</p>
 <p>Se não solicitou a reposição da palavra-passe, pode ignorar este e-mail com segurança. A sua palavra-passe não será alterada.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Se o botão não funcionar, copie e cole o seguinte link no seu navegador:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.sv.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.sv.html
@@ -1,11 +1,11 @@
 <p>Hej,</p>
 <p>Vi har tagit emot en begäran om att återställa lösenordet för kontot kopplat till <strong>{{ model.email | html.escape }}</strong>.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Återställ mitt lösenord</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Återställ mitt lösenord</a>
 </p>
 <p>Denna länk upphör att gälla om <strong>15 minuter</strong>.</p>
 <p>Om du inte har begärt en lösenordsåterställning kan du ignorera detta e-postmeddelande. Ditt lösenord kommer inte att ändras.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Om knappen inte fungerar, kopiera och klistra in följande länk i din webbläsare:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.tr.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.tr.html
@@ -1,11 +1,11 @@
 <p>Merhaba,</p>
 <p><strong>{{ model.email | html.escape }}</strong> ile ilişkili hesabın parolasını sıfırlamak için bir istek aldık.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">Parolamı sıfırla</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Parolamı sıfırla</a>
 </p>
 <p>Bu bağlantı <strong>15 dakika</strong> içinde geçerliliğini yitirecektir.</p>
 <p>Parola sıfırlama talebinde bulunmadıysanız bu e-postayı güvenle yok sayabilirsiniz. Parolanız değiştirilmeyecektir.</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   Düğme çalışmıyorsa aşağıdaki bağlantıyı kopyalayıp tarayıcınıza yapıştırın:<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.zh.html
+++ b/src/Granit.Identity.Local.Notifications/Templates/Security.PasswordReset.zh.html
@@ -1,11 +1,11 @@
 <p>您好，</p>
 <p>我们收到了重置与 <strong>{{ model.email | html.escape }}</strong> 关联的账户密码的请求。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ model.reset_link }}" class="btn">重置我的密码</a>
+  <a href="{{ model.reset_link }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">重置我的密码</a>
 </p>
 <p>此链接将在 <strong>15 分钟</strong>后过期。</p>
 <p>如果您未请求重置密码，可以放心忽略此邮件。您的密码不会被更改。</p>
-<hr class="divider" aria-hidden="true">
+<hr style="border: none; border-top: 1px solid #d1d5db; margin: 24px 0;">
 <p style="font-size: 13px; color: #4b5563;">
   如果按钮无法使用，请复制以下链接并粘贴到您的浏览器中：<br>
   <a href="{{ model.reset_link }}">{{ model.reset_link }}</a>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.cs.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.cs.html
@@ -9,5 +9,5 @@
   {{- end }}
 </ul>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Zobrazit fakturu</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Zobrazit fakturu</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.de.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.de.html
@@ -9,5 +9,5 @@
   {{- end }}
 </ul>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Rechnung anzeigen</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Rechnung anzeigen</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.en-GB.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.en-GB.html
@@ -9,5 +9,5 @@
   {{- end }}
 </ul>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">View invoice</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">View invoice</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.es.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.es.html
@@ -9,5 +9,5 @@
   {{- end }}
 </ul>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Ver factura</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Ver factura</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.fr.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.fr.html
@@ -9,5 +9,5 @@
   {{- end }}
 </ul>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Voir la facture</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Voir la facture</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.hi.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.hi.html
@@ -9,5 +9,5 @@
   {{- end }}
 </ul>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">चालान देखें</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">चालान देखें</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.html
@@ -9,5 +9,5 @@
   {{- end }}
 </ul>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">View invoice</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">View invoice</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.it.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.it.html
@@ -9,5 +9,5 @@
   {{- end }}
 </ul>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Visualizza fattura</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Visualizza fattura</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.ja.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.ja.html
@@ -9,5 +9,5 @@
   {{- end }}
 </ul>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">請求書を表示</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">請求書を表示</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.ko.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.ko.html
@@ -9,5 +9,5 @@
   {{- end }}
 </ul>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">청구서 보기</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">청구서 보기</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.nl.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.nl.html
@@ -9,5 +9,5 @@
   {{- end }}
 </ul>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Factuur bekijken</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Factuur bekijken</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.pl.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.pl.html
@@ -9,5 +9,5 @@
   {{- end }}
 </ul>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Zobacz fakturę</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Zobacz fakturę</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.pt-BR.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.pt-BR.html
@@ -9,5 +9,5 @@
   {{- end }}
 </ul>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Ver fatura</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Ver fatura</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.pt.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.pt.html
@@ -9,5 +9,5 @@
   {{- end }}
 </ul>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Ver fatura</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Ver fatura</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.sv.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.sv.html
@@ -9,5 +9,5 @@
   {{- end }}
 </ul>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Visa faktura</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Visa faktura</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.tr.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.tr.html
@@ -9,5 +9,5 @@
   {{- end }}
 </ul>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Faturayı görüntüle</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Faturayı görüntüle</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.zh.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceIssued.zh.html
@@ -9,5 +9,5 @@
   {{- end }}
 </ul>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">查看发票</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">查看发票</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.cs.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.cs.html
@@ -7,5 +7,5 @@
 </ul>
 <p>Uhraďte prosím dlužnou částku, abyste předešli přerušení služby.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Zaplatit nyní</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Zaplatit nyní</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.de.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.de.html
@@ -7,5 +7,5 @@
 </ul>
 <p>Bitte begleichen Sie den offenen Betrag, um eine Dienstunterbrechung zu vermeiden.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Jetzt bezahlen</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Jetzt bezahlen</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.en-GB.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.en-GB.html
@@ -7,5 +7,5 @@
 </ul>
 <p>Please settle the outstanding balance to avoid service interruption.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Pay now</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Pay now</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.es.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.es.html
@@ -7,5 +7,5 @@
 </ul>
 <p>Le rogamos que abone el saldo pendiente para evitar una interrupción del servicio.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Pagar ahora</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Pagar ahora</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.fr.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.fr.html
@@ -7,5 +7,5 @@
 </ul>
 <p>Veuillez régler le solde impayé pour éviter une interruption de service.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Payer maintenant</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Payer maintenant</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.hi.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.hi.html
@@ -7,5 +7,5 @@
 </ul>
 <p>सेवा में रुकावट से बचने के लिए कृपया बकाया राशि का भुगतान करें।</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">अभी भुगतान करें</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">अभी भुगतान करें</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.html
@@ -7,5 +7,5 @@
 </ul>
 <p>Please settle the outstanding balance to avoid service interruption.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Pay now</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Pay now</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.it.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.it.html
@@ -7,5 +7,5 @@
 </ul>
 <p>La preghiamo di saldare l'importo dovuto per evitare un'interruzione del servizio.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Paga ora</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Paga ora</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.ja.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.ja.html
@@ -7,5 +7,5 @@
 </ul>
 <p>サービスの中断を避けるため、未払い残高をお支払いください。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">今すぐ支払う</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">今すぐ支払う</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.ko.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.ko.html
@@ -7,5 +7,5 @@
 </ul>
 <p>서비스 중단을 방지하기 위해 미결제 잔액을 납부해 주시기 바랍니다.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">지금 결제</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">지금 결제</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.nl.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.nl.html
@@ -7,5 +7,5 @@
 </ul>
 <p>Gelieve het openstaande saldo te voldoen om een onderbreking van de dienstverlening te voorkomen.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Nu betalen</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Nu betalen</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.pl.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.pl.html
@@ -7,5 +7,5 @@
 </ul>
 <p>Prosimy o uregulowanie zaległego salda, aby uniknąć przerwy w świadczeniu usług.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Zapłać teraz</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Zapłać teraz</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.pt-BR.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.pt-BR.html
@@ -7,5 +7,5 @@
 </ul>
 <p>Por favor, regularize o saldo em aberto para evitar a interrupção do serviço.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Pagar agora</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Pagar agora</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.pt.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.pt.html
@@ -7,5 +7,5 @@
 </ul>
 <p>Solicitamos que regularize o saldo em aberto para evitar uma interrupção do serviço.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Pagar agora</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Pagar agora</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.sv.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.sv.html
@@ -7,5 +7,5 @@
 </ul>
 <p>Vänligen reglera det utestående beloppet för att undvika avbrott i tjänsten.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Betala nu</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Betala nu</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.tr.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.tr.html
@@ -7,5 +7,5 @@
 </ul>
 <p>Hizmet kesintisini önlemek için lütfen ödenmemiş bakiyeyi ödeyiniz.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Şimdi öde</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Şimdi öde</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.zh.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoiceOverdue.zh.html
@@ -7,5 +7,5 @@
 </ul>
 <p>请尽快结清未付余额，以免服务中断。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">立即支付</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">立即支付</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.cs.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.cs.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Děkujeme za vaši platbu.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Zobrazit potvrzení</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Zobrazit potvrzení</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.de.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.de.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Vielen Dank für Ihre Zahlung.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Beleg anzeigen</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Beleg anzeigen</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.en-GB.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.en-GB.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Thank you for your payment.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">View receipt</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">View receipt</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.es.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.es.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Gracias por su pago.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Ver recibo</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Ver recibo</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.fr.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.fr.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Merci pour votre paiement.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Voir le reçu</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Voir le reçu</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.hi.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.hi.html
@@ -6,5 +6,5 @@
 </ul>
 <p>आपके भुगतान के लिए धन्यवाद।</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">रसीद देखें</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">रसीद देखें</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Thank you for your payment.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">View receipt</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">View receipt</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.it.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.it.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Grazie per il pagamento.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Visualizza ricevuta</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Visualizza ricevuta</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.ja.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.ja.html
@@ -6,5 +6,5 @@
 </ul>
 <p>お支払いいただきありがとうございます。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">領収書を表示</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">領収書を表示</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.ko.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.ko.html
@@ -6,5 +6,5 @@
 </ul>
 <p>결제해 주셔서 감사합니다.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">영수증 보기</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">영수증 보기</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.nl.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.nl.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Bedankt voor uw betaling.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Ontvangstbewijs bekijken</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Ontvangstbewijs bekijken</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.pl.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.pl.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Dziękujemy za dokonanie płatności.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Zobacz potwierdzenie</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Zobacz potwierdzenie</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.pt-BR.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.pt-BR.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Obrigado pelo pagamento.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Ver recibo</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Ver recibo</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.pt.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.pt.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Obrigado pelo seu pagamento.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Ver recibo</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Ver recibo</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.sv.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.sv.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Tack för din betalning.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Visa kvitto</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Visa kvitto</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.tr.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.tr.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Ödemeniz için teşekkür ederiz.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">Makbuzu görüntüle</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Makbuzu görüntüle</a>
 </p>

--- a/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.zh.html
+++ b/src/Granit.Invoicing.Notifications/Templates/Invoicing.InvoicePaid.zh.html
@@ -6,5 +6,5 @@
 </ul>
 <p>感谢您的付款。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" class="btn">查看收据</a>
+  <a href="{{ app.base_url }}/invoices/{{ model.invoice_id }}" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">查看收据</a>
 </p>

--- a/src/Granit.Notifications.Email/Templates/Layout.Email.html
+++ b/src/Granit.Notifications.Email/Templates/Layout.Email.html
@@ -1,80 +1,53 @@
-<!DOCTYPE html>
-<html lang="{{ context.culture }}" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="x-apple-disable-message-reformatting">
-    <meta name="format-detection" content="telephone=no, date=no, address=no, email=no, url=no">
-    <!--[if mso]>
-    <noscript>
-        <xml>
-            <o:OfficeDocumentSettings>
-                <o:PixelsPerInch>96</o:PixelsPerInch>
-            </o:OfficeDocumentSettings>
-        </xml>
-    </noscript>
-    <![endif]-->
-    <title>{{ model.title }}</title>
-</head>
-<body style="margin: 0; padding: 0; background-color: #f4f5f7; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; color: #1a1a2e; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;">
-    <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #f4f5f7;">
-        <tr>
-            <td align="center" style="padding: 32px 0;">
-                <!--[if mso]><table role="presentation" cellpadding="0" cellspacing="0" border="0" width="600"><tr><td><![endif]-->
-                <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="max-width: 600px; background-color: #ffffff;">
-                    <!-- Header -->
-                    <tr>
-                        <td align="center" style="background-color: #1a1a2e; padding: 24px 32px;">
-                            {{- if app.logo_url != "" }}
-                            <img src="{{ app.logo_url }}" alt="{{ app.name }}" style="max-height: 40px; width: auto; display: block; margin: 0 auto; border: 0;">
-                            {{- else }}
-                            <span style="color: #ffffff; font-size: 20px; font-weight: bold; letter-spacing: 0.5px;" aria-label="{{ app.name }}">{{ app.name }}</span>
-                            {{- end }}
-                        </td>
-                    </tr>
-                    <!-- Body -->
-                    <tr>
-                        <td style="padding: 32px; font-size: 16px; line-height: 1.6; color: #374151;">
-                            {{ body }}
-                            {{- if app.base_url != "" }}
-                            <!-- Divider -->
-                            <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="margin: 24px 0;">
-                                <tr>
-                                    <td style="border-top: 1px solid #d1d5db; font-size: 0; line-height: 0;" height="1">&nbsp;</td>
-                                </tr>
-                            </table>
-                            <!-- CTA Button -->
-                            <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
-                                <tr>
-                                    <td align="center">
-                                        <a href="{{ app.base_url }}" style="color: #1d4ed8; text-decoration: underline; font-size: 14px;">{{ app.name }}</a>
-                                    </td>
-                                </tr>
-                            </table>
-                            {{- end }}
-                        </td>
-                    </tr>
-                    <!-- Footer -->
-                    <tr>
-                        <td style="background-color: #f3f4f6; padding: 20px 32px; text-align: center; border-top: 1px solid #d1d5db;">
-                            {{- if model.allow_opt_out && model.unsubscribe_url != "" }}
-                            <p style="margin: 0 0 6px; font-size: 13px; color: #4b5563;"><a href="{{ model.unsubscribe_url }}" style="color: #374151; text-decoration: underline;">{{ t "NotificationsEmail:ManagePreferences" }}</a></p>
-                            {{- end }}
-                            {{- if model.notification_group != "" }}
-                            <p style="margin: 0 0 6px; font-size: 13px; color: #4b5563;">{{ t "NotificationsEmail:SubscribedReason" model.notification_group }}</p>
-                            {{- end }}
-                            <p style="margin: 0 0 6px; font-size: 13px; color: #4b5563;">{{ t "NotificationsEmail:NoReply" }}</p>
-                            {{- if app.support_email != "" }}
-                            <p style="margin: 0 0 6px; font-size: 13px; color: #4b5563;"><a href="mailto:{{ app.support_email }}" style="color: #374151; text-decoration: underline;">{{ app.support_email }}</a></p>
-                            {{- end }}
-                            <p style="margin: 0; font-size: 13px; color: #4b5563;">&copy; {{ now.year }} {{ app.name }}</p>
-                        </td>
-                    </tr>
-                </table>
-                <!--[if mso]></td></tr></table><![endif]-->
-            </td>
-        </tr>
-    </table>
-</body>
-</html>
+<mjml>
+  <mj-head>
+    <mj-attributes>
+      <mj-all font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" />
+      <mj-text font-size="16px" line-height="1.6" color="#374151" />
+      <mj-section padding="0" />
+    </mj-attributes>
+  </mj-head>
+  <mj-body background-color="#f4f5f7">
+    <!-- Header -->
+    <mj-section background-color="#1a1a2e" padding="24px 32px">
+      <mj-column>
+        {{- if app.logo_url != "" }}
+        <mj-image src="{{ app.logo_url }}" alt="{{ app.name }}" width="160px" />
+        {{- else }}
+        <mj-text align="center" color="#ffffff" font-size="20px" font-weight="bold" letter-spacing="0.5px">{{ app.name }}</mj-text>
+        {{- end }}
+      </mj-column>
+    </mj-section>
+    <!-- Body -->
+    <mj-section background-color="#ffffff" padding="32px">
+      <mj-column>
+        <mj-text>{{ body }}</mj-text>
+        {{- if app.base_url != "" }}
+        <mj-divider border-color="#d1d5db" border-width="1px" padding="24px 0" />
+        <mj-text align="center">
+          <a href="{{ app.base_url }}" style="color: #1d4ed8; text-decoration: underline; font-size: 14px;">{{ app.name }}</a>
+        </mj-text>
+        {{- end }}
+      </mj-column>
+    </mj-section>
+    <!-- Footer -->
+    <mj-section background-color="#f3f4f6" padding="20px 32px" border-top="1px solid #d1d5db">
+      <mj-column>
+        {{- if model.allow_opt_out && model.unsubscribe_url != "" }}
+        <mj-text align="center" font-size="13px" color="#4b5563" padding="0 0 6px">
+          <a href="{{ model.unsubscribe_url }}" style="color: #374151; text-decoration: underline;">{{ t "NotificationsEmail:ManagePreferences" }}</a>
+        </mj-text>
+        {{- end }}
+        {{- if model.notification_group != "" }}
+        <mj-text align="center" font-size="13px" color="#4b5563" padding="0 0 6px">{{ t "NotificationsEmail:SubscribedReason" model.notification_group }}</mj-text>
+        {{- end }}
+        <mj-text align="center" font-size="13px" color="#4b5563" padding="0 0 6px">{{ t "NotificationsEmail:NoReply" }}</mj-text>
+        {{- if app.support_email != "" }}
+        <mj-text align="center" font-size="13px" color="#4b5563" padding="0 0 6px">
+          <a href="mailto:{{ app.support_email }}" style="color: #374151; text-decoration: underline;">{{ app.support_email }}</a>
+        </mj-text>
+        {{- end }}
+        <mj-text align="center" font-size="13px" color="#4b5563" padding="0">&copy; {{ now.year }} {{ app.name }}</mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.cs.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.cs.html
@@ -9,5 +9,5 @@
 </ul>
 <p>Aktualizujte svou platební metodu, abyste předešli přerušení služby. Platba bude automaticky opakována.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Aktualizovat platební metodu</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Aktualizovat platební metodu</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.de.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.de.html
@@ -9,5 +9,5 @@
 </ul>
 <p>Bitte aktualisieren Sie Ihre Zahlungsmethode, um eine Dienstunterbrechung zu vermeiden. Wir werden die Zahlung automatisch erneut versuchen.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Zahlungsmethode aktualisieren</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Zahlungsmethode aktualisieren</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.es.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.es.html
@@ -9,5 +9,5 @@
 </ul>
 <p>Actualice su método de pago para evitar una interrupción del servicio. Reintentaremos el pago automáticamente.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Actualizar método de pago</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Actualizar método de pago</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.fr.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.fr.html
@@ -9,5 +9,5 @@
 </ul>
 <p>Veuillez mettre à jour votre moyen de paiement pour éviter une interruption de service. Nous réessaierons automatiquement le paiement.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Mettre à jour le paiement</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Mettre à jour le paiement</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.hi.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.hi.html
@@ -9,5 +9,5 @@
 </ul>
 <p>सेवा में रुकावट से बचने के लिए कृपया अपनी भुगतान विधि अपडेट करें। हम स्वचालित रूप से भुगतान का पुनः प्रयास करेंगे।</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">भुगतान विधि अपडेट करें</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">भुगतान विधि अपडेट करें</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.html
@@ -9,5 +9,5 @@
 </ul>
 <p>Please update your payment method to avoid service interruption. We will automatically retry the payment.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Update payment method</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Update payment method</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.it.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.it.html
@@ -9,5 +9,5 @@
 </ul>
 <p>Aggiorni il metodo di pagamento per evitare un'interruzione del servizio. Il pagamento verrà ritentato automaticamente.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Aggiornare il metodo di pagamento</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Aggiornare il metodo di pagamento</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.ja.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.ja.html
@@ -9,5 +9,5 @@
 </ul>
 <p>サービスの中断を避けるため、お支払い方法を更新してください。お支払いは自動的に再試行されます。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">お支払い方法を更新</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">お支払い方法を更新</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.ko.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.ko.html
@@ -9,5 +9,5 @@
 </ul>
 <p>서비스 중단을 방지하려면 결제 수단을 업데이트해 주세요. 결제는 자동으로 재시도됩니다.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">결제 수단 업데이트</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">결제 수단 업데이트</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.nl.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.nl.html
@@ -9,5 +9,5 @@
 </ul>
 <p>Werk uw betaalmethode bij om een onderbreking van de dienst te voorkomen. We zullen de betaling automatisch opnieuw proberen.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Betaalmethode bijwerken</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Betaalmethode bijwerken</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.pl.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.pl.html
@@ -9,5 +9,5 @@
 </ul>
 <p>Zaktualizuj swoją metodę płatności, aby uniknąć przerwy w usłudze. Płatność zostanie automatycznie ponowiona.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Zaktualizuj metodę płatności</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Zaktualizuj metodę płatności</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.pt-BR.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.pt-BR.html
@@ -9,5 +9,5 @@
 </ul>
 <p>Atualize seu método de pagamento para evitar a interrupção do serviço. O pagamento será automaticamente tentado novamente.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Atualizar método de pagamento</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Atualizar método de pagamento</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.pt.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.pt.html
@@ -9,5 +9,5 @@
 </ul>
 <p>Atualize o seu método de pagamento para evitar uma interrupção do serviço. O pagamento será automaticamente tentado novamente.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Atualizar método de pagamento</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Atualizar método de pagamento</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.sv.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.sv.html
@@ -9,5 +9,5 @@
 </ul>
 <p>Uppdatera din betalningsmetod för att undvika avbrott i tjänsten. Vi kommer automatiskt att försöka igen med betalningen.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Uppdatera betalningsmetod</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Uppdatera betalningsmetod</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.tr.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.tr.html
@@ -9,5 +9,5 @@
 </ul>
 <p>Hizmet kesintisini önlemek için ödeme yönteminizi güncelleyin. Ödeme otomatik olarak yeniden denenecektir.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Ödeme yöntemini güncelle</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Ödeme yöntemini güncelle</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.zh.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentFailed.zh.html
@@ -9,5 +9,5 @@
 </ul>
 <p>请更新您的付款方式以避免服务中断。我们将自动重试付款。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">更新付款方式</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">更新付款方式</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.cs.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.cs.html
@@ -2,5 +2,5 @@
 <p>Vaše platební metoda <strong>{{ model.display_label | html.escape }}</strong> vyprší za <strong>{{ model.days_remaining }} den/dní</strong>, v {{ model.expires_at | to_user_time | date.to_string "%m/%Y" }}.</p>
 <p>Aktualizujte svou platební metodu, abyste zajistili nepřerušenou službu.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing/methods" class="btn">Aktualizovat platební metodu</a>
+  <a href="{{ app.base_url }}/billing/methods" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Aktualizovat platební metodu</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.de.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.de.html
@@ -2,5 +2,5 @@
 <p>Ihre Zahlungsmethode <strong>{{ model.display_label | html.escape }}</strong> läuft in <strong>{{ model.days_remaining }} Tag(en)</strong> ab, im {{ model.expires_at | to_user_time | date.to_string "%m/%Y" }}.</p>
 <p>Bitte aktualisieren Sie Ihre Zahlungsmethode, um einen unterbrechungsfreien Service zu gewährleisten.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing/methods" class="btn">Zahlungsmethode aktualisieren</a>
+  <a href="{{ app.base_url }}/billing/methods" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Zahlungsmethode aktualisieren</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.es.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.es.html
@@ -2,5 +2,5 @@
 <p>Su método de pago <strong>{{ model.display_label | html.escape }}</strong> vencerá en <strong>{{ model.days_remaining }} día(s)</strong>, en {{ model.expires_at | to_user_time | date.to_string "%m/%Y" }}.</p>
 <p>Actualice su método de pago para garantizar un servicio ininterrumpido.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing/methods" class="btn">Actualizar método de pago</a>
+  <a href="{{ app.base_url }}/billing/methods" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Actualizar método de pago</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.fr.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.fr.html
@@ -2,5 +2,5 @@
 <p>Votre moyen de paiement <strong>{{ model.display_label | html.escape }}</strong> expire dans <strong>{{ model.days_remaining }} jour(s)</strong>, en {{ model.expires_at | to_user_time | date.to_string "%m/%Y" }}.</p>
 <p>Veuillez mettre à jour votre moyen de paiement pour assurer la continuité du service.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing/methods" class="btn">Mettre à jour</a>
+  <a href="{{ app.base_url }}/billing/methods" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Mettre à jour</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.hi.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.hi.html
@@ -2,5 +2,5 @@
 <p>आपकी भुगतान विधि <strong>{{ model.display_label | html.escape }}</strong> <strong>{{ model.days_remaining }} दिन</strong> में, {{ model.expires_at | to_user_time | date.to_string "%B %Y" }} को समाप्त हो जाएगी।</p>
 <p>निर्बाध सेवा सुनिश्चित करने के लिए कृपया अपनी भुगतान विधि अपडेट करें।</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing/methods" class="btn">भुगतान विधि अपडेट करें</a>
+  <a href="{{ app.base_url }}/billing/methods" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">भुगतान विधि अपडेट करें</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.html
@@ -2,5 +2,5 @@
 <p>Your payment method <strong>{{ model.display_label | html.escape }}</strong> will expire in <strong>{{ model.days_remaining }} day(s)</strong>, on {{ model.expires_at | to_user_time | date.to_string "%B %Y" }}.</p>
 <p>Please update your payment method to ensure uninterrupted service.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing/methods" class="btn">Update payment method</a>
+  <a href="{{ app.base_url }}/billing/methods" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Update payment method</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.it.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.it.html
@@ -2,5 +2,5 @@
 <p>Il metodo di pagamento <strong>{{ model.display_label | html.escape }}</strong> scadrà tra <strong>{{ model.days_remaining }} giorno/i</strong>, nel {{ model.expires_at | to_user_time | date.to_string "%m/%Y" }}.</p>
 <p>Aggiorni il metodo di pagamento per garantire la continuità del servizio.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing/methods" class="btn">Aggiornare il metodo di pagamento</a>
+  <a href="{{ app.base_url }}/billing/methods" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Aggiornare il metodo di pagamento</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.ja.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.ja.html
@@ -2,5 +2,5 @@
 <p>お支払い方法 <strong>{{ model.display_label | html.escape }}</strong> は <strong>{{ model.days_remaining }} 日</strong>後に期限切れとなります（{{ model.expires_at | to_user_time | date.to_string "%Y年%m月" }}）。</p>
 <p>サービスの中断を防ぐため、お支払い方法を更新してください。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing/methods" class="btn">お支払い方法を更新</a>
+  <a href="{{ app.base_url }}/billing/methods" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">お支払い方法を更新</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.ko.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.ko.html
@@ -2,5 +2,5 @@
 <p>결제 수단 <strong>{{ model.display_label | html.escape }}</strong>이(가) <strong>{{ model.days_remaining }}일</strong> 후 {{ model.expires_at | to_user_time | date.to_string "%Y년 %m월" }}에 만료됩니다.</p>
 <p>서비스 중단을 방지하려면 결제 수단을 업데이트해 주세요.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing/methods" class="btn">결제 수단 업데이트</a>
+  <a href="{{ app.base_url }}/billing/methods" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">결제 수단 업데이트</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.nl.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.nl.html
@@ -2,5 +2,5 @@
 <p>Uw betaalmethode <strong>{{ model.display_label | html.escape }}</strong> verloopt over <strong>{{ model.days_remaining }} dag(en)</strong>, in {{ model.expires_at | to_user_time | date.to_string "%m/%Y" }}.</p>
 <p>Werk uw betaalmethode bij om een ononderbroken dienstverlening te garanderen.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing/methods" class="btn">Betaalmethode bijwerken</a>
+  <a href="{{ app.base_url }}/billing/methods" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Betaalmethode bijwerken</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.pl.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.pl.html
@@ -2,5 +2,5 @@
 <p>Twoja metoda płatności <strong>{{ model.display_label | html.escape }}</strong> wygaśnie za <strong>{{ model.days_remaining }} dzień/dni</strong>, w {{ model.expires_at | to_user_time | date.to_string "%m/%Y" }}.</p>
 <p>Zaktualizuj swoją metodę płatności, aby zapewnić nieprzerwaną usługę.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing/methods" class="btn">Zaktualizuj metodę płatności</a>
+  <a href="{{ app.base_url }}/billing/methods" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Zaktualizuj metodę płatności</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.pt-BR.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.pt-BR.html
@@ -2,5 +2,5 @@
 <p>Seu método de pagamento <strong>{{ model.display_label | html.escape }}</strong> expira em <strong>{{ model.days_remaining }} dia(s)</strong>, em {{ model.expires_at | to_user_time | date.to_string "%m/%Y" }}.</p>
 <p>Atualize seu método de pagamento para garantir um serviço ininterrupto.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing/methods" class="btn">Atualizar método de pagamento</a>
+  <a href="{{ app.base_url }}/billing/methods" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Atualizar método de pagamento</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.pt.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.pt.html
@@ -2,5 +2,5 @@
 <p>O seu método de pagamento <strong>{{ model.display_label | html.escape }}</strong> expira em <strong>{{ model.days_remaining }} dia(s)</strong>, em {{ model.expires_at | to_user_time | date.to_string "%m/%Y" }}.</p>
 <p>Atualize o seu método de pagamento para garantir um serviço ininterrupto.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing/methods" class="btn">Atualizar método de pagamento</a>
+  <a href="{{ app.base_url }}/billing/methods" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Atualizar método de pagamento</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.sv.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.sv.html
@@ -2,5 +2,5 @@
 <p>Din betalningsmetod <strong>{{ model.display_label | html.escape }}</strong> löper ut om <strong>{{ model.days_remaining }} dag(ar)</strong>, i {{ model.expires_at | to_user_time | date.to_string "%Y-%m" }}.</p>
 <p>Uppdatera din betalningsmetod för att säkerställa en oavbruten tjänst.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing/methods" class="btn">Uppdatera betalningsmetod</a>
+  <a href="{{ app.base_url }}/billing/methods" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Uppdatera betalningsmetod</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.tr.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.tr.html
@@ -2,5 +2,5 @@
 <p>Ödeme yönteminiz <strong>{{ model.display_label | html.escape }}</strong>, <strong>{{ model.days_remaining }} gün</strong> içinde, {{ model.expires_at | to_user_time | date.to_string "%m/%Y" }} tarihinde sona erecektir.</p>
 <p>Kesintisiz hizmet için ödeme yönteminizi güncelleyin.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing/methods" class="btn">Ödeme yöntemini güncelle</a>
+  <a href="{{ app.base_url }}/billing/methods" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Ödeme yöntemini güncelle</a>
 </p>

--- a/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.zh.html
+++ b/src/Granit.Payments.Notifications/Templates/Payments.PaymentMethodExpiring.zh.html
@@ -2,5 +2,5 @@
 <p>您的付款方式 <strong>{{ model.display_label | html.escape }}</strong> 将在 <strong>{{ model.days_remaining }} 天</strong>后到期，届时为 {{ model.expires_at | to_user_time | date.to_string "%Y年%m月" }}。</p>
 <p>请更新您的付款方式以确保服务不中断。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing/methods" class="btn">更新付款方式</a>
+  <a href="{{ app.base_url }}/billing/methods" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">更新付款方式</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.cs.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.cs.html
@@ -6,5 +6,5 @@
 <p>Budete mít přístup až do konce aktuálního fakturačního období.</p>
 <p>Pokud si to rozmyslíte, můžete se kdykoli znovu přihlásit k odběru.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Znovu předplatit</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Znovu předplatit</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.de.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.de.html
@@ -6,5 +6,5 @@
 <p>Sie haben weiterhin Zugriff bis zum Ende Ihres aktuellen Abrechnungszeitraums.</p>
 <p>Sollten Sie Ihre Meinung ändern, können Sie sich jederzeit erneut abonnieren.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Erneut abonnieren</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Erneut abonnieren</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.es.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.es.html
@@ -6,5 +6,5 @@
 <p>Seguirá teniendo acceso hasta el final de su periodo de facturación actual.</p>
 <p>Si cambia de opinión, puede volver a suscribirse en cualquier momento.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Volver a suscribirse</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Volver a suscribirse</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.fr.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.fr.html
@@ -6,5 +6,5 @@
 <p>Vous conserverez votre accès jusqu'à la fin de votre période de facturation en cours.</p>
 <p>Si vous changez d'avis, vous pouvez vous réabonner à tout moment.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Se réabonner</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Se réabonner</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.hi.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.hi.html
@@ -6,5 +6,5 @@
 <p>आपकी वर्तमान बिलिंग अवधि के अंत तक आपकी पहुँच जारी रहेगी।</p>
 <p>यदि आप अपना विचार बदलते हैं, तो आप कभी भी पुनः सब्सक्राइब कर सकते हैं।</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">पुनः सब्सक्राइब करें</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">पुनः सब्सक्राइब करें</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.html
@@ -6,5 +6,5 @@
 <p>You will continue to have access until the end of your current billing period.</p>
 <p>If you change your mind, you can resubscribe at any time.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Resubscribe</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Resubscribe</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.it.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.it.html
@@ -6,5 +6,5 @@
 <p>Continuerà ad avere accesso fino alla fine del periodo di fatturazione corrente.</p>
 <p>Se cambia idea, può abbonarsi nuovamente in qualsiasi momento.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Riabbonarsi</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Riabbonarsi</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.ja.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.ja.html
@@ -6,5 +6,5 @@
 <p>現在の請求期間が終了するまで、引き続きアクセスできます。</p>
 <p>お気持ちが変わった場合は、いつでも再登録できます。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">再登録する</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">再登録する</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.ko.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.ko.html
@@ -6,5 +6,5 @@
 <p>현재 청구 기간이 끝날 때까지 계속 액세스할 수 있습니다.</p>
 <p>마음이 바뀌시면 언제든지 다시 구독하실 수 있습니다.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">다시 구독</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">다시 구독</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.nl.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.nl.html
@@ -6,5 +6,5 @@
 <p>U behoudt toegang tot het einde van uw huidige factureringsperiode.</p>
 <p>Als u van gedachten verandert, kunt u zich op elk moment opnieuw abonneren.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Opnieuw abonneren</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Opnieuw abonneren</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.pl.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.pl.html
@@ -6,5 +6,5 @@
 <p>Zachowasz dostęp do końca bieżącego okresu rozliczeniowego.</p>
 <p>Jeśli zmienisz zdanie, możesz ponownie subskrybować w dowolnym momencie.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Subskrybuj ponownie</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Subskrybuj ponownie</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.pt-BR.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.pt-BR.html
@@ -6,5 +6,5 @@
 <p>Você continuará tendo acesso até o final do período de cobrança atual.</p>
 <p>Se mudar de ideia, você pode assinar novamente a qualquer momento.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Assinar novamente</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Assinar novamente</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.pt.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.pt.html
@@ -6,5 +6,5 @@
 <p>Continuará a ter acesso até ao final do período de faturação atual.</p>
 <p>Se mudar de ideias, pode voltar a subscrever a qualquer momento.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Voltar a subscrever</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Voltar a subscrever</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.sv.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.sv.html
@@ -6,5 +6,5 @@
 <p>Du har fortsatt åtkomst till slutet av din nuvarande faktureringsperiod.</p>
 <p>Om du ändrar dig kan du prenumerera igen när som helst.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Prenumerera igen</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Prenumerera igen</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.tr.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.tr.html
@@ -6,5 +6,5 @@
 <p>Mevcut fatura döneminizin sonuna kadar erişiminiz devam edecektir.</p>
 <p>Fikrinizi değiştirirseniz, istediğiniz zaman yeniden abone olabilirsiniz.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Yeniden abone ol</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Yeniden abone ol</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.zh.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.CancellationConfirmed.zh.html
@@ -6,5 +6,5 @@
 <p>您可以继续使用至当前计费周期结束。</p>
 <p>如果您改变主意，可以随时重新订阅。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">重新订阅</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">重新订阅</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.cs.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.cs.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Pokud chcete tuto změnu zrušit nebo upravit, můžete tak učinit před plánovaným datem.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Spravovat předplatné</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Spravovat předplatné</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.de.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.de.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Wenn Sie diese Änderung stornieren oder anpassen möchten, können Sie dies vor dem geplanten Datum tun.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Abonnement verwalten</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Abonnement verwalten</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.es.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.es.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Si desea cancelar o modificar este cambio, puede hacerlo antes de la fecha prevista.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Gestionar suscripción</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Gestionar suscripción</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.fr.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.fr.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Si vous souhaitez annuler ou modifier ce changement, vous pouvez le faire avant la date prévue.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Gérer l'abonnement</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Gérer l'abonnement</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.hi.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.hi.html
@@ -6,5 +6,5 @@
 </ul>
 <p>यदि आप इस परिवर्तन को रद्द या संशोधित करना चाहते हैं, तो निर्धारित तिथि से पहले ऐसा कर सकते हैं।</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">सब्सक्रिप्शन प्रबंधित करें</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">सब्सक्रिप्शन प्रबंधित करें</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.html
@@ -6,5 +6,5 @@
 </ul>
 <p>If you'd like to cancel or modify this change, you can do so before the scheduled date.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Manage subscription</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Manage subscription</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.it.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.it.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Se desidera annullare o modificare questa modifica, può farlo prima della data prevista.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Gestisci abbonamento</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Gestisci abbonamento</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.ja.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.ja.html
@@ -6,5 +6,5 @@
 </ul>
 <p>この変更をキャンセルまたは修正したい場合は、予定日前に行うことができます。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">サブスクリプションを管理</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">サブスクリプションを管理</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.ko.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.ko.html
@@ -6,5 +6,5 @@
 </ul>
 <p>이 변경을 취소하거나 수정하려면 예정된 날짜 전에 하실 수 있습니다.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">구독 관리</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">구독 관리</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.nl.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.nl.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Als u deze wijziging wilt annuleren of aanpassen, kunt u dit doen vóór de geplande datum.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Abonnement beheren</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Abonnement beheren</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.pl.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.pl.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Jeśli chcesz anulować lub zmodyfikować tę zmianę, możesz to zrobić przed zaplanowaną datą.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Zarządzaj subskrypcją</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Zarządzaj subskrypcją</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.pt-BR.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.pt-BR.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Se quiser cancelar ou modificar essa mudança, você pode fazê-lo antes da data agendada.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Gerenciar assinatura</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Gerenciar assinatura</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.pt.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.pt.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Se pretender cancelar ou alterar esta mudança, pode fazê-lo antes da data prevista.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Gerir subscrição</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Gerir subscrição</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.sv.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.sv.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Om du vill avbryta eller ändra detta kan du göra det före det planerade datumet.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Hantera prenumeration</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Hantera prenumeration</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.tr.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.tr.html
@@ -6,5 +6,5 @@
 </ul>
 <p>Bu değişikliği iptal etmek veya düzenlemek isterseniz, planlanan tarihten önce yapabilirsiniz.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Aboneliği yönet</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Aboneliği yönet</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.zh.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.ScheduledChangeReminder.zh.html
@@ -6,5 +6,5 @@
 </ul>
 <p>如果您想取消或修改此变更，可以在预定日期之前操作。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">管理订阅</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">管理订阅</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.cs.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.cs.html
@@ -2,6 +2,6 @@
 <p>Vaše předplatné plánu <strong>{{ model.plan_name | html.escape }}</strong> bylo <strong>pozastaveno</strong> z důvodu opakovaných neúspěšných plateb.</p>
 <p>Váš přístup k prémiovým funkcím je nyní omezen. Pro obnovení plného přístupu aktualizujte platební metodu a uhraďte nevyrovnaný zůstatek.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Aktualizovat platební metodu</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Aktualizovat platební metodu</a>
 </p>
 <p>Pokud se domníváte, že se jedná o chybu, kontaktujte náš tým podpory.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.de.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.de.html
@@ -2,6 +2,6 @@
 <p>Ihr Abonnement für den <strong>{{ model.plan_name | html.escape }}</strong>-Plan wurde aufgrund wiederholter Zahlungsfehler <strong>gesperrt</strong>.</p>
 <p>Ihr Zugriff auf Premium-Funktionen ist jetzt eingeschränkt. Bitte aktualisieren Sie Ihre Zahlungsmethode und begleichen Sie den ausstehenden Betrag, um den vollen Zugriff wiederherzustellen.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Zahlungsmethode aktualisieren</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Zahlungsmethode aktualisieren</a>
 </p>
 <p>Falls Sie glauben, dass es sich um einen Fehler handelt, kontaktieren Sie bitte unser Support-Team.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.es.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.es.html
@@ -2,6 +2,6 @@
 <p>Su suscripción al plan <strong>{{ model.plan_name | html.escape }}</strong> ha sido <strong>suspendida</strong> debido a fallos de pago reiterados.</p>
 <p>Su acceso a las funcionalidades premium está ahora restringido. Para restaurar el acceso completo, actualice su método de pago y liquide el saldo pendiente.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Actualizar método de pago</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Actualizar método de pago</a>
 </p>
 <p>Si cree que se trata de un error, contacte con nuestro equipo de soporte.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.fr.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.fr.html
@@ -2,6 +2,6 @@
 <p>Votre abonnement au plan <strong>{{ model.plan_name | html.escape }}</strong> a été <strong>suspendu</strong> en raison d'échecs de paiement répétés.</p>
 <p>Votre accès aux fonctionnalités premium est désormais restreint. Pour rétablir un accès complet, veuillez mettre à jour votre moyen de paiement et régler le solde impayé.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Mettre à jour le paiement</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Mettre à jour le paiement</a>
 </p>
 <p>Si vous pensez qu'il s'agit d'une erreur, contactez notre équipe de support.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.hi.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.hi.html
@@ -2,6 +2,6 @@
 <p>बार-बार भुगतान विफलताओं के कारण <strong>{{ model.plan_name | html.escape }}</strong> प्लान की आपकी सब्सक्रिप्शन <strong>निलंबित</strong> कर दी गई है।</p>
 <p>प्रीमियम सुविधाओं तक आपकी पहुँच अब प्रतिबंधित है। पूर्ण पहुँच बहाल करने के लिए, कृपया अपनी भुगतान विधि अपडेट करें और बकाया राशि का भुगतान करें।</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">भुगतान विधि अपडेट करें</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">भुगतान विधि अपडेट करें</a>
 </p>
 <p>यदि आपको लगता है कि यह एक त्रुटि है, तो कृपया हमारी सहायता टीम से संपर्क करें।</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.html
@@ -2,6 +2,6 @@
 <p>Your subscription to the <strong>{{ model.plan_name | html.escape }}</strong> plan has been <strong>suspended</strong> due to repeated payment failures.</p>
 <p>Your access to premium features is now restricted. To restore full access, please update your payment method and settle the outstanding balance.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Update payment method</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Update payment method</a>
 </p>
 <p>If you believe this is an error, please contact our support team.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.it.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.it.html
@@ -2,6 +2,6 @@
 <p>Il suo abbonamento al piano <strong>{{ model.plan_name | html.escape }}</strong> è stato <strong>sospeso</strong> a causa di ripetuti tentativi di pagamento non riusciti.</p>
 <p>L'accesso alle funzionalità premium è ora limitato. Per ripristinare l'accesso completo, aggiorni il metodo di pagamento e saldi l'importo in sospeso.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Aggiorna metodo di pagamento</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Aggiorna metodo di pagamento</a>
 </p>
 <p>Se ritiene che si tratti di un errore, contatti il nostro team di supporto.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.ja.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.ja.html
@@ -2,6 +2,6 @@
 <p><strong>{{ model.plan_name | html.escape }}</strong> プランのサブスクリプションは、支払いの繰り返し失敗により<strong>停止</strong>されました。</p>
 <p>プレミアム機能へのアクセスが制限されています。完全なアクセスを復元するには、お支払い方法を更新し、未払い残高を精算してください。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">支払い方法を更新</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">支払い方法を更新</a>
 </p>
 <p>これが誤りだと思われる場合は、サポートチームまでお問い合わせください。</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.ko.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.ko.html
@@ -2,6 +2,6 @@
 <p><strong>{{ model.plan_name | html.escape }}</strong> 플랜 구독이 반복적인 결제 실패로 인해 <strong>정지</strong>되었습니다.</p>
 <p>프리미엄 기능에 대한 액세스가 현재 제한되어 있습니다. 전체 액세스를 복원하려면 결제 수단을 업데이트하고 미결제 잔액을 정산해 주세요.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">결제 수단 업데이트</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">결제 수단 업데이트</a>
 </p>
 <p>오류라고 생각되시면 지원팀에 문의해 주세요.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.nl.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.nl.html
@@ -2,6 +2,6 @@
 <p>Uw abonnement op het <strong>{{ model.plan_name | html.escape }}</strong>-plan is <strong>opgeschort</strong> wegens herhaalde mislukte betalingen.</p>
 <p>Uw toegang tot premiumfuncties is nu beperkt. Werk uw betaalmethode bij en voldoe het openstaande saldo om de volledige toegang te herstellen.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Betaalmethode bijwerken</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Betaalmethode bijwerken</a>
 </p>
 <p>Als u denkt dat dit een fout is, neem dan contact op met ons supportteam.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.pl.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.pl.html
@@ -2,6 +2,6 @@
 <p>Twoja subskrypcja planu <strong>{{ model.plan_name | html.escape }}</strong> została <strong>zawieszona</strong> z powodu wielokrotnych nieudanych płatności.</p>
 <p>Twój dostęp do funkcji premium jest teraz ograniczony. Aby przywrócić pełny dostęp, zaktualizuj metodę płatności i ureguluj zaległy bilans.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Zaktualizuj metodę płatności</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Zaktualizuj metodę płatności</a>
 </p>
 <p>Jeśli uważasz, że to pomyłka, skontaktuj się z naszym zespołem wsparcia.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.pt-BR.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.pt-BR.html
@@ -2,6 +2,6 @@
 <p>Sua assinatura do plano <strong>{{ model.plan_name | html.escape }}</strong> foi <strong>suspensa</strong> devido a falhas de pagamento repetidas.</p>
 <p>Seu acesso às funcionalidades premium está agora restrito. Para restaurar o acesso completo, atualize seu método de pagamento e quite o saldo pendente.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Atualizar método de pagamento</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Atualizar método de pagamento</a>
 </p>
 <p>Se você acredita que isso é um erro, entre em contato com nossa equipe de suporte.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.pt.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.pt.html
@@ -2,6 +2,6 @@
 <p>A sua subscrição do plano <strong>{{ model.plan_name | html.escape }}</strong> foi <strong>suspensa</strong> devido a falhas de pagamento repetidas.</p>
 <p>O seu acesso às funcionalidades premium está agora restrito. Para restaurar o acesso completo, atualize o seu método de pagamento e liquide o saldo em dívida.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Atualizar método de pagamento</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Atualizar método de pagamento</a>
 </p>
 <p>Se acredita que se trata de um erro, contacte a nossa equipa de suporte.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.sv.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.sv.html
@@ -2,6 +2,6 @@
 <p>Din prenumeration på planen <strong>{{ model.plan_name | html.escape }}</strong> har <strong>stängts av</strong> på grund av upprepade betalningsfel.</p>
 <p>Din åtkomst till premiumfunktioner är nu begränsad. Uppdatera din betalningsmetod och betala det utestående beloppet för att återställa full åtkomst.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Uppdatera betalningsmetod</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Uppdatera betalningsmetod</a>
 </p>
 <p>Om du tror att detta är ett misstag, kontakta vårt supportteam.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.tr.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.tr.html
@@ -2,6 +2,6 @@
 <p><strong>{{ model.plan_name | html.escape }}</strong> planı aboneliğiniz tekrarlanan ödeme hataları nedeniyle <strong>askıya alındı</strong>.</p>
 <p>Premium özelliklere erişiminiz artık kısıtlıdır. Tam erişimi geri yüklemek için lütfen ödeme yönteminizi güncelleyin ve ödenmemiş bakiyeyi ödeyin.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">Ödeme yöntemini güncelle</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Ödeme yöntemini güncelle</a>
 </p>
 <p>Bunun bir hata olduğunu düşünüyorsanız, lütfen destek ekibimizle iletişime geçin.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.zh.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.SuspensionWarning.zh.html
@@ -2,6 +2,6 @@
 <p>由于多次付款失败，您的 <strong>{{ model.plan_name | html.escape }}</strong> 计划订阅已被<strong>暂停</strong>。</p>
 <p>您对高级功能的访问现已受限。要恢复完整访问权限，请更新您的付款方式并结清未付余额。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/billing" class="btn">更新付款方式</a>
+  <a href="{{ app.base_url }}/billing" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">更新付款方式</a>
 </p>
 <p>如果您认为这是一个错误，请联系我们的支持团队。</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.cs.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.cs.html
@@ -2,5 +2,5 @@
 <p>Vaše zkušební období pro plán <strong>{{ model.plan_name | html.escape }}</strong> vypršelo.</p>
 <p>Váš přístup k prémiovým funkcím byl pozastaven. Můžete jej kdykoli obnovit zakoupením placeného předplatného.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Vybrat plán</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Vybrat plán</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.de.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.de.html
@@ -2,5 +2,5 @@
 <p>Ihre Testphase für den <strong>{{ model.plan_name | html.escape }}</strong>-Plan ist abgelaufen.</p>
 <p>Ihr Zugriff auf Premium-Funktionen wurde gesperrt. Sie können jederzeit durch den Abschluss eines kostenpflichtigen Abonnements reaktivieren.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Plan auswählen</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Plan auswählen</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.es.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.es.html
@@ -2,5 +2,5 @@
 <p>Su periodo de prueba del plan <strong>{{ model.plan_name | html.escape }}</strong> ha expirado.</p>
 <p>Su acceso a las funcionalidades premium ha sido suspendido. Puede reactivarlo en cualquier momento suscribiéndose a un plan de pago.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Elegir un plan</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Elegir un plan</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.fr.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.fr.html
@@ -2,5 +2,5 @@
 <p>Votre période d'essai pour le plan <strong>{{ model.plan_name | html.escape }}</strong> a expiré.</p>
 <p>Votre accès aux fonctionnalités premium a été suspendu. Vous pouvez réactiver votre compte à tout moment en souscrivant à un plan payant.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Choisir un plan</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Choisir un plan</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.hi.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.hi.html
@@ -2,5 +2,5 @@
 <p><strong>{{ model.plan_name | html.escape }}</strong> प्लान का आपका ट्रायल समाप्त हो गया है।</p>
 <p>प्रीमियम सुविधाओं तक आपकी पहुँच निलंबित कर दी गई है। आप किसी भी समय सशुल्क प्लान की सदस्यता लेकर पुनः सक्रिय कर सकते हैं।</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">एक प्लान चुनें</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">एक प्लान चुनें</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.html
@@ -2,5 +2,5 @@
 <p>Your trial for the <strong>{{ model.plan_name | html.escape }}</strong> plan has expired.</p>
 <p>Your access to premium features has been suspended. You can reactivate at any time by subscribing to a paid plan.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Choose a plan</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Choose a plan</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.it.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.it.html
@@ -2,5 +2,5 @@
 <p>Il periodo di prova per il piano <strong>{{ model.plan_name | html.escape }}</strong> è scaduto.</p>
 <p>L'accesso alle funzionalità premium è stato sospeso. Può riattivarlo in qualsiasi momento sottoscrivendo un piano a pagamento.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Scegli un piano</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Scegli un piano</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.ja.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.ja.html
@@ -2,5 +2,5 @@
 <p><strong>{{ model.plan_name | html.escape }}</strong> プランの試用期間が終了しました。</p>
 <p>プレミアム機能へのアクセスが停止されました。有料プランに登録することで、いつでも再開できます。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">プランを選択</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">プランを選択</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.ko.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.ko.html
@@ -2,5 +2,5 @@
 <p><strong>{{ model.plan_name | html.escape }}</strong> 플랜의 체험 기간이 종료되었습니다.</p>
 <p>프리미엄 기능에 대한 액세스가 중단되었습니다. 유료 플랜에 가입하면 언제든지 다시 활성화할 수 있습니다.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">플랜 선택</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">플랜 선택</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.nl.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.nl.html
@@ -2,5 +2,5 @@
 <p>Uw proefperiode voor het <strong>{{ model.plan_name | html.escape }}</strong>-plan is verlopen.</p>
 <p>Uw toegang tot premiumfuncties is opgeschort. U kunt op elk moment opnieuw activeren door een betaald abonnement af te sluiten.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Kies een plan</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Kies een plan</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.pl.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.pl.html
@@ -2,5 +2,5 @@
 <p>Twój okres próbny planu <strong>{{ model.plan_name | html.escape }}</strong> wygasł.</p>
 <p>Twój dostęp do funkcji premium został wstrzymany. Możesz go przywrócić w dowolnym momencie, wykupując płatną subskrypcję.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Wybierz plan</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Wybierz plan</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.pt-BR.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.pt-BR.html
@@ -2,5 +2,5 @@
 <p>Seu período de teste para o plano <strong>{{ model.plan_name | html.escape }}</strong> expirou.</p>
 <p>Seu acesso às funcionalidades premium foi suspenso. Você pode reativá-lo a qualquer momento assinando um plano pago.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Escolher um plano</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Escolher um plano</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.pt.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.pt.html
@@ -2,5 +2,5 @@
 <p>O seu período de teste para o plano <strong>{{ model.plan_name | html.escape }}</strong> expirou.</p>
 <p>O seu acesso às funcionalidades premium foi suspenso. Pode reativá-lo a qualquer momento ao subscrever um plano pago.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Escolher um plano</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Escolher um plano</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.sv.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.sv.html
@@ -2,5 +2,5 @@
 <p>Din provperiod för planen <strong>{{ model.plan_name | html.escape }}</strong> har löpt ut.</p>
 <p>Din åtkomst till premiumfunktioner har stängts av. Du kan återaktivera den när som helst genom att teckna en betald prenumeration.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Välj en plan</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Välj en plan</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.tr.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.tr.html
@@ -2,5 +2,5 @@
 <p><strong>{{ model.plan_name | html.escape }}</strong> planı deneme süreniz sona erdi.</p>
 <p>Premium özelliklere erişiminiz askıya alındı. Ücretli bir plana abone olarak istediğiniz zaman yeniden etkinleştirebilirsiniz.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Plan seçin</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Plan seçin</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.zh.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpired.zh.html
@@ -2,5 +2,5 @@
 <p>您的 <strong>{{ model.plan_name | html.escape }}</strong> 计划试用期已到期。</p>
 <p>您对高级功能的访问已被暂停。您可以随时通过订阅付费计划来重新激活。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">选择计划</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">选择计划</a>
 </p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.cs.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.cs.html
@@ -2,6 +2,6 @@
 <p>Vaše zkušební období pro plán <strong>{{ model.plan_name | html.escape }}</strong> vyprší za <strong>{{ model.days_remaining }} den/dní</strong>, dne {{ model.trial_ends_at | to_user_time | date.to_string "%d.%m.%Y v %H:%M" }}.</p>
 <p>Chcete-li si zachovat přístup ke všem funkcím, přejděte na placené předplatné před koncem zkušebního období.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Přejít na placené</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Přejít na placené</a>
 </p>
 <p>Máte-li dotazy, náš tým podpory vám rád pomůže.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.de.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.de.html
@@ -2,6 +2,6 @@
 <p>Ihre Testphase für den <strong>{{ model.plan_name | html.escape }}</strong>-Plan endet in <strong>{{ model.days_remaining }} Tag(en)</strong>, am {{ model.trial_ends_at | to_user_time | date.to_string "%d.%m.%Y um %H:%M" }}.</p>
 <p>Um weiterhin Zugriff auf alle Funktionen zu haben, wechseln Sie vor Ablauf Ihrer Testphase zu einem kostenpflichtigen Abonnement.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Jetzt upgraden</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Jetzt upgraden</a>
 </p>
 <p>Bei Fragen steht Ihnen unser Support-Team gerne zur Verfügung.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.es.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.es.html
@@ -2,6 +2,6 @@
 <p>Su periodo de prueba del plan <strong>{{ model.plan_name | html.escape }}</strong> expira en <strong>{{ model.days_remaining }} día(s)</strong>, el {{ model.trial_ends_at | to_user_time | date.to_string "%d/%m/%Y a las %H:%M" }}.</p>
 <p>Para conservar el acceso a todas las funcionalidades, actualice a una suscripción de pago antes de que finalice su prueba.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Actualizar ahora</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Actualizar ahora</a>
 </p>
 <p>Si tiene alguna pregunta, nuestro equipo de soporte estará encantado de ayudarle.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.fr.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.fr.html
@@ -2,6 +2,6 @@
 <p>Votre période d'essai pour le plan <strong>{{ model.plan_name | html.escape }}</strong> expire dans <strong>{{ model.days_remaining }} jour(s)</strong>, le {{ model.trial_ends_at | to_user_time | date.to_string "%d/%m/%Y à %H:%M" }}.</p>
 <p>Pour conserver l'accès à toutes les fonctionnalités, passez à un abonnement payant avant la fin de votre essai.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Passer à l'abonnement</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Passer à l'abonnement</a>
 </p>
 <p>Si vous avez des questions, notre équipe est à votre disposition.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.hi.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.hi.html
@@ -2,6 +2,6 @@
 <p><strong>{{ model.plan_name | html.escape }}</strong> प्लान का आपका ट्रायल <strong>{{ model.days_remaining }} दिन</strong> में, {{ model.trial_ends_at | to_user_time | date.to_string "%B %d, %Y at %H:%M" }} को समाप्त हो रहा है।</p>
 <p>सभी सुविधाओं तक पहुँच बनाए रखने के लिए, अपने ट्रायल समाप्त होने से पहले सशुल्क सब्सक्रिप्शन में अपग्रेड करें।</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">अभी अपग्रेड करें</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">अभी अपग्रेड करें</a>
 </p>
 <p>यदि आपके कोई प्रश्न हैं, तो हमारी सहायता टीम मदद के लिए तैयार है।</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.html
@@ -2,6 +2,6 @@
 <p>Your trial for the <strong>{{ model.plan_name | html.escape }}</strong> plan expires in <strong>{{ model.days_remaining }} day(s)</strong>, on {{ model.trial_ends_at | to_user_time | date.to_string "%B %d, %Y at %H:%M" }}.</p>
 <p>To keep access to all features, upgrade to a paid subscription before your trial ends.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Upgrade now</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Upgrade now</a>
 </p>
 <p>If you have questions, our support team is happy to help.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.it.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.it.html
@@ -2,6 +2,6 @@
 <p>Il periodo di prova per il piano <strong>{{ model.plan_name | html.escape }}</strong> scade tra <strong>{{ model.days_remaining }} giorno/i</strong>, il {{ model.trial_ends_at | to_user_time | date.to_string "%d/%m/%Y alle %H:%M" }}.</p>
 <p>Per mantenere l'accesso a tutte le funzionalità, effettui l'upgrade a un abbonamento a pagamento prima della scadenza del periodo di prova.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Aggiorna ora</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Aggiorna ora</a>
 </p>
 <p>Per qualsiasi domanda, il nostro team di supporto è a sua disposizione.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.ja.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.ja.html
@@ -2,6 +2,6 @@
 <p><strong>{{ model.plan_name | html.escape }}</strong> プランの試用期間は、あと <strong>{{ model.days_remaining }} 日</strong>で終了します（{{ model.trial_ends_at | to_user_time | date.to_string "%Y年%m月%d日 %H:%M" }}）。</p>
 <p>すべての機能へのアクセスを継続するには、試用期間終了前に有料プランにアップグレードしてください。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">今すぐアップグレード</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">今すぐアップグレード</a>
 </p>
 <p>ご質問がございましたら、サポートチームまでお気軽にお問い合わせください。</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.ko.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.ko.html
@@ -2,6 +2,6 @@
 <p><strong>{{ model.plan_name | html.escape }}</strong> 플랜의 체험 기간이 <strong>{{ model.days_remaining }}일</strong> 후인 {{ model.trial_ends_at | to_user_time | date.to_string "%Y년 %m월 %d일 %H:%M" }}에 만료됩니다.</p>
 <p>모든 기능에 대한 액세스를 유지하려면 체험 기간이 종료되기 전에 유료 구독으로 업그레이드하세요.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">지금 업그레이드</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">지금 업그레이드</a>
 </p>
 <p>궁금한 점이 있으시면 지원팀에 문의해 주세요.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.nl.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.nl.html
@@ -2,6 +2,6 @@
 <p>Uw proefperiode voor het <strong>{{ model.plan_name | html.escape }}</strong>-plan verloopt over <strong>{{ model.days_remaining }} dag(en)</strong>, op {{ model.trial_ends_at | to_user_time | date.to_string "%d-%m-%Y om %H:%M" }}.</p>
 <p>Upgrade naar een betaald abonnement voordat uw proefperiode afloopt om toegang te behouden tot alle functies.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Nu upgraden</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Nu upgraden</a>
 </p>
 <p>Als u vragen heeft, helpt ons supportteam u graag verder.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.pl.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.pl.html
@@ -2,6 +2,6 @@
 <p>Twój okres próbny planu <strong>{{ model.plan_name | html.escape }}</strong> wygasa za <strong>{{ model.days_remaining }} dni</strong>, dnia {{ model.trial_ends_at | to_user_time | date.to_string "%d.%m.%Y o %H:%M" }}.</p>
 <p>Aby zachować dostęp do wszystkich funkcji, przejdź na płatną subskrypcję przed zakończeniem okresu próbnego.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Przejdź na płatną wersję</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Przejdź na płatną wersję</a>
 </p>
 <p>W razie pytań nasz zespół wsparcia chętnie pomoże.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.pt-BR.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.pt-BR.html
@@ -2,6 +2,6 @@
 <p>Seu período de teste para o plano <strong>{{ model.plan_name | html.escape }}</strong> expira em <strong>{{ model.days_remaining }} dia(s)</strong>, em {{ model.trial_ends_at | to_user_time | date.to_string "%d/%m/%Y às %H:%M" }}.</p>
 <p>Para manter o acesso a todas as funcionalidades, faça o upgrade para uma assinatura paga antes do fim do período de teste.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Fazer upgrade</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Fazer upgrade</a>
 </p>
 <p>Se tiver dúvidas, nossa equipe de suporte terá prazer em ajudar.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.pt.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.pt.html
@@ -2,6 +2,6 @@
 <p>O seu período de teste para o plano <strong>{{ model.plan_name | html.escape }}</strong> expira em <strong>{{ model.days_remaining }} dia(s)</strong>, a {{ model.trial_ends_at | to_user_time | date.to_string "%d/%m/%Y às %H:%M" }}.</p>
 <p>Para manter o acesso a todas as funcionalidades, faça o upgrade para uma subscrição paga antes do fim do período de teste.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Fazer upgrade</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Fazer upgrade</a>
 </p>
 <p>Se tiver questões, a nossa equipa de suporte terá todo o gosto em ajudar.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.sv.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.sv.html
@@ -2,6 +2,6 @@
 <p>Din provperiod för planen <strong>{{ model.plan_name | html.escape }}</strong> löper ut om <strong>{{ model.days_remaining }} dag(ar)</strong>, den {{ model.trial_ends_at | to_user_time | date.to_string "%Y-%m-%d kl. %H:%M" }}.</p>
 <p>För att behålla tillgång till alla funktioner, uppgradera till en betald prenumeration innan provperioden löper ut.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Uppgradera nu</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Uppgradera nu</a>
 </p>
 <p>Om du har frågor hjälper vårt supportteam dig gärna.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.tr.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.tr.html
@@ -2,6 +2,6 @@
 <p><strong>{{ model.plan_name | html.escape }}</strong> planı deneme süreniz <strong>{{ model.days_remaining }} gün</strong> içinde, {{ model.trial_ends_at | to_user_time | date.to_string "%d.%m.%Y %H:%M" }} tarihinde sona erecektir.</p>
 <p>Tüm özelliklere erişiminizi sürdürmek için deneme süreniz dolmadan ücretli aboneliğe geçin.</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">Şimdi yükseltin</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">Şimdi yükseltin</a>
 </p>
 <p>Sorularınız varsa destek ekibimiz size yardımcı olmaktan memnuniyet duyar.</p>

--- a/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.zh.html
+++ b/src/Granit.Subscriptions.Notifications/Templates/Subscriptions.TrialExpiring.zh.html
@@ -2,6 +2,6 @@
 <p>您的 <strong>{{ model.plan_name | html.escape }}</strong> 计划试用期将在 <strong>{{ model.days_remaining }} 天</strong>后到期，届时为 {{ model.trial_ends_at | to_user_time | date.to_string "%Y年%m月%d日 %H:%M" }}。</p>
 <p>为了继续使用所有功能，请在试用期结束前升级为付费订阅。</p>
 <p style="text-align: center; margin: 32px 0;">
-  <a href="{{ app.base_url }}/subscriptions" class="btn">立即升级</a>
+  <a href="{{ app.base_url }}/subscriptions" style="display: inline-block; padding: 12px 28px; background-color: #1d4ed8; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: bold;">立即升级</a>
 </p>
 <p>如有任何问题，我们的支持团队随时为您服务。</p>


### PR DESCRIPTION
## Summary

- Convert `Layout.Email.html` from hand-crafted table-based HTML to **MJML markup** — compiled to email-safe HTML at runtime by `MjmlTransformer`
- Replace `class="btn"` with inline button styles in **227 content template fragments** across 5 modules (Identity, Invoicing, Payments, Subscriptions, Notifications)
- Replace `<hr class="divider">` with inline hr styles in **64 content template fragments**
- Content fragments remain plain HTML (injected via `{{ body }}` in the MJML layout)

### Modules affected

| Module | Templates | Changes |
|--------|-----------|---------|
| `Granit.Identity.Local.Notifications` | 160 | btn + divider → inline |
| `Granit.Invoicing.Notifications` | 68 | btn → inline |
| `Granit.Payments.Notifications` | 32 | btn → inline |
| `Granit.Subscriptions.Notifications` | 96 | btn → inline |
| `Granit.Notifications.Email` | 1 | Layout → MJML |

### Why

CSS classes (`class="btn"`, `class="divider"`) were defined in the old `<style>` block of `Layout.Email.html`. With the MJML layout, there is no `<style>` block — MJML generates inline CSS automatically. Content fragments must use inline styles directly.

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `Granit.Notifications.Email.Tests` — 75/75 pass
- [x] No `class="btn"` or `class="divider"` remaining in any template