### PR TITLE
feat(persistence): host tenant bypass with defense-in-depth security

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -6087,6 +6087,22 @@
       ]
     },
     {
+      "name": "HostAccessEndpointExtensions",
+      "fqn": "Granit.Authorization.Extensions.HostAccessEndpointExtensions",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Extensions/HostAccessEndpointExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AllowHostAccess",
+          "kind": "method",
+          "signature": "AllowHostAccess(this RouteHandlerBuilder builder, string hostPermission)",
+          "returnType": "RouteHandlerBuilder"
+        }
+      ]
+    },
+    {
       "name": "GranitAuthorizationModule",
       "fqn": "Granit.Authorization.GranitAuthorizationModule",
       "kind": "class",
@@ -29084,7 +29100,7 @@
       "kind": "class",
       "project": "Granit.Persistence.EntityFrameworkCore",
       "file": "src/Granit.Persistence.EntityFrameworkCore/EfStoreBase.cs",
-      "line": 27,
+      "line": 42,
       "members": []
     },
     {

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -6097,7 +6097,7 @@
         {
           "name": "AllowHostAccess",
           "kind": "method",
-          "signature": "AllowHostAccess(this RouteHandlerBuilder builder, string hostPermission)",
+          "signature": "AllowHostAccess(this RouteHandlerBuilder builder)",
           "returnType": "RouteHandlerBuilder"
         }
       ]

--- a/src/Granit.AI.Endpoints/Endpoints/AIWorkspaceEndpoints.cs
+++ b/src/Granit.AI.Endpoints/Endpoints/AIWorkspaceEndpoints.cs
@@ -1,5 +1,7 @@
 using Granit.AI.Endpoints.Dtos;
+using Granit.AI.Endpoints.Permissions;
 using Granit.AI.Workspaces;
+using Granit.Authorization.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -18,7 +20,8 @@ internal static class AIWorkspaceEndpoints
             .WithDescription(
                 "Returns every registered workspace with its provider, model, and configuration. "
                 + "System workspaces are defined in configuration; dynamic workspaces are user-created.")
-            .Produces<AIWorkspaceListResponse>();
+            .Produces<AIWorkspaceListResponse>()
+            .AllowHostAccess();
 
         group.MapGet("/workspaces/{name}", GetByNameAsync)
             .WithName("GetAIWorkspace")
@@ -27,7 +30,8 @@ internal static class AIWorkspaceEndpoints
                 "Fetches the full configuration of a single workspace including provider, model, "
                 + "system prompt, and active status. Returns 404 if no workspace matches the name.")
             .Produces<AIWorkspaceResponse>()
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .AllowHostAccess();
 
         group.MapPost("/workspaces", CreateAsync)
             .WithName("CreateAIWorkspace")

--- a/src/Granit.AI.EntityFrameworkCore/Internal/EfAIUsageQueryableSource.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/EfAIUsageQueryableSource.cs
@@ -1,4 +1,6 @@
 using Granit.AI.EntityFrameworkCore.Entities;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 
@@ -7,27 +9,38 @@ namespace Granit.AI.EntityFrameworkCore.Internal;
 /// <summary>
 /// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="AIUsageRecord"/>.
 /// Projects internal <see cref="AIUsageRecordEntity"/> to the public <see cref="AIUsageRecord"/> DTO.
+/// When no tenant context is active (host admin), the multi-tenant query filter is
+/// bypassed so all usage records are returned cross-tenant.
 /// </summary>
-internal sealed class EfAIUsageQueryableSource(IDbContextFactory<AIDbContext> contextFactory)
+internal sealed class EfAIUsageQueryableSource(
+    IDbContextFactory<AIDbContext> contextFactory,
+    ICurrentTenant currentTenant)
     : IQueryableSource<AIUsageRecord>
 {
     private readonly AIDbContext _context = contextFactory.CreateDbContext();
+    private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
 
-    public IQueryable<AIUsageRecord> GetQueryable() =>
-        _context.UsageRecords
-            .AsNoTracking()
-            .Select(e => new AIUsageRecord
-            {
-                Id = e.Id,
-                TenantId = e.TenantId,
-                UserId = e.UserId,
-                WorkspaceName = e.WorkspaceName,
-                Provider = e.Provider,
-                Model = e.Model,
-                InputTokens = e.InputTokens,
-                OutputTokens = e.OutputTokens,
-                EstimatedCostUsd = e.EstimatedCostUsd,
-                Timestamp = e.CreatedAt,
-                Duration = e.Duration,
-            });
+    public IQueryable<AIUsageRecord> GetQueryable()
+    {
+        IQueryable<AIUsageRecordEntity> query = _context.UsageRecords.AsNoTracking();
+        if (_bypassTenantFilter)
+        {
+            query = query.IgnoreQueryFilters([GranitFilterNames.MultiTenant]);
+        }
+
+        return query.Select(e => new AIUsageRecord
+        {
+            Id = e.Id,
+            TenantId = e.TenantId,
+            UserId = e.UserId,
+            WorkspaceName = e.WorkspaceName,
+            Provider = e.Provider,
+            Model = e.Model,
+            InputTokens = e.InputTokens,
+            OutputTokens = e.OutputTokens,
+            EstimatedCostUsd = e.EstimatedCostUsd,
+            Timestamp = e.CreatedAt,
+            Duration = e.Duration,
+        });
+    }
 }

--- a/src/Granit.AI.EntityFrameworkCore/Internal/EfAIUsageStore.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/EfAIUsageStore.cs
@@ -1,5 +1,6 @@
 using Granit.AI.Diagnostics;
 using Granit.AI.EntityFrameworkCore.Entities;
+using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
@@ -14,8 +15,9 @@ namespace Granit.AI.EntityFrameworkCore.Internal;
 /// </remarks>
 internal sealed class EfAIUsageStore(
     IDbContextFactory<AIDbContext> contextFactory,
+    ICurrentTenant currentTenant,
     AIMetrics metrics)
