### PR TITLE
fix(ai): rename model listing route to /providers/{name}/models

### DIFF
--- a/src/Granit.AI.Endpoints/Endpoints/AIProviderEndpoints.cs
+++ b/src/Granit.AI.Endpoints/Endpoints/AIProviderEndpoints.cs
@@ -19,7 +19,7 @@ internal static class AIProviderEndpoints
                 + "along with an indication of whether each provider supports chat and embedding capabilities.")
             .Produces<IReadOnlyList<AIProviderResponse>>();
 
-        group.MapGet("/providers/{providerName}", ListProviderModelsAsync)
+        group.MapGet("/providers/{providerName}/models", ListProviderModelsAsync)
             .WithName("ListAIProviderModels")
             .WithSummary("Lists the models available from a specific AI provider.")
             .WithDescription(


### PR DESCRIPTION
## Summary

- Rename `GET /ai/providers/{providerName}` to `GET /ai/providers/{providerName}/models` for a more intuitive REST path

## Test plan

- [ ] `GET /api/v1/ai/providers/Ollama/models` returns installed models