### PR TITLE
fix(bff): convention cleanup from framework audit

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -7025,8 +7025,8 @@
       "fqn": "Granit.Bff.Endpoints.Extensions.BffSecurityHeadersMiddleware",
       "kind": "class",
       "project": "Granit.Bff.Endpoints",
-      "file": "src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs",
-      "line": 172,
+      "file": "src/Granit.Bff.Endpoints/Extensions/BffSecurityHeadersMiddleware.cs",
+      "line": 9,
       "members": [
         {
           "name": "InvokeAsync",

--- a/src/Granit.Bff.BackgroundJobs/Internal/ExpiredSessionCleanupService.cs
+++ b/src/Granit.Bff.BackgroundJobs/Internal/ExpiredSessionCleanupService.cs
@@ -18,6 +18,8 @@ internal sealed partial class ExpiredSessionCleanupService(
         await using BffDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken)
             .ConfigureAwait(false);
 
+        // ExecuteDeleteAsync intentional — BffSessionEntity is neither audited nor soft-deletable,
+        // so bypassing interceptors is safe and avoids loading expired rows into memory.
         int deleted = await db.Sessions
             .Where(s => s.ExpiresAt <= clock.Now)
             .ExecuteDeleteAsync(cancellationToken)

--- a/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
@@ -263,7 +263,7 @@ internal static partial class BffLoginEndpoints
             .ConfigureAwait(false);
 
         metrics.RecordLogin(null);
-        LogLoginSuccess(logger, MaskSessionId(sessionId), frontend.Name);
+        LogLoginSuccess(logger, BffSessionEndpoints.MaskSessionId(sessionId), frontend.Name);
 
         // Redirect to the original URL the user requested, or fall back to the configured post-login path
         string redirectUrl = !string.IsNullOrEmpty(pkceState.ReturnUrl)
@@ -549,9 +549,6 @@ internal static partial class BffLoginEndpoints
             return null;
         }
     }
-
-    internal static string MaskSessionId(string sessionId) =>
-        sessionId.Length > 8 ? $"{sessionId[..4]}...{sessionId[^4..]}" : "****";
 
     /// <summary>
     /// Validates a caller-supplied <c>returnUrl</c> to prevent open-redirect attacks.

--- a/src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs
@@ -164,26 +164,3 @@ public static class BffEndpointRouteBuilderExtensions
             _ => "application/octet-stream",
         };
 }
-
-/// <summary>
-/// Middleware that adds security headers to BFF login/callback endpoints
-/// (<c>X-Frame-Options: DENY</c>, <c>Content-Security-Policy: frame-ancestors 'none'</c>).
-/// </summary>
-public sealed class BffSecurityHeadersMiddleware(RequestDelegate next)
-{
-    /// <summary>Adds X-Frame-Options and CSP headers for BFF auth route paths.</summary>
-    public async Task InvokeAsync(HttpContext context)
-    {
-        string path = context.Request.Path.Value ?? string.Empty;
-
-        // Match any frontend's /bff/login or /bff/callback path
-        if (path.Contains("/bff/login", StringComparison.OrdinalIgnoreCase)
-            || path.Contains("/bff/callback", StringComparison.OrdinalIgnoreCase))
-        {
-            context.Response.Headers.XFrameOptions = "DENY";
-            context.Response.Headers.ContentSecurityPolicy = "frame-ancestors 'none'";
-        }
-
-        await next(context).ConfigureAwait(false);
-    }
-}

