### PR TITLE
fix(subscriptions,metering): SaaS security remediation (VULN-001 + 9 findings)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -36430,6 +36430,12 @@
           "kind": "method",
           "signature": "GetActiveByPlanAsync(PlanId planId, CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyList<Subscription>>"
+        },
+        {
+          "name": "GetPastDueForTenantAsync",
+          "kind": "method",
+          "signature": "GetPastDueForTenantAsync(Guid tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<Subscription?>"
         }
       ]
     },
@@ -36782,12 +36788,12 @@
       "kind": "class",
       "project": "Granit.Subscriptions.Wolverine",
       "file": "src/Granit.Subscriptions.Wolverine/Handlers/PaymentFailedHandler.cs",
-      "line": 9,
+      "line": 11,
       "members": [
         {
           "name": "HandleAsync",
           "kind": "method",
-          "signature": "HandleAsync(PaymentFailedEto eto, IDunningService dunningService, ICurrentTenant currentTenant, CancellationToken cancellationToken)",
+          "signature": "HandleAsync(PaymentFailedEto eto, IDunningService dunningService, ICurrentTenant currentTenant, ILogger<PaymentFailedHandler> logger, CancellationToken cancellationToken)",
           "returnType": "Task"
         }
       ]

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1794,6 +1794,7 @@
         "Granit",
         "Granit.Guids",
         "Granit.Invoicing.Abstractions",
+        "Granit.Metering",
         "Granit.Scheduling",
         "Granit.Timing",
         "Granit.Workflow"
@@ -21314,6 +21315,15 @@
       ]
     },
     {
+      "name": "BillingPeriodBoundaries",
+      "fqn": "Granit.Metering.BillingPeriodBoundaries",
+      "kind": "record",
+      "project": "Granit.Metering",
+      "file": "src/Granit.Metering/IBillingPeriodProvider.cs",
+      "line": 23,
+      "members": []
+    },
+    {
       "name": "MeteringMetrics",
       "fqn": "Granit.Metering.Diagnostics.MeteringMetrics",
       "kind": "class",
@@ -21728,6 +21738,22 @@
           "kind": "method",
           "signature": "RunAsync(CancellationToken cancellationToken = default)",
           "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IBillingPeriodProvider",
+      "fqn": "Granit.Metering.IBillingPeriodProvider",
+      "kind": "interface",
+      "project": "Granit.Metering",
+      "file": "src/Granit.Metering/IBillingPeriodProvider.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "GetCurrentPeriodAsync",
+          "kind": "method",
+          "signature": "GetCurrentPeriodAsync(Guid tenantId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<BillingPeriodBoundaries?>"
         }
       ]
     },
@@ -36039,7 +36065,7 @@
       "kind": "class",
       "project": "Granit.Subscriptions",
       "file": "src/Granit.Subscriptions/Extensions/SubscriptionsHostApplicationBuilderExtensions.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitSubscriptions",
@@ -36071,7 +36097,7 @@
       "kind": "class",
       "project": "Granit.Subscriptions",
       "file": "src/Granit.Subscriptions/GranitSubscriptionsModule.cs",
