### PR TITLE
fix(ai): allow inactive workspaces in listing and lookup, guard execution

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -2468,7 +2468,7 @@
       "kind": "record",
       "project": "Granit.AI.Endpoints",
       "file": "src/Granit.AI.Endpoints/Dtos/AIChatResponse.cs",
-      "line": 24,
+      "line": 25,
       "members": []
     },
     {
@@ -2477,7 +2477,7 @@
       "kind": "record",
       "project": "Granit.AI.Endpoints",
       "file": "src/Granit.AI.Endpoints/Dtos/AIEmbeddingResponse.cs",
-      "line": 19,
+      "line": 21,
       "members": []
     },
     {
@@ -2495,7 +2495,16 @@
       "kind": "record",
       "project": "Granit.AI.Endpoints",
       "file": "src/Granit.AI.Endpoints/Dtos/AIEmbeddingResponse.cs",
-      "line": 9,
+      "line": 10,
+      "members": []
+    },
+    {
+      "name": "AIEmbeddingUsageResponse",
+      "fqn": "Granit.AI.Endpoints.Dtos.AIEmbeddingUsageResponse",
+      "kind": "record",
+      "project": "Granit.AI.Endpoints",
+      "file": "src/Granit.AI.Endpoints/Dtos/AIEmbeddingResponse.cs",
+      "line": 29,
       "members": []
     },
     {
@@ -2779,6 +2788,15 @@
       "members": []
     },
     {
+      "name": "AIWorkspaceNotActiveException",
+      "fqn": "Granit.AI.Exceptions.AIWorkspaceNotActiveException",
+      "kind": "class",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/Exceptions/AIWorkspaceNotActiveException.cs",
+      "line": 6,
+      "members": []
+    },
+    {
       "name": "AIWorkspaceNotFoundException",
       "fqn": "Granit.AI.Exceptions.AIWorkspaceNotFoundException",
       "kind": "class",
@@ -3012,6 +3030,22 @@
           "kind": "method",
           "signature": "CheckAsync(CancellationToken cancellationToken = default)",
           "returnType": "Task<AIQuotaResult>"
+        }
+      ]
+    },
+    {
+      "name": "IAIUsageRecordFactory",
+      "fqn": "Granit.AI.IAIUsageRecordFactory",
+      "kind": "interface",
+      "project": "Granit.AI",
+      "file": "src/Granit.AI/IAIUsageRecordFactory.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(string workspaceName, string provider, string model, int inputTokens, int outputTokens, TimeSpan? duration)",
+          "returnType": "AIUsageRecord"
         }
       ]
     },

--- a/docs-site/src/content/docs/dotnet/ai/endpoints.mdx
+++ b/docs-site/src/content/docs/dotnet/ai/endpoints.mdx
@@ -95,10 +95,10 @@ groupBy with aggregates, saved views, and metadata out of the box.
 | Feature | Fields |
 |---------|--------|
 | Filterable | WorkspaceName, Provider, Model, Timestamp |
-| Sortable | Timestamp (default: `-timestamp`), InputTokens, OutputTokens, EstimatedCostUsd |
+| Sortable | Timestamp (default: `-timestamp`), InputTokens, OutputTokens, EstimatedCost |
 | GlobalSearch | WorkspaceName, Provider, Model |
 | GroupBy | WorkspaceName, Provider, Model |
-| Aggregates | Sum(InputTokens), Sum(OutputTokens), Sum(EstimatedCostUsd) |
+| Aggregates | Sum(InputTokens), Sum(OutputTokens), Sum(EstimatedCost) |
 | DateFilter | Timestamp (ThisMonth default) |
 
 **Usage summary** is achieved via `?groupBy=provider` or `?groupBy=workspaceName` —

--- a/docs-site/src/content/docs/dotnet/ai/setup.mdx
+++ b/docs-site/src/content/docs/dotnet/ai/setup.mdx
@@ -348,7 +348,7 @@ is `true` (default). The `AIUsageRecord` captures:
 | `WorkspaceName` | Workspace used |
 | `Provider` / `Model` | Provider and model identifier |
 | `InputTokens` / `OutputTokens` | Token consumption |
-| `EstimatedCostUsd` | Cost estimate based on configured pricing |
+| `EstimatedCost` / `CostCurrency` | Cost estimate and ISO 4217 currency code |
 | `Duration` | Response time |
 | `Timestamp` | When the interaction occurred (UTC) |
 

--- a/src/Granit.AI.Endpoints/Dtos/AIChatResponse.cs
+++ b/src/Granit.AI.Endpoints/Dtos/AIChatResponse.cs
@@ -20,8 +20,10 @@ public sealed record AIChatResponse(
 /// </summary>
 /// <param name="InputTokens">Number of input tokens consumed.</param>
 /// <param name="OutputTokens">Number of output tokens generated.</param>
-/// <param name="EstimatedCostUsd">Estimated cost in USD, if available.</param>
+/// <param name="EstimatedCost">Estimated cost, if available.</param>
+/// <param name="CostCurrency">ISO 4217 currency code for <paramref name="EstimatedCost"/>.</param>
 public sealed record AIChatUsageResponse(
     int InputTokens,
     int OutputTokens,
-    decimal? EstimatedCostUsd);
+    decimal? EstimatedCost,
+    string? CostCurrency);

--- a/src/Granit.AI.Endpoints/Dtos/AIEmbeddingResponse.cs
+++ b/src/Granit.AI.Endpoints/Dtos/AIEmbeddingResponse.cs
@@ -6,10 +6,12 @@ namespace Granit.AI.Endpoints.Dtos;
 /// <param name="WorkspaceName">Workspace that processed the request.</param>
 /// <param name="Model">Model used for embedding generation.</param>
 /// <param name="Embeddings">Generated embedding vectors.</param>
+/// <param name="Usage">Token usage details, if available.</param>
 public sealed record AIEmbeddingResponse(
     string WorkspaceName,
     string Model,
-    IReadOnlyList<AIEmbeddingDataResponse> Embeddings);
+    IReadOnlyList<AIEmbeddingDataResponse> Embeddings,
+    AIEmbeddingUsageResponse? Usage);
 
 /// <summary>
 /// A single embedding vector with its index.
