### PR TITLE
feat(identity): multi-tenant login support for Identity endpoints

### DIFF
--- a/src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs
@@ -41,6 +41,12 @@ public sealed partial class GranitIdentityLocalAspNetIdentityModule : GranitModu
         // Replace default UserManager with GranitUserManager (exponential backoff lockout)
         context.Services.Replace(ServiceDescriptor.Scoped<UserManager<GranitUser>, GranitUserManager>());
 
+        // Replace default claims principal factory to inject tenant_id into the Identity cookie.
+        // This ensures multi-tenancy middleware can resolve the tenant from the authenticated
+        // cookie on subsequent requests (authorize, refresh, 2FA second step).
+        context.Services.Replace(ServiceDescriptor.Scoped<
+            IUserClaimsPrincipalFactory<GranitUser>, GranitUserClaimsPrincipalFactory>());
+
         // ASP.NET Core Identity service implementations (depend on UserManager<GranitUser>)
         context.Services.TryAddScoped<ITotpService, TotpService>();
         context.Services.TryAddScoped<ITwoFactorService, AspNetTwoFactorService>();

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/GranitUserClaimsPrincipalFactory.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/GranitUserClaimsPrincipalFactory.cs
@@ -1,0 +1,31 @@
+using System.Security.Claims;
+using Granit.Identity.Local.Domain;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Identity.Local.AspNetIdentity.Internal;
+
+/// <summary>
+/// Extends the default <see cref="UserClaimsPrincipalFactory{TUser, TRole}"/> to inject the
+/// <c>tenant_id</c> claim into the Identity cookie principal. This allows multi-tenancy
+/// middleware to resolve the tenant from the authenticated cookie on subsequent requests
+/// (authorize, refresh, 2FA second step).
+/// </summary>
+internal sealed class GranitUserClaimsPrincipalFactory(
+    UserManager<GranitUser> userManager,
+    RoleManager<GranitRole> roleManager,
+    IOptions<IdentityOptions> options)
+    : UserClaimsPrincipalFactory<GranitUser, GranitRole>(userManager, roleManager, options)
+{
+    protected override async Task<ClaimsIdentity> GenerateClaimsAsync(GranitUser user)
+    {
+        ClaimsIdentity identity = await base.GenerateClaimsAsync(user).ConfigureAwait(false);
+
+        if (user.TenantId is not null)
+        {
+            identity.AddClaim(new Claim("tenant_id", user.TenantId.Value.ToString()));
+        }
+
+        return identity;
+    }
+}

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
@@ -1,10 +1,13 @@
 using System.Diagnostics;
 using System.Security.Cryptography;
+using Granit.DataFiltering;
+using Granit.Domain;
 using Granit.Events;
 using Granit.Identity.Local.Diagnostics;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Endpoints.Dtos;
 using Granit.Identity.Local.Events;
+using Granit.MultiTenancy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -95,10 +98,26 @@ internal static partial class AccountLoginEndpoints
             .GetRequiredService<ILoggerFactory>()
             .CreateLogger("Granit.Identity.Local.Endpoints.AccountLoginEndpoints");
         IdentityLocalMetrics? metrics = httpContext.RequestServices.GetService<IdentityLocalMetrics>();
+        ICurrentTenant? currentTenant = httpContext.RequestServices.GetService<ICurrentTenant>();
+        IDataFilter? dataFilter = httpContext.RequestServices.GetService<IDataFilter>();
 
