### PR TITLE
feat(bff): add token injection middleware for self-hosted deployments

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -7005,6 +7005,22 @@
       ]
     },
     {
+      "name": "BffApplicationBuilderExtensions",
+      "fqn": "Granit.Bff.Endpoints.Extensions.BffApplicationBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Bff.Endpoints",
+      "file": "src/Granit.Bff.Endpoints/Extensions/BffApplicationBuilderExtensions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "UseGranitBffTokenInjection",
+          "kind": "method",
+          "signature": "UseGranitBffTokenInjection(this IApplicationBuilder app, string pathPrefix = \"/api\")",
+          "returnType": "IApplicationBuilder"
+        }
+      ]
+    },
+    {
       "name": "BffEndpointRouteBuilderExtensions",
       "fqn": "Granit.Bff.Endpoints.Extensions.BffEndpointRouteBuilderExtensions",
       "kind": "class",
@@ -7037,12 +7053,21 @@
       ]
     },
     {
+      "name": "BffTokenInjectionMiddleware",
+      "fqn": "Granit.Bff.Endpoints.Extensions.BffTokenInjectionMiddleware",
+      "kind": "class",
+      "project": "Granit.Bff.Endpoints",
+      "file": "src/Granit.Bff.Endpoints/Extensions/BffTokenInjectionMiddleware.cs",
+      "line": 33,
+      "members": []
+    },
+    {
       "name": "GranitBffEndpointsModule",
       "fqn": "Granit.Bff.Endpoints.GranitBffEndpointsModule",
       "kind": "class",
       "project": "Granit.Bff.Endpoints",
       "file": "src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs",
-      "line": 28,
+      "line": 29,
       "members": [
         {
           "name": "ConfigureServices",
@@ -33469,6 +33494,40 @@
       ]
     },
     {
+      "name": "ReferenceDataMetrics",
+      "fqn": "Granit.ReferenceData.Diagnostics.ReferenceDataMetrics",
+      "kind": "class",
+      "project": "Granit.ReferenceData",
+      "file": "src/Granit.ReferenceData/Diagnostics/ReferenceDataMetrics.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "RecordEntryUpdated",
+          "kind": "method",
+          "signature": "RecordEntryUpdated(string? tenantId, string typeName)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordEntryDeactivated",
+          "kind": "method",
+          "signature": "RecordEntryDeactivated(string? tenantId, string typeName)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordCacheHit",
+          "kind": "method",
+          "signature": "RecordCacheHit(string? tenantId, string typeName)",
+          "returnType": "void"
+        },
+        {
+          "name": "RecordCacheMiss",
+          "kind": "method",
+          "signature": "RecordCacheMiss(string? tenantId, string typeName)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
       "name": "DynamicReferenceDataEntity",
       "fqn": "Granit.ReferenceData.Domain.DynamicReferenceDataEntity",
       "kind": "class",
@@ -33576,6 +33635,12 @@
           "returnType": "string"
         },
         {
+          "name": "LabelHi",
+          "kind": "property",
+          "signature": "string LabelHi",
+          "returnType": "string"
+        },
+        {
           "name": "Label",
           "kind": "property",
           "signature": "string Label",
@@ -33604,7 +33669,7 @@
       "kind": "record",
       "project": "Granit.ReferenceData.Endpoints",
       "file": "src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataCreateRequest.cs",
-      "line": 28,
+      "line": 29,
       "members": []
     },
     {
@@ -33613,7 +33678,7 @@
       "kind": "record",
       "project": "Granit.ReferenceData.Endpoints",
       "file": "src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataResponse.cs",
-      "line": 29,
+      "line": 30,
       "members": []
     },
     {
@@ -33622,7 +33687,7 @@
       "kind": "record",
       "project": "Granit.ReferenceData.Endpoints",
       "file": "src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataUpdateRequest.cs",
-      "line": 28,
+      "line": 29,
       "members": []
     },
     {
@@ -33695,7 +33760,7 @@
       "kind": "class",
       "project": "Granit.ReferenceData.EntityFrameworkCore",
       "file": "src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs",
-      "line": 10,
+      "line": 9,
       "members": []
     },
     {
@@ -33704,7 +33769,7 @@
       "kind": "class",
       "project": "Granit.ReferenceData.EntityFrameworkCore",
       "file": "src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ReferenceDataEfCoreServiceCollectionExtensions.cs",
-      "line": 19,
+      "line": 20,
       "members": []
     },
     {
@@ -33718,10 +33783,10 @@
     },
     {
       "name": "ReferenceDataEntityTypeConfiguration",
-      "fqn": "Granit.ReferenceData.EntityFrameworkCore.Internal.ReferenceDataEntityTypeConfiguration",
+      "fqn": "Granit.ReferenceData.EntityFrameworkCore.ReferenceDataEntityTypeConfiguration",
       "kind": "class",
       "project": "Granit.ReferenceData.EntityFrameworkCore",
-      "file": "src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataEntityTypeConfiguration.cs",
+      "file": "src/Granit.ReferenceData.EntityFrameworkCore/ReferenceDataEntityTypeConfiguration.cs",
       "line": 33,
       "members": []
     },

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -33499,7 +33499,7 @@
       "kind": "class",
       "project": "Granit.ReferenceData",
       "file": "src/Granit.ReferenceData/Diagnostics/ReferenceDataMetrics.cs",
-      "line": 9,
+      "line": 10,
       "members": [
         {
           "name": "RecordEntryUpdated",

--- a/src/Granit.Bff.Endpoints/Extensions/BffApplicationBuilderExtensions.cs
+++ b/src/Granit.Bff.Endpoints/Extensions/BffApplicationBuilderExtensions.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Builder;
+
+namespace Granit.Bff.Endpoints.Extensions;
+
+/// <summary>
+/// Extension methods for adding BFF middleware to the ASP.NET Core pipeline.
+/// </summary>
+public static class BffApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Adds the BFF token injection middleware for self-hosted deployments where the API
+    /// runs in the same process as the BFF (e.g., colocated OpenIddict + API).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Intercepts requests matching <paramref name="pathPrefix"/>, resolves the BFF frontend
+    /// from session cookies, validates CSRF on mutating methods, performs silent token refresh,
+    /// and injects an <c>Authorization</c> header. Requests without a BFF session cookie pass
+    /// through unmodified.
+    /// </para>
+    /// <para>
+    /// Place this middleware after <c>UseRewriter()</c> (if using path rewriting) and before
+    /// <c>UseAuthentication()</c>. For YARP-based deployments, use <c>Granit.Bff.Yarp</c>
+    /// instead.
+    /// </para>
+    /// </remarks>
+    /// <param name="app">The application builder.</param>
+    /// <param name="pathPrefix">Request path prefix to intercept. Default: <c>/api</c>.</param>
+    /// <returns>The application builder for chaining.</returns>
+    public static IApplicationBuilder UseGranitBffTokenInjection(
+        this IApplicationBuilder app,
+        string pathPrefix = "/api")
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        return app.UseMiddleware<BffTokenInjectionMiddleware>(pathPrefix);
+    }
+}

--- a/src/Granit.Bff.Endpoints/Extensions/BffTokenInjectionMiddleware.cs
+++ b/src/Granit.Bff.Endpoints/Extensions/BffTokenInjectionMiddleware.cs
@@ -1,0 +1,324 @@
+using System.Text.Json;
+using Granit.Bff.Diagnostics;
+using Granit.Bff.Options;
+using Granit.Oidc.ClientAuthentication;
+using Granit.Oidc.ClientAuthentication.Internal;
+using Granit.Oidc.DPoP;
+using Granit.Timing;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Bff.Endpoints.Extensions;
+
+/// <summary>
+/// ASP.NET Core middleware that injects BFF session tokens into downstream requests.
+/// Alternative to YARP-based <c>BffTokenInjectionTransform</c> for self-hosted deployments
+/// where the API runs in the same process as the BFF.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Intercepts requests matching a configurable path prefix (default: <c>/api</c>),
+/// resolves the BFF frontend from session cookies, validates CSRF on mutating methods,
+/// performs silent token refresh when near expiry, and injects an
+/// <c>Authorization</c> header. Includes sliding session extension and metrics.
+/// </para>
+/// <para>
+/// Requests without a BFF session cookie pass through unmodified, allowing the API
+/// to accept other authentication methods (JWT bearer, API keys).
+/// </para>
+/// </remarks>
+#pragma warning disable GRSEC003 // Middleware handles tokens — server-side only
+public sealed partial class BffTokenInjectionMiddleware
+{
+    private static readonly HashSet<string> MutatingMethods = new(StringComparer.OrdinalIgnoreCase)
+    {
+        HttpMethods.Post, HttpMethods.Put, HttpMethods.Delete, HttpMethods.Patch,
+    };
+
+    private readonly RequestDelegate _next;
+    private readonly PathString _pathPrefix;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="BffTokenInjectionMiddleware"/>.
+    /// </summary>
+    /// <param name="next">The next middleware in the pipeline.</param>
+    /// <param name="pathPrefix">Request path prefix to intercept (e.g. <c>/api</c>).</param>
+    public BffTokenInjectionMiddleware(RequestDelegate next, string pathPrefix)
+    {
+        _next = next;
+        _pathPrefix = new PathString(pathPrefix);
+    }
+
+    /// <summary>Processes an HTTP request.</summary>
+    public async Task InvokeAsync(
+        HttpContext context,
+        IOptions<GranitBffOptions> options,
+        IBffTokenStore tokenStore,
+        IBffCsrfTokenGenerator csrfGenerator,
+        BffMetrics metrics,
+        IClock clock,
+        ILogger<BffTokenInjectionMiddleware> logger)
+    {
+        if (!context.Request.Path.StartsWithSegments(_pathPrefix))
+        {
+            await _next(context).ConfigureAwait(false);
+            return;
+        }
+
+        GranitBffOptions bffOptions = options.Value;
+
+        // Resolve frontend from session cookies
+        (BffFrontendOptions? frontend, string? sessionId) = ResolveFrontendFromCookies(context, bffOptions);
+
+        if (frontend is null || string.IsNullOrEmpty(sessionId))
+        {
+            // No BFF session — continue without injection (API may accept other auth methods)
+            await _next(context).ConfigureAwait(false);
+            return;
+        }
+
+        using System.Diagnostics.Activity? activity = BffActivitySource.Source.StartActivity(BffActivitySource.Proxy);
+        metrics.RecordProxyRequest(null);
+
+        // CSRF validation on mutating methods
+        if (MutatingMethods.Contains(context.Request.Method))
+        {
+            string? csrfToken = context.Request.Headers["X-CSRF-Token"].FirstOrDefault();
+            if (string.IsNullOrEmpty(csrfToken) || !csrfGenerator.Validate(sessionId, csrfToken))
+            {
+                LogCsrfRejection(logger, context.Request.Method, context.Request.Path, frontend.Name);
+                metrics.RecordCsrfRejection(null);
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                return;
+            }
+        }
+
+        // Load tokens
+        BffTokenSet? tokens = await tokenStore.GetAsync(frontend.Name, sessionId, context.RequestAborted)
+            .ConfigureAwait(false);
+
+        if (tokens is null)
+        {
+            LogExpiredSession(logger, MaskSessionId(sessionId), frontend.Name);
+            metrics.RecordProxyError(null, "expired_session");
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            return;
+        }
+
+        // Silent refresh if near expiry
+        if (tokens.RefreshToken is not null
+            && tokens.ExpiresAt - clock.Now < bffOptions.RefreshGracePeriod)
+        {
+            BffTokenSet? refreshed = await TryRefreshTokensAsync(
+                context, bffOptions, frontend, tokens, clock, logger)
+                .ConfigureAwait(false);
+
+            if (refreshed is not null)
+            {
+                tokens = refreshed;
+                await tokenStore.StoreAsync(frontend.Name, sessionId, tokens, context.RequestAborted)
+                    .ConfigureAwait(false);
+                metrics.RecordTokenRefresh(null);
+                LogTokenRefreshed(logger, MaskSessionId(sessionId), frontend.Name);
+                context.Response.Headers["X-Bff-Session-Refreshed"] = "true";
+            }
+            else
+            {
+                LogTokenRefreshFailed(logger, MaskSessionId(sessionId), frontend.Name);
+                metrics.RecordProxyError(null, "refresh_failed");
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                return;
+            }
+        }
+
+        // Inject Authorization header
+        InjectAuthorizationHeader(context, tokens);
+
+        // Extend sliding session
+        await ExtendSlidingSessionAsync(
+            bffOptions, frontend, sessionId, tokens, tokenStore, clock, context.RequestAborted)
+            .ConfigureAwait(false);
+
+        await _next(context).ConfigureAwait(false);
+    }
+
+    private static (BffFrontendOptions? Frontend, string? SessionId) ResolveFrontendFromCookies(
+        HttpContext context, GranitBffOptions options)
+    {
+        foreach (BffFrontendOptions frontend in options.Frontends)
+        {
+            string? sessionId = context.Request.Cookies[frontend.SessionCookieName];
+            if (!string.IsNullOrEmpty(sessionId))
+            {
+                return (frontend, sessionId);
+            }
+        }
+
+        return (null, null);
+    }
+
+    private static void InjectAuthorizationHeader(HttpContext context, BffTokenSet tokens)
+    {
+        if (!string.IsNullOrEmpty(tokens.DPoPPrivateKeyJwk))
+        {
+            IDPoPProofService dpopService = context.RequestServices.GetRequiredService<IDPoPProofService>();
+            string targetUri = $"{context.Request.Scheme}://{context.Request.Host}{context.Request.Path}";
+            string dpopProof = dpopService.CreateProof(
+                tokens.DPoPPrivateKeyJwk, context.Request.Method, targetUri, tokens.DPoPNonce);
+
+            context.Request.Headers.Authorization = $"DPoP {tokens.AccessToken}";
+            context.Request.Headers.Append("DPoP", dpopProof);
+        }
+        else
+        {
+            context.Request.Headers.Authorization = $"Bearer {tokens.AccessToken}";
+        }
+    }
+
+    private static async Task ExtendSlidingSessionAsync(
+        GranitBffOptions bffOptions,
+        BffFrontendOptions frontend,
+        string sessionId,
+        BffTokenSet tokens,
+        IBffTokenStore tokenStore,
+        IClock clock,
+        CancellationToken cancellationToken)
+    {
+        if (!bffOptions.UseSessionSlidingExpiration)
+        {
+            return;
+        }
+
+        DateTimeOffset now = clock.Now;
+        DateTimeOffset halfwayPoint = tokens.SessionCreatedAt + (bffOptions.SessionDuration / 2);
+        DateTimeOffset absoluteMax = tokens.SessionCreatedAt + bffOptions.SessionAbsoluteMaxDuration;
+
+        if (now >= halfwayPoint && now < absoluteMax)
+        {
+            await tokenStore.StoreAsync(frontend.Name, sessionId, tokens, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private static async Task<BffTokenSet?> TryRefreshTokensAsync(
+        HttpContext context,
+        GranitBffOptions bffOptions,
+        BffFrontendOptions frontend,
+        BffTokenSet currentTokens,
+        IClock clock,
+        ILogger logger)
+    {
+        try
+        {
+            IHttpClientFactory httpClientFactory = context.RequestServices.GetRequiredService<IHttpClientFactory>();
+            IDPoPProofService dpopService = context.RequestServices.GetRequiredService<IDPoPProofService>();
+
+            using HttpClient httpClient = httpClientFactory.CreateClient("Granit.Bff");
+            string tokenEndpoint = $"{bffOptions.Authority.ToString().TrimEnd('/')}/connect/token";
+
+            Dictionary<string, string> parameters = new()
+            {
+                ["grant_type"] = "refresh_token",
+                ["refresh_token"] = currentTokens.RefreshToken!,
+                ["client_id"] = frontend.ClientId,
+            };
+
+            ResolveClientAuth(frontend, clock).Apply(parameters, frontend.ClientId, tokenEndpoint);
+
+            using FormUrlEncodedContent content = new(parameters);
+            using var request = new HttpRequestMessage(HttpMethod.Post, tokenEndpoint) { Content = content };
+
+            if (!string.IsNullOrEmpty(currentTokens.DPoPPrivateKeyJwk))
+            {
+                string dpopProof = dpopService.CreateProof(
+                    currentTokens.DPoPPrivateKeyJwk, "POST", tokenEndpoint, currentTokens.DPoPNonce);
+                request.Headers.TryAddWithoutValidation("DPoP", dpopProof);
+            }
+
+            using HttpResponseMessage response = await httpClient
+                .SendAsync(request, context.RequestAborted)
+                .ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return null;
+            }
+
+            string? dpopNonce = currentTokens.DPoPNonce;
+            if (response.Headers.TryGetValues("DPoP-Nonce", out IEnumerable<string>? nonceValues))
+            {
+                dpopNonce = nonceValues.FirstOrDefault() ?? dpopNonce;
+            }
+
+            using Stream stream = await response.Content.ReadAsStreamAsync(context.RequestAborted)
+                .ConfigureAwait(false);
+
+            JsonElement tokenResponse = await JsonSerializer.DeserializeAsync<JsonElement>(
+                stream, cancellationToken: context.RequestAborted)
+                .ConfigureAwait(false);
+
+            string accessToken = tokenResponse.GetProperty("access_token").GetString()!;
+            string? newRefreshToken = tokenResponse.TryGetProperty("refresh_token", out JsonElement rt)
+                ? rt.GetString() : currentTokens.RefreshToken;
+            string? idToken = tokenResponse.TryGetProperty("id_token", out JsonElement it)
+                ? it.GetString() : null;
+            int expiresIn = tokenResponse.TryGetProperty("expires_in", out JsonElement ei)
+                ? ei.GetInt32() : 3600;
+
+            return new BffTokenSet(
+                accessToken,
+                newRefreshToken,
+                idToken,
+                clock.Now.AddSeconds(expiresIn))
+            {
+                DPoPPrivateKeyJwk = currentTokens.DPoPPrivateKeyJwk,
+                DPoPNonce = dpopNonce,
+                SessionCreatedAt = currentTokens.SessionCreatedAt,
+                UserId = currentTokens.UserId,
+                UserAgent = currentTokens.UserAgent,
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            LogTokenRefreshException(logger, ex, frontend.Name);
+            return null;
+        }
+    }
+
+    private static IClientAuthenticationStrategy ResolveClientAuth(BffFrontendOptions frontend, IClock clock) =>
+        frontend.ClientAuthenticationMethod == BffClientAuthenticationMethod.PrivateKeyJwt
+            ? new PrivateKeyJwtStrategy(frontend.ClientSigningKeyJwk!, clock)
+            : new ClientSecretPostStrategy(frontend.ClientSecret);
+
+    private static string MaskSessionId(string sessionId) =>
+        sessionId.Length > 8 ? $"{sessionId[..4]}...{sessionId[^4..]}" : "****";
+
+    // ──── Source-generated log messages ────
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "BFF middleware: CSRF validation failed for {Method} {Path} on frontend {FrontendName}")]
+    private static partial void LogCsrfRejection(ILogger logger, string method, string path, string frontendName);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "BFF middleware: session {SessionId} expired or not found for frontend {FrontendName}")]
+    private static partial void LogExpiredSession(ILogger logger, string sessionId, string frontendName);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "BFF middleware: token refreshed for session {SessionId} on frontend {FrontendName}")]
+    private static partial void LogTokenRefreshed(ILogger logger, string sessionId, string frontendName);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "BFF middleware: token refresh failed for session {SessionId} on frontend {FrontendName}")]
+    private static partial void LogTokenRefreshFailed(ILogger logger, string sessionId, string frontendName);
+
+    [LoggerMessage(Level = LogLevel.Error,
+        Message = "BFF middleware: token refresh failed with exception for frontend {FrontendName}")]
+    private static partial void LogTokenRefreshException(ILogger logger, Exception exception, string frontendName);
+}
+#pragma warning restore GRSEC003

