### PR TITLE
fix: resolve code smells and refactor migration pipeline

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -29420,6 +29420,22 @@
       "members": []
     },
     {
+      "name": "MigrationsModelBuilderExtensions",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.Migrations.Extensions.MigrationsModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Persistence.EntityFrameworkCore.Migrations",
+      "file": "src/Granit.Persistence.EntityFrameworkCore.Migrations/Extensions/MigrationsModelBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "ConfigureMigrationsModule",
+          "kind": "method",
+          "signature": "ConfigureMigrationsModule(this ModelBuilder modelBuilder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
       "name": "PersistenceMigrationsHostApplicationBuilderExtensions",
       "fqn": "Granit.Persistence.EntityFrameworkCore.Migrations.Extensions.PersistenceMigrationsHostApplicationBuilderExtensions",
       "kind": "class",
@@ -29540,6 +29556,38 @@
           "kind": "method",
           "signature": "GetActiveTenantIdsAsync(CancellationToken cancellationToken)",
           "returnType": "IAsyncEnumerable<Guid>"
+        }
+      ]
+    },
+    {
+      "name": "MigrationProgress",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.Migrations.Internal.MigrationProgress",
+      "kind": "class",
+      "project": "Granit.Persistence.EntityFrameworkCore.Migrations",
+      "file": "src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationProgress.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Id",
+          "kind": "property",
+          "signature": "Guid Id",
+          "returnType": "Guid"
+        }
+      ]
+    },
+    {
+      "name": "MigrationProgressConfiguration",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.Migrations.Internal.MigrationProgressConfiguration",
+      "kind": "class",
+      "project": "Granit.Persistence.EntityFrameworkCore.Migrations",
+      "file": "src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationProgressConfiguration.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Configure",
+          "kind": "method",
+          "signature": "Configure(EntityTypeBuilder<MigrationProgress> builder)",
+          "returnType": "void"
         }
       ]
     },

--- a/src/Granit.Auditing/Internal/Services/AuditingCleanupWorker.cs
+++ b/src/Granit.Auditing/Internal/Services/AuditingCleanupWorker.cs
@@ -48,6 +48,7 @@ internal sealed partial class AuditingCleanupWorker(
         activity?.SetTag("tenant_id", "global");
 
         AuditingOptions options = optionsMonitor.CurrentValue;
+        LogCleanupStarted();
 
         foreach (AuditCategory category in Enum.GetValues<AuditCategory>())
         {
@@ -71,14 +72,19 @@ internal sealed partial class AuditingCleanupWorker(
             if (totalPurged > 0)
             {
                 metrics.RecordPurged(totalPurged, category.ToString(), tenantId: null);
-                LogEntriesPurged(totalPurged, category.ToString());
             }
+
+            LogCategoryPurged(category.ToString(), totalPurged, cutoff);
         }
     }
 
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "Audit log cleanup started")]
+    private partial void LogCleanupStarted();
+
     [LoggerMessage(Level = LogLevel.Information,
-        Message = "Purged {Count} expired audit log entries for category '{Category}'")]
-    private partial void LogEntriesPurged(long count, string category);
+        Message = "Audit log cleanup '{Category}': purged {Count} entries (cutoff: {Cutoff})")]
+    private partial void LogCategoryPurged(string category, long count, DateTimeOffset cutoff);
 
     [LoggerMessage(Level = LogLevel.Error,
         Message = "Audit log cleanup failed")]

--- a/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
+++ b/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
@@ -420,12 +420,9 @@ internal sealed partial class EmailNotificationChannel(
         }
 
         string result = html;
-        foreach (IRenderedContentTransformer transformer in transformers.OrderBy(t => t.Order))
+        foreach (IRenderedContentTransformer transformer in transformers.OrderBy(t => t.Order).Where(t => t.CanTransform(DocumentFormat.Html)))
         {
-            if (transformer.CanTransform(DocumentFormat.Html))
-            {
-                result = await transformer.TransformAsync(result, DocumentFormat.Html, cancellationToken).ConfigureAwait(false);
-            }
+            result = await transformer.TransformAsync(result, DocumentFormat.Html, cancellationToken).ConfigureAwait(false);
         }
 
         return result;

--- a/src/Granit.Persistence.EntityFrameworkCore.Hosting/Internal/GranitMigrationRunner.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Hosting/Internal/GranitMigrationRunner.cs
@@ -73,9 +73,6 @@ internal sealed partial class GranitMigrationRunner(
                 }
             }
 
