### PR TITLE
fix(subscriptions): add tenant ownership assertions to subscription and seat endpoints

### DIFF
--- a/src/Granit.Subscriptions.Endpoints/Endpoints/SeatEndpoints.cs
+++ b/src/Granit.Subscriptions.Endpoints/Endpoints/SeatEndpoints.cs
@@ -1,5 +1,6 @@
 using Granit.Guids;
 using Granit.Http.Idempotency.Attributes;
+using Granit.MultiTenancy;
 using Granit.Subscriptions.Domain;
 using Granit.Subscriptions.Domain.ValueObjects;
 using Granit.Subscriptions.Endpoints.Dtos;
@@ -22,6 +23,7 @@ internal static class SeatEndpoints
             .WithSummary("Returns all seat assignments for a subscription.")
             .WithDescription("Lists users assigned to seats on the specified subscription.")
             .Produces<IReadOnlyList<SeatResponse>>()
+            .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(SubscriptionsPermissions.Seats.Read);
 
@@ -31,6 +33,7 @@ internal static class SeatEndpoints
             .WithDescription("Adds a user to the subscription. Fails if the seat limit is reached.")
             .WithMetadata(new IdempotentAttribute())
             .Produces<SeatResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict)
             .RequireAuthorization(SubscriptionsPermissions.Seats.Manage);
@@ -41,6 +44,7 @@ internal static class SeatEndpoints
             .WithDescription("Removes the user's seat assignment from the subscription.")
             .WithMetadata(new IdempotentAttribute())
             .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(SubscriptionsPermissions.Seats.Manage);
 
@@ -50,12 +54,23 @@ internal static class SeatEndpoints
     private static async Task<Results<Ok<IReadOnlyList<SeatResponse>>, ProblemHttpResult>> ListSeatsAsync(
         Guid id,
         [FromServices] ISubscriptionReader reader,
+        [FromServices] ICurrentTenant currentTenant,
         CancellationToken cancellationToken)
     {
+        if (!currentTenant.IsAvailable)
+        {
+            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status400BadRequest);
+        }
+
         Subscription? sub = await reader
             .GetByIdAsync(SubscriptionId.Create(id), cancellationToken).ConfigureAwait(false);
 
         if (sub is null)
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
+        }
+
+        if (sub.TenantId != currentTenant.Id!.Value)
         {
             return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
@@ -69,14 +84,25 @@ internal static class SeatEndpoints
         SeatAssignRequest request,
         [FromServices] ISubscriptionReader reader,
         [FromServices] ISubscriptionWriter writer,
+        [FromServices] ICurrentTenant currentTenant,
         [FromServices] IGuidGenerator guidGenerator,
         [FromServices] IClock clock,
         CancellationToken cancellationToken)
     {
+        if (!currentTenant.IsAvailable)
+        {
+            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status400BadRequest);
+        }
+
         Subscription? sub = await reader
             .GetByIdAsync(SubscriptionId.Create(id), cancellationToken).ConfigureAwait(false);
 
         if (sub is null)
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
+        }
+
+        if (sub.TenantId != currentTenant.Id!.Value)
         {
             return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
@@ -102,12 +128,23 @@ internal static class SeatEndpoints
         Guid userId,
         [FromServices] ISubscriptionReader reader,
         [FromServices] ISubscriptionWriter writer,
+        [FromServices] ICurrentTenant currentTenant,
         CancellationToken cancellationToken)
     {
+        if (!currentTenant.IsAvailable)
+        {
+            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status400BadRequest);
+        }
+
         Subscription? sub = await reader
             .GetByIdAsync(SubscriptionId.Create(id), cancellationToken).ConfigureAwait(false);
 
         if (sub is null)
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
+        }
+
+        if (sub.TenantId != currentTenant.Id!.Value)
         {
             return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }

--- a/src/Granit.Subscriptions.Endpoints/Endpoints/SubscriptionEndpoints.cs
+++ b/src/Granit.Subscriptions.Endpoints/Endpoints/SubscriptionEndpoints.cs
@@ -32,6 +32,7 @@ internal static class SubscriptionEndpoints
             .WithSummary("Returns a subscription by ID.")
             .WithDescription("Returns the full subscription details including seat count and dunning status.")
             .Produces<SubscriptionResponse>()