-      "line": 21,
+      "line": 23,
       "members": [
         {
           "name": "ConfigureServices",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -36092,6 +36092,34 @@
       ]
     },
     {
+      "name": "SubscriptionLifecycleCacheInvalidationHandler",
+      "fqn": "Granit.Subscriptions.Features.Handlers.SubscriptionLifecycleCacheInvalidationHandler",
+      "kind": "class",
+      "project": "Granit.Subscriptions.Features",
+      "file": "src/Granit.Subscriptions.Features/Handlers/SubscriptionLifecycleCacheInvalidationHandler.cs",
+      "line": 18,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(SubscriptionSuspendedEto eto, IFeatureDefinitionStore definitionStore, IFusionCache cache, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        },
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(SubscriptionCancelledEto eto, IFeatureDefinitionStore definitionStore, IFusionCache cache, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        },
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(SubscriptionExpiredEto eto, IFeatureDefinitionStore definitionStore, IFusionCache cache, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "GranitSubscriptionsModule",
       "fqn": "Granit.Subscriptions.GranitSubscriptionsModule",
       "kind": "class",

--- a/src/Granit.Features/Granit.Features.csproj
+++ b/src/Granit.Features/Granit.Features.csproj
@@ -14,6 +14,8 @@
     <InternalsVisibleTo Include="Granit.Features.Tests" />
     <InternalsVisibleTo Include="Granit.Features.EntityFrameworkCore" />
     <InternalsVisibleTo Include="Granit.Features.EntityFrameworkCore.Tests" />
+    <!-- Subscriptions bridge needs FeatureCacheKey to invalidate per-tenant feature cache on lifecycle changes -->
+    <InternalsVisibleTo Include="Granit.Subscriptions.Features" />
     <!-- Required by NSubstitute (Castle.DynamicProxy) to mock internal interfaces in tests -->
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/EfAggregationRunner.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/EfAggregationRunner.cs
@@ -106,7 +106,15 @@ internal sealed partial class EfAggregationRunner(
 
         watermark.Advance(events[^1].Id, now);
 
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex) when (IsDuplicateKeyException(ex))
+        {
+            Log.AggregationCollisionIgnored(logger, definition.Name, ex);
+            return;
+        }
 
         metrics.RecordAggregation(
             definition.TenantId?.ToString(),
@@ -126,11 +134,45 @@ internal sealed partial class EfAggregationRunner(
             _ => events.Sum(e => e.Quantity),
         };
 
+    /// <summary>
+    /// Provider-agnostic duplicate key detection. Mirrors the implementation in
+    /// <see cref="EfMeterEventStore"/> to avoid a hard dependency between the two stores.
+    /// </summary>
+    private static bool IsDuplicateKeyException(DbUpdateException ex)
+    {
+        if (ex.InnerException is null)
+        {
+            return false;
+        }
+
+        Type innerType = ex.InnerException.GetType();
+
+        if (innerType.GetProperty("SqlState")?.GetValue(ex.InnerException) is "23505")
+        {
+            return true; // PostgreSQL unique_violation
+        }
+
+        if (innerType.GetProperty("Number")?.GetValue(ex.InnerException) is int and (2601 or 2627))
+        {
+            return true; // SQL Server unique index / unique constraint
+        }
+
+        string? message = ex.InnerException.Message;
+        return message?.Contains("duplicate key", StringComparison.OrdinalIgnoreCase) == true
+            || message?.Contains("unique constraint", StringComparison.OrdinalIgnoreCase) == true
+            || message?.Contains("UNIQUE constraint failed", StringComparison.OrdinalIgnoreCase) == true;
+    }
+
     private static partial class Log
     {
         [LoggerMessage(Level = LogLevel.Debug,
             Message = "Aggregation batch completed for meter '{MeterName}': {EventCount} events")]
         public static partial void AggregationBatchCompleted(
             ILogger logger, string meterName, int eventCount);
+
+        [LoggerMessage(Level = LogLevel.Warning,
+            Message = "Aggregation batch for meter '{MeterName}' skipped due to duplicate key collision; a concurrent runner already committed the same period.")]
+        public static partial void AggregationCollisionIgnored(
+            ILogger logger, string meterName, Exception exception);
     }
 }

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/EfAggregationRunner.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/EfAggregationRunner.cs
@@ -25,10 +25,16 @@ internal sealed partial class EfAggregationRunner(
 {
     public async Task RunAsync(CancellationToken cancellationToken = default)
     {
+        if (dataFilter is null)
+        {
+            Log.DataFilterUnavailable(logger);
+            return;
+        }
+
         // Disable tenant filter for the entire aggregation flow: the job runs
         // without tenant context and must enumerate definitions across all tenants,
         // then query each tenant's events with explicit TenantId predicates.
-        using IDisposable? _ = dataFilter?.Disable<IMultiTenant>();
+        using IDisposable? _ = dataFilter.Disable<IMultiTenant>();
 
         IReadOnlyList<MeterDefinition> definitions = await definitionReader
             .GetActiveAsync(cancellationToken).ConfigureAwait(false);
@@ -174,5 +180,9 @@ internal sealed partial class EfAggregationRunner(
             Message = "Aggregation batch for meter '{MeterName}' skipped due to duplicate key collision; a concurrent runner already committed the same period.")]
         public static partial void AggregationCollisionIgnored(
             ILogger logger, string meterName, Exception exception);
+
+        [LoggerMessage(Level = LogLevel.Warning,
+            Message = "Aggregation runner skipped: IDataFilter is not registered. Without the data filter, cross-tenant queries cannot be safely executed.")]
+        public static partial void DataFilterUnavailable(ILogger logger);
     }
 }

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/EfQuotaChecker.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/EfQuotaChecker.cs
@@ -1,19 +1,22 @@
 using Granit.Metering.Domain;
 using Granit.Metering.Domain.ValueObjects;
 using Granit.Metering.Dtos;
+using Granit.Timing;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Metering.EntityFrameworkCore.Internal;
 
 /// <summary>
 /// EF Core implementation of <see cref="IQuotaChecker"/>.
-/// Reads current billing-period usage from aggregates and quota limits
-/// from <see cref="IQuotaLimitProvider"/>.
+/// Reads current billing-period usage from hourly aggregates, scoped to the
+/// tenant's actual billing period via <see cref="IBillingPeriodProvider"/>.
 /// </summary>
 internal sealed class EfQuotaChecker(
     IDbContextFactory<MeteringDbContext> contextFactory,
     IMeterDefinitionReader definitionReader,
-    IQuotaLimitProvider quotaLimitProvider) : IQuotaChecker
+    IQuotaLimitProvider quotaLimitProvider,
+    IBillingPeriodProvider billingPeriodProvider,
+    IClock clock) : IQuotaChecker
 {
     public async Task<QuotaStatus> CheckAsync(
         Guid tenantId,
@@ -28,18 +31,24 @@ internal sealed class EfQuotaChecker(
             return QuotaStatus.Unlimited("unknown", 0);
         }
 
+        BillingPeriodBoundaries? period = await billingPeriodProvider
+            .GetCurrentPeriodAsync(tenantId, cancellationToken).ConfigureAwait(false);
+
+        DateTimeOffset now = clock.Now;
+        DateTimeOffset start = period?.Start ?? new DateTimeOffset(now.Year, now.Month, 1, 0, 0, 0, now.Offset);
+        DateTimeOffset end = period?.End ?? start.AddMonths(1);
+
         await using MeteringDbContext db = await contextFactory
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
-        UsageAggregate? currentAggregate = await db.UsageAggregates
+        decimal currentUsage = await db.UsageAggregates
             .Where(a => a.TenantId == tenantId
                 && a.MeterDefinitionId == meterId.Value
-                && a.Period == AggregationPeriod.BillingPeriod)
-            .OrderByDescending(a => a.PeriodStart)
-            .FirstOrDefaultAsync(cancellationToken)
+                && a.Period == AggregationPeriod.Hourly
+                && a.PeriodStart >= start
+                && a.PeriodEnd <= end)
+            .SumAsync(a => a.AggregatedValue, cancellationToken)
             .ConfigureAwait(false);
-
-        decimal currentUsage = currentAggregate?.AggregatedValue ?? 0;
 
         decimal? limit = await quotaLimitProvider
             .GetLimitAsync(tenantId, meterId, cancellationToken).ConfigureAwait(false);

--- a/src/Granit.Metering/Extensions/MeteringHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Metering/Extensions/MeteringHostApplicationBuilderExtensions.cs
@@ -24,6 +24,7 @@ public static class MeteringHostApplicationBuilderExtensions
 
         builder.Services.TryAddSingleton<MeteringMetrics>();
         builder.Services.TryAddSingleton<IQuotaLimitProvider, UnlimitedQuotaLimitProvider>();
+        builder.Services.TryAddScoped<IBillingPeriodProvider, CalendarMonthBillingPeriodProvider>();
         GranitActivitySourceRegistry.Register(MeteringActivitySource.Name);
 
         return builder;

--- a/src/Granit.Metering/IBillingPeriodProvider.cs
+++ b/src/Granit.Metering/IBillingPeriodProvider.cs
@@ -1,0 +1,23 @@
+namespace Granit.Metering;
+
+/// <summary>
+/// Provides billing period boundaries for quota enforcement.
+/// </summary>
+/// <remarks>
+/// The default implementation uses the current calendar month. The Subscriptions
+/// bridge overrides this with the tenant's actual subscription period so that
+/// quota resets align with the billing cycle rather than calendar boundaries.
+/// </remarks>
+public interface IBillingPeriodProvider
+{
+    /// <summary>
+    /// Returns the current billing period start and end for the given tenant,
+    /// or <c>null</c> if no active subscription exists.
+    /// </summary>
+    Task<BillingPeriodBoundaries?> GetCurrentPeriodAsync(
+        Guid tenantId,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>Billing period start and end boundaries used for quota calculations.</summary>
+public sealed record BillingPeriodBoundaries(DateTimeOffset Start, DateTimeOffset End);

--- a/src/Granit.Metering/Internal/CalendarMonthBillingPeriodProvider.cs
+++ b/src/Granit.Metering/Internal/CalendarMonthBillingPeriodProvider.cs
@@ -1,0 +1,23 @@
+using Granit.Timing;
+
+namespace Granit.Metering.Internal;
+
+/// <summary>
+/// Default <see cref="IBillingPeriodProvider"/> that returns the current calendar month.
+/// </summary>
+/// <remarks>
+/// Used when no subscription-aware provider is registered. Always returns a period
+/// so quota enforcement never fails silently due to a missing subscription.
+/// </remarks>
+internal sealed class CalendarMonthBillingPeriodProvider(IClock clock) : IBillingPeriodProvider
+{
+    public Task<BillingPeriodBoundaries?> GetCurrentPeriodAsync(
+        Guid tenantId,
+        CancellationToken cancellationToken = default)
+    {
+        DateTimeOffset now = clock.Now;
+        var start = new DateTimeOffset(now.Year, now.Month, 1, 0, 0, 0, now.Offset);
+        DateTimeOffset end = start.AddMonths(1);
+        return Task.FromResult<BillingPeriodBoundaries?>(new BillingPeriodBoundaries(start, end));
+    }
+}

--- a/src/Granit.Subscriptions.BackgroundJobs/Services/TrialExpirationScanner.cs
+++ b/src/Granit.Subscriptions.BackgroundJobs/Services/TrialExpirationScanner.cs
@@ -52,7 +52,7 @@ public sealed partial class TrialExpirationScanner(
                     {
                         int daysRemaining = (int)(sub.TrialEndsAt!.Value - now).TotalDays;
                         await messageBus.PublishAsync(
-                            new TrialExpiringEvent(sub.Id, sub.PlanId, daysRemaining)).ConfigureAwait(false);
+                            new TrialExpiringEvent(sub.Id, sub.PlanId, sub.TenantId!.Value, daysRemaining)).ConfigureAwait(false);
                         Log.TrialExpiring(logger, sub.Id, daysRemaining);
                     }
                 }

--- a/src/Granit.Subscriptions.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Subscriptions.BackgroundJobs/packages.lock.json
@@ -511,6 +511,21 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.metering": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Metering.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.metering.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -532,6 +547,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Metering": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions.Builtin/packages.lock.json
+++ b/src/Granit.Subscriptions.Builtin/packages.lock.json
@@ -55,6 +55,21 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.metering": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Metering.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.metering.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -76,6 +91,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Metering": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions.Endpoints/Dtos/SubscriptionResponse.cs
+++ b/src/Granit.Subscriptions.Endpoints/Dtos/SubscriptionResponse.cs
@@ -14,7 +14,6 @@ public sealed record SubscriptionResponse(
     bool CancelAtPeriodEnd,
     DateTimeOffset? CancelledAt,
     string? CancellationReason,
-    int DunningAttempt,
     int SeatCount,
     Guid? PlanPriceId = null)
 {
@@ -29,7 +28,6 @@ public sealed record SubscriptionResponse(
         sub.CancelAtPeriodEnd,
         sub.CancelledAt,
         sub.CancellationReason,
-        sub.DunningAttempt,
         sub.Seats.Count,
         sub.PlanPriceId);
 }

--- a/src/Granit.Subscriptions.Endpoints/Endpoints/PlanReadEndpoints.cs
+++ b/src/Granit.Subscriptions.Endpoints/Endpoints/PlanReadEndpoints.cs
@@ -2,6 +2,7 @@ using Granit.Subscriptions.Domain;
 using Granit.Subscriptions.Domain.ValueObjects;
 using Granit.Subscriptions.Endpoints.Dtos;
 using Granit.Subscriptions.Endpoints.Permissions;
+using Granit.Workflow.Domain;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -54,6 +55,11 @@ internal static class PlanReadEndpoints
             .GetByIdAsync(PlanId.Create(id), cancellationToken).ConfigureAwait(false);
 
         if (plan is null)
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
+        }
+
+        if (plan.LifecycleStatus == WorkflowLifecycleStatus.Draft)
         {
             return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }

--- a/src/Granit.Subscriptions.Endpoints/Endpoints/SeatEndpoints.cs
+++ b/src/Granit.Subscriptions.Endpoints/Endpoints/SeatEndpoints.cs
@@ -84,6 +84,7 @@ internal static class SeatEndpoints
         SeatAssignRequest request,
         [FromServices] ISubscriptionReader reader,
         [FromServices] ISubscriptionWriter writer,
+        [FromServices] IPlanReader planReader,
         [FromServices] ICurrentTenant currentTenant,
         [FromServices] IGuidGenerator guidGenerator,
         [FromServices] IClock clock,
@@ -107,10 +108,14 @@ internal static class SeatEndpoints
             return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
+        Plan? plan = await planReader
+            .GetByIdAsync(PlanId.Create(sub.PlanId.Value), cancellationToken)
+            .ConfigureAwait(false);
+
         try
         {
             var seat = SubscriptionSeat.Create(guidGenerator.Create(), request.UserId, clock.Now);
-            sub.AssignSeat(seat);
+            sub.AssignSeat(seat, plan?.SeatLimit);
             await writer.UpdateAsync(sub, cancellationToken).ConfigureAwait(false);
 
             return TypedResults.Created(

--- a/src/Granit.Subscriptions.Endpoints/packages.lock.json
+++ b/src/Granit.Subscriptions.Endpoints/packages.lock.json
@@ -95,6 +95,20 @@
           "SmartFormat": "[3.*, )"
         }
       },
+      "granit.metering": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Metering.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.metering.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine": {
         "type": "Project",
         "dependencies": {
@@ -133,6 +147,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Metering": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfSubscriptionReader.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfSubscriptionReader.cs
@@ -60,4 +60,9 @@ internal sealed class EfSubscriptionReader(
                 s.PlanId == planId &&
                 (s.Status == SubscriptionStatus.Active || s.Status == SubscriptionStatus.Trial)),
             cancellationToken);
+
+    public Task<Subscription?> GetPastDueForTenantAsync(Guid tenantId, CancellationToken cancellationToken = default) =>
+        FirstOrDefaultAsync(
+            s => s.TenantId == tenantId && s.Status == SubscriptionStatus.PastDue,
+            cancellationToken);
 }

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/SubscriptionSeatConfiguration.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/SubscriptionSeatConfiguration.cs
@@ -18,5 +18,9 @@ internal sealed class SubscriptionSeatConfiguration : IEntityTypeConfiguration<S
 
         builder.HasIndex(e => e.UserId)
             .HasDatabaseName($"ix_{GranitSubscriptionsDbProperties.DbTablePrefix}seats_user_id");
+
+        builder.HasIndex("SubscriptionId", nameof(SubscriptionSeat.UserId))
+            .IsUnique()
+            .HasDatabaseName($"ix_{GranitSubscriptionsDbProperties.DbTablePrefix}seats_subscription_user_unique");
     }
 }