-            // Ensure Expand & Contract tracking table exists
-            await EnsureExpandContractDbAsync(ct).ConfigureAwait(false);
-
             // Migrate each DbContext in topological order
             foreach ((GranitModule module, Type dbContextType) in migratableModules)
             {
@@ -86,11 +83,6 @@ internal sealed partial class GranitMigrationRunner(
             await MigrateExternalStoresAsync(ct).ConfigureAwait(false);
 
             // Resolve tenant enumerator for post-seed passes
-            ITenantEnumerator? tenantEnumerator;
-            await using (AsyncServiceScope enumScope = scopeFactory.CreateAsyncScope())
-            {
-                tenantEnumerator = enumScope.ServiceProvider.GetService<ITenantEnumerator>();
-            }
 
             // Data seeding — host/tenant split:
             // 1. Host pass: IHostDataSeedContributor + legacy (IsHostOnly=true)
@@ -211,14 +203,12 @@ internal sealed partial class GranitMigrationRunner(
             return;
         }
 
-        {
-            // SharedDatabase or single-tenant — migrate normally in default schema.
-            LogMigratingContext(moduleName, dbContextType.Name);
-            await using DbContext dbContext = await ResolveDbContextAsync(scope.ServiceProvider, dbContextType)
-                .ConfigureAwait(false);
-            await dbContext.Database.MigrateAsync(ct).ConfigureAwait(false);
-            LogMigratedContext(moduleName, dbContextType.Name);
-        }
+        // SharedDatabase or single-tenant — migrate normally in default schema.
+        LogMigratingContext(moduleName, dbContextType.Name);
+        await using DbContext dbContext = await ResolveDbContextAsync(scope.ServiceProvider, dbContextType)
+            .ConfigureAwait(false);
+        await dbContext.Database.MigrateAsync(ct).ConfigureAwait(false);
+        LogMigratedContext(moduleName, dbContextType.Name);
     }
 
     private async Task MigratePerTenantAsync(
@@ -277,24 +267,6 @@ internal sealed partial class GranitMigrationRunner(
             await migrator.MigrateAsync(ct).ConfigureAwait(false);
             LogMigratedExternalStore(migrator.Name);
         }
-    }
-
-    private async Task EnsureExpandContractDbAsync(CancellationToken ct)
-    {
-        await using AsyncServiceScope scope = scopeFactory.CreateAsyncScope();
-
-        // Resolve MigrationProgressDbContext dynamically to avoid exposing the internal type
-        // in this assembly's public surface (which would cause ReflectionTypeLoadException
-        // when other modules scan assemblies).
-        IMigrationProgressDbEnsurer? ensurer = scope.ServiceProvider.GetService<IMigrationProgressDbEnsurer>();
-
-        if (ensurer is null)
-        {
-            return;
-        }
-
-        LogCreatingExpandContractDb();
-        await ensurer.EnsureCreatedAsync(ct).ConfigureAwait(false);
     }
 
     private async Task SeedHostAsync(CancellationToken ct)
@@ -398,10 +370,6 @@ internal sealed partial class GranitMigrationRunner(
     [LoggerMessage(Level = LogLevel.Information,
         Message = "Migrated external store '{StoreName}' successfully.")]
     private partial void LogMigratedExternalStore(string storeName);
-
-    [LoggerMessage(Level = LogLevel.Information,
-        Message = "Creating Expand & Contract progress tracking table.")]
-    private partial void LogCreatingExpandContractDb();
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Running data seeders...")]
     private partial void LogSeedingStart();

--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations/Extensions/MigrationsModelBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations/Extensions/MigrationsModelBuilderExtensions.cs
@@ -1,0 +1,22 @@
+using Granit.Persistence.EntityFrameworkCore.Migrations.Internal;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Persistence.EntityFrameworkCore.Migrations.Extensions;
+
+/// <summary>
+/// <see cref="ModelBuilder"/> extensions for including the Expand &amp; Contract
+/// migration progress tracking table in a host-owned <see cref="DbContext"/>.
+/// </summary>
+public static class MigrationsModelBuilderExtensions
+{
+    /// <summary>
+    /// Applies entity configurations for the Granit Expand &amp; Contract migration tracking module.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder.</param>
+    /// <returns>The same <paramref name="modelBuilder"/> for chaining.</returns>
+    public static ModelBuilder ConfigureMigrationsModule(this ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new MigrationProgressConfiguration());
+        return modelBuilder;
+    }
+}

--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationProgress.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationProgress.cs
@@ -4,7 +4,7 @@ namespace Granit.Persistence.EntityFrameworkCore.Migrations.Internal;
 /// System entity that tracks the progress of a migration cycle's data backfill phase.
 /// Mapped to the <c>data_migration_progress</c> table in the system schema.
 /// </summary>
-internal sealed class MigrationProgress
+public sealed class MigrationProgress
 {
     /// <summary>Surrogate primary key.</summary>
     public Guid Id { get; set; }

--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationProgressConfiguration.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationProgressConfiguration.cs
@@ -7,7 +7,7 @@ namespace Granit.Persistence.EntityFrameworkCore.Migrations.Internal;
 /// EF Core Fluent API configuration for <see cref="MigrationProgress"/>.
 /// Table: <c>data_migration_progress</c> (system schema, never affected by tenant schema switches).
 /// </summary>
-internal sealed class MigrationProgressConfiguration : IEntityTypeConfiguration<MigrationProgress>
+public sealed class MigrationProgressConfiguration : IEntityTypeConfiguration<MigrationProgress>
 {
     public void Configure(EntityTypeBuilder<MigrationProgress> builder)
     {

--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationStartupService.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationStartupService.cs
@@ -1,7 +1,6 @@
 using Granit.Persistence.EntityFrameworkCore.Migrations.Messages;
 using Granit.Persistence.EntityFrameworkCore.Migrations.Options;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -29,7 +28,6 @@ namespace Granit.Persistence.EntityFrameworkCore.Migrations.Internal;
 /// </para>
 /// </remarks>
 internal sealed partial class MigrationStartupService(
-    IServiceScopeFactory scopeFactory,
     IDbContextFactory<MigrationProgressDbContext> progressFactory,
     ITenantEnumerator tenantEnumerator,
     IMigrationBatchDispatcher dispatcher,
@@ -54,11 +52,8 @@ internal sealed partial class MigrationStartupService(
 
     private async Task ResumeAsync(CancellationToken cancellationToken)
     {
-        // Ensure the progress table exists using a dedicated probe + DDL context pair
-        // to avoid PostgreSQL connection-state contamination.
-        await EnsureProgressTableAsync(cancellationToken).ConfigureAwait(false);
-
-        // Use a fresh context for the actual query — the probe contexts are disposed.
+        // The data_migration_progress table is created by EF Core migrations
+        // (via ConfigureMigrationsModule in the host DbContext).
         await using MigrationProgressDbContext db = await progressFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
         List<MigrationProgress> pending = await db.MigrationProgresses
@@ -121,20 +116,6 @@ internal sealed partial class MigrationStartupService(
         }
 
         return commands;
-    }
-
-    /// <summary>
-    /// Creates the <c>data_migration_progress</c> table if it doesn't exist.
-    /// </summary>
-    /// <remarks>
-    /// Uses two separate DbContext instances to avoid PostgreSQL connection-state contamination:
-    /// one for probing table existence (which may throw) and a fresh one for DDL.
-    /// </remarks>
-    private async Task EnsureProgressTableAsync(CancellationToken ct)
-    {
-        await using AsyncServiceScope scope = scopeFactory.CreateAsyncScope();
-        IMigrationProgressDbEnsurer ensurer = scope.ServiceProvider.GetRequiredService<IMigrationProgressDbEnsurer>();
-        await ensurer.EnsureCreatedAsync(ct).ConfigureAwait(false);
     }
 
     [LoggerMessage(Level = LogLevel.Information,

--- a/src/Granit.Wolverine.Postgresql/Internal/WolverineStoreMigrator.cs
+++ b/src/Granit.Wolverine.Postgresql/Internal/WolverineStoreMigrator.cs
@@ -10,8 +10,6 @@ internal sealed class WolverineStoreMigrator(IMessageStore messageStore) : IExte
 {
     public string Name => "Wolverine message storage";
 
-    public async Task MigrateAsync(CancellationToken cancellationToken = default)
-    {
+    public async Task MigrateAsync(CancellationToken cancellationToken = default) =>
         await messageStore.Admin.MigrateAsync().ConfigureAwait(false);
-    }
 }


### PR DESCRIPTION
## Summary

- **WolverineStoreMigrator**: expression body for `MigrateAsync` (IDE0022)
- **EmailNotificationChannel**: merge `if` + `foreach` into LINQ `Where` clause
- **AuditingCleanupWorker**: add `LogCleanupStarted` event, enrich `LogCategoryPurged` with cutoff timestamp
- **GranitMigrationRunner**: remove `EnsureExpandContractDb` (table now created by EF migrations via `ConfigureMigrationsModule`), remove unnecessary braces
- **MigrationStartupService**: remove `EnsureProgressTable` (same reason), drop unused `IServiceScopeFactory` dependency
- **MigrationProgress / MigrationProgressConfiguration**: change from `internal` to `public` for EF Core migration discovery
- **MigrationsModelBuilderExtensions**: new extension for centralized migration table configuration

## Test plan

- [ ] `dotnet build` passes
- [ ] `dotnet test tests/Granit.Persistence.EntityFrameworkCore.Migrations.Tests`
- [ ] `dotnet test tests/Granit.Auditing.Tests`
- [ ] `dotnet test tests/Granit.Wolverine.Postgresql.Tests`
- [ ] Verify `--migrate` mode still creates `data_migration_progress` table
