### PR TITLE
fix(persistence): restore SharedDatabase fallback + eager HostDbSchema in AddGranitDbContext

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -28677,7 +28677,20 @@
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/DataSeeding/DataSeedContext.cs",
       "line": 18,
-      "members": []
+      "members": [
+        {
+          "name": "TenantId",
+          "kind": "property",
+          "signature": "Guid? TenantId",
+          "returnType": "Guid?"
+        },
+        {
+          "name": "Properties",
+          "kind": "property",
+          "signature": "Dictionary<string, object?> Properties",
+          "returnType": "Dictionary<string, object?>"
+        }
+      ]
     },
     {
       "name": "IDataSeedContributor",
@@ -28808,7 +28821,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceTenantExtensions.cs",
-      "line": 15,
+      "line": 14,
       "members": []
     },
     {
@@ -28910,10 +28923,10 @@
       "line": 21,
       "members": [
         {
-          "name": "ResetToDefaults",
+          "name": "EnsureFromConfiguration",
           "kind": "method",
-          "signature": "ResetToDefaults()",
-          "returnType": "string? DbSchema { get; set; } public string? HostDbSchema { get; set; } internal void"
+          "signature": "EnsureFromConfiguration(Microsoft.Extensions.Configuration.IConfiguration configuration)",
+          "returnType": "string? DbSchema { get; set; } public string? HostDbSchema { get; set; } public void"
         }
       ]
     },

--- a/src/Granit.Persistence.EntityFrameworkCore.Hosting/Internal/GranitMigrationRunner.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Hosting/Internal/GranitMigrationRunner.cs
@@ -1,4 +1,5 @@
 using Granit.Modularity;
+using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.EntityFrameworkCore.DataSeeding;
 using Granit.Persistence.EntityFrameworkCore.Hosting.Options;
@@ -93,13 +94,13 @@ internal sealed partial class GranitMigrationRunner(
             }
 
             // Data seeding — two passes for SchemaPerTenant cold start:
-            // Pass 1: seed host data (tenants, OpenIddict). Module seeders will fail
-            //         gracefully because tenant schemas/tables don't exist yet.
+            // Pass 1 (hostOnly): seed host data only (tenants, OpenIddict).
+            //         Tenant seeders skip via DataSeedContext.IsHostOnly.
             // After: re-migrate per-tenant + ensure tenant internal tables.