-    : EfStoreBase<AIUsageRecordEntity, AIDbContext>(contextFactory), IAIUsageTracker
+    : EfStoreBase<AIUsageRecordEntity, AIDbContext>(contextFactory, currentTenant), IAIUsageTracker
 {
     /// <inheritdoc/>
     public async Task RecordAsync(

--- a/src/Granit.AI.EntityFrameworkCore/Internal/EfAIWorkspaceStore.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/EfAIWorkspaceStore.cs
@@ -1,5 +1,6 @@
 using Granit.AI.EntityFrameworkCore.Entities;
 using Granit.AI.Workspaces;
+using Granit.MultiTenancy;
 using Granit.Persistence;
 using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
@@ -14,8 +15,9 @@ namespace Granit.AI.EntityFrameworkCore.Internal;
 /// query filter applied by <c>ApplyGranitConventions</c> on <see cref="AIDbContext"/>.
 /// </remarks>
 internal sealed class EfAIWorkspaceStore(
-    IDbContextFactory<AIDbContext> contextFactory)
-    : EfStoreBase<AIWorkspaceEntity, AIDbContext>(contextFactory), IAIWorkspaceStoreReader, IAIWorkspaceStoreWriter
+    IDbContextFactory<AIDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<AIWorkspaceEntity, AIDbContext>(contextFactory, currentTenant), IAIWorkspaceStoreReader, IAIWorkspaceStoreWriter
 {
     /// <inheritdoc/>
     public async Task<AIWorkspace?> FindAsync(

--- a/src/Granit.Authentication.ApiKeys.Endpoints/Endpoints/ApiKeyReadEndpoints.cs
+++ b/src/Granit.Authentication.ApiKeys.Endpoints/Endpoints/ApiKeyReadEndpoints.cs
@@ -1,5 +1,7 @@
 using Granit.Authentication.ApiKeys.Domain;
 using Granit.Authentication.ApiKeys.Endpoints.Dtos;
+using Granit.Authentication.ApiKeys.Endpoints.Permissions;
+using Granit.Authorization.Extensions;
 using Granit.QueryEngine;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -20,14 +22,16 @@ internal static class ApiKeyReadEndpoints
             .WithName("ListApiKeys")
             .WithSummary("Returns a paginated list of API keys.")
             .WithDescription("Lists all API keys for the current tenant with optional filters on type, environment, search term, and revocation status. The raw secret is never returned — only the prefix and last four characters for identification.")
-            .Produces<PagedResult<ApiKeyResponse>>();
+            .Produces<PagedResult<ApiKeyResponse>>()
+            .AllowHostAccess();
 
         group.MapGet("/{id:guid}", GetByIdAsync)
             .WithName("GetApiKeyById")
             .WithSummary("Returns a single API key by ID.")
             .WithDescription("Returns the metadata of a single API key. The raw secret is never exposed after creation. Returns 404 if the key does not exist.")
             .Produces<ApiKeyResponse>()
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .AllowHostAccess();
 
         return group;
     }

--- a/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Internal/EfCoreApiKeyAdminStore.cs
+++ b/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Internal/EfCoreApiKeyAdminStore.cs
@@ -1,4 +1,5 @@
 using Granit.Authentication.ApiKeys.Domain;
+using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
@@ -10,8 +11,9 @@ namespace Granit.Authentication.ApiKeys.EntityFrameworkCore.Internal;
 /// <see cref="IDbContextFactory{TContext}"/> for safe concurrent access.
 /// </summary>
 internal sealed class EfCoreApiKeyAdminStore(
-    IDbContextFactory<AuthenticationApiKeysDbContext> contextFactory)
-    : EfStoreBase<ApiKeyEntry, AuthenticationApiKeysDbContext>(contextFactory), IApiKeyAdminStore
+    IDbContextFactory<AuthenticationApiKeysDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<ApiKeyEntry, AuthenticationApiKeysDbContext>(contextFactory, currentTenant), IApiKeyAdminStore
 {
     /// <inheritdoc/>
     public new Task<ApiKeyEntry?> FindByIdAsync(Guid id, CancellationToken cancellationToken = default) =>

--- a/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Internal/EfCoreApiKeyStore.cs
+++ b/src/Granit.Authentication.ApiKeys.EntityFrameworkCore/Internal/EfCoreApiKeyStore.cs
@@ -1,4 +1,5 @@
 using Granit.Authentication.ApiKeys.Domain;
+using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -11,8 +12,9 @@ namespace Granit.Authentication.ApiKeys.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed partial class EfCoreApiKeyStore(
     IDbContextFactory<AuthenticationApiKeysDbContext> contextFactory,
+    ICurrentTenant currentTenant,
     ILogger<EfCoreApiKeyStore> logger)
-    : EfStoreBase<ApiKeyEntry, AuthenticationApiKeysDbContext>(contextFactory), IApiKeyStore
+    : EfStoreBase<ApiKeyEntry, AuthenticationApiKeysDbContext>(contextFactory, currentTenant), IApiKeyStore
 {
     /// <inheritdoc/>
     public Task<ApiKeyEntry?> FindByHashAsync(string hashedKey, CancellationToken cancellationToken = default) =>

--- a/src/Granit.Authorization/Extensions/HostAccessEndpointExtensions.cs
+++ b/src/Granit.Authorization/Extensions/HostAccessEndpointExtensions.cs
@@ -11,28 +11,23 @@ public static class HostAccessEndpointExtensions
 {
     /// <summary>
     /// Marks the endpoint as accessible from host context (no active tenant) in addition
-    /// to normal tenant-scoped access. When the caller has no tenant context, the specified
-    /// <paramref name="hostPermission"/> is checked before the handler executes.
+    /// to normal tenant-scoped access.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Endpoints without this filter only serve tenant-scoped data. In host context
+    /// Endpoints without this marker only serve tenant-scoped data. In host context
     /// (no <c>X-Tenant-Id</c> header), the multi-tenant query filter produces
     /// <c>WHERE TenantId IS NULL</c> which returns no tenant data — a safe default.
     /// </para>
     /// <para>
     /// Adding <c>.AllowHostAccess()</c> enables the endpoint to serve cross-tenant data
-    /// by bypassing the multi-tenant query filter, but <b>only after verifying</b> the
-    /// caller has the required host-level permission.
+    /// by bypassing the multi-tenant query filter. Permission checks are handled by the
+    /// existing <c>.RequireAuthorization(permission)</c> — no need to repeat the permission.
     /// </para>
     /// </remarks>
     /// <param name="builder">The route handler builder.</param>
-    /// <param name="hostPermission">
-    /// The permission name to check in host context (e.g. <c>"Subscriptions.Subscriptions.Read"</c>).
-    /// </param>
     /// <returns>The <see cref="RouteHandlerBuilder"/> for further chaining.</returns>
     public static RouteHandlerBuilder AllowHostAccess(
-        this RouteHandlerBuilder builder, string hostPermission) =>
-        builder.AddEndpointFilter(
-            new RequireHostContextEndpointFilter(hostPermission));
+        this RouteHandlerBuilder builder) =>
+        builder.AddEndpointFilter(new RequireHostContextEndpointFilter());
 }

--- a/src/Granit.Authorization/Extensions/HostAccessEndpointExtensions.cs
+++ b/src/Granit.Authorization/Extensions/HostAccessEndpointExtensions.cs
@@ -1,0 +1,38 @@
+using Granit.Authorization.Filters;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace Granit.Authorization.Extensions;
+
+/// <summary>
+/// Extension methods for configuring host-level access on Minimal API endpoints.
+/// </summary>
+public static class HostAccessEndpointExtensions
+{
+    /// <summary>
+    /// Marks the endpoint as accessible from host context (no active tenant) in addition
+    /// to normal tenant-scoped access. When the caller has no tenant context, the specified
+    /// <paramref name="hostPermission"/> is checked before the handler executes.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Endpoints without this filter only serve tenant-scoped data. In host context
+    /// (no <c>X-Tenant-Id</c> header), the multi-tenant query filter produces
+    /// <c>WHERE TenantId IS NULL</c> which returns no tenant data — a safe default.
+    /// </para>
+    /// <para>
+    /// Adding <c>.AllowHostAccess()</c> enables the endpoint to serve cross-tenant data
+    /// by bypassing the multi-tenant query filter, but <b>only after verifying</b> the
+    /// caller has the required host-level permission.
+    /// </para>
+    /// </remarks>
+    /// <param name="builder">The route handler builder.</param>
+    /// <param name="hostPermission">
+    /// The permission name to check in host context (e.g. <c>"Subscriptions.Subscriptions.Read"</c>).
+    /// </param>
+    /// <returns>The <see cref="RouteHandlerBuilder"/> for further chaining.</returns>
+    public static RouteHandlerBuilder AllowHostAccess(
+        this RouteHandlerBuilder builder, string hostPermission) =>
+        builder.AddEndpointFilter(
+            new RequireHostContextEndpointFilter(hostPermission));
+}

--- a/src/Granit.Authorization/Filters/RequireHostContextEndpointFilter.cs
+++ b/src/Granit.Authorization/Filters/RequireHostContextEndpointFilter.cs
@@ -6,33 +6,31 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Granit.Authorization.Filters;
 
 /// <summary>
-/// Endpoint filter that validates host-level authorization on endpoints supporting
-/// cross-tenant administration.
+/// Endpoint filter that marks an endpoint as accessible from host context (no active tenant).
 /// </summary>
 /// <remarks>
 /// <para>
-/// Apply this filter to endpoints that should be accessible from both tenant and host
-/// contexts. When a tenant context is active, the filter is a no-op — the endpoint
-/// executes normally with standard tenant-scoped data access. When no tenant context
-/// is active (host mode), the filter verifies the caller has the specified host-level
-/// permission before proceeding.
+/// When a tenant context is active, the filter is a no-op — the endpoint executes normally
+/// with standard tenant-scoped data access. When no tenant context is active (host mode),
+/// the filter verifies the caller is authenticated before proceeding.
 /// </para>
 /// <para>
-/// This implements <b>defense in depth</b>: even if the data layer bypasses the
-/// multi-tenant query filter in host context, unauthorized callers are rejected here
-/// before reaching the handler.
+/// Permission checks are handled by the existing <c>.RequireAuthorization(permission)</c>
+/// chain which delegates to <see cref="IPermissionChecker"/> — this already uses
+/// <c>perm:global:{role}:{permission}</c> in host context. This filter does NOT duplicate
+/// that check; it only ensures no anonymous caller reaches host endpoints.
 /// </para>
 /// </remarks>
 /// <example>
 /// <code>
 /// group.MapGet("/{id:guid}", GetByIdAsync)
-///     .AllowHostAccess(SubscriptionsPermissions.Subscriptions.Read);
+///     .RequireAuthorization(SubscriptionsPermissions.Subscriptions.Read)
+///     .AllowHostAccess();
 /// </code>
 /// </example>
-internal sealed class RequireHostContextEndpointFilter(
-    string hostPermission) : IEndpointFilter
+internal sealed class RequireHostContextEndpointFilter : IEndpointFilter
 {
-    public async ValueTask<object?> InvokeAsync(
+    public ValueTask<object?> InvokeAsync(
         EndpointFilterInvocationContext context,
         EndpointFilterDelegate next)
     {
@@ -42,20 +40,19 @@ internal sealed class RequireHostContextEndpointFilter(
         // Tenant mode — always allowed, no extra check needed.
         if (currentTenant.IsAvailable)
         {
-            return await next(context).ConfigureAwait(false);
+            return next(context);
         }
 
-        // Host mode — verify caller has host-level permission.
-        IPermissionChecker checker = context.HttpContext.RequestServices
-            .GetRequiredService<IPermissionChecker>();
-
-        if (!await checker.IsGrantedAsync(hostPermission).ConfigureAwait(false))
+        // Host mode — ensure caller is authenticated (defense in depth).
+        // Permission checks are already handled by RequireAuthorization().
+        if (context.HttpContext.User.Identity?.IsAuthenticated != true)
         {
-            return TypedResults.Problem(
-                detail: "Host-level authorization required for this operation.",
-                statusCode: StatusCodes.Status403Forbidden);
+            return new ValueTask<object?>(
+                TypedResults.Problem(
+                    detail: "Authentication required for host-level access.",
+                    statusCode: StatusCodes.Status401Unauthorized));
         }
 
-        return await next(context).ConfigureAwait(false);
+        return next(context);
     }
 }

--- a/src/Granit.Authorization/Filters/RequireHostContextEndpointFilter.cs
+++ b/src/Granit.Authorization/Filters/RequireHostContextEndpointFilter.cs
@@ -34,11 +34,11 @@ internal sealed class RequireHostContextEndpointFilter : IEndpointFilter
         EndpointFilterInvocationContext context,
         EndpointFilterDelegate next)
     {
-        ICurrentTenant currentTenant = context.HttpContext.RequestServices
-            .GetRequiredService<ICurrentTenant>();
+        ICurrentTenant? currentTenant = context.HttpContext.RequestServices
+            .GetService<ICurrentTenant>();
 
-        // Tenant mode — always allowed, no extra check needed.
-        if (currentTenant.IsAvailable)
+        // No multi-tenancy module or tenant is active — pass through.
+        if (currentTenant is null || currentTenant.IsAvailable)
         {
             return next(context);
         }

--- a/src/Granit.Authorization/Filters/RequireHostContextEndpointFilter.cs
+++ b/src/Granit.Authorization/Filters/RequireHostContextEndpointFilter.cs
@@ -1,0 +1,61 @@
+using Granit.MultiTenancy;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.Authorization.Filters;
+
+/// <summary>
+/// Endpoint filter that validates host-level authorization on endpoints supporting
+/// cross-tenant administration.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Apply this filter to endpoints that should be accessible from both tenant and host
+/// contexts. When a tenant context is active, the filter is a no-op — the endpoint
+/// executes normally with standard tenant-scoped data access. When no tenant context
+/// is active (host mode), the filter verifies the caller has the specified host-level
+/// permission before proceeding.
+/// </para>
+/// <para>
+/// This implements <b>defense in depth</b>: even if the data layer bypasses the
+/// multi-tenant query filter in host context, unauthorized callers are rejected here
+/// before reaching the handler.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// group.MapGet("/{id:guid}", GetByIdAsync)
+///     .AllowHostAccess(SubscriptionsPermissions.Subscriptions.Read);
+/// </code>
+/// </example>
+internal sealed class RequireHostContextEndpointFilter(
+    string hostPermission) : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next)
+    {
+        ICurrentTenant currentTenant = context.HttpContext.RequestServices
+            .GetRequiredService<ICurrentTenant>();
+
+        // Tenant mode — always allowed, no extra check needed.
+        if (currentTenant.IsAvailable)
+        {
+            return await next(context).ConfigureAwait(false);
+        }
+
+        // Host mode — verify caller has host-level permission.
+        IPermissionChecker checker = context.HttpContext.RequestServices
+            .GetRequiredService<IPermissionChecker>();
+
+        if (!await checker.IsGrantedAsync(hostPermission).ConfigureAwait(false))
+        {
+            return TypedResults.Problem(
+                detail: "Host-level authorization required for this operation.",
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
+        return await next(context).ConfigureAwait(false);
+    }
+}

--- a/src/Granit.BlobStorage.Endpoints/Endpoints/BlobReadEndpoints.cs
+++ b/src/Granit.BlobStorage.Endpoints/Endpoints/BlobReadEndpoints.cs
@@ -1,5 +1,7 @@
+using Granit.Authorization.Extensions;
 using Granit.BlobStorage.Domain;
 using Granit.BlobStorage.Endpoints.Dtos;
+using Granit.BlobStorage.Endpoints.Permissions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -20,7 +22,8 @@ internal static class BlobReadEndpoints
                 + "and validation results. The containerName query parameter is required. "
                 + "Returns 404 if the blob does not exist in the specified container.")
             .Produces<BlobDescriptorResponse>()
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .AllowHostAccess();
 
         return group;
     }

--- a/src/Granit.BlobStorage.EntityFrameworkCore/Internal/EfBlobDescriptorStore.cs
+++ b/src/Granit.BlobStorage.EntityFrameworkCore/Internal/EfBlobDescriptorStore.cs
@@ -1,4 +1,5 @@
 using Granit.BlobStorage.Domain;
+using Granit.MultiTenancy;
 using Granit.Persistence;
 using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
@@ -15,8 +16,9 @@ namespace Granit.BlobStorage.EntityFrameworkCore.Internal;
 /// <see cref="IDbContextFactory{TContext}"/>, making it safe for concurrent request handling.
 /// </remarks>
 internal sealed class EfBlobDescriptorStore(
-    IDbContextFactory<BlobStorageDbContext> contextFactory)
-    : EfStoreBase<BlobDescriptor, BlobStorageDbContext>(contextFactory), IBlobDescriptorStore
+    IDbContextFactory<BlobStorageDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<BlobDescriptor, BlobStorageDbContext>(contextFactory, currentTenant), IBlobDescriptorStore
 {
     /// <inheritdoc/>
     public Task<BlobDescriptor?> FindAsync(

--- a/src/Granit.BlobStorage.EntityFrameworkCore/Internal/EfBlobQueryableSource.cs
+++ b/src/Granit.BlobStorage.EntityFrameworkCore/Internal/EfBlobQueryableSource.cs
@@ -1,4 +1,6 @@
 using Granit.BlobStorage.Domain;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 
@@ -6,12 +8,22 @@ namespace Granit.BlobStorage.EntityFrameworkCore.Internal;
 
 /// <summary>
 /// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="BlobDescriptor"/>.
+/// When no tenant context is active (host admin), the multi-tenant query filter is
+/// bypassed so all blob descriptors are returned cross-tenant.
 /// </summary>
-internal sealed class EfBlobQueryableSource(IDbContextFactory<BlobStorageDbContext> contextFactory)
+internal sealed class EfBlobQueryableSource(
+    IDbContextFactory<BlobStorageDbContext> contextFactory,
+    ICurrentTenant currentTenant)
     : IQueryableSource<BlobDescriptor>
 {
     private readonly BlobStorageDbContext _context = contextFactory.CreateDbContext();
+    private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
 
-    public IQueryable<BlobDescriptor> GetQueryable() =>
-        _context.Blobs.AsNoTracking();
+    public IQueryable<BlobDescriptor> GetQueryable()
+    {
+        IQueryable<BlobDescriptor> query = _context.Blobs.AsNoTracking();
+        return _bypassTenantFilter
+            ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            : query;
+    }
 }

--- a/src/Granit.CustomerBalance.EntityFrameworkCore/Internal/EfBalanceAccountStore.cs
+++ b/src/Granit.CustomerBalance.EntityFrameworkCore/Internal/EfBalanceAccountStore.cs
@@ -1,5 +1,6 @@
 using Granit.CustomerBalance.Domain;
 using Granit.CustomerBalance.Domain.ValueObjects;
+using Granit.MultiTenancy;
 using Granit.Persistence;
 using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
@@ -7,8 +8,9 @@ using Microsoft.EntityFrameworkCore;
 namespace Granit.CustomerBalance.EntityFrameworkCore.Internal;
 
 internal sealed class EfBalanceAccountStore(
-    IDbContextFactory<CustomerBalanceDbContext> contextFactory)
-    : EfStoreBase<BalanceAccount, CustomerBalanceDbContext>(contextFactory),
+    IDbContextFactory<CustomerBalanceDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<BalanceAccount, CustomerBalanceDbContext>(contextFactory, currentTenant),
       IBalanceAccountReader, IBalanceAccountWriter
 {
     private readonly IDbContextFactory<CustomerBalanceDbContext> _contextFactory = contextFactory;

--- a/src/Granit.DataExchange.Endpoints/Endpoints/Export/ExportPresetEndpoints.cs
+++ b/src/Granit.DataExchange.Endpoints/Endpoints/Export/ExportPresetEndpoints.cs
@@ -1,7 +1,9 @@
+using Granit.Authorization.Extensions;
 using Granit.DataExchange.Endpoints.Dtos.Export;
 using Granit.DataExchange.Endpoints.Dtos.Import;
 using Granit.DataExchange.Endpoints.Internal.Export;
 using Granit.DataExchange.Endpoints.Internal.Import;
+using Granit.DataExchange.Endpoints.Permissions;
 using Granit.DataExchange.Export;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -26,7 +28,8 @@ internal static class ExportPresetEndpoints
             .WithName("ListExportPresets")
             .WithSummary("Lists saved export presets for a given definition.")
             .WithDescription("Returns all saved export presets for the given export definition. Presets store a reusable field selection, output format, and sorting configuration so users can quickly re-export without reconfiguring.")
-            .Produces<IReadOnlyList<ExportPresetResponse>>();
+            .Produces<IReadOnlyList<ExportPresetResponse>>()
+            .AllowHostAccess();
 
         group.MapPost("/presets", SavePresetAsync)
             .WithName("SaveExportPreset")

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/Stores/EfExportJobStore.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Export/Stores/EfExportJobStore.cs
@@ -1,5 +1,6 @@
 using Granit.DataExchange.Export;
 using Granit.DataExchange.Export.Domain;
+using Granit.MultiTenancy;
 using Granit.Persistence;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
@@ -13,8 +14,9 @@ namespace Granit.DataExchange.EntityFrameworkCore.Internal.Export.Stores;
 /// Performs CRUD operations on <see cref="ExportJob"/> via <see cref="DataExchangeDbContext"/>.
 /// </summary>
 internal sealed class EfExportJobStore(
-    IDbContextFactory<DataExchangeDbContext> contextFactory)
-    : EfStoreBase<ExportJob, DataExchangeDbContext>(contextFactory), IExportJobReader, IExportJobWriter
+    IDbContextFactory<DataExchangeDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<ExportJob, DataExchangeDbContext>(contextFactory, currentTenant), IExportJobReader, IExportJobWriter
 {
     /// <inheritdoc/>
     public Task<ExportJob?> GetAsync(Guid id, CancellationToken cancellationToken = default) =>

--- a/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Stores/EfImportJobStore.cs
+++ b/src/Granit.DataExchange.EntityFrameworkCore/Internal/Import/Stores/EfImportJobStore.cs
@@ -1,5 +1,6 @@
 using Granit.DataExchange.Import.Domain;
 using Granit.DataExchange.Import.Pipeline;
+using Granit.MultiTenancy;
 using Granit.Persistence;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
@@ -13,8 +14,9 @@ namespace Granit.DataExchange.EntityFrameworkCore.Internal.Import.Stores;
 /// Performs CRUD operations on <see cref="ImportJob"/> via <see cref="DataExchangeDbContext"/>.
 /// </summary>
 internal sealed class EfImportJobStore(
-    IDbContextFactory<DataExchangeDbContext> contextFactory)
-    : EfStoreBase<ImportJob, DataExchangeDbContext>(contextFactory), IImportJobReader, IImportJobWriter
+    IDbContextFactory<DataExchangeDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<ImportJob, DataExchangeDbContext>(contextFactory, currentTenant), IImportJobReader, IImportJobWriter
 {
     /// <inheritdoc/>
     public Task<ImportJob?> GetAsync(Guid id, CancellationToken cancellationToken = default) =>

--- a/src/Granit.Invoicing.Endpoints/Endpoints/InvoiceEndpoints.cs
+++ b/src/Granit.Invoicing.Endpoints/Endpoints/InvoiceEndpoints.cs
@@ -1,3 +1,4 @@
+using Granit.Authorization.Extensions;
 using Granit.Guids;
 using Granit.Http.Idempotency.Attributes;
 using Granit.Invoicing.Domain;
@@ -26,7 +27,8 @@ internal static class InvoiceEndpoints
                 "Returns 404 if the invoice does not exist.")
             .Produces<InvoiceResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .RequireAuthorization(InvoicingPermissions.Invoices.Read);
+            .RequireAuthorization(InvoicingPermissions.Invoices.Read)
+            .AllowHostAccess();
 
         group.MapGet("/invoices/{id:guid}/pdf", DownloadInvoicePdfAsync)
             .WithName("DownloadInvoicePdf")
@@ -36,7 +38,8 @@ internal static class InvoiceEndpoints
                 "Returns 404 if the invoice does not exist.")
             .Produces(StatusCodes.Status200OK, contentType: "application/pdf")
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .RequireAuthorization(InvoicingPermissions.Invoices.Download);
+            .RequireAuthorization(InvoicingPermissions.Invoices.Download)
+            .AllowHostAccess();
 
         group.MapPost("/invoices", CreateInvoiceAsync)
             .WithName("CreateInvoice")

--- a/src/Granit.Invoicing.EntityFrameworkCore/Internal/EfInvoiceStore.cs
+++ b/src/Granit.Invoicing.EntityFrameworkCore/Internal/EfInvoiceStore.cs
@@ -1,5 +1,6 @@
 using Granit.Invoicing.Domain;
 using Granit.Invoicing.Domain.ValueObjects;
+using Granit.MultiTenancy;
 using Granit.Persistence;
 using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
@@ -7,8 +8,9 @@ using Microsoft.EntityFrameworkCore;
 namespace Granit.Invoicing.EntityFrameworkCore.Internal;
 
 internal sealed class EfInvoiceStore(
-    IDbContextFactory<InvoicingDbContext> contextFactory)
-    : EfStoreBase<Invoice, InvoicingDbContext>(contextFactory),
+    IDbContextFactory<InvoicingDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<Invoice, InvoicingDbContext>(contextFactory, currentTenant),
       IInvoiceReader, IInvoiceWriter
 {
     public Task<Invoice?> GetByIdAsync(InvoiceId id, CancellationToken cancellationToken = default) =>

--- a/src/Granit.Localization.EntityFrameworkCore/Internal/EfCoreLocalizationOverrideStore.cs
+++ b/src/Granit.Localization.EntityFrameworkCore/Internal/EfCoreLocalizationOverrideStore.cs
@@ -1,4 +1,5 @@
 using Granit.Localization.EntityFrameworkCore.Entities;
+using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
@@ -16,8 +17,9 @@ namespace Granit.Localization.EntityFrameworkCore.Internal;
 /// <see cref="LocalizationDbContext"/>, making it safe for concurrent request handling.
 /// </remarks>
 internal sealed class EfCoreLocalizationOverrideStore(
-    IDbContextFactory<LocalizationDbContext> contextFactory)
-    : EfStoreBase<LocalizationOverride, LocalizationDbContext>(contextFactory), ILocalizationOverrideStoreReader, ILocalizationOverrideStoreWriter
+    IDbContextFactory<LocalizationDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<LocalizationOverride, LocalizationDbContext>(contextFactory, currentTenant), ILocalizationOverrideStoreReader, ILocalizationOverrideStoreWriter
 {
     /// <inheritdoc/>
     public async Task<IReadOnlyDictionary<string, string>> GetOverridesAsync(

--- a/src/Granit.Metering.Endpoints/Endpoints/MeterDefinitionEndpoints.cs
+++ b/src/Granit.Metering.Endpoints/Endpoints/MeterDefinitionEndpoints.cs
@@ -1,3 +1,4 @@
+using Granit.Authorization.Extensions;
 using Granit.Guids;
 using Granit.Http.Idempotency.Attributes;
 using Granit.Metering.Domain;
@@ -24,7 +25,8 @@ internal static class MeterDefinitionEndpoints
                 + "Inactive meters are excluded from the results. "
                 + "Use the GET by ID endpoint to retrieve a specific meter regardless of status.")
             .Produces<IReadOnlyList<MeterDefinitionResponse>>()
-            .RequireAuthorization(MeteringPermissions.Meters.Read);
+            .RequireAuthorization(MeteringPermissions.Meters.Read)
+            .AllowHostAccess();
 
         group.MapGet("/meters/{id:guid}", GetMeterByIdAsync)
             .WithName("GetMeterDefinition")
@@ -34,7 +36,8 @@ internal static class MeterDefinitionEndpoints
                 + "and active status. Returns 404 if the meter does not exist.")
             .Produces<MeterDefinitionResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .RequireAuthorization(MeteringPermissions.Meters.Read);
+            .RequireAuthorization(MeteringPermissions.Meters.Read)
+            .AllowHostAccess();
 
         group.MapPost("/meters", CreateMeterAsync)
             .WithName("CreateMeterDefinition")

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/EfMeterDefinitionReader.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/EfMeterDefinitionReader.cs
@@ -1,5 +1,6 @@
 using Granit.Metering.Domain;
 using Granit.Metering.Domain.ValueObjects;
+using Granit.MultiTenancy;
 using Granit.Persistence;
 using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
@@ -7,8 +8,9 @@ using Microsoft.EntityFrameworkCore;
 namespace Granit.Metering.EntityFrameworkCore.Internal;
 
 internal sealed class EfMeterDefinitionReader(
-    IDbContextFactory<MeteringDbContext> contextFactory)
-    : EfStoreBase<MeterDefinition, MeteringDbContext>(contextFactory),
+    IDbContextFactory<MeteringDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<MeterDefinition, MeteringDbContext>(contextFactory, currentTenant),
       IMeterDefinitionReader
 {
     public Task<MeterDefinition?> GetByIdAsync(MeterDefinitionId id, CancellationToken cancellationToken = default) =>

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/EfMeterDefinitionWriter.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/EfMeterDefinitionWriter.cs
@@ -1,12 +1,14 @@
 using Granit.Metering.Domain;
+using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Metering.EntityFrameworkCore.Internal;
 
 internal sealed class EfMeterDefinitionWriter(
-    IDbContextFactory<MeteringDbContext> contextFactory)
-    : EfStoreBase<MeterDefinition, MeteringDbContext>(contextFactory),
+    IDbContextFactory<MeteringDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<MeterDefinition, MeteringDbContext>(contextFactory, currentTenant),
       IMeterDefinitionWriter
 {
     Task IMeterDefinitionWriter.AddAsync(MeterDefinition definition, CancellationToken cancellationToken) =>

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreMobilePushTokenStore.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreMobilePushTokenStore.cs
@@ -1,3 +1,4 @@
+using Granit.MultiTenancy;
 using Granit.Notifications.EntityFrameworkCore.Entities;
 using Granit.Notifications.MobilePush;
 using Granit.Persistence.EntityFrameworkCore;
@@ -9,8 +10,9 @@ namespace Granit.Notifications.EntityFrameworkCore.Internal;
 /// EF Core implementation of <see cref="IMobilePushTokenReader"/> and <see cref="IMobilePushTokenWriter"/>.
 /// </summary>
 internal sealed class EfCoreMobilePushTokenStore(
-    IDbContextFactory<NotificationsDbContext> contextFactory)
-    : EfStoreBase<MobilePushTokenEntity, NotificationsDbContext>(contextFactory), IMobilePushTokenReader, IMobilePushTokenWriter
+    IDbContextFactory<NotificationsDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<MobilePushTokenEntity, NotificationsDbContext>(contextFactory, currentTenant), IMobilePushTokenReader, IMobilePushTokenWriter
 {
     /// <inheritdoc />
     public Task<IReadOnlyList<MobilePushTokenInfo>> GetTokensAsync(

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreNotificationPreferenceStore.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreNotificationPreferenceStore.cs
@@ -1,3 +1,4 @@
+using Granit.MultiTenancy;
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Domain;
 using Granit.Persistence.EntityFrameworkCore;
@@ -10,8 +11,9 @@ namespace Granit.Notifications.EntityFrameworkCore.Internal;
 /// <see cref="INotificationPreferenceWriter"/> backed by PostgreSQL.
 /// </summary>
 internal sealed class EfCoreNotificationPreferenceStore(
-    IDbContextFactory<NotificationsDbContext> contextFactory)
-    : EfStoreBase<NotificationPreference, NotificationsDbContext>(contextFactory), INotificationPreferenceReader, INotificationPreferenceWriter
+    IDbContextFactory<NotificationsDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<NotificationPreference, NotificationsDbContext>(contextFactory, currentTenant), INotificationPreferenceReader, INotificationPreferenceWriter
 {
     /// <inheritdoc/>
     public Task<IReadOnlyList<NotificationPreference>> GetListAsync(string userId, Guid? tenantId, CancellationToken cancellationToken = default) =>

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreNotificationSubscriptionStore.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreNotificationSubscriptionStore.cs
@@ -1,4 +1,5 @@
 using Granit.Guids;
+using Granit.MultiTenancy;
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Domain;
 using Granit.Persistence.EntityFrameworkCore;
@@ -12,8 +13,9 @@ namespace Granit.Notifications.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed class EfCoreNotificationSubscriptionStore(
     IDbContextFactory<NotificationsDbContext> contextFactory,
+    ICurrentTenant currentTenant,
     IGuidGenerator guidGenerator)
-    : EfStoreBase<NotificationSubscription, NotificationsDbContext>(contextFactory), INotificationSubscriptionReader, INotificationSubscriptionWriter
+    : EfStoreBase<NotificationSubscription, NotificationsDbContext>(contextFactory, currentTenant), INotificationSubscriptionReader, INotificationSubscriptionWriter
 {
     /// <inheritdoc/>
     public Task SubscribeAsync(string userId, string notificationTypeName, Guid? tenantId, CancellationToken cancellationToken = default) =>

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreUserNotificationStore.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreUserNotificationStore.cs
@@ -1,3 +1,4 @@
+using Granit.MultiTenancy;
 using Granit.Notifications.Abstractions;
 using Granit.Notifications.Domain;
 using Granit.Persistence;
@@ -13,8 +14,9 @@ namespace Granit.Notifications.EntityFrameworkCore.Internal;
 /// <see cref="IUserNotificationWriter"/> backed by PostgreSQL.
 /// </summary>
 internal sealed class EfCoreUserNotificationStore(
-    IDbContextFactory<NotificationsDbContext> contextFactory)
-    : EfStoreBase<UserNotification, NotificationsDbContext>(contextFactory), IUserNotificationReader, IUserNotificationWriter
+    IDbContextFactory<NotificationsDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<UserNotification, NotificationsDbContext>(contextFactory, currentTenant), IUserNotificationReader, IUserNotificationWriter
 {
     /// <inheritdoc/>
     public Task InsertAsync(UserNotification notification, CancellationToken cancellationToken = default) =>

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/OpenIddictGroupStore.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/OpenIddictGroupStore.cs
@@ -1,6 +1,7 @@
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Services;
 using Granit.Identity.Models;
+using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
@@ -10,8 +11,9 @@ namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
 /// <see cref="ILocalIdentityGroupStore"/> implementation backed by <see cref="OpenIddictDbContext"/>.
 /// </summary>
 internal sealed class OpenIddictGroupStore(
-    IDbContextFactory<OpenIddictDbContext> dbFactory)
-    : EfStoreBase<GranitUserGroup, OpenIddictDbContext>(dbFactory), ILocalIdentityGroupStore
+    IDbContextFactory<OpenIddictDbContext> dbFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<GranitUserGroup, OpenIddictDbContext>(dbFactory, currentTenant), ILocalIdentityGroupStore
 {
     /// <inheritdoc/>
     public async Task<IReadOnlyList<IdentityGroup>> GetGroupsAsync(CancellationToken cancellationToken = default)

--- a/src/Granit.Payments.Endpoints/Endpoints/PaymentMethodEndpoints.cs
+++ b/src/Granit.Payments.Endpoints/Endpoints/PaymentMethodEndpoints.cs
@@ -1,3 +1,4 @@
+using Granit.Authorization.Extensions;
 using Granit.Guids;
 using Granit.Http.Idempotency.Attributes;
 using Granit.MultiTenancy;
@@ -26,7 +27,8 @@ internal static class PaymentMethodEndpoints
                 + "including their type, provider, display label, and default status. "
                 + "Requires the Payments.Methods.Read permission.")
             .Produces<IReadOnlyList<PaymentMethodResponse>>()
-            .RequireAuthorization(PaymentsPermissions.Methods.Read);
+            .RequireAuthorization(PaymentsPermissions.Methods.Read)
+            .AllowHostAccess();
 
         group.MapGet("/methods/available", GetAvailable)
             .WithName("GetAvailablePaymentMethods")
@@ -36,7 +38,8 @@ internal static class PaymentMethodEndpoints
                 + "providers. This includes method types, categories, and display labels as "
                 + "reported by the active payment providers.")
             .Produces<IReadOnlyList<PaymentAvailableMethodResponse>>()
-            .RequireAuthorization(PaymentsPermissions.Methods.Read);
+            .RequireAuthorization(PaymentsPermissions.Methods.Read)
+            .AllowHostAccess();
 
         group.MapPost("/methods", AttachAsync)
             .WithName("AttachPaymentMethod")

--- a/src/Granit.Payments.Endpoints/Endpoints/TransactionEndpoints.cs
+++ b/src/Granit.Payments.Endpoints/Endpoints/TransactionEndpoints.cs
@@ -1,3 +1,4 @@
+using Granit.Authorization.Extensions;
 using Granit.Http.Idempotency.Attributes;
 using Granit.MultiTenancy;
 using Granit.Payments.Commands;
@@ -26,7 +27,8 @@ internal static class TransactionEndpoints
                 + "Each transaction includes its refunds and disputes. "
                 + "Requires the Payments.Transactions.Read permission.")
             .Produces<IReadOnlyList<PaymentTransactionResponse>>()
-            .RequireAuthorization(PaymentsPermissions.Transactions.Read);
+            .RequireAuthorization(PaymentsPermissions.Transactions.Read)
+            .AllowHostAccess();
 
         group.MapGet("/transactions/{id:guid}", GetByIdAsync)
             .WithName("GetPaymentTransaction")
@@ -37,7 +39,8 @@ internal static class TransactionEndpoints
                 + "Returns 404 if the transaction does not exist.")
             .Produces<PaymentTransactionResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .RequireAuthorization(PaymentsPermissions.Transactions.Read);
+            .RequireAuthorization(PaymentsPermissions.Transactions.Read)
+            .AllowHostAccess();
 
         group.MapPost("/charge", ChargeAsync)
             .WithName("InitiatePaymentCharge")

--- a/src/Granit.Payments.EntityFrameworkCore/Internal/EfPaymentMethodStore.cs
+++ b/src/Granit.Payments.EntityFrameworkCore/Internal/EfPaymentMethodStore.cs
@@ -1,3 +1,4 @@
+using Granit.MultiTenancy;
 using Granit.Payments.Domain;
 using Granit.Persistence;
 using Granit.Persistence.EntityFrameworkCore;
@@ -6,8 +7,9 @@ using Microsoft.EntityFrameworkCore;
 namespace Granit.Payments.EntityFrameworkCore.Internal;
 
 internal sealed class EfPaymentMethodStore(
-    IDbContextFactory<PaymentsDbContext> contextFactory)
-    : EfStoreBase<PaymentMethod, PaymentsDbContext>(contextFactory),
+    IDbContextFactory<PaymentsDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<PaymentMethod, PaymentsDbContext>(contextFactory, currentTenant),
       IPaymentMethodReader, IPaymentMethodWriter
 {
     public Task<PaymentMethod?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default) =>

--- a/src/Granit.Payments.EntityFrameworkCore/Internal/EfPaymentTransactionStore.cs
+++ b/src/Granit.Payments.EntityFrameworkCore/Internal/EfPaymentTransactionStore.cs
@@ -1,3 +1,4 @@
+using Granit.MultiTenancy;
 using Granit.Payments.Domain;
 using Granit.Payments.Domain.ValueObjects;
 using Granit.Persistence;
@@ -7,8 +8,9 @@ using Microsoft.EntityFrameworkCore;
 namespace Granit.Payments.EntityFrameworkCore.Internal;
 
 internal sealed class EfPaymentTransactionStore(
-    IDbContextFactory<PaymentsDbContext> contextFactory)
-    : EfStoreBase<PaymentTransaction, PaymentsDbContext>(contextFactory),
+    IDbContextFactory<PaymentsDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<PaymentTransaction, PaymentsDbContext>(contextFactory, currentTenant),
       IPaymentTransactionReader, IPaymentTransactionWriter
 {
     public Task<PaymentTransaction?> GetByIdAsync(TransactionId id, CancellationToken cancellationToken = default) =>

--- a/src/Granit.Persistence.EntityFrameworkCore/EfStoreBase.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/EfStoreBase.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using Granit.Domain;
+using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Specification;
 using Granit.QueryEngine;
@@ -21,14 +22,52 @@ namespace Granit.Persistence.EntityFrameworkCore;
 /// Each method creates and disposes its own <typeparamref name="TContext"/> via the factory,
 /// ensuring thread-safe concurrent access and fresh query filter evaluation per operation.
 /// </para>
+/// <para>
+/// <b>Host context bypass:</b> When <paramref name="currentTenant"/> is provided and no
+/// tenant is active (<see cref="ICurrentTenant.IsAvailable"/> is <c>false</c>), the
+/// <see cref="GranitFilterNames.MultiTenant"/> named query filter is bypassed on all read
+/// operations so the caller sees entities across all tenants. This is used for host-level
+/// administration endpoints protected by <c>RequireHostContextEndpointFilter</c>.
+/// All other filters (soft-delete, GDPR, active) remain active.
+/// </para>
 /// </remarks>
 /// <typeparam name="TEntity">The entity type (must inherit <see cref="Entity"/>).</typeparam>
 /// <typeparam name="TContext">The isolated <see cref="DbContext"/> type.</typeparam>
+/// <param name="contextFactory">The factory for creating isolated <typeparamref name="TContext"/> instances.</param>
+/// <param name="currentTenant">
+/// Optional tenant context. When provided for <see cref="IMultiTenant"/> entities, enables
+/// automatic host-context bypass of the multi-tenant query filter. Pass <c>null</c> (or omit)
+/// to keep the default filtering behavior.
+/// </param>
 public abstract class EfStoreBase<TEntity, TContext>(
-    IDbContextFactory<TContext> contextFactory)
+    IDbContextFactory<TContext> contextFactory,
+    ICurrentTenant? currentTenant = null)
     where TEntity : Entity
     where TContext : DbContext
 {
+    // Pre-computed at construction (Scoped = once per request).
+    // True only when TEntity implements IMultiTenant AND no tenant is active.
+    private readonly bool _bypassTenantFilter =
+        typeof(IMultiTenant).IsAssignableFrom(typeof(TEntity))
+        && currentTenant is { IsAvailable: false };
+
+    // ── Query helper ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns the base queryable for <typeparamref name="TEntity"/>.
+    /// In host context (no active tenant), the <see cref="GranitFilterNames.MultiTenant"/>
+    /// named query filter is bypassed so all entities are visible cross-tenant.
+    /// All other filters (soft-delete, GDPR, active) remain active.
+    /// </summary>
+    /// <remarks>
+    /// This method is safe to call in any context — when a tenant is active, it returns
+    /// the standard <c>DbSet</c> with all filters applied.
+    /// </remarks>
+    protected IQueryable<TEntity> Query(TContext db) =>
+        _bypassTenantFilter
+            ? db.Set<TEntity>().IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            : db.Set<TEntity>();
+
     // ── Read helpers ────────────────────────────────────────────────────
 
     /// <summary>
@@ -46,7 +85,7 @@ public abstract class EfStoreBase<TEntity, TContext>(
         CancellationToken ct = default)
     {
         await using TContext db = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
-        return await db.Set<TEntity>()
+        return await Query(db)
             .FirstOrDefaultAsync(e => e.Id == id, ct).ConfigureAwait(false);
     }
 
@@ -56,7 +95,7 @@ public abstract class EfStoreBase<TEntity, TContext>(
         CancellationToken ct = default)
     {
         await using TContext db = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
-        return await db.Set<TEntity>()
+        return await Query(db)
             .FirstOrDefaultAsync(predicate, ct).ConfigureAwait(false);
     }
 
@@ -67,7 +106,7 @@ public abstract class EfStoreBase<TEntity, TContext>(
     {
         await using TContext db = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         return await SpecificationEvaluator
-            .Apply(db.Set<TEntity>().AsQueryable(), spec)
+            .Apply(Query(db), spec)
             .ToListAsync(ct).ConfigureAwait(false);
     }
 
@@ -80,7 +119,7 @@ public abstract class EfStoreBase<TEntity, TContext>(
     {
         await using TContext db = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         return await SpecificationEvaluator
-            .Apply(db.Set<TEntity>().AsQueryable(), spec)
+            .Apply(Query(db), spec)
             .ToPagedResultAsync(page, pageSize, ct).ConfigureAwait(false);
     }
 
@@ -91,8 +130,8 @@ public abstract class EfStoreBase<TEntity, TContext>(
     {
         await using TContext db = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
         return predicate is null
-            ? await db.Set<TEntity>().CountAsync(ct).ConfigureAwait(false)
-            : await db.Set<TEntity>().CountAsync(predicate, ct).ConfigureAwait(false);
+            ? await Query(db).CountAsync(ct).ConfigureAwait(false)
+            : await Query(db).CountAsync(predicate, ct).ConfigureAwait(false);
     }
 
     /// <summary>Checks whether any entity matches the predicate.</summary>
@@ -101,7 +140,7 @@ public abstract class EfStoreBase<TEntity, TContext>(
         CancellationToken ct = default)
     {
         await using TContext db = await contextFactory.CreateDbContextAsync(ct).ConfigureAwait(false);
-        return await db.Set<TEntity>().AnyAsync(predicate, ct).ConfigureAwait(false);
+        return await Query(db).AnyAsync(predicate, ct).ConfigureAwait(false);
     }
 
     // ── Full DbContext access (complex queries, Include, joins) ────────

--- a/src/Granit.Privacy.EntityFrameworkCore/Internal/EfLegalDocumentStore.cs
+++ b/src/Granit.Privacy.EntityFrameworkCore/Internal/EfLegalDocumentStore.cs
@@ -1,5 +1,6 @@
 using Granit.DataFiltering;
 using Granit.Domain;
+using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Privacy.LegalAgreements;
 using Granit.Privacy.LegalAgreements.Domain;
@@ -9,8 +10,9 @@ namespace Granit.Privacy.EntityFrameworkCore.Internal;
 
 internal sealed class EfLegalDocumentStore(
     IDbContextFactory<PrivacyDbContext> contextFactory,
+    ICurrentTenant currentTenant,
     IDataFilter? dataFilter = null)
-    : EfStoreBase<LegalDocument, PrivacyDbContext>(contextFactory),
+    : EfStoreBase<LegalDocument, PrivacyDbContext>(contextFactory, currentTenant),
       ILegalDocumentReader, ILegalDocumentWriter
 {
     private readonly IDbContextFactory<PrivacyDbContext> _contextFactory = contextFactory;

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/EfCoreSavedViewStore.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/EfCoreSavedViewStore.cs
@@ -1,3 +1,4 @@
+using Granit.MultiTenancy;
 using Granit.Persistence;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.QueryEngine.SavedViews;
@@ -11,8 +12,9 @@ namespace Granit.QueryEngine.EntityFrameworkCore.Internal;
 /// Performs CRUD operations on <see cref="SavedView"/> via <see cref="QueryEngineDbContext"/>.
 /// </summary>
 internal sealed class EfCoreSavedViewStore(
-    IDbContextFactory<QueryEngineDbContext> contextFactory)
-    : EfStoreBase<SavedView, QueryEngineDbContext>(contextFactory), ISavedViewStoreReader, ISavedViewStoreWriter
+    IDbContextFactory<QueryEngineDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<SavedView, QueryEngineDbContext>(contextFactory, currentTenant), ISavedViewStoreReader, ISavedViewStoreWriter
 {
     /// <inheritdoc/>
     public Task<IReadOnlyList<SavedView>> GetListAsync(

--- a/src/Granit.Scheduling.Endpoints/Endpoints/SchedulingReadEndpoints.cs
+++ b/src/Granit.Scheduling.Endpoints/Endpoints/SchedulingReadEndpoints.cs
@@ -1,6 +1,8 @@
+using Granit.Authorization.Extensions;
 using Granit.Scheduling.Domain;
 using Granit.Scheduling.Domain.ValueObjects;
 using Granit.Scheduling.Endpoints.Dtos;
+using Granit.Scheduling.Endpoints.Permissions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -22,7 +24,8 @@ internal static class SchedulingReadEndpoints
             .WithSummary("Returns a scheduled action by ID.")
             .WithDescription("Returns the full details of a single scheduled action identified by its GUID. Returns 404 if the action does not exist or belongs to a different tenant.")
             .Produces<ScheduledActionResponse>()
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .AllowHostAccess();
 
         return group;
     }

--- a/src/Granit.Scheduling.EntityFrameworkCore/Internal/EfScheduledActionQueryableSource.cs
+++ b/src/Granit.Scheduling.EntityFrameworkCore/Internal/EfScheduledActionQueryableSource.cs
@@ -1,3 +1,5 @@
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.QueryEngine;
 using Granit.Scheduling.Domain;
 using Microsoft.EntityFrameworkCore;
@@ -6,12 +8,21 @@ namespace Granit.Scheduling.EntityFrameworkCore.Internal;
 
 /// <summary>
 /// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="ScheduledAction"/>.
+/// When no tenant context is active (host admin), the multi-tenant query filter is
+/// bypassed so all scheduled actions are returned cross-tenant.
 /// </summary>
 internal sealed class EfScheduledActionQueryableSource(
-    IDbContextFactory<SchedulingDbContext> contextFactory) : IQueryableSource<ScheduledAction>
+    IDbContextFactory<SchedulingDbContext> contextFactory,
+    ICurrentTenant currentTenant) : IQueryableSource<ScheduledAction>
 {
     private readonly SchedulingDbContext _context = contextFactory.CreateDbContext();
+    private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
 
-    public IQueryable<ScheduledAction> GetQueryable() =>
-        _context.ScheduledActions.AsNoTracking();
+    public IQueryable<ScheduledAction> GetQueryable()
+    {
+        IQueryable<ScheduledAction> query = _context.ScheduledActions.AsNoTracking();
+        return _bypassTenantFilter
+            ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            : query;
+    }
 }

--- a/src/Granit.Scheduling.EntityFrameworkCore/Internal/EfScheduledActionStore.cs
+++ b/src/Granit.Scheduling.EntityFrameworkCore/Internal/EfScheduledActionStore.cs
@@ -1,3 +1,4 @@
+using Granit.MultiTenancy;
 using Granit.Persistence;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Scheduling.Domain;
@@ -17,8 +18,9 @@ namespace Granit.Scheduling.EntityFrameworkCore.Internal;
 /// be Scoped to avoid captive dependency violations.
 /// </remarks>
 internal sealed class EfScheduledActionStore(
-    IDbContextFactory<SchedulingDbContext> contextFactory)
-    : EfStoreBase<ScheduledAction, SchedulingDbContext>(contextFactory),
+    IDbContextFactory<SchedulingDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<ScheduledAction, SchedulingDbContext>(contextFactory, currentTenant),
       IScheduledActionReader, IScheduledActionWriter
 {
     /// <inheritdoc/>

--- a/src/Granit.Subscriptions.Endpoints/Endpoints/SubscriptionEndpoints.cs
+++ b/src/Granit.Subscriptions.Endpoints/Endpoints/SubscriptionEndpoints.cs
@@ -1,3 +1,4 @@
+using Granit.Authorization.Extensions;
 using Granit.Guids;
 using Granit.Http.Idempotency.Attributes;
 using Granit.MultiTenancy;
@@ -33,7 +34,8 @@ internal static class SubscriptionEndpoints
             .WithDescription("Returns the full subscription details including seat count and dunning status.")
             .Produces<SubscriptionResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .RequireAuthorization(SubscriptionsPermissions.Subscriptions.Read);
+            .RequireAuthorization(SubscriptionsPermissions.Subscriptions.Read)
+            .AllowHostAccess();
 
         group.MapPost("/subscriptions", CreateSubscriptionAsync)
             .WithName("CreateSubscription")

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfSubscriptionReader.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfSubscriptionReader.cs
@@ -1,3 +1,4 @@
+using Granit.MultiTenancy;
 using Granit.Persistence;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Subscriptions.Domain;
@@ -7,8 +8,9 @@ using Microsoft.EntityFrameworkCore;
 namespace Granit.Subscriptions.EntityFrameworkCore.Internal;
 
 internal sealed class EfSubscriptionReader(
-    IDbContextFactory<SubscriptionsDbContext> contextFactory)
-    : EfStoreBase<Subscription, SubscriptionsDbContext>(contextFactory),
+    IDbContextFactory<SubscriptionsDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<Subscription, SubscriptionsDbContext>(contextFactory, currentTenant),
       ISubscriptionReader
 {
     public Task<Subscription?> GetByIdAsync(SubscriptionId id, CancellationToken cancellationToken = default) =>

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfSubscriptionWriter.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfSubscriptionWriter.cs
@@ -1,3 +1,4 @@
+using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Subscriptions.Domain;
 using Microsoft.EntityFrameworkCore;
@@ -5,8 +6,9 @@ using Microsoft.EntityFrameworkCore;
 namespace Granit.Subscriptions.EntityFrameworkCore.Internal;
 
 internal sealed class EfSubscriptionWriter(
-    IDbContextFactory<SubscriptionsDbContext> contextFactory)
-    : EfStoreBase<Subscription, SubscriptionsDbContext>(contextFactory),
+    IDbContextFactory<SubscriptionsDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<Subscription, SubscriptionsDbContext>(contextFactory, currentTenant),
       ISubscriptionWriter
 {
     Task ISubscriptionWriter.AddAsync(Subscription subscription, CancellationToken cancellationToken) =>

--- a/src/Granit.Timeline.Endpoints/Endpoints/TimelineStreamEndpoints.cs
+++ b/src/Granit.Timeline.Endpoints/Endpoints/TimelineStreamEndpoints.cs
@@ -1,4 +1,5 @@
 using Granit.Authorization;
+using Granit.Authorization.Extensions;
 using Granit.QueryEngine;
 using Granit.Timeline.Abstractions;
 using Granit.Timeline.Endpoints.Dtos;
@@ -23,7 +24,8 @@ internal static class TimelineStreamEndpoints
             .WithName("GetTimelineStream")
             .WithSummary("Returns the paginated activity stream for an entity, newest first.")
             .WithDescription("Returns comments, internal notes (staff-only, requires Timeline.InternalNotes.Read), and system log entries. Supports pagination. Soft-deleted entries are excluded.")
-            .Produces<PagedResult<TimelineStreamEntryResponse>>();
+            .Produces<PagedResult<TimelineStreamEntryResponse>>()
+            .AllowHostAccess();
 
         return group;
     }

--- a/src/Granit.Timeline.EntityFrameworkCore/Internal/EfCoreTimelineStore.cs
+++ b/src/Granit.Timeline.EntityFrameworkCore/Internal/EfCoreTimelineStore.cs
@@ -26,7 +26,7 @@ internal sealed class EfCoreTimelineStore(
     ICurrentUserService currentUser,
     IGuidGenerator guidGenerator,
     ICurrentTenant currentTenant)
-    : EfStoreBase<TimelineEntry, TimelineDbContext>(dbContextFactory), ITimelineWriter
+    : EfStoreBase<TimelineEntry, TimelineDbContext>(dbContextFactory, currentTenant), ITimelineWriter
 {
     private readonly AuditContext _audit = new(guidGenerator, clock, currentUser, currentTenant);
 

--- a/src/Granit.Webhooks.Endpoints/Endpoints/WebhookSubscriptionReadEndpoints.cs
+++ b/src/Granit.Webhooks.Endpoints/Endpoints/WebhookSubscriptionReadEndpoints.cs
@@ -1,6 +1,8 @@
+using Granit.Authorization.Extensions;
 using Granit.Webhooks.Abstractions;
 using Granit.Webhooks.Domain;
 using Granit.Webhooks.Endpoints.Dtos;
+using Granit.Webhooks.Endpoints.Permissions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -20,7 +22,8 @@ internal static class WebhookSubscriptionReadEndpoints
                 "Fetches the full details of a single webhook subscription including its current status, "
                 + "target URL, event type, and delivery statistics. Returns 404 if the subscription does not exist.")
             .Produces<WebhookSubscriptionResponse>()
-            .ProducesProblem(StatusCodes.Status404NotFound);
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .AllowHostAccess();
 
         return group;
     }

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookDeliveryAttemptQueryableSource.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookDeliveryAttemptQueryableSource.cs
@@ -1,3 +1,5 @@
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.QueryEngine;
 using Granit.Webhooks.Domain;
 using Microsoft.EntityFrameworkCore;
@@ -6,12 +8,21 @@ namespace Granit.Webhooks.EntityFrameworkCore.Internal;
 
 /// <summary>
 /// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="WebhookDeliveryAttempt"/>.
+/// When no tenant context is active (host admin), the multi-tenant query filter is
+/// bypassed so all delivery attempts are returned cross-tenant.
 /// </summary>
 internal sealed class EfWebhookDeliveryAttemptQueryableSource(
-    IDbContextFactory<WebhooksDbContext> contextFactory) : IQueryableSource<WebhookDeliveryAttempt>
+    IDbContextFactory<WebhooksDbContext> contextFactory,
+    ICurrentTenant currentTenant) : IQueryableSource<WebhookDeliveryAttempt>
 {
     private readonly WebhooksDbContext _context = contextFactory.CreateDbContext();
+    private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
 
-    public IQueryable<WebhookDeliveryAttempt> GetQueryable() =>
-        _context.WebhookDeliveryAttempts.AsNoTracking();
+    public IQueryable<WebhookDeliveryAttempt> GetQueryable()
+    {
+        IQueryable<WebhookDeliveryAttempt> query = _context.WebhookDeliveryAttempts.AsNoTracking();
+        return _bypassTenantFilter
+            ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            : query;
+    }
 }

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookDeliveryStore.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookDeliveryStore.cs
@@ -1,4 +1,5 @@
 using Granit.Guids;
+using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Timing;
 using Granit.Webhooks.Abstractions;
@@ -19,9 +20,10 @@ namespace Granit.Webhooks.EntityFrameworkCore.Internal;
 /// </remarks>
 internal sealed class EfWebhookDeliveryStore(
     IDbContextFactory<WebhooksDbContext> contextFactory,
+    ICurrentTenant currentTenant,
     IClock clock,
     IGuidGenerator guidGenerator)
-    : EfStoreBase<WebhookDeliveryAttempt, WebhooksDbContext>(contextFactory),
+    : EfStoreBase<WebhookDeliveryAttempt, WebhooksDbContext>(contextFactory, currentTenant),
       IWebhookDeliveryWriter, IWebhookDeliveryReader
 {
     public Task<WebhookDeliveryAttempt?> FindByDeliveryIdAsync(

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookSubscriptionQueryableSource.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookSubscriptionQueryableSource.cs
@@ -1,3 +1,5 @@
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
 using Granit.QueryEngine;
 using Granit.Webhooks.Domain;
 using Microsoft.EntityFrameworkCore;
@@ -6,12 +8,21 @@ namespace Granit.Webhooks.EntityFrameworkCore.Internal;
 
 /// <summary>
 /// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="WebhookSubscription"/>.
+/// When no tenant context is active (host admin), the multi-tenant query filter is
+/// bypassed so all webhook subscriptions are returned cross-tenant.
 /// </summary>
 internal sealed class EfWebhookSubscriptionQueryableSource(
-    IDbContextFactory<WebhooksDbContext> contextFactory) : IQueryableSource<WebhookSubscription>
+    IDbContextFactory<WebhooksDbContext> contextFactory,
+    ICurrentTenant currentTenant) : IQueryableSource<WebhookSubscription>
 {
     private readonly WebhooksDbContext _context = contextFactory.CreateDbContext();
+    private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
 
-    public IQueryable<WebhookSubscription> GetQueryable() =>
-        _context.WebhookSubscriptions.AsNoTracking();
+    public IQueryable<WebhookSubscription> GetQueryable()
+    {
+        IQueryable<WebhookSubscription> query = _context.WebhookSubscriptions.AsNoTracking();
+        return _bypassTenantFilter
+            ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            : query;
+    }
 }

--- a/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookSubscriptionStore.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Internal/EfWebhookSubscriptionStore.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using Granit.Domain.ValueObjects;
 using Granit.Exceptions;
 using Granit.Guids;
+using Granit.MultiTenancy;
 using Granit.Persistence;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Timing;
@@ -17,10 +18,11 @@ namespace Granit.Webhooks.EntityFrameworkCore.Internal;
 /// </summary>
 internal sealed class EfWebhookSubscriptionStore(
     IDbContextFactory<WebhooksDbContext> contextFactory,
+    ICurrentTenant currentTenant,
     IGuidGenerator guidGenerator,
     IWebhookSecretProtector secretProtector,
     IClock clock)
-    : EfStoreBase<WebhookSubscription, WebhooksDbContext>(contextFactory),
+    : EfStoreBase<WebhookSubscription, WebhooksDbContext>(contextFactory, currentTenant),
       IWebhookSubscriptionReader, IWebhookSubscriptionWriter
 {
     /// <inheritdoc/>

--- a/tests/Granit.AI.EntityFrameworkCore.Tests/EfAIUsageStoreTests.cs
+++ b/tests/Granit.AI.EntityFrameworkCore.Tests/EfAIUsageStoreTests.cs
@@ -2,8 +2,10 @@ using System.Diagnostics.Metrics;
 using Granit.AI.Diagnostics;
 using Granit.AI.EntityFrameworkCore.Entities;
 using Granit.AI.EntityFrameworkCore.Internal;
+using Granit.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
 using Shouldly;
 
 namespace Granit.AI.EntityFrameworkCore.Tests;
@@ -26,7 +28,7 @@ public sealed class EfAIUsageStoreTests : IAsyncDisposable
         AIMetrics metrics = new(_sp.GetRequiredService<IMeterFactory>());
 
         _factory = new TestDbContextFactory(options);
-        _store = new EfAIUsageStore(_factory, metrics);
+        _store = new EfAIUsageStore(_factory, Substitute.For<ICurrentTenant>(), metrics);
     }
 
     public async ValueTask DisposeAsync()

--- a/tests/Granit.AI.EntityFrameworkCore.Tests/EfAIWorkspaceStoreTests.cs
+++ b/tests/Granit.AI.EntityFrameworkCore.Tests/EfAIWorkspaceStoreTests.cs
@@ -1,7 +1,9 @@
 using Granit.AI.EntityFrameworkCore.Entities;
 using Granit.AI.EntityFrameworkCore.Internal;
 using Granit.AI.Workspaces;
+using Granit.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
+using NSubstitute;
 using Shouldly;
 
 namespace Granit.AI.EntityFrameworkCore.Tests;
@@ -18,7 +20,7 @@ public sealed class EfAIWorkspaceStoreTests : IAsyncDisposable
             .Options;
 
         _factory = new TestDbContextFactory(options);
-        _store = new EfAIWorkspaceStore(_factory);
+        _store = new EfAIWorkspaceStore(_factory, Substitute.For<ICurrentTenant>());
     }
 
     public async ValueTask DisposeAsync()

--- a/tests/Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests/ApiKeysEntityFrameworkCoreServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests/ApiKeysEntityFrameworkCoreServiceCollectionExtensionsTests.cs
@@ -21,6 +21,7 @@ public sealed class ApiKeysEntityFrameworkCoreServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
+        services.AddSingleton(Substitute.For<ICurrentTenant>());
 
         services.AddGranitApiKeysEntityFrameworkCore(
             options => options.UseSqlite("DataSource=:memory:"));

--- a/tests/Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests/EfCoreApiKeyAdminStoreTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests/EfCoreApiKeyAdminStoreTests.cs
@@ -1,7 +1,9 @@
 using Granit.Authentication.ApiKeys.Domain;
 using Granit.Authentication.ApiKeys.EntityFrameworkCore.Internal;
+using Granit.MultiTenancy;
 using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -15,7 +17,7 @@ public sealed class EfCoreApiKeyAdminStoreTests : IDisposable
     public EfCoreApiKeyAdminStoreTests()
     {
         _factory = TestDbContextFactory.Create();
-        _sut = new EfCoreApiKeyAdminStore(_factory);
+        _sut = new EfCoreApiKeyAdminStore(_factory, Substitute.For<ICurrentTenant>());
     }
 
     public void Dispose() => _factory.Dispose();

--- a/tests/Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests/EfCoreApiKeyStoreTests.cs
+++ b/tests/Granit.Authentication.ApiKeys.EntityFrameworkCore.Tests/EfCoreApiKeyStoreTests.cs
@@ -1,5 +1,6 @@
 using Granit.Authentication.ApiKeys.Domain;
 using Granit.Authentication.ApiKeys.EntityFrameworkCore.Internal;
+using Granit.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -17,7 +18,7 @@ public sealed class EfCoreApiKeyStoreTests : IDisposable
     public EfCoreApiKeyStoreTests()
     {
         _factory = TestDbContextFactory.Create();
-        _sut = new EfCoreApiKeyStore(_factory, NullLogger<EfCoreApiKeyStore>.Instance);
+        _sut = new EfCoreApiKeyStore(_factory, Substitute.For<ICurrentTenant>(), NullLogger<EfCoreApiKeyStore>.Instance);
     }
 
     public void Dispose() => _factory.Dispose();
@@ -81,7 +82,7 @@ public sealed class EfCoreApiKeyStoreTests : IDisposable
             .Returns<AuthenticationApiKeysDbContext>(_ => throw new DbUpdateException("Simulated failure"));
 
         ILogger<EfCoreApiKeyStore> logger = Substitute.For<ILogger<EfCoreApiKeyStore>>();
-        var failingSut = new EfCoreApiKeyStore(mockFactory, logger);
+        var failingSut = new EfCoreApiKeyStore(mockFactory, Substitute.For<ICurrentTenant>(), logger);
 
         // Should not throw — the exception is caught and logged
         await Should.NotThrowAsync(

--- a/tests/Granit.BlobStorage.EntityFrameworkCore.Tests/EfBlobDescriptorStoreTests.cs
+++ b/tests/Granit.BlobStorage.EntityFrameworkCore.Tests/EfBlobDescriptorStoreTests.cs
@@ -51,8 +51,11 @@ public sealed class EfBlobDescriptorStoreTests
         await store.UpdateAsync(u, TestContext.Current.CancellationToken);
     }
 
-    private static EfBlobDescriptorStore CreateStore(string dbName, Guid? tenantId = null) =>
-        new(new InMemoryContextFactory(dbName, MakeTenant(tenantId ?? TenantId)));
+    private static EfBlobDescriptorStore CreateStore(string dbName, Guid? tenantId = null)
+    {
+        ICurrentTenant tenant = MakeTenant(tenantId ?? TenantId);
+        return new(new InMemoryContextFactory(dbName, tenant), tenant);
+    }
 
     private static BlobDescriptor MakeDescriptor(
         Guid? id = null,
@@ -273,7 +276,7 @@ public sealed class EfBlobDescriptorStoreTests
         noTenant.IsAvailable.Returns(false);
         noTenant.Id.Returns((Guid?)null);
         EfBlobDescriptorStore store = new(
-            new InMemoryContextFactory(Guid.NewGuid().ToString(), noTenant));
+            new InMemoryContextFactory(Guid.NewGuid().ToString(), noTenant), noTenant);
 
         BlobDescriptor? result = await store.FindAsync(
             Guid.NewGuid(), TestContext.Current.CancellationToken);

--- a/tests/Granit.DataExchange.EntityFrameworkCore.Tests/Export/EfExportJobStoreTests.cs
+++ b/tests/Granit.DataExchange.EntityFrameworkCore.Tests/Export/EfExportJobStoreTests.cs
@@ -2,6 +2,8 @@ using Granit.DataExchange.EntityFrameworkCore.Internal.Export.Stores;
 using Granit.DataExchange.EntityFrameworkCore.Tests.Infrastructure;
 using Granit.DataExchange.Export;
 using Granit.DataExchange.Export.Domain;
+using Granit.MultiTenancy;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -126,7 +128,7 @@ public sealed class EfExportJobStoreTests
     private static EfExportJobStore CreateStore(string dbName)
     {
         InMemoryDataExchangeContextFactory factory = new(dbName);
-        return new EfExportJobStore(factory);
+        return new EfExportJobStore(factory, Substitute.For<ICurrentTenant>());
     }
 
     private static ExportJob BuildJob() =>

--- a/tests/Granit.DataExchange.EntityFrameworkCore.Tests/Stores/EfImportJobStoreTests.cs
+++ b/tests/Granit.DataExchange.EntityFrameworkCore.Tests/Stores/EfImportJobStoreTests.cs
@@ -3,7 +3,9 @@ using Granit.DataExchange.EntityFrameworkCore.Internal.Export.Stores;
 using Granit.DataExchange.EntityFrameworkCore.Internal.Import.Stores;
 using Granit.DataExchange.EntityFrameworkCore.Tests.Infrastructure;
 using Granit.DataExchange.Import.Domain;
+using Granit.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -14,7 +16,7 @@ public sealed class EfImportJobStoreTests
     private static string NewDb() => Guid.NewGuid().ToString();
 
     private static EfImportJobStore CreateStore(string dbName) =>
-        new(new InMemoryDataExchangeContextFactory(dbName));
+        new(new InMemoryDataExchangeContextFactory(dbName), Substitute.For<ICurrentTenant>());
 
     private static ImportJob CreateJob(Guid? id = null) =>
         CreateJobWithTenant(tenantId: null, id);

--- a/tests/Granit.Localization.EntityFrameworkCore.Tests/EfCoreLocalizationOverrideStoreTests.cs
+++ b/tests/Granit.Localization.EntityFrameworkCore.Tests/EfCoreLocalizationOverrideStoreTests.cs
@@ -1,6 +1,8 @@
 using Granit.Localization.EntityFrameworkCore.Entities;
 using Granit.Localization.EntityFrameworkCore.Internal;
+using Granit.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -25,7 +27,7 @@ public sealed class EfCoreLocalizationOverrideStoreTests
     }
 
     private static EfCoreLocalizationOverrideStore CreateStore(string dbName) =>
-        new(new InMemoryContextFactory(dbName));
+        new(new InMemoryContextFactory(dbName), Substitute.For<ICurrentTenant>());
 
     private static async Task SeedAsync(
         string dbName,

--- a/tests/Granit.Localization.EntityFrameworkCore.Tests/Granit.Localization.EntityFrameworkCore.Tests.csproj
+++ b/tests/Granit.Localization.EntityFrameworkCore.Tests/Granit.Localization.EntityFrameworkCore.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="NSubstitute" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="coverlet.collector" />

--- a/tests/Granit.Localization.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Localization.EntityFrameworkCore.Tests/packages.lock.json
@@ -23,12 +23,12 @@
       "Microsoft.EntityFrameworkCore.InMemory": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "zz4THzlDOrJ7fKU2YUOzQFs2LJ9DgOSr5xFXcDdoD59el73MTQLtQQOAJxQ94F4XDegyL9+2sePSQGdcU25ZxQ==",
+        "resolved": "10.0.6",
+        "contentHash": "yQQLR6s0NOBJvg/du/w/mJn9ESlQ0XkAQ0zJEPhtlS/Vsnay6LRSdh39Sxy9/SkpYLoNoI9c6FUyP+UIE+BWdg==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.5",
-          "Microsoft.Extensions.Caching.Memory": "10.0.5",
-          "Microsoft.Extensions.Logging": "10.0.5"
+          "Microsoft.EntityFrameworkCore": "10.0.6",
+          "Microsoft.Extensions.Caching.Memory": "10.0.6",
+          "Microsoft.Extensions.Logging": "10.0.6"
         }
       },
       "Microsoft.NET.Test.Sdk": {
@@ -97,80 +97,80 @@
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "32c58Rnm47Qvhimawf67KO9PytgPz3QoWye7Abapt0Yocw/JnzMiSNj/pRoIKyn8Jxypkv86zxKD4Q/zNTc0Ag=="
+        "resolved": "10.0.6",
+        "contentHash": "4F+e6uxhVmyduu+Ve1INxek94adt4RAddWqykXNDnOOWQrJJ20izw/9qRpZdkLnIW9oj/3qnLWUtsv37U0xJCw=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "ipC4u1VojgEfoIZhtbS2Sx5IluJTP/Jf1hz3yGsxGBgSukYY/CquI6rAjxn5H58CZgVn36qcuPPtNMwZ0AUzMg=="
+        "resolved": "10.0.6",
+        "contentHash": "PIcmALdKzeSJNWmxsLDsS8XKFqiH5+9GzIM+qd3w1efYIwmO0w5304i37/SkfynctHZwkiiQjb2mkoIXU1CGZg=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
+        "resolved": "10.0.6",
+        "contentHash": "lYQ9S1FGXIWIU7243RimdAXQYsFDeLhSSZvbSDwbeI/kCzZ4MIYXpp3kMQ+bDJXwl9pzMRIYkd4f9zGqcYxfAQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Primitives": "10.0.6"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "resolved": "10.0.6",
+        "contentHash": "a7bA7IT3ngIgcOMb/2MVH5CcfSxUCeQ6QXWS1Vt6oFpzLTH3U1+J2Xtc64Uw3whX9akYG8eR/UQeEzxo64zZLg==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.5"
+          "Microsoft.Extensions.Primitives": "10.0.6"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "v1SVsowG6YE1YnHVGmLWz57YTRCQRx9pH5ebIESXfm5isI9gA3QaMyg/oMTzPpXYZwSAVDzYItGJKfmV+pqXkQ==",
+        "resolved": "10.0.6",
+        "contentHash": "poUvwtf92bEs8uBH3aRRs/ZgiAw+Z485EU7TtVPBt//MmD0uMPERe7+v3Ur7lpD8XgIEDL9sDoTBcW1LMG97CQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
         }
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
+        "resolved": "10.0.6",
+        "contentHash": "L98Xe5C+xyKytLNLiEyQ0rcY8GNXAeAn1xKsE0YDxPx/mXBYYtRoj8pC2cnbSFQUlOzBkyO90ivMSV22SRETFg==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Options": "10.0.6"
         }
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "NrIMTy7dpqxAvA6kHAYH8cXID/YgeNOy0OqFKpLtkPu5X4WS/basX91UszANzVrMNRAICJ2GOnGiRxJtsRyEQw=="
+        "resolved": "10.0.6",
+        "contentHash": "ChhUF6HVSz9DwBgTyHtWbGzH8kWMbEFS7gqrqBnZQhHJFFK7L1k5BX7UCiIHiCap5HEDS6bZYks79JK4c+H0GQ=="
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
+        "resolved": "10.0.6",
+        "contentHash": "iU/lPyrjHVA4jJ7Bl/VpXvgsAD4qJWc4oPSVJjMBeZjmv7IIo8wBKxnOUoXdZcSCUJ6MeBMs3WpXNfncO7OzRg==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.5"
+          "Microsoft.Extensions.Primitives": "10.0.6"
         }
       },
       "Microsoft.Extensions.Localization.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "xKobiPRPVkK/bD/oLUTF1OnilG3N+4o0u/T8YWqHq+E97zWgCRr8Zhk9N6OZeLBSNHC7imT53QkH/yv9MaXkew=="
+        "resolved": "10.0.6",
+        "contentHash": "eXchxdBgomnydhkgk1jCoCgiYL5dYp0TKVPhLSClGirmkEMAW5j8yJQjIoIwoRN5nmER/OYglYxc+wO15zuRkQ=="
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "+XTMKQyDWg4ODoNHU/BN3BaI1jhGO7VCS+BnzT/4IauiG6y2iPAte7MyD7rHKS+hNP0TkFkjrae8DFjDUxtcxg==",
+        "resolved": "10.0.6",
+        "contentHash": "ZjpnbMD88IcZQE2pE9lcGv3mkH2mlApPWNh88ya1wJpcxZLp7p4aN7twI2FpawGPAsXNpmMgtKaz3o796YWKWQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.5",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5"
+          "Microsoft.Extensions.DependencyInjection": "10.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Options": "10.0.6"
         }
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "10.0.5",
-        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
+        "resolved": "10.0.6",
+        "contentHash": "L8P21mqaG+CXvPheLndean/cHCOcItJqH8nx+0YQnK7wAiOR0G1IOC418ZSzTMD2D6Gmo0f2M5WR70XtpX2B8g=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -400,143 +400,143 @@
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "9tNBmK3EpYVGRQLiqP+bqK2m+TD0Gv//4vCzR7ZOgl4FWzCFyOpYdIVka13M4kcBdPdSJcs3wbHr3rmzOqbIMA==",
+        "resolved": "10.0.6",
+        "contentHash": "eDy7bu3G+51FRC0cPtXTqUI9iAdDYl/XBQ5UguN8NFOA7QNmFvUEf36wA7PZ4ctsnxRN4t3dIvs2VKVE5H+EQQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.5",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.5",
-          "Microsoft.Extensions.Caching.Memory": "10.0.5",
-          "Microsoft.Extensions.Logging": "10.0.5"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.6",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.6",
+          "Microsoft.Extensions.Caching.Memory": "10.0.6",
+          "Microsoft.Extensions.Logging": "10.0.6"
         }
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "uxmFjZEAB/KbsgWFSS4lLqkEHCfXxB2x0UcbiO4e5fCRpFFeTMSx/me6009nYJLu5IKlDwO1POh++P6RilFTDw==",
+        "resolved": "10.0.6",
+        "contentHash": "t+pXPUjiAemBTstY57yUAoywOO6znVD3lwy7UERJpji0wmS70XHg0h8EcpX6+7KT6ZVCIndr1pW0GdOobZ4yCg==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.5",
-          "Microsoft.Extensions.Caching.Memory": "10.0.5",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Logging": "10.0.5"
+          "Microsoft.EntityFrameworkCore": "10.0.6",
+          "Microsoft.Extensions.Caching.Memory": "10.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Logging": "10.0.6"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "k/QDdQ94/0Shi0KfU+e12m73jfQo+3JpErTtgpZfsCIqkvdEEO0XIx6R+iTbN55rNPaNhOqNY4/sB+jZ8XxVPw==",
+        "resolved": "10.0.6",
+        "contentHash": "Ilr690V+E1H116ncF00KIlvRloKXBdCExaNqcT9BvCcS5nFGR1pcTamSA2EI8pOXbNp0DHZm8K8h6Wl1hMSbIQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.5"
+          "Microsoft.Extensions.Primitives": "10.0.6"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "jUEXmkBUPdOS/MP9areK/sbKhdklq9+tEhvwfxGalZVnmyLUO5rrheNNutUBtvbZ7J8ECkG7/r2KXi/IFC06cA==",
+        "resolved": "10.0.6",
+        "contentHash": "5godKXBBsObgl/dBQKgrFeHFd6vVVOMGK3TuKLPNlwJgabFKl5vISSHLw5hWUtd+zKcl/Llmw25dsGlySxXJJg==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.5",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Options": "10.0.6",
+          "Microsoft.Extensions.Primitives": "10.0.6"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
+        "resolved": "10.0.6",
+        "contentHash": "h22Fm4VxRmr4ty9rxJaW0i51xD56Bl5QhQ2hsGY2vl+6FioWmBhkpg3B78XQaK25N+hE41gZLZuYKGQS+OGbdw==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.5",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+          "Microsoft.Extensions.Configuration": "10.0.6",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+        "resolved": "10.0.6",
+        "contentHash": "w+dX4SIr1X9yegX2yX2dU1XtP4JAUVNdvOG/Evn+H+ndn96YzfIPX52FALXChrRNWFR9l77FQyg1mB7WQo6iOA=="
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "REdt95QXHscGdtw/UUgyCW2lF9DJcAOJxmebKW2IkgUjuCAdMODIi2HNOWg5utW98nm8ekgV0Gjqs/sljwwqMw==",
+        "resolved": "10.0.6",
+        "contentHash": "G6AVN2vs66Gu8IkB2FwsVJRpIkkTmPJ+NmAUH7+N+VGGI6qK38OXMZLipjCaOYdj2DW6ge2IIXdwZjhNJefD0w==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5"
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Options": "10.0.6"
         }
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "RtNhAwrnZcUZgi3SUMvaDVF405ZtKVR7l/6OHcqFj6JY5nT7QOdBxxULnby9dUQ6Jhnfl7cdDlMjsexfASNyjg==",
+        "resolved": "10.0.6",
+        "contentHash": "PkQ8fY/N811NelZ/Hhi9Y+1TDPiE9XGTzNcyMkaXl8ygYhiQ9ykVSvnzsF2YEtrNVRSs1S123b/dF91EHBJ7BQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.5",
-          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.5",
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.5"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.6",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.6",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.6"
         }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "resolved": "10.0.6",
+        "contentHash": "x3C8tgsX+xWvV5u76LFm24/U7sSnCRjuudBkbFsMV/DIqCA85te7YGg6dpa7lBToDhi4Lry9E7Arpy0laUw5AQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.6",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.6"
         }
       },
       "Microsoft.Extensions.Localization": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "Co/URpVB1P1WbvswTumphjYZcvqTA2piSTLVOVtN6qLNrK6pg0OjZ/9SzigI+7NYGS2UpxVMydk/n45VvWZvOg==",
+        "resolved": "10.0.6",
+        "contentHash": "iiM6XtI22oEav13ecJwCgMYaTsxPKAYBVlOv0i6HJ7zlkgPc5Wb++7Ucox8AJjzY3pkCwZLatITHkY23g9QHGA==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Localization.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Options": "10.0.6"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "resolved": "10.0.6",
+        "contentHash": "1YgBO3wAy0dlpQyVTKWBSPND/t0yZHsvd3shGpbeEwH8JSb2hnFI2pNFrOOUi/stsp+T/dqwqmRIGh47ibo9bw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
         }
       },
       "Microsoft.Extensions.Options": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "resolved": "10.0.6",
+        "contentHash": "v5RTWm+3Gdub21ADJeRG5bunOOxutFNBZk6qGH6Az4L5nyRZoLe3Kse7jfAyUcdEoiKp72XpNw/wGR+9wP+MtQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Primitives": "10.0.6"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.5",
-        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "resolved": "10.0.6",
+        "contentHash": "O7xt1vYMxku2+/WpFkh6X8RzUtYbKR+XCt0KOO0W9TbRbFeQdfb9Nry/CdVq57kOyOKS3Z4qD1xqV/8LpJQ0Xw==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Options": "10.0.5",
-          "Microsoft.Extensions.Primitives": "10.0.5"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Options": "10.0.6",
+          "Microsoft.Extensions.Primitives": "10.0.6"
         }
       },
       "OpenTelemetry.Api": {

--- a/tests/Granit.Localization.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Localization.EntityFrameworkCore.Tests/packages.lock.json
@@ -41,6 +41,15 @@
           "Microsoft.TestPlatform.TestHost": "18.4.0"
         }
       },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.*, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
       "Shouldly": {
         "type": "Direct",
         "requested": "[4.*, )",
@@ -64,6 +73,14 @@
         "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
         "dependencies": {
           "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
         }
       },
       "DiffEngine": {
@@ -230,6 +247,11 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
       },
       "System.Management": {
         "type": "Transitive",

--- a/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreNotificationPreferenceStoreTests.cs
+++ b/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreNotificationPreferenceStoreTests.cs
@@ -5,8 +5,10 @@
 // channel enabled check with default-true fallback.
 // =============================================================================
 
+using Granit.MultiTenancy;
 using Granit.Notifications.Domain;
 using Granit.Notifications.EntityFrameworkCore.Internal;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -19,7 +21,7 @@ public sealed class EfCoreNotificationPreferenceStoreTests : IDisposable
 
     public EfCoreNotificationPreferenceStoreTests()
     {
-        _store = new EfCoreNotificationPreferenceStore(_factory);
+        _store = new EfCoreNotificationPreferenceStore(_factory, Substitute.For<ICurrentTenant>());
     }
 
     public void Dispose() => _factory.Dispose();

--- a/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreNotificationSubscriptionStoreTests.cs
+++ b/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreNotificationSubscriptionStoreTests.cs
@@ -6,8 +6,10 @@
 // =============================================================================
 
 using Granit.Guids;
+using Granit.MultiTenancy;
 using Granit.Notifications.Domain;
 using Granit.Notifications.EntityFrameworkCore.Internal;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -20,7 +22,7 @@ public sealed class EfCoreNotificationSubscriptionStoreTests : IDisposable
 
     public EfCoreNotificationSubscriptionStoreTests()
     {
-        _store = new EfCoreNotificationSubscriptionStore(_factory, new SimpleGuidGenerator());
+        _store = new EfCoreNotificationSubscriptionStore(_factory, Substitute.For<ICurrentTenant>(), new SimpleGuidGenerator());
     }
 
     public void Dispose() => _factory.Dispose();

--- a/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreUserNotificationStoreTests.cs
+++ b/tests/Granit.Notifications.EntityFrameworkCore.Tests/EfCoreUserNotificationStoreTests.cs
@@ -6,9 +6,11 @@
 // =============================================================================
 
 using System.Text.Json;
+using Granit.MultiTenancy;
 using Granit.Notifications.Domain;
 using Granit.Notifications.EntityFrameworkCore.Internal;
 using Granit.QueryEngine;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -21,7 +23,7 @@ public sealed class EfCoreUserNotificationStoreTests : IDisposable
 
     public EfCoreUserNotificationStoreTests()
     {
-        _store = new EfCoreUserNotificationStore(_factory);
+        _store = new EfCoreUserNotificationStore(_factory, Substitute.For<ICurrentTenant>());
     }
 
     public void Dispose() => _factory.Dispose();

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/EfCoreSavedViewStoreTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/EfCoreSavedViewStoreTests.cs
@@ -1,7 +1,9 @@
+using Granit.MultiTenancy;
 using Granit.QueryEngine.EntityFrameworkCore.Internal;
 using Granit.QueryEngine.SavedViews;
 using Granit.QueryEngine.SavedViews.Domain;
 using Microsoft.EntityFrameworkCore;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -15,7 +17,7 @@ public sealed class EfCoreSavedViewStoreTests : IAsyncLifetime
     public ValueTask InitializeAsync()
     {
         _factory = new TestQueryEngineDbContextFactory();
-        _store = new EfCoreSavedViewStore(_factory);
+        _store = new EfCoreSavedViewStore(_factory, Substitute.For<ICurrentTenant>());
         return ValueTask.CompletedTask;
     }
 

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookDeliveryStoreTests.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookDeliveryStoreTests.cs
@@ -1,4 +1,5 @@
 using Granit.Guids;
+using Granit.MultiTenancy;
 using Granit.Timing;
 using Granit.Webhooks.Domain;
 using Granit.Webhooks.EntityFrameworkCore.Internal;
@@ -28,7 +29,7 @@ public sealed class EfWebhookDeliveryStoreTests : IAsyncDisposable
             .Options;
 
         _contextFactory = new TestWebhooksDbContextFactory(_options);
-        _sut = new EfWebhookDeliveryStore(_contextFactory, _clock, new SimpleGuidGenerator());
+        _sut = new EfWebhookDeliveryStore(_contextFactory, Substitute.For<ICurrentTenant>(), _clock, new SimpleGuidGenerator());
     }
 
     public async ValueTask DisposeAsync()
@@ -294,7 +295,7 @@ public sealed class EfWebhookDeliveryStoreDeleteTests : IDisposable
         clock.Now.Returns(_ => new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.Zero));
 
         _factory = TestWebhooksSqliteFactory.Create();