--- a/src/Granit.Subscriptions.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/packages.lock.json
@@ -119,6 +119,21 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.metering": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Metering.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.metering.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.persistence": {
         "type": "Project",
         "dependencies": {
@@ -161,6 +176,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Metering": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions.Features/Handlers/SubscriptionLifecycleCacheInvalidationHandler.cs
+++ b/src/Granit.Subscriptions.Features/Handlers/SubscriptionLifecycleCacheInvalidationHandler.cs
@@ -1,0 +1,61 @@
+using Granit.Features.Cache;
+using Granit.Features.Definitions;
+using Granit.Subscriptions.Events;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Granit.Subscriptions.Features.Handlers;
+
+/// <summary>
+/// Wolverine message handler — expires all per-tenant feature cache entries when a
+/// subscription is suspended, cancelled, or expired.
+/// </summary>
+/// <remarks>
+/// Feature values are cached per (tenantId, featureName). When the subscription
+/// lifecycle changes, the resolved values may differ (e.g., downgraded plan), so
+/// stale entries must be evicted immediately. Discovered by Wolverine's handler
+/// scanning convention: non-static public class with public static HandleAsync methods.
+/// </remarks>
+public class SubscriptionLifecycleCacheInvalidationHandler
+{
+    /// <summary>Invalidates the feature cache when a subscription is suspended.</summary>
+    public static async Task HandleAsync(
+        SubscriptionSuspendedEto eto,
+        IFeatureDefinitionStore definitionStore,
+        IFusionCache cache,
+        CancellationToken cancellationToken) =>
+        await InvalidateForTenantAsync(eto.TenantId, definitionStore, cache, cancellationToken)
+            .ConfigureAwait(false);
+
+    /// <summary>Invalidates the feature cache when a subscription is cancelled.</summary>
+    public static async Task HandleAsync(
+        SubscriptionCancelledEto eto,
+        IFeatureDefinitionStore definitionStore,
+        IFusionCache cache,
+        CancellationToken cancellationToken) =>
+        await InvalidateForTenantAsync(eto.TenantId, definitionStore, cache, cancellationToken)
+            .ConfigureAwait(false);
+
+    /// <summary>Invalidates the feature cache when a subscription expires.</summary>
+    public static async Task HandleAsync(
+        SubscriptionExpiredEto eto,
+        IFeatureDefinitionStore definitionStore,
+        IFusionCache cache,
+        CancellationToken cancellationToken) =>
+        await InvalidateForTenantAsync(eto.TenantId, definitionStore, cache, cancellationToken)
+            .ConfigureAwait(false);
+
+    private static async Task InvalidateForTenantAsync(
+        Guid tenantId,
+        IFeatureDefinitionStore definitionStore,
+        IFusionCache cache,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<FeatureDefinition> definitions = definitionStore.GetAll();
+
+        foreach (FeatureDefinition definition in definitions)
+        {
+            string key = FeatureCacheKey.Build(tenantId, definition.Name);
+            await cache.ExpireAsync(key, token: cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Granit.Subscriptions.Features/packages.lock.json
+++ b/src/Granit.Subscriptions.Features/packages.lock.json
@@ -107,6 +107,21 @@
           "SmartFormat": "[3.*, )"
         }
       },
+      "granit.metering": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Metering.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.metering.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -128,6 +143,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Metering": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions.Notifications/packages.lock.json
+++ b/src/Granit.Subscriptions.Notifications/packages.lock.json
@@ -55,6 +55,21 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.metering": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Metering.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.metering.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.notifications.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -83,6 +98,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Metering": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions.Wolverine/Granit.Subscriptions.Wolverine.csproj
+++ b/src/Granit.Subscriptions.Wolverine/Granit.Subscriptions.Wolverine.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="WolverineFx" />
   </ItemGroup>
 

--- a/src/Granit.Subscriptions.Wolverine/Handlers/PaymentFailedHandler.cs
+++ b/src/Granit.Subscriptions.Wolverine/Handlers/PaymentFailedHandler.cs
@@ -1,29 +1,46 @@
 using Granit.MultiTenancy;
 using Granit.Payments.Events;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace Granit.Subscriptions.Wolverine.Handlers;
 
 /// <summary>
 /// Dunning entry point. Delegates to <see cref="IDunningService"/> for payment failure processing.
 /// </summary>
-public class PaymentFailedHandler
+public partial class PaymentFailedHandler
 {
     public static async Task HandleAsync(
         PaymentFailedEto eto,
         IDunningService dunningService,
         ICurrentTenant currentTenant,
+        ILogger<PaymentFailedHandler> logger,
         CancellationToken cancellationToken)
     {
-        using (currentTenant.Change(eto.TenantId))
+        try
         {
-            await dunningService.HandlePaymentFailureAsync(
-                eto.TenantId,
-                eto.InvoiceId,
-                eto.Amount,
-                eto.Currency,
-                eto.MethodType,
-                eto.ProviderName,
-                cancellationToken).ConfigureAwait(false);
+            using (currentTenant.Change(eto.TenantId))
+            {
+                await dunningService.HandlePaymentFailureAsync(
+                    eto.TenantId,
+                    eto.InvoiceId,
+                    eto.Amount,
+                    eto.Currency,
+                    eto.MethodType,
+                    eto.ProviderName,
+                    cancellationToken).ConfigureAwait(false);
+            }
         }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            Log.ConcurrencyConflictSkipped(logger, eto.InvoiceId, ex);
+        }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(Level = LogLevel.Warning,
+            Message = "Payment failure handler skipped due to concurrency conflict on invoice {InvoiceId}; a concurrent update already modified the subscription.")]
+        public static partial void ConcurrencyConflictSkipped(ILogger logger, Guid invoiceId, Exception exception);
     }
 }

--- a/src/Granit.Subscriptions.Wolverine/packages.lock.json
+++ b/src/Granit.Subscriptions.Wolverine/packages.lock.json
@@ -8,6 +8,18 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.6",
+        "contentHash": "eDy7bu3G+51FRC0cPtXTqUI9iAdDYl/XBQ5UguN8NFOA7QNmFvUEf36wA7PZ4ctsnxRN4t3dIvs2VKVE5H+EQQ==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.6",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.6",
+          "Microsoft.Extensions.Caching.Memory": "10.0.6",
+          "Microsoft.Extensions.Logging": "10.0.6"
+        }
+      },
       "WolverineFx": {
         "type": "Direct",
         "requested": "[5.*, )",
@@ -180,6 +192,16 @@
           "System.Composition": "9.0.0"
         }
       },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "4F+e6uxhVmyduu+Ve1INxek94adt4RAddWqykXNDnOOWQrJJ20izw/9qRpZdkLnIW9oj/3qnLWUtsv37U0xJCw=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "PIcmALdKzeSJNWmxsLDsS8XKFqiH5+9GzIM+qd3w1efYIwmO0w5304i37/SkfynctHZwkiiQjb2mkoIXU1CGZg=="
