### PR TITLE
feat(ai): add provider discovery endpoints and model catalog

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2299,6 +2299,24 @@
       "members": []
     },
     {
+      "name": "AIModelCapabilities",
+      "fqn": "Granit.AI.AIModelCapabilities",
+      "kind": "record",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/AIModelCapabilities.cs",
+      "line": 8,
+      "members": []
+    },
+    {
+      "name": "AIModelInfo",
+      "fqn": "Granit.AI.AIModelInfo",
+      "kind": "record",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/AIModelInfo.cs",
+      "line": 10,
+      "members": []
+    },
+    {
       "name": "AIQuotaResult",
       "fqn": "Granit.AI.AIQuotaResult",
       "kind": "record",
@@ -2462,6 +2480,24 @@
       "members": []
     },
     {
+      "name": "AIProviderModelResponse",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIProviderModelResponse",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIProviderModelResponse.cs",
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "AIProviderResponse",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIProviderResponse",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIProviderResponse.cs",
+      "line": 9,
+      "members": []
+    },
+    {
       "name": "AIWorkspaceCreateRequest",
       "fqn": "Granit.AI.Endpoints.Dtos.AIWorkspaceCreateRequest",
       "kind": "record",
@@ -2550,6 +2586,12 @@
           "name": "RoutePrefix",
           "kind": "property",
           "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "ProvidersTagName",
+          "kind": "property",
+          "signature": "string ProvidersTagName",
           "returnType": "string"
         },
         {
@@ -2897,6 +2939,22 @@
           "kind": "method",
           "signature": "CreateAsync(string? workspaceName = null, CancellationToken cancellationToken = default)",
           "returnType": "Task<IEmbeddingGenerator<string, Embedding<float>>>"
+        }
+      ]
+    },
+    {
+      "name": "IAIModelCatalog",
+      "fqn": "Granit.AI.IAIModelCatalog",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/IAIModelCatalog.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "GetAvailableModelsAsync",
+          "kind": "method",
+          "signature": "GetAvailableModelsAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<AIModelInfo>>"
         }
       ]
     },

--- a/src/Granit.AI.AzureOpenAI/Internal/AzureOpenAIProviderFactory.cs
+++ b/src/Granit.AI.AzureOpenAI/Internal/AzureOpenAIProviderFactory.cs
@@ -16,7 +16,7 @@ namespace Granit.AI.AzureOpenAI.Internal;
 /// instances backed by <see cref="AzureOpenAIClient"/>. Supports API key authentication
 /// (dev/staging) and <see cref="DefaultAzureCredential"/> / Managed Identity (production).
 /// </remarks>
