### PR TITLE
feat(query-engine): add QueryDefinition for SaaS modules + fix OpenIddict docs

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2478,8 +2478,15 @@
       "kind": "class",
       "project": "Granit.AI.Endpoints",
       "file": "src/Granit.AI.Endpoints/GranitAIEndpointsModule.cs",
-      "line": 14,
-      "members": []
+      "line": 16,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "AIEndpointsOptions",
@@ -7915,8 +7922,15 @@
       "kind": "class",
       "project": "Granit.BlobStorage.Endpoints",
       "file": "src/Granit.BlobStorage.Endpoints/GranitBlobStorageEndpointsModule.cs",
-      "line": 18,
-      "members": []
+      "line": 21,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "BlobStorageEndpointsOptions",
@@ -7966,6 +7980,22 @@
       "file": "src/Granit.BlobStorage.Endpoints/Permissions/BlobStorageRateLimitPolicies.cs",
       "line": 18,
       "members": []
+    },
+    {
+      "name": "BlobDescriptorQueryDefinition",
+      "fqn": "Granit.BlobStorage.Endpoints.Queries.BlobDescriptorQueryDefinition",
+      "kind": "class",
+      "project": "Granit.BlobStorage.Endpoints",
+      "file": "src/Granit.BlobStorage.Endpoints/Queries/BlobDescriptorQueryDefinition.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
     },
     {
       "name": "BlobStorageEntityFrameworkCoreHostApplicationBuilderExtensions",
@@ -19312,8 +19342,15 @@
       "kind": "class",
       "project": "Granit.Invoicing.Endpoints",
       "file": "src/Granit.Invoicing.Endpoints/GranitInvoicingEndpointsModule.cs",
-      "line": 14,
-      "members": []
+      "line": 17,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "CreditNotes",
@@ -19343,12 +19380,28 @@
       "members": []
     },
     {
+      "name": "InvoiceQueryDefinition",
+      "fqn": "Granit.Invoicing.Endpoints.Queries.InvoiceQueryDefinition",
+      "kind": "class",
+      "project": "Granit.Invoicing.Endpoints",
+      "file": "src/Granit.Invoicing.Endpoints/Queries/InvoiceQueryDefinition.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
       "name": "InvoicingEntityFrameworkCoreHostApplicationBuilderExtensions",
       "fqn": "Granit.Invoicing.EntityFrameworkCore.Extensions.InvoicingEntityFrameworkCoreHostApplicationBuilderExtensions",
       "kind": "class",
       "project": "Granit.Invoicing.EntityFrameworkCore",
       "file": "src/Granit.Invoicing.EntityFrameworkCore/Extensions/InvoicingEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 11,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitInvoicingEntityFrameworkCore",
@@ -32330,7 +32383,7 @@
       "kind": "class",
       "project": "Granit.QueryEngine.EntityFrameworkCore",
       "file": "src/Granit.QueryEngine.EntityFrameworkCore/GranitQueryEngineEntityFrameworkCoreModule.cs",
-      "line": 19,
+      "line": 20,
       "members": [
         {
           "name": "ConfigureServices",
@@ -33899,8 +33952,15 @@
       "kind": "class",
       "project": "Granit.Scheduling.Endpoints",
       "file": "src/Granit.Scheduling.Endpoints/GranitSchedulingEndpointsModule.cs",
-      "line": 22,
-      "members": []
+      "line": 25,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "SchedulingEndpointsOptions",
@@ -33941,6 +34001,22 @@
       "file": "src/Granit.Scheduling.Endpoints/Permissions/SchedulingPermissions.cs",
       "line": 6,
       "members": []
+    },
+    {
+      "name": "ScheduledActionQueryDefinition",
+      "fqn": "Granit.Scheduling.Endpoints.Queries.ScheduledActionQueryDefinition",
+      "kind": "class",
+      "project": "Granit.Scheduling.Endpoints",
+      "file": "src/Granit.Scheduling.Endpoints/Queries/ScheduledActionQueryDefinition.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
     },
     {
       "name": "SchedulingEntityFrameworkCoreHostApplicationBuilderExtensions",
@@ -35554,8 +35630,15 @@
       "kind": "class",
       "project": "Granit.Subscriptions.Endpoints",
       "file": "src/Granit.Subscriptions.Endpoints/GranitSubscriptionsEndpointsModule.cs",
-      "line": 16,
-      "members": []
+      "line": 19,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "Plans",
@@ -35603,12 +35686,28 @@
       "members": []
     },
     {
+      "name": "SubscriptionQueryDefinition",
+      "fqn": "Granit.Subscriptions.Endpoints.Queries.SubscriptionQueryDefinition",
+      "kind": "class",
+      "project": "Granit.Subscriptions.Endpoints",
+      "file": "src/Granit.Subscriptions.Endpoints/Queries/SubscriptionQueryDefinition.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
       "name": "SubscriptionsEntityFrameworkCoreHostApplicationBuilderExtensions",
       "fqn": "Granit.Subscriptions.EntityFrameworkCore.Extensions.SubscriptionsEntityFrameworkCoreHostApplicationBuilderExtensions",
       "kind": "class",
       "project": "Granit.Subscriptions.EntityFrameworkCore",
       "file": "src/Granit.Subscriptions.EntityFrameworkCore/Extensions/SubscriptionsEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 13,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitSubscriptionsEntityFrameworkCore",
@@ -41069,8 +41168,15 @@
       "kind": "class",
       "project": "Granit.Webhooks.Endpoints",
       "file": "src/Granit.Webhooks.Endpoints/GranitWebhooksEndpointsModule.cs",
-      "line": 15,
-      "members": []
+      "line": 18,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
     },
     {
       "name": "WebhooksEndpointsOptions",
@@ -41111,6 +41217,38 @@
       "file": "src/Granit.Webhooks.Endpoints/Permissions/WebhooksPermissions.cs",
       "line": 6,
       "members": []
+    },
+    {
+      "name": "WebhookDeliveryAttemptQueryDefinition",
+      "fqn": "Granit.Webhooks.Endpoints.Queries.WebhookDeliveryAttemptQueryDefinition",
+      "kind": "class",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Queries/WebhookDeliveryAttemptQueryDefinition.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "WebhookSubscriptionQueryDefinition",
+      "fqn": "Granit.Webhooks.Endpoints.Queries.WebhookSubscriptionQueryDefinition",
+      "kind": "class",
+      "project": "Granit.Webhooks.Endpoints",
+      "file": "src/Granit.Webhooks.Endpoints/Queries/WebhookSubscriptionQueryDefinition.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
     },
     {
       "name": "WebhookTargetUrlValidatorExtensions",

--- a/docs-site/src/content/docs/dotnet/security/openiddict/account-management-api.mdx
+++ b/docs-site/src/content/docs/dotnet/security/openiddict/account-management-api.mdx
@@ -12,8 +12,8 @@ The account self-service API lives in `Granit.Identity.Local.Endpoints` -- a
 provider-agnostic module shared between OpenIddict and any future auth provider
 (e.g. Duende Identity Server). Endpoints are available at `/api/account`
 (configurable via `AccountEndpointsOptions.AccountRoutePrefix`). All endpoints
-use `MapGranitGroup()` for automatic FluentValidation. Register them by calling
-`app.MapGranitAccount()`.
+use `MapGranitGroup()` for automatic FluentValidation. Register them on your
+versioned API route group:
 
 ## Endpoint summary
 
@@ -770,10 +770,10 @@ All request DTOs have corresponding FluentValidation validators auto-discovered 
 Route prefixes and OpenAPI tags are configurable:
 
 ```csharp
-app.MapGranitAccount(options =>
+api.MapGranitAccount(options =>
 {
-    options.AccountRoutePrefix = "api/account";    // default
-    options.AdminRoutePrefix = "api/admin";        // default
+    options.AccountRoutePrefix = "account";    // default
+    options.AdminRoutePrefix = "admin";        // default
 });
 ```
 

--- a/docs-site/src/content/docs/dotnet/security/openiddict/configuration.mdx
+++ b/docs-site/src/content/docs/dotnet/security/openiddict/configuration.mdx
@@ -295,18 +295,18 @@ environment variables. Never commit secrets to source control.
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `AccountRoutePrefix` | `string` | `"api/account"` | Route prefix for account self-service endpoints. |
-| `AdminRoutePrefix` | `string` | `"api/admin"` | Route prefix for admin management endpoints. |
+| `AccountRoutePrefix` | `string` | `"account"` | Route prefix for account self-service endpoints. |
+| `AdminRoutePrefix` | `string` | `"admin"` | Route prefix for admin management endpoints. |
 | `AccountTagName` | `string` | `"Account"` | OpenAPI tag for account endpoints. |
 | `AdminTagName` | `string` | `"Administration"` | OpenAPI tag for admin endpoints. |
 
 **Example:**
 
 ```csharp
-app.MapGranitOpenIddict(options =>
+api.MapGranitOpenIddict(options =>
 {
-    options.AccountRoutePrefix = "api/v1/account";
-    options.AdminRoutePrefix = "api/v1/admin";
+    options.AccountRoutePrefix = "account";
+    options.AdminRoutePrefix = "admin";
 });
 ```
 

--- a/docs-site/src/content/docs/dotnet/security/openiddict/index.mdx
+++ b/docs-site/src/content/docs/dotnet/security/openiddict/index.mdx
@@ -120,7 +120,7 @@ app.UseAuthentication();
 app.UseOpenIddict();       // MUST be between Authentication and Authorization
 app.UseAuthorization();
 
-app.MapGranitOpenIddict();
+api.MapGranitOpenIddict();
 ```
 
 ### 5. Run migrations

--- a/src/Granit.AI.Endpoints/GranitAIEndpointsModule.cs
+++ b/src/Granit.AI.Endpoints/GranitAIEndpointsModule.cs
@@ -1,6 +1,8 @@
+using Granit.AI.Endpoints.Queries;
 using Granit.Authorization;
 using Granit.Modularity;
 using Granit.QueryEngine.AspNetCore;
+using Granit.QueryEngine.Extensions;
 
 namespace Granit.AI.Endpoints;
 
@@ -11,4 +13,11 @@ namespace Granit.AI.Endpoints;
     typeof(GranitAIModule),
     typeof(GranitAuthorizationModule),
     typeof(GranitQueryEngineAspNetCoreModule))]
-public sealed class GranitAIEndpointsModule : GranitModule;
+public sealed class GranitAIEndpointsModule : GranitModule
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddQueryDefinition<AIUsageRecord, AIUsageRecordQueryDefinition>();
+    }
+}

--- a/src/Granit.BlobStorage.Endpoints/GranitBlobStorageEndpointsModule.cs
+++ b/src/Granit.BlobStorage.Endpoints/GranitBlobStorageEndpointsModule.cs
@@ -1,6 +1,9 @@
 using Granit.Authorization;
+using Granit.BlobStorage.Domain;
+using Granit.BlobStorage.Endpoints.Queries;
 using Granit.Modularity;
 using Granit.QueryEngine.AspNetCore;
+using Granit.QueryEngine.Extensions;
 using Granit.RateLimiting;
 using Granit.Validation;
 
@@ -15,4 +18,11 @@ namespace Granit.BlobStorage.Endpoints;
     typeof(GranitQueryEngineAspNetCoreModule),
     typeof(GranitRateLimitingModule),
     typeof(GranitValidationModule))]
-public sealed class GranitBlobStorageEndpointsModule : GranitModule;
+public sealed class GranitBlobStorageEndpointsModule : GranitModule
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddQueryDefinition<BlobDescriptor, BlobDescriptorQueryDefinition>();
+    }
+}

--- a/src/Granit.BlobStorage.Endpoints/Queries/BlobDescriptorQueryDefinition.cs
+++ b/src/Granit.BlobStorage.Endpoints/Queries/BlobDescriptorQueryDefinition.cs
@@ -1,0 +1,35 @@
+using Granit.BlobStorage.Domain;
+using Granit.QueryEngine;
+
+namespace Granit.BlobStorage.Endpoints.Queries;
+
+/// <summary>
+/// Query definition for blob descriptors — declares columns, filters, sorting,
+/// and search for the query engine.
+/// </summary>
+public sealed class BlobDescriptorQueryDefinition : QueryDefinition<BlobDescriptor>
+{
+    /// <inheritdoc/>
+    public override string Name => "BlobStorage.BlobDescriptors";
+
+    /// <inheritdoc/>
+    protected override void Configure(QueryDefinitionBuilder<BlobDescriptor> builder)
+    {
+        builder
+            .Column(b => b.TenantId, c => c.Label("Tenant").Filterable().Sortable())
+            .Column(b => b.ContainerName, c => c.Label("Container").Filterable().Sortable())
+            .Column(b => b.OriginalFileName, c => c.Label("File Name").Filterable().Sortable())
+            .Column(b => b.DeclaredContentType, c => c.Label("Content Type").Filterable().Sortable())
+            .Column(b => b.VerifiedContentType, c => c.Label("Verified Content Type").Filterable())
+            .Column(b => b.SizeBytes, c => c.Label("Size (bytes)").Sortable())
+            .Column(b => b.Status, c => c.Label("Status").Filterable().Sortable())
+            .Column(b => b.CreatedAt, c => c.Label("Created At").Sortable())
+            .Column(b => b.ValidatedAt, c => c.Label("Validated At").Sortable())
+            .Column(b => b.DeletedAt, c => c.Label("Deleted At").Sortable())
+            .Column(b => b.RejectionReason, c => c.Label("Rejection Reason"))
+            .GlobalSearch(b => b.OriginalFileName, b => b.ContainerName)
+            .DateFilter(b => b.CreatedAt)
+            .DefaultSort("-createdAt")
+            .DefaultPageSize(25);
+    }
+}

--- a/src/Granit.Identity.Local.Endpoints/README.md
+++ b/src/Granit.Identity.Local.Endpoints/README.md
@@ -12,11 +12,11 @@ provider (e.g. Duende Identity Server).
 ```csharp
 builder.AddGranit(granit => granit.AddOpenIddict());
 
-// Map account self-service endpoints (/api/account)
-app.MapGranitAccount();
+// Map account self-service endpoints (on versioned API group)
+api.MapGranitAccount();
 
-// Map OpenIddict OIDC endpoints (/connect/*, /api/admin/oidc)
-app.MapGranitOpenIddict();
+// Map OpenIddict admin + account OIDC endpoints
+api.MapGranitOpenIddict();
 app.MapGranitOpenIddictServer();
 ```
 

--- a/src/Granit.Invoicing.Endpoints/GranitInvoicingEndpointsModule.cs
+++ b/src/Granit.Invoicing.Endpoints/GranitInvoicingEndpointsModule.cs
@@ -1,6 +1,9 @@
 using Granit.Authorization;
+using Granit.Invoicing.Domain;
+using Granit.Invoicing.Endpoints.Queries;
 using Granit.Modularity;
 using Granit.QueryEngine.AspNetCore;
+using Granit.QueryEngine.Extensions;
 using Granit.Validation;
 
 namespace Granit.Invoicing.Endpoints;
@@ -11,4 +14,10 @@ namespace Granit.Invoicing.Endpoints;
     typeof(GranitInvoicingModule),
     typeof(GranitQueryEngineAspNetCoreModule),
     typeof(GranitValidationModule))]
-public sealed class GranitInvoicingEndpointsModule : GranitModule;
+public sealed class GranitInvoicingEndpointsModule : GranitModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddQueryDefinition<Invoice, InvoiceQueryDefinition>();
+    }
+}

--- a/src/Granit.Invoicing.Endpoints/Queries/InvoiceQueryDefinition.cs
+++ b/src/Granit.Invoicing.Endpoints/Queries/InvoiceQueryDefinition.cs
@@ -1,0 +1,36 @@
+using Granit.Invoicing.Domain;
+using Granit.QueryEngine;
+using Granit.QueryEngine.Filtering;
+
+namespace Granit.Invoicing.Endpoints.Queries;
+
+/// <summary>
+/// Query definition for invoices — declares columns, filters, sorting,
+/// and search for the query engine.
+/// </summary>
+public sealed class InvoiceQueryDefinition : QueryDefinition<Invoice>
+{
+    /// <inheritdoc/>
+    public override string Name => "Invoicing.Invoices";
+
+    /// <inheritdoc/>
+    protected override void Configure(QueryDefinitionBuilder<Invoice> builder)
+    {
+        builder
+            .Column(i => i.TenantId, c => c.Label("Tenant").Filterable().Sortable())
+            .Column(i => i.InvoiceNumber, c => c.Label("Invoice Number").Filterable().Sortable())
+            .Column(i => i.DocumentType, c => c.Label("Document Type").Filterable().Sortable())
+            .Column(i => i.Status, c => c.Label("Status").Filterable().Sortable())
+            .Column(i => i.Currency, c => c.Label("Currency").Filterable().Sortable())
+            .Column(i => i.Total, c => c.Label("Total").Sortable())
+            .Column(i => i.AmountRemaining, c => c.Label("Amount Remaining").Sortable())
+            .Column(i => i.IssuedAt, c => c.Label("Issued At").Sortable())
+            .Column(i => i.DueAt, c => c.Label("Due At").Sortable())
+            .Column(i => i.PaidAt, c => c.Label("Paid At").Sortable())
+            .Column(i => i.BillingReason, c => c.Label("Billing Reason").Filterable())
+            .GlobalSearch(i => i.InvoiceNumber, i => i.Currency)
+            .DateFilter(i => i.IssuedAt)
+            .DefaultSort("-issuedAt")
+            .DefaultPageSize(25);
+    }
+}

--- a/src/Granit.Invoicing.EntityFrameworkCore/Extensions/InvoicingEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Invoicing.EntityFrameworkCore/Extensions/InvoicingEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,5 +1,7 @@
+using Granit.Invoicing.Domain;
 using Granit.Invoicing.EntityFrameworkCore.Internal;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -20,6 +22,8 @@ public static class InvoicingEntityFrameworkCoreHostApplicationBuilderExtensions
         builder.Services.AddScoped<EfInvoiceStore>();
         builder.Services.TryAddScoped<IInvoiceReader>(sp => sp.GetRequiredService<EfInvoiceStore>());
         builder.Services.TryAddScoped<IInvoiceWriter>(sp => sp.GetRequiredService<EfInvoiceStore>());
+
+        builder.Services.AddScoped<IQueryableSource<Invoice>, EfInvoiceQueryableSource>();
 
         return builder;
     }

--- a/src/Granit.Invoicing.EntityFrameworkCore/Internal/EfInvoiceQueryableSource.cs
+++ b/src/Granit.Invoicing.EntityFrameworkCore/Internal/EfInvoiceQueryableSource.cs
@@ -1,0 +1,33 @@
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.Invoicing.Domain;
+using Granit.MultiTenancy;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Invoicing.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="Invoice"/>.
+/// When no tenant context is active (host admin), the multi-tenant query filter is
+/// disabled so all invoices are returned cross-tenant.
+/// </summary>
+internal sealed class EfInvoiceQueryableSource(
+    IDbContextFactory<InvoicingDbContext> contextFactory,
+    ICurrentTenant currentTenant,
+    IDataFilter dataFilter) : IQueryableSource<Invoice>, IDisposable
+{
+    private readonly InvoicingDbContext _context = contextFactory.CreateDbContext();
+    private readonly IDisposable? _tenantBypass = !currentTenant.IsAvailable
+        ? dataFilter.Disable<IMultiTenant>()
+        : null;
+
+    public IQueryable<Invoice> GetQueryable() =>
+        _context.Invoices.AsNoTracking();
+
+    public void Dispose()
+    {
+        _tenantBypass?.Dispose();
+        _context.Dispose();
+    }
+}

--- a/src/Granit.QueryEngine.EntityFrameworkCore/GranitQueryEngineEntityFrameworkCoreModule.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/GranitQueryEngineEntityFrameworkCoreModule.cs
@@ -3,6 +3,7 @@ using Granit.Modularity;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.QueryEngine.Diagnostics;
 using Granit.QueryEngine.EntityFrameworkCore.Diagnostics;
+using Granit.QueryEngine.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -21,6 +22,7 @@ public sealed class GranitQueryEngineEntityFrameworkCoreModule : GranitModule
     /// <inheritdoc/>
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        context.Services.TryAddScoped(typeof(IQueryEngine<>), typeof(QueryEngine<>));
         context.Services.TryAddSingleton<QueryEngineMetrics>();
         GranitActivitySourceRegistry.Register(QueryEngineEfCoreActivitySource.Name);
     }

--- a/src/Granit.Scheduling.Endpoints/GranitSchedulingEndpointsModule.cs
+++ b/src/Granit.Scheduling.Endpoints/GranitSchedulingEndpointsModule.cs
@@ -1,6 +1,9 @@
 using Granit.Authorization;
 using Granit.Modularity;
 using Granit.QueryEngine.AspNetCore;
+using Granit.QueryEngine.Extensions;
+using Granit.Scheduling.Domain;
+using Granit.Scheduling.Endpoints.Queries;
 using Granit.Validation;
 
 namespace Granit.Scheduling.Endpoints;
@@ -19,4 +22,11 @@ namespace Granit.Scheduling.Endpoints;
     typeof(GranitQueryEngineAspNetCoreModule),
     typeof(GranitSchedulingModule),
     typeof(GranitValidationModule))]
-public sealed class GranitSchedulingEndpointsModule : GranitModule;
+public sealed class GranitSchedulingEndpointsModule : GranitModule
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddQueryDefinition<ScheduledAction, ScheduledActionQueryDefinition>();
+    }
+}

--- a/src/Granit.Scheduling.Endpoints/Queries/ScheduledActionQueryDefinition.cs
+++ b/src/Granit.Scheduling.Endpoints/Queries/ScheduledActionQueryDefinition.cs
@@ -1,0 +1,32 @@
+using Granit.QueryEngine;
+using Granit.Scheduling.Domain;
+
+namespace Granit.Scheduling.Endpoints.Queries;
+
+/// <summary>
+/// Query definition for scheduled actions — declares columns, filters, sorting,
+/// and search for the query engine.
+/// </summary>
+public sealed class ScheduledActionQueryDefinition : QueryDefinition<ScheduledAction>
+{
+    /// <inheritdoc/>
+    public override string Name => "Scheduling.ScheduledActions";
+
+    /// <inheritdoc/>
+    protected override void Configure(QueryDefinitionBuilder<ScheduledAction> builder)
+    {
+        builder
+            .Column(a => a.TenantId, c => c.Label("Tenant").Filterable().Sortable())
+            .Column(a => a.PayloadType, c => c.Label("Payload Type").Filterable().Sortable())
+            .Column(a => a.Status, c => c.Label("Status").Filterable().Sortable())
+            .Column(a => a.ExecuteAt, c => c.Label("Execute At").Filterable().Sortable())
+            .Column(a => a.ExecutedAt, c => c.Label("Executed At").Sortable())
+            .Column(a => a.CorrelationId, c => c.Label("Correlation ID").Filterable())
+            .Column(a => a.CancelledBy, c => c.Label("Cancelled By").Filterable())
+            .Column(a => a.FailureReason, c => c.Label("Failure Reason"))
+            .GlobalSearch(a => a.PayloadType, a => a.CorrelationId)
+            .DateFilter(a => a.ExecuteAt)
+            .DefaultSort("-executeAt")
+            .DefaultPageSize(25);
+    }
+}

--- a/src/Granit.Subscriptions.Endpoints/GranitSubscriptionsEndpointsModule.cs
+++ b/src/Granit.Subscriptions.Endpoints/GranitSubscriptionsEndpointsModule.cs
@@ -1,6 +1,9 @@
 using Granit.Authorization;
 using Granit.Modularity;
 using Granit.QueryEngine.AspNetCore;
+using Granit.QueryEngine.Extensions;
+using Granit.Subscriptions.Domain;
+using Granit.Subscriptions.Endpoints.Queries;
 using Granit.Validation;
 
 namespace Granit.Subscriptions.Endpoints;
@@ -13,4 +16,10 @@ namespace Granit.Subscriptions.Endpoints;
     typeof(GranitQueryEngineAspNetCoreModule),
     typeof(GranitSubscriptionsModule),
     typeof(GranitValidationModule))]
-public sealed class GranitSubscriptionsEndpointsModule : GranitModule;
+public sealed class GranitSubscriptionsEndpointsModule : GranitModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddQueryDefinition<Subscription, SubscriptionQueryDefinition>();
+    }
+}

--- a/src/Granit.Subscriptions.Endpoints/Queries/SubscriptionQueryDefinition.cs
+++ b/src/Granit.Subscriptions.Endpoints/Queries/SubscriptionQueryDefinition.cs
@@ -1,0 +1,33 @@
+using Granit.QueryEngine;
+using Granit.QueryEngine.Filtering;
+using Granit.Subscriptions.Domain;
+
+namespace Granit.Subscriptions.Endpoints.Queries;
+
+/// <summary>
+/// Query definition for subscriptions — declares columns, filters, sorting,
+/// and search for the query engine.
+/// </summary>
+public sealed class SubscriptionQueryDefinition : QueryDefinition<Subscription>
+{
+    /// <inheritdoc/>
+    public override string Name => "Subscriptions.Subscriptions";
+
+    /// <inheritdoc/>
+    protected override void Configure(QueryDefinitionBuilder<Subscription> builder)
+    {
+        builder
+            .Column(s => s.TenantId, c => c.Label("Tenant").Filterable().Sortable())
+            .Column(s => s.PlanId, c => c.Label("Plan").Filterable().Sortable())
+            .Column(s => s.Status, c => c.Label("Status").Filterable().Sortable())
+            .Column(s => s.Currency, c => c.Label("Currency").Filterable().Sortable())
+            .Column(s => s.CurrentPeriodStart, c => c.Label("Period Start").Sortable())
+            .Column(s => s.CurrentPeriodEnd, c => c.Label("Period End").Sortable())
+            .Column(s => s.CancelAtPeriodEnd, c => c.Label("Cancel at Period End").Filterable())
+            .Column(s => s.TrialEndsAt, c => c.Label("Trial Ends At").Sortable())
+            .GlobalSearch(s => s.Currency)
+            .DateFilter(s => s.CurrentPeriodStart)
+            .DefaultSort("-currentPeriodEnd")
+            .DefaultPageSize(25);
+    }
+}

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Extensions/SubscriptionsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Extensions/SubscriptionsEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,4 +1,6 @@
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.QueryEngine;
+using Granit.Subscriptions.Domain;
 using Granit.Subscriptions.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -29,6 +31,8 @@ public static class SubscriptionsEntityFrameworkCoreHostApplicationBuilderExtens
         builder.Services.TryAddScoped<ISeatWriter, EfSeatWriter>();
 
         builder.Services.TryAddScoped<IPricingResolver, EfPricingResolver>();
+
+        builder.Services.AddScoped<IQueryableSource<Subscription>, EfSubscriptionQueryableSource>();
 
         return builder;
     }

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfSubscriptionQueryableSource.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfSubscriptionQueryableSource.cs
@@ -1,0 +1,33 @@
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.MultiTenancy;
+using Granit.QueryEngine;
+using Granit.Subscriptions.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Subscriptions.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="Subscription"/>.
+/// When no tenant context is active (host admin), the multi-tenant query filter is
+/// disabled so all subscriptions are returned cross-tenant.
+/// </summary>
+internal sealed class EfSubscriptionQueryableSource(
+    IDbContextFactory<SubscriptionsDbContext> contextFactory,
+    ICurrentTenant currentTenant,
+    IDataFilter dataFilter) : IQueryableSource<Subscription>, IDisposable
+{
+    private readonly SubscriptionsDbContext _context = contextFactory.CreateDbContext();
+    private readonly IDisposable? _tenantBypass = !currentTenant.IsAvailable
+        ? dataFilter.Disable<IMultiTenant>()
+        : null;
+
+    public IQueryable<Subscription> GetQueryable() =>
+        _context.Subscriptions.AsNoTracking();
+
+    public void Dispose()
+    {
+        _tenantBypass?.Dispose();
+        _context.Dispose();
+    }
+}

--- a/src/Granit.Webhooks.Endpoints/GranitWebhooksEndpointsModule.cs
+++ b/src/Granit.Webhooks.Endpoints/GranitWebhooksEndpointsModule.cs
@@ -1,7 +1,10 @@
 using Granit.Authorization;
 using Granit.Modularity;
 using Granit.QueryEngine.AspNetCore;
+using Granit.QueryEngine.Extensions;
 using Granit.Webhooks;
+using Granit.Webhooks.Domain;
+using Granit.Webhooks.Endpoints.Queries;
 
 namespace Granit.Webhooks.Endpoints;
 
@@ -12,4 +15,12 @@ namespace Granit.Webhooks.Endpoints;
     typeof(GranitAuthorizationModule),
     typeof(GranitQueryEngineAspNetCoreModule),
     typeof(GranitWebhooksModule))]
-public sealed class GranitWebhooksEndpointsModule : GranitModule;
+public sealed class GranitWebhooksEndpointsModule : GranitModule
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.AddQueryDefinition<WebhookSubscription, WebhookSubscriptionQueryDefinition>();
+        context.Services.AddQueryDefinition<WebhookDeliveryAttempt, WebhookDeliveryAttemptQueryDefinition>();
+    }
+}

--- a/src/Granit.Webhooks.Endpoints/Queries/WebhookDeliveryAttemptQueryDefinition.cs
+++ b/src/Granit.Webhooks.Endpoints/Queries/WebhookDeliveryAttemptQueryDefinition.cs
@@ -1,0 +1,33 @@
+using Granit.QueryEngine;
+using Granit.Webhooks.Domain;
+
+namespace Granit.Webhooks.Endpoints.Queries;
+
+/// <summary>
+/// Query definition for webhook delivery attempts — declares columns, filters, sorting,
+/// and search for the query engine.
+/// </summary>
+public sealed class WebhookDeliveryAttemptQueryDefinition : QueryDefinition<WebhookDeliveryAttempt>
+{
+    /// <inheritdoc/>
+    public override string Name => "Webhooks.DeliveryAttempts";
+
+    /// <inheritdoc/>
+    protected override void Configure(QueryDefinitionBuilder<WebhookDeliveryAttempt> builder)
+    {
+        builder
+            .Column(d => d.SubscriptionId, c => c.Label("Subscription").Filterable().Sortable())
+            .Column(d => d.TenantId, c => c.Label("Tenant").Filterable().Sortable())
+            .Column(d => d.EventType, c => c.Label("Event Type").Filterable().Sortable())
+            .Column(d => d.TargetUrl, c => c.Label("Target URL").Filterable())
+            .Column(d => d.HttpStatusCode, c => c.Label("HTTP Status").Filterable().Sortable())
+            .Column(d => d.IsSuccess, c => c.Label("Success").Filterable().Sortable())
+            .Column(d => d.OccurredAt, c => c.Label("Occurred At").Sortable())
+            .Column(d => d.DurationMs, c => c.Label("Duration (ms)").Sortable())
+            .Column(d => d.ErrorMessage, c => c.Label("Error Message"))
+            .GlobalSearch(d => d.EventType, d => d.TargetUrl)
+            .DateFilter(d => d.OccurredAt)
+            .DefaultSort("-occurredAt")
+            .DefaultPageSize(25);
+    }
+}

--- a/src/Granit.Webhooks.Endpoints/Queries/WebhookSubscriptionQueryDefinition.cs
+++ b/src/Granit.Webhooks.Endpoints/Queries/WebhookSubscriptionQueryDefinition.cs
@@ -1,0 +1,31 @@
+using Granit.QueryEngine;
+using Granit.Webhooks.Domain;
+
+namespace Granit.Webhooks.Endpoints.Queries;
+
+/// <summary>
+/// Query definition for webhook subscriptions — declares columns, filters, sorting,
+/// and search for the query engine.
+/// </summary>
+public sealed class WebhookSubscriptionQueryDefinition : QueryDefinition<WebhookSubscription>
+{
+    /// <inheritdoc/>
+    public override string Name => "Webhooks.Subscriptions";
+
+    /// <inheritdoc/>
+    protected override void Configure(QueryDefinitionBuilder<WebhookSubscription> builder)
+    {
+        builder
+            .Column(s => s.TenantId, c => c.Label("Tenant").Filterable().Sortable())
+            .Column(s => s.EventType, c => c.Label("Event Type").Filterable().Sortable())
+            .Column(s => s.TargetUrl, c => c.Label("Target URL").Filterable())
+            .Column(s => s.Status, c => c.Label("Status").Filterable().Sortable())
+            .Column(s => s.ConsecutiveFailureCount, c => c.Label("Consecutive Failures").Sortable())
+            .Column(s => s.LastSuccessAt, c => c.Label("Last Success At").Sortable())
+            .Column(s => s.SuspendedAt, c => c.Label("Suspended At").Sortable())
+            .Column(s => s.SuspendedBy, c => c.Label("Suspended By").Filterable())
+            .GlobalSearch(s => s.EventType)
+            .DefaultSort("-lastSuccessAt")
+            .DefaultPageSize(25);
+    }
+}


### PR DESCRIPTION
## Summary

- Add typed `QueryDefinition<T>` and `IQueryableSource<T>` for SaaS modules (AI, BlobStorage, Invoicing, Scheduling, Subscriptions, Webhooks) enabling paginated, filterable, sortable list endpoints via `MapGranitQuery<T>()`
- Fix OpenIddict documentation code samples (`app` → `api` variable name) and update Identity.Local README

## Test plan

- [ ] `dotnet build` passes
- [ ] Verify query engine endpoints return paginated results with correct columns/filters
- [ ] Verify host admin (no tenant context) sees cross-tenant data via disabled multi-tenant filter
- [ ] Verify OpenIddict doc code samples match actual application startup pattern