--- a/src/Granit.Bff.Endpoints/Extensions/BffSecurityHeadersMiddleware.cs
+++ b/src/Granit.Bff.Endpoints/Extensions/BffSecurityHeadersMiddleware.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Granit.Bff.Endpoints.Extensions;
+
+/// <summary>
+/// Middleware that adds security headers to BFF login/callback endpoints
+/// (<c>X-Frame-Options: DENY</c>, <c>Content-Security-Policy: frame-ancestors 'none'</c>).
+/// </summary>
+public sealed class BffSecurityHeadersMiddleware(RequestDelegate next)
+{
+    /// <summary>Adds X-Frame-Options and CSP headers for BFF auth route paths.</summary>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        string path = context.Request.Path.Value ?? string.Empty;
+
+        // Match any frontend's /bff/login or /bff/callback path
+        if (path.Contains("/bff/login", StringComparison.OrdinalIgnoreCase)
+            || path.Contains("/bff/callback", StringComparison.OrdinalIgnoreCase))
+        {
+            context.Response.Headers.XFrameOptions = "DENY";
+            context.Response.Headers.ContentSecurityPolicy = "frame-ancestors 'none'";
+        }
+
+        await next(context).ConfigureAwait(false);
+    }
+}

--- a/src/Granit.Bff.EntityFrameworkCore/Internal/EfCoreBffTokenStore.cs
+++ b/src/Granit.Bff.EntityFrameworkCore/Internal/EfCoreBffTokenStore.cs
@@ -103,6 +103,8 @@ internal sealed partial class EfCoreBffTokenStore(
         await using BffDbContext db = await dbContextFactory.CreateDbContextAsync(cancellationToken)
             .ConfigureAwait(false);
 
+        // ExecuteDeleteAsync intentional — BffSessionEntity is neither audited nor soft-deletable,
+        // so bypassing interceptors is safe and avoids loading the entity into memory.
         await db.Sessions
             .Where(s => s.FrontendName == frontendName && s.SessionId == sessionId)
             .ExecuteDeleteAsync(cancellationToken)

--- a/tests/Granit.Bff.Endpoints.Tests/Endpoints/BffHelperMethodTests.cs
+++ b/tests/Granit.Bff.Endpoints.Tests/Endpoints/BffHelperMethodTests.cs
@@ -142,34 +142,6 @@ public sealed class BffHelperMethodTests
         result.ShouldBeNull();
     }
 
-    // ──── MaskSessionId (BffLoginEndpoints) ────
-
-    [Fact]
-    public void MaskSessionId_Login_LongSessionId_MasksMiddlePortion()
-    {
-        string result = BffLoginEndpoints.MaskSessionId("abcdefghijklmnop");
-
-        result.ShouldStartWith("abcd");
-        result.ShouldEndWith("mnop");
-        result.ShouldContain("...");
-    }
-
-    [Fact]
-    public void MaskSessionId_Login_ShortSessionId_ReturnsFullMask()
-    {
-        string result = BffLoginEndpoints.MaskSessionId("abcd1234");
-
-        result.ShouldBe("****");
-    }
-
-    [Fact]
-    public void MaskSessionId_Login_ExactlyNineChars_MasksMiddle()
-    {
-        string result = BffLoginEndpoints.MaskSessionId("123456789");
-
-        result.ShouldBe("1234...6789");
-    }
-
     // ──── MaskSessionId (BffSessionEndpoints) ────
 
     [Fact]


### PR DESCRIPTION
## Summary

- **ExecuteDeleteAsync bypass comments**: added justification comments in `EfCoreBffTokenStore` and `ExpiredSessionCleanupService` explaining why `ExecuteDeleteAsync` is intentional (entity is neither audited nor soft-deletable)
- **BffSecurityHeadersMiddleware extracted**: moved from `BffEndpointRouteBuilderExtensions.cs` to its own file (one type per file convention)
- **MaskSessionId deduplication**: removed duplicate from `BffLoginEndpoints`, consolidated to `BffSessionEndpoints.MaskSessionId` within the Endpoints project; removed corresponding duplicate tests

## Test plan

- [x] `dotnet build` — all 5 Bff projects compile (0 errors, 0 warnings)
- [x] `dotnet test` — all 329 Bff tests pass (165 + 88 + 42 + 3 + 31)
- [x] `dotnet format --verify-no-changes` — clean