@@ -19,3 +21,9 @@ public sealed record AIEmbeddingResponse(
 public sealed record AIEmbeddingDataResponse(
     int Index,
     IReadOnlyList<float> Vector);
+
+/// <summary>
+/// Token usage details for an embedding generation.
+/// </summary>
+/// <param name="InputTokens">Number of input tokens consumed.</param>
+public sealed record AIEmbeddingUsageResponse(int InputTokens);

--- a/src/Granit.AI.Endpoints/Endpoints/AIChatEndpoints.cs
+++ b/src/Granit.AI.Endpoints/Endpoints/AIChatEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using Granit.AI.Endpoints.Dtos;
 using Granit.AI.Endpoints.Internal;
@@ -25,6 +26,7 @@ internal static class AIChatEndpoints
                 + "Returns 404 if the workspace does not exist, or 502 if the provider is unavailable.")
             .Produces<AIChatResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .ProducesProblem(StatusCodes.Status502BadGateway);
 
         group.MapPost("/chat/{workspaceName}/stream", StreamAsync)
@@ -32,11 +34,15 @@ internal static class AIChatEndpoints
             .WithSummary("Streams a chat completion response via Server-Sent Events.")
             .WithDescription(
                 "Opens an SSE stream that emits incremental content chunks as they arrive from the provider. "
-                + "The stream ends with a [DONE] sentinel. "
-                + "Returns 404 if the workspace does not exist, or 502 if the provider is unavailable.")
+                + "The stream ends with a [DONE] sentinel. If the provider returns an error after streaming has "
+                + "started, an SSE 'error' event is emitted before closing. "
+                + "Returns 404 if the workspace does not exist, 422 if the model is not found, "
+                + "or 502/503 if the provider is unavailable.")
             .Produces<string>(StatusCodes.Status200OK, "text/event-stream")
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesProblem(StatusCodes.Status502BadGateway);
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+            .ProducesProblem(StatusCodes.Status502BadGateway)
+            .ProducesProblem(StatusCodes.Status503ServiceUnavailable);
 
         return group;
     }
@@ -73,7 +79,7 @@ internal static class AIChatEndpoints
         }
 
         AIChatUsageResponse? usageResponse = result.InputTokens is not null
-            ? new AIChatUsageResponse(result.InputTokens.Value, result.OutputTokens!.Value, null)
+            ? new AIChatUsageResponse(result.InputTokens.Value, result.OutputTokens!.Value, null, null)
             : null;
 
         return TypedResults.Ok(new AIChatResponse(
@@ -89,6 +95,8 @@ internal static class AIChatEndpoints
         AIChatRequest request,
         [FromServices] IAIChatClientFactory chatClientFactory,
         [FromServices] IAIWorkspaceProvider workspaceProvider,
+        [FromServices] IAIUsageTracker usageTracker,
+        [FromServices] IAIUsageRecordFactory usageRecordFactory,
         HttpContext httpContext,
         CancellationToken cancellationToken)
     {
@@ -128,16 +136,71 @@ internal static class AIChatEndpoints
         httpContext.Response.Headers.CacheControl = "no-cache";
         httpContext.Response.Headers.Connection = "keep-alive";
 
-        await foreach (ChatResponseUpdate? update in chatClient.GetStreamingResponseAsync(
-            messages, cancellationToken: cancellationToken).ConfigureAwait(false))
+        var stopwatch = Stopwatch.StartNew();
+        bool headersSent = false;
+        UsageContent? accumulatedUsage = null;
+
+        try
         {
-            foreach (TextContent content in update.Contents.OfType<TextContent>())
+            await foreach (ChatResponseUpdate? update in chatClient.GetStreamingResponseAsync(
+                messages, cancellationToken: cancellationToken).ConfigureAwait(false))
             {
-                await httpContext.Response.WriteAsync(
-                    $"data: {JsonSerializer.Serialize(new { content = content.Text })}\n\n",
-                    cancellationToken).ConfigureAwait(false);
-                await httpContext.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
+                foreach (UsageContent usage in update.Contents.OfType<UsageContent>())
+                {
+                    accumulatedUsage = usage;
+                }
+
+                foreach (TextContent content in update.Contents.OfType<TextContent>())
+                {
+                    headersSent = true;
+                    await httpContext.Response.WriteAsync(
+                        $"data: {JsonSerializer.Serialize(new { content = content.Text })}\n\n",
+                        cancellationToken).ConfigureAwait(false);
+                    await httpContext.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
+                }
             }
+        }
+        catch (Exception ex) when (ex is HttpRequestException or OperationCanceledException or IOException)
+        {
+            if (!headersSent && !httpContext.Response.HasStarted)
+            {
+                httpContext.Response.ContentType = "application/problem+json";
+                ProblemHttpResult problem = AIProviderExceptionMapper.MapException(
+                    ex, workspace.Model, workspace.Provider);
+                await problem.ExecuteAsync(httpContext).ConfigureAwait(false);
+                return;
+            }
+
+            string errorMessage = AIProviderExceptionMapper.GetErrorMessage(
+                ex, workspace.Model, workspace.Provider);
+            await httpContext.Response.WriteAsync(
+                $"event: error\ndata: {JsonSerializer.Serialize(new { error = errorMessage })}\n\n",
+                CancellationToken.None).ConfigureAwait(false);
+            await httpContext.Response.Body.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+            return;
+        }
+
+        stopwatch.Stop();
+
+        if (accumulatedUsage is not null)
+        {
+            int inputTokens = (int)(accumulatedUsage.Details.InputTokenCount ?? 0);
+            int outputTokens = (int)(accumulatedUsage.Details.OutputTokenCount ?? 0);
+
+            AIUsageRecord usageRecord = usageRecordFactory.Create(
+                workspaceName,
+                workspace.Provider,
+                workspace.Model,
+                inputTokens,
+                outputTokens,
+                stopwatch.Elapsed);
+
+            await usageTracker.RecordAsync(usageRecord, CancellationToken.None).ConfigureAwait(false);
+
+            await httpContext.Response.WriteAsync(
+                $"event: usage\ndata: {JsonSerializer.Serialize(new { inputTokens, outputTokens })}\n\n",
+                cancellationToken).ConfigureAwait(false);
+            await httpContext.Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
 
         await httpContext.Response.WriteAsync("data: [DONE]\n\n", cancellationToken)

--- a/src/Granit.AI.Endpoints/Endpoints/AIEmbeddingEndpoints.cs
+++ b/src/Granit.AI.Endpoints/Endpoints/AIEmbeddingEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Granit.AI.Endpoints.Dtos;
 using Granit.AI.Endpoints.Internal;
 using Granit.AI.Exceptions;
@@ -34,6 +35,8 @@ internal static class AIEmbeddingEndpoints
         AIEmbeddingRequest request,
         [FromServices] IAIEmbeddingGeneratorFactory embeddingFactory,
         [FromServices] IAIWorkspaceProvider workspaceProvider,
+        [FromServices] IAIUsageTracker usageTracker,
+        [FromServices] IAIUsageRecordFactory usageRecordFactory,
         CancellationToken cancellationToken)
     {
         AIWorkspace? workspace = await workspaceProvider
@@ -57,6 +60,7 @@ internal static class AIEmbeddingEndpoints
             return AIProviderExceptionMapper.MapException(ex);
         }
 
+        var stopwatch = Stopwatch.StartNew();
         GeneratedEmbeddings<Embedding<float>> embeddings;
         try
         {
@@ -69,10 +73,30 @@ internal static class AIEmbeddingEndpoints
             return AIProviderExceptionMapper.MapException(ex);
         }
 
+        stopwatch.Stop();
+
         var data = embeddings
             .Select((e, i) => new AIEmbeddingDataResponse(i, e.Vector.ToArray().ToList()))
             .ToList();
 
-        return TypedResults.Ok(new AIEmbeddingResponse(workspaceName, workspace.Model, data));
+        AIEmbeddingUsageResponse? usageResponse = null;
+        if (embeddings.Usage is not null)
+        {
+            int inputTokens = (int)(embeddings.Usage.InputTokenCount ?? 0);
+
+            AIUsageRecord usageRecord = usageRecordFactory.Create(
+                workspaceName,
+                workspace.Provider,
+                workspace.Model,
+                inputTokens,
+                outputTokens: 0,
+                stopwatch.Elapsed);
+
+            await usageTracker.RecordAsync(usageRecord, cancellationToken).ConfigureAwait(false);
+
+            usageResponse = new AIEmbeddingUsageResponse(inputTokens);
+        }
+
+        return TypedResults.Ok(new AIEmbeddingResponse(workspaceName, workspace.Model, data, usageResponse));
     }
 }

