### PR TITLE
feat(caching): add Aspire-compatible connection string resolution for Redis

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -8923,7 +8923,7 @@
       "kind": "class",
       "project": "Granit.Caching.StackExchangeRedis",
       "file": "src/Granit.Caching.StackExchangeRedis/Extensions/RedisCachingServiceCollectionExtensions.cs",
-      "line": 18,
+      "line": 19,
       "members": [
         {
           "name": "AddGranitCachingRedis",
@@ -8962,6 +8962,12 @@
           "kind": "property",
           "signature": "bool IsEnabled",
           "returnType": "bool"
+        },
+        {
+          "name": "ConnectionStringName",
+          "kind": "property",
+          "signature": "string? ConnectionStringName",
+          "returnType": "string?"
         },
         {
           "name": "Configuration",

--- a/src/Granit.Caching.StackExchangeRedis/Extensions/RedisCachingServiceCollectionExtensions.cs
+++ b/src/Granit.Caching.StackExchangeRedis/Extensions/RedisCachingServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Granit.Caching.Options;
 using Granit.Caching.StackExchangeRedis.HealthChecks;
 using Granit.Caching.StackExchangeRedis.Internal;
 using Granit.Caching.StackExchangeRedis.Options;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
@@ -50,6 +51,26 @@ public static partial class RedisCachingServiceCollectionExtensions
             .BindConfiguration(RedisCachingOptions.SectionName)
             .ValidateDataAnnotations()
             .ValidateOnStart();
+
+        // Resolve ConnectionStrings:{name} → Configuration (Aspire / standard .NET support).
+        // PostConfigure runs after BindConfiguration, so the ConnectionStringName property
+        // is already populated from appsettings. If the named connection string exists,
+        // it takes precedence over the explicit Configuration value.
+        services
+            .AddOptions<RedisCachingOptions>()
+            .PostConfigure<IConfiguration>((opts, config) =>
+            {
+                if (string.IsNullOrEmpty(opts.ConnectionStringName))
+                {
+                    return;
+                }
+
+                string? connectionString = config.GetConnectionString(opts.ConnectionStringName);
+                if (!string.IsNullOrEmpty(connectionString))
+                {
+                    opts.Configuration = connectionString;
+                }
+            });
 
         // Replace IDistributedCache (MemoryDistributedCache -> RedisCache)
         // Deferred configuration: reads RedisCachingOptions at resolution time.

--- a/src/Granit.Caching.StackExchangeRedis/Options/RedisCachingOptions.cs
+++ b/src/Granit.Caching.StackExchangeRedis/Options/RedisCachingOptions.cs
@@ -17,7 +17,22 @@ public sealed class RedisCachingOptions
     public bool IsEnabled { get; set; } = true;
 
     /// <summary>
-    /// Redis connection string in StackExchange.Redis format.
+    /// Name of the connection string in <c>ConnectionStrings:{name}</c>.
+    /// When set and the named connection string exists, it takes precedence
+    /// over <see cref="Configuration"/>. This supports .NET Aspire resource
+    /// injection out-of-the-box (<c>builder.AddRedis("cache")</c>).
+    /// Set to <c>null</c> to disable connection string resolution and use
+    /// <see cref="Configuration"/> directly.
+    /// Default: <c>"cache"</c>.
+    /// </summary>
+#pragma warning disable GRSEC003 // Config key name, not a secret value
+    public string? ConnectionStringName { get; set; } = "cache";
+#pragma warning restore GRSEC003
+
+    /// <summary>
+    /// Explicit Redis connection string in StackExchange.Redis format.
+    /// Used when <see cref="ConnectionStringName"/> is <c>null</c> or the named
+    /// connection string is not found in configuration.
     /// Examples: <c>"localhost:6379"</c>, <c>"redis-service:6379,password=secret"</c>.
     /// In production: provided via Vault or environment variables.
     /// </summary>

--- a/tests/Granit.Caching.StackExchangeRedis.Tests/RedisCachingOptionsTests.cs
+++ b/tests/Granit.Caching.StackExchangeRedis.Tests/RedisCachingOptionsTests.cs
@@ -56,4 +56,28 @@ public sealed class RedisCachingOptionsTests
 
         options.IsEnabled.ShouldBeFalse();
     }
+
+    [Fact]
+    public void Defaults_ConnectionStringName_IsCache()
+    {
+        RedisCachingOptions options = new();
+
+        options.ConnectionStringName.ShouldBe("cache");
+    }
+
+    [Fact]
+    public void ConnectionStringName_CanBeSetToNull()
+    {
+        RedisCachingOptions options = new() { ConnectionStringName = null };
+
+        options.ConnectionStringName.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ConnectionStringName_CanBeOverridden()
+    {
+        RedisCachingOptions options = new() { ConnectionStringName = "my-redis" };
+
+        options.ConnectionStringName.ShouldBe("my-redis");
+    }
 }

--- a/tests/Granit.Caching.StackExchangeRedis.Tests/RedisCachingServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Caching.StackExchangeRedis.Tests/RedisCachingServiceCollectionExtensionsTests.cs
@@ -166,6 +166,118 @@ public sealed class RedisCachingServiceCollectionExtensionsTests
     }
 
     [Fact]
