### PR TITLE
fix(ci): add IsPackable=false to tests Directory.Build.props

### DIFF
--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -2,6 +2,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
+    <IsPackable>false</IsPackable>
     <!-- Granit analyzers target production code — test projects legitimately use
          Guid.NewGuid(), DateTimeOffset.UtcNow, and test secrets for setup/assertions. -->
     <NoWarn>$(NoWarn);GRSEC001;GRSEC002;GRSEC003;GRSEC004;GREF001;RS0030</NoWarn>


### PR DESCRIPTION
## Summary

- Add `<IsPackable>false</IsPackable>` to `tests/Directory.Build.props`
- Fixes NU5019 error on test projects that lack a `README.md` (the root `Directory.Build.props` includes `README.md` in pack output)

## Root cause

`Granit.DataExchange.Definitions.Tests` has no `README.md`. During CI `dotnet build`, MSBuild tries to pack it and fails with `NU5019: File not found: README.md`. Test projects should never be packed.

## Test plan

- [x] `dotnet build tests/Granit.DataExchange.Definitions.Tests` succeeds