--- a/src/Granit.AI.Endpoints/Internal/AIProviderExceptionMapper.cs
+++ b/src/Granit.AI.Endpoints/Internal/AIProviderExceptionMapper.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Granit.AI.Exceptions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -9,26 +10,60 @@ namespace Granit.AI.Endpoints.Internal;
 /// </summary>
 internal static class AIProviderExceptionMapper
 {
-    internal static ProblemHttpResult MapException(Exception exception) => exception switch
-    {
-        AIWorkspaceNotFoundException ex => TypedResults.Problem(
-            detail: $"AI workspace '{ex.WorkspaceName}' was not found.",
-            statusCode: StatusCodes.Status404NotFound),
+    internal static ProblemHttpResult MapException(Exception exception) =>
+        MapException(exception, null, null);
 
-        AIProviderNotRegisteredException ex => TypedResults.Problem(
-            detail: $"No AI provider is registered for '{ex.ProviderName}'.",
-            statusCode: StatusCodes.Status502BadGateway),
+    internal static ProblemHttpResult MapException(Exception exception, string? model, string? provider) =>
+        exception switch
+        {
+            AIWorkspaceNotFoundException ex => TypedResults.Problem(
+                detail: $"AI workspace '{ex.WorkspaceName}' was not found.",
+                statusCode: StatusCodes.Status404NotFound),
 
-        OperationCanceledException => TypedResults.Problem(
-            detail: "The AI service request was cancelled.",
-            statusCode: StatusCodes.Status503ServiceUnavailable),
+            AIWorkspaceNotActiveException ex => TypedResults.Problem(
+                detail: $"AI workspace '{ex.WorkspaceName}' is not active.",
+                statusCode: StatusCodes.Status422UnprocessableEntity),
 
-        HttpRequestException => TypedResults.Problem(
-            detail: "The AI service is currently unavailable.",
-            statusCode: StatusCodes.Status503ServiceUnavailable),
+            AIProviderNotRegisteredException ex => TypedResults.Problem(
+                detail: $"No AI provider is registered for '{ex.ProviderName}'.",
+                statusCode: StatusCodes.Status502BadGateway),
 
-        _ => TypedResults.Problem(
-            detail: "An unexpected error occurred while communicating with the AI service.",
-            statusCode: StatusCodes.Status502BadGateway),
-    };
+            OperationCanceledException => TypedResults.Problem(
+                detail: "The AI service request was cancelled.",
+                statusCode: StatusCodes.Status503ServiceUnavailable),
+
+            HttpRequestException { StatusCode: HttpStatusCode.NotFound } => TypedResults.Problem(
+                detail: model is not null && provider is not null
+                    ? $"AI model '{model}' not found on provider '{provider}'. Verify the model is available."
+                    : "The requested AI model was not found on the provider.",
+                statusCode: StatusCodes.Status422UnprocessableEntity),
+
+            HttpRequestException httpEx => TypedResults.Problem(
+                detail: httpEx.StatusCode is not null
+                    ? $"The AI service returned HTTP {(int)httpEx.StatusCode} and is currently unavailable."
+                    : "The AI service is currently unavailable.",
+                statusCode: StatusCodes.Status503ServiceUnavailable),
+
+            IOException => TypedResults.Problem(
+                detail: "The connection to the AI service was interrupted.",
+                statusCode: StatusCodes.Status503ServiceUnavailable),
+
+            _ => TypedResults.Problem(
+                detail: "An unexpected error occurred while communicating with the AI service.",
+                statusCode: StatusCodes.Status502BadGateway),
+        };
+
+    internal static string GetErrorMessage(Exception exception, string? model, string? provider) =>
+        exception switch
+        {
+            HttpRequestException { StatusCode: HttpStatusCode.NotFound } when model is not null && provider is not null =>
+                $"AI model '{model}' not found on provider '{provider}'. Verify the model is available.",
+            HttpRequestException { StatusCode: HttpStatusCode.NotFound } =>
+                "The requested AI model was not found on the provider.",
+            HttpRequestException httpEx when httpEx.StatusCode is not null =>
+                $"The AI service returned HTTP {(int)httpEx.StatusCode} and is currently unavailable.",
+            OperationCanceledException => "The AI service request was cancelled.",
+            IOException => "The connection to the AI service was interrupted.",
+            _ => "An unexpected error occurred while communicating with the AI service.",
+        };
 }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/cs.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/cs.json
