### PR TITLE
fix(reference-data): rename local variables shadowing primary ctor param

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -17428,12 +17428,12 @@
       "kind": "class",
       "project": "Granit.Identity.Local.Notifications",
       "file": "src/Granit.Identity.Local.Notifications/Handlers/EmailChangeRequestedHandler.cs",
-      "line": 18,
+      "line": 19,
       "members": [
         {
           "name": "HandleAsync",
           "kind": "method",
-          "signature": "HandleAsync(EmailChangeRequestedEto evt, IOptions<IdentityNotificationOptions> options, INotificationPublisher publisher, CancellationToken cancellationToken)",
+          "signature": "HandleAsync(EmailChangeRequestedEto evt, IOptions<IdentityNotificationOptions> options, INotificationPublisher publisher, ITenantUrlResolver? urlResolver = null, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         }
       ]
@@ -17444,12 +17444,12 @@
       "kind": "class",
       "project": "Granit.Identity.Local.Notifications",
       "file": "src/Granit.Identity.Local.Notifications/Handlers/EmailConfirmationRequestedHandler.cs",
-      "line": 13,
+      "line": 14,
       "members": [
         {
           "name": "HandleAsync",
           "kind": "method",
-          "signature": "HandleAsync(EmailConfirmationRequestedEto evt, IIdentityUserReader userReader, IOptions<IdentityNotificationOptions> options, INotificationPublisher publisher, CancellationToken cancellationToken)",
+          "signature": "HandleAsync(EmailConfirmationRequestedEto evt, IIdentityUserReader userReader, IOptions<IdentityNotificationOptions> options, INotificationPublisher publisher, ITenantUrlResolver? urlResolver = null, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         }
       ]
@@ -17476,12 +17476,12 @@
       "kind": "class",
       "project": "Granit.Identity.Local.Notifications",
       "file": "src/Granit.Identity.Local.Notifications/Handlers/PasswordResetRequestedHandler.cs",
-      "line": 13,
+      "line": 14,
       "members": [
         {
           "name": "HandleAsync",
           "kind": "method",
-          "signature": "HandleAsync(PasswordResetRequestedEto evt, IOptions<IdentityNotificationOptions> options, INotificationPublisher publisher, CancellationToken cancellationToken)",
+          "signature": "HandleAsync(PasswordResetRequestedEto evt, IOptions<IdentityNotificationOptions> options, INotificationPublisher publisher, ITenantUrlResolver? urlResolver = null, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         }
       ]
@@ -17888,15 +17888,33 @@
           "returnType": "string"
         },
         {
+          "name": "BuildResetPasswordUrl",
+          "kind": "method",
+          "signature": "BuildResetPasswordUrl(string baseUrl, string userId, string token)",
+          "returnType": "string"
+        },
+        {
           "name": "BuildConfirmEmailUrl",
           "kind": "method",
           "signature": "BuildConfirmEmailUrl(string userId, string token)",
           "returnType": "string"
         },
         {
+          "name": "BuildConfirmEmailUrl",
+          "kind": "method",
+          "signature": "BuildConfirmEmailUrl(string baseUrl, string userId, string token)",
+          "returnType": "string"
+        },
+        {
           "name": "BuildChangeEmailUrl",
           "kind": "method",
           "signature": "BuildChangeEmailUrl(string userId, string newEmail, string token)",
+          "returnType": "string"
+        },
+        {
+          "name": "BuildChangeEmailUrl",
+          "kind": "method",
+          "signature": "BuildChangeEmailUrl(string baseUrl, string userId, string newEmail, string token)",
           "returnType": "string"
         }
       ]
@@ -22046,6 +22064,12 @@
           "returnType": "string?"
         },
         {
+          "name": "CustomDomain",
+          "kind": "property",
+          "signature": "string? CustomDomain",
+          "returnType": "string?"
+        },
+        {
           "name": "Create",
           "kind": "method",
           "signature": "Create(Guid id, string name, string identifier, string? contactEmail = null, string? jurisdiction = null)",
@@ -22129,6 +22153,15 @@
       "members": []
     },
     {
+      "name": "TenantCustomDomainChangedEvent",
+      "fqn": "Granit.MultiTenancy.Events.TenantCustomDomainChangedEvent",
+      "kind": "record",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/Events/TenantCustomDomainChangedEvent.cs",
+      "line": 12,
+      "members": []
+    },
+    {
       "name": "TenantDeactivatedEvent",
       "fqn": "Granit.MultiTenancy.Events.TenantDeactivatedEvent",
       "kind": "record",
@@ -22168,7 +22201,7 @@
       "kind": "class",
       "project": "Granit.MultiTenancy",
       "file": "src/Granit.MultiTenancy/Extensions/MultiTenancyServiceCollectionExtensions.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitMultiTenancy",
@@ -22218,6 +22251,22 @@
       "file": "src/Granit.MultiTenancy/ITenantInfo.cs",
       "line": 6,
       "members": []
+    },
+    {
+      "name": "ITenantUrlResolver",
+      "fqn": "Granit.MultiTenancy.ITenantUrlResolver",
+      "kind": "interface",
+      "project": "Granit",
+      "file": "src/Granit/MultiTenancy/ITenantUrlResolver.cs",
+      "line": 33,
+      "members": [
+        {
+          "name": "ResolveBaseUrlAsync",
+          "kind": "method",
+          "signature": "ResolveBaseUrlAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<string>"
+        }
+      ]
     },
     {
       "name": "TenantResolutionMiddleware",
@@ -22272,6 +22321,18 @@
           "kind": "property",
           "signature": "string? DomainTemplate",
           "returnType": "string?"
+        },
+        {
+          "name": "QueryStringParamName",
+          "kind": "property",
+          "signature": "string? QueryStringParamName",
+          "returnType": "string?"
+        },
+        {
+          "name": "UrlScheme",
+          "kind": "property",
+          "signature": "string UrlScheme",
+          "returnType": "string"
         }
       ]
     },
@@ -22313,6 +22374,28 @@
           "kind": "method",
           "signature": "ResolveAsync(HttpContext context, CancellationToken cancellationToken = default)",
           "returnType": "Task<TenantResolutionResult>"
+        }
+      ]
+    },
+    {
+      "name": "CustomDomainTenantResolver",
+      "fqn": "Granit.MultiTenancy.Resolvers.CustomDomainTenantResolver",
+      "kind": "class",
+      "project": "Granit.MultiTenancy",
+      "file": "src/Granit.MultiTenancy/Resolvers/CustomDomainTenantResolver.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "Order",
+          "kind": "property",
+          "signature": "int Order",
+          "returnType": "int"
+        },
+        {
+          "name": "ResolveAsync",
+          "kind": "method",
+          "signature": "ResolveAsync(HttpContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TenantInfo?>"
         }
       ]
     },