-        // Resolve user by email or username
-        GranitUser? user = await userManager.FindByEmailAsync(request.Login).ConfigureAwait(false)
-            ?? await userManager.FindByNameAsync(request.Login).ConfigureAwait(false);
+        // Resolve user by email or username.
+        // When no tenant context is active (single-URL app, login happens before authentication),
+        // disable the multi-tenant query filter so the user can be found across all tenants.
+        // RequireUniqueEmail=true guarantees no ambiguity.
+        GranitUser? user;
+        IDisposable? tenantFilterScope = currentTenant is { IsAvailable: false }
+            ? dataFilter?.Disable<IMultiTenant>()
+            : null;
+        try
+        {
+            user = await userManager.FindByEmailAsync(request.Login).ConfigureAwait(false)
+                ?? await userManager.FindByNameAsync(request.Login).ConfigureAwait(false);
+        }
+        finally
+        {
+            tenantFilterScope?.Dispose();
+        }
 
         if (user is null)
         {
@@ -113,6 +132,13 @@ internal static partial class AccountLoginEndpoints
                 detail: "Invalid credentials.",
                 statusCode: StatusCodes.Status401Unauthorized);
         }
+
+        // Establish the tenant context from the resolved user so that
+        // PasswordSignInAsync and downstream Identity operations run within
+        // the correct tenant scope. Change(null) for host admins is a no-op.
+        using IDisposable? tenantScope = currentTenant is not null && user.TenantId is not null
+            ? currentTenant.Change(user.TenantId)
+            : null;
 
         Microsoft.AspNetCore.Identity.SignInResult result = await signInManager
             .PasswordSignInAsync(user, request.Password, isPersistent: request.RememberMe, lockoutOnFailure: true)
@@ -178,79 +204,112 @@ internal static partial class AccountLoginEndpoints
             .GetRequiredService<ILoggerFactory>()
             .CreateLogger("Granit.Identity.Local.Endpoints.AccountLoginEndpoints");
         IdentityLocalMetrics? metrics = httpContext.RequestServices.GetService<IdentityLocalMetrics>();
+        ICurrentTenant? currentTenant = httpContext.RequestServices.GetService<ICurrentTenant>();
+        IDataFilter? dataFilter = httpContext.RequestServices.GetService<IDataFilter>();
 