@@ -17,7 +17,8 @@
     "AI.Columns.Model": "Model",
     "AI.Columns.InputTokens": "Input Tokens",
     "AI.Columns.OutputTokens": "Output Tokens",
-    "AI.Columns.EstimatedCostUsd": "Estimated Cost (USD)",
+    "AI.Columns.EstimatedCost": "Odhadované náklady",
+    "AI.Columns.CostCurrency": "Měna",
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration"
   }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/de.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/de.json
@@ -17,7 +17,8 @@
     "AI.Columns.Model": "Modell",
     "AI.Columns.InputTokens": "Eingabe-Token",
     "AI.Columns.OutputTokens": "Ausgabe-Token",
-    "AI.Columns.EstimatedCostUsd": "Geschätzte Kosten (USD)",
+    "AI.Columns.EstimatedCost": "Geschätzte Kosten",
+    "AI.Columns.CostCurrency": "Währung",
     "AI.Columns.Timestamp": "Zeitstempel",
     "AI.Columns.Duration": "Dauer"
   }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/en-GB.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/en-GB.json
@@ -17,7 +17,8 @@
     "AI.Columns.Model": "Model",
     "AI.Columns.InputTokens": "Input Tokens",
     "AI.Columns.OutputTokens": "Output Tokens",
-    "AI.Columns.EstimatedCostUsd": "Estimated Cost (USD)",
+    "AI.Columns.EstimatedCost": "Estimated Cost",
+    "AI.Columns.CostCurrency": "Currency",
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration"
   }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/en.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/en.json
@@ -17,7 +17,8 @@
     "AI.Columns.Model": "Model",
     "AI.Columns.InputTokens": "Input Tokens",
     "AI.Columns.OutputTokens": "Output Tokens",
-    "AI.Columns.EstimatedCostUsd": "Estimated Cost (USD)",
+    "AI.Columns.EstimatedCost": "Estimated Cost",
+    "AI.Columns.CostCurrency": "Currency",
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration"
   }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/es.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/es.json
@@ -17,7 +17,8 @@
     "AI.Columns.Model": "Modelo",
     "AI.Columns.InputTokens": "Tokens de entrada",
     "AI.Columns.OutputTokens": "Tokens de salida",
-    "AI.Columns.EstimatedCostUsd": "Costo estimado (USD)",
+    "AI.Columns.EstimatedCost": "Costo estimado",
+    "AI.Columns.CostCurrency": "Moneda",
     "AI.Columns.Timestamp": "Marca de tiempo",
     "AI.Columns.Duration": "Duración"
   }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/fr-CA.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/fr-CA.json
@@ -17,7 +17,8 @@
     "AI.Columns.Model": "Modèle",
     "AI.Columns.InputTokens": "Jetons d'entrée",
     "AI.Columns.OutputTokens": "Jetons de sortie",
-    "AI.Columns.EstimatedCostUsd": "Coût estimé (USD)",
+    "AI.Columns.EstimatedCost": "Coût estimé",
+    "AI.Columns.CostCurrency": "Devise",
     "AI.Columns.Timestamp": "Horodatage",
     "AI.Columns.Duration": "Durée"
   }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/fr.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/fr.json
@@ -17,7 +17,8 @@
     "AI.Columns.Model": "Modèle",
     "AI.Columns.InputTokens": "Jetons d'entrée",
     "AI.Columns.OutputTokens": "Jetons de sortie",
-    "AI.Columns.EstimatedCostUsd": "Coût estimé (USD)",
+    "AI.Columns.EstimatedCost": "Coût estimé",
+    "AI.Columns.CostCurrency": "Devise",
     "AI.Columns.Timestamp": "Horodatage",
     "AI.Columns.Duration": "Durée"
   }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/hi.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/hi.json
@@ -17,7 +17,8 @@
     "AI.Columns.Model": "Model",
     "AI.Columns.InputTokens": "Input Tokens",
     "AI.Columns.OutputTokens": "Output Tokens",
-    "AI.Columns.EstimatedCostUsd": "Estimated Cost (USD)",
+    "AI.Columns.EstimatedCost": "अनुमानित लागत",
+    "AI.Columns.CostCurrency": "मुद्रा",
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration"
   }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/it.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/it.json
@@ -17,7 +17,8 @@
     "AI.Columns.Model": "Model",
     "AI.Columns.InputTokens": "Input Tokens",
     "AI.Columns.OutputTokens": "Output Tokens",
-    "AI.Columns.EstimatedCostUsd": "Estimated Cost (USD)",
+    "AI.Columns.EstimatedCost": "Costo stimato",
+    "AI.Columns.CostCurrency": "Valuta",
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration"
   }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/ja.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/ja.json
@@ -17,7 +17,8 @@
     "AI.Columns.Model": "Model",
     "AI.Columns.InputTokens": "Input Tokens",
     "AI.Columns.OutputTokens": "Output Tokens",
-    "AI.Columns.EstimatedCostUsd": "Estimated Cost (USD)",
+    "AI.Columns.EstimatedCost": "推定コスト",
+    "AI.Columns.CostCurrency": "通貨",
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration"
   }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/ko.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/ko.json
@@ -17,7 +17,8 @@
     "AI.Columns.Model": "Model",
     "AI.Columns.InputTokens": "Input Tokens",
     "AI.Columns.OutputTokens": "Output Tokens",
-    "AI.Columns.EstimatedCostUsd": "Estimated Cost (USD)",
+    "AI.Columns.EstimatedCost": "예상 비용",
+    "AI.Columns.CostCurrency": "통화",
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration"
   }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/nl.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/nl.json
@@ -17,7 +17,8 @@
     "AI.Columns.Model": "Model",
     "AI.Columns.InputTokens": "Invoertokens",
     "AI.Columns.OutputTokens": "Uitvoertokens",
-    "AI.Columns.EstimatedCostUsd": "Geschatte kosten (USD)",
+    "AI.Columns.EstimatedCost": "Geschatte kosten",
+    "AI.Columns.CostCurrency": "Valuta",
     "AI.Columns.Timestamp": "Tijdstempel",
     "AI.Columns.Duration": "Duur"
   }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/pl.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/pl.json
