### PR TITLE
docs(blog): add 3 April 2026 blog articles

### DIFF
--- a/docs-site/src/content/docs/blog/idempotency-keys-why-every-post-should-be-retry-safe.md
+++ b/docs-site/src/content/docs/blog/idempotency-keys-why-every-post-should-be-retry-safe.md
@@ -1,0 +1,278 @@
+---
+title: "Idempotency Keys: Why Every POST Should Be Retry-Safe"
+date: 2026-04-10
+sidebar:
+  order: 19
+authors:
+  - jfmeyers
+tags:
+  - best-practice
+  - api
+  - architecture
+description: "A dropped connection, a mobile retry, a load-balancer timeout — any of these can duplicate a POST. Idempotency keys make every mutation safe to replay."
+excerpt: >
+  A dropped connection, a mobile retry, a load-balancer timeout — any of these
+  can duplicate a POST. Idempotency keys turn dangerous replays into harmless
+  no-ops, and Granit ships the entire pattern as a single middleware.
+---
+
+Your payment endpoint runs. The database row is inserted. The response is on its way back — and the connection drops. The client retries. Now you have **two charges** for the same order. The customer notices before you do.
+
+This is not a theoretical edge case. It happens every day on every API that accepts POST requests over an unreliable network (all of them). The HTTP specification already solved this for GET, PUT, and DELETE — they are idempotent by definition. POST is the outlier. **Idempotency keys** close that gap.
+
+## What is an idempotency key?
+
+An idempotency key is a client-generated unique identifier attached to a request via a header. The server uses it to recognize retries and return the **original response** instead of executing the operation again.
+
+```text
+POST /api/v1/payments/charge
+Idempotency-Key: 550e8400-e29b-41d4-a716-446655440000
+Content-Type: application/json
+
+{ "orderId": "ORD-42", "amount": 149.99, "currency": "EUR" }
+```
+
+If the server has seen this key before, it returns the cached response — same status code, same body, same headers. The client cannot tell the difference between a fresh response and a replay. That is the point.
+
+## Why client-generated?
+
+The key **must** come from the client because only the client knows whether a request is new or a retry. The server cannot distinguish a legitimate duplicate (user clicked "Pay" twice) from a network retry (load balancer timed out, client resent). The key is the client's declaration: *"this is the same logical operation."*
+
+In practice, a UUID v4 generated before the first attempt works. The client stores it alongside the request and reuses it on retry. Some teams use a deterministic key derived from business data (`SHA-256(orderId + amount + currency)`) — this prevents the "same intent, different key" problem when the client forgets to store the original.
+
+## The three failure modes without idempotency
+
+Every non-idempotent POST is vulnerable to three scenarios:
+
+| Scenario | What happens | Impact |
+| ---------- | ------------- | -------- |
+| **Network retry** | Load balancer times out, resends the request | Double charge, duplicate record |
+| **Client retry** | Mobile app loses connectivity, user taps again | Same as above, plus user frustration |
+| **Saga compensation** | Orchestrator retries a failed step after partial success | Inconsistent state across services |
+
+All three produce the same symptom: **duplicate side effects**. The fix is the same for all three: recognize the retry, return the original result.
+
+## How Granit handles it
+
+`Granit.Http.Idempotency` implements the full Stripe-style idempotency pattern as ASP.NET Core middleware. The state machine has three states:
+
+```text
+Request arrives
+    │
+    ├─ Key absent ──────────────> Execute normally (no idempotency)
+    │
+    └─ Key present
+         │
+         ├─ State: Absent ─────> SET NX (acquire lock) ──> Execute ──> Cache response
+         │
+         ├─ State: InProgress ─> Return 409 Conflict + Retry-After header
+         │
+         └─ State: Completed ──> Verify payload hash
+                                    ├─ Match ──> Return cached response (replay)
+                                    └─ Mismatch ─> Return 422 (key reuse with different body)
+```
+
+### Mark an endpoint as idempotent
+
+Decorate any endpoint with `[Idempotent]`:
+
+```csharp title="PaymentEndpoints.cs"
+group.MapPost("/charge", ChargeAsync)
+    .WithName("ChargePayment")
+    .WithSummary("Initiates a payment charge.")
+    .WithDescription(
+        "Charges the specified amount against the payment method on file. " +
+        "Requires an Idempotency-Key header to prevent duplicate charges.")
+    .Produces<PaymentChargeResponse>(StatusCodes.Status201Created)
+    .ProducesProblem(StatusCodes.Status409Conflict)
+    .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+    .WithMetadata(new IdempotentAttribute { Required = true });
+```
+
+`Required = true` means the middleware **rejects** requests without the header — returning 400 instead of silently executing without protection. For payment endpoints, this is the right default.
+
+### Configure the behavior
+
+```json title="appsettings.json"
+{
+  "Idempotency": {
+    "HeaderName": "Idempotency-Key",
+    "CompletedTtl": "24:00:00",
+    "InProgressTtl": "00:00:30",
+    "ExecutionTimeout": "00:00:25",
+    "MaxBodySizeBytes": 1048576
+  }
+}
+```
+
+| Option | Default | Purpose |
+| -------- | --------- | --------- |
+| `HeaderName` | `Idempotency-Key` | HTTP header name |
+| `CompletedTtl` | 24 hours | How long a completed response is cached |
+| `InProgressTtl` | 30 seconds | Lock duration for in-flight requests |
+| `ExecutionTimeout` | 25 seconds | Max time before the lock is released on timeout |
+| `MaxBodySizeBytes` | 1 MiB | Maximum request body size for hash computation |
+
+The `ExecutionTimeout` **must** be less than `InProgressTtl`. If the handler takes longer than `ExecutionTimeout`, the middleware releases the lock and returns 503 — allowing the client to retry safely.
+
+### Wire the middleware
+
+```csharp title="Program.cs"
+await app.UseGranitAsync();
+app.UseGranitIdempotency(); // After authentication — needs ICurrentUserService
+```
+
+Placement matters: the middleware must run **after** authentication and authorization because the composite Redis key includes the tenant ID and user ID.
+
+## Composite key: tenant isolation by design
+
+The Redis key is not just a hash of the idempotency header. It is a composite of five elements:
+
+```text
+{prefix}:{tenantId}:{userId}:{METHOD}:{routePattern}:{sha256(idempotencyKey)}
+```
+
+Example: `idp:acme-corp:d4e5f6a7:POST:/api/v1/payments/charge:a1b2c3d4...`
+
+This structure prevents three classes of attack:
+
+- **Cross-tenant replay** — tenant A cannot reuse tenant B's idempotency key
+- **Cross-user replay** — user A cannot replay user B's cached response
+- **Cross-endpoint collision** — the same key on `/charge` and `/refund` are independent
+
+The idempotency key value itself is SHA-256 hashed before storage. This prevents enumeration attacks — even with Redis access, an attacker cannot reconstruct client-generated keys.
+
+## Payload hash: catching key reuse with a different body
+
+A common mistake: the client sends the same idempotency key with a different request body. Maybe the user changed the amount and retried. The server **must not** return the cached response for the original amount.
+
+Granit computes a SHA-256 digest over `METHOD + route + idempotency key + request body` using `IncrementalHash` and `ArrayPool<byte>` — zero-allocation streaming. If the hash does not match the cached entry, the middleware returns **422 Unprocessable Entity**:
+
+```json title="422 response"
+{
+  "type": "https://tools.ietf.org/html/rfc7807",
+  "title": "Idempotency payload mismatch",
+  "status": 422,
+  "detail": "The Idempotency-Key has already been used with a different request payload."
+}
+```
+
+The client must generate a **new** key for the modified request. This is correct behavior — changing the payload means it is a different logical operation.
+
+## Double-click protection
+
+When two identical requests arrive simultaneously (the user double-tapped "Pay"), the first request acquires the lock via `SET NX`. The second request finds the key in `InProgress` state and receives **409 Conflict** with a `Retry-After` header:
+
+```text
+HTTP/1.1 409 Conflict
+Retry-After: 2
+Content-Type: application/problem+json
+
+{
+  "type": "https://tools.ietf.org/html/rfc7807",
+  "title": "Request in progress",
+  "status": 409,
+  "detail": "A request with this Idempotency-Key is currently being processed."
+}
+```
+
+The client waits 2 seconds and retries. By then, the first request has completed and the retry receives the cached response. No double charge. No race condition.
+
+## What gets cached (and what does not)
+
+Not every response should be replayed. Authentication failures, for example, should never be cached — the user might fix their token and retry legitimately.
+
+| Status codes | Cached | Rationale |
+| ------------- | -------- | ----------- |
+| 2xx, 400, 404, 409, 410, 422 | Yes | Deterministic outcomes safe to replay |
+| 401, 403 | No | Auth state may change between retries |
+| 5xx | No | Transient failures should be retried fresh |
+| 499 (client disconnect) | No | Response never reached the client |
+
+When a 5xx occurs, the middleware **deletes** the lock — freeing the key for a clean retry.
+
+## Database-level idempotency: defense in depth
+
+HTTP-level idempotency handles the network layer. But what about the database? If two pods process the same payment before the Redis lock propagates, you still get duplicates.
+
+Granit uses **unique indexes** as a second line of defense in domains where duplication has financial impact:
+
+```csharp title="PaymentTransactionConfiguration.cs"
+builder.HasIndex(e => new { e.TenantId, e.IdempotencyKey })
+    .IsUnique()
+    .HasDatabaseName("uq_granitp_transactions_tenant_idempotency");
+```
+
+```csharp title="MeterEventConfiguration.cs"
+builder.HasIndex(e => new { e.TenantId, e.IdempotencyKey })
+    .IsUnique()
+    .HasDatabaseName("ix_granitm_meter_events_dedup");
+```
+
+The database constraint catches what the middleware misses. The middleware prevents unnecessary database round-trips. Together, they provide **defense in depth** — no single layer failure can produce duplicates.
+
+## Observability
+
+The middleware exposes four OpenTelemetry counters:
+
+| Metric | What it tells you |
+| -------- | ------------------ |
+| `granit.http.idempotency.lock_acquired` | Successful lock acquisitions (new requests) |
+| `granit.http.idempotency.conflicts` | 409 responses (concurrent duplicates) |
+| `granit.http.idempotency.replayed` | Cached responses served (successful dedup) |
+| `granit.http.idempotency.hash_mismatches` | 422 responses (key reuse with different payload) |
+
+A spike in `replayed` means clients are retrying heavily — check upstream timeouts. A spike in `hash_mismatches` means clients are reusing keys incorrectly — check the SDK documentation.
+
+## Client-side implementation
+
+A well-behaved client follows this pattern:
+
+```typescript title="api-client.ts"
+async function chargePayment(order: Order): Promise<PaymentResponse> {
+  const idempotencyKey = crypto.randomUUID();
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const response = await fetch("/api/v1/payments/charge", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Idempotency-Key": idempotencyKey, // Same key on every retry
+      },
+      body: JSON.stringify({
+        orderId: order.id,
+        amount: order.total,
+        currency: "EUR",
+      }),
+    });
+
+    if (response.status === 409) {
+      const retryAfter = parseInt(response.headers.get("Retry-After") ?? "2");
+      await sleep(retryAfter * 1000);
+      continue;
+    }
+
+    return response.json();
+  }
+
+  throw new Error("Payment request failed after 3 attempts");
+}
+```
+
+The key is generated **once**, before the loop. Every retry sends the **same** key. If the server returns 409, the client respects `Retry-After`. This is the entire client-side contract.
+
+## Key takeaways
+
+- **Every POST endpoint that mutates state needs idempotency protection.** Network retries are not edge cases — they are normal operation.
+- **The client generates the key** because only the client knows whether a request is new or a retry.
+- **Payload hashing** prevents key reuse with a different body — a common source of subtle bugs.
+- **Double-click protection** (409 + Retry-After) handles concurrent duplicates without data corruption.
+- **Defense in depth**: HTTP middleware + database unique indexes cover both network-level and infrastructure-level races.
+- **`Granit.Http.Idempotency`** implements the full pattern — state machine, tenant isolation, payload verification, observability — in a single middleware call.
+
+## Further reading
+
+- [Idempotency reference](/dotnet/api/idempotency/) — full option reference, state machine diagram, response caching rules
+- [Configure idempotency guide](/dotnet/guides/configure-idempotency/) — step-by-step setup with Redis and endpoint decoration
+- [Idempotency pattern](/dotnet/architecture/patterns/idempotency/) — architecture decision, rationale matrix, algorithm steps
+- [RFC 7807: ProblemDetails — The Only Way to Return Errors](/blog/rfc-7807-problem-details-the-only-way-to-return-errors/) — error format used by idempotency responses

