### PR TITLE
fix(templating): resolve ITenantUrlResolver via IServiceScopeFactory

### DIFF
--- a/src/Granit.Templating.Scriban/GlobalContexts/AppGlobalContext.cs
+++ b/src/Granit.Templating.Scriban/GlobalContexts/AppGlobalContext.cs
@@ -1,5 +1,6 @@
 using Granit.MultiTenancy;
 using Granit.Templating.GlobalContext;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Granit.Templating.Scriban.GlobalContexts;
@@ -27,7 +28,7 @@ namespace Granit.Templating.Scriban.GlobalContexts;
 /// </remarks>
 internal sealed class AppGlobalContext(
     IOptions<AppGlobalContextOptions> options,
-    IServiceProvider serviceProvider) : ITemplateGlobalContext
+    IServiceScopeFactory scopeFactory) : ITemplateGlobalContext
 {
     /// <inheritdoc/>
     public string ContextName => "app";
@@ -37,11 +38,16 @@ internal sealed class AppGlobalContext(
     {
         AppGlobalContextOptions opts = options.Value;
 
-        // Soft dependency: resolve tenant-aware URL when multi-tenancy is configured.
-        // ITenantUrlResolver is scoped (async-local ICurrentTenant), safe to resolve here.
-        // The call is cached in-memory so sync-over-async hits only the ConcurrentDictionary.
-        var urlResolver = serviceProvider.GetService(typeof(ITenantUrlResolver)) as ITenantUrlResolver;
-        string? resolvedUrl = urlResolver?.ResolveBaseUrlAsync().GetAwaiter().GetResult();
+        // ITenantUrlResolver is scoped (depends on ITenantReader/EF Core).
+        // AppGlobalContext is a singleton, so we create a short-lived scope to resolve it.
+        // The resolver uses an in-memory cache so the scope + DB overhead is minimal.
+        string? resolvedUrl = null;
+        using (IServiceScope scope = scopeFactory.CreateScope())
+        {
+            ITenantUrlResolver? urlResolver = scope.ServiceProvider.GetService<ITenantUrlResolver>();
+            resolvedUrl = urlResolver?.ResolveBaseUrlAsync().GetAwaiter().GetResult();
+        }
+
         string baseUrl = !string.IsNullOrEmpty(resolvedUrl) ? resolvedUrl : opts.BaseUrl;
 
         return new

--- a/tests/Granit.Templating.Scriban.Tests/GlobalContexts/AppGlobalContextTests.cs
+++ b/tests/Granit.Templating.Scriban.Tests/GlobalContexts/AppGlobalContextTests.cs
@@ -8,13 +8,14 @@ namespace Granit.Templating.Scriban.Tests.GlobalContexts;
 
 public sealed class AppGlobalContextTests
 {
-    private static ServiceProvider BuildSp() => new ServiceCollection().BuildServiceProvider();
+    private static IServiceScopeFactory BuildScopeFactory() =>
+        new ServiceCollection().BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
 
     [Fact]
     public void ContextName_IsApp()
     {
-        using ServiceProvider sp = BuildSp();
-        AppGlobalContext sut = new(Options.Create(new AppGlobalContextOptions()), sp);
+        IServiceScopeFactory scopeFactory = BuildScopeFactory();
+        AppGlobalContext sut = new(Options.Create(new AppGlobalContextOptions()), scopeFactory);
 
         sut.ContextName.ShouldBe("app");
     }
@@ -29,8 +30,8 @@ public sealed class AppGlobalContextTests
             SupportEmail = "support@example.com",
             LogoUrl = "https://cdn.example.com/logo.png",
         };
-        using ServiceProvider sp = BuildSp();
-        AppGlobalContext sut = new(Options.Create(opts), sp);
+        IServiceScopeFactory scopeFactory = BuildScopeFactory();
+        AppGlobalContext sut = new(Options.Create(opts), scopeFactory);
 
         dynamic resolved = sut.Resolve();
         Type type = resolved.GetType();
@@ -45,8 +46,8 @@ public sealed class AppGlobalContextTests
     public void Resolve_TrimsTrailingSlashFromBaseUrl()
     {
         AppGlobalContextOptions opts = new() { BaseUrl = "https://app.example.com/" };
-        using ServiceProvider sp = BuildSp();
-        AppGlobalContext sut = new(Options.Create(opts), sp);
+        IServiceScopeFactory scopeFactory = BuildScopeFactory();
+        AppGlobalContext sut = new(Options.Create(opts), scopeFactory);
 
         dynamic resolved = sut.Resolve();
 
@@ -57,8 +58,8 @@ public sealed class AppGlobalContextTests
     [Fact]
     public void Resolve_DefaultOptions_ReturnsEmptyStrings()
     {
-        using ServiceProvider sp = BuildSp();
-        AppGlobalContext sut = new(Options.Create(new AppGlobalContextOptions()), sp);
+        IServiceScopeFactory scopeFactory = BuildScopeFactory();
+        AppGlobalContext sut = new(Options.Create(new AppGlobalContextOptions()), scopeFactory);
 
         dynamic resolved = sut.Resolve();
         Type type = resolved.GetType();


### PR DESCRIPTION
## Summary
- `AppGlobalContext` is a **singleton** but `ITenantUrlResolver` is **scoped** → `InvalidOperationException: Cannot resolve scoped service from root provider`
- This broke **all template rendering** in Development mode (ValidateScopes=true), causing emails to show raw `Security.PasswordReset` instead of rendered content
- Fix: inject `IServiceScopeFactory` instead of `IServiceProvider`, create a short-lived scope in `Resolve()`

## Test plan
- [x] `dotnet test tests/Granit.Templating.Scriban.Tests` — 40 passed
- [ ] Showcase: trigger password reset → verify MJML email renders correctly in Mailpit