### PR TITLE
fix(reference-data): align namespace with Internal/ folder

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -33804,7 +33804,7 @@
       "kind": "class",
       "project": "Granit.ReferenceData.EntityFrameworkCore",
       "file": "src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs",
-      "line": 9,
+      "line": 10,
       "members": []
     },
     {
@@ -33827,7 +33827,7 @@
     },
     {
       "name": "ReferenceDataEntityTypeConfiguration",
-      "fqn": "Granit.ReferenceData.EntityFrameworkCore.ReferenceDataEntityTypeConfiguration",
+      "fqn": "Granit.ReferenceData.EntityFrameworkCore.Internal.ReferenceDataEntityTypeConfiguration",
       "kind": "class",
       "project": "Granit.ReferenceData.EntityFrameworkCore",
       "file": "src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataEntityTypeConfiguration.cs",

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.ReferenceData.Domain;
+using Granit.ReferenceData.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.ReferenceData.EntityFrameworkCore.Extensions;

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataEntityTypeConfiguration.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataEntityTypeConfiguration.cs
@@ -2,7 +2,7 @@ using Granit.ReferenceData.Domain;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace Granit.ReferenceData.EntityFrameworkCore;
+namespace Granit.ReferenceData.EntityFrameworkCore.Internal;
 
 /// <summary>
 /// Base EF Core Fluent API configuration for reference data entities.

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEfCoreServiceCollectionExtensionsTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEfCoreServiceCollectionExtensionsTests.cs
@@ -15,7 +15,7 @@ namespace Granit.ReferenceData.EntityFrameworkCore.Tests;
 public sealed class ReferenceDataEfCoreServiceCollectionExtensionsTests
 {
     private sealed class TestEntityConfiguration
-        : Granit.ReferenceData.EntityFrameworkCore.ReferenceDataEntityTypeConfiguration<TestEntity>
+        : Granit.ReferenceData.EntityFrameworkCore.Internal.ReferenceDataEntityTypeConfiguration<TestEntity>
     {
         public TestEntityConfiguration() : base("ref_test_entities") { }
     }


### PR DESCRIPTION
## Summary

- Fixes the `Namespace_should_match_folder_structure_in_src` architecture test failure
- PR #998 moved `ReferenceDataEntityTypeConfiguration` to the `Internal/` folder but kept the old namespace (`Granit.ReferenceData.EntityFrameworkCore` instead of `Granit.ReferenceData.EntityFrameworkCore.Internal`)
- Updates the namespace and all consumer references (`ModelBuilderExtensions`, test fully-qualified reference)

## Test plan

- [x] `Namespace_should_match_folder_structure_in_src` passes locally
- [ ] CI architecture shard passes