--- a/docs-site/src/content/docs/blog/secrets-management-with-hashicorp-vault-in-dotnet-10.md
+++ b/docs-site/src/content/docs/blog/secrets-management-with-hashicorp-vault-in-dotnet-10.md
@@ -1,0 +1,318 @@
+---
+title: "Secrets Management with HashiCorp Vault in .NET 10"
+date: 2026-04-13
+sidebar:
+  order: 20
+authors:
+  - jfmeyers
+tags:
+  - best-practice
+  - architecture
+  - security
+description: "Hardcoded connection strings and static API keys are a breach waiting to happen. HashiCorp Vault gives you dynamic credentials, transit encryption, and per-entity key isolation — and Granit integrates all three."
+excerpt: >
+  Hardcoded connection strings and static API keys are a breach waiting to happen.
+  HashiCorp Vault gives you dynamic credentials, transit encryption, and per-entity
+  key isolation — and Granit integrates all three as a single module dependency.
+---
+
+Your connection string is in `appsettings.json`. Maybe you moved it to an environment variable. Maybe you even use Azure Key Vault or AWS Secrets Manager. But the credential is still **static** — created once, shared across pods, rotated manually (if ever), and valid until someone remembers to revoke it.
+
+That is not secrets management. That is secrets storage with extra steps.
+
+**HashiCorp Vault** solves a fundamentally different problem: it **generates** credentials on demand, with automatic expiration, lease renewal, and zero human intervention. Combined with its Transit engine for encryption and KV v2 for per-entity key isolation, it covers the three pillars of secrets management that compliance frameworks (ISO 27001, SOC 2, GDPR) actually require.
+
+## The three problems Vault solves
+
+### 1. Static database credentials
+
+Every pod in your cluster shares the same PostgreSQL username and password. If one pod is compromised, every pod is compromised. Rotating the credential means restarting all pods simultaneously. Nobody does it.
+
+**Vault's answer: dynamic database credentials.** Each pod requests its own temporary username/password from the Vault database engine. The credentials are scoped to a role (`readwrite`), have a TTL (e.g., 1 hour), and are automatically revoked when the lease expires. Compromise one pod, and you have compromised one short-lived credential that expires before the attacker can move laterally.
+
+### 2. Application-level encryption
+
+You encrypt PII in the database. But your AES key lives in the application config — or worse, in source control. The encryption protects against database breaches, not application breaches.
+
+**Vault's answer: Transit encryption.** The application sends plaintext to Vault, Vault returns ciphertext. The encryption key **never leaves Vault**. The application cannot extract it, exfiltrate it, or accidentally log it. Key rotation is a Vault-side operation — the application does not need to change.
+
+### 3. GDPR right to erasure
+
+A user requests data deletion under GDPR Article 17. You have their data scattered across 15 tables, 3 event streams, and 2 backup systems. Deleting everything is an audit nightmare.
+
+**Vault's answer: crypto-shredding.** Each entity gets its own AES-256 key stored in Vault KV v2. To "delete" the data, you destroy the key. The ciphertext in your database becomes permanently unreadable — across all tables, all backups, all replicas. One API call replaces a multi-week data purge.
+
+## How Granit integrates Vault
+
+`Granit.Vault.HashiCorp` wraps VaultSharp into three focused abstractions, each solving one of the problems above.
+
+### Module setup
+
+```csharp title="AppHostModule.cs"
+[DependsOn(typeof(GranitVaultHashiCorpModule))]
+public sealed class AppHostModule : GranitModule { }
+```
+
+```json title="appsettings.json"
+{
+  "Vault": {
+    "Address": "https://vault.example.com",
+    "AuthMethod": "Kubernetes",
+    "KubernetesRole": "my-backend",
+    "DatabaseMountPoint": "database",
+    "DatabaseRoleName": "readwrite",
+    "TransitMountPoint": "transit",
+    "KvMountPoint": "secret",
+    "LeaseRenewalThreshold": 0.75
+  }
+}
+```
+
+The module is **disabled in Development** — no local Vault instance required. In development, Granit falls back to the local AES provider for encryption and static credentials for the database. The API surface is identical. Your code does not know the difference.
+
+## Dynamic database credentials
+
+`VaultCredentialLeaseManager` is a `BackgroundService` that manages the full credential lifecycle:
+
+```text
+Pod starts
+    │
+    ├─ GET database/creds/readwrite ──> Vault returns username, password, lease ID, TTL
+    │
+    ├─ At 75% of TTL ─────────────────> Renew lease (POST sys/leases/renew)
+    │                                       ├─ Success ──> Update TTL, schedule next renewal
+    │                                       └─ Failure ──> Obtain fresh credentials (step 1)
+    │
+    └─ Pod stops ──────────────────────> Revoke lease (PUT sys/leases/revoke)
+```
+
+The service implements `IDatabaseCredentialProvider`:
+
+```csharp title="Using dynamic credentials"
+public sealed class ConnectionStringBuilder(IDatabaseCredentialProvider credentials)
+{
+    public string Build(string host, string database) =>
+        $"Host={host};Database={database};" +
+        $"Username={credentials.Username};Password={credentials.Password}";
+}
+```
+
+The `LeaseRenewalThreshold` of 0.75 means a 1-hour TTL credential is renewed at the 45-minute mark. This provides a 15-minute buffer for transient Vault unavailability. If renewal fails, the manager obtains entirely fresh credentials — no manual intervention, no pod restart.
+
+### Why this matters for compliance
+
+- **ISO 27001 A.9.2.3**: *"Secret authentication information shall be controlled through a formal management process."* Dynamic credentials with automatic expiration satisfy this control.
+- **SOC 2 CC6.1**: *"Logical access security software and configuration management."* Per-pod credentials with TTL-based revocation demonstrate least-privilege access control.
+- **No shared secrets**: each pod has its own credential, its own lease, its own TTL. Compromising one credential does not affect other pods.
+
+## Transit encryption: keys that never leave Vault
+
+`ITransitEncryptionService` provides three operations:
+
+```csharp title="ITransitEncryptionService.cs"
+public interface ITransitEncryptionService
+{
+    Task<string> EncryptAsync(string keyName, string plaintext,
+        CancellationToken cancellationToken = default);
+
+    Task<string> DecryptAsync(string keyName, string ciphertext,
+        CancellationToken cancellationToken = default);
+
+    Task<string> RewrapAsync(string keyName, string ciphertext,
+        CancellationToken cancellationToken = default);
+
+    int? GetKeyVersion(string ciphertext);
+}
+```
+
+### Encrypt and decrypt
+
+```csharp title="PatientService.cs"
+public sealed class PatientService(ITransitEncryptionService transit)
+{
+    public async Task<string> EncryptSsnAsync(string ssn,
+        CancellationToken cancellationToken = default)
+    {
+        return await transit.EncryptAsync("patient-pii", ssn, cancellationToken)
+            .ConfigureAwait(false);
+        // Returns: "vault:v3:kL9mN2pQ7rS5tV8wX1yZ..."
+    }
+
+    public async Task<string> DecryptSsnAsync(string ciphertext,
+        CancellationToken cancellationToken = default)
+    {
+        return await transit.DecryptAsync("patient-pii", ciphertext, cancellationToken)
+            .ConfigureAwait(false);
+    }
+}
+```
+
+The ciphertext format — `vault:v{N}:...` — embeds the key version. When you rotate the Transit key, new encryptions use `v4`, but existing `v3` ciphertexts remain decryptable. You know which rows need re-encryption by inspecting the version prefix.
+
+### Rewrap: key rotation without plaintext exposure
+
+`RewrapAsync` re-encrypts ciphertext to the latest key version **server-side**. The plaintext never leaves Vault, never transits the network, never touches application memory:
+
+```csharp title="ReEncryptionJob.cs"
+public class ReEncryptionHandler
+{
+    public static async Task Handle(
+        ReEncryptBatchJob job,
+        ITransitEncryptionService transit,
+        AppDbContext db,
+        CancellationToken cancellationToken)
+    {
+        var patients = await db.Patients
+            .Where(p => EF.Functions.Like(p.EncryptedSsn, "vault:v1:%")
+                      || EF.Functions.Like(p.EncryptedSsn, "vault:v2:%"))
+            .Take(job.BatchSize)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        foreach (var patient in patients)
+        {
+            patient.EncryptedSsn = await transit
+                .RewrapAsync("patient-pii", patient.EncryptedSsn, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}
+```
+
+After rotation, retired key versions can be configured in `ReEncryptionOptions.RetiredKeyVersions`. The `IStringEncryptionProvider` will **refuse to decrypt** ciphertext encrypted with a retired version — forcing re-encryption before access.
+
+## Per-entity key isolation: crypto-shredding for GDPR
+
+`IEntityEncryptionKeyStore` manages individual AES-256 keys in Vault KV v2:
+
+```csharp title="UserDataService.cs"
+public sealed class UserDataService(
+    IEntityEncryptionKeyStore keyStore,
+    ITransitEncryptionService transit)
+{
+    public async Task<byte[]> GetEncryptionKeyAsync(Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        // Each user gets their own AES-256 key, stored in Vault
+        return await keyStore.GetOrCreateKeyAsync("User", userId.ToString(),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task EraseUserDataAsync(Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        // Destroy the key — all encrypted data becomes permanently unreadable
+        await keyStore.DeleteKeyAsync("User", userId.ToString(),
+            cancellationToken).ConfigureAwait(false);
+    }
+}
+```
+
+The Vault KV path follows a strict convention:
+
+```text
+secret/data/granit/encryption/isolated/{entityType}/{entityId}
+```
+
+Key operations:
+
+- **GetOrCreateKeyAsync**: Atomic create with CAS=0 (check-and-set). If two pods race, the second reads the key the first created. No duplicates.
+- **DeleteKeyAsync**: Calls `DeleteMetadataAsync` — all versions destroyed, irreversible. Key material is zeroed in memory via `CryptographicOperations.ZeroMemory()`.
+- **In-memory LRU cache**: Reduces Vault round-trips for hot keys. Cache entries are evicted on delete.
+
+### Why crypto-shredding beats row deletion
+
+| Approach | Tables | Backups | Event streams | Audit trail |
+| ---------- | -------- | --------- | --------------- | ------------- |
+| Row deletion | Must find and delete in all 15 tables | Must restore and re-delete in all backups | Cannot delete from immutable event streams | Breaks audit continuity |
+| Crypto-shredding | Data stays, unreadable | Backups stay, unreadable | Events stay, unreadable | Audit trail intact, data inaccessible |
+
+One `DeleteKeyAsync` call. One Vault operation. All data — past, present, and replicated — becomes cryptographic noise. The audit trail proves erasure happened without requiring data destruction proof across every storage system.
+
+## Authentication: Kubernetes in production, token in development
+
+`VaultClientFactory` selects the auth method based on configuration:
+
+```csharp title="appsettings.Development.json"
+{
+  "Vault": {
+    "Address": "http://localhost:8200",
+    "AuthMethod": "Token",
+    "Token": "dev-only-token"
+  }
+}
+```
+
+```csharp title="appsettings.Production.json"
+{
+  "Vault": {
+    "Address": "https://vault.internal",
+    "AuthMethod": "Kubernetes",
+    "KubernetesRole": "my-backend"
+  }
+}
+```
+
+In Kubernetes, the pod's service account JWT (mounted at `/var/run/secrets/kubernetes.io/serviceaccount/token`) authenticates against Vault. No static token, no environment variable, no secret mounted from a ConfigMap. The JWT is rotated by Kubernetes, and the Vault policy is scoped to the pod's service account.
+
+## Health check
+
+`VaultHealthCheck` maps Vault's `/sys/health` endpoint to ASP.NET Core health check states:
+
+| Vault status | Health state | Rationale |
+| ------------- | ------------- | ----------- |
+| Active | Healthy | Primary node, reads and writes |
+| Standby | Degraded | Passive replica, reads work, writes forwarded |
+| Sealed | Unhealthy | No operations possible |
+| Unreachable | Unhealthy | Network or DNS issue |
+
+The health check is tagged `readiness` and `startup` — Kubernetes probes will pull the pod from the load balancer if Vault becomes unreachable. No requests hit a pod that cannot decrypt data.
+
+## Observability
+
+Every Vault operation is traced and metered:
+
+**Metrics** (meter: `Granit.Vault`):
+
+| Metric | What it tells you |
+| -------- | ------------------ |
+| `granit.vault.operations.completed` | Successful operations by type (encrypt, decrypt, rewrap) |
+| `granit.vault.operations.errors` | Failed operations by type and provider |
+| `granit.vault.operation.duration` | Latency histogram per operation |
+| `granit.vault.rotations.detected` | Key version changes detected during decrypt |
+
+**Traces** (activity source: `Granit.Vault.HashiCorp`):
+
+Activities for `vault.transit.encrypt`, `vault.transit.decrypt`, `vault.transit.rewrap`, `vault.db.obtain-credentials`, `vault.db.renew-lease`, `vault.kv.read`, `vault.kv.write`, `vault.kv.delete` — each tagged with `vault.key_name` and `vault.mount_point`.
+
+A spike in `rotations.detected` means rows encrypted with old key versions are being accessed — schedule a re-encryption batch. A spike in `operations.errors` means Vault is degraded — check the health check dashboard.
+
+## Provider abstraction
+
+Granit does not lock you into HashiCorp Vault. The abstraction layer (`Granit.Vault`) defines provider-agnostic interfaces. Four implementations ship today:
+
+| Provider | Transit (server-side rewrap) | Dynamic DB credentials | Per-entity keys |
+| ---------- | ----- | ------ | ------ |
+| `Granit.Vault.HashiCorp` | Yes | Yes | Yes (KV v2) |
+| `Granit.Vault.Azure` | No (client-side rewrap) | No | Yes (Key Vault) |
+| `Granit.Vault.Aws` | No (client-side rewrap) | No | Yes (Secrets Manager) |
+| `Granit.Vault.GoogleCloud` | No (client-side rewrap) | No | Yes (Secret Manager) |
+
+HashiCorp Vault is the only provider that supports **server-side rewrap** — the plaintext never leaves the vault during key rotation. The other providers fall back to decrypt-then-encrypt, which is still secure but requires the plaintext to transit the network twice.
+
+## Key takeaways
+
+- **Static credentials are a single point of compromise.** Dynamic credentials with automatic expiration limit blast radius to one pod and one TTL window.
+- **Application-level encryption is only as strong as key management.** Transit encryption keeps the key in Vault — the application never sees it.
+- **GDPR erasure is a crypto-shredding problem, not a data deletion problem.** Destroying one key makes all encrypted data permanently unreadable.
+- **`Granit.Vault.HashiCorp`** wraps VaultSharp into three focused abstractions — dynamic credentials, transit encryption, and per-entity key isolation — with full observability and health checks.
+- **Development requires zero Vault infrastructure.** The module is disabled in Development, falling back to local AES and static credentials with an identical API surface.
+
+## Further reading
+
+- [Vault module reference](/dotnet/security/vault/) — full option reference, provider comparison, configuration examples
+- [Crypto-Shredding: GDPR Erasure Without Deleting Rows](/blog/crypto-shredding-gdpr-erasure-without-deleting-rows/) — deep dive into per-entity key isolation
+- [GDPR by Design](/blog/gdpr-by-design/) — how Granit modules implement privacy controls
+- [NIS2-Ready .NET Applications](/blog/nis2-ready-dotnet-applications/) — compliance patterns including encryption at rest