--- a/src/Granit.Bff.Endpoints/Extensions/BffTokenInjectionMiddleware.cs
+++ b/src/Granit.Bff.Endpoints/Extensions/BffTokenInjectionMiddleware.cs
@@ -306,16 +306,16 @@ public sealed partial class BffTokenInjectionMiddleware
     private static partial void LogCsrfRejection(ILogger logger, string method, string path, string frontendName);
 
     [LoggerMessage(Level = LogLevel.Warning,
-        Message = "BFF middleware: session {MaskedSession} expired or not found for frontend {FrontendName}")]
-    private static partial void LogExpiredSession(ILogger logger, string maskedSession, string frontendName);
+        Message = "BFF middleware: session {SessionId} expired or not found for frontend {FrontendName}")]
+    private static partial void LogExpiredSession(ILogger logger, string sessionId, string frontendName);
 
     [LoggerMessage(Level = LogLevel.Information,
-        Message = "BFF middleware: token refreshed for session {MaskedSession} on frontend {FrontendName}")]
-    private static partial void LogTokenRefreshed(ILogger logger, string maskedSession, string frontendName);
+        Message = "BFF middleware: token refreshed for session {SessionId} on frontend {FrontendName}")]
+    private static partial void LogTokenRefreshed(ILogger logger, string sessionId, string frontendName);
 
     [LoggerMessage(Level = LogLevel.Warning,
-        Message = "BFF middleware: token refresh failed for session {MaskedSession} on frontend {FrontendName}")]
-    private static partial void LogTokenRefreshFailed(ILogger logger, string maskedSession, string frontendName);
+        Message = "BFF middleware: token refresh failed for session {SessionId} on frontend {FrontendName}")]
+    private static partial void LogTokenRefreshFailed(ILogger logger, string sessionId, string frontendName);
 
     [LoggerMessage(Level = LogLevel.Error,
         Message = "BFF middleware: token refresh failed with exception for frontend {FrontendName}")]

