### PR TITLE
fix(multi-tenancy): tenant URL resolver fallback and identity refactor

### DIFF
--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
@@ -211,88 +211,81 @@ internal static partial class AccountLoginEndpoints
         // GetTwoFactorAuthenticationUserAsync internally calls FindByIdAsync which is subject to
         // the multi-tenant query filter. When no tenant is resolved, disable the filter to find
         // the user, then establish the tenant context for the rest of the handler.
-        IDisposable? tenantScope = await ResolveTenantFromTwoFactorSessionAsync(
+        using IDisposable? tenantScope = await ResolveTenantFromTwoFactorSessionAsync(
             signInManager, currentTenant, dataFilter).ConfigureAwait(false);
 
-        try
+        // Strip whitespace and dashes from the code (authenticator apps often format codes with spaces)
+        string sanitizedCode = request.Code.Replace(" ", string.Empty, StringComparison.Ordinal)
+            .Replace("-", string.Empty, StringComparison.Ordinal);
+
+        string method = request.UseRecoveryCode ? "recovery_code" : "totp";
+        string failureReason = request.UseRecoveryCode ? "invalid_recovery_code" : "invalid_totp_code";
+
+        Microsoft.AspNetCore.Identity.SignInResult result;
+
+        if (request.UseRecoveryCode)
         {
-            // Strip whitespace and dashes from the code (authenticator apps often format codes with spaces)
-            string sanitizedCode = request.Code.Replace(" ", string.Empty, StringComparison.Ordinal)
-                .Replace("-", string.Empty, StringComparison.Ordinal);
+            result = await signInManager
+                .TwoFactorRecoveryCodeSignInAsync(sanitizedCode)
+                .ConfigureAwait(false);
 
-            string method = request.UseRecoveryCode ? "recovery_code" : "totp";
-            string failureReason = request.UseRecoveryCode ? "invalid_recovery_code" : "invalid_totp_code";
-
-            Microsoft.AspNetCore.Identity.SignInResult result;
-
-            if (request.UseRecoveryCode)
+            // TwoFactorRecoveryCodeSignInAsync does not accept isPersistent,
+            // so re-sign the user with a persistent cookie when RememberMe is requested.
+            if (result.Succeeded && request.RememberMe)
             {
-                result = await signInManager
-                    .TwoFactorRecoveryCodeSignInAsync(sanitizedCode)
-                    .ConfigureAwait(false);
+                GranitUser? user = await signInManager.UserManager
+                    .GetUserAsync(httpContext.User).ConfigureAwait(false);
 
-                // TwoFactorRecoveryCodeSignInAsync does not accept isPersistent,
-                // so re-sign the user with a persistent cookie when RememberMe is requested.
-                if (result.Succeeded && request.RememberMe)
+                if (user is not null)
                 {
-                    GranitUser? user = await signInManager.UserManager
-                        .GetUserAsync(httpContext.User).ConfigureAwait(false);
-
-                    if (user is not null)
-                    {
-                        await signInManager.SignInAsync(user, isPersistent: true)
-                            .ConfigureAwait(false);
-                    }
-                }
-            }
-            else
-            {
-                result = await signInManager
-                    .TwoFactorAuthenticatorSignInAsync(sanitizedCode, isPersistent: request.RememberMe, rememberClient: false)
-                    .ConfigureAwait(false);
-            }
-
-            if (result.Succeeded)
-            {
-                LogTwoFactorSuccess(logger, method);
-                metrics?.RecordAuthenticationSuccess(null, method);
-
-                return TypedResults.Ok(new AccountLoginResponse(Succeeded: true));
-            }
-
-            if (result.IsLockedOut)
-            {
-                GranitUser? lockedUser = await signInManager.GetTwoFactorAuthenticationUserAsync()
-                    .ConfigureAwait(false);
-
-                LogLoginLockedOut(logger, lockedUser?.Id.ToString() ?? "two-factor-user");
-                metrics?.RecordAuthenticationFailure(null, "account_locked");
-
-                if (lockedUser is not null)
-                {
-                    await PublishAccountLockedAsync(
-                        httpContext, signInManager.UserManager, lockedUser, cancellationToken)
+                    await signInManager.SignInAsync(user, isPersistent: true)
                         .ConfigureAwait(false);
                 }
+            }
+        }
+        else
+        {
+            result = await signInManager
+                .TwoFactorAuthenticatorSignInAsync(sanitizedCode, isPersistent: request.RememberMe, rememberClient: false)
+                .ConfigureAwait(false);
+        }
 
-                // Return 401 (same as invalid code) to prevent account enumeration.
-                // The user is notified of the lockout exclusively via email.
-                return TypedResults.Problem(
-                    detail: "Invalid verification code.",
-                    statusCode: StatusCodes.Status401Unauthorized);
+        if (result.Succeeded)
+        {
+            LogTwoFactorSuccess(logger, method);
+            metrics?.RecordAuthenticationSuccess(null, method);
+
+            return TypedResults.Ok(new AccountLoginResponse(Succeeded: true));
+        }
+
+        if (result.IsLockedOut)
+        {
+            GranitUser? lockedUser = await signInManager.GetTwoFactorAuthenticationUserAsync()
+                .ConfigureAwait(false);
+
+            LogLoginLockedOut(logger, lockedUser?.Id.ToString() ?? "two-factor-user");
+            metrics?.RecordAuthenticationFailure(null, "account_locked");
+
+            if (lockedUser is not null)
+            {
+                await PublishAccountLockedAsync(
+                    httpContext, signInManager.UserManager, lockedUser, cancellationToken)
+                    .ConfigureAwait(false);
             }
 
-            LogTwoFactorFailed(logger, failureReason);
-            metrics?.RecordAuthenticationFailure(null, "invalid_token");
-
+            // Return 401 (same as invalid code) to prevent account enumeration.
+            // The user is notified of the lockout exclusively via email.
             return TypedResults.Problem(
                 detail: "Invalid verification code.",
                 statusCode: StatusCodes.Status401Unauthorized);
         }
-        finally
-        {
-            tenantScope?.Dispose();
-        }
+
+        LogTwoFactorFailed(logger, failureReason);
+        metrics?.RecordAuthenticationFailure(null, "invalid_token");
+
+        return TypedResults.Problem(
+            detail: "Invalid verification code.",
+            statusCode: StatusCodes.Status401Unauthorized);
     }
 
     /// <summary>