-internal sealed class AzureOpenAIProviderFactory(IOptions<AzureOpenAIProviderOptions> options) : IAIProviderFactory
+internal sealed class AzureOpenAIProviderFactory(IOptions<AzureOpenAIProviderOptions> options) : IAIProviderFactory, IAIModelCatalog
 {
     private readonly AzureOpenAIProviderOptions _options = options.Value;
 
@@ -39,6 +39,19 @@ internal sealed class AzureOpenAIProviderFactory(IOptions<AzureOpenAIProviderOpt
         string deployment = _options.DefaultEmbeddingDeployment;
 
         return client.GetEmbeddingClient(deployment).AsIEmbeddingGenerator();
+    }
+
+    /// <inheritdoc/>
+    public Task<IReadOnlyList<AIModelInfo>> GetAvailableModelsAsync(CancellationToken cancellationToken = default)
+    {
+        // Azure OpenAI uses deployment names configured per-resource — expose the configured defaults.
+        IReadOnlyList<AIModelInfo> models =
+        [
+            new(_options.DefaultDeployment, _options.DefaultDeployment, new AIModelCapabilities(Chat: true, Embeddings: false)),
+            new(_options.DefaultEmbeddingDeployment, _options.DefaultEmbeddingDeployment, new AIModelCapabilities(Chat: false, Embeddings: true)),
+        ];
+
+        return Task.FromResult(models);
     }
 
     private AzureOpenAIClient CreateClient()

--- a/src/Granit.AI.Endpoints/Dtos/AIProviderModelResponse.cs
+++ b/src/Granit.AI.Endpoints/Dtos/AIProviderModelResponse.cs
@@ -1,0 +1,14 @@
+namespace Granit.AI.Endpoints.Dtos;
+
+/// <summary>
+/// Represents an AI model available from a provider.
+/// </summary>
+/// <param name="Id">The model identifier used in API calls.</param>
+/// <param name="DisplayName">A human-readable name for display in the UI.</param>
+/// <param name="Capabilities">The capabilities this model supports.</param>
+/// <param name="MaxContextTokens">Optional maximum context window size in tokens.</param>
+public sealed record AIProviderModelResponse(
+    string Id,
+    string DisplayName,
+    AIModelCapabilities Capabilities,
+    int? MaxContextTokens);

--- a/src/Granit.AI.Endpoints/Dtos/AIProviderResponse.cs
+++ b/src/Granit.AI.Endpoints/Dtos/AIProviderResponse.cs
@@ -1,0 +1,12 @@
+namespace Granit.AI.Endpoints.Dtos;
+
+/// <summary>
+/// Represents a registered AI provider in the discovery response.
+/// </summary>
+/// <param name="Name">The provider identifier (e.g. <c>"OpenAI"</c>, <c>"Ollama"</c>).</param>
+/// <param name="SupportsChat">Whether this provider supports chat completions.</param>
+/// <param name="SupportsEmbeddings">Whether this provider supports embedding generation.</param>
+public sealed record AIProviderResponse(
+    string Name,
+    bool SupportsChat,
+    bool SupportsEmbeddings);

--- a/src/Granit.AI.Endpoints/Endpoints/AIProviderEndpoints.cs
+++ b/src/Granit.AI.Endpoints/Endpoints/AIProviderEndpoints.cs
@@ -16,7 +16,8 @@ internal static class AIProviderEndpoints
             .WithSummary("Lists all registered AI providers.")
             .WithDescription(
                 "Returns every AI provider registered via dependency injection, "
-                + "along with an indication of whether each provider supports chat and embedding capabilities.");
+                + "along with an indication of whether each provider supports chat and embedding capabilities.")
+            .Produces<IReadOnlyList<AIProviderResponse>>();
 
         group.MapGet("/providers/{providerName}", ListProviderModelsAsync)
             .WithName("ListAIProviderModels")