+      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "10.0.6",
@@ -251,10 +273,10 @@
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
+        "resolved": "10.0.6",
+        "contentHash": "poUvwtf92bEs8uBH3aRRs/ZgiAw+Z485EU7TtVPBt//MmD0uMPERe7+v3Ur7lpD8XgIEDL9sDoTBcW1LMG97CQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
         }
       },
       "Microsoft.Extensions.Diagnostics": {
@@ -340,12 +362,12 @@
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "BStFkd5CcnEtarlcgYDBcFzGYCuuNMzPs02wN3WBsOFoYIEmYoUdAiU+au6opzoqfTYJsMTW00AeqDdnXH2CvA==",
+        "resolved": "10.0.6",
+        "contentHash": "ZjpnbMD88IcZQE2pE9lcGv3mkH2mlApPWNh88ya1wJpcxZLp7p4aN7twI2FpawGPAsXNpmMgtKaz3o796YWKWQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection": "10.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Options": "10.0.6"
         }
       },
       "Microsoft.Extensions.Logging.Configuration": {
@@ -588,6 +610,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Metering": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/src/Granit.Subscriptions/Domain/Subscription.cs
+++ b/src/Granit.Subscriptions/Domain/Subscription.cs
@@ -302,10 +302,28 @@ public sealed class Subscription : AuditedAggregateRoot, IWorkflowStateful, IMul
 
     // ── Seat management ────────────────────────────────────────────────
 
-    /// <summary>Assigns a seat to a user.</summary>
-    public void AssignSeat(SubscriptionSeat seat)
+    /// <summary>Assigns a seat to a user. Enforces duplicate-user and seat-limit guards.</summary>
+    /// <param name="seat">The seat to assign.</param>
+    /// <param name="seatLimit">Maximum allowed seats for the plan. Null means unlimited.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the user already holds a seat or when the plan seat limit has been reached.
+    /// </exception>
+    public void AssignSeat(SubscriptionSeat seat, int? seatLimit = null)
     {
         ArgumentNullException.ThrowIfNull(seat);
+
+        if (_seats.Any(s => s.UserId == seat.UserId))
+        {
+            throw new InvalidOperationException(
+                $"User '{seat.UserId}' already has a seat on subscription '{Id}'.");
+        }
+
+        if (seatLimit.HasValue && _seats.Count >= seatLimit.Value)
+        {
+            throw new InvalidOperationException(
+                $"Subscription '{Id}' has reached the seat limit of {seatLimit.Value}.");
+        }
+
         _seats.Add(seat);
     }
 

--- a/src/Granit.Subscriptions/Events/TrialExpiringEvent.cs
+++ b/src/Granit.Subscriptions/Events/TrialExpiringEvent.cs
@@ -6,4 +6,5 @@ namespace Granit.Subscriptions.Events;
 public sealed record TrialExpiringEvent(
     Guid SubscriptionId,
     Guid PlanId,
+    Guid TenantId,
     int DaysRemaining) : IDomainEvent;

--- a/src/Granit.Subscriptions/Extensions/SubscriptionsHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Subscriptions/Extensions/SubscriptionsHostApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Diagnostics;
+using Granit.Metering;
 using Granit.Subscriptions.Definitions;
 using Granit.Subscriptions.Diagnostics;
 using Granit.Subscriptions.Internal;
@@ -35,6 +36,8 @@ public static class SubscriptionsHostApplicationBuilderExtensions
         builder.Services.TryAddTransient<ISubscriptionProviderSyncService, DefaultSubscriptionProviderSyncService>();
         builder.Services.TryAddTransient<IUsageInvoiceOrchestrator, DefaultUsageInvoiceOrchestrator>();
         builder.Services.TryAddTransient<IBillingCycleInvoiceOrchestrator, DefaultBillingCycleInvoiceOrchestrator>();
+        // Override the calendar-month default: quota must track the subscription billing period.
+        builder.Services.AddScoped<IBillingPeriodProvider, SubscriptionBillingPeriodProvider>();
         GranitActivitySourceRegistry.Register(SubscriptionsActivitySource.Name);
 
         return builder;

--- a/src/Granit.Subscriptions/Granit.Subscriptions.csproj
+++ b/src/Granit.Subscriptions/Granit.Subscriptions.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\Granit\Granit.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
     <ProjectReference Include="..\Granit.Invoicing.Abstractions\Granit.Invoicing.Abstractions.csproj" />
+    <ProjectReference Include="..\Granit.Metering\Granit.Metering.csproj" />
     <ProjectReference Include="..\Granit.Scheduling\Granit.Scheduling.csproj" />
     <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />
     <ProjectReference Include="..\Granit.Workflow\Granit.Workflow.csproj" />

--- a/src/Granit.Subscriptions/GranitSubscriptionsModule.cs
+++ b/src/Granit.Subscriptions/GranitSubscriptionsModule.cs
@@ -1,3 +1,4 @@
+using Granit.Metering;
 using Granit.Modularity;
 using Granit.Scheduling;
 using Granit.Subscriptions.Extensions;
@@ -15,6 +16,7 @@ namespace Granit.Subscriptions;
 /// a concrete <see cref="ISubscriptionProvider"/> implementation.
 /// </remarks>
 [DependsOn(
+    typeof(GranitMeteringModule),
     typeof(GranitSchedulingModule),
     typeof(GranitTimingModule),
     typeof(GranitWorkflowModule))]

--- a/src/Granit.Subscriptions/ISubscriptionReader.cs
+++ b/src/Granit.Subscriptions/ISubscriptionReader.cs
@@ -34,4 +34,7 @@ public interface ISubscriptionReader
     Task<IReadOnlyList<Subscription>> GetActiveByPlanAsync(
         PlanId planId,
         CancellationToken cancellationToken = default);
+
+    /// <summary>Returns the PastDue subscription for a tenant, or <c>null</c> if none exists.</summary>
+    Task<Subscription?> GetPastDueForTenantAsync(Guid tenantId, CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Subscriptions/Internal/DefaultSubscriptionReactivationService.cs
+++ b/src/Granit.Subscriptions/Internal/DefaultSubscriptionReactivationService.cs
@@ -11,15 +11,10 @@ internal sealed partial class DefaultSubscriptionReactivationService(
     public async Task<bool> TryReactivateAsync(Guid tenantId, CancellationToken cancellationToken = default)
     {
         Subscription? subscription = await subscriptionReader
-            .GetActiveForTenantAsync(tenantId, cancellationToken)
+            .GetPastDueForTenantAsync(tenantId, cancellationToken)
             .ConfigureAwait(false);
 
         if (subscription is null)
-        {
-            return false;
-        }
-
-        if (subscription.Status != SubscriptionStatus.PastDue)
         {
             return false;
         }

--- a/src/Granit.Subscriptions/Internal/SubscriptionBillingPeriodProvider.cs
+++ b/src/Granit.Subscriptions/Internal/SubscriptionBillingPeriodProvider.cs
@@ -1,0 +1,36 @@
+using Granit.Metering;
+using Granit.Subscriptions.Domain;
+
+namespace Granit.Subscriptions.Internal;
+
+/// <summary>
+/// <see cref="IBillingPeriodProvider"/> implementation that aligns quota enforcement
+/// with the tenant's actual subscription billing period.
+/// </summary>
+/// <remarks>
+/// Registered by <c>Granit.Subscriptions</c> to override the default calendar-month
+/// fallback from <c>Granit.Metering</c>. When no active subscription exists the method
+/// returns <c>null</c>, causing <see cref="Granit.Metering.EntityFrameworkCore"/> to
+/// fall back to the current calendar month.
+/// </remarks>
+internal sealed class SubscriptionBillingPeriodProvider(
+    ISubscriptionReader subscriptionReader) : IBillingPeriodProvider
+{
+    public async Task<BillingPeriodBoundaries?> GetCurrentPeriodAsync(
+        Guid tenantId,
+        CancellationToken cancellationToken = default)
+    {
+        Subscription? subscription = await subscriptionReader
+            .GetActiveForTenantAsync(tenantId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (subscription is null)
+        {
+            return null;
+        }
+
+        return new BillingPeriodBoundaries(
+            subscription.CurrentPeriodStart,
+            subscription.CurrentPeriodEnd);
+    }
+}

--- a/src/Granit.Subscriptions/packages.lock.json
+++ b/src/Granit.Subscriptions/packages.lock.json
@@ -68,6 +68,21 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.metering": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Metering.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.metering.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -3075,6 +3075,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Metering": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )"
@@ -3137,6 +3138,7 @@
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.Subscriptions": "[0.1.0-dev, )",
           "Granit.Wolverine": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
           "WolverineFx": "[5.*, )"
         }
       },

--- a/tests/Granit.Subscriptions.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.BackgroundJobs.Tests/packages.lock.json
@@ -705,6 +705,21 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.metering": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Metering.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.metering.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -726,6 +741,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Metering": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Builtin.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Builtin.Tests/packages.lock.json
@@ -287,6 +287,21 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.metering": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Metering.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.metering.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -308,6 +323,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Metering": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Endpoints.Tests/packages.lock.json
@@ -590,6 +590,21 @@
           "SmartFormat": "[3.*, )"
         }
       },
