### PR TITLE
docs: document host tenant bypass defense-in-depth architecture

### DIFF
--- a/docs-site/src/content/docs/dotnet/data/query-filters.mdx
+++ b/docs-site/src/content/docs/dotnet/data/query-filters.mdx
@@ -123,8 +123,72 @@ enum-to-string conversions, and JSON columns. Always use SQLite or Testcontainer
 (PostgreSQL) for tests that depend on converters or query filters.
 :::
 
+## Host admin bypass — `EfStoreBase.Query(db)`
+
+In host context (no active tenant), the `MultiTenant` filter produces
+`WHERE TenantId IS NULL` — which returns no tenant data. This is the correct
+**safe default**, but host administrators need cross-tenant visibility.
+
+`EfStoreBase` solves this with its `Query(db)` helper method:
+
+```csharp
+// Inside EfStoreBase<TEntity, TContext>
+protected IQueryable<TEntity> Query(TContext db) =>
+    _bypassTenantFilter
+        ? db.Set<TEntity>().IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+        : db.Set<TEntity>();
+```
+
+The bypass activates **only** when:
+
+1. `TEntity` implements `IMultiTenant`
+2. `ICurrentTenant.IsAvailable` is `false` (no tenant header)
+3. The subclass passes `ICurrentTenant` to the base constructor
+
+All built-in read methods (`FindByIdAsync`, `FirstOrDefaultAsync`, `ListAsync`,
+`PagedAsync`, `CountAsync`, `AnyAsync`) use `Query(db)` automatically.
+
+```csharp
+// Subclass opt-in — just pass ICurrentTenant to base
+internal sealed class EfInvoiceStore(
+    IDbContextFactory<InvoicingDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<Invoice, InvoicingDbContext>(contextFactory, currentTenant),
+      IInvoiceReader, IInvoiceWriter
+{
+    // All read methods automatically bypass MultiTenant filter in host context.
+    // Write methods (Add, Update, Delete) are unaffected — entities keep their TenantId.
+}
+```
+
+For custom queries via `ReadAsync` (raw `DbContext` access), use `Query(db)` explicitly:
+
+```csharp
+return await ReadAsync(async db =>
+    await Query(db)
+        .Include(e => e.Lines)
+        .FirstOrDefaultAsync(e => e.Id == id, ct)
+        .ConfigureAwait(false),
+    ct).ConfigureAwait(false);
+```
+
+### Defense in depth
+
+The data layer bypass is one of three security layers. See
+[Authorization — Host access](/dotnet/security/authorization/#host-admin-access)
+for the full architecture.
+
+:::tip[Per-query, not per-scope]
+Unlike `IDataFilter.Disable<IMultiTenant>()` which mutates `AsyncLocal` state for
+the entire async flow, `Query(db)` applies `IgnoreQueryFilters` **per query**.
+No side effects on other services in the same request. Background jobs are
+unaffected — they must explicitly use `IDataFilter.Disable<IMultiTenant>()` when
+cross-tenant access is needed.
+:::
+
 ## See also
 
 - [Persistence overview](./persistence/) — setup, isolated DbContext, host-owned migrations
 - [Interceptors](./interceptors/) — audit, soft delete, concurrency, events
 - [Zero-downtime migrations](./migrations/) — Expand & Contract pattern
+- [Authorization — Host access](/dotnet/security/authorization/#host-admin-access) — endpoint-level defense

--- a/docs-site/src/content/docs/dotnet/infrastructure/multi-tenancy/host-tenant.mdx
+++ b/docs-site/src/content/docs/dotnet/infrastructure/multi-tenancy/host-tenant.mdx
@@ -186,6 +186,40 @@ Schema: tenant_3fa85f6456954b5ab7d9c4f11f0b7f5e
 └── (application-specific tables)
 ```
 
+## Host admin cross-tenant access
+
+By default, host context (no `X-Tenant-Id` header) results in the `MultiTenant`
+query filter matching `TenantId IS NULL` — returning only host-level entities.
+This is a safe default, but host administrators need to see data across all tenants.
+
+Granit provides a **3-layer defense-in-depth** architecture for this:
+
+1. **Endpoint layer** — `.AllowHostAccess()` marks endpoints that support host admin.
+   Verifies the caller is authenticated.
+2. **Authorization layer** — `.RequireAuthorization(permission)` checks permissions
+   using the `perm:global:{role}:{permission}` cache key in host context.
+3. **Data layer** — `EfStoreBase.Query(db)` bypasses the `MultiTenant` named query
+   filter per-query via `IgnoreQueryFilters`, without affecting other filters.
+
+```csharp
+// Endpoint: opt-in to host admin access
+group.MapGet("/{id:guid}", GetByIdAsync)
+    .RequireAuthorization(InvoicingPermissions.Invoices.Read)
+    .AllowHostAccess();
+
+// Store: pass ICurrentTenant to EfStoreBase for automatic bypass
+internal sealed class EfInvoiceStore(
+    IDbContextFactory<InvoicingDbContext> contextFactory,
+    ICurrentTenant currentTenant)
+    : EfStoreBase<Invoice, InvoicingDbContext>(contextFactory, currentTenant),
+      IInvoiceReader, IInvoiceWriter
+{ }
+```
+
+For detailed API and security scenarios, see
+[Authorization — Host access](/dotnet/security/authorization/#host-admin-access)
+and [Query Filters — Host admin bypass](/dotnet/data/query-filters/#host-admin-bypass--efstorebasequery-db).
+
 ## See also
 
 - [Isolation Strategies](./isolation/) — the three strategies and how they interact
@@ -193,3 +227,5 @@ Schema: tenant_3fa85f6456954b5ab7d9c4f11f0b7f5e
 - [Cache Isolation](./cache/) — tenant-scoped cache keys
 - [Multi-tenancy concept](/dotnet/concepts/multi-tenancy/) — query filters, soft
   dependency rule
+- [Authorization — Host access](/dotnet/security/authorization/#host-admin-access) — endpoint-level defense
+- [Query Filters — Host bypass](/dotnet/data/query-filters/#host-admin-bypass--efstorebasequery-db) — data-level bypass

--- a/docs-site/src/content/docs/dotnet/security/authorization.mdx
+++ b/docs-site/src/content/docs/dotnet/security/authorization.mdx
@@ -266,6 +266,58 @@ in the dependency graph, it will not be found. Verify with a breakpoint in
 `DefinePermissions`.
 :::
 
+## Host admin access
+
+Multi-tenant endpoints default to **tenant-only mode**: without an `X-Tenant-Id`
+header, the `MultiTenant` query filter produces `WHERE TenantId IS NULL` — returning
+no tenant data. Host administrators need cross-tenant visibility on specific
+endpoints.
+
+### `.AllowHostAccess()` marker
+
+Chain `.AllowHostAccess()` after `.RequireAuthorization()` on endpoints that should
+support host admin access:
+
+```csharp
+group.MapGet("/{id:guid}", GetByIdAsync)
+    .WithName("GetSubscription")
+    .RequireAuthorization(SubscriptionsPermissions.Subscriptions.Read)
+    .AllowHostAccess();  // Host admin can see any tenant's subscription
+```
+
+The `RequireHostContextEndpointFilter` behind `.AllowHostAccess()` checks:
+
+- **Tenant context active** — filter is a no-op, normal tenant-scoped access
+- **No tenant context** — verifies the caller is authenticated (defense in depth)
+
+Permission checks are handled by `.RequireAuthorization()` which already calls
+`IPermissionChecker` with the contextual cache key
+`perm:global:{role}:{permission}` in host context. No need to repeat the
+permission in `.AllowHostAccess()`.
+
+### Three-layer defense
+
+| Layer | Component | Role |
+|-------|-----------|------|
+| **Endpoint** | `.AllowHostAccess()` | Authentication gate for host requests |
+| **Authorization** | `.RequireAuthorization(perm)` | Permission check (`global` scope in host context) |
+| **Data** | `EfStoreBase.Query(db)` | `IgnoreQueryFilters([MultiTenant])` per query |
+
+A tenant user who omits the `X-Tenant-Id` header gets **no data** (safe default)
+on endpoints without `.AllowHostAccess()`, and **403 Forbidden** from the
+authorization layer on endpoints with `.AllowHostAccess()` (no global permissions).
+
+### When to use
+
+Add `.AllowHostAccess()` on **read** endpoints where host administrators need
+cross-tenant visibility: GET by ID, list, and admin dashboards.
+
+Do **not** add it on:
+
+- **Tenant-only writes** — `CreateSubscription`, `AssignSeat` (require tenant context)
+- **Endpoints with explicit tenant checks** — already return 400 if `!currentTenant.IsAvailable`
+- **QueryEngine endpoints** — `IQueryableSource` implementations handle the bypass separately
+
 ## Testing authorization
 
 Mock `IPermissionChecker` in unit tests to isolate business logic from the permission system:


### PR DESCRIPTION
## Summary

- Add `EfStoreBase.Query(db)` host bypass documentation to **query-filters.mdx** — per-query pattern, opt-in via `ICurrentTenant`, custom query usage, comparison with `IDataFilter.Disable`
- Add `.AllowHostAccess()` and 3-layer defense table to **authorization.mdx** — when to use, security scenarios, guidelines
- Add cross-tenant access overview to **host-tenant.mdx** — code example, links to detailed docs

## Test plan

- [ ] `npx markdownlint-cli2` — only pre-existing MD060 table style warnings
- [ ] `cd docs-site && npx astro build` — verify no broken links in new cross-references