--- a/src/Granit.AI.Endpoints/Endpoints/AIProviderEndpoints.cs
+++ b/src/Granit.AI.Endpoints/Endpoints/AIProviderEndpoints.cs
@@ -1,0 +1,103 @@
+using Granit.AI.Endpoints.Dtos;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.AI.Endpoints.Endpoints;
+
+internal static class AIProviderEndpoints
+{
+    internal static RouteGroupBuilder MapProviderEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/providers", ListProvidersAsync)
+            .WithName("ListAIProviders")
+            .WithSummary("Lists all registered AI providers.")
+            .WithDescription(
+                "Returns every AI provider registered via dependency injection, "
+                + "along with an indication of whether each provider supports chat and embedding capabilities.");
+
+        group.MapGet("/providers/{providerName}", ListProviderModelsAsync)
+            .WithName("ListAIProviderModels")
+            .WithSummary("Lists the models available from a specific AI provider.")
+            .WithDescription(
+                "Returns the models currently available from the specified provider. "
+                + "For cloud providers (OpenAI, AzureOpenAI) this is a static catalog. "
+                + "For local providers (Ollama) this queries the server for installed models. "
+                + "Returns 404 if the provider is not registered, or 502 if the provider's model listing fails.")
+            .Produces<IReadOnlyList<AIProviderModelResponse>>()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status502BadGateway);
+
+        return group;
+    }
+
+    private static async Task<Ok<IReadOnlyList<AIProviderResponse>>> ListProvidersAsync(
+        [FromServices] IEnumerable<IAIProviderFactory> providerFactories,
+        CancellationToken cancellationToken)
+    {
+        var providers = new List<AIProviderResponse>();
+
+        foreach (IAIProviderFactory factory in providerFactories)
+        {
+            bool supportsChat = false;
+            bool supportsEmbeddings = false;
+
+            if (factory is IAIModelCatalog catalog)
+            {
+                IReadOnlyList<AIModelInfo> models = await catalog
+                    .GetAvailableModelsAsync(cancellationToken)
+                    .ConfigureAwait(false);
+
+                supportsChat = models.Any(m => m.Capabilities.Chat);
+                supportsEmbeddings = models.Any(m => m.Capabilities.Embeddings);
+            }
+
+            providers.Add(new AIProviderResponse(factory.ProviderName, supportsChat, supportsEmbeddings));
+        }
+
+        return TypedResults.Ok<IReadOnlyList<AIProviderResponse>>(providers);
+    }
+
+    private static async Task<Results<Ok<IReadOnlyList<AIProviderModelResponse>>, ProblemHttpResult>> ListProviderModelsAsync(
+        string providerName,
+        [FromServices] IEnumerable<IAIProviderFactory> providerFactories,
+        CancellationToken cancellationToken)
+    {
+        IAIProviderFactory? factory = providerFactories
+            .FirstOrDefault(p => string.Equals(p.ProviderName, providerName, StringComparison.OrdinalIgnoreCase));
+
+        if (factory is null)
+        {
+            return TypedResults.Problem(
+                detail: $"Provider '{providerName}' is not registered.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
+        if (factory is not IAIModelCatalog catalog)
+        {
+            return TypedResults.Problem(
+                detail: $"Provider '{providerName}' does not support model discovery.",
+                statusCode: StatusCodes.Status502BadGateway);
+        }
+
+        IReadOnlyList<AIModelInfo> models;
+        try
+        {
+            models = await catalog.GetAvailableModelsAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or IOException)
+        {
+            return TypedResults.Problem(
+                detail: $"Failed to retrieve models from provider '{providerName}'.",
+                statusCode: StatusCodes.Status502BadGateway);
+        }
+
+        IReadOnlyList<AIProviderModelResponse> response = models
+            .Select(m => new AIProviderModelResponse(m.Id, m.DisplayName, m.Capabilities, m.MaxContextTokens))
+            .ToList();
+
+        return TypedResults.Ok(response);
+    }
+}

--- a/src/Granit.AI.Endpoints/Extensions/AIEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.AI.Endpoints/Extensions/AIEndpointRouteBuilderExtensions.cs
@@ -53,6 +53,12 @@ public static class AIEndpointRouteBuilderExtensions
             .RequireAuthorization(AIPermissions.Usage.Read);
         usageGroup.MapGranitQuery<AIUsageRecord>();
 
+        // Discovery endpoints — provider and model listing
+        RouteGroupBuilder providerGroup = group.MapGranitGroup("")
+            .WithTags(options.ProvidersTagName)
+            .RequireAuthorization(AIPermissions.Workspaces.Read);
+        providerGroup.MapProviderEndpoints();
+
         // User endpoints — chat completion proxy
         RouteGroupBuilder chatGroup = group.MapGranitGroup("")
             .WithTags(options.InferenceTagName)

--- a/src/Granit.AI.Endpoints/Options/AIEndpointsOptions.cs
+++ b/src/Granit.AI.Endpoints/Options/AIEndpointsOptions.cs
@@ -15,6 +15,12 @@ public sealed class AIEndpointsOptions
     public string RoutePrefix { get; set; } = "ai";
 
     /// <summary>
+    /// OpenAPI tag name for provider discovery endpoints.
+    /// Default: <c>"AI Providers"</c>.
+    /// </summary>
+    public string ProvidersTagName { get; set; } = "AI Providers";
+
+    /// <summary>
     /// OpenAPI tag name for workspace management endpoints.
     /// Default: <c>"AI Workspaces"</c>.
     /// </summary>

--- a/src/Granit.AI.Ollama/Internal/OllamaProviderFactory.cs
+++ b/src/Granit.AI.Ollama/Internal/OllamaProviderFactory.cs
@@ -3,11 +3,12 @@ using Granit.AI.Workspaces;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Options;
 using OllamaSharp;
+using OllamaSharp.Models;
 
 namespace Granit.AI.Ollama.Internal;
 
 /// <summary>
-/// Ollama implementation of <see cref="IAIProviderFactory"/>.
+/// Ollama implementation of <see cref="IAIProviderFactory"/> and <see cref="IAIModelCatalog"/>.
 /// Creates <see cref="OllamaApiClient"/> instances that implement both
 /// <see cref="IChatClient"/> and <see cref="IEmbeddingGenerator{TInput,TEmbedding}"/>.
 /// </summary>
@@ -15,9 +16,17 @@ namespace Granit.AI.Ollama.Internal;
 /// <see cref="OllamaApiClient"/> natively supports the <c>Microsoft.Extensions.AI</c>
 /// abstractions. Each call creates a new client pointing at the configured
 /// endpoint with the workspace model (or the default model from options).
+/// Model catalog is fetched dynamically via <c>GET /api/tags</c> and cached for 30 seconds.
 /// </remarks>
-internal sealed class OllamaProviderFactory(IOptions<OllamaOptions> options) : IAIProviderFactory
+internal sealed class OllamaProviderFactory(
+    IOptions<OllamaOptions> options,
+    TimeProvider timeProvider) : IAIProviderFactory, IAIModelCatalog
 {
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromSeconds(30);
+    private readonly Lock _lock = new();
+    private IReadOnlyList<AIModelInfo>? _cachedModels;
+    private DateTimeOffset _cacheExpiry;
+
     /// <inheritdoc/>
     public string ProviderName => "Ollama";
 
@@ -41,5 +50,39 @@ internal sealed class OllamaProviderFactory(IOptions<OllamaOptions> options) : I
         var endpoint = new Uri(options.Value.Endpoint);
 
         return new OllamaApiClient(endpoint, model);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<AIModelInfo>> GetAvailableModelsAsync(CancellationToken cancellationToken = default)
+    {
+        lock (_lock)
+        {
+            if (_cachedModels is not null && timeProvider.GetUtcNow() < _cacheExpiry)
+            {
+                return _cachedModels;
+            }
+        }
+
+        var endpoint = new Uri(options.Value.Endpoint);
+        var client = new OllamaApiClient(endpoint);
+
+        IEnumerable<Model> localModels = await client
+            .ListLocalModelsAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        IReadOnlyList<AIModelInfo> models = localModels
+            .Select(m => new AIModelInfo(
+                m.Name,
+                m.Name,
+                new AIModelCapabilities(Chat: true, Embeddings: true)))
+            .ToList();
+
+        lock (_lock)
+        {
+            _cachedModels = models;
+            _cacheExpiry = timeProvider.GetUtcNow().Add(CacheDuration);
+        }
+
+        return models;
     }
 }

--- a/src/Granit.AI.OpenAI/Internal/OpenAIProviderFactory.cs
+++ b/src/Granit.AI.OpenAI/Internal/OpenAIProviderFactory.cs
@@ -1,22 +1,53 @@
 using System.ClientModel;
+using System.Collections.Frozen;
 using Granit.AI.OpenAI.Options;
 using Granit.AI.Workspaces;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Options;
 using OpenAI;
+using OpenAI.Models;
 
 namespace Granit.AI.OpenAI.Internal;
 
 /// <summary>
-/// OpenAI implementation of <see cref="IAIProviderFactory"/>.
+/// OpenAI implementation of <see cref="IAIProviderFactory"/> and <see cref="IAIModelCatalog"/>.
 /// </summary>
 /// <remarks>
 /// Creates <see cref="IChatClient"/> and <see cref="IEmbeddingGenerator{String, Embedding}"/>
 /// instances backed by the OpenAI API via <see cref="OpenAIClient"/>.
+/// Model catalog is fetched dynamically from the OpenAI <c>GET /v1/models</c> endpoint
+/// and enriched with known metadata (context window, capabilities) for well-known models.
+/// Results are cached for 5 minutes.
 /// </remarks>
-internal sealed class OpenAIProviderFactory(IOptions<OpenAIProviderOptions> options) : IAIProviderFactory
+internal sealed class OpenAIProviderFactory(
+    IOptions<OpenAIProviderOptions> options,
+    TimeProvider timeProvider) : IAIProviderFactory, IAIModelCatalog
 {
     private readonly OpenAIProviderOptions _options = options.Value;
+
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
+    private readonly Lock _lock = new();
+    private IReadOnlyList<AIModelInfo>? _cachedModels;
+    private DateTimeOffset _cacheExpiry;
+
+    /// <summary>
+    /// Known metadata for well-known OpenAI models. Models not in this map
+    /// get default chat capabilities with no context window info.
+    /// </summary>
+    private static readonly FrozenDictionary<string, (string DisplayName, AIModelCapabilities Capabilities, int? MaxContextTokens)> KnownModels =
+        new Dictionary<string, (string, AIModelCapabilities, int?)>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["gpt-4o"] = ("GPT-4o", new AIModelCapabilities(Chat: true, Embeddings: false), 128_000),
+            ["gpt-4o-mini"] = ("GPT-4o Mini", new AIModelCapabilities(Chat: true, Embeddings: false), 128_000),
+            ["gpt-4.1"] = ("GPT-4.1", new AIModelCapabilities(Chat: true, Embeddings: false), 1_047_576),
+            ["gpt-4.1-mini"] = ("GPT-4.1 Mini", new AIModelCapabilities(Chat: true, Embeddings: false), 1_047_576),
+            ["gpt-4.1-nano"] = ("GPT-4.1 Nano", new AIModelCapabilities(Chat: true, Embeddings: false), 1_047_576),
+            ["o3"] = ("o3", new AIModelCapabilities(Chat: true, Embeddings: false), 200_000),
+            ["o3-mini"] = ("o3 Mini", new AIModelCapabilities(Chat: true, Embeddings: false), 200_000),
+            ["o4-mini"] = ("o4 Mini", new AIModelCapabilities(Chat: true, Embeddings: false), 200_000),
+            ["text-embedding-3-small"] = ("Text Embedding 3 Small", new AIModelCapabilities(Chat: false, Embeddings: true), 8_191),
+            ["text-embedding-3-large"] = ("Text Embedding 3 Large", new AIModelCapabilities(Chat: false, Embeddings: true), 8_191),
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
     public string ProviderName => "OpenAI";
@@ -36,6 +67,52 @@ internal sealed class OpenAIProviderFactory(IOptions<OpenAIProviderOptions> opti
         OpenAIClient client = CreateOpenAIClient();
 
         return client.GetEmbeddingClient(_options.DefaultEmbeddingModel).AsIEmbeddingGenerator();
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<AIModelInfo>> GetAvailableModelsAsync(CancellationToken cancellationToken = default)
+    {
+        lock (_lock)
+        {
+            if (_cachedModels is not null && timeProvider.GetUtcNow() < _cacheExpiry)
+            {
+                return _cachedModels;
+            }
+        }
+
+        OpenAIClient client = CreateOpenAIClient();
+        OpenAIModelClient modelClient = client.GetOpenAIModelClient();
+
+        OpenAIModelCollection apiModels = await modelClient
+            .GetModelsAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        IReadOnlyList<AIModelInfo> models = apiModels
+            .Select(m => EnrichModel(m.Id))
+            .OrderBy(m => m.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        lock (_lock)
+        {
+            _cachedModels = models;
+            _cacheExpiry = timeProvider.GetUtcNow().Add(CacheDuration);
+        }
+
+        return models;
+    }
+
+    private static AIModelInfo EnrichModel(string modelId)
+    {
+        if (KnownModels.TryGetValue(modelId, out (string DisplayName, AIModelCapabilities Capabilities, int? MaxContextTokens) known))
+        {
+            return new AIModelInfo(modelId, known.DisplayName, known.Capabilities, known.MaxContextTokens);
+        }
+
+        AIModelCapabilities capabilities = modelId.Contains("embedding", StringComparison.OrdinalIgnoreCase)
+            ? new AIModelCapabilities(Chat: false, Embeddings: true)
+            : new AIModelCapabilities(Chat: true, Embeddings: false);
+
+        return new AIModelInfo(modelId, modelId, capabilities);
     }
 
     private OpenAIClient CreateOpenAIClient()

--- a/src/Granit.AI/AIModelCapabilities.cs
+++ b/src/Granit.AI/AIModelCapabilities.cs
@@ -1,0 +1,10 @@
+namespace Granit.AI;
+
+/// <summary>
+/// Describes the capabilities supported by an AI model.
+/// </summary>
+/// <param name="Chat">Whether the model supports chat completions. Default <c>true</c>.</param>
+/// <param name="Embeddings">Whether the model supports embedding generation. Default <c>false</c>.</param>
+public sealed record AIModelCapabilities(
+    bool Chat = true,
+    bool Embeddings = false);

--- a/src/Granit.AI/AIModelInfo.cs
+++ b/src/Granit.AI/AIModelInfo.cs
@@ -1,0 +1,14 @@
+namespace Granit.AI;
+
+/// <summary>
+/// Describes an AI model available from a provider.
+/// </summary>
+/// <param name="Id">The model identifier used in API calls (e.g. <c>"gpt-4o"</c>, <c>"llama3.1"</c>).</param>
+/// <param name="DisplayName">A human-readable name for the model.</param>
+/// <param name="Capabilities">The capabilities this model supports.</param>
+/// <param name="MaxContextTokens">Optional maximum context window size in tokens.</param>
+public sealed record AIModelInfo(
+    string Id,
+    string DisplayName,
+    AIModelCapabilities Capabilities,
+    int? MaxContextTokens = null);

--- a/src/Granit.AI/Extensions/AIServiceCollectionExtensions.cs
+++ b/src/Granit.AI/Extensions/AIServiceCollectionExtensions.cs
@@ -36,20 +36,20 @@ public static class AIServiceCollectionExtensions
             .AddOptions<GranitAIOptions>()
             .BindConfiguration(GranitAIOptions.SectionName);
 
-        // Workspace infrastructure
-        builder.Services.TryAddSingleton<IAIWorkspaceProvider, DefaultAIWorkspaceProvider>();
-        builder.Services.TryAddSingleton<IAIWorkspaceStoreReader, NullAIWorkspaceStoreReader>();
-        builder.Services.TryAddSingleton<IAIWorkspaceStoreWriter, NullAIWorkspaceStoreWriter>();
+        // Workspace infrastructure (Scoped — EF Core persistence overrides with scoped stores)
+        builder.Services.TryAddScoped<IAIWorkspaceProvider, DefaultAIWorkspaceProvider>();
+        builder.Services.TryAddScoped<IAIWorkspaceStoreReader, NullAIWorkspaceStoreReader>();
+        builder.Services.TryAddScoped<IAIWorkspaceStoreWriter, NullAIWorkspaceStoreWriter>();
 
-        // Factories
-        builder.Services.TryAddSingleton<IAIChatClientFactory, DefaultAIChatClientFactory>();
-        builder.Services.TryAddSingleton<IAIEmbeddingGeneratorFactory, DefaultAIEmbeddingGeneratorFactory>();
+        // Factories (Scoped — depend on IAIWorkspaceProvider which may consume scoped stores)
+        builder.Services.TryAddScoped<IAIChatClientFactory, DefaultAIChatClientFactory>();
+        builder.Services.TryAddScoped<IAIEmbeddingGeneratorFactory, DefaultAIEmbeddingGeneratorFactory>();
 
         // Metrics
         builder.Services.TryAddSingleton<AIMetrics>();
 
         // Usage tracking (no-op by default, overridden by EF Core package)
-        builder.Services.TryAddSingleton<IAIUsageTracker, NullAIUsageTracker>();
+        builder.Services.TryAddScoped<IAIUsageTracker, NullAIUsageTracker>();
 
         // Quota guard: InMemory by default (no-op when MaxRequestsPerTenantPerHour=0)
         builder.Services

--- a/src/Granit.AI/IAIModelCatalog.cs
+++ b/src/Granit.AI/IAIModelCatalog.cs
@@ -1,0 +1,18 @@
+namespace Granit.AI;
+
+/// <summary>
+/// Provides the list of models available from an AI provider.
+/// </summary>
+/// <remarks>
+/// Implemented alongside <see cref="IAIProviderFactory"/> by each provider package.
+/// Some providers (e.g. Ollama) discover models dynamically, so the method is asynchronous.
+/// </remarks>
+public interface IAIModelCatalog
+{
+    /// <summary>
+    /// Returns the models currently available from this provider.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of available models with their capabilities.</returns>
+    Task<IReadOnlyList<AIModelInfo>> GetAvailableModelsAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Granit.MultiTenancy;
 using Granit.QueryEngine.Diagnostics;
@@ -184,6 +185,32 @@ internal sealed class QueryEngine<TEntity>(
         GroupedResult<TEntity> result = await query.ApplyGroupByAsync(
             request.GroupBy, _builder, engineOptions.Value.MaxGroupCount, cancellationToken)
             .ConfigureAwait(false);
+
+        // Populate items per group: sort the filtered set, materialize, then distribute by group key
+        if (result.Groups.Count > 0)
+        {
+            IQueryable<TEntity> sorted = query.ApplySort(request.Sort, _builder);
+            List<TEntity> allItems = await sorted
+                .Take(_builder.MaxPageSizeValue * result.Groups.Count)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            PropertyInfo? groupProp = typeof(TEntity).GetProperty(
+                request.GroupBy,
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+
+            if (groupProp is not null)
+            {
+                ILookup<string, TEntity> itemsByKey = allItems
+                    .ToLookup(e => groupProp.GetValue(e)?.ToString() ?? "(null)");
+
+                var populated = result.Groups
+                    .Select(g => g with { Items = itemsByKey[g.Value?.ToString() ?? "(null)"].ToList() })
+                    .ToList();
+
+                result = new GroupedResult<TEntity>(populated, result.TotalCount);
+            }
+        }
 
         RecordMetrics("grouped", startTimestamp);
         return result;

--- a/tests/Granit.AI.Ollama.Tests/OllamaProviderFactoryAdditionalTests.cs
+++ b/tests/Granit.AI.Ollama.Tests/OllamaProviderFactoryAdditionalTests.cs
@@ -12,7 +12,7 @@ public sealed class OllamaProviderFactoryAdditionalTests
     private static OllamaProviderFactory CreateFactory(OllamaOptions? options = null)
     {
         OllamaOptions opts = options ?? new OllamaOptions();
-        return new OllamaProviderFactory(Microsoft.Extensions.Options.Options.Create(opts));
+        return new OllamaProviderFactory(Microsoft.Extensions.Options.Options.Create(opts), TimeProvider.System);
     }
 
     private static AIWorkspace CreateWorkspace(string? model = "llama3.2") =>

--- a/tests/Granit.AI.Ollama.Tests/OllamaProviderFactoryTests.cs
+++ b/tests/Granit.AI.Ollama.Tests/OllamaProviderFactoryTests.cs
@@ -12,7 +12,7 @@ public sealed class OllamaProviderFactoryTests
     private static OllamaProviderFactory CreateFactory(OllamaOptions? options = null)
     {
         OllamaOptions opts = options ?? new OllamaOptions();
-        return new OllamaProviderFactory(Microsoft.Extensions.Options.Options.Create(opts));
+        return new OllamaProviderFactory(Microsoft.Extensions.Options.Options.Create(opts), TimeProvider.System);
     }
 
     private static AIWorkspace CreateWorkspace(string? model = "llama3.2") =>

--- a/tests/Granit.AI.OpenAI.Tests/OpenAIProviderFactoryTests.cs
+++ b/tests/Granit.AI.OpenAI.Tests/OpenAIProviderFactoryTests.cs
@@ -23,7 +23,7 @@ public sealed class OpenAIProviderFactoryTests
             DefaultEmbeddingModel = defaultEmbeddingModel,
         });
 
-        return new OpenAIProviderFactory(options);
+        return new OpenAIProviderFactory(options, TimeProvider.System);
     }
 
     private static AIWorkspace CreateWorkspace(string model = "gpt-4o") =>


### PR DESCRIPTION
## Summary

- Add `IAIModelCatalog` interface and `GET /ai/providers` + `GET /ai/providers/{name}` endpoints for frontend dropdown population
- OpenAI lists models dynamically via SDK (`GET /v1/models`) with known metadata enrichment (context window, capabilities), Ollama queries `GET /api/tags` with 30s cache, AzureOpenAI exposes configured deployments
- Fix AI service lifetimes from Singleton to Scoped to avoid captive dependency with EF Core stores
- Populate items per group in QueryEngine grouped queries

## Test plan

- [ ] `dotnet build` — all projects compile
- [ ] `dotnet test` — all existing AI tests pass (102 tests across 5 projects)
- [ ] Verify `GET /ai/providers` returns registered providers with capabilities
- [ ] Verify `GET /ai/providers/Ollama` returns installed models from Ollama server
- [ ] Verify `GET /ai/providers/OpenAI` returns models from OpenAI API (requires API key)
- [ ] Verify grouped query results now include items per group