### PR TITLE
fix(ai): replace typographic quotes with ASCII in zh.json

### DIFF
--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/zh.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/zh.json
@@ -8,7 +8,7 @@
     "Permission:AI.Chat.Execute": "Execute AI chat completions",
     "Permission:AI.Embeddings.Execute": "Generate AI embeddings",
     "AIEndpoints:Workspace:SystemImmutable": "System workspace '{0}' cannot be modified or deleted.",
-    "AIEndpoints:Workspace:DuplicateName": "名为"{0}"的工作区已存在。",
+    "AIEndpoints:Workspace:DuplicateName": "名为\"{0}\"的工作区已存在。",
     "AI.Workspaces.Kind.Dynamic": "动态",
     "AI.Workspaces.Kind.System": "系统",
     "AI.Workspaces.Kind.System:Hint": "系统工作区为只读，无法修改或删除。",


### PR DESCRIPTION
## Summary

- Fix `System.Text.Json.JsonReaderException` caused by Chinese typographic quotes (`"…"` U+201C/U+201D) in `zh.json` localization file
- Replace with escaped ASCII quotes (`\"…\"`) on the `AIEndpoints:Workspace:DuplicateName` key

## Root cause

Commit 93a791c2 introduced Chinese curly quotes in the `DuplicateName` value. `System.Text.Json` interprets `"` (U+201C) as the end of the JSON string, then fails on `{0}` with: *"'{' is invalid after a value"*.

## Test plan

- [ ] Verify `GET /api/granit/localization?cultureName=zh` returns without error
- [ ] Verify all 18 locale JSON files pass `python3 -c "import json; json.load(open(f))"` validation