+      "granit.metering": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Metering.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.metering.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine": {
         "type": "Project",
         "dependencies": {
@@ -629,6 +644,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Metering": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.EntityFrameworkCore.Tests/packages.lock.json
@@ -337,6 +337,21 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.metering": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Metering.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.metering.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.persistence": {
         "type": "Project",
         "dependencies": {
@@ -379,6 +394,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Metering": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Features.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Features.Tests/packages.lock.json
@@ -339,6 +339,21 @@
           "SmartFormat": "[3.*, )"
         }
       },
+      "granit.metering": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Metering.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.metering.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -360,6 +375,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Metering": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Notifications.Tests/packages.lock.json
@@ -287,6 +287,21 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.metering": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Metering.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.metering.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.notifications.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -315,6 +330,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Metering": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Tests/packages.lock.json
@@ -287,6 +287,21 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.metering": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Metering.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.metering.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -308,6 +323,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Metering": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",

--- a/tests/Granit.Subscriptions.Wolverine.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Wolverine.Tests/packages.lock.json
@@ -245,6 +245,16 @@
         "resolved": "18.4.0",
         "contentHash": "9O0BtCfzCWrkAmK187ugKdq72HHOXoOUjuWFDVc2LsZZ0pOnA9bTt+Sg9q4cF+MoAaUU+MuWtvBuFsnduviJow=="
       },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "4F+e6uxhVmyduu+Ve1INxek94adt4RAddWqykXNDnOOWQrJJ20izw/9qRpZdkLnIW9oj/3qnLWUtsv37U0xJCw=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "PIcmALdKzeSJNWmxsLDsS8XKFqiH5+9GzIM+qd3w1efYIwmO0w5304i37/SkfynctHZwkiiQjb2mkoIXU1CGZg=="
