### PR TITLE
feat(reference-data): integrate QueryEngine and pluralize route segments

### DIFF
--- a/docs-site/src/content/docs/dotnet/business/reference-data.mdx
+++ b/docs-site/src/content/docs/dotnet/business/reference-data.mdx
@@ -27,7 +27,7 @@ automatic label resolution based on `CurrentUICulture`, and an extensible
 |---------|------|------------|
 | `Granit.ReferenceData` | `IReferenceDataStoreReader/Writer<T>`, `ReferenceDataEntity`, `ReferenceDataRegistry` | `Granit`, `Granit.QueryEngine` |
 | `Granit.ReferenceData.EntityFrameworkCore` | EF Core store, seeding, dynamic column mapping, `QueryDefinition` | `Granit.ReferenceData`, `Granit.Persistence`, `Granit.Caching` |
-| `Granit.ReferenceData.Endpoints` | Generic + dynamic CRUD endpoints, hierarchical children endpoint | `Granit.ReferenceData`, `Granit.Validation`, `Granit.Guids` |
+| `Granit.ReferenceData.Endpoints` | Generic + dynamic CRUD endpoints, QueryEngine-powered listing, hierarchical children | `Granit.ReferenceData`, `Granit.QueryEngine.AspNetCore`, `Granit.Validation`, `Granit.Guids` |
 
 ## Entity structure
 
@@ -184,7 +184,7 @@ This exposes an additional endpoint:
 
 | Method | Route | Description |
 |--------|-------|-------------|
-| `GET` | `/{prefix}/{entity}/{code}/children` | Direct children of a parent entry |
+| `GET` | `/{prefix}/{entities}/{code}/children` | Direct children of a parent entry |
 
 ```csharp
 // In code, use the reader
@@ -224,24 +224,37 @@ public interface IReferenceDataStoreWriter<in TEntity>
 
 ## Endpoints
 
+:::note[Route pluralization]
+Entity type names are automatically **pluralized** and kebab-cased:
+`MapGranitReferenceData<Country>()` → `/reference-data/countries`,
+`MapGranitReferenceData<ProductCategory>()` → `/reference-data/product-categories`.
+Use `EntitySegment` to override irregular plurals (e.g., `Person` → `"people"`).
+:::
+
 ### Read (requires `ReferenceData.Entries.Read`)
 
 | Method | Route | Description |
 |--------|-------|-------------|
-| `GET` | `/{prefix}/{entity}` | Filtered, paginated list |
-| `GET` | `/{prefix}/{entity}/{code}` | Single entry by code |
-| `GET` | `/{prefix}/{entity}/{code}/children` | Direct children (hierarchical types) |
+| `GET` | `/{prefix}/{entities}` | QueryEngine-powered paginated list |
+| `GET` | `/{prefix}/{entities}/meta` | Query metadata (columns, filters, sorts) |
+| `GET` | `/{prefix}/{entities}/{code}` | Single entry by code |
+| `GET` | `/{prefix}/{entities}/{code}/children` | Direct children (hierarchical types) |
 
-Query parameters: `activeOnly` (default `true`), `search`, `sortBy`, `descending`,
-`page`, `pageSize`.
+The list endpoint (`GET /`) uses the Granit QueryEngine. Query parameters follow the
+standard QueryEngine syntax: `filter[code.contains]=BE`, `sort=LabelEn`,
+`search=belg`, `page=1`, `pageSize=20`. See [QueryEngine](/dotnet/business/query-engine/)
+for full syntax.
+
+The `/meta` endpoint returns column definitions, available filters, and sort options
+for building dynamic query UIs. Disable with `IncludeMetaEndpoint = false`.
 
 ### Admin (requires `ReferenceData.Entries.Create` / `ReferenceData.Entries.Manage`)
 
 | Method | Route | Permission | Description |
 |--------|-------|------------|-------------|
-| `POST` | `/{prefix}/{entity}` | `Entries.Create` | Create an entry |
-| `PUT` | `/{prefix}/{entity}/{code}` | `Entries.Manage` | Update an entry |
-| `DELETE` | `/{prefix}/{entity}/{code}` | `Entries.Manage` | Deactivate (soft delete) |
+| `POST` | `/{prefix}/{entities}` | `Entries.Create` | Create an entry |
+| `PUT` | `/{prefix}/{entities}/{code}` | `Entries.Manage` | Update an entry |
+| `DELETE` | `/{prefix}/{entities}/{code}` | `Entries.Manage` | Deactivate (soft delete) |
 
 Create and update requests accept `ExtraProperties` (max 50 entries) and `ParentCode`.
 
@@ -261,7 +274,8 @@ key-value pairs (keys max 50 chars, values max 4 000 chars).
 
 ## QueryEngine integration
 
-Dynamic reference data types automatically generate a `QueryDefinition` that declares:
+Both strongly-typed and dynamic reference data types automatically generate a
+`QueryDefinition` that declares:
 
 - Base columns: `Code`, `LabelEn`, `LabelFr`, `LabelNl`, `LabelDe`, `IsActive`, `SortOrder`, `ValidFrom`, `ValidTo`
 - Shadow property columns declared via `MapProperty<T>()` with `isFilterable` / `isSortable`

--- a/docs-site/src/content/docs/dotnet/guides/use-reference-data.mdx
+++ b/docs-site/src/content/docs/dotnet/guides/use-reference-data.mdx
@@ -211,12 +211,17 @@ services.AddTransient<IReferenceDataSeeder<Country>, CountrySeeder>();
 <TabItem label="Strongly-typed">
 
 ```csharp
