### PR TITLE
fix: SonarCloud findings and MJML template contrast issue

### DIFF
--- a/src/Granit.Notifications.Email/Templates/Layout.Email.html
+++ b/src/Granit.Notifications.Email/Templates/Layout.Email.html
@@ -9,7 +9,7 @@
   <mj-body background-color="#f4f5f7">
     <!-- Header -->
     <mj-section background-color="#1a1a2e" padding="24px 32px">
-      <mj-column>
+      <mj-column background-color="#1a1a2e">
         {{- if app.logo_url != "" }}
         <mj-image src="{{ app.logo_url }}" alt="{{ app.name }}" width="160px" />
         {{- else }}

--- a/src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Granit.Observability/Extensions/ObservabilityServiceCollectionExtensions.cs
@@ -28,28 +28,8 @@ public static class ObservabilityServiceCollectionExtensions
             // Apply smart fallbacks when the Observability section is absent or incomplete.
             // PostConfigure runs after BindConfiguration so explicit config always wins.
             .PostConfigure<IHostEnvironment, IConfiguration>((opts, env, config) =>
-            {
-                if (string.IsNullOrWhiteSpace(opts.ServiceName) || opts.ServiceName is "unknown-service")
-                {
-                    opts.ServiceName = env.ApplicationName;
-                }
-
-                if (string.IsNullOrWhiteSpace(opts.Environment) || opts.Environment is "development")
-                {
-                    opts.Environment = env.EnvironmentName.ToLowerInvariant();
-                }
-
-                // Respect OTEL_EXPORTER_OTLP_ENDPOINT injected by Aspire when OtlpEndpoint
-                // is not explicitly configured (still at default value).
-                if (opts.OtlpEndpoint is "http://localhost:4317")
-                {
-                    string? envEndpoint = config["OTEL_EXPORTER_OTLP_ENDPOINT"];
-                    if (!string.IsNullOrWhiteSpace(envEndpoint))
-                    {
-                        opts.OtlpEndpoint = envEndpoint;
-                    }
-                }
-            })
+                ApplyFallbacks(opts, env.ApplicationName, env.EnvironmentName,
+                    config["OTEL_EXPORTER_OTLP_ENDPOINT"]))
             .ValidateDataAnnotations()
             .ValidateOnStart();
 
@@ -61,31 +41,34 @@ public static class ObservabilityServiceCollectionExtensions
             .GetSection(ObservabilityOptions.SectionName)
             .Bind(options);
 
-        if (string.IsNullOrWhiteSpace(options.ServiceName) || options.ServiceName is "unknown-service")
-        {
-            options.ServiceName = builder.Environment.ApplicationName;
-        }
-
-        if (string.IsNullOrWhiteSpace(options.Environment) || options.Environment is "development")
-        {
-            options.Environment = builder.Environment.EnvironmentName.ToLowerInvariant();
-        }
-
-        // Respect OTEL_EXPORTER_OTLP_ENDPOINT injected by Aspire when OtlpEndpoint
-        // is not explicitly configured (still at default value).
-        if (options.OtlpEndpoint is "http://localhost:4317")
-        {
-            string? envEndpoint = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
-            if (!string.IsNullOrWhiteSpace(envEndpoint))
-            {
-                options.OtlpEndpoint = envEndpoint;
-            }
-        }
+        ApplyFallbacks(options, builder.Environment.ApplicationName,
+            builder.Environment.EnvironmentName, builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
 
         ConfigureSerilog(builder, options);
         ConfigureOpenTelemetry(builder, options);
 
         return builder;
+    }
+
+    private static void ApplyFallbacks(
+        ObservabilityOptions opts, string appName, string envName, string? otlpEndpointEnv)
+    {
+        if (string.IsNullOrWhiteSpace(opts.ServiceName) || opts.ServiceName is "unknown-service")
+        {
+            opts.ServiceName = appName;
+        }
+
+        if (string.IsNullOrWhiteSpace(opts.Environment) || opts.Environment is "development")
+        {
+            opts.Environment = envName.ToLowerInvariant();
+        }
+
+        // Respect OTEL_EXPORTER_OTLP_ENDPOINT injected by Aspire when OtlpEndpoint
+        // is not explicitly configured (still at default value).
+        if (opts.OtlpEndpoint is "http://localhost:4317" && !string.IsNullOrWhiteSpace(otlpEndpointEnv))
+        {
+            opts.OtlpEndpoint = otlpEndpointEnv;
+        }
     }
 
     private static void ConfigureSerilog(IHostApplicationBuilder builder, ObservabilityOptions options)

--- a/src/Granit.Templating.Mjml/Templates/Layout.Email.mjml.html
+++ b/src/Granit.Templating.Mjml/Templates/Layout.Email.mjml.html
@@ -9,7 +9,7 @@
   <mj-body background-color="#f4f5f7">
     <!-- Header -->
     <mj-section background-color="#1a1a2e" padding="24px 32px">
-      <mj-column>
+      <mj-column background-color="#1a1a2e">
         {{- if app.logo_url != "" }}
         <mj-image src="{{ app.logo_url }}" alt="{{ app.name }}" width="160px" />
         {{- else }}

--- a/src/Granit.Templating/Internal/TextTemplateRenderer.cs
+++ b/src/Granit.Templating/Internal/TextTemplateRenderer.cs
@@ -159,12 +159,9 @@ internal sealed partial class TextTemplateRenderer(
         }
 
         string html = textContent.Html;
-        foreach (IRenderedContentTransformer transformer in _transformers)
+        foreach (IRenderedContentTransformer transformer in _transformers.Where(t => t.CanTransform(format)))
         {
-            if (transformer.CanTransform(format))
-            {
-                html = await transformer.TransformAsync(html, format, cancellationToken).ConfigureAwait(false);
-            }
+            html = await transformer.TransformAsync(html, format, cancellationToken).ConfigureAwait(false);
         }
 
         return html == textContent.Html


### PR DESCRIPTION
## Summary

- **Observability**: extract `ApplyFallbacks()` helper to reduce cognitive complexity from 18 to 10 (S3776)
- **Templating**: use `.Where()` LINQ in transformer loop instead of `foreach` + `if` (S3267)
- **MJML templates**: add `background-color="#1a1a2e"` on `<mj-column>` in dark header sections to fix WCAG color contrast (white text was inheriting `#f4f5f7` from `<mj-body>`)

## Test plan

- [x] `dotnet build` — 0 errors
- [x] No behavior change — pure refactoring + accessibility fix