### PR TITLE
docs: update for Host/Tenant ensurer split and double-seed flow

### DIFF
--- a/docs-site/src/content/docs/dotnet/data/migrations.mdx
+++ b/docs-site/src/content/docs/dotnet/data/migrations.mdx
@@ -115,9 +115,12 @@ flowchart TD
     F -->|lock unavailable| G[Log warning — skip]
     F -->|acquired| H[MigrateAsync per module]
     H --> I[EnsureCreated — Expand & Contract table]
-    I --> L[EnsureCreated — internal DbContext tables]
-    L --> J[SeedAsync — if SeedAfterMigration = true]
-    J --> K[Release lock — return exit code 0]
+    I --> L1[EnsureCreated — host internal tables]
+    L1 --> J1["Seed pass 1 (host-only)"]
+    J1 --> M[Re-migrate per-tenant]
+    M --> L2[EnsureCreated — tenant internal tables per-tenant]
+    L2 --> J2["Seed pass 2 (full)"]
+    J2 --> K[Release lock — return exit code 0]
 ```
 
 The discovery step reads the topologically sorted module list from `GranitApplication`
@@ -126,12 +129,24 @@ The discovery step reads the topologically sorted module list from `GranitApplic
 `BackgroundJobsDbContext` or `WebhooksDbContext` — are skipped by the migration step.
 Only **host application DbContexts** that own migration files should implement the interface.
 
-After host migrations complete, the runner discovers all `IInternalDbContextEnsurer`
-implementations and calls `EnsureCreatedAsync()` on each. This handles internal
-DbContexts that cannot be composed into a host DbContext via `Configure*Module()`
-extensions — for example `OpenIddictDbContext`, which extends `IdentityDbContext`
-and requires its own model configuration. Tables are created idempotently via
-`IRelationalDatabaseCreator.CreateTablesAsync()`.
+After host migrations complete, the runner runs two types of internal ensurers:
+
+- **`IHostInternalDbContextEnsurer`** — creates tables for host-level modules
+  (BackgroundJobs, BFF, MultiTenancy, Features, OpenIddict, Auditing, Localization,
+  Scheduling) in the host schema. Runs once before seeding.
+- **`ITenantInternalDbContextEnsurer`** — creates tables for tenant-level modules
+  (Templating, Timeline, BlobStorage, DataExchange, QueryEngine, Webhooks,
+  Notifications) in each tenant's schema. Runs per-tenant after the post-seed
+  re-migration pass.
+
+In SchemaPerTenant mode, the runner uses a **double-seed** flow:
+1. **Seed pass 1** (`IsHostOnly = true`): only host seeders run (tenant creation, OpenIddict).
+   Tenant-scoped seeders skip via `context.IsHostOnly`.
+2. **Re-migrate per-tenant**: now that tenants exist, create schemas and apply migrations.
+3. **Tenant internal ensurers**: create infra tables per tenant schema.
+4. **Seed pass 2** (full): all seeders run — tenant tables now exist.
+
+Tables are created idempotently via `IRelationalDatabaseCreator.CreateTablesAsync()`.
 
 ### `IMigratableModule<TContext>`
 

--- a/docs-site/src/content/docs/dotnet/infrastructure/multi-tenancy/host-tenant.mdx
+++ b/docs-site/src/content/docs/dotnet/infrastructure/multi-tenancy/host-tenant.mdx
@@ -90,21 +90,21 @@ is a data filter, not a schema router.
 
 ### Tenant modules (business data)
 
-These modules use `AddGranitIsolatedDbContext`. Their tables live in tenant-specific
-schemas (or are filtered by `TenantId` in shared database mode).
+These modules use `AddGranitIsolatedDbContext` (for `IMigratableModule` modules)
+or `AddTenantInternalDbContextEnsurer` (for internal modules). Their tables live
+in tenant-specific schemas (or are filtered by `TenantId` in shared database mode).
 
-| Module | Justification |
-|--------|---------------|
-| Authorization | Permission grants per tenant |
-| ApiKeys | API keys per tenant |
-| Notifications | Notifications per tenant |
-| Localization | Translation overrides per tenant |
-| BlobStorage | Blobs per tenant |
-| Timeline | Activity stream per tenant |
-| Webhooks | Subscriptions per tenant |
-| Workflow | State transitions per tenant |
-| DataExchange | Import/export mappings per tenant |
-| Templating | Templates per tenant |
+| Module | Registration | Justification |
+|--------|-------------|---------------|
+| Authorization | `IMigratableModule` | Permission grants per tenant |
+| ApiKeys | `TenantInternalDbContextEnsurer` | API keys per tenant |
+| Notifications | `TenantInternalDbContextEnsurer` | Notifications per tenant |
+| BlobStorage | `TenantInternalDbContextEnsurer` | Blobs per tenant |
+| Timeline | `TenantInternalDbContextEnsurer` | Activity stream per tenant |
+| Webhooks | `TenantInternalDbContextEnsurer` | Subscriptions per tenant |
+| Workflow | `TenantInternalDbContextEnsurer` | State transitions per tenant |
+| DataExchange | `TenantInternalDbContextEnsurer` | Import/export mappings per tenant |
+| Templating | `TenantInternalDbContextEnsurer` | Templates per tenant |
 | QueryEngine | Saved views per tenant |
 
 ### Mixed modules (TenantId nullable in host)

--- a/docs-site/src/content/docs/dotnet/security/openiddict/index.mdx
+++ b/docs-site/src/content/docs/dotnet/security/openiddict/index.mdx
@@ -126,8 +126,9 @@ app.MapGranitOpenIddict();
 ### 5. Run migrations
 
 `OpenIddictDbContext` tables are created **automatically** during `--migrate`.
-The framework registers an `IInternalDbContextEnsurer` that calls
+The framework registers an `IHostInternalDbContextEnsurer` that calls
 `CreateTablesAsync()` when the `openiddict_*` tables do not yet exist.
+In SchemaPerTenant mode, tables are created in the host schema.
 
 ```bash
 dotnet run --migrate


### PR DESCRIPTION
Update migrations.mdx, host-tenant.mdx, and openiddict/index.mdx for the new IHostInternalDbContextEnsurer / ITenantInternalDbContextEnsurer split and the double-seed migration runner flow.