-            // Pass 2: re-seed — all seeders succeed with complete tenant schemas.
+            // Pass 2 (full): all seeders run — tenant tables now exist.
             if (options.SeedAfterMigration)
             {
-                await SeedAsync(ct).ConfigureAwait(false);
+                await SeedAsync(ct, hostOnly: true).ConfigureAwait(false);
 
                 // Post-seed per-tenant migration: seeding may have created tenants
                 // (cold start). Re-run migrations — ITenantEnumerator now finds them.
@@ -225,6 +226,12 @@ internal sealed partial class GranitMigrationRunner(
         {
             await using AsyncServiceScope tenantScope = scopeFactory.CreateAsyncScope();
 
+            // Activate tenant context BEFORE resolving the DbContext so the scoped
+            // TContext registration uses the IsolatedDbContextFactory (not the
+            // SharedDatabase fallback which creates in public schema).
+            ICurrentTenant currentTenant = tenantScope.ServiceProvider.GetRequiredService<ICurrentTenant>();
+            using IDisposable tenantChange = currentTenant.Change(tenantId);
+
             // Create tenant schema if SchemaPerTenant (PostgreSQL never auto-creates).
             if (schemaProvider is not null)
             {
@@ -299,7 +306,7 @@ internal sealed partial class GranitMigrationRunner(
         }
     }
 
-    private async Task SeedAsync(CancellationToken ct)
+    private async Task SeedAsync(CancellationToken ct, bool hostOnly = false)
     {
         await using AsyncServiceScope scope = scopeFactory.CreateAsyncScope();
         IDataSeeder? seeder = scope.ServiceProvider.GetService<IDataSeeder>();
@@ -311,6 +318,11 @@ internal sealed partial class GranitMigrationRunner(
 
         LogSeedingStart();
         DataSeedContext seedContext = new();
+        if (hostOnly)
+        {
+            seedContext[DataSeedContext.HostOnlyKey] = true;
+        }
+
         await seeder.SeedAsync(seedContext, ct).ConfigureAwait(false);
         LogSeedingCompleted();
     }

--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationProgressConfiguration.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationProgressConfiguration.cs
@@ -11,7 +11,7 @@ internal sealed class MigrationProgressConfiguration : IEntityTypeConfiguration<
 {
     public void Configure(EntityTypeBuilder<MigrationProgress> builder)
     {
-        builder.ToTable("data_migration_progress");
+        builder.ToTable("data_migration_progress", Granit.Persistence.EntityFrameworkCore.GranitDbDefaults.HostDbSchema);
 
         builder.HasKey(e => e.Id);
 

--- a/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/DataSeedContext.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/DataSeedContext.cs
@@ -29,9 +29,22 @@ public sealed class DataSeedContext
     }
 
     /// <summary>
+    /// Well-known property key for host-only seeding mode.
+    /// When <c>true</c>, tenant-scoped seed contributors should skip their work
+    /// (tenant tables don't exist yet during the first seed pass).
+    /// </summary>
+    public const string HostOnlyKey = "Granit:HostOnly";
+
+    /// <summary>
     /// Identifier of the tenant being seeded, or <c>null</c> for host-level seeding.
     /// </summary>
     public Guid? TenantId { get; }
+
+    /// <summary>
+    /// Indicates whether this is a host-only seed pass (first pass in SchemaPerTenant mode).
+    /// Tenant-scoped seed contributors should return early when this is <c>true</c>.
+    /// </summary>
+    public bool IsHostOnly => this[HostOnlyKey] is true;
 
     /// <summary>
     /// Arbitrary key-value pairs for passing data to seed contributors.

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceTenantExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceTenantExtensions.cs
@@ -1,7 +1,6 @@
 using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
@@ -182,22 +181,9 @@ public static class PersistenceTenantExtensions
                 "Valid values: SharedDatabase, DatabasePerTenant, SchemaPerTenant.")
             .ValidateOnStart();
 
-        // Wire HostSchema EAGERLY during ConfigureServices. EF Core caches the
-        // compiled model on first DbContext creation — if GranitDbDefaults.HostDbSchema
-        // is not set before that, *DbProperties.DbSchema returns null and the model
-        // is cached with the wrong (public) schema permanently.
-        //
-        // PostConfigure runs only when IOptions<T>.Value is first accessed, which may
-        // be too late. Reading IConfiguration directly ensures the value is set
-        // before any DbContextFactory registration captures it.
-        var configuration = services
-            .FirstOrDefault(d => d.ServiceType == typeof(IConfiguration))
-            ?.ImplementationInstance as IConfiguration;
-        string? hostSchema = configuration?["TenantIsolation:HostSchema"];
-        if (hostSchema is not null)
-        {
-            GranitDbDefaults.HostDbSchema = hostSchema;
-        }
+        // HostDbSchema is set eagerly by GranitPersistenceEntityFrameworkCoreModule
+        // via GranitDbDefaults.EnsureFromConfiguration(). No need to read config here —
+        // the module runs before any downstream module registers DbContexts.
 
         services.TryAddSingleton<ITenantIsolationStrategyProvider,
             ConfigurationTenantIsolationStrategyProvider>();
@@ -255,8 +241,10 @@ public static class PersistenceTenantExtensions
         services.TryAddScoped<IDbContextFactory<TContext>, IsolatedDbContextFactory<TContext>>();
 
         // Scoped TContext: tries the isolated factory first, falls back to the
-        // SharedDatabase keyed factory when no tenant is active (e.g., Wolverine
-        // startup introspection, migration orchestration, health checks).
+        // SharedDatabase keyed factory when no tenant is active. This fallback is
+        // needed for Wolverine handler graph compilation (startup introspection)
+        // which resolves DbContext types without a tenant context.
+        // The fallback context is read-only — no migrations or table creation.
         services.TryAddScoped<TContext>(static sp =>
         {
             ICurrentTenant? tenant = sp.GetService<ICurrentTenant>();

--- a/src/Granit.Persistence.EntityFrameworkCore/GranitDbDefaults.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/GranitDbDefaults.cs
@@ -37,6 +37,33 @@ public static class GranitDbDefaults
     public static string? HostDbSchema { get; set; }
 
     /// <summary>
+    /// Sets <see cref="HostDbSchema"/> from <c>TenantIsolation:HostSchema</c> in
+    /// configuration if not already set. Idempotent — first call wins.
+    /// </summary>
+    /// <remarks>
+    /// Call from module extension methods that have access to <see cref="Microsoft.Extensions.Configuration.IConfiguration"/>
+    /// (typically via <c>IHostApplicationBuilder.Configuration</c>). This must run
+    /// before any EF Core model compilation — EF Core caches the compiled model
+    /// after first use, making later mutations ineffective.
+    /// </remarks>
+    /// <param name="configuration">The application configuration.</param>
+    public static void EnsureFromConfiguration(Microsoft.Extensions.Configuration.IConfiguration configuration)
+    {
+        if (HostDbSchema is not null)
+        {
+            System.Diagnostics.Trace.WriteLine($"[GranitDbDefaults] EnsureFromConfiguration SKIPPED — already '{HostDbSchema}'");
+            return;
+        }
+
+        string? hostSchema = configuration["TenantIsolation:HostSchema"];
+        System.Diagnostics.Trace.WriteLine($"[GranitDbDefaults] EnsureFromConfiguration read '{hostSchema ?? "(null)"}' from config");
+        if (hostSchema is not null)
+        {
+            HostDbSchema = hostSchema;
+        }
+    }
+
+    /// <summary>
     /// Resets all properties to their default values. Test use only.
     /// </summary>
     internal static void ResetToDefaults()

--- a/src/Granit.Persistence.EntityFrameworkCore/GranitPersistenceEntityFrameworkCoreModule.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/GranitPersistenceEntityFrameworkCoreModule.cs
@@ -19,6 +19,9 @@ namespace Granit.Persistence.EntityFrameworkCore;
     typeof(GranitTimingModule))]
 public sealed class GranitPersistenceEntityFrameworkCoreModule : GranitModule
 {
-    public override void ConfigureServices(ServiceConfigurationContext context) =>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        GranitDbDefaults.EnsureFromConfiguration(context.Configuration);
         context.Services.AddGranitPersistence();
+    }
 }


### PR DESCRIPTION
Restore SharedDatabase fallback for Wolverine startup introspection + fix eager HostDbSchema read in AddGranitDbContext (not just AddGranitIsolatedDbContext). Fix 9 host modules missing HostDbSchema fallback.