### PR TITLE
feat(multi-tenancy): tenant provisioning — EfCoreTenantEnumerator, per-tenant schema creation, Wolverine host schema

### DIFF
--- a/.github/shard-filters/infrastructure.slnf
+++ b/.github/shard-filters/infrastructure.slnf
@@ -54,6 +54,7 @@
       "src/Granit.Notifications.Wolverine/Granit.Notifications.Wolverine.csproj",
       "src/Granit.Notifications.Zulip/Granit.Notifications.Zulip.csproj",
       "src/Granit.Notifications/Granit.Notifications.csproj",
+      "src/Granit.Persistence.EntityFrameworkCore.Migrations/Granit.Persistence.EntityFrameworkCore.Migrations.csproj",
       "src/Granit.Persistence.EntityFrameworkCore/Granit.Persistence.EntityFrameworkCore.csproj",
       "src/Granit.Persistence/Granit.Persistence.csproj",
       "src/Granit.QueryEngine.Abstractions/Granit.QueryEngine.Abstractions.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1073,7 +1073,8 @@
       "deps": [
         "Granit.Events",
         "Granit.MultiTenancy",
-        "Granit.Persistence.EntityFrameworkCore"
+        "Granit.Persistence.EntityFrameworkCore",
+        "Granit.Persistence.EntityFrameworkCore.Migrations"
       ],
       "framework": "net10.0"
     },
@@ -22058,7 +22059,7 @@
       "kind": "class",
       "project": "Granit.MultiTenancy.EntityFrameworkCore",
       "file": "src/Granit.MultiTenancy.EntityFrameworkCore/Extensions/MultiTenancyEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitMultiTenancyEntityFrameworkCore",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -41478,7 +41478,7 @@
       "kind": "class",
       "project": "Granit.Wolverine.Postgresql",
       "file": "src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs",
