### PR TITLE
fix(openiddict): make ConfigureOpenIddictModule() self-contained

### DIFF
--- a/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictModelBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictModelBuilderExtensions.cs
@@ -92,13 +92,44 @@ public static class OpenIddictModelBuilderExtensions
             b.Property(r => r.Description).HasMaxLength(512);
         });
 
-        modelBuilder.Entity<IdentityUserRole<Guid>>().ToTable(prefix + "user_roles", schema);
-        modelBuilder.Entity<IdentityUserClaim<Guid>>().ToTable(prefix + "user_claims", schema);
-        modelBuilder.Entity<IdentityUserLogin<Guid>>().ToTable(prefix + "user_logins", schema);
-        modelBuilder.Entity<IdentityUserToken<Guid>>().ToTable(prefix + "user_tokens", schema);
-        modelBuilder.Entity<IdentityRoleClaim<Guid>>().ToTable(prefix + "role_claims", schema);
+        // ASP.NET Identity join/claim entities — define keys explicitly so that
+        // ConfigureOpenIddictModule() is self-contained and works in any DbContext,
+        // not only those inheriting from IdentityDbContext.
+        modelBuilder.Entity<IdentityUserRole<Guid>>(b =>
+        {
+            b.ToTable(prefix + "user_roles", schema);
+            b.HasKey(r => new { r.UserId, r.RoleId });
+        });
 
-        // ──── Remap OpenIddict core tables to openiddict_* prefix ────
+        modelBuilder.Entity<IdentityUserClaim<Guid>>(b =>
+        {
+            b.ToTable(prefix + "user_claims", schema);
+            b.HasKey(c => c.Id);
+        });
+
+        modelBuilder.Entity<IdentityUserLogin<Guid>>(b =>
+        {
+            b.ToTable(prefix + "user_logins", schema);
+            b.HasKey(l => new { l.LoginProvider, l.ProviderKey });
+        });
+
+        modelBuilder.Entity<IdentityUserToken<Guid>>(b =>
+        {
+            b.ToTable(prefix + "user_tokens", schema);
+            b.HasKey(t => new { t.UserId, t.LoginProvider, t.Name });
+        });
+
+        modelBuilder.Entity<IdentityRoleClaim<Guid>>(b =>
+        {
+            b.ToTable(prefix + "role_claims", schema);
+            b.HasKey(c => c.Id);
+        });
+
+        // ──── OpenIddict conventions + table remapping ────
+        // UseOpenIddict registers key/index conventions for the custom OpenIddict entities.
+        // Must be called before ToTable remapping.
+        modelBuilder.UseOpenIddict<GranitOpenIddictApplication, GranitOpenIddictAuthorization,
+            GranitOpenIddictScope, GranitOpenIddictToken, Guid>();
 
         modelBuilder.Entity<GranitOpenIddictApplication>().ToTable(prefix + "applications", schema);
         modelBuilder.Entity<GranitOpenIddictAuthorization>().ToTable(prefix + "authorizations", schema);

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/OpenIddictDbContext.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/OpenIddictDbContext.cs
@@ -42,14 +42,14 @@ internal sealed class OpenIddictDbContext(
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        // 1. ASP.NET Identity conventions (default table names, keys, indexes)
+        // 1. ASP.NET Identity conventions (default table names, keys, indexes).
+        // ConfigureOpenIddictModule() is self-contained (defines Identity keys +
+        // calls UseOpenIddict), but base.OnModelCreating() is still needed for
+        // IdentityDbContext-specific conventions (navigation properties, indexes).
         base.OnModelCreating(builder);
 
-        // 2. OpenIddict conventions with custom multi-tenant entities
-        builder.UseOpenIddict<GranitOpenIddictApplication, GranitOpenIddictAuthorization,
-            GranitOpenIddictScope, GranitOpenIddictToken, Guid>();
-
-        // 3. Granit OpenIddict conventions (openiddict_* table prefix, column constraints, manual filters)
+        // 2. Granit OpenIddict conventions (Identity keys, OpenIddict conventions,
+        //    openiddict_* table prefix, column constraints, manual soft-delete filter)
         builder.ConfigureOpenIddictModule(dataFilter, extensionOptions?.Value);
 
         // 4. Granit cross-cutting conventions (IMultiTenant, ISoftDeletable, IActive, etc.)


### PR DESCRIPTION
## Summary

- Make `ConfigureOpenIddictModule()` self-contained so it works in any `DbContext`, not only those inheriting from `IdentityDbContext`
- Add explicit `HasKey()` for ASP.NET Identity join entities (`IdentityUserLogin`, `IdentityUserRole`, `IdentityUserToken`, `IdentityUserClaim`, `IdentityRoleClaim`)
- Move `UseOpenIddict<>()` call inside `ConfigureOpenIddictModule()` (was previously a separate step in `OpenIddictDbContext.OnModelCreating`)

### Why

Follow-up to #955. The host-owned migration pattern requires `ConfigureOpenIddictModule()` to be callable from a plain `DbContext` (e.g., `ShowcaseHostDbContext`). Previously it depended on `IdentityDbContext.OnModelCreating()` for key definitions and a separate `UseOpenIddict<>()` call for OpenIddict conventions.

## Test plan

- [ ] `dotnet build` succeeds
- [ ] OpenIddict unit + integration tests pass
- [ ] Showcase `dotnet run --migrate` with `ConfigureOpenIddictModule()` in host DbContext