--- a/src/Granit.Bff.Endpoints/Extensions/BffTokenInjectionMiddleware.cs
+++ b/src/Granit.Bff.Endpoints/Extensions/BffTokenInjectionMiddleware.cs
@@ -306,16 +306,16 @@ public sealed partial class BffTokenInjectionMiddleware
     private static partial void LogCsrfRejection(ILogger logger, string method, string path, string frontendName);
 
     [LoggerMessage(Level = LogLevel.Warning,
-        Message = "BFF middleware: session {SessionId} expired or not found for frontend {FrontendName}")]
-    private static partial void LogExpiredSession(ILogger logger, string sessionId, string frontendName);
+        Message = "BFF middleware: session {MaskedSession} expired or not found for frontend {FrontendName}")]
+    private static partial void LogExpiredSession(ILogger logger, string maskedSession, string frontendName);
 
     [LoggerMessage(Level = LogLevel.Information,
-        Message = "BFF middleware: token refreshed for session {SessionId} on frontend {FrontendName}")]
-    private static partial void LogTokenRefreshed(ILogger logger, string sessionId, string frontendName);
+        Message = "BFF middleware: token refreshed for session {MaskedSession} on frontend {FrontendName}")]
+    private static partial void LogTokenRefreshed(ILogger logger, string maskedSession, string frontendName);
 
     [LoggerMessage(Level = LogLevel.Warning,
-        Message = "BFF middleware: token refresh failed for session {SessionId} on frontend {FrontendName}")]
-    private static partial void LogTokenRefreshFailed(ILogger logger, string sessionId, string frontendName);
+        Message = "BFF middleware: token refresh failed for session {MaskedSession} on frontend {FrontendName}")]
+    private static partial void LogTokenRefreshFailed(ILogger logger, string maskedSession, string frontendName);
 
     [LoggerMessage(Level = LogLevel.Error,
         Message = "BFF middleware: token refresh failed with exception for frontend {FrontendName}")]