--- a/src/Granit.Identity.Local.Notifications/Handlers/EmailChangeRequestedHandler.cs
+++ b/src/Granit.Identity.Local.Notifications/Handlers/EmailChangeRequestedHandler.cs
@@ -37,9 +37,10 @@ public class EmailChangeRequestedHandler
         // Confirmation to the new email — override recipient so the email
         // goes to the new address, not the one currently on file.
         IdentityNotificationOptions opts = options.Value;
-        string baseUrl = urlResolver is not null
+        string? resolvedUrl = urlResolver is not null
             ? await urlResolver.ResolveBaseUrlAsync(cancellationToken).ConfigureAwait(false)
-            : opts.FrontendBaseUrl;
+            : null;
+        string baseUrl = !string.IsNullOrEmpty(resolvedUrl) ? resolvedUrl : opts.FrontendBaseUrl;
 
         string confirmLink = opts.BuildChangeEmailUrl(
             baseUrl, userId, evt.NewEmail, evt.Token);

--- a/src/Granit.Identity.Local.Notifications/Handlers/EmailConfirmationRequestedHandler.cs
+++ b/src/Granit.Identity.Local.Notifications/Handlers/EmailConfirmationRequestedHandler.cs
@@ -30,9 +30,10 @@ public class EmailConfirmationRequestedHandler
         }
 
         IdentityNotificationOptions opts = options.Value;
-        string baseUrl = urlResolver is not null
+        string? resolvedUrl = urlResolver is not null
             ? await urlResolver.ResolveBaseUrlAsync(cancellationToken).ConfigureAwait(false)
-            : opts.FrontendBaseUrl;
+            : null;
+        string baseUrl = !string.IsNullOrEmpty(resolvedUrl) ? resolvedUrl : opts.FrontendBaseUrl;
 
         string confirmLink = opts.BuildConfirmEmailUrl(
             baseUrl, evt.UserId.ToString(), evt.Token);

