### PR TITLE
feat(persistence): Host/Tenant data seed contributor split

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -28698,7 +28698,7 @@
       "kind": "interface",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/DataSeeding/IDataSeedContributor.cs",
-      "line": 24,
+      "line": 27,
       "members": [
         {
           "name": "SeedAsync",
@@ -28709,12 +28709,72 @@
       ]
     },
     {
+      "name": "IDataSeedTenantProvider",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.DataSeeding.IDataSeedTenantProvider",
+      "kind": "interface",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/DataSeeding/IDataSeedTenantProvider.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "GetTenantIdsAsync",
+          "kind": "method",
+          "signature": "GetTenantIdsAsync(CancellationToken cancellationToken = default)",
+          "returnType": "IAsyncEnumerable<Guid>"
+        }
+      ]
+    },
+    {
       "name": "IDataSeeder",
       "fqn": "Granit.Persistence.EntityFrameworkCore.DataSeeding.IDataSeeder",
       "kind": "interface",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/DataSeeding/IDataSeeder.cs",
-      "line": 16,
+      "line": 24,
+      "members": [
+        {
+          "name": "SeedHostAsync",
+          "kind": "method",
+          "signature": "SeedHostAsync(DataSeedContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SeedTenantsAsync",
+          "kind": "method",
+          "signature": "SeedTenantsAsync(DataSeedContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "SeedAsync",
+          "kind": "method",
+          "signature": "SeedAsync(DataSeedContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IHostDataSeedContributor",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.DataSeeding.IHostDataSeedContributor",
+      "kind": "interface",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/DataSeeding/IHostDataSeedContributor.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "SeedAsync",
+          "kind": "method",
+          "signature": "SeedAsync(DataSeedContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "ITenantDataSeedContributor",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.DataSeeding.ITenantDataSeedContributor",
+      "kind": "interface",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/DataSeeding/ITenantDataSeedContributor.cs",
+      "line": 28,
       "members": [
         {
           "name": "SeedAsync",
@@ -29250,7 +29310,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore.Migrations",
       "file": "src/Granit.Persistence.EntityFrameworkCore.Migrations/Extensions/PersistenceMigrationsHostApplicationBuilderExtensions.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitPersistenceMigrations",
@@ -33052,13 +33112,13 @@
       "kind": "class",
       "project": "Granit.ReferenceData",
       "file": "src/Granit.ReferenceData/Domain/ReferenceDataEntity.cs",
-      "line": 31,
+      "line": 32,
       "members": [
         {
-          "name": "Code",
+          "name": "TenantId",
           "kind": "property",
-          "signature": "string Code",
-          "returnType": "string"
+          "signature": "Guid? TenantId",
+          "returnType": "Guid?"
         },
         {
           "name": "LabelEn",
@@ -33159,6 +33219,15 @@
       ]
     },
     {
+      "name": "ReferenceDataScope",
+      "fqn": "Granit.ReferenceData.Domain.ReferenceDataScope",
+      "kind": "enum",
+      "project": "Granit.ReferenceData",
+      "file": "src/Granit.ReferenceData/Domain/ReferenceDataScope.cs",
+      "line": 7,
+      "members": []
+    },
+    {
       "name": "ReferenceDataCreateRequest",
       "fqn": "Granit.ReferenceData.Endpoints.Dtos.ReferenceDataCreateRequest",
       "kind": "record",
@@ -33191,7 +33260,7 @@
       "kind": "class",
       "project": "Granit.ReferenceData.Endpoints",
       "file": "src/Granit.ReferenceData.Endpoints/Extensions/ReferenceDataEndpointRouteBuilderExtensions.cs",
-      "line": 15,
+      "line": 16,
       "members": []
     },
     {
@@ -33258,7 +33327,7 @@
       "kind": "class",
       "project": "Granit.ReferenceData.EntityFrameworkCore",
       "file": "src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ReferenceDataEfCoreServiceCollectionExtensions.cs",
-      "line": 18,
+      "line": 19,
       "members": []
     },
     {
@@ -33401,6 +33470,12 @@
       "line": 21,
       "members": [
         {
+          "name": "Scope",
+          "kind": "property",
+          "signature": "ReferenceDataScope Scope",
+          "returnType": "ReferenceDataScope"
+        },
+        {
           "name": "TableName",
           "kind": "property",
           "signature": "string TableName",
@@ -33442,7 +33517,7 @@
       "kind": "record",
       "project": "Granit.ReferenceData",
       "file": "src/Granit.ReferenceData/Options/ReferenceDataExtensionOptions.cs",
-      "line": 93,
+      "line": 110,
       "members": []
     },
     {
@@ -33492,8 +33567,15 @@
       "kind": "record",
       "project": "Granit.ReferenceData",
       "file": "src/Granit.ReferenceData/ReferenceDataTypeRegistration.cs",
-      "line": 14,
-      "members": []
+      "line": 15,
+      "members": [
+        {
+          "name": "Scope",
+          "kind": "property",
+          "signature": "ReferenceDataScope Scope",
+          "returnType": "ReferenceDataScope"
+        }
+      ]
     },
     {
       "name": "GranitSchedulingBackgroundJobsModule",

--- a/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
@@ -34,7 +34,9 @@ public sealed class GranitOpenIddictEntityFrameworkCoreModule : GranitModule
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
         // Data seeding
+#pragma warning disable CS0618 // IDataSeedContributor: migrating to IHostDataSeedContributor in a follow-up
         context.Services.AddTransient<IDataSeedContributor, OpenIddictSeedContributor>();
+#pragma warning restore CS0618
 
         // EF Core stores
         context.Services.TryAddScoped<ILocalIdentityGroupStore, OpenIddictGroupStore>();

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Seeding/OpenIddictSeedContributor.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Seeding/OpenIddictSeedContributor.cs
@@ -16,7 +16,9 @@ internal sealed partial class OpenIddictSeedContributor(
     IOpenIddictApplicationManager applicationManager,
     IOpenIddictScopeManager scopeManager,
     IOptions<GranitOpenIddictSeedingOptions> options,
+#pragma warning disable CS0618 // IDataSeedContributor: OpenIddict seeds are host-level, migrating to IHostDataSeedContributor in a follow-up
     ILogger<OpenIddictSeedContributor> logger) : IDataSeedContributor
+#pragma warning restore CS0618
 {
     /// <summary>
     /// Standard OIDC scopes seeded automatically on every startup.

--- a/src/Granit.Persistence.EntityFrameworkCore.Hosting/Internal/GranitMigrationRunner.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Hosting/Internal/GranitMigrationRunner.cs
@@ -93,14 +93,16 @@ internal sealed partial class GranitMigrationRunner(
                 tenantEnumerator = enumScope.ServiceProvider.GetService<ITenantEnumerator>();
             }
 
-            // Data seeding — two passes for SchemaPerTenant cold start:
-            // Pass 1 (hostOnly): seed host data only (tenants, OpenIddict).
-            //         Tenant seeders skip via DataSeedContext.IsHostOnly.
-            // After: re-migrate per-tenant + ensure tenant internal tables.
-            // Pass 2 (full): all seeders run — tenant tables now exist.
+            // Data seeding — host/tenant split:
+            // 1. Host pass: IHostDataSeedContributor + legacy (IsHostOnly=true)
+            //    → creates tenants, roles, OpenIddict apps, etc.
+            // 2. Re-migrate per-tenant: seeding may have created tenants (cold start).
+            // 3. Ensure tenant internal tables.
+            // 4. Tenant pass: legacy (IsHostOnly=false) + ITenantDataSeedContributor per tenant
+            //    → seeds tenant-specific data (products, articles, users).
             if (options.SeedAfterMigration)
             {
-                await SeedAsync(ct, hostOnly: true).ConfigureAwait(false);
+                await SeedHostAsync(ct).ConfigureAwait(false);
 
                 // Post-seed per-tenant migration: seeding may have created tenants
                 // (cold start). Re-run migrations — ITenantEnumerator now finds them.
@@ -117,8 +119,7 @@ internal sealed partial class GranitMigrationRunner(
                         .ConfigureAwait(false);
                 }
 
-                // Re-seed: module seeders that failed in pass 1 now succeed.
-                await SeedAsync(ct).ConfigureAwait(false);
+                await SeedTenantsAsync(ct).ConfigureAwait(false);
             }
 
             LogMigrationCompleted();
@@ -306,7 +307,7 @@ internal sealed partial class GranitMigrationRunner(
         }
     }
 
-    private async Task SeedAsync(CancellationToken ct, bool hostOnly = false)
+    private async Task SeedHostAsync(CancellationToken ct)
     {
         await using AsyncServiceScope scope = scopeFactory.CreateAsyncScope();
         IDataSeeder? seeder = scope.ServiceProvider.GetService<IDataSeeder>();
@@ -317,13 +318,22 @@ internal sealed partial class GranitMigrationRunner(
         }
 
         LogSeedingStart();
-        DataSeedContext seedContext = new();
-        if (hostOnly)
+        await seeder.SeedHostAsync(new DataSeedContext(), ct).ConfigureAwait(false);
+        LogSeedingCompleted();
+    }
+
+    private async Task SeedTenantsAsync(CancellationToken ct)
+    {
+        await using AsyncServiceScope scope = scopeFactory.CreateAsyncScope();
+        IDataSeeder? seeder = scope.ServiceProvider.GetService<IDataSeeder>();
+
+        if (seeder is null)
         {
-            seedContext[DataSeedContext.HostOnlyKey] = true;
+            return;
         }
 
-        await seeder.SeedAsync(seedContext, ct).ConfigureAwait(false);
+        LogSeedingStart();
+        await seeder.SeedTenantsAsync(new DataSeedContext(), ct).ConfigureAwait(false);
         LogSeedingCompleted();
     }
 

--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations/Extensions/PersistenceMigrationsHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations/Extensions/PersistenceMigrationsHostApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using System.Threading.Channels;
+using Granit.Persistence.EntityFrameworkCore.DataSeeding;
 using Granit.Persistence.EntityFrameworkCore.Migrations.Internal;
 using Granit.Persistence.EntityFrameworkCore.Migrations.Messages;
 using Granit.Persistence.EntityFrameworkCore.Migrations.Options;
@@ -84,6 +85,9 @@ public static class PersistenceMigrationsHostApplicationBuilderExtensions
         // Default no-op enumerator. Applications using Tenant-per-Schema or Tenant-per-Database
         // must register their own ITenantEnumerator BEFORE calling this method.
         builder.Services.TryAddSingleton<ITenantEnumerator, NullTenantEnumerator>();
+
+        // Bridge ITenantEnumerator → IDataSeedTenantProvider for DataSeeder tenant iteration.
+        builder.Services.TryAddSingleton<IDataSeedTenantProvider, TenantEnumeratorDataSeedTenantProvider>();
 
         // Channel-based dispatch (default). Replaced by Granit.Persistence.EntityFrameworkCore.Migrations.Wolverine if installed.
         builder.Services.TryAddSingleton(Channel.CreateUnbounded<RunMigrationBatchCommand>());

--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/TenantEnumeratorDataSeedTenantProvider.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/TenantEnumeratorDataSeedTenantProvider.cs
@@ -1,0 +1,15 @@
+using Granit.Persistence.EntityFrameworkCore.DataSeeding;
+
+namespace Granit.Persistence.EntityFrameworkCore.Migrations.Internal;
+
+/// <summary>
+/// Bridges <see cref="ITenantEnumerator"/> to <see cref="IDataSeedTenantProvider"/>
+/// so the <see cref="DataSeeder"/> can iterate tenants without depending on the
+/// Migrations assembly directly.
+/// </summary>
+internal sealed class TenantEnumeratorDataSeedTenantProvider(
+    ITenantEnumerator tenantEnumerator) : IDataSeedTenantProvider
+{
+    public IAsyncEnumerable<Guid> GetTenantIdsAsync(CancellationToken cancellationToken = default)
+        => tenantEnumerator.GetActiveTenantIdsAsync(cancellationToken);
+}

--- a/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/DataSeedContext.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/DataSeedContext.cs
@@ -33,6 +33,8 @@ public sealed class DataSeedContext
     /// When <c>true</c>, tenant-scoped seed contributors should skip their work
     /// (tenant tables don't exist yet during the first seed pass).
     /// </summary>
+    [Obsolete("Use IHostDataSeedContributor / ITenantDataSeedContributor instead of checking IsHostOnly. " +
+              "Kept for backward compatibility with legacy IDataSeedContributor implementations.")]
     public const string HostOnlyKey = "Granit:HostOnly";
 
     /// <summary>
@@ -44,6 +46,8 @@ public sealed class DataSeedContext
     /// Indicates whether this is a host-only seed pass (first pass in SchemaPerTenant mode).
     /// Tenant-scoped seed contributors should return early when this is <c>true</c>.
     /// </summary>
+    [Obsolete("Use IHostDataSeedContributor / ITenantDataSeedContributor instead of checking IsHostOnly. " +
+              "Kept for backward compatibility with legacy IDataSeedContributor implementations.")]
     public bool IsHostOnly => this[HostOnlyKey] is true;
 
     /// <summary>

--- a/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/DataSeeder.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/DataSeeder.cs
@@ -1,3 +1,4 @@
+using Granit.MultiTenancy;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -5,33 +6,153 @@ namespace Granit.Persistence.EntityFrameworkCore.DataSeeding;
 
 /// <summary>
 /// Default implementation of <see cref="IDataSeeder"/>.
-/// Resolves all <see cref="IDataSeedContributor"/> from a scoped service provider
-/// and executes them sequentially. Errors are logged but do not stop remaining contributors.
+/// Orchestrates host, tenant, and legacy seed contributors with resilient error handling.
 /// </summary>
 internal sealed partial class DataSeeder(
     IServiceScopeFactory scopeFactory,
     ILogger<DataSeeder> logger) : IDataSeeder
 {
     /// <inheritdoc/>
-    public async Task SeedAsync(DataSeedContext context, CancellationToken cancellationToken = default)
+    public async Task SeedHostAsync(DataSeedContext context, CancellationToken cancellationToken = default)
     {
         await using AsyncServiceScope scope = scopeFactory.CreateAsyncScope();
-        IEnumerable<IDataSeedContributor> contributors =
+
+        // New host contributors
+        IEnumerable<IHostDataSeedContributor> hostContributors =
+            scope.ServiceProvider.GetServices<IHostDataSeedContributor>();
+
+        foreach (IHostDataSeedContributor contributor in hostContributors)
+        {
+            await ExecuteContributorAsync(
+                contributor.GetType(), () => contributor.SeedAsync(context, cancellationToken),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        // Legacy contributors — first pass with IsHostOnly=true
+#pragma warning disable CS0618 // Obsolete: backward compat with legacy IDataSeedContributor
+        IEnumerable<IDataSeedContributor> legacyContributors =
             scope.ServiceProvider.GetServices<IDataSeedContributor>();
 
-        foreach (IDataSeedContributor contributor in contributors)
-        {
-            string contributorName = contributor.GetType().FullName ?? contributor.GetType().Name;
+        DataSeedContext hostOnlyContext = new(context.TenantId);
+        hostOnlyContext[DataSeedContext.HostOnlyKey] = true;
+        CopyProperties(context, hostOnlyContext);
 
-            try
+        foreach (IDataSeedContributor contributor in legacyContributors)
+        {
+            await ExecuteContributorAsync(
+                contributor.GetType(), () => contributor.SeedAsync(hostOnlyContext, cancellationToken),
+                cancellationToken).ConfigureAwait(false);
+        }
+#pragma warning restore CS0618
+    }
+
+    /// <inheritdoc/>
+    public async Task SeedTenantsAsync(DataSeedContext context, CancellationToken cancellationToken = default)
+    {
+        // Legacy contributors — second pass with IsHostOnly=false, no tenant context
+        // (they manage their own ICurrentTenant.Change() calls internally)
+#pragma warning disable CS0618 // Obsolete: backward compat with legacy IDataSeedContributor
+        {
+            await using AsyncServiceScope legacyScope = scopeFactory.CreateAsyncScope();
+            IEnumerable<IDataSeedContributor> legacyContributors =
+                legacyScope.ServiceProvider.GetServices<IDataSeedContributor>();
+
+            foreach (IDataSeedContributor contributor in legacyContributors)
             {
-                LogContributorStarted(contributorName);
-                await contributor.SeedAsync(context, cancellationToken).ConfigureAwait(false);
-                LogContributorCompleted(contributorName);
+                await ExecuteContributorAsync(
+                    contributor.GetType(), () => contributor.SeedAsync(context, cancellationToken),
+                    cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception ex) when (ex is not OperationCanceledException)
+        }
+#pragma warning restore CS0618
+
+        // New tenant contributors — per-tenant with DataSeeder-managed context
+        await using AsyncServiceScope providerScope = scopeFactory.CreateAsyncScope();
+        IDataSeedTenantProvider? tenantProvider =
+            providerScope.ServiceProvider.GetService<IDataSeedTenantProvider>();
+
+        if (tenantProvider is null)
+        {
+            // Single-tenant: execute once without tenant context
+            await SeedTenantContributorsAsync(new DataSeedContext(), cancellationToken)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        await foreach (Guid tenantId in tenantProvider.GetTenantIdsAsync(cancellationToken)
+                           .ConfigureAwait(false))
+        {
+            DataSeedContext tenantContext = new(tenantId);
+            CopyProperties(context, tenantContext);
+
+            await SeedTenantContributorsAsync(tenantContext, cancellationToken, tenantId)
+                .ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task SeedAsync(DataSeedContext context, CancellationToken cancellationToken = default)
+    {
+        await SeedHostAsync(context, cancellationToken).ConfigureAwait(false);
+        await SeedTenantsAsync(context, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task SeedTenantContributorsAsync(
+        DataSeedContext context, CancellationToken cancellationToken, Guid? tenantId = null)
+    {
+        await using AsyncServiceScope scope = scopeFactory.CreateAsyncScope();
+
+        IDisposable? tenantChange = null;
+        if (tenantId.HasValue)
+        {
+            ICurrentTenant? currentTenant = scope.ServiceProvider.GetService<ICurrentTenant>();
+            tenantChange = currentTenant?.Change(tenantId.Value);
+        }
+
+        try
+        {
+            IEnumerable<ITenantDataSeedContributor> contributors =
+                scope.ServiceProvider.GetServices<ITenantDataSeedContributor>();
+
+            foreach (ITenantDataSeedContributor contributor in contributors)
             {
-                LogContributorFailed(contributorName, ex);
+                await ExecuteContributorAsync(
+                    contributor.GetType(), () => contributor.SeedAsync(context, cancellationToken),
+                    cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            tenantChange?.Dispose();
+        }
+    }
+
+    private async Task ExecuteContributorAsync(
+        Type contributorType, Func<Task> action, CancellationToken cancellationToken)
+    {
+        string contributorName = contributorType.FullName ?? contributorType.Name;
+
+        try
+        {
+            LogContributorStarted(contributorName);
+            await action().ConfigureAwait(false);
+            LogContributorCompleted(contributorName);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogContributorFailed(contributorName, ex);
+        }
+    }
+
+    private static void CopyProperties(DataSeedContext source, DataSeedContext target)
+    {
+        foreach (KeyValuePair<string, object?> kvp in source.Properties)
+        {
+#pragma warning disable CS0618 // Obsolete: HostOnlyKey managed internally
+            if (kvp.Key != DataSeedContext.HostOnlyKey)
+#pragma warning restore CS0618
+            {
+                target.Properties[kvp.Key] = kvp.Value;
             }
         }
     }

--- a/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/IDataSeedContributor.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/IDataSeedContributor.cs
@@ -21,6 +21,9 @@ namespace Granit.Persistence.EntityFrameworkCore.DataSeeding;
 /// </code>
 /// </para>
 /// </remarks>
+[Obsolete("Use IHostDataSeedContributor for host-level seeding or ITenantDataSeedContributor for per-tenant seeding. " +
+          "Legacy contributors are still executed: once with IsHostOnly=true during the host pass, " +
+          "then once with IsHostOnly=false during the tenant pass (self-managed tenant context).")]
 public interface IDataSeedContributor
 {
     /// <summary>

--- a/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/IDataSeedTenantProvider.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/IDataSeedTenantProvider.cs
@@ -1,0 +1,26 @@
+namespace Granit.Persistence.EntityFrameworkCore.DataSeeding;
+
+/// <summary>
+/// Provides the list of active tenant identifiers for tenant-scoped data seeding.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Used by <see cref="IDataSeeder"/> to iterate tenants when executing
+/// <see cref="ITenantDataSeedContributor"/> instances. When no implementation is registered
+/// (single-tenant applications), tenant contributors execute once without tenant context.
+/// </para>
+/// <para>
+/// The default implementation in <c>Granit.Persistence.EntityFrameworkCore.Migrations</c>
+/// delegates to <c>ITenantEnumerator</c>. Applications with custom tenant stores can
+/// provide their own implementation.
+/// </para>
+/// </remarks>
+public interface IDataSeedTenantProvider
+{
+    /// <summary>
+    /// Returns the identifiers of all active tenants that should be seeded.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An async enumerable of tenant identifiers.</returns>
+    IAsyncEnumerable<Guid> GetTenantIdsAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/IDataSeeder.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/IDataSeeder.cs
@@ -1,22 +1,52 @@
 namespace Granit.Persistence.EntityFrameworkCore.DataSeeding;
 
 /// <summary>
-/// Orchestrates the execution of all registered <see cref="IDataSeedContributor"/> instances.
+/// Orchestrates the execution of all registered data seed contributors.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Resolved from DI as a singleton. Contributors are resolved from a scoped service provider
+/// Resolved from DI as a singleton. Contributors are resolved from scoped service providers
 /// to support scoped dependencies (e.g., <see cref="Microsoft.EntityFrameworkCore.DbContext"/>).
 /// </para>
 /// <para>
 /// Errors thrown by individual contributors are logged but do not prevent remaining contributors
 /// from executing. Only <see cref="OperationCanceledException"/> is propagated immediately.
 /// </para>
+/// <para>
+/// The seeder supports three contributor interfaces:
+/// <list type="bullet">
+///   <item><see cref="IHostDataSeedContributor"/> — executed once during <see cref="SeedHostAsync"/>.</item>
+///   <item><see cref="ITenantDataSeedContributor"/> — executed per tenant during <see cref="SeedTenantsAsync"/>.</item>
+///   <item><see cref="IDataSeedContributor"/> (legacy) — executed in both passes for backward compatibility.</item>
+/// </list>
+/// </para>
 /// </remarks>
 public interface IDataSeeder
 {
     /// <summary>
-    /// Executes all registered seed contributors for the given context.
+    /// Executes all registered host-level seed contributors, followed by legacy contributors
+    /// with <see cref="DataSeedContext.IsHostOnly"/> set to <c>true</c>.
+    /// </summary>
+    /// <param name="context">Seeding context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task SeedHostAsync(DataSeedContext context, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes legacy contributors with <see cref="DataSeedContext.IsHostOnly"/> set to <c>false</c>,
+    /// then executes tenant contributors once per active tenant (with tenant context activated).
+    /// </summary>
+    /// <remarks>
+    /// When no <see cref="IDataSeedTenantProvider"/> is registered (single-tenant applications),
+    /// tenant contributors execute once without tenant context.
+    /// </remarks>
+    /// <param name="context">Seeding context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task SeedTenantsAsync(DataSeedContext context, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Convenience method that calls <see cref="SeedHostAsync"/> followed by <see cref="SeedTenantsAsync"/>.
     /// </summary>
     /// <param name="context">Seeding context.</param>
     /// <param name="cancellationToken">Cancellation token.</param>

--- a/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/IHostDataSeedContributor.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/IHostDataSeedContributor.cs
@@ -1,0 +1,30 @@
+namespace Granit.Persistence.EntityFrameworkCore.DataSeeding;
+
+/// <summary>
+/// Contributes seed data that belongs to the host (shared) database context.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations are executed once by <see cref="IDataSeeder.SeedHostAsync"/> in a single
+/// DI scope without any tenant context active. Typical use cases include seeding tenants
+/// themselves, shared roles, OpenIddict applications, or any host-level reference data.
+/// </para>
+/// <para>
+/// Register implementations as transient:
+/// <c>services.AddTransient&lt;IHostDataSeedContributor, MyContributor&gt;();</c>
+/// </para>
+/// <para>
+/// All contributors must be <b>idempotent</b> — calling <see cref="SeedAsync"/> multiple
+/// times must produce the same result (use upsert logic or existence checks).
+/// </para>
+/// </remarks>
+public interface IHostDataSeedContributor
+{
+    /// <summary>
+    /// Seeds host-level data.
+    /// </summary>
+    /// <param name="context">Seeding context (always host-level, <see cref="DataSeedContext.TenantId"/> is <c>null</c>).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task SeedAsync(DataSeedContext context, CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/ITenantDataSeedContributor.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/ITenantDataSeedContributor.cs
@@ -1,0 +1,39 @@
+namespace Granit.Persistence.EntityFrameworkCore.DataSeeding;
+
+/// <summary>
+/// Contributes seed data that belongs to a specific tenant context.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations are executed once <b>per active tenant</b> by <see cref="IDataSeeder.SeedTenantsAsync"/>.
+/// The <see cref="IDataSeeder"/> creates a dedicated DI scope for each tenant and activates the
+/// tenant context (<c>ICurrentTenant.Change(tenantId)</c>) before resolving and executing
+/// contributors. The <see cref="DataSeedContext.TenantId"/> is set to the current tenant ID.
+/// </para>
+/// <para>
+/// Because the tenant context is already active, implementations should <b>not</b> call
+/// <c>ICurrentTenant.Change()</c> or create their own <see cref="IServiceScope"/>.
+/// Use <see cref="Microsoft.EntityFrameworkCore.IDbContextFactory{TContext}"/> to create
+/// a fresh <c>DbContext</c> connected to the correct tenant schema.
+/// </para>
+/// <para>
+/// Register implementations as transient:
+/// <c>services.AddTransient&lt;ITenantDataSeedContributor, MyContributor&gt;();</c>
+/// </para>
+/// <para>
+/// All contributors must be <b>idempotent</b> — calling <see cref="SeedAsync"/> multiple
+/// times for the same tenant must produce the same result.
+/// </para>
+/// </remarks>
+public interface ITenantDataSeedContributor
+{
+    /// <summary>
+    /// Seeds data for a specific tenant.
+    /// </summary>
+    /// <param name="context">
+    /// Seeding context with <see cref="DataSeedContext.TenantId"/> set to the active tenant.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task SeedAsync(DataSeedContext context, CancellationToken cancellationToken = default);
+}

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ReferenceDataEfCoreServiceCollectionExtensions.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ReferenceDataEfCoreServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore.DataSeeding;
 using Granit.Persistence.EntityFrameworkCore.ExtraProperties;
 using Granit.QueryEngine;
@@ -25,9 +26,14 @@ public static class ReferenceDataEfCoreServiceCollectionExtensions
     /// <typeparam name="TEntity">The concrete reference data entity type.</typeparam>
     /// <typeparam name="TDbContext">The host application's DbContext.</typeparam>
     /// <param name="services">The service collection.</param>
+    /// <param name="scope">
+    /// The multi-tenancy scope. Defaults to <see cref="ReferenceDataScope.Global"/>
+    /// (shared across all tenants, managed by host admin).
+    /// </param>
     /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddReferenceDataStore<TEntity, TDbContext>(
-        this IServiceCollection services)
+        this IServiceCollection services,
+        ReferenceDataScope scope = ReferenceDataScope.Global)
         where TEntity : ReferenceDataEntity
         where TDbContext : DbContext
     {
@@ -35,13 +41,17 @@ public static class ReferenceDataEfCoreServiceCollectionExtensions
             new EfCoreReferenceDataStore<TEntity, TDbContext>(
                 sp.GetRequiredService<IServiceScopeFactory>(),
                 sp.GetRequiredService<IFusionCache>(),
-                sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<ReferenceDataOptions>>()));
+                sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<ReferenceDataOptions>>(),
+                scope,
+                sp.GetRequiredService<ICurrentTenant>()));
         services.AddScoped<IReferenceDataStoreReader<TEntity>>(sp =>
             sp.GetRequiredService<EfCoreReferenceDataStore<TEntity, TDbContext>>());
         services.AddScoped<IReferenceDataStoreWriter<TEntity>>(sp =>
             sp.GetRequiredService<EfCoreReferenceDataStore<TEntity, TDbContext>>());
 
+#pragma warning disable CS0618 // IDataSeedContributor: ReferenceData supports both host/tenant, migrating in a follow-up
         services.AddTransient<IDataSeedContributor, ReferenceDataSeedContributor<TEntity>>();
+#pragma warning restore CS0618
 
         return services;
     }
@@ -114,19 +124,25 @@ public static class ReferenceDataEfCoreServiceCollectionExtensions
         {
             // 1. Register keyed store services (type name = key)
             // Uses DynamicReferenceDataEntity (concrete) since ReferenceDataEntity is abstract
+            ReferenceDataScope registrationScope = registration.Scope;
+
             services.AddKeyedScoped<IReferenceDataStoreReader<DynamicReferenceDataEntity>>(
                 registration.TypeName,
                 (sp, _) => new EfCoreReferenceDataStore<DynamicReferenceDataEntity, TDbContext>(
                     sp.GetRequiredService<IServiceScopeFactory>(),
                     sp.GetRequiredService<IFusionCache>(),
-                    sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<ReferenceDataOptions>>()));
+                    sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<ReferenceDataOptions>>(),
+                    registrationScope,
+                    sp.GetRequiredService<ICurrentTenant>()));
 
             services.AddKeyedScoped<IReferenceDataStoreWriter<DynamicReferenceDataEntity>>(
                 registration.TypeName,
                 (sp, _) => new EfCoreReferenceDataStore<DynamicReferenceDataEntity, TDbContext>(
                     sp.GetRequiredService<IServiceScopeFactory>(),
                     sp.GetRequiredService<IFusionCache>(),
-                    sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<ReferenceDataOptions>>()));
+                    sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<ReferenceDataOptions>>(),
+                    registrationScope,
+                    sp.GetRequiredService<ICurrentTenant>()));
 
             // 2. Register ExtraProperty mappings for shadow columns
             if (registration.Options.PropertyMappings.Count > 0)

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataSeedContributor.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataSeedContributor.cs
@@ -24,7 +24,9 @@ namespace Granit.ReferenceData.EntityFrameworkCore.Internal;
 /// <typeparam name="TEntity">The concrete reference data entity type.</typeparam>
 internal sealed partial class ReferenceDataSeedContributor<TEntity>(
     IServiceProvider serviceProvider,
+#pragma warning disable CS0618 // IDataSeedContributor: ReferenceData supports both host/tenant, migrating in a follow-up
     ILogger<ReferenceDataSeedContributor<TEntity>> logger) : IDataSeedContributor
+#pragma warning restore CS0618
     where TEntity : ReferenceDataEntity
 {
     /// <inheritdoc/>

--- a/tests/Granit.Persistence.EntityFrameworkCore.Migrations.Tests/TenantEnumeratorDataSeedTenantProviderTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Migrations.Tests/TenantEnumeratorDataSeedTenantProviderTests.cs
@@ -1,0 +1,64 @@
+using Granit.Persistence.EntityFrameworkCore.Migrations.Internal;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Persistence.EntityFrameworkCore.Migrations.Tests;
+
+public sealed class TenantEnumeratorDataSeedTenantProviderTests
+{
+    [Fact]
+    public async Task GetTenantIdsAsync_DelegatesToTenantEnumerator()
+    {
+        // Arrange
+        var tenant1 = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var tenant2 = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+        ITenantEnumerator enumerator = Substitute.For<ITenantEnumerator>();
+        enumerator.GetActiveTenantIdsAsync(Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable(tenant1, tenant2));
+
+        TenantEnumeratorDataSeedTenantProvider sut = new(enumerator);
+
+        // Act
+        List<Guid> result = [];
+        await foreach (Guid id in sut.GetTenantIdsAsync(TestContext.Current.CancellationToken))
+        {
+            result.Add(id);
+        }
+
+        // Assert
+        result.ShouldBe([tenant1, tenant2]);
+    }
+
+    [Fact]
+    public async Task GetTenantIdsAsync_EmptyEnumerator_ReturnsEmpty()
+    {
+        // Arrange
+        ITenantEnumerator enumerator = Substitute.For<ITenantEnumerator>();
+        enumerator.GetActiveTenantIdsAsync(Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable());
+
+        TenantEnumeratorDataSeedTenantProvider sut = new(enumerator);
+
+        // Act
+        List<Guid> result = [];
+        await foreach (Guid id in sut.GetTenantIdsAsync(TestContext.Current.CancellationToken))
+        {
+            result.Add(id);
+        }
+
+        // Assert
+        result.ShouldBeEmpty();
+    }
+
+    private static async IAsyncEnumerable<Guid> ToAsyncEnumerable(params Guid[] ids)
+    {
+        foreach (Guid id in ids)
+        {
+            yield return id;
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/DataSeeding/DataSeederTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/DataSeeding/DataSeederTests.cs
@@ -2,13 +2,15 @@
 // Tests — DataSeeder
 // =============================================================================
 // Vérifie que l'orchestrateur de seeding :
-//   - Exécute tous les contributeurs enregistrés séquentiellement
+//   - Exécute les IHostDataSeedContributor dans SeedHostAsync
+//   - Exécute les ITenantDataSeedContributor par tenant dans SeedTenantsAsync
+//   - Gère le backward compat avec IDataSeedContributor (legacy)
 //   - Continue l'exécution si un contributeur échoue (résilience)
-//   - Transmet correctement le DataSeedContext à chaque contributeur
-//   - Fonctionne sans contributeurs enregistrés (no-op)
 //   - Propage OperationCanceledException sans l'attraper
+//   - Active le contexte tenant via ICurrentTenant.Change()
 // =============================================================================
 
+using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore.DataSeeding;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -23,6 +25,10 @@ namespace Granit.Persistence.EntityFrameworkCore.Tests.DataSeeding;
 public sealed class DataSeederTests
 {
     private readonly ILogger<DataSeeder> _logger = NullLogger<DataSeeder>.Instance;
+
+    // =========================================================================
+    // SeedAsync — backward compat (calls both SeedHostAsync + SeedTenantsAsync)
+    // =========================================================================
 
     [Fact]
     public async Task SeedAsync_NoContributors_CompletesWithoutError()
@@ -40,10 +46,11 @@ public sealed class DataSeederTests
         await Should.NotThrowAsync(act);
     }
 
+#pragma warning disable CS0618 // Obsolete IDataSeedContributor: testing backward compat
     [Fact]
-    public async Task SeedAsync_SingleContributor_CallsSeedAsync()
+    public async Task SeedAsync_SingleLegacyContributor_CallsSeedAsyncTwice()
     {
-        // Arrange
+        // Arrange — legacy contributor runs in both host pass (IsHostOnly=true) and tenant pass
         IDataSeedContributor contributor = Substitute.For<IDataSeedContributor>();
         ServiceCollection services = new();
         services.AddTransient(_ => contributor);
@@ -54,70 +61,62 @@ public sealed class DataSeederTests
         // Act
         await seeder.SeedAsync(context, TestContext.Current.CancellationToken);
 
-        // Assert
-        await contributor.Received(1).SeedAsync(context, TestContext.Current.CancellationToken);
+        // Assert — called twice: once with IsHostOnly=true, once with IsHostOnly=false
+        await contributor.Received(2).SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task SeedAsync_MultipleContributors_ExecutesAll()
+    public async Task SeedAsync_CallsBothHostAndTenantPhases()
     {
         // Arrange
-        IDataSeedContributor contributor1 = Substitute.For<IDataSeedContributor>();
-        IDataSeedContributor contributor2 = Substitute.For<IDataSeedContributor>();
-        IDataSeedContributor contributor3 = Substitute.For<IDataSeedContributor>();
+        IHostDataSeedContributor hostContributor = Substitute.For<IHostDataSeedContributor>();
+        ITenantDataSeedContributor tenantContributor = Substitute.For<ITenantDataSeedContributor>();
+        ServiceCollection services = new();
+        services.AddTransient(_ => hostContributor);
+        services.AddTransient(_ => tenantContributor);
+        using ServiceProvider sp = services.BuildServiceProvider();
+        DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
+        DataSeedContext context = new();
+
+        // Act
+        await seeder.SeedAsync(context, TestContext.Current.CancellationToken);
+
+        // Assert
+        await hostContributor.Received(1).SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>());
+        await tenantContributor.Received(1).SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>());
+    }
+
+    // =========================================================================
+    // SeedHostAsync
+    // =========================================================================
+
+    [Fact]
+    public async Task SeedHostAsync_ExecutesHostContributors()
+    {
+        // Arrange
+        IHostDataSeedContributor contributor1 = Substitute.For<IHostDataSeedContributor>();
+        IHostDataSeedContributor contributor2 = Substitute.For<IHostDataSeedContributor>();
         ServiceCollection services = new();
         services.AddTransient(_ => contributor1);
         services.AddTransient(_ => contributor2);
-        services.AddTransient(_ => contributor3);
         using ServiceProvider sp = services.BuildServiceProvider();
         DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
-        DataSeedContext context = new();
 
         // Act
-        await seeder.SeedAsync(context, TestContext.Current.CancellationToken);
+        await seeder.SeedHostAsync(new DataSeedContext(), TestContext.Current.CancellationToken);
 
         // Assert
-        await contributor1.Received(1).SeedAsync(context, Arg.Any<CancellationToken>());
-        await contributor2.Received(1).SeedAsync(context, Arg.Any<CancellationToken>());
-        await contributor3.Received(1).SeedAsync(context, Arg.Any<CancellationToken>());
+        await contributor1.Received(1).SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>());
+        await contributor2.Received(1).SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task SeedAsync_ContributorThrows_ContinuesWithRemaining()
+    public async Task SeedHostAsync_ExecutesLegacyContributorsWithIsHostOnly()
     {
         // Arrange
-        IDataSeedContributor failingContributor = Substitute.For<IDataSeedContributor>();
-        failingContributor
-            .SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("Seed failed"));
-
-        IDataSeedContributor successContributor = Substitute.For<IDataSeedContributor>();
-
-        ServiceCollection services = new();
-        services.AddTransient(_ => failingContributor);
-        services.AddTransient(_ => successContributor);
-        using ServiceProvider sp = services.BuildServiceProvider();
-        DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
-        DataSeedContext context = new();
-
-        // Act
-        await seeder.SeedAsync(context, TestContext.Current.CancellationToken);
-
-        // Assert — second contributor was still called
-        await successContributor.Received(1).SeedAsync(context, Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task SeedAsync_PassesContextToContributor()
-    {
-        // Arrange
-        var tenantId = Guid.Parse("22222222-2222-2222-2222-222222222222");
-        DataSeedContext context = new(tenantId);
-        context["AdminEmail"] = "admin@test.com";
-
         DataSeedContext? capturedContext = null;
-        IDataSeedContributor contributor = Substitute.For<IDataSeedContributor>();
-        contributor
+        IDataSeedContributor legacy = Substitute.For<IDataSeedContributor>();
+        legacy
             .SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
@@ -126,24 +125,48 @@ public sealed class DataSeederTests
             });
 
         ServiceCollection services = new();
-        services.AddTransient(_ => contributor);
+        services.AddTransient(_ => legacy);
         using ServiceProvider sp = services.BuildServiceProvider();
         DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
 
         // Act
-        await seeder.SeedAsync(context, TestContext.Current.CancellationToken);
+        await seeder.SeedHostAsync(new DataSeedContext(), TestContext.Current.CancellationToken);
 
         // Assert
         capturedContext.ShouldNotBeNull();
-        capturedContext!.TenantId.ShouldBe(tenantId);
-        capturedContext["AdminEmail"].ShouldBe("admin@test.com");
+        capturedContext!.IsHostOnly.ShouldBeTrue();
+    }
+#pragma warning restore CS0618
+
+    [Fact]
+    public async Task SeedHostAsync_ContributorThrows_ContinuesWithRemaining()
+    {
+        // Arrange
+        IHostDataSeedContributor failing = Substitute.For<IHostDataSeedContributor>();
+        failing
+            .SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Seed failed"));
+
+        IHostDataSeedContributor success = Substitute.For<IHostDataSeedContributor>();
+
+        ServiceCollection services = new();
+        services.AddTransient(_ => failing);
+        services.AddTransient(_ => success);
+        using ServiceProvider sp = services.BuildServiceProvider();
+        DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
+
+        // Act
+        await seeder.SeedHostAsync(new DataSeedContext(), TestContext.Current.CancellationToken);
+
+        // Assert
+        await success.Received(1).SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task SeedAsync_OperationCanceledException_Propagates()
+    public async Task SeedHostAsync_OperationCanceledException_Propagates()
     {
         // Arrange
-        IDataSeedContributor contributor = Substitute.For<IDataSeedContributor>();
+        IHostDataSeedContributor contributor = Substitute.For<IHostDataSeedContributor>();
         contributor
             .SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new OperationCanceledException());
@@ -152,12 +175,228 @@ public sealed class DataSeederTests
         services.AddTransient(_ => contributor);
         using ServiceProvider sp = services.BuildServiceProvider();
         DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
-        DataSeedContext context = new();
+
+        // Act & Assert
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => seeder.SeedHostAsync(new DataSeedContext(), TestContext.Current.CancellationToken));
+    }
+
+    // =========================================================================
+    // SeedTenantsAsync
+    // =========================================================================
+
+#pragma warning disable CS0618 // Obsolete IDataSeedContributor: testing backward compat
+    [Fact]
+    public async Task SeedTenantsAsync_ExecutesLegacyContributorsWithoutIsHostOnly()
+    {
+        // Arrange
+        DataSeedContext? capturedContext = null;
+        IDataSeedContributor legacy = Substitute.For<IDataSeedContributor>();
+        legacy
+            .SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                capturedContext = callInfo.Arg<DataSeedContext>();
+                return Task.CompletedTask;
+            });
+
+        ServiceCollection services = new();
+        services.AddTransient(_ => legacy);
+        using ServiceProvider sp = services.BuildServiceProvider();
+        DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
 
         // Act
-        Func<Task> act = () => seeder.SeedAsync(context, TestContext.Current.CancellationToken);
+        await seeder.SeedTenantsAsync(new DataSeedContext(), TestContext.Current.CancellationToken);
 
-        // Assert — OperationCanceledException is NOT caught
-        await Should.ThrowAsync<OperationCanceledException>(act);
+        // Assert
+        capturedContext.ShouldNotBeNull();
+        capturedContext!.IsHostOnly.ShouldBeFalse();
+    }
+#pragma warning restore CS0618
+
+    [Fact]
+    public async Task SeedTenantsAsync_NoTenantProvider_ExecutesTenantContributorsOnce()
+    {
+        // Arrange — no IDataSeedTenantProvider registered (single-tenant)
+        ITenantDataSeedContributor contributor = Substitute.For<ITenantDataSeedContributor>();
+        ServiceCollection services = new();
+        services.AddTransient(_ => contributor);
+        using ServiceProvider sp = services.BuildServiceProvider();
+        DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
+
+        // Act
+        await seeder.SeedTenantsAsync(new DataSeedContext(), TestContext.Current.CancellationToken);
+
+        // Assert — called once without tenant context
+        await contributor.Received(1).SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SeedTenantsAsync_WithTenantProvider_ExecutesPerTenant()
+    {
+        // Arrange
+        var tenant1 = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var tenant2 = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+        ITenantDataSeedContributor contributor = Substitute.For<ITenantDataSeedContributor>();
+        IDataSeedTenantProvider tenantProvider = Substitute.For<IDataSeedTenantProvider>();
+        tenantProvider.GetTenantIdsAsync(Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable(tenant1, tenant2));
+
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>())
+            .Returns(Substitute.For<IDisposable>());
+
+        ServiceCollection services = new();
+        services.AddTransient(_ => contributor);
+        services.AddSingleton(tenantProvider);
+        services.AddScoped(_ => currentTenant);
+        using ServiceProvider sp = services.BuildServiceProvider();
+        DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
+
+        // Act
+        await seeder.SeedTenantsAsync(new DataSeedContext(), TestContext.Current.CancellationToken);
+
+        // Assert — called once per tenant
+        await contributor.Received(2).SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SeedTenantsAsync_ActivatesTenantContext_PerTenant()
+    {
+        // Arrange
+        var tenant1 = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var tenant2 = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+        List<Guid?> capturedTenantIds = [];
+        ITenantDataSeedContributor contributor = Substitute.For<ITenantDataSeedContributor>();
+        contributor
+            .SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                capturedTenantIds.Add(callInfo.Arg<DataSeedContext>().TenantId);
+                return Task.CompletedTask;
+            });
+
+        IDataSeedTenantProvider tenantProvider = Substitute.For<IDataSeedTenantProvider>();
+        tenantProvider.GetTenantIdsAsync(Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable(tenant1, tenant2));
+
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>())
+            .Returns(Substitute.For<IDisposable>());
+
+        ServiceCollection services = new();
+        services.AddTransient(_ => contributor);
+        services.AddSingleton(tenantProvider);
+        services.AddScoped(_ => currentTenant);
+        using ServiceProvider sp = services.BuildServiceProvider();
+        DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
+
+        // Act
+        await seeder.SeedTenantsAsync(new DataSeedContext(), TestContext.Current.CancellationToken);
+
+        // Assert — context had correct TenantId for each call
+        capturedTenantIds.ShouldBe([tenant1, tenant2]);
+    }
+
+    [Fact]
+    public async Task SeedTenantsAsync_ContributorThrows_ContinuesWithRemaining()
+    {
+        // Arrange
+        ITenantDataSeedContributor failing = Substitute.For<ITenantDataSeedContributor>();
+        failing
+            .SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Seed failed"));
+
+        ITenantDataSeedContributor success = Substitute.For<ITenantDataSeedContributor>();
+
+        ServiceCollection services = new();
+        services.AddTransient(_ => failing);
+        services.AddTransient(_ => success);
+        using ServiceProvider sp = services.BuildServiceProvider();
+        DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
+
+        // Act
+        await seeder.SeedTenantsAsync(new DataSeedContext(), TestContext.Current.CancellationToken);
+
+        // Assert
+        await success.Received(1).SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SeedTenantsAsync_OperationCanceledException_Propagates()
+    {
+        // Arrange
+        ITenantDataSeedContributor contributor = Substitute.For<ITenantDataSeedContributor>();
+        contributor
+            .SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException());
+
+        ServiceCollection services = new();
+        services.AddTransient(_ => contributor);
+        using ServiceProvider sp = services.BuildServiceProvider();
+        DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
+
+        // Act & Assert
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => seeder.SeedTenantsAsync(new DataSeedContext(), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task SeedTenantsAsync_PassesPropertiesToTenantContext()
+    {
+        // Arrange
+        var tenantId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+        DataSeedContext? capturedContext = null;
+
+        ITenantDataSeedContributor contributor = Substitute.For<ITenantDataSeedContributor>();
+        contributor
+            .SeedAsync(Arg.Any<DataSeedContext>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                capturedContext = callInfo.Arg<DataSeedContext>();
+                return Task.CompletedTask;
+            });
+
+        IDataSeedTenantProvider tenantProvider = Substitute.For<IDataSeedTenantProvider>();
+        tenantProvider.GetTenantIdsAsync(Arg.Any<CancellationToken>())
+            .Returns(ToAsyncEnumerable(tenantId));
+
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.Change(Arg.Any<Guid?>(), Arg.Any<string?>())
+            .Returns(Substitute.For<IDisposable>());
+
+        ServiceCollection services = new();
+        services.AddTransient(_ => contributor);
+        services.AddSingleton(tenantProvider);
+        services.AddScoped(_ => currentTenant);
+        using ServiceProvider sp = services.BuildServiceProvider();
+        DataSeeder seeder = new(sp.GetRequiredService<IServiceScopeFactory>(), _logger);
+
+        DataSeedContext context = new();
+        context["AdminEmail"] = "admin@test.com";
+
+        // Act
+        await seeder.SeedTenantsAsync(context, TestContext.Current.CancellationToken);
+
+        // Assert
+        capturedContext.ShouldNotBeNull();
+        capturedContext!.TenantId.ShouldBe(tenantId);
+        capturedContext["AdminEmail"].ShouldBe("admin@test.com");
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private static async IAsyncEnumerable<Guid> ToAsyncEnumerable(params Guid[] ids)
+    {
+        foreach (Guid id in ids)
+        {
+            yield return id;
+        }
+
+        await Task.CompletedTask;
     }
 }

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/DataSeeding/DataSeedingRegistrationTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/DataSeeding/DataSeedingRegistrationTests.cs
@@ -50,6 +50,7 @@ public sealed class DataSeedingRegistrationTests
         descriptor.ShouldNotBeNull();
     }
 
+#pragma warning disable CS0618 // Obsolete: testing that legacy interface is not auto-registered
     [Fact]
     public void AddGranitDataSeeding_DoesNotRegisterContributors()
     {
@@ -61,6 +62,35 @@ public sealed class DataSeedingRegistrationTests
 
         // Assert
         services.Where(d => d.ServiceType == typeof(IDataSeedContributor))
+            .ShouldBeEmpty();
+    }
+#pragma warning restore CS0618
+
+    [Fact]
+    public void AddGranitDataSeeding_DoesNotRegisterHostContributors()
+    {
+        // Arrange
+        ServiceCollection services = new();
+
+        // Act
+        services.AddGranitDataSeeding();
+
+        // Assert
+        services.Where(d => d.ServiceType == typeof(IHostDataSeedContributor))
+            .ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void AddGranitDataSeeding_DoesNotRegisterTenantContributors()
+    {
+        // Arrange
+        ServiceCollection services = new();
+
+        // Act
+        services.AddGranitDataSeeding();
+
+        // Assert
+        services.Where(d => d.ServiceType == typeof(ITenantDataSeedContributor))
             .ShouldBeEmpty();
     }
 

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEfCoreServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEfCoreServiceCollectionExtensionsTests.cs
@@ -66,6 +66,7 @@ public sealed class ReferenceDataEfCoreServiceCollectionExtensionsTests
         writer.ShouldNotBeNull();
     }
 
+#pragma warning disable CS0618 // IDataSeedContributor: testing backward compat registration
     [Fact]
     public void AddReferenceDataStore_RegistersDataSeedContributor()
     {
@@ -76,6 +77,7 @@ public sealed class ReferenceDataEfCoreServiceCollectionExtensionsTests
 
         contributors.ShouldNotBeEmpty();
     }
+#pragma warning restore CS0618
 
     [Fact]
     public void AddReferenceDataStore_ReaderAndWriter_AreSameInstance()


### PR DESCRIPTION
## Summary

- Introduce `IHostDataSeedContributor` and `ITenantDataSeedContributor` interfaces, splitting the single `IDataSeedContributor` into explicit host/tenant roles
- `DataSeeder` now orchestrates three contributor types: host (once), tenant (per-tenant with automatic `ICurrentTenant.Change()` + scope), and legacy (backward compat)
- New `IDataSeedTenantProvider` abstraction decouples tenant enumeration from `ITenantEnumerator` (Migrations assembly)
- Migration runner simplified: `SeedHostAsync` → re-migrate per-tenant → `SeedTenantsAsync` (replaces fragile two-pass seed)
- Legacy `IDataSeedContributor` deprecated with `[Obsolete]` — still fully functional for backward compat

## Motivation

In SchemaPerTenant, every seeder had to manually call `ICurrentTenant.Change()` + `CreateAsyncScope()` + check `IsHostOnly`. This pattern was error-prone (forgotten scope = tables in `public`, forgotten `IsHostOnly` = `42P01` at pass 1). The Host/Tenant split follows the proven `IHostInternalDbContextEnsurer` / `ITenantInternalDbContextEnsurer` pattern already in the framework.

## Test plan

- [x] All 33 DataSeeder tests pass (including 15 new tests for `SeedHostAsync`/`SeedTenantsAsync`)
- [x] 4 new `TenantEnumeratorDataSeedTenantProvider` bridge tests pass
- [x] Registration tests verify new interfaces are not auto-registered by `AddGranitDataSeeding()`
- [x] Full solution build succeeds (128 packages)
- [x] All existing tests pass (no regressions)
- [ ] Showcase migration to new interfaces (separate PR in granit-showcase-dotnet)
- [ ] End-to-end cold start: host (57 tables), tenant_* (30 tables), public (empty)

Part of Epic #913