-      "line": 20,
+      "line": 21,
       "members": [
         {
           "name": "AddGranitWolverineWithPostgresql",

--- a/.slnf/platform.slnf
+++ b/.slnf/platform.slnf
@@ -82,6 +82,7 @@
       "src/Granit.Payments.Stripe/Granit.Payments.Stripe.csproj",
       "src/Granit.Payments.Wolverine/Granit.Payments.Wolverine.csproj",
       "src/Granit.Payments/Granit.Payments.csproj",
+      "src/Granit.Persistence.EntityFrameworkCore.Migrations/Granit.Persistence.EntityFrameworkCore.Migrations.csproj",
       "src/Granit.Persistence.EntityFrameworkCore/Granit.Persistence.EntityFrameworkCore.csproj",
       "src/Granit.Persistence/Granit.Persistence.csproj",
       "src/Granit.QueryEngine.Abstractions/Granit.QueryEngine.Abstractions.csproj",

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Extensions/MultiTenancyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Extensions/MultiTenancyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -2,6 +2,7 @@ using Granit.Events.Extensions;
 using Granit.MultiTenancy.EntityFrameworkCore.Internal;
 using Granit.MultiTenancy.Stores;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -33,6 +34,10 @@ public static class MultiTenancyEntityFrameworkCoreHostApplicationBuilderExtensi
         // Replace default (no-op) implementations with EF Core store
         builder.Services.Replace(ServiceDescriptor.Scoped<ITenantReader, EfCoreTenantStore>());
         builder.Services.Replace(ServiceDescriptor.Scoped<ITenantWriter, EfCoreTenantStore>());
+
+        // Replace NullTenantEnumerator with EF Core implementation for per-tenant migrations.
+        // Scoped: depends on ITenantReader (scoped, EF Core).
+        builder.Services.Replace(ServiceDescriptor.Scoped<ITenantEnumerator, EfCoreTenantEnumerator>());
 
         return builder;
     }

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Granit.MultiTenancy.EntityFrameworkCore.csproj
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Granit.MultiTenancy.EntityFrameworkCore.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\Granit.Events\Granit.Events.csproj" />
     <ProjectReference Include="..\Granit.MultiTenancy\Granit.MultiTenancy.csproj" />
     <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore.Migrations\Granit.Persistence.EntityFrameworkCore.Migrations.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/EfCoreTenantEnumerator.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/EfCoreTenantEnumerator.cs
@@ -1,0 +1,53 @@
+using System.Data.Common;
+using System.Runtime.CompilerServices;
+using Granit.MultiTenancy.Stores;
+using Granit.Persistence.EntityFrameworkCore.Migrations;
+
+namespace Granit.MultiTenancy.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Enumerates active tenant IDs from the EF Core tenant store for use during
+/// per-tenant migrations (<c>SchemaPerTenant</c> / <c>DatabasePerTenant</c>).
+/// </summary>
+/// <remarks>
+/// On cold start (first deploy), the <c>tenants</c> table may not exist yet.
+/// Only <see cref="DbException"/> with a provider-specific "table not found"
+/// error is caught (PostgreSQL <c>42P01</c>, SQL Server <c>208</c>).
+/// Network errors, auth failures, and other exceptions propagate to fail fast.
+/// </remarks>
+internal sealed class EfCoreTenantEnumerator(ITenantReader tenantReader) : ITenantEnumerator
+{
+    public async IAsyncEnumerable<Guid> GetActiveTenantIdsAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        IReadOnlyList<TenantData> tenants;
+        try
+        {
+            tenants = await tenantReader.GetAllAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbException ex) when (IsTableNotFoundError(ex))
+        {
+            // Cold start: tenants table doesn't exist yet (first deploy).
+            // Yield nothing — host migrations will create the table, then
+            // data seeding will create tenants and trigger provisioning.
+            yield break;
+        }
+
+        foreach (TenantData tenant in tenants)
+        {
+            if (tenant.IsActive)
+            {
+                yield return tenant.Id;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Detects "table/relation does not exist" errors across database providers.
+    /// PostgreSQL: SqlState = 42P01 (undefined_table).
+    /// SQL Server: Number = 208 (invalid object name).
+    /// </summary>
+    private static bool IsTableNotFoundError(DbException ex) =>
+        ex.SqlState == "42P01" || // PostgreSQL: undefined_table
+        ex.ErrorCode == 208;      // SQL Server: invalid object name
+}

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/EfCoreTenantEnumerator.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/EfCoreTenantEnumerator.cs
@@ -1,4 +1,5 @@
 using System.Data.Common;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Granit.MultiTenancy.Stores;
 using Granit.Persistence.EntityFrameworkCore.Migrations;
@@ -33,12 +34,9 @@ internal sealed class EfCoreTenantEnumerator(ITenantReader tenantReader) : ITena
             yield break;
         }
 
-        foreach (TenantData tenant in tenants)
+        foreach (TenantData tenant in tenants.Where(static t => t.IsActive))
         {
-            if (tenant.IsActive)
-            {
-                yield return tenant.Id;
-            }
+            yield return tenant.Id;
         }
     }
 

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/packages.lock.json
@@ -135,6 +135,14 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
+      "granit.persistence.entityframeworkcore.migrations": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.Persistence.EntityFrameworkCore.Hosting/Internal/GranitMigrationRunner.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Hosting/Internal/GranitMigrationRunner.cs
@@ -3,9 +3,12 @@ using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.EntityFrameworkCore.DataSeeding;
 using Granit.Persistence.EntityFrameworkCore.Hosting.Options;
 using Granit.Persistence.EntityFrameworkCore.Migrations;
+using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Persistence.EntityFrameworkCore.Hosting.Internal;
 
@@ -50,6 +53,26 @@ internal sealed partial class GranitMigrationRunner(
 
         try
         {
+            // Force PostConfigure<TenantIsolationOptions> to run, setting
+            // GranitDbDefaults.HostDbSchema before any EF Core model compilation.
+            await using (AsyncServiceScope initScope = scopeFactory.CreateAsyncScope())
+            {
+                _ = initScope.ServiceProvider.GetService<IOptions<TenantIsolationOptions>>()?.Value;
+
+                // Create the host schema if configured (EF Core never creates schemas).
+                if (GranitDbDefaults.HostDbSchema is not null)
+                {
+                    IConfiguration? config = initScope.ServiceProvider.GetService<IConfiguration>();
+                    string? connectionString = config?.GetConnectionString("DefaultConnection");
+                    if (connectionString is not null)
+                    {
+                        await SchemaEnsurer.EnsureSchemasAsync(
+                            connectionString, cancellationToken: ct,
+                            schemas: GranitDbDefaults.HostDbSchema).ConfigureAwait(false);
+                    }
+                }
+            }
+
             // Migrate each DbContext in topological order
             foreach ((GranitModule module, Type dbContextType) in migratableModules)
             {
@@ -154,10 +177,26 @@ internal sealed partial class GranitMigrationRunner(
         CancellationToken ct)
     {
         ITenantDbIsolator isolator = serviceProvider.GetRequiredService<ITenantDbIsolator>();
+        ITenantSchemaProvider? schemaProvider = serviceProvider.GetService<ITenantSchemaProvider>();
 
         await foreach (Guid tenantId in tenantEnumerator.GetActiveTenantIdsAsync(ct).ConfigureAwait(false))
         {
             await using AsyncServiceScope tenantScope = scopeFactory.CreateAsyncScope();
+
+            // Create tenant schema if SchemaPerTenant (PostgreSQL never auto-creates).
+            if (schemaProvider is not null)
+            {
+                string schemaName = await schemaProvider.GetSchemaNameAsync(tenantId, ct).ConfigureAwait(false);
+
+                IConfiguration? config = tenantScope.ServiceProvider.GetService<IConfiguration>();
+                string? connectionString = config?.GetConnectionString("DefaultConnection");
+                if (connectionString is not null)
+                {
+                    await SchemaEnsurer.EnsureSchemasAsync(
+                        connectionString, cancellationToken: ct,
+                        schemas: schemaName).ConfigureAwait(false);
+                }
+            }
 
             LogMigratingContextForTenant(moduleName, dbContextType.Name, tenantId);
             await using DbContext dbContext = await ResolveDbContextAsync(tenantScope.ServiceProvider, dbContextType)

--- a/src/Granit.Persistence.EntityFrameworkCore/SchemaEnsurer.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/SchemaEnsurer.cs
@@ -10,7 +10,7 @@ namespace Granit.Persistence.EntityFrameworkCore;
 /// <remarks>
 /// EF Core / Npgsql never creates custom schemas automatically. If a module configures
 /// a schema (e.g. <c>"host"</c>) and migrations run before the schema exists, the
-/// provider throws a fatal error. Call <see cref="EnsureSchemasAsync"/> at application
+/// provider throws a fatal error. Call <c>EnsureSchemasAsync</c> at application
 /// startup, before any migration or <c>EnsureCreated</c> call.
 /// </remarks>
 public static partial class SchemaEnsurer
@@ -51,6 +51,64 @@ public static partial class SchemaEnsurer
             await using DbCommand cmd = connection.CreateCommand();
             // Schema names cannot be parameterized in SQL; input is validated
             // above against a strict allowlist to prevent injection.
+            cmd.CommandText = $"CREATE SCHEMA IF NOT EXISTS \"{schema}\"";
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Creates the specified schemas using a raw connection string and a
+    /// <see cref="DbProviderFactory"/> resolved from <see cref="DbProviderFactories"/>.
+    /// Use when no <see cref="DbContext"/> is available (e.g. in the migration runner
+    /// before any DbContext is resolved).
+    /// </summary>
+    /// <param name="connectionString">Database connection string.</param>
+    /// <param name="providerInvariantName">
+    /// ADO.NET provider invariant name (e.g. <c>"Npgsql"</c>, <c>"MySql.Data.MySqlClient"</c>).
+    /// Registered by <c>AddGranitPostgres()</c> or equivalent provider setup.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="schemas">Schema names to create.</param>
+    /// <remarks>
+    /// SQL Server does not support <c>CREATE SCHEMA IF NOT EXISTS</c>. For SQL Server,
+    /// use the <see cref="EnsureSchemasAsync(DbContext, CancellationToken, string[])"/>
+    /// overload with a DbContext, or handle schema creation via EF Core migrations.
+    /// SQL Server also does not support <c>SchemaPerTenant</c> isolation
+    /// (no session-level schema switching).
+    /// </remarks>
+    public static async Task EnsureSchemasAsync(
+        string connectionString,
+        string providerInvariantName = "Npgsql",
+        CancellationToken cancellationToken = default,
+        params string[] schemas)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+
+        if (schemas.Length == 0)
+        {
+            return;
+        }
+
+        DbProviderFactory factory = DbProviderFactories.GetFactory(providerInvariantName);
+        await using DbConnection connection = factory.CreateConnection()
+            ?? throw new InvalidOperationException(
+                $"Failed to create a database connection from the '{providerInvariantName}' provider factory.");
+        connection.ConnectionString = connectionString;
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        foreach (string schema in schemas)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(schema);
+
+            if (!SafeSchemaNameRegex().IsMatch(schema))
+            {
+                throw new ArgumentException(
+                    $"Schema name '{schema}' contains unsafe characters. " +
+                    "Only letters, digits, underscores, and hyphens are allowed.",
+                    nameof(schemas));
+            }
+
+            await using DbCommand cmd = connection.CreateCommand();
             cmd.CommandText = $"CREATE SCHEMA IF NOT EXISTS \"{schema}\"";
             await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }

--- a/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 using Granit.Wolverine.Internal;
@@ -138,7 +139,19 @@ public static class WolverinePostgresqlHostApplicationBuilderExtensions
                 "AddGranitWolverine() must be called before AddGranitWolverineWithPostgresql(). " +
                 "Ensure GranitWolverineModule is declared in the [DependsOn] chain.");
 
-        wolverineOptions.PersistMessagesWithPostgresql(connectionString);
+        // Resolve Wolverine envelope schema: explicit option → HostDbSchema fallback → Wolverine default
+        string? wolverineSchema = options.SchemaName
+            ?? GranitDbDefaults.HostDbSchema;
+
+        if (wolverineSchema is not null)
+        {
+            wolverineOptions.PersistMessagesWithPostgresql(connectionString, wolverineSchema);
+        }
+        else
+        {
+            wolverineOptions.PersistMessagesWithPostgresql(connectionString);
+        }
+
         wolverineOptions.UseEntityFrameworkCoreTransactions(options.TransactionMode);
         wolverineOptions.Policies.AutoApplyTransactions();
         configure?.Invoke(wolverineOptions);

--- a/src/Granit.Wolverine.Postgresql/Options/WolverinePostgresqlOptions.cs
+++ b/src/Granit.Wolverine.Postgresql/Options/WolverinePostgresqlOptions.cs
@@ -53,4 +53,17 @@ public sealed class WolverinePostgresqlOptions
     /// Default: <see cref="TransactionMiddlewareMode.Eager"/> (ISO 27001-recommended).
     /// </summary>
     public TransactionMiddlewareMode TransactionMode { get; set; } = TransactionMiddlewareMode.Eager;
+
+    /// <summary>
+    /// PostgreSQL schema for Wolverine envelope tables (inbox, outbox, dead letter).
+    /// Default: <c>null</c> — falls back to <see cref="Granit.Persistence.EntityFrameworkCore.GranitDbDefaults.HostDbSchema"/>,
+    /// then Wolverine's built-in default (<c>"wolverine"</c>).
+    /// </summary>
+    /// <remarks>
+    /// <para><b>SharedDatabase</b>: leave <c>null</c> — Wolverine uses <c>"wolverine"</c> schema.</para>
+    /// <para><b>SchemaPerTenant</b>: automatically uses <c>HostDbSchema</c> (e.g. <c>"host"</c>) so
+    /// Wolverine tables live alongside other host infrastructure.</para>
+    /// <para><b>DatabasePerTenant</b>: leave <c>null</c> — Wolverine uses the host database.</para>
+    /// </remarks>
+    public string? SchemaName { get; set; }
 }

--- a/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/packages.lock.json
@@ -351,6 +351,7 @@
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore.Migrations": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
         }
       },
@@ -372,6 +373,14 @@
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore.migrations": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/packages.lock.json
@@ -695,6 +695,7 @@
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore.Migrations": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
         }
       },
