### PR TITLE
fix(endpoints): remove redundant async wrapper in ModuleConfigAsync lambda

### DIFF
--- a/src/Granit/Endpoints/ModuleConfigEndpointExtensions.cs
+++ b/src/Granit/Endpoints/ModuleConfigEndpointExtensions.cs
@@ -83,7 +83,7 @@ public static class ModuleConfigEndpointExtensions
         RouteHandlerBuilder builder = endpoints
             .MapGet(
                 $"{routePrefix}/config",
-                async ([FromServices] TProvider provider, CancellationToken cancellationToken) =>
+                ([FromServices] TProvider provider, CancellationToken cancellationToken) =>
                     HandleGetConfigAsync(provider, cancellationToken))
             .WithName(endpointName)
             .WithTags(tag)


### PR DESCRIPTION
## Summary

- Remove unnecessary `async` keyword from the lambda in `MapGranitModuleConfigAsync` that wraps `HandleGetConfigAsync`
- The double async wrapping created a nested state machine (`AsyncStateMachineBox<Ok<T>, HandleGetConfigAsync.d__3<T>>`) that the JSON serializer tried to walk when custom converters forced cold type-info resolution
- Root cause: `ConfigureHttpJsonOptions` (added in #973) registers `JsonStringEnumConverter` + `SingleValueObjectJsonConverterFactory` globally, which triggers `DefaultJsonTypeInfoResolver` to resolve type info for the Task's internal `AsyncStateMachineBox` — hitting `ExecutionContext&` (a ref struct) and throwing `InvalidOperationException`

## Test plan

- [ ] Verify `GET /identity-local/config` returns 200 in Showcase (was throwing `InvalidOperationException`)
- [ ] Verify all other `MapGranitModuleConfigAsync` endpoints respond correctly
- [ ] `dotnet test tests/Granit.Tests` — 457 tests pass