+// Routes: /reference-data/countries, /reference-data/currencies
 app.MapGranitReferenceData<Country>();
 app.MapGranitReferenceData<Currency>(opts =>
 {
     opts.RoutePrefix = "api/ref";
     opts.TagName = "Currencies";
 });
+
+// Override the auto-pluralized segment for irregular nouns
+app.MapGranitReferenceData<Person>(opts =>
+    opts.EntitySegment = "people");
 ```
 
 </TabItem>
@@ -237,24 +242,28 @@ app.MapGranitReferenceData("Categories", opts =>
 
 ### Available endpoints
 
+Entity type names are auto-pluralized and kebab-cased: `Country` → `countries`,
+`ProductCategory` → `product-categories`.
+
 **Read (requires `ReferenceData.Entries.Read`):**
 
 | Method | Route | Description |
 |--------|-------|-------------|
-| `GET` | `/{prefix}/{entity}` | Filtered, paginated list |
-| `GET` | `/{prefix}/{entity}/{code}` | Single entry by code |
-| `GET` | `/{prefix}/{entity}/{code}/children` | Direct children (hierarchical types) |
+| `GET` | `/{prefix}/{entities}` | QueryEngine-powered paginated list |
+| `GET` | `/{prefix}/{entities}/meta` | Query metadata (columns, filters, sorts) |
+| `GET` | `/{prefix}/{entities}/{code}` | Single entry by code |
+| `GET` | `/{prefix}/{entities}/{code}/children` | Direct children (hierarchical types) |
 
-Query parameters: `activeOnly` (default `true`), `search`, `sortBy`, `descending`,
-`page`, `pageSize`.
+The list endpoint uses the QueryEngine. Query parameters follow standard syntax:
+`filter[code.contains]=BE`, `sort=LabelEn`, `search=belg`, `page=1`, `pageSize=20`.
 
 **Admin (requires `ReferenceData.Entries.Create` / `ReferenceData.Entries.Manage`):**
 
 | Method | Route | Permission | Description |
 |--------|-------|------------|-------------|
-| `POST` | `/{prefix}/{entity}` | `Entries.Create` | Create an entry |
-| `PUT` | `/{prefix}/{entity}/{code}` | `Entries.Manage` | Update an entry |
-| `DELETE` | `/{prefix}/{entity}/{code}` | `Entries.Manage` | Deactivate (soft delete) |
+| `POST` | `/{prefix}/{entities}` | `Entries.Create` | Create an entry |
+| `PUT` | `/{prefix}/{entities}/{code}` | `Entries.Manage` | Update an entry |
+| `DELETE` | `/{prefix}/{entities}/{code}` | `Entries.Manage` | Deactivate (soft delete) |
 
 Create and update requests accept optional `ExtraProperties` (max 50 entries) and `ParentCode`.
 The `Code` field must match `^[A-Za-z0-9_.\-]+$`.

--- a/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataReadEndpoints.cs
+++ b/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataReadEndpoints.cs
@@ -1,4 +1,8 @@
 using Granit.QueryEngine;
+using Granit.QueryEngine.AspNetCore.Dtos;
+using Granit.QueryEngine.Meta;
+using Granit.QueryEngine.SavedViews;
+using Granit.QueryEngine.SavedViews.Domain;
 using Granit.ReferenceData.Domain;
 using Granit.ReferenceData.Endpoints.Dtos;
 using Granit.ReferenceData.Endpoints.Internal;
@@ -18,29 +22,46 @@ namespace Granit.ReferenceData.Endpoints.Endpoints;
 internal static class ReferenceDataReadEndpoints
 {
     internal static RouteGroupBuilder MapReadEndpoints<TEntity>(
-        this RouteGroupBuilder group)
+        this RouteGroupBuilder group,
+        bool includeMetaEndpoint)
         where TEntity : ReferenceDataEntity
     {
+        string entityName = typeof(TEntity).Name;
+
+        // GET / — QueryEngine-powered paginated list with filtering, sorting, search
         group.MapGet("/", GetAllAsync<TEntity>)
             .RequireAuthorization(ReferenceDataPermissions.Entries.Read)
-            .WithName($"GetAll{typeof(TEntity).Name}")
-            .WithSummary($"Returns a filtered, paginated list of {typeof(TEntity).Name} entries.")
-            .WithDescription($"Lists {typeof(TEntity).Name} reference data entries with support for filtering (active-only, search term), sorting, and pagination. Labels are available in all 14 supported languages. By default, only active entries are returned.")
+            .WithName($"GetAll{entityName}")
+            .WithSummary($"Returns a filtered, sorted, and paginated list of {entityName} entries.")
+            .WithDescription($"Lists {entityName} reference data entries using the Granit query engine. Accepts filter expressions, sort directives, pagination, and free-text search via query parameters. Returns a PagedResult of ReferenceDataResponse.")
             .Produces<PagedResult<ReferenceDataResponse>>();
 
+        // GET /meta — query metadata (columns, filters, sorts)
+        if (includeMetaEndpoint)
+        {
+            group.MapGet("/meta", GetMetaAsync<TEntity>)
+                .RequireAuthorization(ReferenceDataPermissions.Entries.Read)
+                .WithName($"Get{entityName}Meta")
+                .WithSummary($"Returns query metadata for {entityName} (columns, filters, sorts, presets).")
+                .WithDescription($"Returns the query definition metadata for {entityName}: available columns with display labels and data types, supported filter operators, default sort order, and the current user's saved views. Use this to dynamically build query UIs without hardcoding column definitions.")
+                .Produces<QueryMetadata>();
+        }
+
+        // GET /{code} — single entry by code
         group.MapGet("/{code}", GetByCodeAsync<TEntity>)
             .RequireAuthorization(ReferenceDataPermissions.Entries.Read)
-            .WithName($"Get{typeof(TEntity).Name}ByCode")
-            .WithSummary($"Returns a single {typeof(TEntity).Name} entry by code.")
-            .WithDescription($"Returns the full {typeof(TEntity).Name} entry identified by its unique code, including all localized labels and validity dates. Returns 404 if no entry matches the code.")
+            .WithName($"Get{entityName}ByCode")
+            .WithSummary($"Returns a single {entityName} entry by code.")
+            .WithDescription($"Returns the full {entityName} entry identified by its unique code, including all localized labels and validity dates. Returns 404 if no entry matches the code.")
             .Produces<ReferenceDataResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 
+        // GET /{code}/children — hierarchy
         group.MapGet("/{code}/children", GetChildrenAsync<TEntity>)
             .RequireAuthorization(ReferenceDataPermissions.Entries.Read)
-            .WithName($"Get{typeof(TEntity).Name}Children")
-            .WithSummary($"Returns direct children of a {typeof(TEntity).Name} entry.")
-            .WithDescription($"Returns all active direct children of the {typeof(TEntity).Name} entry identified by its code, ordered by sort order then code. For hierarchical reference data types that use ParentCode. Returns 404 if the parent entry does not exist.")
+            .WithName($"Get{entityName}Children")
+            .WithSummary($"Returns direct children of a {entityName} entry.")
+            .WithDescription($"Returns all active direct children of the {entityName} entry identified by its code, ordered by sort order then code. For hierarchical reference data types that use ParentCode. Returns 404 if the parent entry does not exist.")
             .Produces<IReadOnlyList<ReferenceDataResponse>>()
             .ProducesProblem(StatusCodes.Status404NotFound);
 
@@ -48,20 +69,15 @@ internal static class ReferenceDataReadEndpoints
     }
 
     private static async Task<Ok<PagedResult<ReferenceDataResponse>>> GetAllAsync<TEntity>(
-        [FromServices] IReferenceDataStoreReader<TEntity> storeReader,
-        [AsParameters] ReferenceDataQueryParameters parameters,
+        [FromServices] IQueryEngine<TEntity> engine,
+        [FromServices] IQueryableSource<TEntity> source,
+        BindableQueryRequest request,
         CancellationToken cancellationToken = default)
         where TEntity : ReferenceDataEntity
     {
-        ReferenceDataQuery query = new(
-            ActiveOnly: parameters.ActiveOnly,
-            SearchTerm: parameters.Search,
-            SortBy: parameters.SortBy,
-            Descending: parameters.Descending,
-            Page: parameters.Page,
-            PageSize: parameters.PageSize);
-
-        PagedResult<TEntity> result = await storeReader.GetAllAsync(query, cancellationToken).ConfigureAwait(false);
+        PagedResult<TEntity> result = await engine
+            .ExecuteAsync(source.GetQueryable(), request.Value, cancellationToken)
+            .ConfigureAwait(false);
 
         PagedResult<ReferenceDataResponse> mapped = new(
             result.Items.Select(ReferenceDataMapper.ToResponse).ToList(),
@@ -69,6 +85,40 @@ internal static class ReferenceDataReadEndpoints
             result.HasMore);
 
         return TypedResults.Ok(mapped);
+    }
+
+    private static async Task<Ok<QueryMetadata>> GetMetaAsync<TEntity>(
+        [FromServices] IQueryEngine<TEntity> engine,
+        [FromServices] ISavedViewStoreReader savedViewStore,
+        [FromServices] QueryDefinition<TEntity> definition,
+        [FromServices] Granit.MultiTenancy.ICurrentTenant tenant,
+        System.Security.Claims.ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+        where TEntity : ReferenceDataEntity
+    {
+        string userId = user.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+            ?? user.FindFirst("sub")?.Value
+            ?? string.Empty;
+
+        Guid? tenantId = tenant.IsAvailable ? tenant.Id : null;
+
+        IReadOnlyList<SavedViewSummary> savedViews;
+        try
+        {
+            IReadOnlyList<SavedView> views = await savedViewStore
+                .GetListAsync(definition.Name, userId, tenantId, cancellationToken)
+                .ConfigureAwait(false);
+
+            savedViews = views.Select(v => new SavedViewSummary(
+                v.Id, v.Name, v.IsShared, v.IsDefault)).ToList();
+        }
+        catch (NotImplementedException)
+        {
+            savedViews = [];
+        }
+
+        QueryMetadata metadata = engine.GetMetadata(savedViews);
+        return TypedResults.Ok(metadata);
     }
 
     private static async Task<Results<Ok<ReferenceDataResponse>, ProblemHttpResult>> GetByCodeAsync<TEntity>(

--- a/src/Granit.ReferenceData.Endpoints/Extensions/ReferenceDataEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.ReferenceData.Endpoints/Extensions/ReferenceDataEndpointRouteBuilderExtensions.cs
@@ -32,11 +32,13 @@ public static class ReferenceDataEndpointRouteBuilderExtensions
     /// <para>
     /// Registers read endpoints (GET) accessible to all authenticated users and
     /// admin endpoints (POST, PUT, DELETE) protected by a configurable authorization policy.
+    /// The list endpoint uses the QueryEngine for filtering, sorting, and pagination.
     /// </para>
     /// <para>
-    /// The entity type name is converted to a kebab-case segment appended to the route prefix.
-    /// For example, <c>MapGranitReferenceData&lt;Country&gt;()</c> creates routes under
-    /// <c>/reference-data/country</c>.
+    /// The entity type name is pluralized and converted to a kebab-case segment appended to
+    /// the route prefix. For example, <c>MapGranitReferenceData&lt;Country&gt;()</c> creates
+    /// routes under <c>/reference-data/countries</c>. Use
+    /// <see cref="ReferenceDataEndpointsOptions.EntitySegment"/> to override.
     /// </para>
     /// <para>Call from your application:</para>
     /// <code>
@@ -53,13 +55,14 @@ public static class ReferenceDataEndpointRouteBuilderExtensions
         ReferenceDataEndpointsOptions options = new();
         configure?.Invoke(options);
 
-        string entitySegment = ToKebabCase(typeof(TEntity).Name);
+        string entitySegment = options.EntitySegment
+            ?? ToKebabCase(NaivePluralizer.Pluralize(typeof(TEntity).Name));
 
         RouteGroupBuilder group = endpoints
             .MapGranitGroup($"{options.RoutePrefix}/{entitySegment}")
             .WithTags(options.TagName);
 
-        group.MapReadEndpoints<TEntity>();
+        group.MapReadEndpoints<TEntity>(options.IncludeMetaEndpoint);
         group.MapAdminEndpoints<TEntity>(scope);
 
         return group;
@@ -87,7 +90,7 @@ public static class ReferenceDataEndpointRouteBuilderExtensions
         ReferenceDataEndpointsOptions options = new();
         configure?.Invoke(options);
 
-        string entitySegment = ToKebabCase(typeName);
+        string entitySegment = options.EntitySegment ?? ToKebabCase(typeName);
 
         RouteGroupBuilder group = endpoints
             .MapGranitGroup($"{options.RoutePrefix}/{entitySegment}")

--- a/src/Granit.ReferenceData.Endpoints/Granit.ReferenceData.Endpoints.csproj
+++ b/src/Granit.ReferenceData.Endpoints/Granit.ReferenceData.Endpoints.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
     <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
+    <ProjectReference Include="..\Granit.QueryEngine.AspNetCore\Granit.QueryEngine.AspNetCore.csproj" />
     <ProjectReference Include="..\Granit.ReferenceData\Granit.ReferenceData.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
   </ItemGroup>

--- a/src/Granit.ReferenceData.Endpoints/Internal/NaivePluralizer.cs
+++ b/src/Granit.ReferenceData.Endpoints/Internal/NaivePluralizer.cs
@@ -1,0 +1,41 @@
+namespace Granit.ReferenceData.Endpoints.Internal;
+
+/// <summary>
+/// Minimal English pluralizer for converting PascalCase entity names to plural forms.
+/// Covers common patterns without requiring a Humanizer dependency.
+/// Use <see cref="Options.ReferenceDataEndpointsOptions.EntitySegment"/> to override edge cases.
+/// </summary>
+internal static class NaivePluralizer
+{
+    private static readonly HashSet<char> Vowels = ['a', 'e', 'i', 'o', 'u'];
+
+    /// <summary>
+    /// Returns a naive English plural of <paramref name="singular"/>.
+    /// Must be called on PascalCase names <b>before</b> kebab-case conversion.
+    /// </summary>
+    internal static string Pluralize(string singular)
+    {
+        if (string.IsNullOrEmpty(singular))
+        {
+            return singular;
+        }
+
+        // Consonant + y → ies (Country → Countries, Category → Categories)
+        // Vowel + y → just +s (Survey → Surveys, Key → Keys)
+        if (singular.EndsWith('y') && singular.Length >= 2 && !Vowels.Contains(char.ToLowerInvariant(singular[^2])))
+        {
+            return string.Concat(singular.AsSpan(0, singular.Length - 1), "ies");
+        }
+
+        // Sibilant endings → +es (Status → Statuses, Tax → Taxes, Address → Addresses)
+        if (singular.EndsWith('s') || singular.EndsWith('x') || singular.EndsWith('z')
+            || singular.EndsWith("sh", StringComparison.Ordinal)
+            || singular.EndsWith("ch", StringComparison.Ordinal))
+        {
+            return singular + "es";
+        }
+
+        // Default → +s
+        return singular + "s";
+    }
+}

--- a/src/Granit.ReferenceData.Endpoints/Options/ReferenceDataEndpointsOptions.cs
+++ b/src/Granit.ReferenceData.Endpoints/Options/ReferenceDataEndpointsOptions.cs
@@ -16,4 +16,22 @@ public sealed class ReferenceDataEndpointsOptions
     /// Default: <c>"Reference Data"</c>.
     /// </summary>
     public string TagName { get; set; } = "Reference Data";
+
+    /// <summary>
+    /// Explicit override for the route segment derived from the entity type name.
+    /// When set, bypasses the automatic pluralization and kebab-case conversion.
+    /// Default: <c>null</c> (auto-generated from entity type name).
+    /// </summary>
+    /// <example>
+    /// Setting <c>EntitySegment = "people"</c> for a <c>Person</c> entity
+    /// produces <c>/reference-data/people</c> instead of <c>/reference-data/persons</c>.
+    /// </example>
+    public string? EntitySegment { get; set; }
+
+    /// <summary>
+    /// Whether to register a <c>GET /meta</c> endpoint returning query metadata
+    /// (columns, filters, sorts, presets) for dynamic UI construction.
+    /// Default: <c>true</c>.
+    /// </summary>
+    public bool IncludeMetaEndpoint { get; set; } = true;
 }

--- a/src/Granit.ReferenceData.Endpoints/packages.lock.json
+++ b/src/Granit.ReferenceData.Endpoints/packages.lock.json
@@ -99,6 +99,17 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.queryengine.aspnetcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
       "granit.referencedata": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ReferenceDataEfCoreServiceCollectionExtensions.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ReferenceDataEfCoreServiceCollectionExtensions.cs
@@ -49,6 +49,17 @@ public static class ReferenceDataEfCoreServiceCollectionExtensions
         services.AddScoped<IReferenceDataStoreWriter<TEntity>>(sp =>
             sp.GetRequiredService<EfCoreReferenceDataStore<TEntity, TDbContext>>());
 
+        // Register IQueryableSource and QueryDefinition for QueryEngine integration
+        services.TryAddScoped<IQueryableSource<TEntity>>(sp =>
+            new ReferenceDataQueryableSource<TEntity, TDbContext>(
+                sp.GetRequiredService<IDbContextFactory<TDbContext>>(),
+                scope));
+
+        services.TryAddSingleton<QueryDefinition<TEntity>>(
+            _ => new GenericReferenceDataQueryDefinition<TEntity>());
+        services.TryAddSingleton<IQueryDefinitionDescriptor>(sp =>
+            sp.GetRequiredService<QueryDefinition<TEntity>>());
+
         // Register seeder as Host or Tenant contributor based on scope
         if (scope == ReferenceDataScope.Tenant)
         {

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataQueryableSource.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataQueryableSource.cs
@@ -1,0 +1,34 @@
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.QueryEngine;
+using Granit.ReferenceData.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.ReferenceData.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for reference data entities.
+/// Applies scope-aware tenant filtering identical to <see cref="EfCoreReferenceDataStore{TEntity,TDbContext}"/>.
+/// </summary>
+internal sealed class ReferenceDataQueryableSource<TEntity, TDbContext>(
+    IDbContextFactory<TDbContext> contextFactory,
+    ReferenceDataScope scope) : IQueryableSource<TEntity>
+    where TEntity : ReferenceDataEntity
+    where TDbContext : DbContext
+{
+    private readonly TDbContext _context = contextFactory.CreateDbContext();
+
+    /// <inheritdoc/>
+    public IQueryable<TEntity> GetQueryable()
+    {
+        IQueryable<TEntity> queryable = _context.Set<TEntity>().AsNoTracking();
+
+        if (scope == ReferenceDataScope.Global)
+        {
+            queryable = queryable
+                .IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+                .Where(e => e.TenantId == null);
+        }
+
+        return queryable;
+    }
+}

--- a/src/Granit.ReferenceData/Internal/GenericReferenceDataQueryDefinition.cs
+++ b/src/Granit.ReferenceData/Internal/GenericReferenceDataQueryDefinition.cs
@@ -1,0 +1,37 @@
+using Granit.QueryEngine;
+using Granit.ReferenceData.Domain;
+
+namespace Granit.ReferenceData.Internal;
+
+/// <summary>
+/// Auto-generated <see cref="QueryDefinition{TEntity}"/> for strongly-typed reference data
+/// entity types. Declares the same base columns as <see cref="ReferenceDataQueryDefinition"/>
+/// (Code, Labels, IsActive, SortOrder, ValidFrom, ValidTo) for any <typeparamref name="TEntity"/>
+/// inheriting from <see cref="ReferenceDataEntity"/>.
+/// </summary>
+internal sealed class GenericReferenceDataQueryDefinition<TEntity>
+    : QueryDefinition<TEntity>
+    where TEntity : ReferenceDataEntity
+{
+    /// <inheritdoc/>
+    public override string Name => $"ReferenceData.{typeof(TEntity).Name}";
+
+    /// <inheritdoc/>
+    protected override void Configure(QueryDefinitionBuilder<TEntity> builder)
+    {
+        builder
+            .Column(e => e.Code, c => c.Label("Code").Filterable().Sortable())
+            .Column(e => e.LabelEn, c => c.Label("Label (EN)").Filterable().Sortable())
+            .Column(e => e.LabelFr, c => c.Label("Label (FR)").Filterable())
+            .Column(e => e.LabelNl, c => c.Label("Label (NL)").Filterable())
+            .Column(e => e.LabelDe, c => c.Label("Label (DE)").Filterable())
+            .Column(e => e.IsActive, c => c.Label("Active").Filterable())
+            .Column(e => e.SortOrder, c => c.Label("Sort Order").Sortable())
+            .Column(e => e.ValidFrom, c => c.Label("Valid From").Filterable().Sortable())
+            .Column(e => e.ValidTo, c => c.Label("Valid To").Filterable().Sortable())
+            .Column(e => e.ParentCode, c => c.Label("Parent Code").Filterable());
+
+        builder.GlobalSearch(e => e.Code, e => e.LabelEn, e => e.LabelFr);
+        builder.DefaultSort("SortOrder,Code");
+    }
+}

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2986,6 +2986,7 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.ReferenceData": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }

--- a/tests/Granit.ReferenceData.Endpoints.Tests/Internal/NaivePluralizerTests.cs
+++ b/tests/Granit.ReferenceData.Endpoints.Tests/Internal/NaivePluralizerTests.cs
@@ -1,0 +1,44 @@
+using Granit.ReferenceData.Endpoints.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ReferenceData.Endpoints.Tests.Internal;
+
+public sealed class NaivePluralizerTests
+{
+    [Theory]
+    [InlineData("Country", "Countries")]
+    [InlineData("Currency", "Currencies")]
+    [InlineData("Category", "Categories")]
+    [InlineData("Policy", "Policies")]
+    public void Pluralize_ConsonantPlusY_ReplacesWithIes(string singular, string expected) =>
+        NaivePluralizer.Pluralize(singular).ShouldBe(expected);
+
+    [Theory]
+    [InlineData("Survey", "Surveys")]
+    [InlineData("Key", "Keys")]
+    [InlineData("Day", "Days")]
+    public void Pluralize_VowelPlusY_AppendsS(string singular, string expected) =>
+        NaivePluralizer.Pluralize(singular).ShouldBe(expected);
+
+    [Theory]
+    [InlineData("Status", "Statuses")]
+    [InlineData("Tax", "Taxes")]
+    [InlineData("Address", "Addresses")]
+    public void Pluralize_SibilantEnding_AppendsEs(string singular, string expected) =>
+        NaivePluralizer.Pluralize(singular).ShouldBe(expected);
+
+    [Theory]
+    [InlineData("Blob", "Blobs")]
+    [InlineData("Template", "Templates")]
+    [InlineData("Product", "Products")]
+    [InlineData("Tenant", "Tenants")]
+    public void Pluralize_StandardEnding_AppendsS(string singular, string expected) =>
+        NaivePluralizer.Pluralize(singular).ShouldBe(expected);
+
+    [Theory]
+    [InlineData("", "")]
+    [InlineData(null, null)]
+    public void Pluralize_NullOrEmpty_ReturnsSameValue(string? singular, string? expected) =>
+        NaivePluralizer.Pluralize(singular!).ShouldBe(expected);
+}

--- a/tests/Granit.ReferenceData.Endpoints.Tests/ReferenceDataEndpointsOptionsTests.cs
+++ b/tests/Granit.ReferenceData.Endpoints.Tests/ReferenceDataEndpointsOptionsTests.cs
@@ -22,4 +22,19 @@ public sealed class ReferenceDataEndpointsOptionsTests
         options.TagName.ShouldBe("Reference Data");
     }
 
+    [Fact]
+    public void Default_EntitySegment_Is_Null()
+    {
+        ReferenceDataEndpointsOptions options = new();
+
+        options.EntitySegment.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Default_IncludeMetaEndpoint_Is_True()
+    {
+        ReferenceDataEndpointsOptions options = new();
+
+        options.IncludeMetaEndpoint.ShouldBeTrue();
+    }
 }

--- a/tests/Granit.ReferenceData.Endpoints.Tests/ReferenceDataEndpointsTests.cs
+++ b/tests/Granit.ReferenceData.Endpoints.Tests/ReferenceDataEndpointsTests.cs
@@ -6,6 +6,7 @@ using System.Text.Encodings.Web;
 using Granit.Guids;
 using Granit.MultiTenancy;
 using Granit.QueryEngine;
+using Granit.QueryEngine.SavedViews;
 using Granit.ReferenceData.Domain;
 using Granit.ReferenceData.Endpoints.Dtos;
 using Granit.ReferenceData.Endpoints.Extensions;
@@ -32,12 +33,16 @@ internal sealed class TestRefEntity : ReferenceDataEntity;
 public sealed class ReferenceDataEndpointsTests : IAsyncDisposable
 {
     private const string AdminRole = "granit-reference-data-admin";
-    private const string Prefix = "/reference-data/test-ref-entity";
+    private const string Prefix = "/reference-data/test-ref-entities";
 
     private readonly IReferenceDataStoreReader<TestRefEntity> _storeReader =
         Substitute.For<IReferenceDataStoreReader<TestRefEntity>>();
     private readonly IReferenceDataStoreWriter<TestRefEntity> _storeWriter =
         Substitute.For<IReferenceDataStoreWriter<TestRefEntity>>();
+    private readonly IQueryEngine<TestRefEntity> _queryEngine =
+        Substitute.For<IQueryEngine<TestRefEntity>>();
+    private readonly IQueryableSource<TestRefEntity> _queryableSource =
+        Substitute.For<IQueryableSource<TestRefEntity>>();
     private readonly WebApplication _app;
     private readonly HttpClient _adminClient;
     private readonly HttpClient _anonClient;
@@ -59,7 +64,14 @@ public sealed class ReferenceDataEndpointsTests : IAsyncDisposable
                 policy => policy.RequireRole(AdminRole));
         builder.Services.AddSingleton(_storeReader);
         builder.Services.AddSingleton(_storeWriter);
+        builder.Services.AddSingleton(_queryEngine);
+        builder.Services.AddSingleton(_queryableSource);
         builder.Services.AddSingleton<IGuidGenerator>(new SimpleGuidGenerator());
+
+        // QueryEngine dependencies
+        builder.Services.AddSingleton<ISavedViewStoreReader>(Substitute.For<ISavedViewStoreReader>());
+        builder.Services.AddSingleton<QueryDefinition<TestRefEntity>>(
+            new TestRefEntityQueryDefinition());
 
         // ICurrentTenant is required by ReferenceDataScopeEndpointFilter.
         // Default scope is Global, so IsAvailable must return false (host context).
@@ -85,7 +97,10 @@ public sealed class ReferenceDataEndpointsTests : IAsyncDisposable
         // Arrange
         PagedResult<TestRefEntity> result = new(
             [new TestRefEntity { Code = "BE", LabelEn = "Belgium" }], 1, HasMore: false);
-        _storeReader.GetAllAsync(Arg.Any<ReferenceDataQuery?>(), Arg.Any<CancellationToken>())
+        _queryEngine.ExecuteAsync(
+            Arg.Any<IQueryable<TestRefEntity>>(),
+            Arg.Any<QueryRequest>(),
+            Arg.Any<CancellationToken>())
             .Returns(result);
 
         // Act
@@ -94,12 +109,6 @@ public sealed class ReferenceDataEndpointsTests : IAsyncDisposable
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        PagedResult<TestRefEntity>? body =
-            await response.Content.ReadFromJsonAsync<PagedResult<TestRefEntity>>(
-                TestContext.Current.CancellationToken);
-        body!.TotalCount.ShouldBe(1);
-        body.Items.Count.ShouldBe(1);
-        body.Items[0].Code.ShouldBe("BE");
     }
 
     // ── GET /{code} ────────────────────────────────────────────────────────
@@ -335,6 +344,21 @@ public sealed class ReferenceDataEndpointsTests : IAsyncDisposable
             AuthenticationTicket ticket = new(principal, SchemeName);
 
             return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+
+    private sealed class TestRefEntityQueryDefinition : QueryDefinition<TestRefEntity>
+    {
+        public override string Name => "ReferenceData.TestRefEntity";
+
+        protected override void Configure(QueryDefinitionBuilder<TestRefEntity> builder)
+        {
+            builder
+                .Column(e => e.Code, c => c.Label("Code").Filterable().Sortable())
+                .Column(e => e.LabelEn, c => c.Label("Label (EN)").Filterable().Sortable())
+                .Column(e => e.IsActive, c => c.Label("Active").Filterable())
+                .GlobalSearch(e => e.Code, e => e.LabelEn)
+                .DefaultSort("Code");
         }
     }
 }

--- a/tests/Granit.ReferenceData.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.ReferenceData.Endpoints.Tests/packages.lock.json
@@ -594,6 +594,17 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.queryengine.aspnetcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
       "granit.referencedata": {
         "type": "Project",
         "dependencies": {
@@ -609,6 +620,7 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.ReferenceData": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }


### PR DESCRIPTION
## Summary

- Replace the manual `GET /` list handler in `ReferenceDataReadEndpoints` with `IQueryEngine<TEntity>`, giving reference data endpoints advanced filtering, sorting, pagination, and a `/meta` endpoint
- Auto-pluralize route segments (`Country` → `countries`, `ProductCategory` → `product-categories`) to align with all other Granit modules
- Add `EntitySegment` option to override irregular plurals (e.g., `Person` → `"people"`)
- Add `IncludeMetaEndpoint` option (default `true`) for query metadata endpoint
- Register `GenericReferenceDataQueryDefinition<TEntity>` and `IQueryableSource<TEntity>` automatically in `AddReferenceDataStore<TEntity, TDbContext>()`

**BREAKING CHANGE:** route segments are now plural (e.g. `/reference-data/countries` instead of `/reference-data/country`).

## New files

| File | Purpose |
|------|---------|
| `NaivePluralizer.cs` | Internal pluralizer (consonant+y→ies, sibilant→es, default→s) |
| `GenericReferenceDataQueryDefinition.cs` | QueryDefinition for strongly-typed reference data entities |
| `ReferenceDataQueryableSource.cs` | IQueryableSource with scope-aware tenant filtering |
| `NaivePluralizerTests.cs` | Unit tests for pluralization rules |

## Test plan

- [x] `dotnet build` — full solution compiles (0 errors, 0 warnings)
- [x] `dotnet test tests/Granit.ReferenceData.Endpoints.Tests` — 124 tests pass
- [x] `dotnet test tests/Granit.ArchitectureTests` — 102 architecture tests pass
- [x] `dotnet format --verify-no-changes` — clean
- [x] Astro docs build (only pre-existing broken links remain)