@@ -22441,6 +22524,12 @@
           "returnType": "Task<TenantData?>"
         },
         {
+          "name": "FindByCustomDomainAsync",
+          "kind": "method",
+          "signature": "FindByCustomDomainAsync(string customDomain, CancellationToken cancellationToken = default)",
+          "returnType": "Task<TenantData?>"
+        },
+        {
           "name": "GetAllAsync",
           "kind": "method",
           "signature": "GetAllAsync(CancellationToken cancellationToken = default)",
@@ -22494,7 +22583,7 @@
       "kind": "record",
       "project": "Granit.MultiTenancy",
       "file": "src/Granit.MultiTenancy/Stores/TenantData.cs",
-      "line": 15,
+      "line": 16,
       "members": []
     },
     {
@@ -22503,6 +22592,15 @@
       "kind": "record",
       "project": "Granit.MultiTenancy",
       "file": "src/Granit.MultiTenancy/TenantInfo.cs",
+      "line": 6,
+      "members": []
+    },
+    {
+      "name": "TenantUrlStrategy",
+      "fqn": "Granit.MultiTenancy.TenantUrlStrategy",
+      "kind": "enum",
+      "project": "Granit",
+      "file": "src/Granit/MultiTenancy/TenantUrlStrategy.cs",
       "line": 6,
       "members": []
     },

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -29613,6 +29613,22 @@
       ]
     },
     {
+      "name": "IsolatedDbContextMarker",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.MultiTenancy.IsolatedDbContextMarker",
+      "kind": "class",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/IsolatedDbContextMarker.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "DbContextType",
+          "kind": "property",
+          "signature": "Type DbContextType",
+          "returnType": "Type"
+        }
+      ]
+    },
+    {
       "name": "TenantIsolationOptions",
       "fqn": "Granit.Persistence.EntityFrameworkCore.MultiTenancy.TenantIsolationOptions",
       "kind": "class",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -28698,7 +28698,7 @@
       "kind": "interface",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/DataSeeding/IDataSeedContributor.cs",
-      "line": 27,
+      "line": 24,
       "members": [
         {
           "name": "SeedAsync",

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
@@ -211,25 +211,8 @@ internal static partial class AccountLoginEndpoints
         // GetTwoFactorAuthenticationUserAsync internally calls FindByIdAsync which is subject to
         // the multi-tenant query filter. When no tenant is resolved, disable the filter to find
         // the user, then establish the tenant context for the rest of the handler.
-        IDisposable? tenantScope = null;
-        if (currentTenant is { IsAvailable: false })
-        {
-            IDisposable? filterScope = dataFilter?.Disable<IMultiTenant>();
-            try
-            {
-                GranitUser? twoFactorUser = await signInManager.GetTwoFactorAuthenticationUserAsync()
-                    .ConfigureAwait(false);
-
-                if (twoFactorUser?.TenantId is not null)
-                {
-                    tenantScope = currentTenant.Change(twoFactorUser.TenantId);
-                }
-            }
-            finally
-            {
-                filterScope?.Dispose();
-            }
-        }
+        IDisposable? tenantScope = await ResolveTenantFromTwoFactorSessionAsync(
+            signInManager, currentTenant, dataFilter).ConfigureAwait(false);
 
         try
         {
@@ -310,6 +293,31 @@ internal static partial class AccountLoginEndpoints
         {
             tenantScope?.Dispose();
         }
+    }
+
+    /// <summary>
+    /// Resolves the tenant context from the 2FA session cookie when no tenant is active.
+    /// Returns an <see cref="IDisposable"/> that restores the previous tenant on dispose,
+    /// or <c>null</c> if no tenant switch was needed.
+    /// </summary>
+    private static async Task<IDisposable?> ResolveTenantFromTwoFactorSessionAsync(
+        SignInManager<GranitUser> signInManager,
+        ICurrentTenant? currentTenant,
+        IDataFilter? dataFilter)
+    {
+        if (currentTenant is not { IsAvailable: false })
+        {
+            return null;
+        }
+
+        using IDisposable? filterScope = dataFilter?.Disable<IMultiTenant>();
+
+        GranitUser? twoFactorUser = await signInManager.GetTwoFactorAuthenticationUserAsync()
+            .ConfigureAwait(false);
+
+        return twoFactorUser?.TenantId is not null
+            ? currentTenant.Change(twoFactorUser.TenantId)
+            : null;
     }
 
     // ──── Timing attack mitigation ────

--- a/src/Granit.Identity.Local.Notifications/Handlers/EmailChangeRequestedHandler.cs
+++ b/src/Granit.Identity.Local.Notifications/Handlers/EmailChangeRequestedHandler.cs
@@ -1,6 +1,7 @@
 using Granit.Identity.Local.Events;
 using Granit.Identity.Local.Notifications.NotificationTypes;
 using Granit.Identity.Local.Notifications.Options;
+using Granit.MultiTenancy;
 using Granit.Notifications;
 using Granit.Notifications.Abstractions;
 using Microsoft.Extensions.Options;
@@ -21,7 +22,8 @@ public class EmailChangeRequestedHandler
         EmailChangeRequestedEto evt,
         IOptions<IdentityNotificationOptions> options,
         INotificationPublisher publisher,
-        CancellationToken cancellationToken)
+        ITenantUrlResolver? urlResolver = null,
+        CancellationToken cancellationToken = default)
     {
         string userId = evt.UserId.ToString();
 
@@ -34,8 +36,13 @@ public class EmailChangeRequestedHandler
 
         // Confirmation to the new email — override recipient so the email
         // goes to the new address, not the one currently on file.
-        string confirmLink = options.Value.BuildChangeEmailUrl(
-            userId, evt.NewEmail, evt.Token);
+        IdentityNotificationOptions opts = options.Value;
+        string baseUrl = urlResolver is not null
+            ? await urlResolver.ResolveBaseUrlAsync(cancellationToken).ConfigureAwait(false)
+            : opts.FrontendBaseUrl;
+
+        string confirmLink = opts.BuildChangeEmailUrl(
+            baseUrl, userId, evt.NewEmail, evt.Token);
 
         await publisher.PublishAsync(
             EmailChangeConfirmationNotificationType.Instance,

--- a/src/Granit.Identity.Local.Notifications/Handlers/EmailConfirmationRequestedHandler.cs
+++ b/src/Granit.Identity.Local.Notifications/Handlers/EmailConfirmationRequestedHandler.cs
@@ -1,6 +1,7 @@
 using Granit.Identity.Local.Events;
 using Granit.Identity.Local.Notifications.NotificationTypes;
 using Granit.Identity.Local.Notifications.Options;
+using Granit.MultiTenancy;
 using Granit.Notifications.Abstractions;
 using Microsoft.Extensions.Options;
 
@@ -17,7 +18,8 @@ public class EmailConfirmationRequestedHandler
         IIdentityUserReader userReader,
         IOptions<IdentityNotificationOptions> options,
         INotificationPublisher publisher,
-        CancellationToken cancellationToken)
+        ITenantUrlResolver? urlResolver = null,
+        CancellationToken cancellationToken = default)
     {
         IIdentityUser? user = await userReader.GetUserAsync(evt.UserId.ToString(), cancellationToken)
             .ConfigureAwait(false);
@@ -27,8 +29,13 @@ public class EmailConfirmationRequestedHandler
             return;
         }
 
-        string confirmLink = options.Value.BuildConfirmEmailUrl(
-            evt.UserId.ToString(), evt.Token);
+        IdentityNotificationOptions opts = options.Value;
+        string baseUrl = urlResolver is not null
+            ? await urlResolver.ResolveBaseUrlAsync(cancellationToken).ConfigureAwait(false)
+            : opts.FrontendBaseUrl;
+
+        string confirmLink = opts.BuildConfirmEmailUrl(
+            baseUrl, evt.UserId.ToString(), evt.Token);
 
         await publisher.PublishAsync(
             EmailConfirmationNotificationType.Instance,

--- a/src/Granit.Identity.Local.Notifications/Handlers/PasswordResetRequestedHandler.cs
+++ b/src/Granit.Identity.Local.Notifications/Handlers/PasswordResetRequestedHandler.cs
@@ -1,6 +1,7 @@
 using Granit.Identity.Local.Events;
 using Granit.Identity.Local.Notifications.NotificationTypes;
 using Granit.Identity.Local.Notifications.Options;
+using Granit.MultiTenancy;
 using Granit.Notifications.Abstractions;
 using Microsoft.Extensions.Options;
 
@@ -16,10 +17,16 @@ public class PasswordResetRequestedHandler
         PasswordResetRequestedEto evt,
         IOptions<IdentityNotificationOptions> options,
         INotificationPublisher publisher,
-        CancellationToken cancellationToken)
+        ITenantUrlResolver? urlResolver = null,
+        CancellationToken cancellationToken = default)
     {
-        string resetLink = options.Value.BuildResetPasswordUrl(
-            evt.UserId.ToString(), evt.ResetToken);
+        IdentityNotificationOptions opts = options.Value;
+        string baseUrl = urlResolver is not null
+            ? await urlResolver.ResolveBaseUrlAsync(cancellationToken).ConfigureAwait(false)
+            : opts.FrontendBaseUrl;
+
+        string resetLink = opts.BuildResetPasswordUrl(
+            baseUrl, evt.UserId.ToString(), evt.ResetToken);
 
         await publisher.PublishAsync(
             PasswordResetNotificationType.Instance,

--- a/src/Granit.Identity.Local.Notifications/Options/IdentityNotificationOptions.cs
+++ b/src/Granit.Identity.Local.Notifications/Options/IdentityNotificationOptions.cs
@@ -28,13 +28,25 @@ public sealed class IdentityNotificationOptions
 
     /// <summary>Builds a password reset URL with the given user ID and token.</summary>
     public string BuildResetPasswordUrl(string userId, string token) =>
-        $"{FrontendBaseUrl.TrimEnd('/')}/{ResetPasswordPath}?userId={Uri.EscapeDataString(userId)}&token={Uri.EscapeDataString(token)}";
+        BuildResetPasswordUrl(FrontendBaseUrl, userId, token);
+
+    /// <summary>Builds a password reset URL using an explicit base URL (tenant-aware).</summary>
+    public string BuildResetPasswordUrl(string baseUrl, string userId, string token) =>
+        $"{baseUrl.TrimEnd('/')}/{ResetPasswordPath}?userId={Uri.EscapeDataString(userId)}&token={Uri.EscapeDataString(token)}";
 
     /// <summary>Builds an email confirmation URL with the given user ID and token.</summary>
     public string BuildConfirmEmailUrl(string userId, string token) =>
-        $"{FrontendBaseUrl.TrimEnd('/')}/{ConfirmEmailPath}?userId={Uri.EscapeDataString(userId)}&token={Uri.EscapeDataString(token)}";
+        BuildConfirmEmailUrl(FrontendBaseUrl, userId, token);
+
+    /// <summary>Builds an email confirmation URL using an explicit base URL (tenant-aware).</summary>
+    public string BuildConfirmEmailUrl(string baseUrl, string userId, string token) =>
+        $"{baseUrl.TrimEnd('/')}/{ConfirmEmailPath}?userId={Uri.EscapeDataString(userId)}&token={Uri.EscapeDataString(token)}";
 
     /// <summary>Builds an email change confirmation URL with the given user ID, new email, and token.</summary>
     public string BuildChangeEmailUrl(string userId, string newEmail, string token) =>
-        $"{FrontendBaseUrl.TrimEnd('/')}/{ChangeEmailPath}?userId={Uri.EscapeDataString(userId)}&newEmail={Uri.EscapeDataString(newEmail)}&token={Uri.EscapeDataString(token)}";
+        BuildChangeEmailUrl(FrontendBaseUrl, userId, newEmail, token);
+
+    /// <summary>Builds an email change confirmation URL using an explicit base URL (tenant-aware).</summary>
+    public string BuildChangeEmailUrl(string baseUrl, string userId, string newEmail, string token) =>
+        $"{baseUrl.TrimEnd('/')}/{ChangeEmailPath}?userId={Uri.EscapeDataString(userId)}&newEmail={Uri.EscapeDataString(newEmail)}&token={Uri.EscapeDataString(token)}";
 }

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Entities/Tenant.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Entities/Tenant.cs
@@ -29,6 +29,14 @@ public sealed class Tenant : FullAuditedAggregateRoot, ITenantInfo
     /// <summary>Whether the tenant is active and can be resolved by the middleware.</summary>
     public bool IsActive { get; private set; } = true;
 
+    /// <summary>
+    /// Optional custom domain for this tenant (e.g., <c>"app.acme-corp.com"</c>).
+    /// When set, outbound URLs (emails, templates) use this domain instead of
+    /// the subdomain derived from <see cref="Identifier"/>.
+    /// Max 253 characters (RFC 1035).
+    /// </summary>
+    public string? CustomDomain { get; private set; }
+
     // Explicit interface: Entity.Id is Guid, ITenantInfo.Id is Guid?
     Guid? ITenantInfo.Id => Id;
 
@@ -85,6 +93,27 @@ public sealed class Tenant : FullAuditedAggregateRoot, ITenantInfo
         Jurisdiction = jurisdiction;
 
         AddDomainEvent(new TenantUpdatedEvent(Id, name, contactEmail));
+    }
+
+    /// <summary>
+    /// Sets or clears the custom domain for this tenant.
+    /// Raises <see cref="TenantCustomDomainChangedEvent"/> for cache invalidation.
+    /// </summary>
+    /// <param name="customDomain">
+    /// The custom domain (e.g., <c>"app.acme-corp.com"</c>), or <c>null</c> to clear.
+    /// </param>
+    public void SetCustomDomain(string? customDomain)
+    {
+        string? normalized = string.IsNullOrWhiteSpace(customDomain) ? null : customDomain.Trim().ToLowerInvariant();
+
+        if (string.Equals(CustomDomain, normalized, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        string? oldDomain = CustomDomain;
+        CustomDomain = normalized;
+        AddDomainEvent(new TenantCustomDomainChangedEvent(Id, oldDomain, normalized));
     }
 
     /// <summary>

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/EfCoreTenantStore.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/EfCoreTenantStore.cs
@@ -66,6 +66,21 @@ internal sealed partial class EfCoreTenantStore(
     }
 
     /// <inheritdoc/>
+    public async Task<TenantData?> FindByCustomDomainAsync(string customDomain, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(customDomain);
+
+        Tenant? tenant = await ReadAsync(
+            async db => await db.Tenants
+                .AsNoTracking()
+                .FirstOrDefaultAsync(t => t.CustomDomain == customDomain, cancellationToken)
+                .ConfigureAwait(false),
+            cancellationToken).ConfigureAwait(false);
+
+        return tenant is null ? null : ToData(tenant);
+    }
+
+    /// <inheritdoc/>
     public async Task<bool> ExistsAsync(Guid id, CancellationToken cancellationToken = default) =>
         await ReadAsync(
             async db => await db.Tenants
@@ -151,7 +166,7 @@ internal sealed partial class EfCoreTenantStore(
     // -------------------------------------------------------------------------
 
     private static TenantData ToData(Tenant tenant) =>
-        new(tenant.Id, tenant.Name, tenant.Identifier, tenant.ContactEmail, tenant.IsActive, tenant.Jurisdiction, tenant.CreatedAt);
+        new(tenant.Id, tenant.Name, tenant.Identifier, tenant.ContactEmail, tenant.IsActive, tenant.Jurisdiction, tenant.CreatedAt, tenant.CustomDomain);
 
     // -------------------------------------------------------------------------
     // Logging

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/TenantEntityTypeConfiguration.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/TenantEntityTypeConfiguration.cs
@@ -36,6 +36,9 @@ internal sealed class TenantEntityTypeConfiguration : IEntityTypeConfiguration<T
         builder.Property(e => e.IsActive)
                .IsRequired();
 
+        builder.Property(e => e.CustomDomain)
+               .HasMaxLength(253);
+
         // Audit columns (FullAuditedAggregateRoot)
         builder.Property(e => e.CreatedAt).IsRequired();
         builder.Property(e => e.CreatedBy).HasMaxLength(450).IsRequired();
@@ -49,5 +52,11 @@ internal sealed class TenantEntityTypeConfiguration : IEntityTypeConfiguration<T
         builder.HasIndex(e => e.Identifier)
                .IsUnique()
                .HasDatabaseName("uq_tenants_identifier");
+
+        // Unique filtered index on CustomDomain (non-null only) for inbound resolution
+        builder.HasIndex(e => e.CustomDomain)
+               .IsUnique()
+               .HasFilter("\"CustomDomain\" IS NOT NULL")
+               .HasDatabaseName("uq_tenants_custom_domain");
     }
 }

--- a/src/Granit.MultiTenancy/Events/TenantCustomDomainChangedEvent.cs
+++ b/src/Granit.MultiTenancy/Events/TenantCustomDomainChangedEvent.cs
@@ -1,0 +1,15 @@
+using Granit.Events;
+
+namespace Granit.MultiTenancy.Events;
+
+/// <summary>
+/// Raised when a tenant's custom domain is set or cleared.
+/// Handlers should invalidate cached URL data for this tenant.
+/// </summary>
+/// <param name="TenantId">The unique identifier of the tenant.</param>
+/// <param name="OldDomain">Previous custom domain, or <c>null</c> if none was set.</param>
+/// <param name="NewDomain">New custom domain, or <c>null</c> if cleared.</param>
+public sealed record TenantCustomDomainChangedEvent(
+    Guid TenantId,
+    string? OldDomain,
+    string? NewDomain) : IDomainEvent;

--- a/src/Granit.MultiTenancy/Extensions/MultiTenancyServiceCollectionExtensions.cs
+++ b/src/Granit.MultiTenancy/Extensions/MultiTenancyServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Granit.MultiTenancy.Options;
 using Granit.MultiTenancy.Pipeline;
 using Granit.MultiTenancy.Resolvers;
 using Granit.MultiTenancy.Stores;
+using Granit.MultiTenancy.Url;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -33,9 +34,10 @@ public static class MultiTenancyServiceCollectionExtensions
         // Granit.MultiTenancy.EntityFrameworkCore is in the module tree.
         services.TryAddScoped<ITenantReader, NullTenantReader>();
 
-        // Resolvers: Domain (50) → Header (100) → JWT (200) → QueryString (300)
+        // Resolvers: CustomDomain (25) → Domain (50) → Header (100) → JWT (200) → QueryString (300)
         // Registered as scoped: DomainTenantResolver depends on ITenantReader (scoped, EF Core).
         // All resolvers aligned to scoped for consistency.
+        services.AddScoped<ITenantResolver, CustomDomainTenantResolver>();
         services.AddScoped<ITenantResolver, DomainTenantResolver>();
         services.AddScoped<ITenantResolver, HeaderTenantResolver>();
         services.AddScoped<ITenantResolver, JwtClaimTenantResolver>();
@@ -43,6 +45,9 @@ public static class MultiTenancyServiceCollectionExtensions
 
         services.TryAddScoped<TenantResolverPipeline>();
         services.TryAddSingleton<MultiTenancyMetrics>();
+
+        // Outbound URL resolution (scoped: depends on ICurrentTenant + ITenantReader)
+        services.TryAddScoped<ITenantUrlResolver, TenantUrlResolver>();
 
         // IMiddleware pattern: resolved per scope (per request)
         services.AddScoped<TenantResolutionMiddleware>();

--- a/src/Granit.MultiTenancy/Options/MultiTenancyOptions.cs
+++ b/src/Granit.MultiTenancy/Options/MultiTenancyOptions.cs
@@ -81,4 +81,24 @@ public sealed class MultiTenancyOptions
     /// unauthenticated callers to select an arbitrary tenant context.
     /// </summary>
     public string? QueryStringParamName { get; set; }
+
+    /// <summary>
+    /// Strategy for generating outbound tenant-specific URLs (email links, templates, etc.).
+    /// Default: <see cref="TenantUrlStrategy.Shared"/> (backward-compatible, static URL).
+    /// </summary>
+    public TenantUrlStrategy UrlStrategy { get; set; } = TenantUrlStrategy.Shared;
+
+    /// <summary>
+    /// URI scheme for generated tenant URLs.
+    /// Default: <c>"https"</c>. Use <c>"http"</c> only in development.
+    /// </summary>
+    public string UrlScheme { get; set; } = "https";
+
+    /// <summary>
+    /// Static fallback base URL used when <see cref="UrlStrategy"/> is
+    /// <see cref="TenantUrlStrategy.Shared"/> or when no tenant context is active.
+    /// Typically matches <c>Granit:Templating:App:BaseUrl</c>.
+    /// No trailing slash.
+    /// </summary>
+    public string? FallbackBaseUrl { get; set; }
 }

--- a/src/Granit.MultiTenancy/Resolvers/CustomDomainTenantResolver.cs
+++ b/src/Granit.MultiTenancy/Resolvers/CustomDomainTenantResolver.cs
@@ -1,0 +1,84 @@
+using Granit.MultiTenancy.Options;
+using Granit.MultiTenancy.Stores;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+namespace Granit.MultiTenancy.Resolvers;
+
+/// <summary>
+/// Resolves the tenant from the request <c>Host</c> header by matching against
+/// the <c>CustomDomain</c> field stored on each tenant entity.
+/// </summary>
+/// <remarks>
+/// <para>Order = 25 (highest priority) — custom domain resolution takes precedence
+/// over subdomain (<see cref="DomainTenantResolver"/>, Order = 50) because a
+/// custom domain is an explicit configuration that must not be shadowed by
+/// template-based extraction.</para>
+/// <para>Only active when <see cref="TenantUrlStrategy"/> is
+/// <see cref="TenantUrlStrategy.CustomDomain"/> or
+/// <see cref="TenantUrlStrategy.Hybrid"/>.</para>
+/// </remarks>
+public sealed class CustomDomainTenantResolver(
+    ITenantReader tenantReader,
+    IOptions<MultiTenancyOptions> options) : ITenantResolver
+{
+    private readonly MultiTenancyOptions _options = options.Value;
+
+    /// <inheritdoc/>
+    public int Order => 25;
+
+    /// <inheritdoc/>
+    public async Task<TenantInfo?> ResolveAsync(
+        HttpContext context,
+        CancellationToken cancellationToken = default)
+    {
+        // Only active for strategies that use custom domains
+        if (_options.UrlStrategy is not (TenantUrlStrategy.CustomDomain
+            or TenantUrlStrategy.Hybrid))
+        {
+            return null;
+        }
+
+        string host = context.Request.Host.Host;
+
+        // Skip if the host matches the DomainTemplate pattern (handled by DomainTenantResolver)
+        if (MatchesDomainTemplate(host))
+        {
+            return null;
+        }
+
+        TenantData? tenant = await tenantReader
+            .FindByCustomDomainAsync(host, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (tenant is null || !tenant.IsActive)
+        {
+            return null;
+        }
+
+        return new TenantInfo(tenant.Id, tenant.Name, tenant.Identifier, tenant.Jurisdiction);
+    }
+
+    /// <summary>
+    /// Checks whether the host matches the configured <see cref="MultiTenancyOptions.DomainTemplate"/>
+    /// pattern to avoid collisions with <see cref="DomainTenantResolver"/>.
+    /// </summary>
+    private bool MatchesDomainTemplate(string host)
+    {
+        string? template = _options.DomainTemplate;
+        if (string.IsNullOrEmpty(template))
+        {
+            return false;
+        }
+
+        // Extract the suffix from the template (everything after {0})
+        int placeholderIndex = template.IndexOf("{0}", StringComparison.Ordinal);
+        if (placeholderIndex < 0)
+        {
+            return false;
+        }
+
+        string suffix = template[(placeholderIndex + 3)..];
+        return suffix.Length > 0 && host.EndsWith(suffix, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Granit.MultiTenancy/Stores/ITenantReader.cs
+++ b/src/Granit.MultiTenancy/Stores/ITenantReader.cs
@@ -23,6 +23,15 @@ public interface ITenantReader
     Task<TenantData?> FindByIdentifierAsync(string identifier, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Finds a tenant by its custom domain.
+    /// Used by <see cref="Resolvers.CustomDomainTenantResolver"/> for inbound resolution.
+    /// </summary>
+    /// <param name="customDomain">The custom domain to look up (e.g., <c>"app.acme-corp.com"</c>).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The tenant data, or <c>null</c> if no tenant uses this domain.</returns>
+    Task<TenantData?> FindByCustomDomainAsync(string customDomain, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Returns all tenants.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>

--- a/src/Granit.MultiTenancy/Stores/NullTenantReader.cs
+++ b/src/Granit.MultiTenancy/Stores/NullTenantReader.cs
@@ -13,6 +13,9 @@ internal sealed class NullTenantReader : ITenantReader
     public Task<TenantData?> FindByIdentifierAsync(string identifier, CancellationToken cancellationToken = default) =>
         Task.FromResult<TenantData?>(null);
 
+    public Task<TenantData?> FindByCustomDomainAsync(string customDomain, CancellationToken cancellationToken = default) =>
+        Task.FromResult<TenantData?>(null);
+
     public Task<IReadOnlyList<TenantData>> GetAllAsync(CancellationToken cancellationToken = default) =>
         Task.FromResult<IReadOnlyList<TenantData>>([]);
 

--- a/src/Granit.MultiTenancy/Stores/TenantData.cs
+++ b/src/Granit.MultiTenancy/Stores/TenantData.cs
@@ -12,6 +12,7 @@ namespace Granit.MultiTenancy.Stores;
 /// <param name="IsActive">Whether the tenant is active.</param>
 /// <param name="Jurisdiction">Privacy regulation code or ISO country code, or <c>null</c>.</param>
 /// <param name="CreatedAt">Timestamp when the tenant was created.</param>
+/// <param name="CustomDomain">Optional custom domain for outbound URL generation (e.g., <c>"app.acme-corp.com"</c>).</param>
 public sealed record TenantData(
     Guid Id,
     string Name,
@@ -19,4 +20,5 @@ public sealed record TenantData(
     string? ContactEmail,
     bool IsActive,
     string? Jurisdiction,
-    DateTimeOffset CreatedAt);
+    DateTimeOffset CreatedAt,
+    string? CustomDomain = null);

--- a/src/Granit.MultiTenancy/Url/TenantUrlData.cs
+++ b/src/Granit.MultiTenancy/Url/TenantUrlData.cs
@@ -1,0 +1,9 @@
+namespace Granit.MultiTenancy.Url;
+
+/// <summary>
+/// Lightweight DTO cached in-memory for URL resolution.
+/// Contains only the fields needed to compute outbound tenant URLs.
+/// </summary>
+/// <param name="Identifier">Tenant slug/subdomain identifier (e.g., <c>"acme"</c>).</param>
+/// <param name="CustomDomain">Optional custom domain (e.g., <c>"app.acme-corp.com"</c>).</param>
+internal sealed record TenantUrlData(string Identifier, string? CustomDomain);

--- a/src/Granit.MultiTenancy/Url/TenantUrlResolver.cs
+++ b/src/Granit.MultiTenancy/Url/TenantUrlResolver.cs
@@ -1,0 +1,110 @@
+using System.Collections.Concurrent;
+using Granit.MultiTenancy.Events;
+using Granit.MultiTenancy.Options;
+using Granit.MultiTenancy.Stores;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Granit.MultiTenancy.Url;
+
+/// <summary>
+/// Resolves the base URL for the current tenant based on the configured
+/// <see cref="TenantUrlStrategy"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registered as <b>scoped</b> because it depends on <see cref="ICurrentTenant"/>
+/// (async-local) and <see cref="ITenantReader"/> (scoped, EF Core).
+/// </para>
+/// <para>
+/// Tenant URL data is cached in a static <see cref="ConcurrentDictionary{TKey,TValue}"/>
+/// to avoid repeated database lookups. Cache entries expire after 5 minutes.
+/// The cache is invalidated by <see cref="TenantUpdatedEvent"/> and
+/// <see cref="TenantCustomDomainChangedEvent"/> handlers.
+/// </para>
+/// </remarks>
+internal sealed class TenantUrlResolver(
+    ICurrentTenant currentTenant,
+    ITenantReader tenantReader,
+    IOptions<MultiTenancyOptions> options) : ITenantUrlResolver
+{
+    private static readonly ConcurrentDictionary<Guid, (TenantUrlData Data, long ExpiresAtTicks)> Cache = new();
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
+
+    private readonly MultiTenancyOptions _options = options.Value;
+
+    /// <inheritdoc/>
+    public async Task<string> ResolveBaseUrlAsync(CancellationToken cancellationToken = default)
+    {
+        if (_options.UrlStrategy == TenantUrlStrategy.Shared || !currentTenant.IsAvailable)
+        {
+            return GetFallbackUrl();
+        }
+
+        Guid tenantId = currentTenant.Id!.Value;
+        TenantUrlData? urlData = await GetOrLoadUrlDataAsync(tenantId, cancellationToken).ConfigureAwait(false);
+
+        if (urlData is null)
+        {
+            return GetFallbackUrl();
+        }
+
+        return _options.UrlStrategy switch
+        {
+            TenantUrlStrategy.Subdomain => BuildSubdomainUrl(urlData.Identifier),
+            TenantUrlStrategy.CustomDomain => BuildCustomDomainUrl(urlData.CustomDomain),
+            TenantUrlStrategy.Hybrid => BuildHybridUrl(urlData),
+            _ => GetFallbackUrl(),
+        };
+    }
+
+    /// <summary>
+    /// Evicts the cached URL data for a tenant. Called by domain event handlers
+    /// when tenant details or custom domain change.
+    /// </summary>
+    internal static void Evict(Guid tenantId) => Cache.TryRemove(tenantId, out _);
+
+    private async Task<TenantUrlData?> GetOrLoadUrlDataAsync(Guid tenantId, CancellationToken cancellationToken)
+    {
+        if (Cache.TryGetValue(tenantId, out (TenantUrlData Data, long ExpiresAtTicks) entry) && entry.ExpiresAtTicks > Environment.TickCount64)
+        {
+            return entry.Data;
+        }
+
+        TenantData? tenant = await tenantReader.FindByIdAsync(tenantId, cancellationToken).ConfigureAwait(false);
+        if (tenant is null)
+        {
+            return null;
+        }
+
+        TenantUrlData data = new(tenant.Identifier, tenant.CustomDomain);
+        long expiresAt = Environment.TickCount64 + (long)CacheDuration.TotalMilliseconds;
+        Cache[tenantId] = (data, expiresAt);
+        return data;
+    }
+
+    private string BuildSubdomainUrl(string identifier)
+    {
+        string? template = _options.DomainTemplate;
+        if (string.IsNullOrEmpty(template))
+        {
+            return GetFallbackUrl();
+        }
+
+        string domain = template.Replace("{0}", identifier, StringComparison.Ordinal);
+        return $"{_options.UrlScheme}://{domain}";
+    }
+
+    private string BuildCustomDomainUrl(string? customDomain) =>
+        !string.IsNullOrEmpty(customDomain)
+            ? $"{_options.UrlScheme}://{customDomain}"
+            : GetFallbackUrl();
+
+    private string BuildHybridUrl(TenantUrlData data) =>
+        !string.IsNullOrEmpty(data.CustomDomain)
+            ? $"{_options.UrlScheme}://{data.CustomDomain}"
+            : BuildSubdomainUrl(data.Identifier);
+
+    private string GetFallbackUrl() =>
+        _options.FallbackBaseUrl?.TrimEnd('/') ?? string.Empty;
+}

--- a/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
+++ b/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Granit.MultiTenancy;
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Email.Options;
 using Granit.Templating.Keys;
@@ -83,7 +84,7 @@ internal sealed partial class EmailNotificationChannel(
         string unsubscribeUrl = "";
         if (allowOptOut)
         {
-            unsubscribeUrl = ResolveUnsubscribeUrl();
+            unsubscribeUrl = await ResolveUnsubscribeUrlAsync(cancellationToken).ConfigureAwait(false);
             if (unsubscribeUrl.Length > 0)
             {
                 headers = new()
@@ -134,10 +135,10 @@ internal sealed partial class EmailNotificationChannel(
     }
 
     /// <summary>
-    /// Resolves the unsubscribe URL from <see cref="EmailChannelOptions.UnsubscribeUrl"/>
-    /// or falls back to <c>{BaseUrl}/notifications/preferences</c>.
+    /// Resolves the unsubscribe URL from <see cref="EmailChannelOptions.UnsubscribeUrl"/>,
+    /// then tenant-aware URL, then static configuration fallback.
     /// </summary>
-    private string ResolveUnsubscribeUrl()
+    private async Task<string> ResolveUnsubscribeUrlAsync(CancellationToken cancellationToken)
     {
         string? url = options.Value.UnsubscribeUrl;
         if (!string.IsNullOrEmpty(url))
@@ -145,7 +146,12 @@ internal sealed partial class EmailNotificationChannel(
             return url;
         }
 
-        string? baseUrl = configuration["Granit:Templating:App:BaseUrl"];
+        // Soft dependency: use tenant-aware URL when multi-tenancy is configured
+        ITenantUrlResolver? urlResolver = serviceProvider.GetService<ITenantUrlResolver>();
+        string? baseUrl = urlResolver is not null
+            ? await urlResolver.ResolveBaseUrlAsync(cancellationToken).ConfigureAwait(false)
+            : configuration["Granit:Templating:App:BaseUrl"];
+
         return string.IsNullOrEmpty(baseUrl) ? "" : baseUrl.TrimEnd('/') + "/notifications/preferences";
     }
 

--- a/src/Granit.Notifications.EntityFrameworkCore/Extensions/NotificationsEfCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Extensions/NotificationsEfCoreHostApplicationBuilderExtensions.cs
@@ -49,7 +49,7 @@ public static class NotificationsEfCoreHostApplicationBuilderExtensions
             options.UseGranitInterceptors(sp);
             options.AddInterceptors(sp.GetRequiredService<EntityTrackingInterceptor>());
         }, ServiceLifetime.Scoped);
-        builder.Services.AddTenantInternalDbContextEnsurer<NotificationsDbContext>();
+        builder.Services.AddHostInternalDbContextEnsurer<NotificationsDbContext>();
 
         // UserNotification store — CQRS forwarding pattern
         // Scoped: AddGranitDbContext registers IDbContextFactory<T> as Scoped (interceptors

--- a/src/Granit.Notifications.EntityFrameworkCore/Extensions/NotificationsEfCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Extensions/NotificationsEfCoreHostApplicationBuilderExtensions.cs
@@ -49,6 +49,7 @@ public static class NotificationsEfCoreHostApplicationBuilderExtensions
             options.UseGranitInterceptors(sp);
             options.AddInterceptors(sp.GetRequiredService<EntityTrackingInterceptor>());
         }, ServiceLifetime.Scoped);
+        builder.Services.AddHostInternalDbContextEnsurer<NotificationsDbContext>();
         builder.Services.AddTenantInternalDbContextEnsurer<NotificationsDbContext>();
 
         // UserNotification store — CQRS forwarding pattern

--- a/src/Granit.Notifications.EntityFrameworkCore/Extensions/NotificationsEfCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Extensions/NotificationsEfCoreHostApplicationBuilderExtensions.cs
@@ -49,7 +49,6 @@ public static class NotificationsEfCoreHostApplicationBuilderExtensions
             options.UseGranitInterceptors(sp);
             options.AddInterceptors(sp.GetRequiredService<EntityTrackingInterceptor>());
         }, ServiceLifetime.Scoped);
-        builder.Services.AddHostInternalDbContextEnsurer<NotificationsDbContext>();
         builder.Services.AddTenantInternalDbContextEnsurer<NotificationsDbContext>();
 
         // UserNotification store — CQRS forwarding pattern

--- a/src/Granit.Notifications.EntityFrameworkCore/GranitNotificationsDbProperties.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/GranitNotificationsDbProperties.cs
@@ -29,12 +29,13 @@ public static class GranitNotificationsDbProperties
     private static bool _dbSchemaExplicitlySet;
 
     /// <summary>
-    /// Database schema for tenant-level tables.
-    /// Falls back to <see cref="GranitDbDefaults.DbSchema"/> when not explicitly set.
+    /// Database schema for notification tables.
+    /// Falls back to <see cref="GranitDbDefaults.HostDbSchema"/>, then
+    /// <see cref="GranitDbDefaults.DbSchema"/> when not explicitly set.
     /// </summary>
     public static string? DbSchema
     {
-        get => _dbSchemaExplicitlySet ? _dbSchema : GranitDbDefaults.DbSchema;
+        get => _dbSchemaExplicitlySet ? _dbSchema : GranitDbDefaults.HostDbSchema ?? GranitDbDefaults.DbSchema;
         set { _dbSchema = value; _dbSchemaExplicitlySet = true; }
     }
 }

--- a/src/Granit.Notifications/Handlers/NotificationDeliveryHandler.cs
+++ b/src/Granit.Notifications/Handlers/NotificationDeliveryHandler.cs
@@ -66,25 +66,13 @@ public sealed partial class NotificationDeliveryHandler(
         };
 
         var stopwatch = Stopwatch.StartNew();
+        bool sent = false;
         try
         {
             await channel.SendAsync(context, cancellationToken).ConfigureAwait(false);
+            sent = true;
             stopwatch.Stop();
             activity?.SetTag("notifications.success", true);
-
-            await deliveryWriter.RecordAsync(new NotificationDeliveryAttempt
-            {
-                Id = guidGenerator.Create(),
-                DeliveryId = command.DeliveryId,
-                NotificationId = command.NotificationId,
-                NotificationTypeName = command.NotificationTypeName,
-                ChannelName = command.ChannelName,
-                RecipientUserId = command.RecipientUserId,
-                TenantId = command.TenantId,
-                OccurredAt = clock.Now,
-                DurationMs = stopwatch.ElapsedMilliseconds,
-                IsSuccess = true,
-            }, cancellationToken).ConfigureAwait(false);
 
             metrics.RecordDeliverySucceeded(
                 command.TenantId?.ToString(), command.ChannelName, command.NotificationTypeName);
@@ -99,6 +87,21 @@ public sealed partial class NotificationDeliveryHandler(
             activity?.SetTag("notifications.success", false);
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
 
+            metrics.RecordDeliveryFailed(
+                command.TenantId?.ToString(), command.ChannelName, command.NotificationTypeName);
+            metrics.RecordDeliveryDuration(
+                command.TenantId?.ToString(), command.ChannelName, "failure", stopwatch.Elapsed);
+
+            LogNotificationDeliveryFailed(ex, command.ChannelName, command.DeliveryId, command.NotificationId);
+
+            throw new NotificationDeliveryException(
+                $"Failed to deliver notification {command.NotificationId} via {command.ChannelName}", ex);
+        }
+
+        // Record the delivery attempt AFTER the send — audit failures must NOT
+        // trigger a retry of the send (which would cause duplicate emails).
+        try
+        {
             await deliveryWriter.RecordAsync(new NotificationDeliveryAttempt
             {
                 Id = guidGenerator.Create(),
@@ -110,19 +113,14 @@ public sealed partial class NotificationDeliveryHandler(
                 TenantId = command.TenantId,
                 OccurredAt = clock.Now,
                 DurationMs = stopwatch.ElapsedMilliseconds,
-                ErrorMessage = ex.Message,
-                IsSuccess = false,
+                IsSuccess = sent,
+                ErrorMessage = sent ? null : "Send failed — see previous log entry",
             }, cancellationToken).ConfigureAwait(false);
-
-            metrics.RecordDeliveryFailed(
-                command.TenantId?.ToString(), command.ChannelName, command.NotificationTypeName);
-            metrics.RecordDeliveryDuration(
-                command.TenantId?.ToString(), command.ChannelName, "failure", stopwatch.Elapsed);
-
-            LogNotificationDeliveryFailed(ex, command.ChannelName, command.DeliveryId, command.NotificationId);
-
-            throw new NotificationDeliveryException(
-                $"Failed to deliver notification {command.NotificationId} via {command.ChannelName}", ex);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Audit persistence failure must not mask a successful send or trigger retry.
+            LogAuditRecordFailed(ex, command.ChannelName, command.DeliveryId);
         }
     }
 
@@ -137,4 +135,7 @@ public sealed partial class NotificationDeliveryHandler(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Notification delivery failed via '{ChannelName}' for delivery {DeliveryId} notification {NotificationId}")]
     private partial void LogNotificationDeliveryFailed(Exception exception, string channelName, Guid deliveryId, Guid notificationId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to record delivery audit for '{ChannelName}' delivery {DeliveryId} — the notification was sent but the audit trail is incomplete")]
+    private partial void LogAuditRecordFailed(Exception exception, string channelName, Guid deliveryId);
 }

--- a/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/GranitOpenIddictEntityFrameworkCoreModule.cs
@@ -33,10 +33,8 @@ public sealed class GranitOpenIddictEntityFrameworkCoreModule : GranitModule
     /// <inheritdoc/>
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        // Data seeding
-#pragma warning disable CS0618 // IDataSeedContributor: migrating to IHostDataSeedContributor in a follow-up
-        context.Services.AddTransient<IDataSeedContributor, OpenIddictSeedContributor>();
-#pragma warning restore CS0618
+        // Data seeding (host-level: OIDC apps and scopes are global)
+        context.Services.AddTransient<IHostDataSeedContributor, OpenIddictSeedContributor>();
 
         // EF Core stores
         context.Services.TryAddScoped<ILocalIdentityGroupStore, OpenIddictGroupStore>();

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Seeding/OpenIddictSeedContributor.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Seeding/OpenIddictSeedContributor.cs
@@ -16,9 +16,7 @@ internal sealed partial class OpenIddictSeedContributor(
     IOpenIddictApplicationManager applicationManager,
     IOpenIddictScopeManager scopeManager,
     IOptions<GranitOpenIddictSeedingOptions> options,
-#pragma warning disable CS0618 // IDataSeedContributor: OpenIddict seeds are host-level, migrating to IHostDataSeedContributor in a follow-up
-    ILogger<OpenIddictSeedContributor> logger) : IDataSeedContributor
-#pragma warning restore CS0618
+    ILogger<OpenIddictSeedContributor> logger) : IHostDataSeedContributor
 {
     /// <summary>
     /// Standard OIDC scopes seeded automatically on every startup.

--- a/src/Granit.Persistence.EntityFrameworkCore.Hosting/Internal/GranitMigrationRunner.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Hosting/Internal/GranitMigrationRunner.cs
@@ -199,28 +199,27 @@ internal sealed partial class GranitMigrationRunner(
     {
         await using AsyncServiceScope scope = scopeFactory.CreateAsyncScope();
 
-        // Check for multi-tenant migration
-        ITenantEnumerator? tenantEnumerator = scope.ServiceProvider.GetService<ITenantEnumerator>();
-        bool hasTenants = tenantEnumerator is not null
-            && await HasTenantsAsync(tenantEnumerator, ct).ConfigureAwait(false);
+        // Check if this DbContext is tenant-isolated (registered via AddGranitIsolatedDbContext)
+        bool isIsolated = scope.ServiceProvider.GetServices<MultiTenancy.IsolatedDbContextMarker>()
+            .Any(m => m.DbContextType == dbContextType);
 
-        if (hasTenants)
+        if (isIsolated)
         {
-            await MigratePerTenantAsync(moduleName, dbContextType, scope.ServiceProvider, tenantEnumerator!, ct)
-                .ConfigureAwait(false);
-        }
-        else if (tenantEnumerator is not null)
-        {
-            // ITenantEnumerator is registered (SchemaPerTenant / DatabasePerTenant)
-            // but no tenants exist yet (cold start). Skip migration — migrating
-            // without a tenant context would create tables in "public" schema.
-            // Per-tenant schemas will be created by the post-seed re-migration pass
-            // once host seeders have created the tenant records.
-            // Host-level tables belong in a separate SharedDatabase DbContext
-            // with HasDefaultSchema(HostDbSchema).
+            ITenantEnumerator? tenantEnumerator = scope.ServiceProvider.GetService<ITenantEnumerator>();
+            bool hasTenants = tenantEnumerator is not null
+                && await HasTenantsAsync(tenantEnumerator, ct).ConfigureAwait(false);
+
+            if (hasTenants)
+            {
+                await MigratePerTenantAsync(moduleName, dbContextType, scope.ServiceProvider, tenantEnumerator!, ct)
+                    .ConfigureAwait(false);
+            }
+
+            // No tenants yet (cold start): skip — tables will be created per-tenant
+            // by the post-seed re-migration pass once host seeders create tenants.
             return;
         }
-        else
+
         {
             // SharedDatabase or single-tenant — migrate normally in default schema.
             LogMigratingContext(moduleName, dbContextType.Name);

--- a/src/Granit.Persistence.EntityFrameworkCore.Hosting/Internal/GranitMigrationRunner.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Hosting/Internal/GranitMigrationRunner.cs
@@ -195,11 +195,19 @@ internal sealed partial class GranitMigrationRunner(
         else if (tenantEnumerator is not null)
         {
             // ITenantEnumerator is registered (SchemaPerTenant / DatabasePerTenant)
-            // but no tenants exist yet (cold start). Skip migration — migrating
-            // without a tenant would create tables in "public" schema. The
-            // __EFMigrationsHistory in public would then prevent per-tenant migration
-            // later (SET search_path includes "public" → EF sees migrations as applied).
-            // Tables will be created per-tenant after seeding creates tenants.
+            // but no tenants exist yet (cold start). Migrate in the HOST schema so
+            // that host-level tables (permissions, global reference data, etc.) are
+            // created before seeding. Per-tenant schemas will be created later when
+            // the post-seed re-migration pass finds the tenants created by host seeders.
+            if (GranitDbDefaults.HostDbSchema is not null)
+            {
+                LogMigratingContext(moduleName, $"{dbContextType.Name} (host schema)");
+                await using DbContext hostContext = await ResolveDbContextAsync(scope.ServiceProvider, dbContextType)
+                    .ConfigureAwait(false);
+                await hostContext.Database.MigrateAsync(ct).ConfigureAwait(false);
+                LogMigratedContext(moduleName, $"{dbContextType.Name} (host schema)");
+            }
+
             return;
         }
         else

--- a/src/Granit.Persistence.EntityFrameworkCore.Hosting/Internal/GranitMigrationRunner.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Hosting/Internal/GranitMigrationRunner.cs
@@ -74,17 +74,18 @@ internal sealed partial class GranitMigrationRunner(
                 }
             }
 
+            // Ensure HOST internal DbContext tables BEFORE migrations so that
+            // HasTenantsAsync (which queries tenants_tenants) doesn't hit a missing table.
+            await EnsureHostInternalDbContextsAsync(ct).ConfigureAwait(false);
+
+            // Ensure Expand & Contract tracking table exists
+            await EnsureExpandContractDbAsync(ct).ConfigureAwait(false);
+
             // Migrate each DbContext in topological order
             foreach ((GranitModule module, Type dbContextType) in migratableModules)
             {
                 await MigrateWithRetryAsync(module, dbContextType, ct).ConfigureAwait(false);
             }
-
-            // Ensure Expand & Contract tracking table exists
-            await EnsureExpandContractDbAsync(ct).ConfigureAwait(false);
-
-            // Ensure HOST internal DbContext tables (BackgroundJobs, OpenIddict, etc.)
-            await EnsureHostInternalDbContextsAsync(ct).ConfigureAwait(false);
 
             // Resolve tenant enumerator for post-seed passes
             ITenantEnumerator? tenantEnumerator;
@@ -376,25 +377,14 @@ internal sealed partial class GranitMigrationRunner(
 
     private static async Task<bool> HasTenantsAsync(ITenantEnumerator enumerator, CancellationToken ct)
     {
+        IAsyncEnumerator<Guid> e = enumerator.GetActiveTenantIdsAsync(ct).GetAsyncEnumerator(ct);
         try
         {
-            IAsyncEnumerator<Guid> e = enumerator.GetActiveTenantIdsAsync(ct).GetAsyncEnumerator(ct);
-            try
-            {
-                return await e.MoveNextAsync().ConfigureAwait(false);
-            }
-            finally
-            {
-                await e.DisposeAsync().ConfigureAwait(false);
-            }
+            return await e.MoveNextAsync().ConfigureAwait(false);
         }
-        catch (Exception) when (!ct.IsCancellationRequested)
+        finally
         {
-            // Cold start: the tenant table may not exist yet (created by
-            // EnsureHostInternalDbContextsAsync after the migration loop).
-            // Treat as "no tenants" — the post-seed re-migration pass will
-            // pick them up after host seeding creates the tenant records.
-            return false;
+            await e.DisposeAsync().ConfigureAwait(false);
         }
     }
 

--- a/src/Granit.Persistence.EntityFrameworkCore.Hosting/Internal/GranitMigrationRunner.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Hosting/Internal/GranitMigrationRunner.cs
@@ -148,7 +148,23 @@ internal sealed partial class GranitMigrationRunner(
 
         foreach (GranitModule module in application.GetModuleInstances())
         {
-            if (module is IMigratableModule migratable)
+            // A module may implement IMigratableModule<T> for multiple DbContexts
+            // (e.g., a host DbContext + a tenant DbContext). Scan all implemented
+            // generic interfaces to discover every DbContext type.
+            bool found = false;
+            foreach (Type iface in module.GetType().GetInterfaces())
+            {
+                if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IMigratableModule<>))
+                {
+                    Type dbContextType = iface.GetGenericArguments()[0];
+                    LogModuleDiscovered(module.GetType().Name, dbContextType.Name);
+                    result.Add((module, dbContextType));
+                    found = true;
+                }
+            }
+
+            // Fallback: non-generic IMigratableModule (custom DbContextType override)
+            if (!found && module is IMigratableModule migratable)
             {
                 Type dbContextType = migratable.DbContextType;
                 LogModuleDiscovered(module.GetType().Name, dbContextType.Name);

--- a/src/Granit.Persistence.EntityFrameworkCore.Hosting/Internal/GranitMigrationRunner.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Hosting/Internal/GranitMigrationRunner.cs
@@ -212,19 +212,12 @@ internal sealed partial class GranitMigrationRunner(
         else if (tenantEnumerator is not null)
         {
             // ITenantEnumerator is registered (SchemaPerTenant / DatabasePerTenant)
-            // but no tenants exist yet (cold start). Migrate in the HOST schema so
-            // that host-level tables (permissions, global reference data, etc.) are
-            // created before seeding. Per-tenant schemas will be created later when
-            // the post-seed re-migration pass finds the tenants created by host seeders.
-            if (GranitDbDefaults.HostDbSchema is not null)
-            {
-                LogMigratingContext(moduleName, $"{dbContextType.Name} (host schema)");
-                await using DbContext hostContext = await ResolveDbContextAsync(scope.ServiceProvider, dbContextType)
-                    .ConfigureAwait(false);
-                await hostContext.Database.MigrateAsync(ct).ConfigureAwait(false);
-                LogMigratedContext(moduleName, $"{dbContextType.Name} (host schema)");
-            }
-
+            // but no tenants exist yet (cold start). Skip migration — migrating
+            // without a tenant context would create tables in "public" schema.
+            // Per-tenant schemas will be created by the post-seed re-migration pass
+            // once host seeders have created the tenant records.
+            // Host-level tables belong in a separate SharedDatabase DbContext
+            // with HasDefaultSchema(HostDbSchema).
             return;
         }
         else

--- a/src/Granit.Persistence.EntityFrameworkCore.Hosting/Internal/GranitMigrationRunner.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Hosting/Internal/GranitMigrationRunner.cs
@@ -376,14 +376,25 @@ internal sealed partial class GranitMigrationRunner(
 
     private static async Task<bool> HasTenantsAsync(ITenantEnumerator enumerator, CancellationToken ct)
     {
-        IAsyncEnumerator<Guid> e = enumerator.GetActiveTenantIdsAsync(ct).GetAsyncEnumerator(ct);
         try
         {
-            return await e.MoveNextAsync().ConfigureAwait(false);
+            IAsyncEnumerator<Guid> e = enumerator.GetActiveTenantIdsAsync(ct).GetAsyncEnumerator(ct);
+            try
+            {
+                return await e.MoveNextAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                await e.DisposeAsync().ConfigureAwait(false);
+            }
         }
-        finally
+        catch (Exception) when (!ct.IsCancellationRequested)
         {
-            await e.DisposeAsync().ConfigureAwait(false);
+            // Cold start: the tenant table may not exist yet (created by
+            // EnsureHostInternalDbContextsAsync after the migration loop).
+            // Treat as "no tenants" — the post-seed re-migration pass will
+            // pick them up after host seeding creates the tenant records.
+            return false;
         }
     }
 

--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationProgressDbEnsurer.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationProgressDbEnsurer.cs
@@ -63,10 +63,10 @@ internal sealed class MigrationProgressDbEnsurer(
 
         string sql = schema is not null
             ? string.Concat(
-                "SELECT COUNT(1) FROM information_schema.tables WHERE table_schema = '", schema,
+                "SELECT COUNT(1) AS \"Value\" FROM information_schema.tables WHERE table_schema = '", schema,
                 "' AND table_name = '", tableName, "'")
             : string.Concat(
-                "SELECT COUNT(1) FROM information_schema.tables WHERE table_name = '", tableName, "'");
+                "SELECT COUNT(1) AS \"Value\" FROM information_schema.tables WHERE table_name = '", tableName, "'");
 
         int count = await db.Database
             .SqlQueryRaw<int>(sql) // NOSONAR — schema/table from EF model metadata

--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationProgressDbEnsurer.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationProgressDbEnsurer.cs
@@ -47,22 +47,32 @@ internal sealed class MigrationProgressDbEnsurer(
             return true; // Non-relational providers don't need table creation
         }
 
-        IRelationalDatabaseCreator creator = db.GetService<IRelationalDatabaseCreator>();
+        // Query information_schema instead of probing with a SELECT that would generate
+        // Npgsql error-level log noise when the table does not exist yet.
+        Microsoft.EntityFrameworkCore.Metadata.IEntityType? entityType = db.Model
+            .GetEntityTypes()
+            .FirstOrDefault(e => e.GetTableName() is not null);
 
-        if (!await creator.HasTablesAsync(cancellationToken).ConfigureAwait(false))
+        if (entityType is null)
         {
-            return false; // Database has no tables at all
-        }
-
-        // Database has tables (from host migrations) — probe the specific table.
-        try
-        {
-            await db.MigrationProgresses.AnyAsync(cancellationToken).ConfigureAwait(false);
             return true;
         }
-        catch (Exception) when (!cancellationToken.IsCancellationRequested)
-        {
-            return false;
-        }
+
+        string tableName = entityType.GetTableName()!;
+        string? schema = entityType.GetSchema();
+
+        string sql = schema is not null
+            ? string.Concat(
+                "SELECT COUNT(1) FROM information_schema.tables WHERE table_schema = '", schema,
+                "' AND table_name = '", tableName, "'")
+            : string.Concat(
+                "SELECT COUNT(1) FROM information_schema.tables WHERE table_name = '", tableName, "'");
+
+        int count = await db.Database
+            .SqlQueryRaw<int>(sql) // NOSONAR — schema/table from EF model metadata
+            .SingleAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return count > 0;
     }
 }

--- a/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/DataSeedContext.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/DataSeedContext.cs
@@ -33,8 +33,6 @@ public sealed class DataSeedContext
     /// When <c>true</c>, tenant-scoped seed contributors should skip their work
     /// (tenant tables don't exist yet during the first seed pass).
     /// </summary>
-    [Obsolete("Use IHostDataSeedContributor / ITenantDataSeedContributor instead of checking IsHostOnly. " +
-              "Kept for backward compatibility with legacy IDataSeedContributor implementations.")]
     public const string HostOnlyKey = "Granit:HostOnly";
 
     /// <summary>
@@ -46,8 +44,6 @@ public sealed class DataSeedContext
     /// Indicates whether this is a host-only seed pass (first pass in SchemaPerTenant mode).
     /// Tenant-scoped seed contributors should return early when this is <c>true</c>.
     /// </summary>
-    [Obsolete("Use IHostDataSeedContributor / ITenantDataSeedContributor instead of checking IsHostOnly. " +
-              "Kept for backward compatibility with legacy IDataSeedContributor implementations.")]
     public bool IsHostOnly => this[HostOnlyKey] is true;
 
     /// <summary>

--- a/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/DataSeeder.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/DataSeeder.cs
@@ -17,33 +17,20 @@ internal sealed partial class DataSeeder(
     {
         await using AsyncServiceScope scope = scopeFactory.CreateAsyncScope();
 
-        // New host contributors
+        // Host contributors
         IEnumerable<IHostDataSeedContributor> hostContributors =
             scope.ServiceProvider.GetServices<IHostDataSeedContributor>();
 
         foreach (IHostDataSeedContributor contributor in hostContributors)
         {
             await ExecuteContributorAsync(
-                contributor.GetType(), () => contributor.SeedAsync(context, cancellationToken),
-                cancellationToken).ConfigureAwait(false);
+                contributor.GetType(), () => contributor.SeedAsync(context, cancellationToken))
+                .ConfigureAwait(false);
         }
 
         // Legacy contributors — first pass with IsHostOnly=true
-#pragma warning disable CS0618 // Obsolete: backward compat with legacy IDataSeedContributor
-        IEnumerable<IDataSeedContributor> legacyContributors =
-            scope.ServiceProvider.GetServices<IDataSeedContributor>();
-
-        DataSeedContext hostOnlyContext = new(context.TenantId);
-        hostOnlyContext[DataSeedContext.HostOnlyKey] = true;
-        CopyProperties(context, hostOnlyContext);
-
-        foreach (IDataSeedContributor contributor in legacyContributors)
-        {
-            await ExecuteContributorAsync(
-                contributor.GetType(), () => contributor.SeedAsync(hostOnlyContext, cancellationToken),
-                cancellationToken).ConfigureAwait(false);
-        }
-#pragma warning restore CS0618
+        await ExecuteLegacyContributorsAsync(scope.ServiceProvider, context, isHostOnly: true, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -51,22 +38,9 @@ internal sealed partial class DataSeeder(
     {
         // Legacy contributors — second pass with IsHostOnly=false, no tenant context
         // (they manage their own ICurrentTenant.Change() calls internally)
-#pragma warning disable CS0618 // Obsolete: backward compat with legacy IDataSeedContributor
-        {
-            await using AsyncServiceScope legacyScope = scopeFactory.CreateAsyncScope();
-            IEnumerable<IDataSeedContributor> legacyContributors =
-                legacyScope.ServiceProvider.GetServices<IDataSeedContributor>();
+        await ExecuteLegacyTenantPassAsync(context, cancellationToken).ConfigureAwait(false);
 
-            foreach (IDataSeedContributor contributor in legacyContributors)
-            {
-                await ExecuteContributorAsync(
-                    contributor.GetType(), () => contributor.SeedAsync(context, cancellationToken),
-                    cancellationToken).ConfigureAwait(false);
-            }
-        }
-#pragma warning restore CS0618
-
-        // New tenant contributors — per-tenant with DataSeeder-managed context
+        // Tenant contributors — per-tenant with DataSeeder-managed context
         await using AsyncServiceScope providerScope = scopeFactory.CreateAsyncScope();
         IDataSeedTenantProvider? tenantProvider =
             providerScope.ServiceProvider.GetService<IDataSeedTenantProvider>();
@@ -117,8 +91,8 @@ internal sealed partial class DataSeeder(
             foreach (ITenantDataSeedContributor contributor in contributors)
             {
                 await ExecuteContributorAsync(
-                    contributor.GetType(), () => contributor.SeedAsync(context, cancellationToken),
-                    cancellationToken).ConfigureAwait(false);
+                    contributor.GetType(), () => contributor.SeedAsync(context, cancellationToken))
+                    .ConfigureAwait(false);
             }
         }
         finally
@@ -127,8 +101,32 @@ internal sealed partial class DataSeeder(
         }
     }
 
-    private async Task ExecuteContributorAsync(
-        Type contributorType, Func<Task> action, CancellationToken cancellationToken)
+    private async Task ExecuteLegacyContributorsAsync(
+        IServiceProvider serviceProvider, DataSeedContext context, bool isHostOnly, CancellationToken cancellationToken)
+    {
+        IEnumerable<IDataSeedContributor> contributors =
+            serviceProvider.GetServices<IDataSeedContributor>();
+
+        DataSeedContext legacyContext = new(context.TenantId);
+        legacyContext[DataSeedContext.HostOnlyKey] = isHostOnly;
+        CopyProperties(context, legacyContext);
+
+        foreach (IDataSeedContributor contributor in contributors)
+        {
+            await ExecuteContributorAsync(
+                contributor.GetType(), () => contributor.SeedAsync(legacyContext, cancellationToken))
+                .ConfigureAwait(false);
+        }
+    }
+
+    private async Task ExecuteLegacyTenantPassAsync(DataSeedContext context, CancellationToken cancellationToken)
+    {
+        await using AsyncServiceScope scope = scopeFactory.CreateAsyncScope();
+        await ExecuteLegacyContributorsAsync(scope.ServiceProvider, context, isHostOnly: false, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task ExecuteContributorAsync(Type contributorType, Func<Task> action)
     {
         string contributorName = contributorType.FullName ?? contributorType.Name;
 
@@ -148,9 +146,7 @@ internal sealed partial class DataSeeder(
     {
         foreach (KeyValuePair<string, object?> kvp in source.Properties)
         {
-#pragma warning disable CS0618 // Obsolete: HostOnlyKey managed internally
             if (kvp.Key != DataSeedContext.HostOnlyKey)
-#pragma warning restore CS0618
             {
                 target.Properties[kvp.Key] = kvp.Value;
             }

--- a/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/IDataSeedContributor.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/DataSeeding/IDataSeedContributor.cs
@@ -21,9 +21,6 @@ namespace Granit.Persistence.EntityFrameworkCore.DataSeeding;
 /// </code>
 /// </para>
 /// </remarks>
-[Obsolete("Use IHostDataSeedContributor for host-level seeding or ITenantDataSeedContributor for per-tenant seeding. " +
-          "Legacy contributors are still executed: once with IsHostOnly=true during the host pass, " +
-          "then once with IsHostOnly=false during the tenant pass (self-managed tenant context).")]
 public interface IDataSeedContributor
 {
     /// <summary>

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceTenantExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/PersistenceTenantExtensions.cs
@@ -240,6 +240,9 @@ public static class PersistenceTenantExtensions
         // Facade — dispatches to the keyed factory resolved at runtime.
         services.TryAddScoped<IDbContextFactory<TContext>, IsolatedDbContextFactory<TContext>>();
 
+        // Marker for migration runner: this DbContext is tenant-isolated, skip on cold start.
+        services.AddSingleton(new IsolatedDbContextMarker(typeof(TContext)));
+
         // Scoped TContext: tries the isolated factory first, falls back to the
         // SharedDatabase keyed factory when no tenant is active. This fallback is
         // needed for Wolverine handler graph compilation (startup introspection)

--- a/src/Granit.Persistence.EntityFrameworkCore/GranitDbDefaults.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/GranitDbDefaults.cs
@@ -51,12 +51,12 @@ public static class GranitDbDefaults
     {
         if (HostDbSchema is not null)
         {
-            System.Diagnostics.Trace.WriteLine($"[GranitDbDefaults] EnsureFromConfiguration SKIPPED — already '{HostDbSchema}'");
+            System.Diagnostics.Trace.TraceInformation("[GranitDbDefaults] EnsureFromConfiguration SKIPPED — already '{0}'", HostDbSchema);
             return;
         }
 
         string? hostSchema = configuration["TenantIsolation:HostSchema"];
-        System.Diagnostics.Trace.WriteLine($"[GranitDbDefaults] EnsureFromConfiguration read '{hostSchema ?? "(null)"}' from config");
+        System.Diagnostics.Trace.TraceInformation("[GranitDbDefaults] EnsureFromConfiguration read '{0}' from config", hostSchema ?? "(null)");
         if (hostSchema is not null)
         {
             HostDbSchema = hostSchema;

--- a/src/Granit.Persistence.EntityFrameworkCore/Internal/HostInternalDbContextEnsurer.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Internal/HostInternalDbContextEnsurer.cs
@@ -35,23 +35,6 @@ internal sealed partial class HostInternalDbContextEnsurer<TContext>(
             .CreateDbContextAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        // For modules whose DbProperties.DbSchema is null (tenant-internal modules
-        // reused in host context), set search_path so CreateTablesAsync creates tables
-        // in the host schema instead of public. Open the connection explicitly to ensure
-        // the SET and CREATE use the same underlying connection.
-        if (GranitDbDefaults.HostDbSchema is not null)
-        {
-            System.Data.Common.DbConnection connection = db.Database.GetDbConnection();
-            if (connection.State != System.Data.ConnectionState.Open)
-            {
-                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-            }
-
-            await db.Database.ExecuteSqlRawAsync(
-                string.Concat("SET search_path TO ", GranitDbDefaults.HostDbSchema),
-                cancellationToken).ConfigureAwait(false);
-        }
-
         IRelationalDatabaseCreator creator = db.GetService<IRelationalDatabaseCreator>();
 
         LogCreatingTables(ContextName);

--- a/src/Granit.Persistence.EntityFrameworkCore/Internal/HostInternalDbContextEnsurer.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Internal/HostInternalDbContextEnsurer.cs
@@ -63,10 +63,10 @@ internal sealed partial class HostInternalDbContextEnsurer<TContext>(
         // Npgsql error-level log noise when the table does not exist yet.
         string sql = schema is not null
             ? string.Concat(
-                "SELECT COUNT(1) FROM information_schema.tables WHERE table_schema = '", schema,
+                "SELECT COUNT(1) AS \"Value\" FROM information_schema.tables WHERE table_schema = '", schema,
                 "' AND table_name = '", tableName, "'")
             : string.Concat(
-                "SELECT COUNT(1) FROM information_schema.tables WHERE table_name = '", tableName, "'");
+                "SELECT COUNT(1) AS \"Value\" FROM information_schema.tables WHERE table_name = '", tableName, "'");
 
         int count = await db.Database
             .SqlQueryRaw<int>(sql) // NOSONAR — schema/table from EF model metadata, not user input

--- a/src/Granit.Persistence.EntityFrameworkCore/Internal/HostInternalDbContextEnsurer.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Internal/HostInternalDbContextEnsurer.cs
@@ -58,26 +58,28 @@ internal sealed partial class HostInternalDbContextEnsurer<TContext>(
 
         string tableName = entityType.GetTableName()!;
         string? schema = entityType.GetSchema();
-        ISqlGenerationHelper helper = db.GetService<ISqlGenerationHelper>();
 
-        string qualifiedName = schema is not null
-            ? $"{helper.DelimitIdentifier(schema)}.{helper.DelimitIdentifier(tableName)}"
-            : helper.DelimitIdentifier(tableName);
+        // Query information_schema instead of probing with SELECT — avoids
+        // Npgsql error-level log noise when the table does not exist yet.
+        string sql = schema is not null
+            ? string.Concat(
+                "SELECT COUNT(1) FROM information_schema.tables WHERE table_schema = '", schema,
+                "' AND table_name = '", tableName, "'")
+            : string.Concat(
+                "SELECT COUNT(1) FROM information_schema.tables WHERE table_name = '", tableName, "'");
 
-        try
+        int count = await db.Database
+            .SqlQueryRaw<int>(sql) // NOSONAR — schema/table from EF model metadata, not user input
+            .SingleAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (count == 0)
         {
-            string probeSql = string.Concat("SELECT 1 FROM ", qualifiedName, " WHERE 1=0");
-            await db.Database
-                .ExecuteSqlRawAsync(probeSql, cancellationToken) // NOSONAR — table name from EF model, delimiter-escaped
-                .ConfigureAwait(false);
-
-            return true;
-        }
-        catch (Exception) when (!cancellationToken.IsCancellationRequested)
-        {
+            string qualifiedName = schema is not null ? $"{schema}.{tableName}" : tableName;
             LogTableNotFound(ContextName, qualifiedName);
-            return false;
         }
+
+        return count > 0;
     }
 
     [LoggerMessage(Level = LogLevel.Debug,

--- a/src/Granit.Persistence.EntityFrameworkCore/Internal/HostInternalDbContextEnsurer.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Internal/HostInternalDbContextEnsurer.cs
@@ -35,11 +35,18 @@ internal sealed partial class HostInternalDbContextEnsurer<TContext>(
             .CreateDbContextAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        // Set search_path to the host schema so CreateTablesAsync creates tables
-        // in the correct schema (not public) for modules whose DbProperties.DbSchema
-        // falls back to null (tenant-internal modules reused in host context).
+        // For modules whose DbProperties.DbSchema is null (tenant-internal modules
+        // reused in host context), set search_path so CreateTablesAsync creates tables
+        // in the host schema instead of public. Open the connection explicitly to ensure
+        // the SET and CREATE use the same underlying connection.
         if (GranitDbDefaults.HostDbSchema is not null)
         {
+            System.Data.Common.DbConnection connection = db.Database.GetDbConnection();
+            if (connection.State != System.Data.ConnectionState.Open)
+            {
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            }
+
             await db.Database.ExecuteSqlRawAsync(
                 string.Concat("SET search_path TO ", GranitDbDefaults.HostDbSchema),
                 cancellationToken).ConfigureAwait(false);

--- a/src/Granit.Persistence.EntityFrameworkCore/Internal/HostInternalDbContextEnsurer.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Internal/HostInternalDbContextEnsurer.cs
@@ -35,6 +35,16 @@ internal sealed partial class HostInternalDbContextEnsurer<TContext>(
             .CreateDbContextAsync(cancellationToken)
             .ConfigureAwait(false);
 
+        // Set search_path to the host schema so CreateTablesAsync creates tables
+        // in the correct schema (not public) for modules whose DbProperties.DbSchema
+        // falls back to null (tenant-internal modules reused in host context).
+        if (GranitDbDefaults.HostDbSchema is not null)
+        {
+            await db.Database.ExecuteSqlRawAsync(
+                string.Concat("SET search_path TO ", GranitDbDefaults.HostDbSchema),
+                cancellationToken).ConfigureAwait(false);
+        }
+
         IRelationalDatabaseCreator creator = db.GetService<IRelationalDatabaseCreator>();
 
         LogCreatingTables(ContextName);
@@ -57,7 +67,10 @@ internal sealed partial class HostInternalDbContextEnsurer<TContext>(
         }
 
         string tableName = entityType.GetTableName()!;
-        string? schema = entityType.GetSchema();
+        // Host internal tables should be in the host schema. If the model has no
+        // schema (tenant-internal modules like Templating/Notifications), fall back
+        // to HostDbSchema so the probe looks in the correct schema.
+        string? schema = entityType.GetSchema() ?? GranitDbDefaults.HostDbSchema;
 
         // Query information_schema instead of probing with SELECT — avoids
         // Npgsql error-level log noise when the table does not exist yet.

--- a/src/Granit.Persistence.EntityFrameworkCore/Internal/TenantInternalDbContextEnsurer.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Internal/TenantInternalDbContextEnsurer.cs
@@ -82,26 +82,23 @@ internal sealed partial class TenantInternalDbContextEnsurer<TContext>(
         }
 
         string tableName = entityType.GetTableName()!;
-        ISqlGenerationHelper helper = db.GetService<ISqlGenerationHelper>();
 
-        // search_path is set by ActivateTenantSchemaAsync above.
-        // Use unqualified table name — the search_path handles schema resolution.
-        string qualifiedName = helper.DelimitIdentifier(tableName);
+        // Query information_schema using the current search_path (set by ActivateTenantSchemaAsync).
+        // This avoids Npgsql error-level log noise when the table does not exist yet.
+        // The search_path resolves the schema, so we only filter by table_name.
+        string sql = string.Concat(
+            "SELECT COUNT(1) FROM information_schema.tables WHERE table_name = '", tableName, "'");
+        int count = await db.Database
+            .SqlQueryRaw<int>(sql) // NOSONAR — table name from EF model metadata, not user input
+            .SingleAsync(cancellationToken)
+            .ConfigureAwait(false);
 
-        try
-        {
-            string probeSql = string.Concat("SELECT 1 FROM ", qualifiedName, " WHERE 1=0");
-            await db.Database
-                .ExecuteSqlRawAsync(probeSql, cancellationToken) // NOSONAR — table name from EF model, delimiter-escaped
-                .ConfigureAwait(false);
-
-            return true;
-        }
-        catch (Exception) when (!cancellationToken.IsCancellationRequested)
+        if (count == 0)
         {
             LogTableNotFoundForTenant(ContextName, tableName, currentTenant.Id);
-            return false;
         }
+
+        return count > 0;
     }
 
     /// <summary>

--- a/src/Granit.Persistence.EntityFrameworkCore/Internal/TenantInternalDbContextEnsurer.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Internal/TenantInternalDbContextEnsurer.cs
@@ -87,7 +87,7 @@ internal sealed partial class TenantInternalDbContextEnsurer<TContext>(
         // This avoids Npgsql error-level log noise when the table does not exist yet.
         // The search_path resolves the schema, so we only filter by table_name.
         string sql = string.Concat(
-            "SELECT COUNT(1) FROM information_schema.tables WHERE table_name = '", tableName, "'");
+            "SELECT COUNT(1) AS \"Value\" FROM information_schema.tables WHERE table_name = '", tableName, "'");
         int count = await db.Database
             .SqlQueryRaw<int>(sql) // NOSONAR — table name from EF model metadata, not user input
             .SingleAsync(cancellationToken)

--- a/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/IsolatedDbContextMarker.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/IsolatedDbContextMarker.cs
@@ -1,0 +1,11 @@
+namespace Granit.Persistence.EntityFrameworkCore.MultiTenancy;
+
+/// <summary>
+/// Marker registered by <c>AddGranitIsolatedDbContext&lt;T&gt;</c> to identify DbContext types
+/// that require tenant isolation. Used by the migration runner to skip these contexts
+/// when no tenants exist (cold start) — they should only be migrated per-tenant.
+/// </summary>
+public sealed class IsolatedDbContextMarker(Type dbContextType)
+{
+    public Type DbContextType { get; } = dbContextType;
+}

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ReferenceDataEfCoreServiceCollectionExtensions.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ReferenceDataEfCoreServiceCollectionExtensions.cs
@@ -49,7 +49,15 @@ public static class ReferenceDataEfCoreServiceCollectionExtensions
         services.AddScoped<IReferenceDataStoreWriter<TEntity>>(sp =>
             sp.GetRequiredService<EfCoreReferenceDataStore<TEntity, TDbContext>>());
 
-        services.AddTransient<IHostDataSeedContributor, ReferenceDataSeedContributor<TEntity>>();
+        // Register seeder as Host or Tenant contributor based on scope
+        if (scope == ReferenceDataScope.Tenant)
+        {
+            services.AddTransient<ITenantDataSeedContributor, ReferenceDataSeedContributor<TEntity>>();
+        }
+        else
+        {
+            services.AddTransient<IHostDataSeedContributor, ReferenceDataSeedContributor<TEntity>>();
+        }
 
         return services;
     }

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ReferenceDataEfCoreServiceCollectionExtensions.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ReferenceDataEfCoreServiceCollectionExtensions.cs
@@ -49,9 +49,7 @@ public static class ReferenceDataEfCoreServiceCollectionExtensions
         services.AddScoped<IReferenceDataStoreWriter<TEntity>>(sp =>
             sp.GetRequiredService<EfCoreReferenceDataStore<TEntity, TDbContext>>());
 
-#pragma warning disable CS0618 // IDataSeedContributor: ReferenceData supports both host/tenant, migrating in a follow-up
-        services.AddTransient<IDataSeedContributor, ReferenceDataSeedContributor<TEntity>>();
-#pragma warning restore CS0618
+        services.AddTransient<IHostDataSeedContributor, ReferenceDataSeedContributor<TEntity>>();
 
         return services;
     }

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Internal/EfCoreReferenceDataStore.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Internal/EfCoreReferenceDataStore.cs
@@ -63,8 +63,8 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
         ReferenceDataQuery? query = null,
         CancellationToken cancellationToken = default)
     {
-        await using AsyncServiceScope scope = _scopeFactory.CreateAsyncScope();
-        TDbContext context = scope.ServiceProvider.GetRequiredService<TDbContext>();
+        await using AsyncServiceScope serviceScope = _scopeFactory.CreateAsyncScope();
+        TDbContext context = serviceScope.ServiceProvider.GetRequiredService<TDbContext>();
 
         query ??= new ReferenceDataQuery();
 
@@ -151,8 +151,8 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
             return maybe.Value;
         }
 
-        await using AsyncServiceScope scope = _scopeFactory.CreateAsyncScope();
-        TDbContext context = scope.ServiceProvider.GetRequiredService<TDbContext>();
+        await using AsyncServiceScope serviceScope = _scopeFactory.CreateAsyncScope();
+        TDbContext context = serviceScope.ServiceProvider.GetRequiredService<TDbContext>();
 
         IQueryable<TEntity> queryable = context.Set<TEntity>().AsNoTracking();
 
@@ -233,8 +233,8 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
     /// <inheritdoc/>
     public async Task UpdateAsync(TEntity entity, CancellationToken cancellationToken = default)
     {
-        await using AsyncServiceScope scope = _scopeFactory.CreateAsyncScope();
-        TDbContext context = scope.ServiceProvider.GetRequiredService<TDbContext>();
+        await using AsyncServiceScope serviceScope = _scopeFactory.CreateAsyncScope();
+        TDbContext context = serviceScope.ServiceProvider.GetRequiredService<TDbContext>();
 
         context.Set<TEntity>().Update(entity);
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataSeedContributor.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataSeedContributor.cs
@@ -24,7 +24,7 @@ namespace Granit.ReferenceData.EntityFrameworkCore.Internal;
 /// <typeparam name="TEntity">The concrete reference data entity type.</typeparam>
 internal sealed partial class ReferenceDataSeedContributor<TEntity>(
     IServiceProvider serviceProvider,
-    ILogger<ReferenceDataSeedContributor<TEntity>> logger) : IHostDataSeedContributor
+    ILogger<ReferenceDataSeedContributor<TEntity>> logger) : IHostDataSeedContributor, ITenantDataSeedContributor
     where TEntity : ReferenceDataEntity
 {
     /// <inheritdoc/>

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataSeedContributor.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataSeedContributor.cs
@@ -24,9 +24,7 @@ namespace Granit.ReferenceData.EntityFrameworkCore.Internal;
 /// <typeparam name="TEntity">The concrete reference data entity type.</typeparam>
 internal sealed partial class ReferenceDataSeedContributor<TEntity>(
     IServiceProvider serviceProvider,
-#pragma warning disable CS0618 // IDataSeedContributor: ReferenceData supports both host/tenant, migrating in a follow-up
-    ILogger<ReferenceDataSeedContributor<TEntity>> logger) : IDataSeedContributor
-#pragma warning restore CS0618
+    ILogger<ReferenceDataSeedContributor<TEntity>> logger) : IHostDataSeedContributor
     where TEntity : ReferenceDataEntity
 {
     /// <inheritdoc/>

--- a/src/Granit.Templating.EntityFrameworkCore/Extensions/TemplatingEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Extensions/TemplatingEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -58,7 +58,6 @@ public static class TemplatingEntityFrameworkCoreHostApplicationBuilderExtension
         }, ServiceLifetime.Scoped);
 
         builder.Services.AddHostInternalDbContextEnsurer<TemplatingDbContext>();
-        builder.Services.AddTenantInternalDbContextEnsurer<TemplatingDbContext>();
         builder.Services.AddScoped<EfDocumentTemplateStore>();
         builder.Services.AddScoped<IDocumentTemplateStoreReader>(sp => sp.GetRequiredService<EfDocumentTemplateStore>());
         builder.Services.AddScoped<IDocumentTemplateStoreWriter>(sp => sp.GetRequiredService<EfDocumentTemplateStore>());

--- a/src/Granit.Templating.EntityFrameworkCore/Extensions/TemplatingEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/Extensions/TemplatingEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -57,6 +57,7 @@ public static class TemplatingEntityFrameworkCoreHostApplicationBuilderExtension
             }
         }, ServiceLifetime.Scoped);
 
+        builder.Services.AddHostInternalDbContextEnsurer<TemplatingDbContext>();
         builder.Services.AddTenantInternalDbContextEnsurer<TemplatingDbContext>();
         builder.Services.AddScoped<EfDocumentTemplateStore>();
         builder.Services.AddScoped<IDocumentTemplateStoreReader>(sp => sp.GetRequiredService<EfDocumentTemplateStore>());

--- a/src/Granit.Templating.EntityFrameworkCore/GranitTemplatingDbProperties.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/GranitTemplatingDbProperties.cs
@@ -27,7 +27,7 @@ public static class GranitTemplatingDbProperties
     /// </summary>
     public static string? DbSchema
     {
-        get => _dbSchemaExplicitlySet ? _dbSchema : GranitDbDefaults.DbSchema;
+        get => _dbSchemaExplicitlySet ? _dbSchema : GranitDbDefaults.HostDbSchema ?? GranitDbDefaults.DbSchema;
         set { _dbSchema = value; _dbSchemaExplicitlySet = true; }
     }
 }

--- a/src/Granit.Templating.EntityFrameworkCore/GranitTemplatingDbProperties.cs
+++ b/src/Granit.Templating.EntityFrameworkCore/GranitTemplatingDbProperties.cs
@@ -21,8 +21,9 @@ public static class GranitTemplatingDbProperties
     private static bool _dbSchemaExplicitlySet;
 
     /// <summary>
-    /// Database schema for tenant-level tables.
-    /// Falls back to <see cref="GranitDbDefaults.DbSchema"/> when not explicitly set.
+    /// Database schema for templating tables.
+    /// Falls back to <see cref="GranitDbDefaults.HostDbSchema"/>, then
+    /// <see cref="GranitDbDefaults.DbSchema"/> when not explicitly set.
     /// </summary>
     public static string? DbSchema
     {

--- a/src/Granit.Templating.Mjml/Internal/MjmlTransformer.cs
+++ b/src/Granit.Templating.Mjml/Internal/MjmlTransformer.cs
@@ -40,7 +40,7 @@ internal sealed class MjmlTransformer : IRenderedContentTransformer
 
         RenderResult result = Renderer.Render(content, new MjmlOptions
         {
-            Beautify = false,
+            Beautify = true,
         });
 
         return Task.FromResult(result.Html);

--- a/src/Granit.Templating.Scriban/GlobalContexts/AppGlobalContext.cs
+++ b/src/Granit.Templating.Scriban/GlobalContexts/AppGlobalContext.cs
@@ -1,3 +1,4 @@
+using Granit.MultiTenancy;
 using Granit.Templating.GlobalContext;
 using Microsoft.Extensions.Options;
 
@@ -9,17 +10,24 @@ namespace Granit.Templating.Scriban.GlobalContexts;
 /// <remarks>
 /// Configured via <see cref="AppGlobalContextOptions"/> (section <c>Granit:Templating:App</c>).
 /// <para>
+/// When <see cref="ITenantUrlResolver"/> is registered (multi-tenant apps),
+/// <c>{{ app.base_url }}</c> resolves to the current tenant's URL.
+/// Otherwise, it falls back to the static <see cref="AppGlobalContextOptions.BaseUrl"/>.
+/// </para>
+/// <para>
 /// Available template variables:
 /// <list type="table">
 ///   <listheader><term>Variable</term><description>Example output</description></listheader>
 ///   <item><term><c>{{ app.name }}</c></term><description><c>Guava Admin</c></description></item>
-///   <item><term><c>{{ app.base_url }}</c></term><description><c>https://app.example.com</c></description></item>
+///   <item><term><c>{{ app.base_url }}</c></term><description><c>https://app.example.com</c> (tenant-aware)</description></item>
 ///   <item><term><c>{{ app.support_email }}</c></term><description><c>support@example.com</c></description></item>
 ///   <item><term><c>{{ app.logo_url }}</c></term><description><c>https://cdn.example.com/logo.png</c></description></item>
 /// </list>
 /// </para>
 /// </remarks>
-internal sealed class AppGlobalContext(IOptions<AppGlobalContextOptions> options) : ITemplateGlobalContext
+internal sealed class AppGlobalContext(
+    IOptions<AppGlobalContextOptions> options,
+    IServiceProvider serviceProvider) : ITemplateGlobalContext
 {
     /// <inheritdoc/>
     public string ContextName => "app";
@@ -28,10 +36,19 @@ internal sealed class AppGlobalContext(IOptions<AppGlobalContextOptions> options
     public object Resolve()
     {
         AppGlobalContextOptions opts = options.Value;
+
+        // Soft dependency: resolve tenant-aware URL when multi-tenancy is configured.
+        // ITenantUrlResolver is scoped (async-local ICurrentTenant), safe to resolve here.
+        // The call is cached in-memory so sync-over-async hits only the ConcurrentDictionary.
+        var urlResolver = serviceProvider.GetService(typeof(ITenantUrlResolver)) as ITenantUrlResolver;
+        string baseUrl = urlResolver is not null
+            ? urlResolver.ResolveBaseUrlAsync().GetAwaiter().GetResult()
+            : opts.BaseUrl;
+
         return new
         {
             name = opts.Name,
-            base_url = opts.BaseUrl.TrimEnd('/'),
+            base_url = baseUrl.TrimEnd('/'),
             support_email = opts.SupportEmail,
             logo_url = opts.LogoUrl,
         };

--- a/src/Granit/Extensions/GranitHostBuilderExtensions.cs
+++ b/src/Granit/Extensions/GranitHostBuilderExtensions.cs
@@ -98,6 +98,7 @@ public static class GranitHostBuilderExtensions
             moduleAssemblies);
 
         builder.Services.TryAddSingleton<ICurrentTenant>(NullTenantContext.Instance);
+        builder.Services.TryAddScoped<ITenantUrlResolver, NullTenantUrlResolver>();
 
         application.ConfigureServices(context);
 
@@ -121,6 +122,7 @@ public static class GranitHostBuilderExtensions
             moduleAssemblies);
 
         builder.Services.TryAddSingleton<ICurrentTenant>(NullTenantContext.Instance);
+        builder.Services.TryAddScoped<ITenantUrlResolver, NullTenantUrlResolver>();
 
         await application.ConfigureServicesAsync(context).ConfigureAwait(false);
 

--- a/src/Granit/MultiTenancy/ITenantUrlResolver.cs
+++ b/src/Granit/MultiTenancy/ITenantUrlResolver.cs
@@ -1,0 +1,46 @@
+namespace Granit.MultiTenancy;
+
+/// <summary>
+/// Resolves the base URL for the current tenant context.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Used by email templates (<c>{{ app.base_url }}</c>), notification channels
+/// (unsubscribe links), and identity handlers (password reset, email confirmation)
+/// to generate tenant-aware URLs.
+/// </para>
+/// <para>
+/// The resolution strategy is controlled by configuration:
+/// <list type="bullet">
+///   <item><b>Shared</b> — static fallback URL (default, backward-compatible)</item>
+///   <item><b>Subdomain</b> — derived from domain template + tenant identifier</item>
+///   <item><b>CustomDomain</b> — per-tenant custom domain from database</item>
+///   <item><b>Hybrid</b> — custom domain override, subdomain fallback</item>
+/// </list>
+/// </para>
+/// <para>
+/// Consumers should resolve this interface as a soft dependency via
+/// <c>IServiceProvider.GetService&lt;ITenantUrlResolver&gt;()</c> or Wolverine
+/// optional parameter injection and fall back to static configuration when unavailable
+/// (apps without multi-tenancy).
+/// </para>
+/// <para>
+/// The default implementation is <c>NullTenantUrlResolver</c> (returns empty string).
+/// When <c>Granit.MultiTenancy</c> is registered, it is replaced by
+/// <c>TenantUrlResolver</c> which performs strategy-based resolution.
+/// </para>
+/// </remarks>
+public interface ITenantUrlResolver
+{
+    /// <summary>
+    /// Resolves the base URL for the current tenant.
+    /// Returns the static fallback URL when no tenant context is active or
+    /// the strategy is <b>Shared</b>.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The base URL without trailing slash (e.g., <c>"https://acme.example.com"</c>).
+    /// Returns an empty string when no URL can be resolved.
+    /// </returns>
+    Task<string> ResolveBaseUrlAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Granit/MultiTenancy/NullTenantUrlResolver.cs
+++ b/src/Granit/MultiTenancy/NullTenantUrlResolver.cs
@@ -1,0 +1,12 @@
+namespace Granit.MultiTenancy;
+
+/// <summary>
+/// No-op <see cref="ITenantUrlResolver"/> used when <c>Granit.MultiTenancy</c> is not registered.
+/// Always returns an empty string, signaling consumers to fall back to static configuration.
+/// Replaced by <c>TenantUrlResolver</c> when the multi-tenancy module is loaded.
+/// </summary>
+internal sealed class NullTenantUrlResolver : ITenantUrlResolver
+{
+    public Task<string> ResolveBaseUrlAsync(CancellationToken cancellationToken = default) =>
+        Task.FromResult(string.Empty);
+}

--- a/src/Granit/MultiTenancy/TenantUrlStrategy.cs
+++ b/src/Granit/MultiTenancy/TenantUrlStrategy.cs
@@ -1,0 +1,33 @@
+namespace Granit.MultiTenancy;
+
+/// <summary>
+/// Strategy for generating outbound tenant-specific URLs (email links, templates, etc.).
+/// </summary>
+public enum TenantUrlStrategy
+{
+    /// <summary>
+    /// Shared URL for all tenants (default, backward-compatible).
+    /// Uses the static fallback base URL from configuration.
+    /// </summary>
+    Shared,
+
+    /// <summary>
+    /// Subdomain per tenant, derived from the domain template.
+    /// Example: domain template <c>"{0}.example.com"</c> + tenant identifier <c>"acme"</c>
+    /// → <c>https://acme.example.com</c>.
+    /// </summary>
+    Subdomain,
+
+    /// <summary>
+    /// Custom domain per tenant, stored in the <c>Tenant.CustomDomain</c> property.
+    /// Falls back to the static base URL when no custom domain is configured.
+    /// </summary>
+    CustomDomain,
+
+    /// <summary>
+    /// Hybrid mode (industry standard): uses the tenant's custom domain when set,
+    /// otherwise derives the URL from the domain template.
+    /// This is the recommended strategy for production SaaS deployments.
+    /// </summary>
+    Hybrid,
+}

--- a/tests/Granit.Identity.Local.Notifications.Tests/Handlers/HandlerTests.cs
+++ b/tests/Granit.Identity.Local.Notifications.Tests/Handlers/HandlerTests.cs
@@ -63,7 +63,7 @@ public sealed class HandlerTests
             Guid.Parse("00000000-0000-0000-0000-000000000001"),
             "alice@test.com", "reset-token-123", null);
 
-        await PasswordResetRequestedHandler.HandleAsync(evt, _options, _publisher, TestContext.Current.CancellationToken);
+        await PasswordResetRequestedHandler.HandleAsync(evt, _options, _publisher, cancellationToken: TestContext.Current.CancellationToken);
 
         await _publisher.Received(1).PublishAsync(
             PasswordResetNotificationType.Instance,
@@ -84,7 +84,7 @@ public sealed class HandlerTests
             Guid.Parse("00000000-0000-0000-0000-000000000001"),
             "confirm-token-456", null);
 
-        await EmailConfirmationRequestedHandler.HandleAsync(evt, _userReader, _options, _publisher, TestContext.Current.CancellationToken);
+        await EmailConfirmationRequestedHandler.HandleAsync(evt, _userReader, _options, _publisher, cancellationToken: TestContext.Current.CancellationToken);
 
         await _publisher.Received(1).PublishAsync(
             EmailConfirmationNotificationType.Instance,
@@ -102,7 +102,7 @@ public sealed class HandlerTests
             .Returns((IIdentityUser?)null);
         var evt = new EmailConfirmationRequestedEto(Guid.NewGuid(), "token", null);
 
-        await EmailConfirmationRequestedHandler.HandleAsync(evt, _userReader, _options, _publisher, TestContext.Current.CancellationToken);
+        await EmailConfirmationRequestedHandler.HandleAsync(evt, _userReader, _options, _publisher, cancellationToken: TestContext.Current.CancellationToken);
 
         await _publisher.DidNotReceiveWithAnyArgs().PublishAsync(
             Arg.Any<NotificationType<EmailConfirmationNotificationData>>(),
@@ -120,7 +120,7 @@ public sealed class HandlerTests
             Guid.Parse("00000000-0000-0000-0000-000000000001"),
             "old@test.com", "new@test.com", "change-token", null);
 
-        await EmailChangeRequestedHandler.HandleAsync(evt, _options, _publisher, TestContext.Current.CancellationToken);
+        await EmailChangeRequestedHandler.HandleAsync(evt, _options, _publisher, cancellationToken: TestContext.Current.CancellationToken);
 
         // Alert to old email (standard publish)
         await _publisher.Received(1).PublishAsync(

--- a/tests/Granit.MultiTenancy.Tests/GranitMultiTenancyModuleTests.cs
+++ b/tests/Granit.MultiTenancy.Tests/GranitMultiTenancyModuleTests.cs
@@ -57,18 +57,18 @@ public sealed class GranitMultiTenancyModuleTests
     }
 
     [Fact]
-    public void Four_TenantResolvers_Are_Registered()
+    public void Five_TenantResolvers_Are_Registered()
     {
         using WebApplication app = BuildApp();
         using IServiceScope scope = app.Services.CreateScope();
 
         IEnumerable<ITenantResolver> resolvers = scope.ServiceProvider.GetRequiredService<IEnumerable<ITenantResolver>>();
 
-        resolvers.Count().ShouldBe(4);
+        resolvers.Count().ShouldBe(5);
     }
 
     [Fact]
-    public void Resolvers_Are_Ordered_Domain_Header_Jwt_QueryString()
+    public void Resolvers_Are_Ordered_CustomDomain_Domain_Header_Jwt_QueryString()
     {
         using WebApplication app = BuildApp();
         using IServiceScope scope = app.Services.CreateScope();
@@ -78,10 +78,11 @@ public sealed class GranitMultiTenancyModuleTests
             .OrderBy(r => r.Order)
             .ToList();
 
-        ordered[0].ShouldBeOfType<DomainTenantResolver>("Domain (order=50)");
-        ordered[1].ShouldBeOfType<HeaderTenantResolver>("Header (order=100)");
-        ordered[2].ShouldBeOfType<JwtClaimTenantResolver>("JWT (order=200)");
-        ordered[3].ShouldBeOfType<QueryStringTenantResolver>("QueryString (order=300)");
+        ordered[0].ShouldBeOfType<CustomDomainTenantResolver>("CustomDomain (order=25)");
+        ordered[1].ShouldBeOfType<DomainTenantResolver>("Domain (order=50)");
+        ordered[2].ShouldBeOfType<HeaderTenantResolver>("Header (order=100)");
+        ordered[3].ShouldBeOfType<JwtClaimTenantResolver>("JWT (order=200)");
+        ordered[4].ShouldBeOfType<QueryStringTenantResolver>("QueryString (order=300)");
     }
 
     [Fact]

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEfCoreServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEfCoreServiceCollectionExtensionsTests.cs
@@ -69,18 +69,16 @@ public sealed class ReferenceDataEfCoreServiceCollectionExtensionsTests
         writer.ShouldNotBeNull();
     }
 
-#pragma warning disable CS0618 // IDataSeedContributor: testing backward compat registration
     [Fact]
-    public void AddReferenceDataStore_RegistersDataSeedContributor()
+    public void AddReferenceDataStore_RegistersHostDataSeedContributor()
     {
         using ServiceProvider sp = BuildProvider();
 
-        IEnumerable<IDataSeedContributor> contributors =
-            sp.GetServices<IDataSeedContributor>();
+        IEnumerable<IHostDataSeedContributor> contributors =
+            sp.GetServices<IHostDataSeedContributor>();
 
         contributors.ShouldNotBeEmpty();
     }
-#pragma warning restore CS0618
 
     [Fact]
     public void AddReferenceDataStore_ReaderAndWriter_AreSameInstance()

--- a/tests/Granit.Templating.Scriban.Tests/GlobalContexts/AppGlobalContextTests.cs
+++ b/tests/Granit.Templating.Scriban.Tests/GlobalContexts/AppGlobalContextTests.cs
@@ -1,4 +1,5 @@
 using Granit.Templating.Scriban.GlobalContexts;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Shouldly;
 using Xunit;
@@ -7,10 +8,13 @@ namespace Granit.Templating.Scriban.Tests.GlobalContexts;
 
 public sealed class AppGlobalContextTests
 {
+    private static ServiceProvider BuildSp() => new ServiceCollection().BuildServiceProvider();
+
     [Fact]
     public void ContextName_IsApp()
     {
-        AppGlobalContext sut = new(Options.Create(new AppGlobalContextOptions()));
+        using ServiceProvider sp = BuildSp();
+        AppGlobalContext sut = new(Options.Create(new AppGlobalContextOptions()), sp);
 
         sut.ContextName.ShouldBe("app");
     }
@@ -25,7 +29,8 @@ public sealed class AppGlobalContextTests
             SupportEmail = "support@example.com",
             LogoUrl = "https://cdn.example.com/logo.png",
         };
-        AppGlobalContext sut = new(Options.Create(opts));
+        using ServiceProvider sp = BuildSp();
+        AppGlobalContext sut = new(Options.Create(opts), sp);
 
         dynamic resolved = sut.Resolve();
         Type type = resolved.GetType();
@@ -40,7 +45,8 @@ public sealed class AppGlobalContextTests
     public void Resolve_TrimsTrailingSlashFromBaseUrl()
     {
         AppGlobalContextOptions opts = new() { BaseUrl = "https://app.example.com/" };
-        AppGlobalContext sut = new(Options.Create(opts));
+        using ServiceProvider sp = BuildSp();
+        AppGlobalContext sut = new(Options.Create(opts), sp);
 
         dynamic resolved = sut.Resolve();
 
@@ -51,7 +57,8 @@ public sealed class AppGlobalContextTests
     [Fact]
     public void Resolve_DefaultOptions_ReturnsEmptyStrings()
     {
-        AppGlobalContext sut = new(Options.Create(new AppGlobalContextOptions()));
+        using ServiceProvider sp = BuildSp();
+        AppGlobalContext sut = new(Options.Create(new AppGlobalContextOptions()), sp);
 
         dynamic resolved = sut.Resolve();
         Type type = resolved.GetType();


### PR DESCRIPTION
## Summary

- Rename `AsyncServiceScope scope` to `serviceScope` in 3 methods of `EfCoreReferenceDataStore` to resolve SonarQube S3353 (variable shadowing the `scope` primary constructor parameter of type `ReferenceDataScope`)

## Test plan

- [x] 73 EF Core tests pass
- [x] Build succeeds with 0 warnings