### PR TITLE
fix(reference-data): use host DbContext fallback for global-scope QueryEngine integration

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -4,7 +4,7 @@ Ce fichier répertorie les bibliothèques tierces utilisées par le projet
 **granit-dotnet** ainsi que leurs licences respectives. Il est mis à jour
 à chaque ajout ou modification de dépendance externe.
 
-Dernière mise à jour : 2026-04-13
+Dernière mise à jour : 2026-04-14
 
 ---
 
@@ -109,7 +109,7 @@ Dernière mise à jour : 2026-04-13
 | FluentValidation | 12.1.1 | Copyright (c) Jeremy Skinner, .NET Foundation 2008-2025 |
 | GoCardless | 7.11.2 | Copyright (c) 2017 GoCardless |
 | FluentValidation.DependencyInjectionExtensions | 12.1.1 | Copyright (c) Jeremy Skinner, .NET Foundation 2008-2025 |
-| Google.Cloud.Kms.V1 | 3.23.0 | Copyright (c) Google LLC |
+| Google.Cloud.Kms.V1 | 3.24.0 | Copyright (c) Google LLC |
 | Google.Cloud.SecretManager.V1 | 2.7.0 | Copyright (c) Google LLC |
 | Google.Cloud.Storage.V1 | 4.14.0 | Copyright (c) Google LLC |
 | Magick.NET-Q8-AnyCPU | 14.12.0 | Copyright 2013-2026 Dirk Lemstra |

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ReferenceDataEfCoreServiceCollectionExtensions.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ReferenceDataEfCoreServiceCollectionExtensions.cs
@@ -50,9 +50,15 @@ public static class ReferenceDataEfCoreServiceCollectionExtensions
             sp.GetRequiredService<EfCoreReferenceDataStore<TEntity, TDbContext>>());
 
         // Register IQueryableSource and QueryDefinition for QueryEngine integration