+      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "10.0.6",
@@ -316,10 +326,10 @@
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
+        "resolved": "10.0.6",
+        "contentHash": "poUvwtf92bEs8uBH3aRRs/ZgiAw+Z485EU7TtVPBt//MmD0uMPERe7+v3Ur7lpD8XgIEDL9sDoTBcW1LMG97CQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
         }
       },
       "Microsoft.Extensions.Diagnostics": {
@@ -405,12 +415,12 @@
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "BStFkd5CcnEtarlcgYDBcFzGYCuuNMzPs02wN3WBsOFoYIEmYoUdAiU+au6opzoqfTYJsMTW00AeqDdnXH2CvA==",
+        "resolved": "10.0.6",
+        "contentHash": "ZjpnbMD88IcZQE2pE9lcGv3mkH2mlApPWNh88ya1wJpcxZLp7p4aN7twI2FpawGPAsXNpmMgtKaz3o796YWKWQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection": "10.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Options": "10.0.6"
         }
       },
       "Microsoft.Extensions.Logging.Configuration": {
@@ -782,6 +792,7 @@
           "Granit": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Invoicing.Abstractions": "[0.1.0-dev, )",
+          "Granit.Metering": "[0.1.0-dev, )",
           "Granit.Scheduling": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Granit.Workflow": "[0.1.0-dev, )",
@@ -797,6 +808,7 @@
           "Granit.Payments.Abstractions": "[0.1.0-dev, )",
           "Granit.Subscriptions": "[0.1.0-dev, )",
           "Granit.Wolverine": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
           "WolverineFx": "[5.*, )"
         }
       },