-        // Strip whitespace and dashes from the code (authenticator apps often format codes with spaces)
-        string sanitizedCode = request.Code.Replace(" ", string.Empty, StringComparison.Ordinal)
-            .Replace("-", string.Empty, StringComparison.Ordinal);
-
-        string method = request.UseRecoveryCode ? "recovery_code" : "totp";
-        string failureReason = request.UseRecoveryCode ? "invalid_recovery_code" : "invalid_totp_code";
-
-        Microsoft.AspNetCore.Identity.SignInResult result;
-
-        if (request.UseRecoveryCode)
+        // The 2FA session stores the user's ID from the first login step (Identity.TwoFactorUserId cookie).
+        // GetTwoFactorAuthenticationUserAsync internally calls FindByIdAsync which is subject to
+        // the multi-tenant query filter. When no tenant is resolved, disable the filter to find
+        // the user, then establish the tenant context for the rest of the handler.
+        IDisposable? tenantScope = null;
+        if (currentTenant is { IsAvailable: false })
         {
-            result = await signInManager
-                .TwoFactorRecoveryCodeSignInAsync(sanitizedCode)
-                .ConfigureAwait(false);
-
-            // TwoFactorRecoveryCodeSignInAsync does not accept isPersistent,
-            // so re-sign the user with a persistent cookie when RememberMe is requested.
-            if (result.Succeeded && request.RememberMe)
+            IDisposable? filterScope = dataFilter?.Disable<IMultiTenant>();
+            try
             {
-                GranitUser? user = await signInManager.UserManager
-                    .GetUserAsync(httpContext.User).ConfigureAwait(false);
+                GranitUser? twoFactorUser = await signInManager.GetTwoFactorAuthenticationUserAsync()
+                    .ConfigureAwait(false);
 
-                if (user is not null)
+                if (twoFactorUser?.TenantId is not null)
                 {
-                    await signInManager.SignInAsync(user, isPersistent: true)
-                        .ConfigureAwait(false);
+                    tenantScope = currentTenant.Change(twoFactorUser.TenantId);
                 }
             }
-        }
-        else
-        {
-            result = await signInManager
-                .TwoFactorAuthenticatorSignInAsync(sanitizedCode, isPersistent: request.RememberMe, rememberClient: false)
-                .ConfigureAwait(false);
-        }
-
-        if (result.Succeeded)
-        {
-            LogTwoFactorSuccess(logger, method);
-            metrics?.RecordAuthenticationSuccess(null, method);
-
-            return TypedResults.Ok(new AccountLoginResponse(Succeeded: true));
-        }
-
-        if (result.IsLockedOut)
-        {
-            GranitUser? lockedUser = await signInManager.GetTwoFactorAuthenticationUserAsync()
-                .ConfigureAwait(false);
-
-            LogLoginLockedOut(logger, lockedUser?.Id.ToString() ?? "two-factor-user");
-            metrics?.RecordAuthenticationFailure(null, "account_locked");
-
-            if (lockedUser is not null)
+            finally
             {
-                await PublishAccountLockedAsync(
-                    httpContext, signInManager.UserManager, lockedUser, cancellationToken)
+                filterScope?.Dispose();
+            }
+        }
+
+        try
+        {
+            // Strip whitespace and dashes from the code (authenticator apps often format codes with spaces)
+            string sanitizedCode = request.Code.Replace(" ", string.Empty, StringComparison.Ordinal)
+                .Replace("-", string.Empty, StringComparison.Ordinal);
+
+            string method = request.UseRecoveryCode ? "recovery_code" : "totp";
+            string failureReason = request.UseRecoveryCode ? "invalid_recovery_code" : "invalid_totp_code";
+
+            Microsoft.AspNetCore.Identity.SignInResult result;
+
+            if (request.UseRecoveryCode)
+            {
+                result = await signInManager
+                    .TwoFactorRecoveryCodeSignInAsync(sanitizedCode)
+                    .ConfigureAwait(false);
+
+                // TwoFactorRecoveryCodeSignInAsync does not accept isPersistent,
+                // so re-sign the user with a persistent cookie when RememberMe is requested.
+                if (result.Succeeded && request.RememberMe)
+                {
+                    GranitUser? user = await signInManager.UserManager
+                        .GetUserAsync(httpContext.User).ConfigureAwait(false);
+
+                    if (user is not null)
+                    {
+                        await signInManager.SignInAsync(user, isPersistent: true)
+                            .ConfigureAwait(false);
+                    }
+                }
+            }
+            else
+            {
+                result = await signInManager
+                    .TwoFactorAuthenticatorSignInAsync(sanitizedCode, isPersistent: request.RememberMe, rememberClient: false)
                     .ConfigureAwait(false);
             }
 
-            // Return 401 (same as invalid code) to prevent account enumeration.
-            // The user is notified of the lockout exclusively via email.
+            if (result.Succeeded)
+            {
+                LogTwoFactorSuccess(logger, method);
+                metrics?.RecordAuthenticationSuccess(null, method);
+
+                return TypedResults.Ok(new AccountLoginResponse(Succeeded: true));
+            }
+
+            if (result.IsLockedOut)
+            {
+                GranitUser? lockedUser = await signInManager.GetTwoFactorAuthenticationUserAsync()
+                    .ConfigureAwait(false);
+
+                LogLoginLockedOut(logger, lockedUser?.Id.ToString() ?? "two-factor-user");
+                metrics?.RecordAuthenticationFailure(null, "account_locked");
+
+                if (lockedUser is not null)
+                {
+                    await PublishAccountLockedAsync(
+                        httpContext, signInManager.UserManager, lockedUser, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+
+                // Return 401 (same as invalid code) to prevent account enumeration.
+                // The user is notified of the lockout exclusively via email.
+                return TypedResults.Problem(
+                    detail: "Invalid verification code.",
+                    statusCode: StatusCodes.Status401Unauthorized);
+            }
+
+            LogTwoFactorFailed(logger, failureReason);
+            metrics?.RecordAuthenticationFailure(null, "invalid_token");
+
             return TypedResults.Problem(
                 detail: "Invalid verification code.",
                 statusCode: StatusCodes.Status401Unauthorized);
         }
-
-        LogTwoFactorFailed(logger, failureReason);
-        metrics?.RecordAuthenticationFailure(null, "invalid_token");
-
-        return TypedResults.Problem(
-            detail: "Invalid verification code.",
-            statusCode: StatusCodes.Status401Unauthorized);
+        finally
+        {
+            tenantScope?.Dispose();
+        }
     }
 
     // ──── Timing attack mitigation ────

--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectTokenEndpoints.cs
@@ -89,38 +89,57 @@ internal static partial class ConnectTokenEndpoints
                 authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
         }
 
