### PR TITLE
refactor(ai): add DefaultAIWorkspaceManager and align store writer naming

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -3524,9 +3524,9 @@
       "line": 10,
       "members": [
         {
-          "name": "SaveAsync",
+          "name": "CreateAsync",
           "kind": "method",
-          "signature": "SaveAsync(AIWorkspace workspace, CancellationToken cancellationToken = default)",
+          "signature": "CreateAsync(AIWorkspace workspace, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         },
         {

--- a/src/Granit.AI.EntityFrameworkCore/Internal/EfAIWorkspaceStore.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/EfAIWorkspaceStore.cs
@@ -44,7 +44,7 @@ internal sealed class EfAIWorkspaceStore(
     }
 
     /// <inheritdoc/>
-    public async Task SaveAsync(
+    public async Task CreateAsync(
         AIWorkspace workspace,
         CancellationToken cancellationToken = default)
     {

--- a/src/Granit.AI/Extensions/AIServiceCollectionExtensions.cs
+++ b/src/Granit.AI/Extensions/AIServiceCollectionExtensions.cs
@@ -40,6 +40,7 @@ public static class AIServiceCollectionExtensions
         builder.Services.TryAddScoped<IAIWorkspaceProvider, DefaultAIWorkspaceProvider>();
         builder.Services.TryAddScoped<IAIWorkspaceStoreReader, NullAIWorkspaceStoreReader>();
         builder.Services.TryAddScoped<IAIWorkspaceStoreWriter, NullAIWorkspaceStoreWriter>();
+        builder.Services.TryAddScoped<IAIWorkspaceManager, DefaultAIWorkspaceManager>();
 
         // Factories (Scoped — depend on IAIWorkspaceProvider which may consume scoped stores)
         builder.Services.TryAddScoped<IAIChatClientFactory, DefaultAIChatClientFactory>();

--- a/src/Granit.AI/Internal/DefaultAIWorkspaceManager.cs
+++ b/src/Granit.AI/Internal/DefaultAIWorkspaceManager.cs
@@ -1,0 +1,57 @@
+using Granit.AI.Workspaces;
+
+namespace Granit.AI.Internal;
+
+/// <summary>
+/// Default workspace manager that delegates to <see cref="IAIWorkspaceStoreWriter"/>
+/// after validating that only <see cref="AIWorkspaceKind.Dynamic"/> workspaces are modified.
+/// </summary>
+internal sealed class DefaultAIWorkspaceManager(
+    IAIWorkspaceStoreReader reader,
+    IAIWorkspaceStoreWriter writer) : IAIWorkspaceManager
+{
+    public async Task CreateAsync(AIWorkspace workspace, CancellationToken cancellationToken = default)
+    {
+        EnsureDynamic(workspace.Kind);
+
+        AIWorkspace? existing = await reader.FindAsync(workspace.Name, cancellationToken);
+        if (existing is not null)
+        {
+            throw new InvalidOperationException($"Workspace '{workspace.Name}' already exists.");
+        }
+
+        await writer.CreateAsync(workspace, cancellationToken);
+    }
+
+    public async Task UpdateAsync(AIWorkspace workspace, CancellationToken cancellationToken = default)
+    {
+        AIWorkspace? existing = await reader.FindAsync(workspace.Name, cancellationToken);
+        if (existing is null)
+        {
+            throw new InvalidOperationException($"Workspace '{workspace.Name}' not found.");
+        }
+
+        EnsureDynamic(existing.Kind);
+        await writer.UpdateAsync(workspace, cancellationToken);
+    }
+
+    public async Task DeleteAsync(string workspaceName, CancellationToken cancellationToken = default)
+    {
+        AIWorkspace? existing = await reader.FindAsync(workspaceName, cancellationToken);
+        if (existing is null)
+        {
+            return;
+        }
+
+        EnsureDynamic(existing.Kind);
+        await writer.DeleteAsync(workspaceName, cancellationToken);
+    }
+
+    private static void EnsureDynamic(AIWorkspaceKind kind)
+    {
+        if (kind != AIWorkspaceKind.Dynamic)
+        {
+            throw new InvalidOperationException("Only dynamic workspaces can be created, updated, or deleted.");
+        }
+    }
+}

--- a/src/Granit.AI/Internal/NullAIWorkspaceStoreWriter.cs
+++ b/src/Granit.AI/Internal/NullAIWorkspaceStoreWriter.cs
@@ -7,7 +7,7 @@ namespace Granit.AI.Internal;
 /// </summary>
 internal sealed class NullAIWorkspaceStoreWriter : IAIWorkspaceStoreWriter
 {
-    public Task SaveAsync(AIWorkspace workspace, CancellationToken cancellationToken = default) =>
+    public Task CreateAsync(AIWorkspace workspace, CancellationToken cancellationToken = default) =>
         Task.CompletedTask;
 
     public Task UpdateAsync(AIWorkspace workspace, CancellationToken cancellationToken = default) =>

--- a/src/Granit.AI/Workspaces/IAIWorkspaceStoreWriter.cs
+++ b/src/Granit.AI/Workspaces/IAIWorkspaceStoreWriter.cs
@@ -10,7 +10,7 @@ namespace Granit.AI.Workspaces;
 public interface IAIWorkspaceStoreWriter
 {
     /// <inheritdoc cref="IAIWorkspaceManager.CreateAsync"/>
-    Task SaveAsync(AIWorkspace workspace, CancellationToken cancellationToken = default);
+    Task CreateAsync(AIWorkspace workspace, CancellationToken cancellationToken = default);
 
     /// <inheritdoc cref="IAIWorkspaceManager.UpdateAsync"/>
     Task UpdateAsync(AIWorkspace workspace, CancellationToken cancellationToken = default);


### PR DESCRIPTION
## Summary
- Add `DefaultAIWorkspaceManager` to centralize workspace mutation invariants (Dynamic-only guard, duplicate/existence checks) following the standard Granit Manager pattern
- Rename `IAIWorkspaceStoreWriter.SaveAsync` → `CreateAsync` for consistent Create/Update/Delete naming across manager and store interfaces
- Register `IAIWorkspaceManager` in DI via `TryAddScoped`

## Test plan
- [ ] `dotnet build` passes (verified locally)
- [ ] Existing AI workspace tests pass
- [ ] Verify `CreateAsync` rejects duplicate workspace names
- [ ] Verify `CreateAsync`/`UpdateAsync`/`DeleteAsync` reject System workspaces