--- a/src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs
+++ b/src/Granit.Bff.Endpoints/GranitBffEndpointsModule.cs
@@ -5,6 +5,7 @@ using Granit.Http.ApiDocumentation;
 using Granit.Http.Cookies;
 using Granit.Modularity;
 using Granit.Validation;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -30,6 +31,12 @@ public sealed class GranitBffEndpointsModule : GranitModule
     /// <inheritdoc/>
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        // Auto-bind BFF options from the "Bff" configuration section so consumers
+        // don't need to call Configure<GranitBffOptions> manually. Idempotent if
+        // AddGranitBffYarp also binds from the same section.
+        context.Services.Configure<GranitBffOptions>(
+            context.Builder!.Configuration.GetSection(GranitBffOptions.SectionName));
+
         context.Services.TryAddScoped<IBffLogoutOrchestrator, DefaultBffLogoutOrchestrator>();
 
         bool isDevelopment = context.Builder!.Environment.IsDevelopment();

--- a/src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataCreateRequest.cs
+++ b/src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataCreateRequest.cs
@@ -20,6 +20,7 @@ namespace Granit.ReferenceData.Endpoints.Dtos;
 /// <param name="LabelKo">Korean display label.</param>
 /// <param name="LabelSv">Swedish display label.</param>
 /// <param name="LabelCs">Czech display label.</param>
+/// <param name="LabelHi">Hindi display label.</param>
 /// <param name="SortOrder">Display order (lower values first).</param>
 /// <param name="ValidFrom">Optional start of validity period.</param>
 /// <param name="ValidTo">Optional end of validity period.</param>