-        _sut = new EfWebhookDeliveryStore(_factory, clock, new SimpleGuidGenerator());
+        _sut = new EfWebhookDeliveryStore(_factory, Substitute.For<ICurrentTenant>(), clock, new SimpleGuidGenerator());
     }
 
     public void Dispose() => _factory.Dispose();

--- a/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookSubscriptionStoreTests.cs
+++ b/tests/Granit.Webhooks.EntityFrameworkCore.Tests/EfWebhookSubscriptionStoreTests.cs
@@ -1,4 +1,5 @@
 using Granit.Guids;
+using Granit.MultiTenancy;
 using Granit.Timing;
 using Granit.Webhooks.Abstractions;
 using Granit.Webhooks.Domain;
@@ -35,7 +36,7 @@ public sealed class EfWebhookSubscriptionStoreTests : IAsyncDisposable
         clock.Now.Returns(Now);
 
         _contextFactory = new TestWebhooksDbContextFactory(_options);
-        _sut = new EfWebhookSubscriptionStore(_contextFactory, guidGenerator, secretProtector, clock);
+        _sut = new EfWebhookSubscriptionStore(_contextFactory, Substitute.For<ICurrentTenant>(), guidGenerator, secretProtector, clock);
     }
 
     public async ValueTask DisposeAsync()