--- a/src/Granit.Identity.Local.Notifications/Handlers/PasswordResetRequestedHandler.cs
+++ b/src/Granit.Identity.Local.Notifications/Handlers/PasswordResetRequestedHandler.cs
@@ -21,9 +21,10 @@ public class PasswordResetRequestedHandler
         CancellationToken cancellationToken = default)
     {
         IdentityNotificationOptions opts = options.Value;
-        string baseUrl = urlResolver is not null
+        string? resolvedUrl = urlResolver is not null
             ? await urlResolver.ResolveBaseUrlAsync(cancellationToken).ConfigureAwait(false)
-            : opts.FrontendBaseUrl;
+            : null;
+        string baseUrl = !string.IsNullOrEmpty(resolvedUrl) ? resolvedUrl : opts.FrontendBaseUrl;
 
         string resetLink = opts.BuildResetPasswordUrl(
             baseUrl, evt.UserId.ToString(), evt.ResetToken);

--- a/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
+++ b/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
@@ -148,9 +148,10 @@ internal sealed partial class EmailNotificationChannel(
 
         // Soft dependency: use tenant-aware URL when multi-tenancy is configured
         ITenantUrlResolver? urlResolver = serviceProvider.GetService<ITenantUrlResolver>();
-        string? baseUrl = urlResolver is not null
+        string? resolvedUrl = urlResolver is not null
             ? await urlResolver.ResolveBaseUrlAsync(cancellationToken).ConfigureAwait(false)
-            : configuration["Granit:Templating:App:BaseUrl"];
+            : null;
+        string? baseUrl = !string.IsNullOrEmpty(resolvedUrl) ? resolvedUrl : configuration["Granit:Templating:App:BaseUrl"];
 
         return string.IsNullOrEmpty(baseUrl) ? "" : baseUrl.TrimEnd('/') + "/notifications/preferences";
     }

--- a/src/Granit.Templating.Scriban/GlobalContexts/AppGlobalContext.cs
+++ b/src/Granit.Templating.Scriban/GlobalContexts/AppGlobalContext.cs
@@ -41,9 +41,8 @@ internal sealed class AppGlobalContext(
         // ITenantUrlResolver is scoped (async-local ICurrentTenant), safe to resolve here.
         // The call is cached in-memory so sync-over-async hits only the ConcurrentDictionary.
         var urlResolver = serviceProvider.GetService(typeof(ITenantUrlResolver)) as ITenantUrlResolver;
-        string baseUrl = urlResolver is not null
-            ? urlResolver.ResolveBaseUrlAsync().GetAwaiter().GetResult()
-            : opts.BaseUrl;
+        string? resolvedUrl = urlResolver?.ResolveBaseUrlAsync().GetAwaiter().GetResult();
+        string baseUrl = !string.IsNullOrEmpty(resolvedUrl) ? resolvedUrl : opts.BaseUrl;
 
         return new
         {

--- a/src/Granit/Extensions/GranitHostBuilderExtensions.cs
+++ b/src/Granit/Extensions/GranitHostBuilderExtensions.cs
@@ -98,7 +98,6 @@ public static class GranitHostBuilderExtensions
             moduleAssemblies);
 
         builder.Services.TryAddSingleton<ICurrentTenant>(NullTenantContext.Instance);
-        builder.Services.TryAddScoped<ITenantUrlResolver, NullTenantUrlResolver>();
 
         application.ConfigureServices(context);
 
@@ -122,7 +121,6 @@ public static class GranitHostBuilderExtensions
             moduleAssemblies);
 
         builder.Services.TryAddSingleton<ICurrentTenant>(NullTenantContext.Instance);
-        builder.Services.TryAddScoped<ITenantUrlResolver, NullTenantUrlResolver>();
 
         await application.ConfigureServicesAsync(context).ConfigureAwait(false);
 


### PR DESCRIPTION
## Summary
- Remove `NullTenantUrlResolver` auto-registration from `GranitHostBuilderExtensions` — it blocked the real `TenantUrlResolver` registration via `TryAddScoped` in `AddGranitMultiTenancy`
- Add double-fallback in all `ITenantUrlResolver` consumers: if the resolver returns an empty string (e.g., `FallbackBaseUrl` not configured), fall back to static config (`AppGlobalContextOptions.BaseUrl`, `IdentityNotificationOptions.FrontendBaseUrl`, or `Granit:Templating:App:BaseUrl`)
- Refactor `AccountLoginEndpoints.TwoFactorLoginAsync` to use `using` declaration for `tenantScope` instead of `try/finally`

## Test plan
- [ ] `dotnet test tests/Granit.MultiTenancy.Tests` — 93 passed
- [ ] `dotnet test tests/Granit.Notifications.Email.Tests` — 75 passed
- [ ] `dotnet test tests/Granit.Identity.Local.Notifications.Tests` — 15 passed
- [ ] `dotnet test tests/Granit.Templating.Scriban.Tests` — 40 passed