@@ -41,6 +42,7 @@ public sealed record ReferenceDataCreateRequest(
     string LabelKo = "",
     string LabelSv = "",
     string LabelCs = "",
+    string LabelHi = "",
     int SortOrder = 0,
     DateTimeOffset? ValidFrom = null,
     DateTimeOffset? ValidTo = null,

--- a/src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataResponse.cs
+++ b/src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataResponse.cs
@@ -20,6 +20,7 @@ namespace Granit.ReferenceData.Endpoints.Dtos;
 /// <param name="LabelKo">Korean display label.</param>
 /// <param name="LabelSv">Swedish display label.</param>
 /// <param name="LabelCs">Czech display label.</param>
+/// <param name="LabelHi">Hindi display label.</param>
 /// <param name="IsActive">Whether the entry is active.</param>
 /// <param name="SortOrder">Display order (lower values first).</param>
 /// <param name="ValidFrom">Optional start of validity period.</param>
@@ -44,6 +45,7 @@ public sealed record ReferenceDataResponse(
     string LabelKo,
     string LabelSv,
     string LabelCs,
+    string LabelHi,
     bool IsActive,
     int SortOrder,
     DateTimeOffset? ValidFrom,

--- a/src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataUpdateRequest.cs
+++ b/src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataUpdateRequest.cs
@@ -19,6 +19,7 @@ namespace Granit.ReferenceData.Endpoints.Dtos;
 /// <param name="LabelKo">Updated Korean display label.</param>
 /// <param name="LabelSv">Updated Swedish display label.</param>
 /// <param name="LabelCs">Updated Czech display label.</param>
+/// <param name="LabelHi">Updated Hindi display label.</param>
 /// <param name="SortOrder">Updated display order.</param>
 /// <param name="IsActive">Updated active status.</param>
 /// <param name="ValidFrom">Updated start of validity period.</param>
@@ -40,6 +41,7 @@ public sealed record ReferenceDataUpdateRequest(
     string LabelKo = "",
     string LabelSv = "",
     string LabelCs = "",
+    string LabelHi = "",
     int SortOrder = 0,
     bool IsActive = true,
     DateTimeOffset? ValidFrom = null,

--- a/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataAdminEndpoints.cs
+++ b/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataAdminEndpoints.cs
@@ -88,6 +88,7 @@ internal static class ReferenceDataAdminEndpoints
             LabelKo = request.LabelKo,
             LabelSv = request.LabelSv,
             LabelCs = request.LabelCs,
+            LabelHi = request.LabelHi,
             SortOrder = request.SortOrder,
             ValidFrom = request.ValidFrom,
             ValidTo = request.ValidTo,
@@ -136,6 +137,7 @@ internal static class ReferenceDataAdminEndpoints
         existing.LabelKo = request.LabelKo;
         existing.LabelSv = request.LabelSv;
         existing.LabelCs = request.LabelCs;
+        existing.LabelHi = request.LabelHi;
         existing.SortOrder = request.SortOrder;
         existing.IsActive = request.IsActive;
         existing.ValidFrom = request.ValidFrom;

--- a/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataDynamicEndpoints.cs
+++ b/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataDynamicEndpoints.cs
@@ -211,6 +211,7 @@ internal static class ReferenceDataDynamicEndpoints
             LabelKo = request.LabelKo,
             LabelSv = request.LabelSv,
             LabelCs = request.LabelCs,
+            LabelHi = request.LabelHi,
             SortOrder = request.SortOrder,
             ValidFrom = request.ValidFrom,
             ValidTo = request.ValidTo,
@@ -264,6 +265,7 @@ internal static class ReferenceDataDynamicEndpoints
         existing.LabelKo = request.LabelKo;
         existing.LabelSv = request.LabelSv;
         existing.LabelCs = request.LabelCs;
+        existing.LabelHi = request.LabelHi;
         existing.SortOrder = request.SortOrder;
         existing.IsActive = request.IsActive;
         existing.ValidFrom = request.ValidFrom;

--- a/src/Granit.ReferenceData.Endpoints/Internal/ReferenceDataMapper.cs
+++ b/src/Granit.ReferenceData.Endpoints/Internal/ReferenceDataMapper.cs
@@ -33,6 +33,7 @@ internal static class ReferenceDataMapper
             entity.LabelKo,
             entity.LabelSv,
             entity.LabelCs,
+            entity.LabelHi,
             entity.IsActive,
             entity.SortOrder,
             entity.ValidFrom,

--- a/src/Granit.ReferenceData.Endpoints/Internal/ReferenceDataScopeMetadata.cs
+++ b/src/Granit.ReferenceData.Endpoints/Internal/ReferenceDataScopeMetadata.cs
@@ -1,9 +1,0 @@
-using Granit.ReferenceData.Domain;
-
-namespace Granit.ReferenceData.Endpoints.Internal;
-
-/// <summary>
-/// Endpoint metadata that stores the reference data scope for tenant context enforcement.
-/// </summary>
-/// <param name="Scope">The multi-tenancy scope declared for this reference data type.</param>
-internal sealed record ReferenceDataScopeMetadata(ReferenceDataScope Scope);

--- a/src/Granit.ReferenceData.Endpoints/Validators/ReferenceDataMutableFieldsValidator.cs
+++ b/src/Granit.ReferenceData.Endpoints/Validators/ReferenceDataMutableFieldsValidator.cs
@@ -45,6 +45,7 @@ internal sealed class ReferenceDataMutableFieldsValidator<T> : GranitValidator<T
         RuleFor(x => x.LabelKo).MaximumLength(MaxLabelLength);
         RuleFor(x => x.LabelSv).MaximumLength(MaxLabelLength);
         RuleFor(x => x.LabelCs).MaximumLength(MaxLabelLength);
+        RuleFor(x => x.LabelHi).MaximumLength(MaxLabelLength);
 
         RuleFor(x => x.SortOrder)
             .GreaterThanOrEqualTo(0);

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -1,5 +1,4 @@
 using Granit.ReferenceData.Domain;
-using Granit.ReferenceData.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.ReferenceData.EntityFrameworkCore.Extensions;

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ReferenceDataEfCoreServiceCollectionExtensions.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ReferenceDataEfCoreServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Guids;
 using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore.DataSeeding;
 using Granit.Persistence.EntityFrameworkCore.ExtraProperties;
@@ -43,7 +44,8 @@ public static class ReferenceDataEfCoreServiceCollectionExtensions
                 sp.GetRequiredService<IFusionCache>(),
                 sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<ReferenceDataOptions>>(),
                 scope,
-                sp.GetRequiredService<ICurrentTenant>()));
+                sp.GetRequiredService<ICurrentTenant>(),
+                sp.GetRequiredService<IGuidGenerator>()));
         services.AddScoped<IReferenceDataStoreReader<TEntity>>(sp =>
             sp.GetRequiredService<EfCoreReferenceDataStore<TEntity, TDbContext>>());
         services.AddScoped<IReferenceDataStoreWriter<TEntity>>(sp =>
@@ -156,7 +158,8 @@ public static class ReferenceDataEfCoreServiceCollectionExtensions
                     sp.GetRequiredService<IFusionCache>(),
                     sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<ReferenceDataOptions>>(),
                     registrationScope,
-                    sp.GetRequiredService<ICurrentTenant>()));
+                    sp.GetRequiredService<ICurrentTenant>(),
+                    sp.GetRequiredService<IGuidGenerator>()));
 
             services.AddKeyedScoped<IReferenceDataStoreWriter<DynamicReferenceDataEntity>>(
                 registration.TypeName,
@@ -165,7 +168,8 @@ public static class ReferenceDataEfCoreServiceCollectionExtensions
                     sp.GetRequiredService<IFusionCache>(),
                     sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<ReferenceDataOptions>>(),
                     registrationScope,
-                    sp.GetRequiredService<ICurrentTenant>()));
+                    sp.GetRequiredService<ICurrentTenant>(),
+                    sp.GetRequiredService<IGuidGenerator>()));
 
             // 2. Register ExtraProperty mappings for shadow columns
             if (registration.Options.PropertyMappings.Count > 0)

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Internal/EfCoreReferenceDataStore.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Internal/EfCoreReferenceDataStore.cs
@@ -1,3 +1,4 @@
+using Granit.Guids;
 using Granit.MultiTenancy;
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.QueryEngine;
@@ -38,7 +39,8 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
     IFusionCache cache,
     IOptions<ReferenceDataOptions> options,
     ReferenceDataScope scope,