@@ -17,7 +17,8 @@
     "AI.Columns.Model": "Model",
     "AI.Columns.InputTokens": "Input Tokens",
     "AI.Columns.OutputTokens": "Output Tokens",
-    "AI.Columns.EstimatedCostUsd": "Estimated Cost (USD)",
+    "AI.Columns.EstimatedCost": "Szacowany koszt",
+    "AI.Columns.CostCurrency": "Waluta",
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration"
   }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/pt-BR.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/pt-BR.json
@@ -17,7 +17,8 @@
     "AI.Columns.Model": "Model",
     "AI.Columns.InputTokens": "Input Tokens",
     "AI.Columns.OutputTokens": "Output Tokens",
-    "AI.Columns.EstimatedCostUsd": "Estimated Cost (USD)",
+    "AI.Columns.EstimatedCost": "Custo estimado",
+    "AI.Columns.CostCurrency": "Moeda",
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration"
   }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/pt.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/pt.json
@@ -17,7 +17,8 @@
     "AI.Columns.Model": "Model",
     "AI.Columns.InputTokens": "Input Tokens",
     "AI.Columns.OutputTokens": "Output Tokens",
-    "AI.Columns.EstimatedCostUsd": "Estimated Cost (USD)",
+    "AI.Columns.EstimatedCost": "Custo estimado",
+    "AI.Columns.CostCurrency": "Moeda",
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration"
   }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/sv.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/sv.json
@@ -17,7 +17,8 @@
     "AI.Columns.Model": "Model",
     "AI.Columns.InputTokens": "Input Tokens",
     "AI.Columns.OutputTokens": "Output Tokens",
-    "AI.Columns.EstimatedCostUsd": "Estimated Cost (USD)",
+    "AI.Columns.EstimatedCost": "Uppskattad kostnad",
+    "AI.Columns.CostCurrency": "Valuta",
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration"
   }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/tr.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/tr.json
@@ -17,7 +17,8 @@
     "AI.Columns.Model": "Model",
     "AI.Columns.InputTokens": "Input Tokens",
     "AI.Columns.OutputTokens": "Output Tokens",
-    "AI.Columns.EstimatedCostUsd": "Estimated Cost (USD)",
+    "AI.Columns.EstimatedCost": "Tahmini maliyet",
+    "AI.Columns.CostCurrency": "Para birimi",
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration"
   }

--- a/src/Granit.AI.Endpoints/Localization/AIEndpoints/zh.json
+++ b/src/Granit.AI.Endpoints/Localization/AIEndpoints/zh.json
@@ -17,7 +17,8 @@
     "AI.Columns.Model": "Model",
     "AI.Columns.InputTokens": "Input Tokens",
     "AI.Columns.OutputTokens": "Output Tokens",
-    "AI.Columns.EstimatedCostUsd": "Estimated Cost (USD)",
+    "AI.Columns.EstimatedCost": "预估费用",
+    "AI.Columns.CostCurrency": "货币",
     "AI.Columns.Timestamp": "Timestamp",
     "AI.Columns.Duration": "Duration"
   }

--- a/src/Granit.AI.Endpoints/Queries/AIUsageRecordQueryDefinition.cs
+++ b/src/Granit.AI.Endpoints/Queries/AIUsageRecordQueryDefinition.cs
@@ -25,7 +25,8 @@ public sealed class AIUsageRecordQueryDefinition : QueryDefinition<AIUsageRecord
             .Column(r => r.Model, c => c.Label("Model").LabelKey("AI.Columns.Model").Filterable().Sortable())
             .Column(r => r.InputTokens, c => c.Label("Input Tokens").LabelKey("AI.Columns.InputTokens").Sortable())
             .Column(r => r.OutputTokens, c => c.Label("Output Tokens").LabelKey("AI.Columns.OutputTokens").Sortable())
-            .Column(r => r.EstimatedCostUsd, c => c.Label("Estimated Cost (USD)").LabelKey("AI.Columns.EstimatedCostUsd").Sortable())
+            .Column(r => r.EstimatedCost, c => c.Label("Estimated Cost").LabelKey("AI.Columns.EstimatedCost").Sortable())
+            .Column(r => r.CostCurrency, c => c.Label("Currency").LabelKey("AI.Columns.CostCurrency"))
             .Column(r => r.Timestamp, c => c.Label("Timestamp").LabelKey("AI.Columns.Timestamp").Sortable())
             .Column(r => r.Duration, c => c.Label("Duration").LabelKey("AI.Columns.Duration"))
             .GlobalSearch(r => r.WorkspaceName, r => r.Provider, r => r.Model)
@@ -35,7 +36,7 @@ public sealed class AIUsageRecordQueryDefinition : QueryDefinition<AIUsageRecord
             .AllowGroupBy(r => r.Model)
             .Aggregate(r => r.InputTokens, AggregateFunction.Sum, "totalInputTokens")
             .Aggregate(r => r.OutputTokens, AggregateFunction.Sum, "totalOutputTokens")
-            .Aggregate(r => r.EstimatedCostUsd, AggregateFunction.Sum, "totalEstimatedCostUsd")
+            .Aggregate(r => r.EstimatedCost, AggregateFunction.Sum, "totalEstimatedCost")
             .DefaultSort("-timestamp")
             .DefaultPageSize(25);
     }

--- a/src/Granit.AI.EntityFrameworkCore/Entities/AIUsageRecordEntity.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Entities/AIUsageRecordEntity.cs
@@ -21,7 +21,9 @@ internal sealed class AIUsageRecordEntity : CreationAuditedEntity, IMultiTenant
 
     public int OutputTokens { get; set; }
 
-    public decimal? EstimatedCostUsd { get; set; }
+    public decimal? EstimatedCost { get; set; }
+
+    public string? CostCurrency { get; set; }
 
     public TimeSpan? Duration { get; set; }
 
@@ -35,7 +37,8 @@ internal sealed class AIUsageRecordEntity : CreationAuditedEntity, IMultiTenant
         Model = record.Model,
         InputTokens = record.InputTokens,
         OutputTokens = record.OutputTokens,
-        EstimatedCostUsd = record.EstimatedCostUsd,
+        EstimatedCost = record.EstimatedCost,
+        CostCurrency = record.CostCurrency,
         Duration = record.Duration,
     };
 }

