### PR TITLE
docs(saas): update Subscriptions and Metering docs after security remediation

### DIFF
--- a/docs-site/src/content/docs/dotnet/saas/metering.mdx
+++ b/docs-site/src/content/docs/dotnet/saas/metering.mdx
@@ -88,6 +88,7 @@ UsageAggregate
 | `IQuotaChecker` | Query | `CheckAsync → QuotaStatus` |
 | `IQuotaLimitProvider` | Query | `GetLimitAsync` — returns plan limit (default: unlimited) |
 | `IAggregationRunner` | Command | `RunAsync` — aggregates pending events for all active meters |
+| `IBillingPeriodProvider` | Query | `GetCurrentPeriodAsync` — billing period boundaries for quota checks |
 
 ## Watermark-based aggregation
 
@@ -128,6 +129,28 @@ var status = await quotaChecker.CheckAsync(tenantId, meterId, ct);
 QuotaStatus.Unlimited("API Calls", 500m);           // No limit
 QuotaStatus.WithLimit("API Calls", 800m, 1000m);    // 80%, not exceeded
 ```
+
+### Billing period resolution
+
+Quota checks sum **hourly aggregates** within the current billing period.
+The period boundaries are resolved via `IBillingPeriodProvider`:
+
+```csharp
+public interface IBillingPeriodProvider
+{
+    Task<BillingPeriodBoundaries?> GetCurrentPeriodAsync(
+        Guid tenantId, CancellationToken cancellationToken = default);
+}
+```
+
+| Provider | Package | Resolution |
+|----------|---------|------------|
+| `CalendarMonthBillingPeriodProvider` | `Granit.Metering` | 1st to last day of the current month (default) |
+| `SubscriptionBillingPeriodProvider` | `Granit.Subscriptions` | `Subscription.CurrentPeriodStart` / `CurrentPeriodEnd` |
+
+When `Granit.Subscriptions` is loaded, it overrides the default with the actual
+subscription billing cycle. Without it (standalone metering), the calendar month
+is used as fallback.
 
 ### Threshold alerts
 
@@ -241,6 +264,10 @@ Table prefix: `metering_` (configurable via `GranitMeteringDbProperties.DbTableP
 | PUT | `/api/granit/metering/meters/{id}` | `Metering.Meters.Manage` |
 | GET | `/api/granit/metering/usage` | `Metering.Usage.Read` |
 | GET | `/api/granit/metering/quota/{meterId}` | `Metering.Usage.Read` |
+| POST | `/api/granit/metering/events` | `Metering.Usage.Record` |
+
+All usage endpoints require tenant context. `POST /events` validates that each
+`MeterDefinitionId` in the batch belongs to the current tenant and is active.
 
 ## See also
 

--- a/docs-site/src/content/docs/dotnet/saas/subscriptions.mdx
+++ b/docs-site/src/content/docs/dotnet/saas/subscriptions.mdx
@@ -226,17 +226,29 @@ InvoicePaidEto → InvoicePaidHandler
 Retry attempts use the **exact same provider and method type** as the original
 payment (propagated via `ProviderName` + `MethodType` in the retry chain).
 
+:::note[Concurrency safety]
+`PaymentFailedHandler` catches `DbUpdateConcurrencyException` — if two webhook
+deliveries arrive simultaneously for the same invoice, only one dunning increment
+is processed. The other is safely skipped with a warning log.
+:::
+
 ## Seat management
 
 ```csharp
-// Assign a seat
-subscription.AssignSeat(SubscriptionSeat.Create(Guid.NewGuid(), userId));
+// Assign a seat (seatLimit from the plan prevents over-allocation)
+var seat = SubscriptionSeat.Create(Guid.NewGuid(), userId, clock.Now);
+subscription.AssignSeat(seat, plan.SeatLimit);
 
 // Revoke a seat
 subscription.RevokeSeat(userId);
-
-// Seat limit enforced by Plan.SeatLimit
 ```
+
+`AssignSeat` enforces two invariants:
+
+1. **Duplicate guard** — a user cannot hold two seats on the same subscription
+   (backed by a unique DB index on `(SubscriptionId, UserId)`)
+2. **Seat limit** — when `seatLimit` is provided, the current seat count is
+   checked before adding
 
 CQRS split: `ISeatReader` (query) / `ISeatWriter` (command).
 
@@ -271,6 +283,13 @@ creation, payment retry dispatch) are internal to their respective
 `Granit.Subscriptions.Features` implements `IPlanIdProvider` and `IPlanFeatureStore`
 from `Granit.Features`. This enables automatic feature resolution per plan — existing
 feature flag cascade works without any additional configuration.
+
+### Cache invalidation on lifecycle changes
+
+When a subscription is suspended, cancelled, or expired, a Wolverine handler
+(`SubscriptionLifecycleCacheInvalidationHandler`) automatically expires **all**
+cached feature values for the affected tenant. This prevents a suspended tenant
+from retaining premium feature access through stale cache entries.
 
 ## Admin API
 


### PR DESCRIPTION
## Summary

Update SaaS module documentation to reflect the security remediation changes
from PRs #981, #982, #983, #989.

- **Subscriptions**: seat limit enforcement + duplicate guard, concurrency safety
  on dunning handler, feature cache invalidation on lifecycle changes
- **Metering**: `IBillingPeriodProvider` abstraction for quota checks, `POST /events`
  endpoint in API table, tenant validation on all usage endpoints

## Test plan

- [ ] `cd docs-site && npx astro build` — 0 errors