-    ICurrentTenant currentTenant) : IReferenceDataStoreReader<TEntity>, IReferenceDataStoreWriter<TEntity>
+    ICurrentTenant currentTenant,
+    IGuidGenerator guidGenerator) : IReferenceDataStoreReader<TEntity>, IReferenceDataStoreWriter<TEntity>
     where TEntity : ReferenceDataEntity
     where TDbContext : DbContext
 {
@@ -49,6 +51,7 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
     private readonly ReferenceDataOptions _options = options.Value;
     private readonly ReferenceDataScope _scope = scope;
     private readonly ICurrentTenant _currentTenant = currentTenant;
+    private readonly IGuidGenerator _guidGenerator = guidGenerator;
 
     private string AllCacheKey => _scope == ReferenceDataScope.Global
         ? $"refdata:{EntityName}:host:all"
@@ -106,7 +109,8 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
                 EF.Functions.Like(e.LabelTr, $"%{term}%") ||
                 EF.Functions.Like(e.LabelKo, $"%{term}%") ||
                 EF.Functions.Like(e.LabelSv, $"%{term}%") ||
-                EF.Functions.Like(e.LabelCs, $"%{term}%"));
+                EF.Functions.Like(e.LabelCs, $"%{term}%") ||
+                EF.Functions.Like(e.LabelHi, $"%{term}%"));
         }
 
         // Total count before pagination
@@ -177,6 +181,12 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
     /// <inheritdoc/>
     public async Task CreateAsync(TEntity entity, CancellationToken cancellationToken = default)
     {
+        // Ensure a sequential GUID is assigned when callers (e.g. seeders) don't set one.
+        if (entity.Id == Guid.Empty)
+        {
+            entity.Id = _guidGenerator.Create();
+        }
+
         // For Global scope, neutralize the tenant context so that AuditedEntityInterceptor
         // does not auto-inject a TenantId. TenantId must remain null for global entries.
         using IDisposable? tenantOverride = _scope == ReferenceDataScope.Global

--- a/src/Granit.ReferenceData.EntityFrameworkCore/ReferenceDataEntityTypeConfiguration.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/ReferenceDataEntityTypeConfiguration.cs
@@ -2,7 +2,7 @@ using Granit.ReferenceData.Domain;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace Granit.ReferenceData.EntityFrameworkCore.Internal;
+namespace Granit.ReferenceData.EntityFrameworkCore;
 
 /// <summary>
 /// Base EF Core Fluent API configuration for reference data entities.
@@ -88,7 +88,7 @@ public abstract class ReferenceDataEntityTypeConfiguration<TEntity>
                .HasMaxLength(250)
                .IsRequired();
 
-        // Translation labels (13 supported locales besides English)
+        // Translation labels (14 supported locales besides English)
         builder.Property(e => e.LabelFr).HasMaxLength(250);
         builder.Property(e => e.LabelNl).HasMaxLength(250);
         builder.Property(e => e.LabelDe).HasMaxLength(250);
@@ -102,6 +102,7 @@ public abstract class ReferenceDataEntityTypeConfiguration<TEntity>
         builder.Property(e => e.LabelKo).HasMaxLength(250);
         builder.Property(e => e.LabelSv).HasMaxLength(250);
         builder.Property(e => e.LabelCs).HasMaxLength(250);
+        builder.Property(e => e.LabelHi).HasMaxLength(250);
 
         // IsActive — indexed for global query filter performance
         builder.HasIndex(e => e.IsActive)

--- a/src/Granit.ReferenceData/Diagnostics/ReferenceDataMetrics.cs
+++ b/src/Granit.ReferenceData/Diagnostics/ReferenceDataMetrics.cs
@@ -1,0 +1,83 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Granit.ReferenceData.Diagnostics;
+
+/// <summary>
+/// OpenTelemetry metrics for the reference data module.
+/// Meter: <c>Granit.ReferenceData</c>.
+/// </summary>
+public sealed class ReferenceDataMetrics
+{
+    public const string MeterName = "Granit.ReferenceData";
+
+    private const string TagTenantId = "tenant_id";
+    private const string TagTypeName = "type_name";
+    private const string DefaultTenant = "global";
+
+    private readonly Counter<long> _entriesCreated;
+    private readonly Counter<long> _entriesUpdated;
+    private readonly Counter<long> _entriesDeactivated;
+    private readonly Counter<long> _cacheHits;
+    private readonly Counter<long> _cacheMisses;
+
+    public ReferenceDataMetrics(IMeterFactory meterFactory)
+    {
+        Meter meter = meterFactory.Create(MeterName);
+
+        _entriesCreated = meter.CreateCounter<long>(
+            "granit.reference_data.entry.created",
+            description: "Number of reference data entries created.");
+
+        _entriesUpdated = meter.CreateCounter<long>(
+            "granit.reference_data.entry.updated",
+            description: "Number of reference data entries updated.");
+
+        _entriesDeactivated = meter.CreateCounter<long>(
+            "granit.reference_data.entry.deactivated",
+            description: "Number of reference data entries deactivated.");
+
+        _cacheHits = meter.CreateCounter<long>(
+            "granit.reference_data.cache.hit",
+            description: "Number of cache hits for reference data lookups.");
+
+        _cacheMisses = meter.CreateCounter<long>(
+            "granit.reference_data.cache.miss",
+            description: "Number of cache misses for reference data lookups.");
+    }
+
+    public void RecordEntryCreated(string? tenantId, string typeName) =>
+        _entriesCreated.Add(1, new TagList
+        {
+            { TagTenantId, tenantId ?? DefaultTenant },
+            { TagTypeName, typeName },
+        });
+
+    public void RecordEntryUpdated(string? tenantId, string typeName) =>
+        _entriesUpdated.Add(1, new TagList
+        {
+            { TagTenantId, tenantId ?? DefaultTenant },
+            { TagTypeName, typeName },
+        });
+
+    public void RecordEntryDeactivated(string? tenantId, string typeName) =>
+        _entriesDeactivated.Add(1, new TagList
+        {
+            { TagTenantId, tenantId ?? DefaultTenant },
+            { TagTypeName, typeName },
+        });
+
+    public void RecordCacheHit(string? tenantId, string typeName) =>
+        _cacheHits.Add(1, new TagList
+        {
+            { TagTenantId, tenantId ?? DefaultTenant },
+            { TagTypeName, typeName },
+        });
+
+    public void RecordCacheMiss(string? tenantId, string typeName) =>
+        _cacheMisses.Add(1, new TagList
+        {
+            { TagTenantId, tenantId ?? DefaultTenant },
+            { TagTypeName, typeName },
+        });
+}

--- a/src/Granit.ReferenceData/Domain/ReferenceDataEntity.cs
+++ b/src/Granit.ReferenceData/Domain/ReferenceDataEntity.cs
@@ -13,7 +13,7 @@ namespace Granit.ReferenceData.Domain;
 /// <remarks>
 /// <para>
 /// Each reference data entity has a unique <see cref="Code"/> (business key) and labels
-/// for the 14 supported locales (en, fr, nl, de, es, it, pt, zh, ja, pl, tr, ko, sv, cs).
+/// for the 15 supported locales (en, fr, nl, de, es, it, pt, zh, ja, pl, tr, ko, sv, cs, hi).
 /// The virtual <see cref="Label"/> property resolves the appropriate label based on
 /// <see cref="CultureInfo.CurrentUICulture"/>, falling back to <see cref="LabelEn"/>
 /// when the requested locale has no value.
@@ -85,6 +85,9 @@ public abstract class ReferenceDataEntity : AuditedEntity, IActive, IHasExtraPro
     /// <summary>Czech display label.</summary>
     public string LabelCs { get; set; } = string.Empty;
 
+    /// <summary>Hindi display label.</summary>
+    public string LabelHi { get; set; } = string.Empty;
+
     /// <summary>
     /// Resolved display label for the current UI culture. Returns the locale-specific
     /// label when available, falling back to <see cref="LabelEn"/> when the translation
@@ -110,6 +113,7 @@ public abstract class ReferenceDataEntity : AuditedEntity, IActive, IHasExtraPro
         "ko" when LabelKo.Length > 0 => LabelKo,
         "sv" when LabelSv.Length > 0 => LabelSv,
         "cs" when LabelCs.Length > 0 => LabelCs,
+        "hi" when LabelHi.Length > 0 => LabelHi,
         _ => LabelEn,
     };
 