--- a/src/Granit.AI.EntityFrameworkCore/Internal/AIUsageRecordEntityConfiguration.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/AIUsageRecordEntityConfiguration.cs
@@ -41,9 +41,12 @@ internal sealed class AIUsageRecordEntityConfiguration : IEntityTypeConfiguratio
         builder.Property(e => e.OutputTokens)
             .IsRequired();
 
-        // Precision 18,8 for accurate cost tracking (e.g. $0.00000150 per token).
-        builder.Property(e => e.EstimatedCostUsd)
+        // Precision 18,8 for accurate cost tracking (e.g. 0.00000150 per token).
+        builder.Property(e => e.EstimatedCost)
             .HasPrecision(18, 8);
+
+        builder.Property(e => e.CostCurrency)
+            .HasMaxLength(3);
 
         builder.Property(e => e.Duration);
 

--- a/src/Granit.AI.EntityFrameworkCore/Internal/EfAIUsageQueryableSource.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/EfAIUsageQueryableSource.cs
@@ -38,7 +38,8 @@ internal sealed class EfAIUsageQueryableSource(
             Model = e.Model,
             InputTokens = e.InputTokens,
             OutputTokens = e.OutputTokens,
-            EstimatedCostUsd = e.EstimatedCostUsd,
+            EstimatedCost = e.EstimatedCost,
+            CostCurrency = e.CostCurrency,
             Timestamp = e.CreatedAt,
             Duration = e.Duration,
         });

--- a/src/Granit.AI.EntityFrameworkCore/Internal/EfAIWorkspaceStore.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/EfAIWorkspaceStore.cs
@@ -26,7 +26,7 @@ internal sealed class EfAIWorkspaceStore(
         CancellationToken cancellationToken = default)
     {
         AIWorkspaceEntity? entity = await FirstOrDefaultAsync(
-            w => w.Name == workspaceName && w.IsActive, cancellationToken).ConfigureAwait(false);
+            w => w.Name == workspaceName, cancellationToken).ConfigureAwait(false);
 
         return entity?.ToRecord();
     }
