### PR TITLE
docs(data-exchange): clarify ContainerName is a key prefix, not a bucket

### DIFF
--- a/docs-site/src/content/docs/dotnet/business/data-exchange.mdx
+++ b/docs-site/src/content/docs/dotnet/business/data-exchange.mdx
@@ -186,7 +186,7 @@ public class AppModule : GranitModule { }
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `ContainerName` | `data-exchange` | Logical blob container for import/export files |
+| `ContainerName` | `data-exchange` | Key-prefix segment in the object path (not a physical bucket) |
 | `DefaultContentType` | `application/octet-stream` | MIME type for stored export files |
 
 ### Custom implementation

--- a/src/Granit.DataExchange.BlobStorage/Options/DataExchangeBlobStorageOptions.cs
+++ b/src/Granit.DataExchange.BlobStorage/Options/DataExchangeBlobStorageOptions.cs
@@ -13,7 +13,10 @@ public sealed class DataExchangeBlobStorageOptions
     public const string SectionName = "Granit:DataExchange:BlobStorage";
 
     /// <summary>
-    /// Logical container name used for data exchange files (import uploads and export outputs).
+    /// Logical container name used as a key-prefix segment in the object key path
+    /// (e.g. <c>{tenantId}/data-exchange/2026/04/{blobId}</c>).
+    /// This is NOT a physical bucket — the physical bucket is resolved by
+    /// <c>IBlobKeyStrategy.ResolveBucketName</c> (typically <c>S3BlobOptions.DefaultBucket</c>).
     /// </summary>
     [Required]
     public string ContainerName { get; set; } = "data-exchange";


### PR DESCRIPTION
## Summary

- Clarify that `DataExchangeBlobStorageOptions.ContainerName` is a key-prefix segment in the S3 object path, not a physical bucket
- Update docs-site table description to match

## Test plan

- [x] Documentation-only change, no code behavior modified
