### PR TITLE
fix(query-engine): use host schema fallback for SavedView table

### DIFF
--- a/docs-site/scripts/generate-search-index.mjs
+++ b/docs-site/scripts/generate-search-index.mjs
@@ -11,7 +11,7 @@
  */
 
 import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
-import { join, relative, extname, dirname } from 'node:path';
+import { join, relative, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dir = dirname(fileURLToPath(import.meta.url));

--- a/src/Granit.AI.Endpoints/GranitAIEndpointsModule.cs
+++ b/src/Granit.AI.Endpoints/GranitAIEndpointsModule.cs
@@ -16,8 +16,6 @@ namespace Granit.AI.Endpoints;
 public sealed class GranitAIEndpointsModule : GranitModule
 {
     /// <inheritdoc/>
-    public override void ConfigureServices(ServiceConfigurationContext context)
-    {
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
         context.Services.AddQueryDefinition<AIUsageRecord, AIUsageRecordQueryDefinition>();
-    }
 }

--- a/src/Granit.BlobStorage.Endpoints/GranitBlobStorageEndpointsModule.cs
+++ b/src/Granit.BlobStorage.Endpoints/GranitBlobStorageEndpointsModule.cs
@@ -21,8 +21,6 @@ namespace Granit.BlobStorage.Endpoints;
 public sealed class GranitBlobStorageEndpointsModule : GranitModule
 {
     /// <inheritdoc/>
-    public override void ConfigureServices(ServiceConfigurationContext context)
-    {
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
         context.Services.AddQueryDefinition<BlobDescriptor, BlobDescriptorQueryDefinition>();
-    }
 }

--- a/src/Granit.Http.Idempotency/Internal/IdempotencyMiddleware.cs
+++ b/src/Granit.Http.Idempotency/Internal/IdempotencyMiddleware.cs
@@ -244,7 +244,7 @@ internal sealed partial class IdempotencyMiddleware(
             }
         }
 
-        byte[] responseBody = captureStream.ToArray();
+        byte[] responseBody = captureStream.GetReadOnlySequence().ToArray();
 
         TimeSpan completedTtl = meta.CompletedTtlSeconds > 0
             ? TimeSpan.FromSeconds(meta.CompletedTtlSeconds)

--- a/src/Granit.Invoicing.Endpoints/GranitInvoicingEndpointsModule.cs
+++ b/src/Granit.Invoicing.Endpoints/GranitInvoicingEndpointsModule.cs
@@ -16,8 +16,6 @@ namespace Granit.Invoicing.Endpoints;
     typeof(GranitValidationModule))]
 public sealed class GranitInvoicingEndpointsModule : GranitModule
 {
-    public override void ConfigureServices(ServiceConfigurationContext context)
-    {
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
         context.Services.AddQueryDefinition<Invoice, InvoiceQueryDefinition>();
-    }
 }

--- a/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
+++ b/src/Granit.Notifications.Email/Internal/EmailNotificationChannel.cs
@@ -420,7 +420,7 @@ internal sealed partial class EmailNotificationChannel(
         }
 
         string result = html;
-        foreach (IRenderedContentTransformer transformer in transformers.OrderBy(t => t.Order).Where(t => t.CanTransform(DocumentFormat.Html)))
+        foreach (IRenderedContentTransformer transformer in transformers.Where(t => t.CanTransform(DocumentFormat.Html)).OrderBy(t => t.Order))
         {
             result = await transformer.TransformAsync(result, DocumentFormat.Html, cancellationToken).ConfigureAwait(false);
         }

--- a/src/Granit.QueryEngine.EntityFrameworkCore/GranitQueryEngineDbProperties.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/GranitQueryEngineDbProperties.cs
@@ -21,12 +21,13 @@ public static class GranitQueryEngineDbProperties
     private static bool _dbSchemaExplicitlySet;
 
     /// <summary>
-    /// Database schema for tenant-level tables.
-    /// Falls back to <see cref="GranitDbDefaults.DbSchema"/> when not explicitly set.
+    /// Database schema for host-level tables.
+    /// Falls back to <see cref="GranitDbDefaults.HostDbSchema"/>, then
+    /// <see cref="GranitDbDefaults.DbSchema"/> when not explicitly set.
     /// </summary>
     public static string? DbSchema
     {
-        get => _dbSchemaExplicitlySet ? _dbSchema : GranitDbDefaults.DbSchema;
+        get => _dbSchemaExplicitlySet ? _dbSchema : GranitDbDefaults.HostDbSchema ?? GranitDbDefaults.DbSchema;
         set { _dbSchema = value; _dbSchemaExplicitlySet = true; }
     }
 }