+    public void AddGranitCachingRedis_ConnectionStringName_ResolvesFromConnectionStrings()
+    {
+        // Arrange — Aspire-style: ConnectionStrings:cache contains the dynamic endpoint
+        IConfiguration configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:cache"] = "aspire-redis:12345",
+            ["Cache:Redis:ConnectionStringName"] = "cache",
+            ["Cache:Redis:InstanceName"] = "test:",
+        });
+
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddGranitCachingRedis();
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        // Act
+        RedisCachingOptions opts = sp.GetRequiredService<IOptions<RedisCachingOptions>>().Value;
+
+        // Assert — ConnectionStrings:cache takes precedence over default Configuration
+        opts.Configuration.ShouldBe("aspire-redis:12345");
+    }
+
+    [Fact]
+    public void AddGranitCachingRedis_ConnectionStringName_DefaultCache_ResolvesAutomatically()
+    {
+        // Arrange — default ConnectionStringName is "cache"; no explicit setting needed
+        IConfiguration configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:cache"] = "aspire-redis:55123",
+        });
+
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddGranitCachingRedis();
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        // Act
+        RedisCachingOptions opts = sp.GetRequiredService<IOptions<RedisCachingOptions>>().Value;
+
+        // Assert
+        opts.Configuration.ShouldBe("aspire-redis:55123");
+    }
+
+    [Fact]
+    public void AddGranitCachingRedis_ConnectionStringName_Null_UsesExplicitConfiguration()
+    {
+        // Arrange — opt-out: ConnectionStringName = null → use Configuration directly
+        IConfiguration configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:cache"] = "should-be-ignored",
+            ["Cache:Redis:ConnectionStringName"] = null,
+            ["Cache:Redis:Configuration"] = "explicit-redis:6379",
+        });
+
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddGranitCachingRedis();
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        // Act
+        RedisCachingOptions opts = sp.GetRequiredService<IOptions<RedisCachingOptions>>().Value;
+
+        // Assert — explicit Configuration is used, not the connection string
+        opts.Configuration.ShouldBe("explicit-redis:6379");
+    }
+
+    [Fact]
+    public void AddGranitCachingRedis_ConnectionStringName_NotFound_FallsBackToConfiguration()
+    {
+        // Arrange — ConnectionStringName set but no matching ConnectionStrings entry
+        IConfiguration configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Cache:Redis:ConnectionStringName"] = "nonexistent",
+            ["Cache:Redis:Configuration"] = "fallback-redis:6379",
+        });
+
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddGranitCachingRedis();
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        // Act
+        RedisCachingOptions opts = sp.GetRequiredService<IOptions<RedisCachingOptions>>().Value;
+
+        // Assert — falls back to explicit Configuration
+        opts.Configuration.ShouldBe("fallback-redis:6379");
+    }
+
+    [Fact]
+    public void AddGranitCachingRedis_ConnectionStringName_PropagatedToStackExchangeOptions()
+    {
+        // Arrange — verify the resolved connection string flows through to RedisCacheOptions
+        IConfiguration configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:cache"] = "aspire-redis:12345",
+            ["Cache:Redis:InstanceName"] = "myapp:",
+        });
+
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddGranitCachingRedis();
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        // Act
+        RedisCacheOptions redisOpts = sp.GetRequiredService<IOptions<RedisCacheOptions>>().Value;
+
+        // Assert — StackExchange RedisCacheOptions uses the resolved connection string
+        redisOpts.Configuration.ShouldBe("aspire-redis:12345");
+        redisOpts.InstanceName.ShouldBe("myapp:");
+    }
+
+    [Fact]
     public void AddGranitRedisHealthCheck_WhenIConnectionMultiplexerNotRegistered_RegistersIt()
     {
         // Arrange


### PR DESCRIPTION
## Summary

- Add `ConnectionStringName` property to `RedisCachingOptions` (default: `"cache"`) to resolve Redis endpoints from `ConnectionStrings:{name}` via `PostConfigure`
- Enables seamless .NET Aspire integration (`builder.AddRedis("cache")`) without extra configuration
- Set `ConnectionStringName` to `null` to opt out and use explicit `Configuration` value
- Add unit and integration tests covering default resolution, opt-out, fallback, and propagation to `RedisCacheOptions`

## Test plan

- [x] `RedisCachingOptionsTests` — default value, nullable, override
- [x] `RedisCachingServiceCollectionExtensionsTests` — connection string resolution, null opt-out, missing fallback, propagation to StackExchange options