### PR TITLE
feat(reference-data): multi-tenant scoping (Global + Tenant)

### DIFF
--- a/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataAdminEndpoints.cs
+++ b/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataAdminEndpoints.cs
@@ -2,6 +2,7 @@ using Granit.Domain;
 using Granit.Guids;
 using Granit.ReferenceData.Domain;
 using Granit.ReferenceData.Endpoints.Dtos;
+using Granit.ReferenceData.Endpoints.Internal;
 using Granit.ReferenceData.Endpoints.Permissions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -18,33 +19,44 @@ internal static class ReferenceDataAdminEndpoints
 {
     /// <summary>
     /// Registers POST /, PUT /{code}, and DELETE /{code} onto the given route group.
+    /// Admin endpoints are protected by a scope-based filter: Global types require host context,
+    /// Tenant types require tenant context.
     /// </summary>
     internal static RouteGroupBuilder MapAdminEndpoints<TEntity>(
-        this RouteGroupBuilder group)
+        this RouteGroupBuilder group,
+        ReferenceDataScope scope = ReferenceDataScope.Global)
         where TEntity : ReferenceDataEntity, new()
     {
+        ReferenceDataScopeEndpointFilter scopeFilter = new(scope);
+
         group.MapPost("/", CreateAsync<TEntity>)
+            .AddEndpointFilter(scopeFilter)
             .RequireAuthorization(ReferenceDataPermissions.Entries.Create)
             .WithName($"Create{typeof(TEntity).Name}")
             .WithSummary($"Creates a new {typeof(TEntity).Name} entry.")
             .WithDescription($"Creates a new {typeof(TEntity).Name} reference data entry with a unique code and localized labels for all supported languages. The entry is active by default. Optional validity date range can restrict when the entry is selectable.")
-            .Produces(StatusCodes.Status201Created);
+            .Produces(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status403Forbidden);
 
         group.MapPut("/{code}", UpdateAsync<TEntity>)
+            .AddEndpointFilter(scopeFilter)
             .RequireAuthorization(ReferenceDataPermissions.Entries.Manage)
             .WithName($"Update{typeof(TEntity).Name}")
             .WithSummary($"Updates an existing {typeof(TEntity).Name} entry.")
             .WithDescription($"Updates the labels, sort order, active status, and validity dates of an existing {typeof(TEntity).Name} entry. The code is immutable and cannot be changed. ExtraProperties use merge semantics: properties in the request are added or updated, properties not in the request are preserved. Returns 404 if no entry matches the code.")
             .Produces(StatusCodes.Status200OK)
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status403Forbidden);
 
         group.MapDelete("/{code}", DeactivateAsync<TEntity>)
+            .AddEndpointFilter(scopeFilter)
             .RequireAuthorization(ReferenceDataPermissions.Entries.Manage)
             .WithName($"Deactivate{typeof(TEntity).Name}")
             .WithSummary($"Deactivates a {typeof(TEntity).Name} entry (soft delete).")
             .WithDescription($"Sets the entry's active flag to false. Deactivated entries are excluded from default queries but remain in the database for referential integrity. Returns 404 if no entry matches the code.")
             .Produces(StatusCodes.Status204NoContent)
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status403Forbidden);
 
         return group;
     }

--- a/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataDynamicEndpoints.cs
+++ b/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataDynamicEndpoints.cs
@@ -57,35 +57,45 @@ internal static class ReferenceDataDynamicEndpoints
 
     /// <summary>
     /// Registers POST /, PUT /{code}, and DELETE /{code} for a dynamic reference data type.
