### PR TITLE
fix(deps): bump Magick.NET-Q8-AnyCPU 14.11.1 → 14.12.0 (3 CVEs)

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -4,7 +4,7 @@ Ce fichier répertorie les bibliothèques tierces utilisées par le projet
 **granit-dotnet** ainsi que leurs licences respectives. Il est mis à jour
 à chaque ajout ou modification de dépendance externe.
 
-Dernière mise à jour : 2026-04-08
+Dernière mise à jour : 2026-04-13
 
 ---
 
@@ -112,7 +112,7 @@ Dernière mise à jour : 2026-04-08
 | Google.Cloud.Kms.V1 | 3.23.0 | Copyright (c) Google LLC |
 | Google.Cloud.SecretManager.V1 | 2.7.0 | Copyright (c) Google LLC |
 | Google.Cloud.Storage.V1 | 4.14.0 | Copyright (c) Google LLC |
-| Magick.NET-Q8-AnyCPU | 14.11.1 | Copyright 2013-2026 Dirk Lemstra |
+| Magick.NET-Q8-AnyCPU | 14.12.0 | Copyright 2013-2026 Dirk Lemstra |
 | ModelContextProtocol | 1.1.0 | Copyright (c) Anthropic, PBC and Microsoft Corporation |
 | ModelContextProtocol.AspNetCore | 1.1.0 | Copyright (c) Anthropic, PBC and Microsoft Corporation |
 | OpenIddict | 7.4.0 | Copyright (c) Kévin Chalet |

--- a/src/Granit.Imaging.MagickNet/packages.lock.json
+++ b/src/Granit.Imaging.MagickNet/packages.lock.json
@@ -5,10 +5,10 @@
       "Magick.NET-Q8-AnyCPU": {
         "type": "Direct",
         "requested": "[14.*, )",
-        "resolved": "14.11.1",
-        "contentHash": "okzVwr299MM6vq2L+YR51ywoXITr3Ewiu6FXsBEj3egKQ0XJI1fn5E2WiBAnxAhlPnvnUE2pdeNvj6IBdmOjKA==",
+        "resolved": "14.12.0",
+        "contentHash": "YGEgNTZ6DaMhXgJYLClRrmEe6CMsEL5E8hy4c2iH/aEmj41ojFAtA/PIXYH1AOYINNEUX/83nLp/y5obt9P/vw==",
         "dependencies": {
-          "Magick.NET.Core": "14.11.1"
+          "Magick.NET.Core": "14.12.0"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -19,8 +19,8 @@
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.11.1",
-        "contentHash": "e9ejYUe6+GgbB6KBOpMp0jVDS72u0siDBz0RKSjBAEIZcigKDXDsOcoPLmLJJJqhorx3C4soRak2hCL/gaKdcg=="
+        "resolved": "14.12.0",
+        "contentHash": "QPyuk1Lxp1xgSTP8xomnoZjeOtUeTSoeSuEckhGaUAi6GdZ5d2PmZqzr0O4m/zPbC4So/yg5rr2QO4vYD6fB5g=="
       },
       "granit": {
         "type": "Project"

--- a/tests/Granit.Imaging.MagickNet.Tests/packages.lock.json
+++ b/tests/Granit.Imaging.MagickNet.Tests/packages.lock.json
@@ -88,8 +88,8 @@
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.11.1",
-        "contentHash": "e9ejYUe6+GgbB6KBOpMp0jVDS72u0siDBz0RKSjBAEIZcigKDXDsOcoPLmLJJJqhorx3C4soRak2hCL/gaKdcg=="
+        "resolved": "14.12.0",
+        "contentHash": "QPyuk1Lxp1xgSTP8xomnoZjeOtUeTSoeSuEckhGaUAi6GdZ5d2PmZqzr0O4m/zPbC4So/yg5rr2QO4vYD6fB5g=="
       },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
@@ -265,10 +265,10 @@
       "Magick.NET-Q8-AnyCPU": {
         "type": "CentralTransitive",
         "requested": "[14.*, )",
-        "resolved": "14.11.1",
-        "contentHash": "okzVwr299MM6vq2L+YR51ywoXITr3Ewiu6FXsBEj3egKQ0XJI1fn5E2WiBAnxAhlPnvnUE2pdeNvj6IBdmOjKA==",
+        "resolved": "14.12.0",
+        "contentHash": "YGEgNTZ6DaMhXgJYLClRrmEe6CMsEL5E8hy4c2iH/aEmj41ojFAtA/PIXYH1AOYINNEUX/83nLp/y5obt9P/vw==",
         "dependencies": {
-          "Magick.NET.Core": "14.11.1"
+          "Magick.NET.Core": "14.12.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {


### PR DESCRIPTION
## Summary

- Bump `Magick.NET-Q8-AnyCPU` from 14.11.1 to 14.12.0 via lock file regeneration
- Resolves 3 moderate-severity advisories in the native ImageMagick component:
  - [GHSA-v67w-737x-v2c9](https://github.com/advisories/GHSA-v67w-737x-v2c9)
  - [GHSA-26qp-ffjh-2x4v](https://github.com/advisories/GHSA-26qp-ffjh-2x4v)
  - [GHSA-cr67-pvmx-2pp2](https://github.com/advisories/GHSA-cr67-pvmx-2pp2)
- `THIRD-PARTY-NOTICES.md` updated

## Test plan

- [x] `dotnet test tests/Granit.Imaging.MagickNet.Tests` — 81 passed
- [x] `dotnet list ... --vulnerable` — zero remaining vulnerabilities