+        // Global scope: resolve TDbContext directly — the scoped registration
+        // falls back to SharedDatabase when no tenant is active (host context).
+        // Tenant scope: resolve via IDbContextFactory to preserve fail-fast when
+        // no tenant is active (defense in depth — middleware should reject first).
         services.TryAddScoped<IQueryableSource<TEntity>>(sp =>
             new ReferenceDataQueryableSource<TEntity, TDbContext>(
-                sp.GetRequiredService<IDbContextFactory<TDbContext>>(),
+                scope == ReferenceDataScope.Global
+                    ? sp.GetRequiredService<TDbContext>()
+                    : sp.GetRequiredService<IDbContextFactory<TDbContext>>().CreateDbContext(),
                 scope));
 
         services.TryAddSingleton<QueryDefinition<TEntity>>(

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataQueryableSource.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataQueryableSource.cs
@@ -10,17 +10,15 @@ namespace Granit.ReferenceData.EntityFrameworkCore.Internal;
 /// Applies scope-aware tenant filtering identical to <see cref="EfCoreReferenceDataStore{TEntity,TDbContext}"/>.
 /// </summary>
 internal sealed class ReferenceDataQueryableSource<TEntity, TDbContext>(
-    IDbContextFactory<TDbContext> contextFactory,
+    TDbContext context,
     ReferenceDataScope scope) : IQueryableSource<TEntity>
     where TEntity : ReferenceDataEntity
     where TDbContext : DbContext
 {
-    private readonly TDbContext _context = contextFactory.CreateDbContext();
-
     /// <inheritdoc/>
     public IQueryable<TEntity> GetQueryable()
     {
-        IQueryable<TEntity> queryable = _context.Set<TEntity>().AsNoTracking();
+        IQueryable<TEntity> queryable = context.Set<TEntity>().AsNoTracking();
 
         if (scope == ReferenceDataScope.Global)
         {

--- a/tests/Granit.Vault.GoogleCloud.Tests/packages.lock.json
+++ b/tests/Granit.Vault.GoogleCloud.Tests/packages.lock.json
@@ -107,8 +107,8 @@
       },
       "Google.Api.Gax": {
         "type": "Transitive",
-        "resolved": "4.12.1",
-        "contentHash": "G62dRNOv5DolfRviT6CCrL2a5nZ/CWWdRzhADkGnpCkYSOc3QnH5xxRvZiOKuHU8weJ/pAqAqrj7+T9IWdlu2Q==",
+        "resolved": "4.13.1",
+        "contentHash": "ujDpZk7O2VqAEIqcSlhH0FKzVpGZWly/qcNjHxpNUrL445Tei9PHnu4V1pwW2WDiMDvo3TpL1Bi4DeU525Afrg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
           "Newtonsoft.Json": "13.0.4"
@@ -116,12 +116,12 @@
       },
       "Google.Api.Gax.Grpc": {
         "type": "Transitive",
-        "resolved": "4.12.1",
-        "contentHash": "W3LjuitOWxWyvbwqeHvpgp0LdshEiTnw/pneDAfAhQ02VgU2gVEzSXfGNPsvL8hDPBXjngR/fWNme8Kungwwkw==",
+        "resolved": "4.13.1",
+        "contentHash": "QgYF0bd8z6xWSVLGkGAMPB70seJSa9J02lFn8LT0Rb7PjSxZYpX+wU6LbVmghxDi6Wd64taulpX37pFq20J61g==",
         "dependencies": {
           "Google.Api.CommonProtos": "2.17.0",
-          "Google.Api.Gax": "4.12.1",
-          "Google.Apis.Auth": "1.72.0",
+          "Google.Api.Gax": "4.13.1",
+          "Google.Apis.Auth": "1.73.0",
           "Grpc.Auth": "[2.71.0, 3.0.0)",
           "Grpc.Core.Api": "[2.71.0, 3.0.0)",
           "Grpc.Net.Client": "[2.71.0, 3.0.0)",
@@ -130,26 +130,26 @@
       },
       "Google.Apis": {
         "type": "Transitive",
-        "resolved": "1.72.0",
-        "contentHash": "QbSJ08W7QuqsfzDPOZDHl1aFzCYwMcfBoHqQRh7koglwDN5WacShCKYMpU/zR1Pf3h3sH6JTGEeM/txAxaJuEg==",
+        "resolved": "1.73.0",
+        "contentHash": "TnCjEyV2aCLQ6Zl40OCbEJULDuEkEWc6C/g81KYw5l1PqGo+G7pFZrV+YH8XgUL0JRUanz+IrUp8SsKF4dzkqg==",
         "dependencies": {
-          "Google.Apis.Core": "1.72.0"
+          "Google.Apis.Core": "1.73.0"
         }
       },
       "Google.Apis.Auth": {
         "type": "Transitive",
-        "resolved": "1.72.0",
-        "contentHash": "RBoFwFKBHKUjuyJf2weEnqICQLaY0TdIrdFv2yC8bsiR2VFYxizOn3C/qN1FWCCb0Uh9GhW+zwAV1yUxPjiocw==",
+        "resolved": "1.73.0",
+        "contentHash": "wEu12uhnRv3zrPBSqv4E2vPH6lYLtc1RPAnU9MJRCMFlBVwZ7Lnq3NfbYXi6VG7EurkYInTaMpeBZkbM/HrAog==",
         "dependencies": {
-          "Google.Apis": "1.72.0",
-          "Google.Apis.Core": "1.72.0",
+          "Google.Apis": "1.73.0",
+          "Google.Apis.Core": "1.73.0",
           "System.Management": "7.0.2"
         }
       },
       "Google.Apis.Core": {
         "type": "Transitive",
-        "resolved": "1.72.0",
-        "contentHash": "ZmYX1PU0vTKFT42c7gp4zaYcb/0TFAXrt9qw8yEz0wjvaug85+/WddlPTfT525Qei8iIUsF6t4bHYrsb2O7crg==",
+        "resolved": "1.73.0",
+        "contentHash": "vSc7CY4KCP7HE4QTElDx/ExnGLbg9kXb89MS6cdvI+0D4sxvTYb16vGtXmF2jSDMV3iDmykSXdIUPTz8TDS6gg==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.4"
         }
@@ -491,10 +491,10 @@
       "Google.Cloud.Kms.V1": {
         "type": "CentralTransitive",
         "requested": "[3.*, )",
-        "resolved": "3.23.0",
-        "contentHash": "xiNFtKeWx0k6k7RG3g66IA2510iMhMxKjxNQafsEXuBD8FrPX/YV1W/TvES6fSX6XV1EYSDWrFVgNZ0cH5MXrA==",
+        "resolved": "3.24.0",
+        "contentHash": "ZKiL+HWnCM49uiUxnotE2M83LXGSBDEDzeA7tWBxQ6HugSb4th/KvlmSfebhwecJ6BgzF9zS2a1DPBteiC77YQ==",
         "dependencies": {
-          "Google.Api.Gax.Grpc": "[4.12.1, 5.0.0)",
+          "Google.Api.Gax.Grpc": "[4.13.1, 5.0.0)",
           "Google.Cloud.Iam.V1": "[3.5.0, 4.0.0)",
           "Google.Cloud.Location": "[2.4.0, 3.0.0)",
           "Google.LongRunning": "[3.5.0, 4.0.0)"


### PR DESCRIPTION
## Summary

- **Fix**: `ReferenceDataQueryableSource` was resolving `IDbContextFactory<TDbContext>` in its constructor, which routes through `TenantPerSchemaDbContextFactory` and throws `InvalidOperationException` when no tenant context is active. This broke QueryEngine endpoints (`/meta`, list) for global-scope reference data in `SchemaPerTenant` mode.
- **Approach**: Switch to scoped `TDbContext` resolution for `Global` scope, which leverages the existing `SharedDatabase` fallback registered by `AddGranitIsolatedDbContext`. `Tenant`-scoped reference data preserves fail-fast via `IDbContextFactory` (defense in depth).
- **Housekeeping**: Regenerate `Vault.GoogleCloud.Tests` lock file to resolve `Google.Cloud.Kms.V1` version conflict (3.23.0 → 3.24.0).

## Test plan

- [ ] Verify `/api/v1/reference-data/{type}/meta` returns 200 without tenant header (global scope)
- [ ] Verify `/api/v1/reference-data/{type}?page=1&pageSize=20` returns data without tenant header (global scope)
- [ ] Verify tenant-scoped reference data still requires active tenant (returns 500 without tenant)
- [ ] CI build passes (KMS version conflict resolved)