@@ -37,7 +37,6 @@ internal sealed class EfAIWorkspaceStore(
     {
         IReadOnlyList<AIWorkspaceEntity> entities = await ListAsync(
             Spec.For<AIWorkspaceEntity>()
-                .Where(w => w.IsActive)
                 .OrderBy(w => (object)w.Name),
             cancellationToken).ConfigureAwait(false);
 

--- a/src/Granit.AI/AIUsageRecord.cs
+++ b/src/Granit.AI/AIUsageRecord.cs
@@ -29,8 +29,11 @@ public sealed record AIUsageRecord
     /// <summary>Number of output tokens generated.</summary>
     public int OutputTokens { get; init; }
 
-    /// <summary>Estimated cost in USD (based on configured pricing).</summary>
-    public decimal? EstimatedCostUsd { get; init; }
+    /// <summary>Estimated cost (based on configured pricing).</summary>
+    public decimal? EstimatedCost { get; init; }
+
+    /// <summary>ISO 4217 currency code for <see cref="EstimatedCost"/> (e.g. <c>USD</c>, <c>CNY</c>).</summary>
+    public string? CostCurrency { get; init; }
 
     /// <summary>When the interaction occurred (UTC).</summary>
     public required DateTimeOffset Timestamp { get; init; }

--- a/src/Granit.AI/Exceptions/AIWorkspaceNotActiveException.cs
+++ b/src/Granit.AI/Exceptions/AIWorkspaceNotActiveException.cs
@@ -1,0 +1,13 @@
+namespace Granit.AI.Exceptions;
+
+/// <summary>
+/// Thrown when a requested AI workspace exists but is not active.
+/// </summary>
+public sealed class AIWorkspaceNotActiveException(string workspaceName)
+    : InvalidOperationException($"AI workspace '{workspaceName}' is not active.")
+{
+    /// <summary>
+    /// Name of the inactive workspace.
+    /// </summary>
+    public string WorkspaceName { get; } = workspaceName;
+}

--- a/src/Granit.AI/Extensions/AIServiceCollectionExtensions.cs
+++ b/src/Granit.AI/Extensions/AIServiceCollectionExtensions.cs
@@ -52,6 +52,7 @@ public static class AIServiceCollectionExtensions
 
         // Usage tracking (no-op by default, overridden by EF Core package)
         builder.Services.TryAddScoped<IAIUsageTracker, NullAIUsageTracker>();
+        builder.Services.TryAddScoped<IAIUsageRecordFactory, AIUsageRecordFactory>();
 
         // Quota guard: InMemory by default (no-op when MaxRequestsPerTenantPerHour=0)
         builder.Services

--- a/src/Granit.AI/IAIUsageRecordFactory.cs
+++ b/src/Granit.AI/IAIUsageRecordFactory.cs
@@ -1,0 +1,19 @@
+namespace Granit.AI;
+
+/// <summary>
+/// Factory for creating <see cref="AIUsageRecord"/> instances with tenant and user context
+/// resolved from the current scope.
+/// </summary>
+public interface IAIUsageRecordFactory
+{
+    /// <summary>
+    /// Creates an <see cref="AIUsageRecord"/> populated with tenant, user, and timestamp context.
+    /// </summary>
+    AIUsageRecord Create(
+        string workspaceName,
+        string provider,
+        string model,
+        int inputTokens,
+        int outputTokens,
+        TimeSpan? duration);
+}

--- a/src/Granit.AI/Internal/AIUsageRecordFactory.cs
+++ b/src/Granit.AI/Internal/AIUsageRecordFactory.cs
@@ -1,0 +1,36 @@
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Users;
+
+namespace Granit.AI.Internal;
+
+/// <summary>
+/// Creates <see cref="AIUsageRecord"/> instances with tenant and user context resolved from the current scope.
+/// </summary>
+internal sealed class AIUsageRecordFactory(
+    ICurrentTenant currentTenant,
+    ICurrentUserService currentUserService,
+    IGuidGenerator guidGenerator,
+    TimeProvider timeProvider) : IAIUsageRecordFactory
+{
+    /// <inheritdoc/>
+    public AIUsageRecord Create(
+        string workspaceName,
+        string provider,
+        string model,
+        int inputTokens,
+        int outputTokens,
+        TimeSpan? duration) => new()
+        {
+            Id = guidGenerator.Create(),
+            TenantId = currentTenant.IsAvailable ? currentTenant.Id : null,
+            UserId = Guid.TryParse(currentUserService.UserId, out Guid uid) ? uid : null,
+            WorkspaceName = workspaceName,
+            Provider = provider,
+            Model = model,
+            InputTokens = inputTokens,
+            OutputTokens = outputTokens,
+            Timestamp = timeProvider.GetUtcNow(),
+            Duration = duration,
+        };
+}

--- a/src/Granit.AI/Internal/DefaultAIChatClientFactory.cs
+++ b/src/Granit.AI/Internal/DefaultAIChatClientFactory.cs
@@ -26,6 +26,11 @@ internal sealed class DefaultAIChatClientFactory(
         AIWorkspace workspace = await workspaceProvider.GetAsync(name, cancellationToken).ConfigureAwait(false)
             ?? throw new AIWorkspaceNotFoundException(name);
 
+        if (!workspace.IsActive)
+        {
+            throw new AIWorkspaceNotActiveException(name);
+        }
+
         if (!_providers.TryGetValue(workspace.Provider, out IAIProviderFactory? providerFactory))
         {
             throw new AIProviderNotRegisteredException(workspace.Provider);

--- a/src/Granit.AI/Internal/DefaultAIChatCompletionService.cs
+++ b/src/Granit.AI/Internal/DefaultAIChatCompletionService.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using Granit.AI.Workspaces;
-using Granit.Guids;
 using Microsoft.Extensions.AI;
 
 namespace Granit.AI.Internal;
@@ -13,8 +12,7 @@ internal sealed class DefaultAIChatCompletionService(
     IAIChatClientFactory chatClientFactory,
     IAIWorkspaceProvider workspaceProvider,
     IAIUsageTracker usageTracker,
-    TimeProvider timeProvider,
-    IGuidGenerator guidGenerator) : IAIChatCompletionService
+    IAIUsageRecordFactory usageRecordFactory) : IAIChatCompletionService
 {
     /// <inheritdoc/>
     public async Task<AIChatCompletionResult?> CompleteAsync(
@@ -58,17 +56,15 @@ internal sealed class DefaultAIChatCompletionService(
             inputTokens = (int)(usage.InputTokenCount ?? 0);
             outputTokens = (int)(usage.OutputTokenCount ?? 0);
 
-            await usageTracker.RecordAsync(new AIUsageRecord
-            {
-                Id = guidGenerator.Create(),
-                WorkspaceName = workspaceName,
-                Provider = workspace.Provider,
-                Model = workspace.Model,
-                InputTokens = inputTokens.Value,
-                OutputTokens = outputTokens.Value,
-                Timestamp = timeProvider.GetUtcNow(),
-                Duration = stopwatch.Elapsed,
-            }, cancellationToken).ConfigureAwait(false);
+            AIUsageRecord usageRecord = usageRecordFactory.Create(
+                workspaceName,
+                workspace.Provider,
+                workspace.Model,
+                inputTokens.Value,
+                outputTokens.Value,
+                stopwatch.Elapsed);
+
+            await usageTracker.RecordAsync(usageRecord, cancellationToken).ConfigureAwait(false);
         }
 
         return new AIChatCompletionResult(

--- a/src/Granit.AI/Internal/DefaultAIEmbeddingGeneratorFactory.cs
+++ b/src/Granit.AI/Internal/DefaultAIEmbeddingGeneratorFactory.cs
@@ -26,6 +26,11 @@ internal sealed class DefaultAIEmbeddingGeneratorFactory(
         AIWorkspace workspace = await workspaceProvider.GetAsync(name, cancellationToken).ConfigureAwait(false)
             ?? throw new AIWorkspaceNotFoundException(name);
 
+        if (!workspace.IsActive)
+        {
+            throw new AIWorkspaceNotActiveException(name);
+        }
+
         if (!_providers.TryGetValue(workspace.Provider, out IAIProviderFactory? providerFactory))
         {
             throw new AIProviderNotRegisteredException(workspace.Provider);

--- a/tests/Granit.AI.Endpoints.Tests/Queries/AIUsageRecordQueryDefinitionTests.cs
+++ b/tests/Granit.AI.Endpoints.Tests/Queries/AIUsageRecordQueryDefinitionTests.cs
@@ -16,13 +16,14 @@ public sealed class AIUsageRecordQueryDefinitionTests
     public void Declares_expected_columns()
     {
         System.Collections.Generic.IReadOnlyList<Granit.QueryEngine.ColumnDescriptor> columns = _definition.GetColumns();
-        columns.Count.ShouldBe(8);
+        columns.Count.ShouldBe(9);
         columns.Select(c => c.PropertyName).ShouldContain("WorkspaceName");
         columns.Select(c => c.PropertyName).ShouldContain("Provider");
         columns.Select(c => c.PropertyName).ShouldContain("Model");
         columns.Select(c => c.PropertyName).ShouldContain("InputTokens");
         columns.Select(c => c.PropertyName).ShouldContain("OutputTokens");
-        columns.Select(c => c.PropertyName).ShouldContain("EstimatedCostUsd");
+        columns.Select(c => c.PropertyName).ShouldContain("EstimatedCost");
+        columns.Select(c => c.PropertyName).ShouldContain("CostCurrency");
         columns.Select(c => c.PropertyName).ShouldContain("Timestamp");
         columns.Select(c => c.PropertyName).ShouldContain("Duration");
     }
@@ -44,7 +45,7 @@ public sealed class AIUsageRecordQueryDefinitionTests
         aggregates.Count.ShouldBe(3);
         aggregates.Select(a => a.Alias).ShouldContain("totalInputTokens");
         aggregates.Select(a => a.Alias).ShouldContain("totalOutputTokens");
-        aggregates.Select(a => a.Alias).ShouldContain("totalEstimatedCostUsd");
+        aggregates.Select(a => a.Alias).ShouldContain("totalEstimatedCost");
     }
 
     [Fact]

--- a/tests/Granit.AI.EntityFrameworkCore.Tests/EfAIUsageStoreTests.cs
+++ b/tests/Granit.AI.EntityFrameworkCore.Tests/EfAIUsageStoreTests.cs
@@ -49,7 +49,8 @@ public sealed class EfAIUsageStoreTests : IAsyncDisposable
             Model = "gpt-4o",
             InputTokens = 150,
             OutputTokens = 200,
-            EstimatedCostUsd = 0.00525m,
+            EstimatedCost = 0.00525m,
+            CostCurrency = "USD",
             Timestamp = DateTimeOffset.UtcNow,
             Duration = TimeSpan.FromMilliseconds(450),
         };
@@ -66,7 +67,8 @@ public sealed class EfAIUsageStoreTests : IAsyncDisposable
         entity.Model.ShouldBe("gpt-4o");
         entity.InputTokens.ShouldBe(150);
         entity.OutputTokens.ShouldBe(200);
-        entity.EstimatedCostUsd.ShouldBe(0.00525m);
+        entity.EstimatedCost.ShouldBe(0.00525m);
+        entity.CostCurrency.ShouldBe("USD");
     }
 
     private sealed class TestDbContextFactory(DbContextOptions<AIDbContext> options) : IDbContextFactory<AIDbContext>

--- a/tests/Granit.AI.EntityFrameworkCore.Tests/EfAIWorkspaceStoreTests.cs
+++ b/tests/Granit.AI.EntityFrameworkCore.Tests/EfAIWorkspaceStoreTests.cs
@@ -60,15 +60,26 @@ public sealed class EfAIWorkspaceStoreTests : IAsyncDisposable
     }
 
     [Fact]
-    public async Task GetAllAsync_ReturnsOnlyActiveWorkspaces()
+    public async Task FindAsync_ReturnsInactiveWorkspace()
+    {
+        await _store.CreateAsync(CreateWorkspace() with { IsActive = false }, TestContext.Current.CancellationToken);
+
+        AIWorkspace? result = await _store.FindAsync("test-ws", TestContext.Current.CancellationToken);
+
+        result.ShouldNotBeNull();
+        result.IsActive.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsActiveAndInactiveWorkspaces()
     {
         await _store.CreateAsync(CreateWorkspace("active"), TestContext.Current.CancellationToken);
         await _store.CreateAsync(CreateWorkspace("inactive") with { IsActive = false }, TestContext.Current.CancellationToken);
 
         IReadOnlyList<AIWorkspace> results = await _store.GetAllAsync(TestContext.Current.CancellationToken);
 
-        results.Count.ShouldBe(1);
-        results[0].Name.ShouldBe("active");
+        results.Count.ShouldBe(2);
+        results.Select(r => r.Name).ShouldBe(["active", "inactive"]);
     }
 
     [Fact]

--- a/tests/Granit.AI.Tests/AIUsageRecordFactoryTests.cs
+++ b/tests/Granit.AI.Tests/AIUsageRecordFactoryTests.cs
@@ -1,0 +1,74 @@
+using Granit.AI.Internal;
+using Granit.Guids;
+using Granit.MultiTenancy;
+using Granit.Users;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Shouldly;
+
+namespace Granit.AI.Tests;
+
+public sealed class AIUsageRecordFactoryTests
+{
+    private readonly ICurrentTenant _currentTenant = Substitute.For<ICurrentTenant>();
+    private readonly ICurrentUserService _currentUserService = Substitute.For<ICurrentUserService>();
+    private readonly IGuidGenerator _guidGenerator = Substitute.For<IGuidGenerator>();
+    private readonly FakeTimeProvider _timeProvider = new();
+
+    private AIUsageRecordFactory CreateFactory() =>
+        new(_currentTenant, _currentUserService, _guidGenerator, _timeProvider);
+
+    [Fact]
+    public void Create_WithTenantAndUser_PopulatesBothIds()
+    {
+        var tenantId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var recordId = Guid.NewGuid();
+
+        _currentTenant.IsAvailable.Returns(true);
+        _currentTenant.Id.Returns(tenantId);
+        _currentUserService.UserId.Returns(userId.ToString());
+        _guidGenerator.Create().Returns(recordId);
+
+        AIUsageRecord record = CreateFactory().Create(
+            "workspace-1", "OpenAI", "gpt-4o", 100, 50, TimeSpan.FromMilliseconds(200));
+
+        record.Id.ShouldBe(recordId);
+        record.TenantId.ShouldBe(tenantId);
+        record.UserId.ShouldBe(userId);
+        record.WorkspaceName.ShouldBe("workspace-1");
+        record.Provider.ShouldBe("OpenAI");
+        record.Model.ShouldBe("gpt-4o");
+        record.InputTokens.ShouldBe(100);
+        record.OutputTokens.ShouldBe(50);
+        record.Duration.ShouldBe(TimeSpan.FromMilliseconds(200));
+    }
+
+    [Fact]
+    public void Create_WithoutTenant_LeavesNull()
+    {
+        _currentTenant.IsAvailable.Returns(false);
+        _currentUserService.UserId.Returns((string?)null);
+        _guidGenerator.Create().Returns(Guid.NewGuid());
+
+        AIUsageRecord record = CreateFactory().Create(
+            "ws", "Anthropic", "claude-sonnet-4-6", 10, 20, null);
+
+        record.TenantId.ShouldBeNull();
+        record.UserId.ShouldBeNull();
+        record.Duration.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Create_WithNonGuidUserId_LeavesNull()
+    {
+        _currentTenant.IsAvailable.Returns(false);
+        _currentUserService.UserId.Returns("not-a-guid");
+        _guidGenerator.Create().Returns(Guid.NewGuid());
+
+        AIUsageRecord record = CreateFactory().Create(
+            "ws", "OpenAI", "gpt-4o", 10, 20, null);
+
+        record.UserId.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Remove `IsActive` filter from `EfAIWorkspaceStore.FindAsync` and `GetAllAsync` so inactive dynamic workspaces are visible in admin endpoints (list, get, update, delete)
- Add `AIWorkspaceNotActiveException` and guard `DefaultAIChatClientFactory` / `DefaultAIEmbeddingGeneratorFactory` to reject execution against inactive workspaces (422 Unprocessable Entity)
- Add streaming usage tracking, SSE error handling, usage record factory extraction, exception mapper improvements, localization updates, and documentation refresh

## Test plan

- [x] `Granit.AI.Tests` — 31 passed
- [x] `Granit.AI.Endpoints.Tests` — 36 passed
- [x] `Granit.AI.EntityFrameworkCore.Tests` — 8 passed (includes new `FindAsync_ReturnsInactiveWorkspace` and updated `GetAllAsync_ReturnsActiveAndInactiveWorkspaces`)
- [ ] CI shards pass