+    /// Admin endpoints are protected by a scope-based filter.
     /// </summary>
     internal static RouteGroupBuilder MapDynamicAdminEndpoints(
         this RouteGroupBuilder group,
-        string typeName)
+        string typeName,
+        ReferenceDataScope scope = ReferenceDataScope.Global)
     {
+        ReferenceDataScopeEndpointFilter scopeFilter = new(scope);
+
         group.MapPost("/", CreateAsync)
+            .AddEndpointFilter(scopeFilter)
             .RequireAuthorization(ReferenceDataPermissions.Entries.Create)
             .WithName($"Create{typeName}")
             .WithSummary($"Creates a new {typeName} entry.")
             .WithDescription($"Creates a new {typeName} reference data entry with a unique code and localized labels.")
             .Produces(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
             .WithMetadata(new ReferenceDataTypeNameMetadata(typeName));
 
         group.MapPut("/{code}", UpdateAsync)
+            .AddEndpointFilter(scopeFilter)
             .RequireAuthorization(ReferenceDataPermissions.Entries.Manage)
             .WithName($"Update{typeName}")
             .WithSummary($"Updates an existing {typeName} entry.")
             .WithDescription($"Updates labels, sort order, active status, and validity dates. ExtraProperties use merge semantics: properties in the request are added or updated, properties not in the request are preserved. Returns 404 if not found.")
             .Produces(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
             .WithMetadata(new ReferenceDataTypeNameMetadata(typeName));
 
         group.MapDelete("/{code}", DeactivateAsync)
+            .AddEndpointFilter(scopeFilter)
             .RequireAuthorization(ReferenceDataPermissions.Entries.Manage)
             .WithName($"Deactivate{typeName}")
             .WithSummary($"Deactivates a {typeName} entry (soft delete).")
             .WithDescription($"Sets the entry's active flag to false. Returns 404 if not found.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
             .WithMetadata(new ReferenceDataTypeNameMetadata(typeName));
 
         return group;

--- a/src/Granit.ReferenceData.Endpoints/Extensions/ReferenceDataEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.ReferenceData.Endpoints/Extensions/ReferenceDataEndpointRouteBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Granit.ReferenceData.Domain;
 using Granit.ReferenceData.Endpoints.Endpoints;
+using Granit.ReferenceData.Endpoints.Internal;
 using Granit.ReferenceData.Endpoints.Options;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
@@ -19,6 +20,12 @@ public static class ReferenceDataEndpointRouteBuilderExtensions
     /// </summary>
     /// <typeparam name="TEntity">The concrete reference data entity type.</typeparam>
     /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="scope">
+    /// The multi-tenancy scope. Determines which admin operations are allowed based on
+    /// the current tenant context: <see cref="ReferenceDataScope.Global"/> entries can only
+    /// be managed from the host context, <see cref="ReferenceDataScope.Tenant"/> entries
+    /// can only be managed from a tenant context.
+    /// </param>
     /// <param name="configure">Optional delegate to customize <see cref="ReferenceDataEndpointsOptions"/>.</param>
     /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
     /// <remarks>
@@ -33,12 +40,13 @@ public static class ReferenceDataEndpointRouteBuilderExtensions
     /// </para>
     /// <para>Call from your application:</para>
     /// <code>
-    /// app.MapGranitReferenceData&lt;Country&gt;();
-    /// app.MapGranitReferenceData&lt;Currency&gt;(opts => opts.TagName = "Currencies");
+    /// app.MapGranitReferenceData&lt;Country&gt;(ReferenceDataScope.Global);
+    /// app.MapGranitReferenceData&lt;ProductCategory&gt;(ReferenceDataScope.Tenant);
     /// </code>
     /// </remarks>
     public static RouteGroupBuilder MapGranitReferenceData<TEntity>(
         this IEndpointRouteBuilder endpoints,
+        ReferenceDataScope scope = ReferenceDataScope.Global,
         Action<ReferenceDataEndpointsOptions>? configure = null)
         where TEntity : ReferenceDataEntity, new()
     {
@@ -52,7 +60,7 @@ public static class ReferenceDataEndpointRouteBuilderExtensions
             .WithTags(options.TagName);
 
         group.MapReadEndpoints<TEntity>();
-        group.MapAdminEndpoints<TEntity>();
+        group.MapAdminEndpoints<TEntity>(scope);
 
         return group;
     }
@@ -65,11 +73,13 @@ public static class ReferenceDataEndpointRouteBuilderExtensions
     /// The logical type name (e.g., <c>"Countries"</c>) as declared in
     /// <c>AddReferenceData&lt;TDbContext&gt;()</c>.
     /// </param>
+    /// <param name="scope">The multi-tenancy scope for this type.</param>
     /// <param name="configure">Optional delegate to customize <see cref="ReferenceDataEndpointsOptions"/>.</param>
     /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
     public static RouteGroupBuilder MapGranitReferenceData(
         this IEndpointRouteBuilder endpoints,
         string typeName,
+        ReferenceDataScope scope = ReferenceDataScope.Global,
         Action<ReferenceDataEndpointsOptions>? configure = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(typeName);
@@ -84,7 +94,7 @@ public static class ReferenceDataEndpointRouteBuilderExtensions
             .WithTags(options.TagName);
 
         group.MapDynamicReadEndpoints(typeName);
-        group.MapDynamicAdminEndpoints(typeName);
+        group.MapDynamicAdminEndpoints(typeName, scope);
 
         return group;
     }
@@ -104,7 +114,7 @@ public static class ReferenceDataEndpointRouteBuilderExtensions
 
         foreach (ReferenceDataTypeRegistration registration in registry.Types)
         {
-            endpoints.MapGranitReferenceData(registration.TypeName, configure);
+            endpoints.MapGranitReferenceData(registration.TypeName, registration.Scope, configure);
         }
 
         return endpoints;

--- a/src/Granit.ReferenceData.Endpoints/Internal/ReferenceDataScopeEndpointFilter.cs
+++ b/src/Granit.ReferenceData.Endpoints/Internal/ReferenceDataScopeEndpointFilter.cs
@@ -1,0 +1,36 @@
+using Granit.MultiTenancy;
+using Granit.ReferenceData.Domain;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.ReferenceData.Endpoints.Internal;
+
+/// <summary>
+/// Endpoint filter that enforces scope-based access control on reference data admin endpoints.
+/// <list type="bullet">
+/// <item><description><see cref="ReferenceDataScope.Global"/>: rejects requests from a tenant context (403).</description></item>
+/// <item><description><see cref="ReferenceDataScope.Tenant"/>: rejects requests from the host context (403).</description></item>
+/// </list>
+/// </summary>
+internal sealed class ReferenceDataScopeEndpointFilter(ReferenceDataScope scope) : IEndpointFilter
+{
+    public ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        ICurrentTenant currentTenant = context.HttpContext.RequestServices.GetRequiredService<ICurrentTenant>();
+
+        return scope switch
+        {
+            ReferenceDataScope.Global when currentTenant.IsAvailable =>
+                new ValueTask<object?>(TypedResults.Problem(
+                    detail: "Global reference data can only be managed from the host context.",
+                    statusCode: StatusCodes.Status403Forbidden)),
+
+            ReferenceDataScope.Tenant when !currentTenant.IsAvailable =>
+                new ValueTask<object?>(TypedResults.Problem(
+                    detail: "Tenant reference data can only be managed from a tenant context.",
+                    statusCode: StatusCodes.Status403Forbidden)),
+
+            _ => next(context),
+        };
+    }
+}

--- a/src/Granit.ReferenceData.Endpoints/Internal/ReferenceDataScopeMetadata.cs
+++ b/src/Granit.ReferenceData.Endpoints/Internal/ReferenceDataScopeMetadata.cs
@@ -1,0 +1,9 @@
+using Granit.ReferenceData.Domain;
+
+namespace Granit.ReferenceData.Endpoints.Internal;
+
+/// <summary>
+/// Endpoint metadata that stores the reference data scope for tenant context enforcement.
+/// </summary>
+/// <param name="Scope">The multi-tenancy scope declared for this reference data type.</param>
+internal sealed record ReferenceDataScopeMetadata(ReferenceDataScope Scope);

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Internal/EfCoreReferenceDataStore.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Internal/EfCoreReferenceDataStore.cs
@@ -1,3 +1,4 @@
+using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.QueryEngine;
 using Granit.ReferenceData.Domain;
@@ -17,23 +18,45 @@ namespace Granit.ReferenceData.EntityFrameworkCore.Internal;
 /// <typeparam name="TEntity">The concrete reference data entity type.</typeparam>
 /// <typeparam name="TDbContext">The host application's DbContext.</typeparam>
 /// <remarks>
+/// <para>
 /// Registered as Scoped. Uses <see cref="IServiceScopeFactory"/> to create
 /// a dedicated scope per database operation, ensuring correct EF Core lifetime.
+/// </para>
+/// <para>
+/// Multi-tenancy behavior depends on <see cref="ReferenceDataScope"/>:
+/// <list type="bullet">
+/// <item><description><see cref="ReferenceDataScope.Global"/>: bypasses the MultiTenant query filter
+/// and explicitly filters on <c>TenantId IS NULL</c>. Writes neutralize the tenant context
+/// via <see cref="ICurrentTenant.Change"/> to prevent the interceptor from injecting a TenantId.</description></item>
+/// <item><description><see cref="ReferenceDataScope.Tenant"/>: relies on the standard MultiTenant query filter
+/// for read isolation. The interceptor auto-injects the current tenant's ID on writes.</description></item>
+/// </list>
+/// </para>
 /// </remarks>
 internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
     IServiceScopeFactory scopeFactory,
     IFusionCache cache,
-    IOptions<ReferenceDataOptions> options) : IReferenceDataStoreReader<TEntity>, IReferenceDataStoreWriter<TEntity>
+    IOptions<ReferenceDataOptions> options,
+    ReferenceDataScope scope,
+    ICurrentTenant currentTenant) : IReferenceDataStoreReader<TEntity>, IReferenceDataStoreWriter<TEntity>
     where TEntity : ReferenceDataEntity
     where TDbContext : DbContext
 {
     private static readonly string EntityName = typeof(TEntity).Name;
-    private static string AllCacheKey => $"refdata:{EntityName}:all";
-    private static string CodeCacheKey(string code) => $"refdata:{EntityName}:{code}";
 
     private readonly IServiceScopeFactory _scopeFactory = scopeFactory;
     private readonly IFusionCache _cache = cache;
     private readonly ReferenceDataOptions _options = options.Value;
+    private readonly ReferenceDataScope _scope = scope;
+    private readonly ICurrentTenant _currentTenant = currentTenant;
+
+    private string AllCacheKey => _scope == ReferenceDataScope.Global
+        ? $"refdata:{EntityName}:host:all"
+        : $"refdata:{EntityName}:t:{_currentTenant.Id}:all";
+
+    private string CodeCacheKey(string code) => _scope == ReferenceDataScope.Global
+        ? $"refdata:{EntityName}:host:{code}"
+        : $"refdata:{EntityName}:t:{_currentTenant.Id}:{code}";
 
     /// <inheritdoc/>
     public async Task<PagedResult<TEntity>> GetAllAsync(
@@ -46,6 +69,17 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
         query ??= new ReferenceDataQuery();
 
         IQueryable<TEntity> queryable = context.Set<TEntity>().AsNoTracking();
+
+        // Scope-aware tenant filtering
+        if (_scope == ReferenceDataScope.Global)
+        {
+            // Global data has TenantId=null; bypass the auto MultiTenant filter
+            // and explicitly filter for null TenantId.
+            queryable = queryable
+                .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+                .Where(e => e.TenantId == null);
+        }
+        // Tenant scope: the standard MultiTenant query filter handles isolation automatically.
 
         // Active filter
         if (query.ActiveOnly)
@@ -120,8 +154,16 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
         await using AsyncServiceScope scope = _scopeFactory.CreateAsyncScope();
         TDbContext context = scope.ServiceProvider.GetRequiredService<TDbContext>();
 
-        TEntity? entity = await context.Set<TEntity>()
-            .AsNoTracking()
+        IQueryable<TEntity> queryable = context.Set<TEntity>().AsNoTracking();
+
+        if (_scope == ReferenceDataScope.Global)
+        {
+            queryable = queryable
+                .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+                .Where(e => e.TenantId == null);
+        }
+
+        TEntity? entity = await queryable
             .FirstOrDefaultAsync(e => e.Code == code, cancellationToken).ConfigureAwait(false);
 
         if (entity is not null)
@@ -135,15 +177,20 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
     /// <inheritdoc/>
     public async Task CreateAsync(TEntity entity, CancellationToken cancellationToken = default)
     {
-        await using AsyncServiceScope scope = _scopeFactory.CreateAsyncScope();
-        TDbContext context = scope.ServiceProvider.GetRequiredService<TDbContext>();
+        // For Global scope, neutralize the tenant context so that AuditedEntityInterceptor
+        // does not auto-inject a TenantId. TenantId must remain null for global entries.
+        using IDisposable? tenantOverride = _scope == ReferenceDataScope.Global
+            ? _currentTenant.Change(null)
+            : null;
 
-        // Bypass the Active filter so inactive records are detected, preventing a
-        // duplicate-key error when the seeder runs a second time against an existing
-        // (possibly inactive) entry with the same Code.
+        await using AsyncServiceScope serviceScope = _scopeFactory.CreateAsyncScope();
+        TDbContext context = serviceScope.ServiceProvider.GetRequiredService<TDbContext>();
+
+        // Bypass Active and MultiTenant filters so inactive and cross-tenant records are
+        // detected, preventing a duplicate-key error when the seeder runs a second time.
         bool exists = await context.Set<TEntity>()
-            .IgnoreQueryFilters([GranitFilterNames.Active])
-            .AnyAsync(e => e.Code == entity.Code, cancellationToken)
+            .IgnoreQueryFilters([GranitFilterNames.Active, GranitFilterNames.MultiTenant])
+            .AnyAsync(DuplicateCheck(entity.Code), cancellationToken)
             .ConfigureAwait(false);
 
         if (exists)
@@ -166,8 +213,8 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
             TDbContext verifyContext = verifyScope.ServiceProvider.GetRequiredService<TDbContext>();
 
             bool concurrentInsert = await verifyContext.Set<TEntity>()
-                .IgnoreQueryFilters([GranitFilterNames.Active])
-                .AnyAsync(e => e.Code == entity.Code, cancellationToken)
+                .IgnoreQueryFilters([GranitFilterNames.Active, GranitFilterNames.MultiTenant])
+                .AnyAsync(DuplicateCheck(entity.Code), cancellationToken)
                 .ConfigureAwait(false);
 
             if (!concurrentInsert)
@@ -201,19 +248,22 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
         bool isActive,
         CancellationToken cancellationToken = default)
     {
-        await using AsyncServiceScope scope = _scopeFactory.CreateAsyncScope();
-        TDbContext context = scope.ServiceProvider.GetRequiredService<TDbContext>();
+        await using AsyncServiceScope serviceScope = _scopeFactory.CreateAsyncScope();
+        TDbContext context = serviceScope.ServiceProvider.GetRequiredService<TDbContext>();
 
-        // Bypass the Active filter so inactive records can be found and reactivated.
-        TEntity? entity = await context.Set<TEntity>()
-            .IgnoreQueryFilters([GranitFilterNames.Active])
-            .FirstOrDefaultAsync(e => e.Code == code, cancellationToken).ConfigureAwait(false);
+        // Bypass Active filter so inactive records can be found and reactivated.
+        // Also bypass MultiTenant for Global scope where no tenant context is active.
+        IQueryable<TEntity> queryable = context.Set<TEntity>()
+            .IgnoreQueryFilters([GranitFilterNames.Active, GranitFilterNames.MultiTenant]);
+
+        TEntity? entity = _scope == ReferenceDataScope.Global
+            ? await queryable.FirstOrDefaultAsync(e => e.Code == code && e.TenantId == null, cancellationToken).ConfigureAwait(false)
+            : await queryable.FirstOrDefaultAsync(e => e.Code == code && e.TenantId == _currentTenant.Id, cancellationToken).ConfigureAwait(false);
 
         if (entity is not null)
         {
             entity.IsActive = isActive;
             await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-
         }
 
         InvalidateCache(code);
@@ -224,11 +274,19 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
         string? parentCode,
         CancellationToken cancellationToken = default)
     {
-        await using AsyncServiceScope scope = _scopeFactory.CreateAsyncScope();
-        TDbContext context = scope.ServiceProvider.GetRequiredService<TDbContext>();
+        await using AsyncServiceScope serviceScope = _scopeFactory.CreateAsyncScope();
+        TDbContext context = serviceScope.ServiceProvider.GetRequiredService<TDbContext>();
 
-        List<TEntity> children = await context.Set<TEntity>()
-            .AsNoTracking()
+        IQueryable<TEntity> queryable = context.Set<TEntity>().AsNoTracking();
+
+        if (_scope == ReferenceDataScope.Global)
+        {
+            queryable = queryable
+                .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+                .Where(e => e.TenantId == null);
+        }
+
+        List<TEntity> children = await queryable
             .Where(e => e.ParentCode == parentCode && e.IsActive)
             .OrderBy(e => e.SortOrder)
             .ThenBy(e => e.Code)
@@ -237,6 +295,15 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
 
         return children;
     }
+
+    /// <summary>
+    /// Returns a scope-aware duplicate predicate: for Global checks Code only (TenantId=null),
+    /// for Tenant checks Code + current TenantId.
+    /// </summary>
+    private System.Linq.Expressions.Expression<Func<TEntity, bool>> DuplicateCheck(string code) =>
+        _scope == ReferenceDataScope.Global
+            ? e => e.Code == code && e.TenantId == null
+            : e => e.Code == code && e.TenantId == _currentTenant.Id;
 
     private void InvalidateCache(string code)
     {

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataEntityTypeConfiguration.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataEntityTypeConfiguration.cs
@@ -35,14 +35,21 @@ public abstract class ReferenceDataEntityTypeConfiguration<TEntity>
     where TEntity : ReferenceDataEntity
 {
     private readonly string _tableName;
+    private readonly ReferenceDataScope _scope;
 
     /// <summary>
-    /// Initializes a new instance with the specified table name.
+    /// Initializes a new instance with the specified table name and multi-tenancy scope.
     /// </summary>
     /// <param name="tableName">The database table name (e.g., "ref_countries").</param>
-    protected ReferenceDataEntityTypeConfiguration(string tableName)
+    /// <param name="scope">
+    /// The multi-tenancy scope. <see cref="ReferenceDataScope.Global"/> uses a unique index on
+    /// <c>Code</c> alone; <see cref="ReferenceDataScope.Tenant"/> uses a composite index on
+    /// <c>(Code, TenantId)</c>.
+    /// </param>
+    protected ReferenceDataEntityTypeConfiguration(string tableName, ReferenceDataScope scope = ReferenceDataScope.Global)
     {
         _tableName = tableName;
+        _scope = scope;
     }
 
     /// <inheritdoc/>
@@ -52,14 +59,26 @@ public abstract class ReferenceDataEntityTypeConfiguration<TEntity>
 
         builder.HasKey(e => e.Id);
 
-        // Business key — unique
+        // TenantId — nullable for IMultiTenant support
+        builder.Property(e => e.TenantId);
+
+        // Business key — unique constraint depends on scope
         builder.Property(e => e.Code)
                .HasMaxLength(50)
                .IsRequired();
 
-        builder.HasIndex(e => e.Code)
-               .IsUnique()
-               .HasDatabaseName($"uq_{_tableName}_code");
+        if (_scope == ReferenceDataScope.Tenant)
+        {
+            builder.HasIndex(e => new { e.Code, e.TenantId })
+                   .IsUnique()
+                   .HasDatabaseName($"uq_{_tableName}_code_tenant");
+        }
+        else
+        {
+            builder.HasIndex(e => e.Code)
+                   .IsUnique()
+                   .HasDatabaseName($"uq_{_tableName}_code");
+        }
 
         // Label (not mapped — virtual property)
         builder.Ignore(e => e.Label);

--- a/src/Granit.ReferenceData/Domain/ReferenceDataEntity.cs
+++ b/src/Granit.ReferenceData/Domain/ReferenceDataEntity.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 
 using Granit.Domain;
+using Granit.MultiTenancy;
 
 namespace Granit.ReferenceData.Domain;
 
@@ -28,8 +29,11 @@ namespace Granit.ReferenceData.Domain;
 /// <c>ExtraPropertyMappingOptions&lt;T&gt;.MapProperty()</c> for indexing and querying.
 /// </para>
 /// </remarks>
-public abstract class ReferenceDataEntity : AuditedEntity, IActive, IHasExtraProperties, IEmitEntityLifecycleEvents
+public abstract class ReferenceDataEntity : AuditedEntity, IActive, IHasExtraProperties, IEmitEntityLifecycleEvents, IMultiTenant
 {
+    /// <inheritdoc/>
+    public Guid? TenantId { get; set; }
+
     /// <summary>
     /// Unique business key for the reference data entry (e.g., "BE", "EUR", "fr").
     /// Immutable after creation. Used as the lookup key in APIs and seeders.

--- a/src/Granit.ReferenceData/Domain/ReferenceDataScope.cs
+++ b/src/Granit.ReferenceData/Domain/ReferenceDataScope.cs
@@ -1,0 +1,22 @@
+namespace Granit.ReferenceData.Domain;
+
+/// <summary>
+/// Defines the multi-tenancy scope of a reference data type.
+/// Controls query filtering, unique constraints, cache isolation, and admin authorization.
+/// </summary>
+public enum ReferenceDataScope
+{
+    /// <summary>
+    /// Data shared across all tenants, managed by the host administrator.
+    /// <c>TenantId</c> is always <see langword="null"/>. Unique constraint on <c>Code</c> alone.
+    /// Tenants can read but not create, update, or deactivate entries.
+    /// </summary>
+    Global = 0,
+
+    /// <summary>
+    /// Data isolated per tenant, managed by the tenant administrator.
+    /// <c>TenantId</c> is always set to the current tenant. Unique constraint on
+    /// <c>(Code, TenantId)</c> — different tenants can use the same code independently.
+    /// </summary>
+    Tenant = 1,
+}

--- a/src/Granit.ReferenceData/Options/ReferenceDataExtensionOptions.cs
+++ b/src/Granit.ReferenceData/Options/ReferenceDataExtensionOptions.cs
@@ -21,6 +21,12 @@ namespace Granit.ReferenceData.Options;
 public sealed class ReferenceDataExtensionOptions
 {
     /// <summary>
+    /// Gets or sets the multi-tenancy scope for this reference data type.
+    /// Defaults to <see cref="ReferenceDataScope.Global"/> (shared across all tenants).
+    /// </summary>
+    public ReferenceDataScope Scope { get; set; } = ReferenceDataScope.Global;
+
+    /// <summary>
     /// Gets or sets the database table name for this reference data type.
     /// </summary>
     public string TableName { get; set; } = "ref_data";
@@ -55,6 +61,17 @@ public sealed class ReferenceDataExtensionOptions
     public ReferenceDataExtensionOptions Hierarchical()
     {
         IsHierarchical = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the multi-tenancy scope for this reference data type.
+    /// </summary>
+    /// <param name="scope">The scope to apply.</param>
+    /// <returns>This options instance for chaining.</returns>
+    public ReferenceDataExtensionOptions WithScope(ReferenceDataScope scope)
+    {
+        Scope = scope;
         return this;
     }
 

--- a/src/Granit.ReferenceData/ReferenceDataTypeRegistration.cs
+++ b/src/Granit.ReferenceData/ReferenceDataTypeRegistration.cs
@@ -1,3 +1,4 @@
+using Granit.ReferenceData.Domain;
 using Granit.ReferenceData.Options;
 
 namespace Granit.ReferenceData;
@@ -13,4 +14,10 @@ namespace Granit.ReferenceData;
 /// <param name="Options">The extension options declared via the fluent builder.</param>
 public sealed record ReferenceDataTypeRegistration(
     string TypeName,
-    ReferenceDataExtensionOptions Options);
+    ReferenceDataExtensionOptions Options)
+{
+    /// <summary>
+    /// Multi-tenancy scope declared for this reference data type.
+    /// </summary>
+    public ReferenceDataScope Scope => Options.Scope;
+}

--- a/tests/Granit.ReferenceData.Endpoints.Tests/ReferenceDataEndpointsTests.cs
+++ b/tests/Granit.ReferenceData.Endpoints.Tests/ReferenceDataEndpointsTests.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using Granit.Guids;
+using Granit.MultiTenancy;
 using Granit.QueryEngine;
 using Granit.ReferenceData.Domain;
 using Granit.ReferenceData.Endpoints.Dtos;
@@ -61,6 +62,12 @@ public sealed class ReferenceDataEndpointsTests : IAsyncDisposable
         builder.Services.AddSingleton(_storeReader);
         builder.Services.AddSingleton(_storeWriter);
         builder.Services.AddSingleton<IGuidGenerator>(new SimpleGuidGenerator());
+
+        // ICurrentTenant is required by ReferenceDataScopeEndpointFilter.
+        // Default scope is Global, so IsAvailable must return false (host context).
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.IsAvailable.Returns(false);
+        builder.Services.AddSingleton(currentTenant);
 
         _app = builder.Build();
         _app.MapGranitReferenceData<TestRefEntity>();

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreAdditionalTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreAdditionalTests.cs
@@ -1,10 +1,13 @@
+using Granit.MultiTenancy;
 using Granit.QueryEngine;
+using Granit.ReferenceData.Domain;
 using Granit.ReferenceData.EntityFrameworkCore.Extensions;
 using Granit.ReferenceData.EntityFrameworkCore.Internal;
 using Granit.ReferenceData.Options;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 using ZiggyCreatures.Caching.Fusion;
@@ -47,7 +50,9 @@ public sealed class EfCoreReferenceDataStoreAdditionalTests
         return new EfCoreReferenceDataStore<TestEntity, TestDbContext>(
             sp.GetRequiredService<IServiceScopeFactory>(),
             cache,
-            options);
+            options,
+            ReferenceDataScope.Global,
+            Substitute.For<ICurrentTenant>());
     }
 
     private static async Task SeedAsync(
@@ -341,7 +346,7 @@ public sealed class EfCoreReferenceDataStoreAdditionalTests
         ServiceProvider sp = services.BuildServiceProvider();
         IServiceScopeFactory scopeFactory = sp.GetRequiredService<IServiceScopeFactory>();
 
-        EfCoreReferenceDataStore<TestEntity, TestDbContext> store = new(scopeFactory, cache, opts);
+        EfCoreReferenceDataStore<TestEntity, TestDbContext> store = new(scopeFactory, cache, opts, ReferenceDataScope.Global, Substitute.For<ICurrentTenant>());
 
         // Create entity
         TestEntity entity = new()
@@ -364,7 +369,7 @@ public sealed class EfCoreReferenceDataStoreAdditionalTests
         await store.UpdateAsync(cached, TestContext.Current.CancellationToken);
 
         // Re-fetch — should get updated value
-        EfCoreReferenceDataStore<TestEntity, TestDbContext> freshStore = new(scopeFactory, cache, opts);
+        EfCoreReferenceDataStore<TestEntity, TestDbContext> freshStore = new(scopeFactory, cache, opts, ReferenceDataScope.Global, Substitute.For<ICurrentTenant>());
         TestEntity? updated = await freshStore.GetByCodeAsync("BE", TestContext.Current.CancellationToken);
 
         updated!.LabelEn.ShouldBe("Kingdom of Belgium");

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreConcurrencyTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreConcurrencyTests.cs
@@ -1,3 +1,5 @@
+using Granit.MultiTenancy;
+using Granit.ReferenceData.Domain;
 using Granit.ReferenceData.EntityFrameworkCore.Extensions;
 using Granit.ReferenceData.EntityFrameworkCore.Internal;
 using Granit.ReferenceData.Options;
@@ -6,6 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 using ZiggyCreatures.Caching.Fusion;
@@ -116,7 +119,9 @@ public sealed class EfCoreReferenceDataStoreConcurrencyTests : IAsyncLifetime
     private static EfCoreReferenceDataStore<TestEntity, TestDbContext> CreateStore(IServiceScopeFactory scopeFactory) =>
         new(scopeFactory,
             new FusionCache(new FusionCacheOptions()),
-            Microsoft.Extensions.Options.Options.Create(new ReferenceDataOptions()));
+            Microsoft.Extensions.Options.Options.Create(new ReferenceDataOptions()),
+            ReferenceDataScope.Global,
+            Substitute.For<ICurrentTenant>());
 
     [Fact]
     public async Task CreateAsync_ConcurrentInsert_RecoveredGracefully()

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreTests.cs
@@ -1,10 +1,13 @@
+using Granit.MultiTenancy;
 using Granit.QueryEngine;
+using Granit.ReferenceData.Domain;
 using Granit.ReferenceData.EntityFrameworkCore.Extensions;
 using Granit.ReferenceData.EntityFrameworkCore.Internal;
 using Granit.ReferenceData.Options;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 using ZiggyCreatures.Caching.Fusion;
@@ -47,7 +50,9 @@ public sealed class EfCoreReferenceDataStoreTests
         return new EfCoreReferenceDataStore<TestEntity, TestDbContext>(
             sp.GetRequiredService<IServiceScopeFactory>(),
             cache,
-            options);
+            options,
+            ReferenceDataScope.Global,
+            Substitute.For<ICurrentTenant>());
     }
 
     private static async Task SeedAsync(
@@ -361,7 +366,7 @@ public sealed class EfCoreReferenceDataStoreTests
         ServiceProvider sp = services.BuildServiceProvider();
         IServiceScopeFactory scopeFactory = sp.GetRequiredService<IServiceScopeFactory>();
 
-        EfCoreReferenceDataStore<TestEntity, TestDbContext> store = new(scopeFactory, cache, opts);
+        EfCoreReferenceDataStore<TestEntity, TestDbContext> store = new(scopeFactory, cache, opts, ReferenceDataScope.Global, Substitute.For<ICurrentTenant>());
 
         // Populate cache by querying
         await store.GetByCodeAsync("DE", TestContext.Current.CancellationToken);

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEfCoreServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEfCoreServiceCollectionExtensionsTests.cs
@@ -1,9 +1,11 @@
+using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore.DataSeeding;
 using Granit.ReferenceData.EntityFrameworkCore.Extensions;
 using Granit.ReferenceData.Options;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 using ZiggyCreatures.Caching.Fusion;
@@ -39,6 +41,7 @@ public sealed class ReferenceDataEfCoreServiceCollectionExtensionsTests
         services.AddSingleton<IOptions<ReferenceDataOptions>>(
             Microsoft.Extensions.Options.Options.Create(new ReferenceDataOptions()));
         services.AddLogging();
+        services.AddSingleton(Substitute.For<ICurrentTenant>());
         services.AddReferenceDataStore<TestEntity, TestDbContext>();
 
         return services.BuildServiceProvider();


### PR DESCRIPTION
## Summary

- Add `ReferenceDataScope` enum (`Global`, `Tenant`) to control multi-tenancy behavior per reference data type
- `ReferenceDataEntity` now implements `IMultiTenant` with nullable `TenantId`
- Global scope: bypasses MultiTenant filter, `UNIQUE(Code)`, host admin only, cache key `refdata:{type}:host:*`
- Tenant scope: standard MultiTenant filter, `UNIQUE(Code, TenantId)`, tenant admin only, cache key `refdata:{type}:t:{tenantId}:*`
- `ReferenceDataScopeEndpointFilter` returns 403 on scope/context mismatch
- Store uses `ICurrentTenant.Change(null)` to neutralize TenantId injection on Global writes

## API Changes

```csharp
// Strongly-typed registration
services.AddReferenceDataStore<Country, AppDbContext>(ReferenceDataScope.Global);
services.AddReferenceDataStore<ProductCategory, AppDbContext>(ReferenceDataScope.Tenant);

// Dynamic registration
services.AddReferenceData<AppDbContext>(rd =>
{
    rd.Add("Countries", opts => opts.Table("ref_countries").WithScope(ReferenceDataScope.Global));
    rd.Add("Tags", opts => opts.Table("ref_tags").WithScope(ReferenceDataScope.Tenant));
});

// EF Configuration
public CountryConfiguration() : base("ref_countries", ReferenceDataScope.Global) { }
public ProductCategoryConfiguration() : base("ref_product_categories", ReferenceDataScope.Tenant) { }

// Endpoint mapping
app.MapGranitReferenceData<Country>(ReferenceDataScope.Global);
app.MapGranitReferenceData<ProductCategory>(ReferenceDataScope.Tenant);
```

## Test plan

- [x] 85 unit tests pass (Granit.ReferenceData.Tests)
- [x] 73 EF Core tests pass (existing + scope-aware constructor)
- [x] 106 endpoint tests pass (existing + ICurrentTenant mock)
- [x] 101 architecture tests pass
- [x] `dotnet format --verify-no-changes` clean
- [ ] Showcase adaptation (separate commit)