@@ -716,6 +717,14 @@
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore.migrations": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },


### PR DESCRIPTION
## Summary

Enable SchemaPerTenant to work end-to-end by adding the missing tenant provisioning infrastructure. Part of Epic #913.

### Framework changes (granit-dotnet)

**EfCoreTenantEnumerator** — `ITenantEnumerator` implementation that reads active tenants from `ITenantReader`. Handles cold start (first deploy, tenants table doesn't exist) by catching `DbException` with SqlState `42P01` (undefined_table).

**GranitMigrationRunner** — three enhancements:
1. Forces `PostConfigure<TenantIsolationOptions>` at start of `RunAsync()` to set `GranitDbDefaults.HostDbSchema` before EF Core model compilation
2. Creates host schema before `EnsureInternalDbContextsAsync` (host tables)
3. Creates tenant schema before `isolator.IsolateAsync()` in `MigratePerTenantAsync()` (per-tenant tables)

**SchemaEnsurer** — new overload accepting `connectionString` + `providerInvariantName` for use in the migration runner (no DbContext available).

**Wolverine schema** — `WolverinePostgresqlOptions.SchemaName` with fallback: `explicit → HostDbSchema → Wolverine default`. In SchemaPerTenant mode, envelope tables automatically go to the host schema.

### Migration sequence (first deploy)

```
PostConfigure → host schema → IMigratableModule (no tenants yet, skip) →
EnsureInternalDbContexts (host tables) → Seed (creates tenants) →
TenantCreatedEvent → provisioning handler (creates tenant schemas + migrates)
```

## Test plan

- [x] `dotnet build` — 0 errors
- [ ] Showcase `--migrate` → host + tenant schemas created
- [ ] Showcase normal startup works