--- a/src/Granit.ReferenceData/Extensions/ReferenceDataServiceCollectionExtensions.cs
+++ b/src/Granit.ReferenceData/Extensions/ReferenceDataServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ public static class ReferenceDataServiceCollectionExtensions
 
         // Ensure singleton registry + initializer exist (idempotent for multiple AddReferenceData calls)
         services.TryAddSingleton<ReferenceDataRegistry>();
+        services.TryAddSingleton<ReferenceDataMetrics>();
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IHostedService, ReferenceDataRegistryInitializer>());
 

--- a/src/Granit.ReferenceData/IReferenceDataMutableFields.cs
+++ b/src/Granit.ReferenceData/IReferenceDataMutableFields.cs
@@ -48,6 +48,9 @@ public interface IReferenceDataMutableFields
     /// <summary>Czech display label.</summary>
     string LabelCs { get; }
 
+    /// <summary>Hindi display label.</summary>
+    string LabelHi { get; }
+
     /// <summary>Display order (lower values first).</summary>
     int SortOrder { get; }
 

--- a/src/Granit.ReferenceData/Internal/GenericReferenceDataQueryDefinition.cs
+++ b/src/Granit.ReferenceData/Internal/GenericReferenceDataQueryDefinition.cs
@@ -25,6 +25,7 @@ internal sealed class GenericReferenceDataQueryDefinition<TEntity>
             .Column(e => e.LabelFr, c => c.Label("Label (FR)").Filterable())
             .Column(e => e.LabelNl, c => c.Label("Label (NL)").Filterable())
             .Column(e => e.LabelDe, c => c.Label("Label (DE)").Filterable())
+            .Column(e => e.LabelHi, c => c.Label("Label (HI)").Filterable())
             .Column(e => e.IsActive, c => c.Label("Active").Filterable())
             .Column(e => e.SortOrder, c => c.Label("Sort Order").Sortable())
             .Column(e => e.ValidFrom, c => c.Label("Valid From").Filterable().Sortable())

--- a/src/Granit.ReferenceData/Internal/ReferenceDataQueryDefinition.cs
+++ b/src/Granit.ReferenceData/Internal/ReferenceDataQueryDefinition.cs
@@ -27,6 +27,7 @@ internal sealed class ReferenceDataQueryDefinition(
             .Column(e => e.LabelFr, c => c.Label("Label (FR)").Filterable())
             .Column(e => e.LabelNl, c => c.Label("Label (NL)").Filterable())
             .Column(e => e.LabelDe, c => c.Label("Label (DE)").Filterable())
+            .Column(e => e.LabelHi, c => c.Label("Label (HI)").Filterable())
             .Column(e => e.IsActive, c => c.Label("Active").Filterable())
             .Column(e => e.SortOrder, c => c.Label("Sort Order").Sortable())
             .Column(e => e.ValidFrom, c => c.Label("Valid From").Filterable().Sortable())

--- a/tests/Granit.ArchitectureTests/LoggerMessagePiiConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/LoggerMessagePiiConventionTests.cs
@@ -50,6 +50,7 @@ public sealed partial class LoggerMessagePiiConventionTests
         "ConnectAuthorizationEndpoints.Subject",
         "ConnectTokenEndpoints.Subject",
         "BffTokenInjectionTransform.SessionId",
+        "BffTokenInjectionMiddleware.SessionId",
         "KeycloakUserTokenExchangeService.UserId",
         "BackgroundJobManager.UserId",
 

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreAdditionalTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreAdditionalTests.cs
@@ -1,6 +1,7 @@
 using Granit.MultiTenancy;
 using Granit.QueryEngine;
 using Granit.ReferenceData.Domain;
+using Granit.ReferenceData.EntityFrameworkCore;
 using Granit.ReferenceData.EntityFrameworkCore.Extensions;
 using Granit.ReferenceData.EntityFrameworkCore.Internal;
 using Granit.ReferenceData.Options;
@@ -52,7 +53,8 @@ public sealed class EfCoreReferenceDataStoreAdditionalTests
             cache,
             options,
             ReferenceDataScope.Global,
-            Substitute.For<ICurrentTenant>());
+            Substitute.For<ICurrentTenant>(),
+            Substitute.For<Granit.Guids.IGuidGenerator>());
     }
 
     private static async Task SeedAsync(
@@ -346,7 +348,7 @@ public sealed class EfCoreReferenceDataStoreAdditionalTests
         ServiceProvider sp = services.BuildServiceProvider();
         IServiceScopeFactory scopeFactory = sp.GetRequiredService<IServiceScopeFactory>();
 
-        EfCoreReferenceDataStore<TestEntity, TestDbContext> store = new(scopeFactory, cache, opts, ReferenceDataScope.Global, Substitute.For<ICurrentTenant>());
+        EfCoreReferenceDataStore<TestEntity, TestDbContext> store = new(scopeFactory, cache, opts, ReferenceDataScope.Global, Substitute.For<ICurrentTenant>(), Substitute.For<Granit.Guids.IGuidGenerator>());
 
         // Create entity
         TestEntity entity = new()
@@ -369,7 +371,7 @@ public sealed class EfCoreReferenceDataStoreAdditionalTests
         await store.UpdateAsync(cached, TestContext.Current.CancellationToken);
 
         // Re-fetch — should get updated value
-        EfCoreReferenceDataStore<TestEntity, TestDbContext> freshStore = new(scopeFactory, cache, opts, ReferenceDataScope.Global, Substitute.For<ICurrentTenant>());
+        EfCoreReferenceDataStore<TestEntity, TestDbContext> freshStore = new(scopeFactory, cache, opts, ReferenceDataScope.Global, Substitute.For<ICurrentTenant>(), Substitute.For<Granit.Guids.IGuidGenerator>());
         TestEntity? updated = await freshStore.GetByCodeAsync("BE", TestContext.Current.CancellationToken);
 
         updated!.LabelEn.ShouldBe("Kingdom of Belgium");

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreConcurrencyTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreConcurrencyTests.cs
@@ -1,5 +1,6 @@
 using Granit.MultiTenancy;
 using Granit.ReferenceData.Domain;
+using Granit.ReferenceData.EntityFrameworkCore;
 using Granit.ReferenceData.EntityFrameworkCore.Extensions;
 using Granit.ReferenceData.EntityFrameworkCore.Internal;
 using Granit.ReferenceData.Options;
@@ -121,7 +122,8 @@ public sealed class EfCoreReferenceDataStoreConcurrencyTests : IAsyncLifetime
             new FusionCache(new FusionCacheOptions()),
             Microsoft.Extensions.Options.Options.Create(new ReferenceDataOptions()),
             ReferenceDataScope.Global,
-            Substitute.For<ICurrentTenant>());
+            Substitute.For<ICurrentTenant>(),
+            Substitute.For<Granit.Guids.IGuidGenerator>());
 
     [Fact]
     public async Task CreateAsync_ConcurrentInsert_RecoveredGracefully()

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreTests.cs
@@ -1,6 +1,7 @@
 using Granit.MultiTenancy;
 using Granit.QueryEngine;
 using Granit.ReferenceData.Domain;