+            .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(SubscriptionsPermissions.Subscriptions.Read);
 
@@ -61,6 +62,7 @@ internal static class SubscriptionEndpoints
             .WithDescription("Switches to a different plan. Only allowed for Active or Trial subscriptions.")
             .WithMetadata(new IdempotentAttribute())
             .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict)
             .RequireAuthorization(SubscriptionsPermissions.Subscriptions.Manage);
@@ -89,14 +91,28 @@ internal static class SubscriptionEndpoints
     private static async Task<Results<Ok<SubscriptionResponse>, ProblemHttpResult>> GetSubscriptionByIdAsync(
         Guid id,
         [FromServices] ISubscriptionReader reader,
+        [FromServices] ICurrentTenant currentTenant,
         CancellationToken cancellationToken)
     {
+        if (!currentTenant.IsAvailable)
+        {
+            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status400BadRequest);
+        }
+
         Subscription? sub = await reader
             .GetByIdAsync(SubscriptionId.Create(id), cancellationToken).ConfigureAwait(false);
 
-        return sub is null
-            ? TypedResults.Problem(statusCode: StatusCodes.Status404NotFound)
-            : TypedResults.Ok(SubscriptionResponse.FromEntity(sub));
+        if (sub is null)
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
+        }
+
+        if (sub.TenantId != currentTenant.Id!.Value)
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
+        }
+
+        return TypedResults.Ok(SubscriptionResponse.FromEntity(sub));
     }
 
     private static async Task<Results<Created<SubscriptionResponse>, ValidationProblem, ProblemHttpResult>> CreateSubscriptionAsync(
@@ -132,13 +148,24 @@ internal static class SubscriptionEndpoints
         SubscriptionCancelRequest request,
         [FromServices] ISubscriptionReader reader,
         [FromServices] ISubscriptionWriter writer,
+        [FromServices] ICurrentTenant currentTenant,
         [FromServices] IClock clock,
         CancellationToken cancellationToken)
     {
+        if (!currentTenant.IsAvailable)
+        {
+            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status400BadRequest);
+        }
+
         Subscription? sub = await reader
             .GetByIdAsync(SubscriptionId.Create(id), cancellationToken).ConfigureAwait(false);
 
         if (sub is null)
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
+        }
+
+        if (sub.TenantId != currentTenant.Id!.Value)
         {
             return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
@@ -168,12 +195,23 @@ internal static class SubscriptionEndpoints
         SubscriptionChangePlanRequest request,
         [FromServices] ISubscriptionReader reader,
         [FromServices] ISubscriptionWriter writer,
+        [FromServices] ICurrentTenant currentTenant,
         CancellationToken cancellationToken)
     {
+        if (!currentTenant.IsAvailable)
+        {
+            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status400BadRequest);
+        }
+
         Subscription? sub = await reader
             .GetByIdAsync(SubscriptionId.Create(id), cancellationToken).ConfigureAwait(false);
 
         if (sub is null)
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
+        }
+
+        if (sub.TenantId != currentTenant.Id!.Value)
         {
             return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }


### PR DESCRIPTION
## Summary

- Add `ICurrentTenant` injection and `IsAvailable` guard to `GetSubscriptionByIdAsync`, `CancelSubscriptionAsync`, and `ChangePlanAsync`
- Add `ICurrentTenant` injection and tenant ownership assertion to `ListSeatsAsync`, `AssignSeatAsync`, and `RevokeSeatAsync`
- Return 404 (not 403) on tenant mismatch to avoid tenant existence oracle

## Security

Fixes **VULN-100** (HIGH) and **VULN-101** (HIGH) — BOLA/IDOR on subscription and seat endpoints. Previously, these endpoints relied solely on ambient EF query filters for tenant isolation, which are bypassed when `ICurrentTenant.IsAvailable == false`.

## Test plan

- [ ] Verify 400 returned when tenant context is missing
- [ ] Verify 404 returned when subscription belongs to different tenant
- [ ] Verify happy path with matching tenant still works
- [ ] Run `dotnet test tests/Granit.Subscriptions.Endpoints.Tests`