@@ -888,6 +900,18 @@
           "Microsoft.CodeAnalysis.Common": "[5.0.0]",
           "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
           "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.6",
+        "contentHash": "eDy7bu3G+51FRC0cPtXTqUI9iAdDYl/XBQ5UguN8NFOA7QNmFvUEf36wA7PZ4ctsnxRN4t3dIvs2VKVE5H+EQQ==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.6",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.6",
+          "Microsoft.Extensions.Caching.Memory": "10.0.6",
+          "Microsoft.Extensions.Logging": "10.0.6"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {


### PR DESCRIPTION
## Summary

Security remediation for 22 findings across Subscriptions + Metering modules
(PRs #981, #982, #983 already merged — this covers the remaining fixes).

- **VULN-105, VULN-201**: Enforce `Plan.SeatLimit` in `AssignSeat` + unique index on `(SubscriptionId, UserId)`
- **VULN-001** (CRITICAL): Fix non-functional quota — `EfQuotaChecker` now sums hourly aggregates via `IBillingPeriodProvider`
- **VULN-104**: Invalidate feature cache on `SubscriptionSuspendedEto` / `CancelledEto` / `ExpiredEto`
- **VULN-106**: `DefaultSubscriptionReactivationService` queries PastDue (not Active) subscriptions
- **VULN-200**: `PaymentFailedHandler` catches `DbUpdateConcurrencyException`
- **VULN-202**: `EfAggregationRunner` catches duplicate aggregate collisions
- **VULN-302**: Remove `DunningAttempt` from public `SubscriptionResponse`
- **VULN-303**: Hide Draft plans from `Plans.Read` holders
- **VULN-306**: Add `TenantId` to `TrialExpiringEvent`
- **VULN-401**: Guard null `IDataFilter` in aggregation runner

## Test plan

- [ ] `dotnet build` — zero errors
- [ ] `dotnet test` — all pass
- [ ] `dotnet format --verify-no-changes`
- [ ] Verify quota returns non-zero usage after events + aggregation
- [ ] Verify seat limit enforcement (409)
- [ ] Verify feature cache expires on subscription suspension
- [ ] Verify PastDue subscription reactivates on invoice payment