--- a/docs-site/src/content/docs/blog/the-options-pattern-3-levels-of-configuration-binding.md
+++ b/docs-site/src/content/docs/blog/the-options-pattern-3-levels-of-configuration-binding.md
@@ -1,0 +1,367 @@
+---
+title: "The Options Pattern — 3 Levels of Configuration Binding"
+date: 2026-04-15
+sidebar:
+  order: 21
+authors:
+  - jfmeyers
+tags:
+  - best-practice
+  - architecture
+  - tutorial
+description: "IOptions, IOptionsSnapshot, and IOptionsMonitor solve different problems. Picking the wrong one causes stale config, unnecessary allocations, or subtle concurrency bugs."
+excerpt: >
+  IOptions, IOptionsSnapshot, and IOptionsMonitor solve different problems. Picking
+  the wrong one causes stale config, unnecessary allocations, or subtle concurrency
+  bugs. Here is when to use each — with real examples from Granit's 128 packages.
+---
+
+You bind your configuration to a POCO, inject `IOptions<T>`, and move on. It works. Until it does not — your feature flag change requires a pod restart, your background worker reads stale config for hours, or your per-request options snapshot allocates a new object 5,000 times per second for no reason.
+
+The .NET Options pattern has **three levels**. Each one exists for a reason, and using the wrong one creates problems that are invisible until production.
+
+## Level 1: `IOptions<T>` — read once, cached forever
+
+`IOptions<T>` resolves the configuration **once** at first injection and caches the result for the lifetime of the application. It is a singleton. It never re-reads the configuration source.
+
+```csharp title="WebhooksOptions.cs — registration"
+builder.Services
+    .AddOptions<WebhooksOptions>()
+    .BindConfiguration("Webhooks")
+    .ValidateOnStart();
+```
+
+```csharp title="WebhookDispatcher.cs — consumption"
+public sealed class WebhookDispatcher(IOptions<WebhooksOptions> options)
+{
+    private readonly WebhooksOptions _options = options.Value;
+
+    public async Task DispatchAsync(WebhookEvent webhookEvent,
+        CancellationToken cancellationToken = default)
+    {
+        if (_options.MaxRetryAttempts <= 0) return;
+        // _options never changes — same instance for the entire app lifetime
+    }
+}
+```
+
+### When to use it
+
+- **Static configuration** that does not change without a restart: database connection strings, feature module toggles, API base URLs, encryption key names.
+- **Singleton services** — `IOptionsSnapshot<T>` and `IOptionsMonitor<T>` are scoped and singleton respectively, but `IOptions<T>` is the simplest choice when you know the value is fixed.
+- **Startup validation** — combine with `ValidateOnStart()` to fail fast if configuration is invalid. The application does not start with a missing connection string.
+
+### When NOT to use it
+
+- Configuration that changes at runtime (feature flags, rate limits, cleanup intervals)
+- Named options (multiple instances of the same type with different names)
+
+### The trap
+
+`IOptions<T>` does **not** support named options. Calling `IOptions<T>.Value` always returns the default (unnamed) instance. If you register named options with `services.Configure("client-a", ...)`, `IOptions<T>` ignores them silently.
+
+## Level 2: `IOptionsSnapshot<T>` — fresh per request
+
+`IOptionsSnapshot<T>` is **scoped**. It re-reads the configuration at the beginning of each DI scope — typically once per HTTP request. Within the scope, the value is consistent. Across scopes, it picks up changes.
+
+```csharp title="FeatureFlagMiddleware.cs"
+public sealed class FeatureFlagMiddleware(RequestDelegate next)
+{
+    public async Task InvokeAsync(HttpContext context,
+        IOptionsSnapshot<FeatureOptions> options)
+    {
+        // options.Value is fresh for this request
+        if (options.Value.EnableBetaEndpoints)
+        {
+            context.Items["beta"] = true;
+        }
+
+        await next(context).ConfigureAwait(false);
+    }
+}
+```
+
+### When to use it
+
+- **Configuration that may change between requests** without a restart: feature flags backed by a config provider that supports reload, rate limit thresholds, UI toggle switches.
+- **Per-request consistency** is required — all code within the same request sees the same configuration snapshot.
+- **Named options** — `IOptionsSnapshot<T>` supports `.Get(name)` for named instances.
+
+### When NOT to use it
+
+- **Singleton services** — you cannot inject `IOptionsSnapshot<T>` into a singleton. The DI container will throw at runtime because a scoped service cannot be consumed by a singleton.
+- **Background services** (`BackgroundService`, `IHostedService`) — these are singletons. Use `IOptionsMonitor<T>` instead.
+
+### The trap
+
+`IOptionsSnapshot<T>` allocates a **new options instance per scope**. If your configuration never actually changes, you are paying the allocation cost for nothing. At 5,000 requests per second, that is 5,000 objects per second that `IOptions<T>` would have served from a single cached instance.
+
+## Level 3: `IOptionsMonitor<T>` — live reload with change notification
+
+`IOptionsMonitor<T>` is a **singleton** that actively watches the configuration source for changes. When a change is detected, it updates its internal cache and fires an `OnChange` callback. You always get the latest value via `.CurrentValue`.
+
+```csharp title="AuditingCleanupWorker.cs — background service"
+internal sealed partial class AuditingCleanupWorker(
+    IServiceScopeFactory scopeFactory,
+    IOptionsMonitor<AuditingOptions> optionsMonitor,
+    IClock clock,
+    AuditingMetrics metrics,
+    ILogger<AuditingCleanupWorker> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await PurgeExpiredEntriesAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                LogCleanupFailed(ex);
+            }
+
+            // Re-reads interval on every iteration — no restart needed
+            await Task.Delay(optionsMonitor.CurrentValue.CleanupInterval, stoppingToken)
+                .ConfigureAwait(false);
+        }
+    }
+}
+```
+
+Every loop iteration reads `optionsMonitor.CurrentValue.CleanupInterval`. If an operator changes the interval from 5 minutes to 1 minute via a config reload, the next iteration picks it up — no pod restart, no deployment.
+
+### Named options with `IOptionsMonitor<T>.Get(name)`
+
+`IOptionsMonitor<T>` supports named options, which is critical for patterns like per-client HTTP configuration:
+
+```csharp title="ClientCredentialsTokenHandler.cs"
+internal sealed partial class ClientCredentialsTokenHandler(
+    ITokenEndpointService tokenEndpointService,
+    IClientCredentialsTokenCache tokenCache,
+    IDPoPProofService dpopProofService,
+    IOptionsMonitor<ClientCredentialsOptions> clientCredentialsOptionsMonitor,
+    IOptions<TokenManagementOptions> tokenManagementOptions,
+    IClock clock,
+    TokenManagementMetrics metrics,
+    ILogger<ClientCredentialsTokenHandler> logger) : DelegatingHandler
+{
+    internal string ClientName { get; set; } = string.Empty;
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        // Each named client gets its own ClientCredentialsOptions
+        ClientCredentialsOptions options = clientCredentialsOptionsMonitor.Get(ClientName);
+        // ...
+    }
+}
+```
+
+Registration uses the named overload:
+
+```csharp title="TokenManagementServiceCollectionExtensions.cs"
+public static IHttpClientBuilder AddClientCredentialsHttpClient(
+    this IServiceCollection services,
+    string name,
+    Action<ClientCredentialsOptions> configure)
+{
+    services.AddGranitTokenManagement();
+    services.Configure(name, configure); // Named configuration
+
+    return services.AddGranitHttpClient(name)
+        .AddHttpMessageHandler(sp =>
+        {
+            var handler = ActivatorUtilities
+                .CreateInstance<ClientCredentialsTokenHandler>(sp);
+            handler.ClientName = name;
+            return handler;
+        });
+}
+```
+
+### When to use it
+
+- **Background services** and other singletons that need live configuration
+- **Named options** in singleton scope (where `IOptionsSnapshot<T>` cannot be injected)
+- **Change notification** — subscribe to `OnChange` for cache invalidation or reconnection logic
+
+### When NOT to use it
+
+- Simple static configuration where `IOptions<T>` suffices — `IOptionsMonitor<T>` adds watcher overhead that is unnecessary if the value never changes
+
+## PostConfigure: computed configuration that depends on other services
+
+Sometimes the value you need is not in `appsettings.json` — it depends on the environment, another options instance, or a runtime service. `PostConfigure` runs **after** all `Configure` calls, letting you compute or override values:
+
+```csharp title="ObservabilityServiceCollectionExtensions.cs"
+builder.Services
+    .AddOptions<ObservabilityOptions>()
+    .BindConfiguration(ObservabilityOptions.SectionName)
+    .PostConfigure<IHostEnvironment, IConfiguration>((opts, env, config) =>
+        ApplyFallbacks(opts, env.ApplicationName, env.EnvironmentName,
+            config["OTEL_EXPORTER_OTLP_ENDPOINT"]))
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
+```
+
+Here, `PostConfigure` injects `IHostEnvironment` and `IConfiguration` to compute fallback values — the service name defaults to the assembly name, the OTLP endpoint defaults to the environment variable. The caller only needs to set what they want to override.
+
+### `IPostConfigureOptions<T>`: the class-based variant
+
+When post-configuration logic is complex or needs DI-injected services, implement `IPostConfigureOptions<T>`:
+
+```csharp title="DatabaseSigningKeyPostConfigure.cs"
+internal sealed partial class DatabaseSigningKeyPostConfigure(
+    IServiceScopeFactory scopeFactory,
+    IOptions<GranitKeyRotationOptions> rotationOptions,
+    ILogger<DatabaseSigningKeyPostConfigure> logger)
+    : IPostConfigureOptions<OpenIddictServerOptions>
+{
+    public void PostConfigure(string? name, OpenIddictServerOptions options)
+    {
+        if (!rotationOptions.Value.Enabled) return;
+
+        using IServiceScope scope = scopeFactory.CreateScope();
+        ISigningKeyStore keyStore = scope.ServiceProvider
+            .GetRequiredService<ISigningKeyStore>();
+
+        IReadOnlyList<SigningKey> keys = keyStore
+            .GetKeysAsync(SigningKeyStatus.Active, SigningKeyStatus.Retired)
+            .GetAwaiter().GetResult();
+
+        // Load signing keys from database into OpenIddict at startup
+        foreach (SigningKey key in keys)
+        {
+            options.SigningCredentials.Add(key.ToSigningCredentials());
+        }
+    }
+}
+```
+
+This loads OpenIddict signing keys from the database — a dependency that cannot be expressed via `BindConfiguration`. The `IPostConfigureOptions<T>` interface gives you full DI access.
+
+### `PostConfigureAll<T>`: environment-dependent defaults
+
+When the same override applies to **all** named instances:
+
+```csharp title="GranitBffEndpointsModule.cs"
+bool isDevelopment = context.Builder!.Environment.IsDevelopment();
+
+context.Services.PostConfigureAll<BffFrontendOptions>(options =>
+{
+    options.CookiePrefix = isDevelopment ? "." : "__Host-";
+});
+```
+
+In development, cookies use a simple `.` prefix (works without HTTPS). In production, `__Host-` enforces Secure + Path=/ + no Domain — a browser-level security guarantee. The application code never checks the environment — the prefix is computed once and applied everywhere.
+
+## Validation: fail fast, not at 3 AM
+
+Options without validation are a time bomb. A missing URL, an invalid TTL, a negative retry count — all of these work fine in `appsettings.json` but explode at runtime, usually in production, usually at night.
+
+### Data annotations
+
+The simplest validation — decorate properties and chain `.ValidateDataAnnotations()`:
+
+```csharp title="ApiDocumentationOptions.cs"
+public sealed class ApiDocumentationOptions
+{
+    public const string SectionName = "ApiDocumentation";
+
+    [Required]
+    public string Title { get; set; } = "API";
+
+    public string? Description { get; set; }
+
+    [EmailAddress]
+    public string? ContactEmail { get; set; }
+}
+```
+
+```csharp title="Registration"
+builder.Services
+    .AddOptions<ApiDocumentationOptions>()
+    .BindConfiguration(ApiDocumentationOptions.SectionName)
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
+```
+
+### `IValidateOptions<T>`: custom validation logic
+
+When annotations are not enough — cross-property validation, conditional rules, URI format checks:
+
+```csharp title="GranitBffOptionsValidator.cs"
+internal sealed class GranitBffOptionsValidator
+    : IValidateOptions<GranitBffOptions>
+{
+    public ValidateOptionsResult Validate(string? name, GranitBffOptions options)
+    {
+        List<string> failures = [];
+
+        if (options.Authority is null)
+        {
+            failures.Add(
+                "Authority must not be null — set the OIDC authority URL " +
+                "in the 'Bff' configuration section.");
+        }
+
+        ValidateCsrfHmacKey(options, failures);
+        ValidateFrontends(options, failures);
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+}
+```
+
+Registered alongside the options:
+
+```csharp title="Registration"
+builder.Services
+    .AddOptions<GranitBffOptions>()
+    .BindConfiguration("Bff")
+    .ValidateOnStart();
+
+builder.Services.AddSingleton<IValidateOptions<GranitBffOptions>,
+    GranitBffOptionsValidator>();
+```
+
+### `ValidateOnStart()`: the non-negotiable
+
+Without `.ValidateOnStart()`, validation runs **lazily** — only when the options are first resolved. If no code path touches the options during startup, the invalid configuration sits dormant until a user hits the affected endpoint.
+
+`.ValidateOnStart()` forces validation during `IHost.StartAsync()`. The application **refuses to start** with invalid configuration. You find out in CI, not in production.
+
+Across Granit's 128 packages, every options registration that binds configuration uses `ValidateOnStart()`. No exceptions.
+
+## The decision matrix
+
+| Question | `IOptions<T>` | `IOptionsSnapshot<T>` | `IOptionsMonitor<T>` |
+| ---------- | :---: | :---: | :---: |
+| Can inject into singletons? | Yes | **No** | Yes |
+| Can inject into scoped services? | Yes | Yes | Yes |
+| Picks up runtime config changes? | **No** | Yes (per scope) | Yes (immediate) |
+| Supports named options? | **No** | Yes | Yes |
+| Supports `OnChange` callback? | **No** | **No** | Yes |
+| Allocation per resolution | Zero (cached) | One per scope | Zero (cached) |
+| Best for | Static config | Per-request config | Background services, live reload |
+
+The default choice should be `IOptions<T>`. Upgrade to `IOptionsMonitor<T>` when you need live reload or named options in a singleton. Use `IOptionsSnapshot<T>` only when you specifically need per-request consistency with automatic reload — and you are injecting into a scoped service.
+
+## Key takeaways
+
+- **`IOptions<T>`** is a singleton cache — read once, never reloaded. Use it for static configuration and always combine with `ValidateOnStart()`.
+- **`IOptionsSnapshot<T>`** is scoped — fresh per request, consistent within. Use it when configuration changes between requests and you need per-scope consistency.
+- **`IOptionsMonitor<T>`** is a singleton with live reload — use it in background services, for named options, and when you need `OnChange` notifications.
+- **`PostConfigure`** computes values that depend on other services or the environment. The class-based `IPostConfigureOptions<T>` gives full DI access.
+- **`ValidateOnStart()`** is non-negotiable. Fail at startup, not at 3 AM.
+- **Default to `IOptions<T>`**, upgrade only when you have a concrete reason. The simplest abstraction that solves your problem is the right one.
+
+## Further reading
+
+- [Configuration & Settings reference](/dotnet/core/configuration/) — Granit configuration architecture, provider chain, environment overrides
+- [[LoggerMessage] Over String Interpolation](/blog/loggermessage-over-string-interpolation/) — another "the framework gives you better tools" best-practice
+- [Guard Clauses Done Right](/blog/guard-clauses-done-right/) — fail-fast validation at the method level, complementing fail-fast at the config level


### PR DESCRIPTION
## Summary

- Add **Idempotency Keys: Why Every POST Should Be Retry-Safe** (April 10) — covers Stripe-style idempotency middleware, composite Redis keys, payload hash verification, double-click protection, and defense-in-depth with DB unique indexes
- Add **Secrets Management with HashiCorp Vault in .NET 10** (April 13) — covers dynamic database credentials, transit encryption, per-entity key isolation for crypto-shredding, provider abstraction across HashiCorp/Azure/AWS/GCP
- Add **The Options Pattern — 3 Levels of Configuration Binding** (April 15) — covers IOptions vs IOptionsSnapshot vs IOptionsMonitor, PostConfigure patterns, validation with ValidateOnStart, decision matrix

## Test plan

- [ ] Verify `cd docs-site && npx astro build` produces 0 errors
- [ ] Check each article renders correctly in Starlight blog
- [ ] Verify sidebar ordering (19, 20, 21) places articles after existing content
- [ ] Confirm all internal links resolve