-        // Retrieve the user from the subject claim.
+        // Restore tenant context from the token's tenant_id claim before looking up the user.
+        // For refresh_token grants, no tenant middleware has run — the claim is the only source.
+        // When absent (host admin), the filter naturally matches TenantId IS NULL.
         string? subject = authenticateResult.Principal.GetClaim(OpenIddictConstants.Claims.Subject);
-        UserManager<GranitUser> userManager = context.RequestServices
-            .GetRequiredService<UserManager<GranitUser>>();
-
-        GranitUser? user = subject is not null
-            ? await userManager.FindByIdAsync(subject).ConfigureAwait(false)
-            : null;
-
-        if (user is null)
+        string? tokenTenantId = authenticateResult.Principal.GetClaim("tenant_id");
+        ICurrentTenant? currentTenant = context.RequestServices.GetService<ICurrentTenant>();
+        IDisposable? tenantScope = null;
+        if (tokenTenantId is not null && Guid.TryParse(tokenTenantId, out Guid tenantGuid))
         {
-            LogUserNotFound(logger, subject ?? "(null)");
-            metrics.RecordAuthenticationFailure(tenantId, "invalid_credentials");
-            return Results.Forbid(
-                authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
+            tenantScope = currentTenant?.Change(tenantGuid);
+            tenantId ??= tokenTenantId;
         }
 
-        // Rebuild the principal with up-to-date claims.
-        // Preserve scopes from the original principal (including offline_access for refresh tokens).
-        ImmutableArray<string> scopes = authenticateResult.Principal.GetScopes();
+        try
+        {
+            // Retrieve the user from the subject claim.
+            UserManager<GranitUser> userManager = context.RequestServices
+                .GetRequiredService<UserManager<GranitUser>>();
 
-        ClaimsPrincipal principal = await principalFactory.CreateUserPrincipalAsync(
-            user, scopes, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme)
-            .ConfigureAwait(false);
+            GranitUser? user = subject is not null
+                ? await userManager.FindByIdAsync(subject).ConfigureAwait(false)
+                : null;
 
-        string grantType = request.GrantType!;
-        metrics.RecordTokenIssued(tenantId, grantType);
-        metrics.RecordAuthenticationSuccess(tenantId, grantType);
-        LogTokenIssued(logger, user.Id.ToString(), grantType);
+            if (user is null)
+            {
+                LogUserNotFound(logger, subject ?? "(null)");
+                metrics.RecordAuthenticationFailure(tenantId, "invalid_credentials");
+                return Results.Forbid(
+                    authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
+            }
 
-        return Results.SignIn(principal,
-            authenticationScheme: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+            // Rebuild the principal with up-to-date claims.
+            // Preserve scopes from the original principal (including offline_access for refresh tokens).
+            ImmutableArray<string> scopes = authenticateResult.Principal.GetScopes();
+
+            ClaimsPrincipal principal = await principalFactory.CreateUserPrincipalAsync(
+                user, scopes, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme)
+                .ConfigureAwait(false);
+
+            string grantType = request.GrantType!;
+            metrics.RecordTokenIssued(tenantId, grantType);
+            metrics.RecordAuthenticationSuccess(tenantId, grantType);
+            LogTokenIssued(logger, user.Id.ToString(), grantType);
+
+            return Results.SignIn(principal,
+                authenticationScheme: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+        }
+        finally
+        {
+            tenantScope?.Dispose();
+        }
     }
 
     private static IResult HandleClientCredentials(

--- a/src/Granit.OpenIddict.Endpoints/Internal/OidcPrincipalFactory.cs
+++ b/src/Granit.OpenIddict.Endpoints/Internal/OidcPrincipalFactory.cs
@@ -82,6 +82,12 @@ internal sealed class OidcPrincipalFactory(
             identity.AddClaim(OpenIddictConstants.Claims.Role, role);
         }
 
+        // Tenant
+        if (user.TenantId is not null)
+        {
+            identity.AddClaim("tenant_id", user.TenantId.Value.ToString());
+        }
+
         // Custom claims from UserManager store
         IList<Claim> customClaims = await userManager.GetClaimsAsync(user).ConfigureAwait(false);
         identity.AddClaims(customClaims);

--- a/src/Granit.OpenIddict/Services/DefaultClaimsDestinationProvider.cs
+++ b/src/Granit.OpenIddict/Services/DefaultClaimsDestinationProvider.cs
@@ -82,8 +82,8 @@ public class DefaultClaimsDestinationProvider : IClaimsDestinationProvider
             yield break;
         }
 
-        // Subject — always in both tokens
-        if (claim.Type is ClaimTypes.NameIdentifier or "sub")
+        // Subject and tenant — always in both tokens
+        if (claim.Type is ClaimTypes.NameIdentifier or "sub" or "tenant_id")
         {
             yield return ClaimsDestinations.AccessToken;
             yield return ClaimsDestinations.IdentityToken;


### PR DESCRIPTION
## Summary

- **GranitUserClaimsPrincipalFactory** injects `tenant_id` into the Identity cookie so multi-tenancy middleware can resolve the tenant on subsequent requests (authorize, refresh, 2FA second step)
- **OidcPrincipalFactory** adds `tenant_id` claim to JWT tokens from `user.TenantId`; **DefaultClaimsDestinationProvider** routes it to both access_token and id_token
- **AccountLoginEndpoints**: disables `IDataFilter<IMultiTenant>` during `FindByEmailAsync`/`FindByNameAsync` when no tenant is resolved, then calls `ICurrentTenant.Change(user.TenantId)` for the rest of the handler (password sign-in, lockout, etc.). Same pattern for 2FA via `GetTwoFactorAuthenticationUserAsync`
- **ConnectTokenEndpoints**: reads `tenant_id` from the authenticated principal on code/refresh grants and calls `Change(tenantGuid)` before `FindByIdAsync`. No disable-filter fallback — absent claim means host admin, `TenantId IS NULL` matches naturally

### Design notes

- `RequireUniqueEmail=true` guarantees no ambiguity when the filter is disabled at login
- Host admins (`TenantId = null`) work naturally — `Change(null)` is a no-op, filter returns `TenantId IS NULL`
- No `TenantId` on join tables (`IdentityUserRole`, `IdentityUserClaim`) — queries use globally unique `UserId`, isolation is guaranteed by the filter on `GranitUser`

## Test plan

- [ ] Existing unit tests pass (167 + 142 + 66 + 238 = 613 tests)
- [ ] Architecture tests pass (101/101)
- [ ] Integration: login tenant user **without** tenant context → success, token contains `tenant_id`
- [ ] Integration: login tenant user **with** tenant context → success
- [ ] Integration: login host admin without tenant context → success
- [ ] Integration: refresh token for tenant user → tenant resolved from claim
- [ ] Integration: 2FA for tenant user without tenant context → success