--- a/src/Granit.Scheduling.Endpoints/GranitSchedulingEndpointsModule.cs
+++ b/src/Granit.Scheduling.Endpoints/GranitSchedulingEndpointsModule.cs
@@ -25,8 +25,6 @@ namespace Granit.Scheduling.Endpoints;
 public sealed class GranitSchedulingEndpointsModule : GranitModule
 {
     /// <inheritdoc/>
-    public override void ConfigureServices(ServiceConfigurationContext context)
-    {
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
         context.Services.AddQueryDefinition<ScheduledAction, ScheduledActionQueryDefinition>();
-    }
 }

--- a/src/Granit.Subscriptions.Endpoints/GranitSubscriptionsEndpointsModule.cs
+++ b/src/Granit.Subscriptions.Endpoints/GranitSubscriptionsEndpointsModule.cs
@@ -18,8 +18,6 @@ namespace Granit.Subscriptions.Endpoints;
     typeof(GranitValidationModule))]
 public sealed class GranitSubscriptionsEndpointsModule : GranitModule
 {
-    public override void ConfigureServices(ServiceConfigurationContext context)
-    {
+    public override void ConfigureServices(ServiceConfigurationContext context) =>
         context.Services.AddQueryDefinition<Subscription, SubscriptionQueryDefinition>();
-    }
 }