### PR DESCRIPTION
## Summary

- Add `RequireHostContextEndpointFilter` + `.AllowHostAccess(permission)` extension for defense-in-depth host admin authorization (Layer 1)
- Add `EfStoreBase.Query(db)` method that bypasses `MultiTenant` named query filter per-query via `IgnoreQueryFilters` when no tenant context is active — zero side-effects, no `AsyncLocal` mutation, background-job safe (Layer 3)
- Update all 26 `EfStoreBase` subclasses with `IMultiTenant` entities to receive `ICurrentTenant`
- Update 5 `IQueryableSource` implementations (Scheduling, Webhooks x2, AI, BlobStorage) with the same per-query bypass pattern

## Architecture

3-layer defense-in-depth:

| Layer | Component | Role |
|-------|-----------|------|
| Endpoint | `RequireHostContextEndpointFilter` | Validates host-level permission before handler |
| Authorization | `PermissionChecker` (existing) | Uses `perm:global:{role}:{permission}` in host context |
| Data | `EfStoreBase.Query(db)` | `IgnoreQueryFilters([MultiTenant])` per-query |

## Security scenarios

| Scenario | Layer 1 | Layer 2 | Layer 3 | Result |
|----------|---------|---------|---------|--------|
| Tenant with header | No-op | Perm tenant | Filter active | Own data |
| Tenant omits header, normal endpoint | — | — | `TenantId IS NULL` | Empty |
| Tenant omits header, `AllowHostAccess` | Perm host → **denied** | — | — | 403 |
| Host admin, `AllowHostAccess` | Perm host → OK | Perm global OK | Bypass query | Cross-tenant |
| Background job without tenant | — | — | No auto bypass | Safe |

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet format --verify-no-changes` — clean
- [x] Architecture tests (102 passed)
- [x] Subscription tests (109 passed)
- [x] Authorization tests (180 passed)
- [x] 9 additional EF module test suites (450+ passed)
- [ ] Step 6 (annotate endpoints with `.AllowHostAccess()`) will be done in a follow-up commit on this PR