+using Granit.ReferenceData.EntityFrameworkCore;
 using Granit.ReferenceData.EntityFrameworkCore.Extensions;
 using Granit.ReferenceData.EntityFrameworkCore.Internal;
 using Granit.ReferenceData.Options;
@@ -52,7 +53,8 @@ public sealed class EfCoreReferenceDataStoreTests
             cache,
             options,
             ReferenceDataScope.Global,
-            Substitute.For<ICurrentTenant>());
+            Substitute.For<ICurrentTenant>(),
+            Substitute.For<Granit.Guids.IGuidGenerator>());
     }
 
     private static async Task SeedAsync(
@@ -366,7 +368,7 @@ public sealed class EfCoreReferenceDataStoreTests
         ServiceProvider sp = services.BuildServiceProvider();
         IServiceScopeFactory scopeFactory = sp.GetRequiredService<IServiceScopeFactory>();
 
-        EfCoreReferenceDataStore<TestEntity, TestDbContext> store = new(scopeFactory, cache, opts, ReferenceDataScope.Global, Substitute.For<ICurrentTenant>());
+        EfCoreReferenceDataStore<TestEntity, TestDbContext> store = new(scopeFactory, cache, opts, ReferenceDataScope.Global, Substitute.For<ICurrentTenant>(), Substitute.For<Granit.Guids.IGuidGenerator>());
 
         // Populate cache by querying
         await store.GetByCodeAsync("DE", TestContext.Current.CancellationToken);

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ModelBuilderExtensionsTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ModelBuilderExtensionsTests.cs
@@ -1,3 +1,4 @@
+using Granit.ReferenceData.EntityFrameworkCore;
 using Granit.ReferenceData.EntityFrameworkCore.Extensions;
 using Granit.ReferenceData.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEfCoreServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEfCoreServiceCollectionExtensionsTests.cs
@@ -15,7 +15,7 @@ namespace Granit.ReferenceData.EntityFrameworkCore.Tests;
 public sealed class ReferenceDataEfCoreServiceCollectionExtensionsTests
 {
     private sealed class TestEntityConfiguration
-        : Granit.ReferenceData.EntityFrameworkCore.Internal.ReferenceDataEntityTypeConfiguration<TestEntity>
+        : Granit.ReferenceData.EntityFrameworkCore.ReferenceDataEntityTypeConfiguration<TestEntity>
     {
         public TestEntityConfiguration() : base("ref_test_entities") { }
     }
@@ -42,6 +42,7 @@ public sealed class ReferenceDataEfCoreServiceCollectionExtensionsTests
             Microsoft.Extensions.Options.Options.Create(new ReferenceDataOptions()));
         services.AddLogging();
         services.AddSingleton(Substitute.For<ICurrentTenant>());
+        services.AddSingleton(Substitute.For<Granit.Guids.IGuidGenerator>());
         services.AddReferenceDataStore<TestEntity, TestDbContext>();
 
         return services.BuildServiceProvider();

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEntityTypeConfigurationAdditionalTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEntityTypeConfigurationAdditionalTests.cs
@@ -1,3 +1,4 @@
+using Granit.ReferenceData.EntityFrameworkCore;
 using Granit.ReferenceData.EntityFrameworkCore.Extensions;
 using Granit.ReferenceData.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEntityTypeConfigurationTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEntityTypeConfigurationTests.cs
@@ -1,3 +1,4 @@
+using Granit.ReferenceData.EntityFrameworkCore;
 using Granit.ReferenceData.EntityFrameworkCore.Extensions;
 using Granit.ReferenceData.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;


### PR DESCRIPTION
## Summary

- **`BffTokenInjectionMiddleware`**: ASP.NET Core middleware alternative to YARP-based `BffTokenInjectionTransform` for self-hosted deployments (API + BFF in same process). Includes CSRF validation on mutating methods, silent token refresh, DPoP support, sliding session extension, and metrics recording
- **`UseGranitBffTokenInjection()`**: extension method to register the middleware with a configurable path prefix (default: `/api`)
- **Auto-bind `GranitBffOptions`**: options are now auto-bound from the `Bff` config section in `GranitBffEndpointsModule`, removing the need for manual `Configure<GranitBffOptions>` in non-YARP deployments

### Motivation

The showcase's self-hosted BFF used a 20-line inline middleware that only injected `Authorization: Bearer` — missing silent refresh, CSRF validation, DPoP, sliding sessions, and metrics. This middleware provides full feature parity with the YARP transform.

## Test plan

- [x] `dotnet build src/Granit.Bff.Endpoints` — 0 errors, 0 warnings
- [x] `dotnet test tests/Granit.Bff.Endpoints.Tests` — 91 tests pass
- [x] Verified showcase compiles with local feed (pre-existing errors in other modules unrelated)
- [ ] Integration test with showcase (login → CSRF → API call → token refresh cycle)