--- a/src/Granit.Vault.GoogleCloud/packages.lock.json
+++ b/src/Granit.Vault.GoogleCloud/packages.lock.json
@@ -5,10 +5,10 @@
       "Google.Cloud.Kms.V1": {
         "type": "Direct",
         "requested": "[3.*, )",
-        "resolved": "3.23.0",
-        "contentHash": "xiNFtKeWx0k6k7RG3g66IA2510iMhMxKjxNQafsEXuBD8FrPX/YV1W/TvES6fSX6XV1EYSDWrFVgNZ0cH5MXrA==",
+        "resolved": "3.24.0",
+        "contentHash": "ZKiL+HWnCM49uiUxnotE2M83LXGSBDEDzeA7tWBxQ6HugSb4th/KvlmSfebhwecJ6BgzF9zS2a1DPBteiC77YQ==",
         "dependencies": {
-          "Google.Api.Gax.Grpc": "[4.12.1, 5.0.0)",
+          "Google.Api.Gax.Grpc": "[4.13.1, 5.0.0)",
           "Google.Cloud.Iam.V1": "[3.5.0, 4.0.0)",
           "Google.Cloud.Location": "[2.4.0, 3.0.0)",
           "Google.LongRunning": "[3.5.0, 4.0.0)"
@@ -104,8 +104,8 @@
       },
       "Google.Api.Gax": {
         "type": "Transitive",
-        "resolved": "4.12.1",
-        "contentHash": "G62dRNOv5DolfRviT6CCrL2a5nZ/CWWdRzhADkGnpCkYSOc3QnH5xxRvZiOKuHU8weJ/pAqAqrj7+T9IWdlu2Q==",
+        "resolved": "4.13.1",
+        "contentHash": "ujDpZk7O2VqAEIqcSlhH0FKzVpGZWly/qcNjHxpNUrL445Tei9PHnu4V1pwW2WDiMDvo3TpL1Bi4DeU525Afrg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
           "Newtonsoft.Json": "13.0.4"
@@ -113,12 +113,12 @@
       },
       "Google.Api.Gax.Grpc": {
         "type": "Transitive",
-        "resolved": "4.12.1",
-        "contentHash": "W3LjuitOWxWyvbwqeHvpgp0LdshEiTnw/pneDAfAhQ02VgU2gVEzSXfGNPsvL8hDPBXjngR/fWNme8Kungwwkw==",
+        "resolved": "4.13.1",
+        "contentHash": "QgYF0bd8z6xWSVLGkGAMPB70seJSa9J02lFn8LT0Rb7PjSxZYpX+wU6LbVmghxDi6Wd64taulpX37pFq20J61g==",
         "dependencies": {
           "Google.Api.CommonProtos": "2.17.0",
-          "Google.Api.Gax": "4.12.1",
-          "Google.Apis.Auth": "1.72.0",
+          "Google.Api.Gax": "4.13.1",
+          "Google.Apis.Auth": "1.73.0",
           "Grpc.Auth": "[2.71.0, 3.0.0)",
           "Grpc.Core.Api": "[2.71.0, 3.0.0)",
           "Grpc.Net.Client": "[2.71.0, 3.0.0)",
@@ -127,26 +127,26 @@
       },
       "Google.Apis": {
         "type": "Transitive",
-        "resolved": "1.72.0",
-        "contentHash": "QbSJ08W7QuqsfzDPOZDHl1aFzCYwMcfBoHqQRh7koglwDN5WacShCKYMpU/zR1Pf3h3sH6JTGEeM/txAxaJuEg==",
+        "resolved": "1.73.0",
+        "contentHash": "TnCjEyV2aCLQ6Zl40OCbEJULDuEkEWc6C/g81KYw5l1PqGo+G7pFZrV+YH8XgUL0JRUanz+IrUp8SsKF4dzkqg==",
         "dependencies": {
-          "Google.Apis.Core": "1.72.0"
+          "Google.Apis.Core": "1.73.0"
         }
       },
       "Google.Apis.Auth": {
         "type": "Transitive",
-        "resolved": "1.72.0",
-        "contentHash": "RBoFwFKBHKUjuyJf2weEnqICQLaY0TdIrdFv2yC8bsiR2VFYxizOn3C/qN1FWCCb0Uh9GhW+zwAV1yUxPjiocw==",
+        "resolved": "1.73.0",
+        "contentHash": "wEu12uhnRv3zrPBSqv4E2vPH6lYLtc1RPAnU9MJRCMFlBVwZ7Lnq3NfbYXi6VG7EurkYInTaMpeBZkbM/HrAog==",
         "dependencies": {
-          "Google.Apis": "1.72.0",
-          "Google.Apis.Core": "1.72.0",
+          "Google.Apis": "1.73.0",
+          "Google.Apis.Core": "1.73.0",
           "System.Management": "7.0.2"
         }
       },
       "Google.Apis.Core": {
         "type": "Transitive",
-        "resolved": "1.72.0",
-        "contentHash": "ZmYX1PU0vTKFT42c7gp4zaYcb/0TFAXrt9qw8yEz0wjvaug85+/WddlPTfT525Qei8iIUsF6t4bHYrsb2O7crg==",
+        "resolved": "1.73.0",
+        "contentHash": "vSc7CY4KCP7HE4QTElDx/ExnGLbg9kXb89MS6cdvI+0D4sxvTYb16vGtXmF2jSDMV3iDmykSXdIUPTz8TDS6gg==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.4"
         }

--- a/tests/Granit.Http.Bulkhead.Tests/TenantPartitionedBulkheadTests.cs
+++ b/tests/Granit.Http.Bulkhead.Tests/TenantPartitionedBulkheadTests.cs
@@ -23,7 +23,7 @@ public sealed class TenantPartitionedBulkheadTests : IDisposable
     private readonly ConcurrencyLimiterRegistry _registry;
     private readonly IMeterFactory _meterFactory;
 
-    private GranitBulkheadOptions _options = new()
+    private readonly GranitBulkheadOptions _options = new()
     {
         Enabled = true,
         Policies = new Dictionary<string, BulkheadPolicyOptions>(StringComparer.OrdinalIgnoreCase)

--- a/tests/Granit.MultiTenancy.Wolverine.Tests/GranitMultiTenancyWolverineModuleTests.cs
+++ b/tests/Granit.MultiTenancy.Wolverine.Tests/GranitMultiTenancyWolverineModuleTests.cs
@@ -45,8 +45,6 @@ public sealed class GranitMultiTenancyWolverineModuleTests
     }
 
     [Fact]
-    public void Module_ShouldBeSealed()
-    {
+    public void Module_ShouldBeSealed() =>
         typeof(GranitMultiTenancyWolverineModule).IsSealed.ShouldBeTrue();
-    }
 }

--- a/tests/Granit.Persistence.EntityFrameworkCore.Hosting.Tests/AutoTenantProvisionerTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Hosting.Tests/AutoTenantProvisionerTests.cs
@@ -41,7 +41,8 @@ public sealed class AutoTenantProvisionerTests : IDisposable
         AutoTenantProvisioner sut = CreateProvisioner(sp);
 
         // Act & Assert — should complete without throwing
-        await sut.ProvisionAsync(TenantId, TenantName, TestContext.Current.CancellationToken);
+        await Should.NotThrowAsync(
+            () => sut.ProvisionAsync(TenantId, TenantName, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -57,7 +58,7 @@ public sealed class AutoTenantProvisionerTests : IDisposable
         await sut.ProvisionAsync(TenantId, TenantName, TestContext.Current.CancellationToken);
 
         // Assert — the test context's Database.MigrateAsync would have been called.
-        // Since we use InMemory, we verify the context was resolved (no exception thrown)
+        // Since we use SQLite in-memory, we verify the context was resolved (no exception thrown)
         // and the isolator was called.
         ITenantDbIsolator isolator = sp.GetRequiredService<ITenantDbIsolator>();
         await isolator.Received(1).IsolateAsync(
@@ -92,7 +93,8 @@ public sealed class AutoTenantProvisionerTests : IDisposable
         AutoTenantProvisioner sut = CreateProvisioner(sp);
 
         // Act & Assert — should not throw
-        await sut.ProvisionAsync(TenantId, TenantName, TestContext.Current.CancellationToken);
+        await Should.NotThrowAsync(
+            () => sut.ProvisionAsync(TenantId, TenantName, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -158,7 +160,8 @@ public sealed class AutoTenantProvisionerTests : IDisposable
         AutoTenantProvisioner sut = CreateProvisioner(sp);
 
         // Act & Assert — should complete without error (schema step skipped)
-        await sut.ProvisionAsync(TenantId, TenantName, TestContext.Current.CancellationToken);
+        await Should.NotThrowAsync(
+            () => sut.ProvisionAsync(TenantId, TenantName, TestContext.Current.CancellationToken));
     }
 
     private static AutoTenantProvisioner CreateProvisioner(ServiceProvider sp) =>
@@ -191,6 +194,6 @@ public sealed class AutoTenantProvisionerTests : IDisposable
 
 /// <summary>
 /// Minimal DbContext for testing AutoTenantProvisioner.
-/// Uses InMemory provider (MigrateAsync is a no-op with InMemory).
+/// Uses SQLite in-memory provider so MigrateAsync works with a relational backend.
 /// </summary>
 internal sealed class TestTenantDbContext(DbContextOptions<TestTenantDbContext> options) : DbContext(options);

--- a/tests/Granit.RateLimiting.Tests/TenantPartitionedRateLimiterTests.cs
+++ b/tests/Granit.RateLimiting.Tests/TenantPartitionedRateLimiterTests.cs
@@ -22,7 +22,7 @@ public sealed class TenantPartitionedRateLimiterTests : IDisposable
     private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
     private readonly IMeterFactory _meterFactory;
 
-    private GranitRateLimitingOptions _options = new()
+    private readonly GranitRateLimitingOptions _options = new()
     {
         Enabled = true,
         KeyPrefix = "rl",

--- a/tests/Granit.Tax.Builtin.Tests/TaxBuiltinModuleTests.cs
+++ b/tests/Granit.Tax.Builtin.Tests/TaxBuiltinModuleTests.cs
@@ -1,3 +1,8 @@
+using Granit.Invoicing;
+using Granit.Modularity;
+using Granit.Tax;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Shouldly;
 using Xunit;
 
@@ -6,9 +11,23 @@ namespace Granit.Tax.Builtin.Tests;
 public sealed class TaxBuiltinModuleTests
 {
     [Fact]
-    public void GranitTaxBuiltinModule_should_be_instantiable()
+    public void ConfigureServices_RegistersTaxServices()
     {
-        var module = new GranitTaxBuiltinModule();
-        module.ShouldNotBeNull();
+        // Arrange
+        GranitTaxBuiltinModule module = new();
+        HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
+        ServiceConfigurationContext context = new(
+            builder.Services,
+            builder.Configuration,
+            builder);
+
+        // Act
+        module.ConfigureServices(context);
+
+        // Assert — verify registrations without resolving transitive dependencies
+        IServiceCollection services = builder.Services;
+        services.ShouldContain(d => d.ServiceType == typeof(ITaxCalculator));
+        services.ShouldContain(d => d.ServiceType == typeof(ITaxIdValidator));
+        services.ShouldContain(d => d.ServiceType == typeof(ITaxRateProvider));
     }
 }


### PR DESCRIPTION
## Summary

- **fix(query-engine):** `GranitQueryEngineDbProperties.DbSchema` used the tenant fallback chain (`explicit → DbSchema → null`), causing `query_engine_saved_views` to only exist in tenant schemas. In host mode this produced a `PostgresException` (42P01: relation does not exist). Switched to the host fallback chain (`explicit → HostDbSchema → DbSchema → null`), matching the Auditing/OpenIddict pattern. `SavedView` already implements `IMultiTenant`, so tenant isolation is preserved via the `TenantId` query filter.
- **feat(reference-data):** Integrate QueryEngine into ReferenceData endpoints for filtering, sorting, and saved views. Pluralize API route segments. Includes related endpoint module updates, test fixes, and lockfile regeneration.

## Showcase follow-up

After merging, the showcase app needs:
1. Move `ConfigureQueryEngineModule()` from `ShowcaseTenantDbContext` to `ShowcaseHostDbContext`
2. Regenerate migrations

## Test plan

- [ ] Verify `GET /api/v1/reference-data/countries/meta` returns 200 in host mode
- [ ] Verify saved views CRUD works in tenant mode
- [ ] Run `dotnet test tests/Granit.QueryEngine.EntityFrameworkCore.Tests`
- [ ] Run architecture tests
