### PR TITLE
fix(notifications): record delivery audit on failure + architecture test (#950)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -23943,7 +23943,7 @@
       "kind": "class",
       "project": "Granit.Notifications",
       "file": "src/Granit.Notifications/Handlers/NotificationDeliveryHandler.cs",
-      "line": 17,
+      "line": 18,
       "members": [
         {
           "name": "HandleAsync",

--- a/src/Granit.Notifications/Handlers/NotificationDeliveryHandler.cs
+++ b/src/Granit.Notifications/Handlers/NotificationDeliveryHandler.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 using Granit.Guids;
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Diagnostics;
@@ -67,6 +68,8 @@ public sealed partial class NotificationDeliveryHandler(
 
         var stopwatch = Stopwatch.StartNew();
         bool sent = false;
+        string? errorMessage = null;
+        ExceptionDispatchInfo? failure = null;
         try
         {
             await channel.SendAsync(context, cancellationToken).ConfigureAwait(false);
@@ -94,8 +97,9 @@ public sealed partial class NotificationDeliveryHandler(
 
             LogNotificationDeliveryFailed(ex, command.ChannelName, command.DeliveryId, command.NotificationId);
 
-            throw new NotificationDeliveryException(
-                $"Failed to deliver notification {command.NotificationId} via {command.ChannelName}", ex);
+            errorMessage = ex.Message;
+            failure = ExceptionDispatchInfo.Capture(new NotificationDeliveryException(
+                $"Failed to deliver notification {command.NotificationId} via {command.ChannelName}", ex));
         }
 
         // Record the delivery attempt AFTER the send — audit failures must NOT
@@ -114,7 +118,7 @@ public sealed partial class NotificationDeliveryHandler(
                 OccurredAt = clock.Now,
                 DurationMs = stopwatch.ElapsedMilliseconds,
                 IsSuccess = sent,
-                ErrorMessage = sent ? null : "Send failed — see previous log entry",
+                ErrorMessage = errorMessage,
             }, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
@@ -122,6 +126,8 @@ public sealed partial class NotificationDeliveryHandler(
             // Audit persistence failure must not mask a successful send or trigger retry.
             LogAuditRecordFailed(ex, command.ChannelName, command.DeliveryId);
         }
+
+        failure?.Throw();
     }
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Duplicate delivery {DeliveryId} skipped for notification {NotificationId} via '{ChannelName}' (already delivered)")]


### PR DESCRIPTION
## Summary
- Delivery failures were never audited: the catch block threw `NotificationDeliveryException` immediately, skipping `RecordAsync`
- Defer the throw via `ExceptionDispatchInfo.Capture/Throw` so the audit record is written before the exception propagates
- Satisfies `SourceCodeAntiPatternTests.Throw_ex_should_not_be_used_in_src` (no bare `throw identifier;`)

## Test plan
- [x] `dotnet test tests/Granit.Notifications.Tests` — 249 passed
- [ ] `dotnet test tests/Granit.ArchitectureTests` — `Throw_ex_should_not_be_used_in_src` should pass