### PR TITLE
fix(auditing): auto-register AuditingChangeTrackingInterceptor on all Granit DbContexts

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4315,7 +4315,7 @@
       "kind": "class",
       "project": "Granit.Auditing.EntityFrameworkCore",
       "file": "src/Granit.Auditing.EntityFrameworkCore/Extensions/AuditingEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 20,
+      "line": 21,
       "members": [
         {
           "name": "AddGranitAuditingEntityFrameworkCore",
@@ -4388,7 +4388,7 @@
       "kind": "class",
       "project": "Granit.Auditing.EntityFrameworkCore",
       "file": "src/Granit.Auditing.EntityFrameworkCore/Interceptors/AuditingChangeTrackingInterceptor.cs",
-      "line": 32,
+      "line": 33,
       "members": [
         {
           "name": "SavingChanges",
@@ -30601,6 +30601,15 @@
           "returnType": "InterceptionResult<int>"
         }
       ]
+    },
+    {
+      "name": "IGranitAutoInterceptor",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.Interceptors.IGranitAutoInterceptor",
+      "kind": "interface",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/Interceptors/IGranitAutoInterceptor.cs",
+      "line": 31,
+      "members": []
     },
     {
       "name": "SoftDeleteInterceptor",

--- a/src/Granit.Auditing.EntityFrameworkCore/Extensions/AuditingEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Auditing.EntityFrameworkCore/Extensions/AuditingEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -5,6 +5,7 @@ using Granit.Auditing.EntityFrameworkCore.Internal.Services;
 using Granit.Auditing.Internal.Services;
 using Granit.Auditing.Options;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore.Interceptors;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -66,7 +67,11 @@ public static class AuditingEntityFrameworkCoreHostApplicationBuilderExtensions
         builder.Services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
         // Interceptor + capture service (scoped — host DbContext resolves from its SP).
+        // Registered as both concrete type (for UseGranitAuditingInterceptor backward compat)
+        // and IGranitAutoInterceptor (for automatic wiring via UseGranitInterceptors).
         builder.Services.AddScoped<AuditingChangeTrackingInterceptor>();
+        builder.Services.AddScoped<IGranitAutoInterceptor>(sp =>
+            sp.GetRequiredService<AuditingChangeTrackingInterceptor>());
         builder.Services.AddScoped<ChangeTrackingCaptureService>();
 
         return builder;

--- a/src/Granit.Auditing.EntityFrameworkCore/Interceptors/AuditingChangeTrackingInterceptor.cs
+++ b/src/Granit.Auditing.EntityFrameworkCore/Interceptors/AuditingChangeTrackingInterceptor.cs
@@ -1,4 +1,5 @@
 using Granit.Auditing.EntityFrameworkCore.Internal.Services;
+using Granit.Persistence.EntityFrameworkCore.Interceptors;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -29,7 +30,7 @@ namespace Granit.Auditing.EntityFrameworkCore.Interceptors;
 /// state are already applied when we read them.
 /// </para>
 /// </remarks>
-public sealed class AuditingChangeTrackingInterceptor : SaveChangesInterceptor
+public sealed class AuditingChangeTrackingInterceptor : SaveChangesInterceptor, IGranitAutoInterceptor
 {
     /// <inheritdoc/>
     public override InterceptionResult<int> SavingChanges(

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/DbContextOptionsBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/DbContextOptionsBuilderExtensions.cs
@@ -68,6 +68,14 @@ public static class DbContextOptionsBuilderExtensions
         AddInterceptorIfRegistered<EntityLifecycleEventInterceptor>(options, serviceProvider);
         AddInterceptorIfRegistered<SoftDeleteInterceptor>(options, serviceProvider);
 
+        // Module-provided interceptors registered via IGranitAutoInterceptor.
+        // These run after the standard interceptors so they can observe the final
+        // entity state (audit fields set, soft-delete applied, events collected).
+        foreach (IGranitAutoInterceptor additional in serviceProvider.GetServices<IGranitAutoInterceptor>())
+        {
+            options.AddInterceptors(additional);
+        }
+
         return options;
     }
 

--- a/src/Granit.Persistence.EntityFrameworkCore/Interceptors/IGranitAutoInterceptor.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Interceptors/IGranitAutoInterceptor.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Granit.Persistence.EntityFrameworkCore.Interceptors;
+
+/// <summary>
+/// Marker interface for interceptors that should be automatically registered on all
+/// Granit DbContexts via <see cref="Extensions.DbContextOptionsBuilderExtensions.UseGranitInterceptors"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Use this interface when a module provides an interceptor that must run on every
+/// DbContext (e.g. audit change tracking, cross-cutting concerns). The interceptor
+/// will be resolved from the service provider and added after the 6 standard
+/// Granit.Persistence interceptors.
+/// </para>
+/// <para>
+/// <b>Registration:</b> Register the interceptor as both its concrete type and
+/// <see cref="IGranitAutoInterceptor"/> in the DI container:
+/// <code>
+/// services.AddScoped&lt;MyInterceptor&gt;();
+/// services.AddScoped&lt;IGranitAutoInterceptor&gt;(sp =&gt; sp.GetRequiredService&lt;MyInterceptor&gt;());
+/// </code>
+/// </para>
+/// <para>
+/// <b>Ordering:</b> Auto-interceptors run after all standard Granit interceptors
+/// (AuditedEntity, Versioning, ConcurrencyStamp, DomainEvents, EntityLifecycle, SoftDelete).
+/// If ordering between auto-interceptors matters, implement <see cref="IGranitAutoInterceptor"/>
+/// and register them in the desired order.
+/// </para>
+/// </remarks>
+public interface IGranitAutoInterceptor : IInterceptor;

--- a/tests/Granit.Auditing.EntityFrameworkCore.Tests/Extensions/AuditingEntityFrameworkCoreHostApplicationBuilderExtensionsTests.cs
+++ b/tests/Granit.Auditing.EntityFrameworkCore.Tests/Extensions/AuditingEntityFrameworkCoreHostApplicationBuilderExtensionsTests.cs
@@ -17,6 +17,7 @@ using Granit.Auditing.Extensions;
 using Granit.Auditing.Internal.Services;
 using Granit.Auditing.Messages;
 using Granit.Auditing.Options;
+using Granit.Persistence.EntityFrameworkCore.Interceptors;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -172,6 +173,26 @@ public sealed class AuditingEntityFrameworkCoreHostApplicationBuilderExtensionsT
 
         descriptor.ShouldNotBeNull();
         descriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+    }
+
+    [Fact]
+    public void Registers_IGranitAutoInterceptor_AsScoped()
+    {
+        ServiceDescriptor? descriptor = _builder.Services
+            .FirstOrDefault(d => d.ServiceType == typeof(IGranitAutoInterceptor));
+
+        descriptor.ShouldNotBeNull();
+        descriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+    }
+
+    [Fact]
+    public void Resolves_IGranitAutoInterceptor_AsAuditingChangeTrackingInterceptor()
+    {
+        using IServiceScope scope = _sp.CreateScope();
+        IGranitAutoInterceptor interceptor = scope.ServiceProvider
+            .GetRequiredService<IGranitAutoInterceptor>();
+
+        interceptor.ShouldBeOfType<AuditingChangeTrackingInterceptor>();
     }
 
     [Fact]

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/DbContextOptionsBuilderExtensionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/DbContextOptionsBuilderExtensionsTests.cs
@@ -42,6 +42,29 @@ public sealed class DbContextOptionsBuilderExtensionsTests
     }
 
     [Fact]
+    public void UseGranitInterceptors_AddsAutoInterceptors()
+    {
+        // Arrange
+        ServiceCollection services = new();
+        FakeAutoInterceptor autoInterceptor = new();
+        services.AddSingleton<IGranitAutoInterceptor>(autoInterceptor);
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        DbContextOptionsBuilder builder = new();
+
+        // Act
+        builder.UseGranitInterceptors(sp);
+
+        // Assert
+        DbContextOptions options = builder.Options;
+        IEnumerable<IInterceptor> interceptors = options.Extensions
+            .OfType<Microsoft.EntityFrameworkCore.Infrastructure.CoreOptionsExtension>()
+            .SelectMany(e => e.Interceptors ?? []);
+
+        interceptors.ShouldContain(i => i is FakeAutoInterceptor);
+    }
+
+    [Fact]
     public void UseGranitInterceptors_SkipsUnregisteredInterceptors()
     {
         // Arrange — empty service provider with no interceptors registered
@@ -164,4 +187,7 @@ public sealed class DbContextOptionsBuilderExtensionsTests
     /// <summary>Minimal test DbContext for AddGranitDbContext tests.</summary>
     private sealed class TestDbContext(DbContextOptions<TestDbContext> options)
         : DbContext(options);
+
+    /// <summary>Fake auto-interceptor for testing IGranitAutoInterceptor resolution.</summary>
+    private sealed class FakeAutoInterceptor : SaveChangesInterceptor, IGranitAutoInterceptor;
 }


### PR DESCRIPTION
## Summary

- `UseGranitInterceptors` only added the 6 standard `Granit.Persistence` interceptors. The `AuditingChangeTrackingInterceptor` was never wired into module DbContexts created via `AddGranitDbContext` or multi-tenant factories, leaving the audit table permanently empty.
- Introduces `IGranitAutoInterceptor` marker interface in `Granit.Persistence.EntityFrameworkCore` so that modules can register interceptors that `UseGranitInterceptors` resolves automatically after the standard ones.
- `AuditingChangeTrackingInterceptor` now implements `IGranitAutoInterceptor` and is registered as such in `AddGranitAuditingEntityFrameworkCore`.

## Test plan

- [x] Existing `DbContextOptionsBuilderExtensionsTests` pass (307 tests)
- [x] New `UseGranitInterceptors_AddsAutoInterceptors` test validates auto-resolution
- [x] Existing `AuditingEntityFrameworkCoreHostApplicationBuilderExtensionsTests` pass (136 tests)
- [x] New `Registers_IGranitAutoInterceptor_AsScoped` and `Resolves_IGranitAutoInterceptor_AsAuditingChangeTrackingInterceptor` tests validate DI wiring
- [x] Architecture tests pass (102 tests)