### PR TITLE
fix(subscriptions): resolve concurrency bug and module audit findings

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -28327,52 +28327,6 @@
       "members": []
     },
     {
-      "name": "PaymentMethodConfiguration",
-      "fqn": "Granit.Payments.Domain.PaymentMethodConfiguration",
-      "kind": "class",
-      "project": "Granit.Payments",
-      "file": "src/Granit.Payments/Domain/PaymentMethodConfiguration.cs",
-      "line": 11,
-      "members": [
-        {
-          "name": "Create",
-          "kind": "method",
-          "signature": "Create(Guid id, string providerName, string methodType, string displayLabel)",
-          "returnType": "PaymentMethodConfiguration"
-        },
-        {
-          "name": "ProviderName",
-          "kind": "property",
-          "signature": "string ProviderName",
-          "returnType": "string"
-        },
-        {
-          "name": "DisplayLabel",
-          "kind": "property",
-          "signature": "string DisplayLabel",
-          "returnType": "string"
-        },
-        {
-          "name": "Activate",
-          "kind": "method",
-          "signature": "Activate()",
-          "returnType": "PaymentMethodCategory Category { get; private set; } public bool IsActive { get; private set; } public void"
-        },
-        {
-          "name": "Deactivate",
-          "kind": "method",
-          "signature": "Deactivate()",
-          "returnType": "void"
-        },
-        {
-          "name": "UpdateDisplayLabel",
-          "kind": "method",
-          "signature": "UpdateDisplayLabel(string displayLabel)",
-          "returnType": "void"
-        }
-      ]
-    },
-    {
       "name": "PaymentMethods",
       "fqn": "Granit.Payments.Domain.PaymentMethods",
       "kind": "class",
@@ -28596,15 +28550,6 @@
       ]
     },
     {
-      "name": "CreatePaymentMethodConfigurationRequest",
-      "fqn": "Granit.Payments.Endpoints.Dtos.CreatePaymentMethodConfigurationRequest",
-      "kind": "record",
-      "project": "Granit.Payments.Endpoints",
-      "file": "src/Granit.Payments.Endpoints/Dtos/PaymentMethodConfigurationDtos.cs",
-      "line": 15,
-      "members": []
-    },
-    {
       "name": "PaymentAttachMethodRequest",
       "fqn": "Granit.Payments.Endpoints.Dtos.PaymentAttachMethodRequest",
       "kind": "record",
@@ -28656,15 +28601,6 @@
       "project": "Granit.Payments.Endpoints",
       "file": "src/Granit.Payments.Endpoints/Dtos/TransactionResponse.cs",
       "line": 44,
-      "members": []
-    },
-    {
-      "name": "PaymentMethodConfigurationResponse",
-      "fqn": "Granit.Payments.Endpoints.Dtos.PaymentMethodConfigurationResponse",
-      "kind": "record",
-      "project": "Granit.Payments.Endpoints",
-      "file": "src/Granit.Payments.Endpoints/Dtos/PaymentMethodConfigurationDtos.cs",
-      "line": 6,
       "members": []
     },
     {
@@ -28735,15 +28671,6 @@
       "project": "Granit.Payments.Endpoints",
       "file": "src/Granit.Payments.Endpoints/Permissions/PaymentsPermissions.cs",
       "line": 13,
-      "members": []
-    },
-    {
-      "name": "Configuration",
-      "fqn": "Granit.Payments.Endpoints.Permissions.Configuration",
-      "kind": "class",
-      "project": "Granit.Payments.Endpoints",
-      "file": "src/Granit.Payments.Endpoints/Permissions/PaymentsPermissions.cs",
-      "line": 29,
       "members": []
     },
     {
@@ -28890,7 +28817,7 @@
       "kind": "class",
       "project": "Granit.Payments",
       "file": "src/Granit.Payments/Extensions/PaymentsHostApplicationBuilderExtensions.cs",
-      "line": 13,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitPayments",
@@ -28960,68 +28887,6 @@
           "name": "SendAsync",
           "kind": "method",
           "signature": "SendAsync(InitiatePaymentCommand command, CancellationToken cancellationToken = default)",
-          "returnType": "Task"
-        }
-      ]
-    },
-    {
-      "name": "IPaymentMethodConfigurationReader",
-      "fqn": "Granit.Payments.IPaymentMethodConfigurationReader",
-      "kind": "interface",
-      "project": "Granit.Payments",
-      "file": "src/Granit.Payments/IPaymentMethodConfigurationReader.cs",
-      "line": 6,
-      "members": [
-        {
-          "name": "GetAllAsync",
-          "kind": "method",
-          "signature": "GetAllAsync(CancellationToken cancellationToken = default)",
-          "returnType": "Task<IReadOnlyList<PaymentMethodConfiguration>>"
-        },
-        {
-          "name": "GetActiveAsync",
-          "kind": "method",
-          "signature": "GetActiveAsync(CancellationToken cancellationToken = default)",
-          "returnType": "Task<IReadOnlyList<PaymentMethodConfiguration>>"
-        },
-        {
-          "name": "GetByIdAsync",
-          "kind": "method",
-          "signature": "GetByIdAsync(Guid id, CancellationToken cancellationToken = default)",
-          "returnType": "Task<PaymentMethodConfiguration?>"
-        },
-        {
-          "name": "FindAsync",
-          "kind": "method",
-          "signature": "FindAsync(string providerName, string methodType, CancellationToken cancellationToken = default)",
-          "returnType": "Task<PaymentMethodConfiguration?>"
-        }
-      ]
-    },
-    {
-      "name": "IPaymentMethodConfigurationWriter",
-      "fqn": "Granit.Payments.IPaymentMethodConfigurationWriter",
-      "kind": "interface",
-      "project": "Granit.Payments",
-      "file": "src/Granit.Payments/IPaymentMethodConfigurationWriter.cs",
-      "line": 6,
-      "members": [
-        {
-          "name": "AddAsync",
-          "kind": "method",
-          "signature": "AddAsync(PaymentMethodConfiguration configuration, CancellationToken cancellationToken = default)",
-          "returnType": "Task"
-        },
-        {
-          "name": "UpdateAsync",
-          "kind": "method",
-          "signature": "UpdateAsync(PaymentMethodConfiguration configuration, CancellationToken cancellationToken = default)",
-          "returnType": "Task"
-        },
-        {
-          "name": "DeleteAsync",
-          "kind": "method",
-          "signature": "DeleteAsync(PaymentMethodConfiguration configuration, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         }
       ]
@@ -36893,6 +36758,15 @@
       "members": []
     },
     {
+      "name": "BulkMigratePriceResponse",
+      "fqn": "Granit.Subscriptions.Endpoints.Dtos.BulkMigratePriceResponse",
+      "kind": "record",
+      "project": "Granit.Subscriptions.Endpoints",
+      "file": "src/Granit.Subscriptions.Endpoints/Dtos/PriceVersioningDtos.cs",
+      "line": 19,
+      "members": []
+    },
+    {
       "name": "CreatePriceVersionRequest",
       "fqn": "Granit.Subscriptions.Endpoints.Dtos.CreatePriceVersionRequest",
       "kind": "record",
@@ -36951,8 +36825,8 @@
       "fqn": "Granit.Subscriptions.Endpoints.Dtos.SeatAssignRequest",
       "kind": "record",
       "project": "Granit.Subscriptions.Endpoints",
-      "file": "src/Granit.Subscriptions.Endpoints/Dtos/SubscriptionCreateRequest.cs",
-      "line": 19,
+      "file": "src/Granit.Subscriptions.Endpoints/Dtos/SeatDtos.cs",
+      "line": 4,
       "members": []
     },
     {
@@ -36960,8 +36834,8 @@
       "fqn": "Granit.Subscriptions.Endpoints.Dtos.SeatResponse",
       "kind": "record",
       "project": "Granit.Subscriptions.Endpoints",
-      "file": "src/Granit.Subscriptions.Endpoints/Dtos/SubscriptionCreateRequest.cs",
-      "line": 23,
+      "file": "src/Granit.Subscriptions.Endpoints/Dtos/SeatDtos.cs",
+      "line": 8,
       "members": []
     },
     {
@@ -36998,15 +36872,6 @@
       "project": "Granit.Subscriptions.Endpoints",
       "file": "src/Granit.Subscriptions.Endpoints/Dtos/SubscriptionResponse.cs",
       "line": 6,
-      "members": []
-    },
-    {
-      "name": "BulkMigratePriceResponse",
-      "fqn": "Granit.Subscriptions.Endpoints.Endpoints.BulkMigratePriceResponse",
-      "kind": "record",
-      "project": "Granit.Subscriptions.Endpoints",
-      "file": "src/Granit.Subscriptions.Endpoints/Endpoints/PriceVersioningEndpoints.cs",
-      "line": 215,
       "members": []
     },
     {
@@ -37513,13 +37378,13 @@
       "kind": "interface",
       "project": "Granit.Subscriptions",
       "file": "src/Granit.Subscriptions/ISeatWriter.cs",
-      "line": 6,
+      "line": 7,
       "members": [
         {
           "name": "AssignSeatAsync",
           "kind": "method",
-          "signature": "AssignSeatAsync(SubscriptionId subscriptionId, Guid userId, CancellationToken cancellationToken = default)",
-          "returnType": "Task"
+          "signature": "AssignSeatAsync(SubscriptionId subscriptionId, Guid userId, int? seatLimit = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<SubscriptionSeat>"
         },
         {
           "name": "RevokeSeatAsync",

--- a/src/Granit.Subscriptions.Endpoints/Dtos/PriceVersioningDtos.cs
+++ b/src/Granit.Subscriptions.Endpoints/Dtos/PriceVersioningDtos.cs
@@ -14,3 +14,6 @@ public sealed record BulkMigratePriceRequest(
     Guid PlanId,
     Guid NewPlanPriceId,
     Guid? OldPlanPriceId = null);
+
+/// <summary>Response for bulk price migration.</summary>
+public sealed record BulkMigratePriceResponse(int MigratedCount);

--- a/src/Granit.Subscriptions.Endpoints/Dtos/SeatDtos.cs
+++ b/src/Granit.Subscriptions.Endpoints/Dtos/SeatDtos.cs
@@ -1,0 +1,13 @@
+namespace Granit.Subscriptions.Endpoints.Dtos;
+
+/// <summary>Request to assign a seat.</summary>
+public sealed record SeatAssignRequest(
+    Guid UserId);
+
+/// <summary>Seat assignment details.</summary>
+public sealed record SeatResponse(
+    Guid Id, Guid UserId, DateTimeOffset AssignedAt)
+{
+    internal static SeatResponse FromEntity(Domain.SubscriptionSeat seat) =>
+        new(seat.Id, seat.UserId, seat.AssignedAt);
+}

--- a/src/Granit.Subscriptions.Endpoints/Dtos/SubscriptionCreateRequest.cs
+++ b/src/Granit.Subscriptions.Endpoints/Dtos/SubscriptionCreateRequest.cs
@@ -15,14 +15,3 @@ public sealed record SubscriptionCancelRequest(
 public sealed record SubscriptionChangePlanRequest(
     Guid NewPlanId);
 
-/// <summary>Request to assign a seat.</summary>
-public sealed record SeatAssignRequest(
-    Guid UserId);
-
-/// <summary>Seat assignment details.</summary>
-public sealed record SeatResponse(
-    Guid Id, Guid UserId, DateTimeOffset AssignedAt)
-{
-    internal static SeatResponse FromEntity(Domain.SubscriptionSeat seat) =>
-        new(seat.Id, seat.UserId, seat.AssignedAt);
-}

--- a/src/Granit.Subscriptions.Endpoints/Endpoints/PlanWriteEndpoints.cs
+++ b/src/Granit.Subscriptions.Endpoints/Endpoints/PlanWriteEndpoints.cs
@@ -33,6 +33,7 @@ internal static class PlanWriteEndpoints
             .Produces<PlanResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict)
+            .ProducesValidationProblem()
             .RequireAuthorization(SubscriptionsPermissions.Plans.Manage);
 
         group.MapPost("/plans/{id:guid}/publish", PublishPlanAsync)

--- a/src/Granit.Subscriptions.Endpoints/Endpoints/PriceVersioningEndpoints.cs
+++ b/src/Granit.Subscriptions.Endpoints/Endpoints/PriceVersioningEndpoints.cs
@@ -210,6 +210,3 @@ internal static class PriceVersioningEndpoints
         return TypedResults.Ok(new BulkMigratePriceResponse(migrated));
     }
 }
-
-/// <summary>Response for bulk price migration.</summary>
-public sealed record BulkMigratePriceResponse(int MigratedCount);

--- a/src/Granit.Subscriptions.Endpoints/Endpoints/SeatEndpoints.cs
+++ b/src/Granit.Subscriptions.Endpoints/Endpoints/SeatEndpoints.cs
@@ -1,11 +1,9 @@
-using Granit.Guids;
 using Granit.Http.Idempotency.Attributes;
 using Granit.MultiTenancy;
 using Granit.Subscriptions.Domain;
 using Granit.Subscriptions.Domain.ValueObjects;
 using Granit.Subscriptions.Endpoints.Dtos;
 using Granit.Subscriptions.Endpoints.Permissions;
-using Granit.Timing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -54,6 +52,7 @@ internal static class SeatEndpoints
     private static async Task<Results<Ok<IReadOnlyList<SeatResponse>>, ProblemHttpResult>> ListSeatsAsync(
         Guid id,
         [FromServices] ISubscriptionReader reader,
+        [FromServices] ISeatReader seatReader,
         [FromServices] ICurrentTenant currentTenant,
         CancellationToken cancellationToken)
     {
@@ -65,29 +64,25 @@ internal static class SeatEndpoints
         Subscription? sub = await reader
             .GetByIdAsync(SubscriptionId.Create(id), cancellationToken).ConfigureAwait(false);
 
-        if (sub is null)
+        if (sub is null || sub.TenantId != currentTenant.Id!.Value)
         {
             return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
-        if (sub.TenantId != currentTenant.Id!.Value)
-        {
-            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
-        }
+        IReadOnlyList<SubscriptionSeat> seats = await seatReader
+            .GetSeatsAsync(SubscriptionId.Create(id), cancellationToken).ConfigureAwait(false);
 
         return TypedResults.Ok<IReadOnlyList<SeatResponse>>(
-            sub.Seats.Select(SeatResponse.FromEntity).ToList());
+            seats.Select(SeatResponse.FromEntity).ToList());
     }
 
     private static async Task<Results<Created<SeatResponse>, ProblemHttpResult>> AssignSeatAsync(
         Guid id,
         SeatAssignRequest request,
         [FromServices] ISubscriptionReader reader,
-        [FromServices] ISubscriptionWriter writer,
+        [FromServices] ISeatWriter seatWriter,
         [FromServices] IPlanReader planReader,
         [FromServices] ICurrentTenant currentTenant,
-        [FromServices] IGuidGenerator guidGenerator,
-        [FromServices] IClock clock,
         CancellationToken cancellationToken)
     {
         if (!currentTenant.IsAvailable)
@@ -98,12 +93,7 @@ internal static class SeatEndpoints
         Subscription? sub = await reader
             .GetByIdAsync(SubscriptionId.Create(id), cancellationToken).ConfigureAwait(false);
 
-        if (sub is null)
-        {
-            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
-        }
-
-        if (sub.TenantId != currentTenant.Id!.Value)
+        if (sub is null || sub.TenantId != currentTenant.Id!.Value)
         {
             return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
@@ -114,9 +104,9 @@ internal static class SeatEndpoints
 
         try
         {
-            var seat = SubscriptionSeat.Create(guidGenerator.Create(), request.UserId, clock.Now);
-            sub.AssignSeat(seat, plan?.SeatLimit);
-            await writer.UpdateAsync(sub, cancellationToken).ConfigureAwait(false);
+            SubscriptionSeat seat = await seatWriter.AssignSeatAsync(
+                SubscriptionId.Create(id), request.UserId, plan?.SeatLimit, cancellationToken)
+                .ConfigureAwait(false);
 
             return TypedResults.Created(
                 $"/subscriptions/{id}/seats/{request.UserId}",
@@ -132,7 +122,7 @@ internal static class SeatEndpoints
         Guid id,
         Guid userId,
         [FromServices] ISubscriptionReader reader,
-        [FromServices] ISubscriptionWriter writer,
+        [FromServices] ISeatWriter seatWriter,
         [FromServices] ICurrentTenant currentTenant,
         CancellationToken cancellationToken)
     {
@@ -144,22 +134,16 @@ internal static class SeatEndpoints
         Subscription? sub = await reader
             .GetByIdAsync(SubscriptionId.Create(id), cancellationToken).ConfigureAwait(false);
 
-        if (sub is null)
+        if (sub is null || sub.TenantId != currentTenant.Id!.Value)
         {
             return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
-        if (sub.TenantId != currentTenant.Id!.Value)
-        {
-            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
-        }
+        bool revoked = await seatWriter.RevokeSeatAsync(
+            SubscriptionId.Create(id), userId, cancellationToken).ConfigureAwait(false);
 
-        if (!sub.RevokeSeat(userId))
-        {
-            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
-        }
-
-        await writer.UpdateAsync(sub, cancellationToken).ConfigureAwait(false);
-        return TypedResults.NoContent();
+        return revoked
+            ? TypedResults.NoContent()
+            : TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
     }
 }

--- a/src/Granit.Subscriptions.Endpoints/Endpoints/SubscriptionEndpoints.cs
+++ b/src/Granit.Subscriptions.Endpoints/Endpoints/SubscriptionEndpoints.cs
@@ -96,11 +96,6 @@ internal static class SubscriptionEndpoints
         [FromServices] ICurrentTenant currentTenant,
         CancellationToken cancellationToken)
     {
-        if (!currentTenant.IsAvailable)
-        {
-            return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status400BadRequest);
-        }
-
         Subscription? sub = await reader
             .GetByIdAsync(SubscriptionId.Create(id), cancellationToken).ConfigureAwait(false);
 
@@ -109,7 +104,9 @@ internal static class SubscriptionEndpoints
             return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
-        if (sub.TenantId != currentTenant.Id!.Value)
+        // Host context (AllowHostAccess): bypass tenant ownership check.
+        // Tenant context: verify the subscription belongs to the current tenant.
+        if (currentTenant.IsAvailable && sub.TenantId != currentTenant.Id!.Value)
         {
             return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
@@ -120,6 +117,7 @@ internal static class SubscriptionEndpoints
     private static async Task<Results<Created<SubscriptionResponse>, ValidationProblem, ProblemHttpResult>> CreateSubscriptionAsync(
         SubscriptionCreateRequest request,
         [FromServices] ISubscriptionWriter writer,
+        [FromServices] IPlanReader planReader,
         [FromServices] ICurrentTenant currentTenant,
         [FromServices] IGuidGenerator guidGenerator,
         [FromServices] IClock clock,
@@ -130,14 +128,36 @@ internal static class SubscriptionEndpoints
             return TypedResults.Problem("Tenant context required.", statusCode: StatusCodes.Status400BadRequest);
         }
 
+        Plan? plan = await planReader
+            .GetByIdAsync(PlanId.Create(request.PlanId), cancellationToken).ConfigureAwait(false);
+
+        if (plan is null)
+        {
+            return TypedResults.Problem(
+                detail: $"Plan '{request.PlanId}' not found.",
+                statusCode: StatusCodes.Status404NotFound);
+        }
+
         DateTimeOffset now = clock.Now;
+        DateTimeOffset periodEnd = plan.DefaultInterval switch
+        {
+            BillingInterval.Monthly => now.AddMonths(1),
+            BillingInterval.Quarterly => now.AddMonths(3),
+            BillingInterval.Yearly => now.AddYears(1),
+            _ => now.AddMonths(1),
+        };
+
+        // Pin to the current active price for the requested currency and default interval.
+        PlanPrice? activePrice = plan.GetActivePrice(request.Currency, plan.DefaultInterval);
+
         var sub = Subscription.Create(
             guidGenerator.Create(),
             currentTenant.Id!.Value,
             PlanId.Create(request.PlanId),
             request.Currency,
-            new SubscriptionPeriod(now, now.AddMonths(1), BillingCycleAnchor: now),
-            trialEndsAt: request.TrialEndsAt);
+            new SubscriptionPeriod(now, periodEnd, BillingCycleAnchor: now),
+            trialEndsAt: request.TrialEndsAt,
+            planPriceId: activePrice?.Id);
 
         await writer.AddAsync(sub, cancellationToken).ConfigureAwait(false);
 

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/cs.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/cs.json
@@ -10,13 +10,13 @@
     "Permission:Subscriptions.Prices.Manage": "Spravovat ceny (vytvářet verze, migrovat předplatné)",
     "Permission:Subscriptions.Seats.Read": "Zobrazit přiřazení míst",
     "Permission:Subscriptions.Seats.Manage": "Spravovat přiřazení míst (přiřadit, odvolat)",
-    "Subscriptions.Columns.Tenant": "Tenant",
-    "Subscriptions.Columns.Plan": "Plan",
-    "Subscriptions.Columns.Status": "Status",
-    "Subscriptions.Columns.Currency": "Currency",
-    "Subscriptions.Columns.PeriodStart": "Period Start",
-    "Subscriptions.Columns.PeriodEnd": "Period End",
-    "Subscriptions.Columns.CancelAtPeriodEnd": "Cancel at Period End",
-    "Subscriptions.Columns.TrialEndsAt": "Trial Ends At"
+    "Subscriptions.Columns.Tenant": "Nájemce",
+    "Subscriptions.Columns.Plan": "Plán",
+    "Subscriptions.Columns.Status": "Stav",
+    "Subscriptions.Columns.Currency": "Měna",
+    "Subscriptions.Columns.PeriodStart": "Začátek období",
+    "Subscriptions.Columns.PeriodEnd": "Konec období",
+    "Subscriptions.Columns.CancelAtPeriodEnd": "Zrušit na konci období",
+    "Subscriptions.Columns.TrialEndsAt": "Konec zkušebního období"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/hi.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/hi.json
@@ -10,13 +10,13 @@
     "Permission:Subscriptions.Prices.Manage": "मूल्य प्रबंधित करें (संस्करण बनाएँ, सब्सक्रिप्शन माइग्रेट करें)",
     "Permission:Subscriptions.Seats.Read": "सीट असाइनमेंट देखें",
     "Permission:Subscriptions.Seats.Manage": "सीट असाइनमेंट प्रबंधित करें (असाइन करें, निरस्त करें)",
-    "Subscriptions.Columns.Tenant": "Tenant",
-    "Subscriptions.Columns.Plan": "Plan",
-    "Subscriptions.Columns.Status": "Status",
-    "Subscriptions.Columns.Currency": "Currency",
-    "Subscriptions.Columns.PeriodStart": "Period Start",
-    "Subscriptions.Columns.PeriodEnd": "Period End",
-    "Subscriptions.Columns.CancelAtPeriodEnd": "Cancel at Period End",
-    "Subscriptions.Columns.TrialEndsAt": "Trial Ends At"
+    "Subscriptions.Columns.Tenant": "किरायेदार",
+    "Subscriptions.Columns.Plan": "योजना",
+    "Subscriptions.Columns.Status": "स्थिति",
+    "Subscriptions.Columns.Currency": "मुद्रा",
+    "Subscriptions.Columns.PeriodStart": "अवधि प्रारंभ",
+    "Subscriptions.Columns.PeriodEnd": "अवधि समाप्ति",
+    "Subscriptions.Columns.CancelAtPeriodEnd": "अवधि समाप्ति पर रद्द करें",
+    "Subscriptions.Columns.TrialEndsAt": "परीक्षण समाप्ति तिथि"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/it.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/it.json
@@ -11,12 +11,12 @@
     "Permission:Subscriptions.Seats.Read": "Visualizzare le assegnazioni dei posti",
     "Permission:Subscriptions.Seats.Manage": "Gestire le assegnazioni dei posti (assegnare, revocare)",
     "Subscriptions.Columns.Tenant": "Tenant",
-    "Subscriptions.Columns.Plan": "Plan",
-    "Subscriptions.Columns.Status": "Status",
-    "Subscriptions.Columns.Currency": "Currency",
-    "Subscriptions.Columns.PeriodStart": "Period Start",
-    "Subscriptions.Columns.PeriodEnd": "Period End",
-    "Subscriptions.Columns.CancelAtPeriodEnd": "Cancel at Period End",
-    "Subscriptions.Columns.TrialEndsAt": "Trial Ends At"
+    "Subscriptions.Columns.Plan": "Piano",
+    "Subscriptions.Columns.Status": "Stato",
+    "Subscriptions.Columns.Currency": "Valuta",
+    "Subscriptions.Columns.PeriodStart": "Inizio periodo",
+    "Subscriptions.Columns.PeriodEnd": "Fine periodo",
+    "Subscriptions.Columns.CancelAtPeriodEnd": "Annulla a fine periodo",
+    "Subscriptions.Columns.TrialEndsAt": "Fine prova"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ja.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ja.json
@@ -6,17 +6,17 @@
     "Permission:Subscriptions.Plans.Manage": "サブスクリプションプランの管理（作成、公開、アーカイブ）",
     "Permission:Subscriptions.Subscriptions.Read": "サブスクリプションの表示",
     "Permission:Subscriptions.Subscriptions.Manage": "サブスクリプションの管理（作成、キャンセル、プラン変更）",
-    "Permission:Subscriptions.Prices.Read": "価格バージョン��歴を表示",
+    "Permission:Subscriptions.Prices.Read": "価格バージョン履歴を表示",
     "Permission:Subscriptions.Prices.Manage": "価格を管理（バージョン作成、サブスクリプション移行）",
     "Permission:Subscriptions.Seats.Read": "シート割り当ての表示",
     "Permission:Subscriptions.Seats.Manage": "シート割り当ての管理（割り当て、取り消し）",
-    "Subscriptions.Columns.Tenant": "Tenant",
-    "Subscriptions.Columns.Plan": "Plan",
-    "Subscriptions.Columns.Status": "Status",
-    "Subscriptions.Columns.Currency": "Currency",
-    "Subscriptions.Columns.PeriodStart": "Period Start",
-    "Subscriptions.Columns.PeriodEnd": "Period End",
-    "Subscriptions.Columns.CancelAtPeriodEnd": "Cancel at Period End",
-    "Subscriptions.Columns.TrialEndsAt": "Trial Ends At"
+    "Subscriptions.Columns.Tenant": "テナント",
+    "Subscriptions.Columns.Plan": "プラン",
+    "Subscriptions.Columns.Status": "ステータス",
+    "Subscriptions.Columns.Currency": "通貨",
+    "Subscriptions.Columns.PeriodStart": "期間開始",
+    "Subscriptions.Columns.PeriodEnd": "期間終了",
+    "Subscriptions.Columns.CancelAtPeriodEnd": "期間終了時にキャンセル",
+    "Subscriptions.Columns.TrialEndsAt": "トライアル終了日"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ko.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/ko.json
@@ -7,16 +7,16 @@
     "Permission:Subscriptions.Subscriptions.Read": "구독 보기",
     "Permission:Subscriptions.Subscriptions.Manage": "구독 관리 (생성, 취소, 플랜 변경)",
     "Permission:Subscriptions.Prices.Read": "가격 버전 이력 조회",
-    "Permission:Subscriptions.Prices.Manage": "가격 관리 (버��� 생성, 구독 마이그레이션)",
+    "Permission:Subscriptions.Prices.Manage": "가격 관리 (버전 생성, 구독 마이그레이션)",
     "Permission:Subscriptions.Seats.Read": "시트 할당 보기",
     "Permission:Subscriptions.Seats.Manage": "시트 할당 관리 (할당, 철회)",
-    "Subscriptions.Columns.Tenant": "Tenant",
-    "Subscriptions.Columns.Plan": "Plan",
-    "Subscriptions.Columns.Status": "Status",
-    "Subscriptions.Columns.Currency": "Currency",
-    "Subscriptions.Columns.PeriodStart": "Period Start",
-    "Subscriptions.Columns.PeriodEnd": "Period End",
-    "Subscriptions.Columns.CancelAtPeriodEnd": "Cancel at Period End",
-    "Subscriptions.Columns.TrialEndsAt": "Trial Ends At"
+    "Subscriptions.Columns.Tenant": "테넌트",
+    "Subscriptions.Columns.Plan": "플랜",
+    "Subscriptions.Columns.Status": "상태",
+    "Subscriptions.Columns.Currency": "통화",
+    "Subscriptions.Columns.PeriodStart": "기간 시작",
+    "Subscriptions.Columns.PeriodEnd": "기간 종료",
+    "Subscriptions.Columns.CancelAtPeriodEnd": "기간 종료 시 취소",
+    "Subscriptions.Columns.TrialEndsAt": "체험 종료일"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pl.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pl.json
@@ -10,13 +10,13 @@
     "Permission:Subscriptions.Prices.Manage": "Zarządzaj cenami (twórz wersje, migruj subskrypcje)",
     "Permission:Subscriptions.Seats.Read": "Wyświetlanie przypisań miejsc",
     "Permission:Subscriptions.Seats.Manage": "Zarządzanie przypisaniami miejsc (przypisywanie, cofanie)",
-    "Subscriptions.Columns.Tenant": "Tenant",
+    "Subscriptions.Columns.Tenant": "Najemca",
     "Subscriptions.Columns.Plan": "Plan",
     "Subscriptions.Columns.Status": "Status",
-    "Subscriptions.Columns.Currency": "Currency",
-    "Subscriptions.Columns.PeriodStart": "Period Start",
-    "Subscriptions.Columns.PeriodEnd": "Period End",
-    "Subscriptions.Columns.CancelAtPeriodEnd": "Cancel at Period End",
-    "Subscriptions.Columns.TrialEndsAt": "Trial Ends At"
+    "Subscriptions.Columns.Currency": "Waluta",
+    "Subscriptions.Columns.PeriodStart": "Początek okresu",
+    "Subscriptions.Columns.PeriodEnd": "Koniec okresu",
+    "Subscriptions.Columns.CancelAtPeriodEnd": "Anuluj na koniec okresu",
+    "Subscriptions.Columns.TrialEndsAt": "Koniec okresu próbnego"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt-BR.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt-BR.json
@@ -10,13 +10,13 @@
     "Permission:Subscriptions.Prices.Manage": "Gerenciar preços (criar versões, migrar assinaturas)",
     "Permission:Subscriptions.Seats.Read": "Visualizar atribuições de assentos",
     "Permission:Subscriptions.Seats.Manage": "Gerenciar atribuições de assentos (atribuir, revogar)",
-    "Subscriptions.Columns.Tenant": "Tenant",
-    "Subscriptions.Columns.Plan": "Plan",
+    "Subscriptions.Columns.Tenant": "Inquilino",
+    "Subscriptions.Columns.Plan": "Plano",
     "Subscriptions.Columns.Status": "Status",
-    "Subscriptions.Columns.Currency": "Currency",
-    "Subscriptions.Columns.PeriodStart": "Period Start",
-    "Subscriptions.Columns.PeriodEnd": "Period End",
-    "Subscriptions.Columns.CancelAtPeriodEnd": "Cancel at Period End",
-    "Subscriptions.Columns.TrialEndsAt": "Trial Ends At"
+    "Subscriptions.Columns.Currency": "Moeda",
+    "Subscriptions.Columns.PeriodStart": "Início do período",
+    "Subscriptions.Columns.PeriodEnd": "Fim do período",
+    "Subscriptions.Columns.CancelAtPeriodEnd": "Cancelar no fim do período",
+    "Subscriptions.Columns.TrialEndsAt": "Fim do período de teste"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/pt.json
@@ -6,17 +6,17 @@
     "Permission:Subscriptions.Plans.Manage": "Gerir planos de subscrição (criar, publicar, arquivar)",
     "Permission:Subscriptions.Subscriptions.Read": "Ver subscrições",
     "Permission:Subscriptions.Subscriptions.Manage": "Gerir subscrições (criar, cancelar, alterar plano)",
-    "Permission:Subscriptions.Prices.Read": "Ver hist��rico de versões de preços",
+    "Permission:Subscriptions.Prices.Read": "Ver histórico de versões de preços",
     "Permission:Subscriptions.Prices.Manage": "Gerir preços (criar versões, migrar assinaturas)",
     "Permission:Subscriptions.Seats.Read": "Ver atribuições de lugares",
     "Permission:Subscriptions.Seats.Manage": "Gerir atribuições de lugares (atribuir, revogar)",
-    "Subscriptions.Columns.Tenant": "Tenant",
-    "Subscriptions.Columns.Plan": "Plan",
-    "Subscriptions.Columns.Status": "Status",
-    "Subscriptions.Columns.Currency": "Currency",
-    "Subscriptions.Columns.PeriodStart": "Period Start",
-    "Subscriptions.Columns.PeriodEnd": "Period End",
-    "Subscriptions.Columns.CancelAtPeriodEnd": "Cancel at Period End",
-    "Subscriptions.Columns.TrialEndsAt": "Trial Ends At"
+    "Subscriptions.Columns.Tenant": "Inquilino",
+    "Subscriptions.Columns.Plan": "Plano",
+    "Subscriptions.Columns.Status": "Estado",
+    "Subscriptions.Columns.Currency": "Moeda",
+    "Subscriptions.Columns.PeriodStart": "Início do período",
+    "Subscriptions.Columns.PeriodEnd": "Fim do período",
+    "Subscriptions.Columns.CancelAtPeriodEnd": "Cancelar no fim do período",
+    "Subscriptions.Columns.TrialEndsAt": "Fim do período de teste"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/sv.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/sv.json
@@ -10,13 +10,13 @@
     "Permission:Subscriptions.Prices.Manage": "Hantera priser (skapa versioner, migrera prenumerationer)",
     "Permission:Subscriptions.Seats.Read": "Visa platstilldelningar",
     "Permission:Subscriptions.Seats.Manage": "Hantera platstilldelningar (tilldela, återkalla)",
-    "Subscriptions.Columns.Tenant": "Tenant",
+    "Subscriptions.Columns.Tenant": "Hyresgäst",
     "Subscriptions.Columns.Plan": "Plan",
     "Subscriptions.Columns.Status": "Status",
-    "Subscriptions.Columns.Currency": "Currency",
-    "Subscriptions.Columns.PeriodStart": "Period Start",
-    "Subscriptions.Columns.PeriodEnd": "Period End",
-    "Subscriptions.Columns.CancelAtPeriodEnd": "Cancel at Period End",
-    "Subscriptions.Columns.TrialEndsAt": "Trial Ends At"
+    "Subscriptions.Columns.Currency": "Valuta",
+    "Subscriptions.Columns.PeriodStart": "Periodstart",
+    "Subscriptions.Columns.PeriodEnd": "Periodslut",
+    "Subscriptions.Columns.CancelAtPeriodEnd": "Avsluta vid periodens slut",
+    "Subscriptions.Columns.TrialEndsAt": "Provperiod slutar"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/tr.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/tr.json
@@ -7,16 +7,16 @@
     "Permission:Subscriptions.Subscriptions.Read": "Abonelikleri görüntüle",
     "Permission:Subscriptions.Subscriptions.Manage": "Abonelikleri yönet (oluştur, iptal et, plan değiştir)",
     "Permission:Subscriptions.Prices.Read": "Fiyat sürüm geçmişini görüntüle",
-    "Permission:Subscriptions.Prices.Manage": "Fiyatları yönet (sür��m oluştur, abonelikleri taşı)",
+    "Permission:Subscriptions.Prices.Manage": "Fiyatları yönet (sürüm oluştur, abonelikleri taşı)",
     "Permission:Subscriptions.Seats.Read": "Koltuk atamalarını görüntüle",
     "Permission:Subscriptions.Seats.Manage": "Koltuk atamalarını yönet (ata, iptal et)",
-    "Subscriptions.Columns.Tenant": "Tenant",
+    "Subscriptions.Columns.Tenant": "Kiracı",
     "Subscriptions.Columns.Plan": "Plan",
-    "Subscriptions.Columns.Status": "Status",
-    "Subscriptions.Columns.Currency": "Currency",
-    "Subscriptions.Columns.PeriodStart": "Period Start",
-    "Subscriptions.Columns.PeriodEnd": "Period End",
-    "Subscriptions.Columns.CancelAtPeriodEnd": "Cancel at Period End",
-    "Subscriptions.Columns.TrialEndsAt": "Trial Ends At"
+    "Subscriptions.Columns.Status": "Durum",
+    "Subscriptions.Columns.Currency": "Para birimi",
+    "Subscriptions.Columns.PeriodStart": "Dönem başlangıcı",
+    "Subscriptions.Columns.PeriodEnd": "Dönem sonu",
+    "Subscriptions.Columns.CancelAtPeriodEnd": "Dönem sonunda iptal et",
+    "Subscriptions.Columns.TrialEndsAt": "Deneme bitiş tarihi"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/zh.json
+++ b/src/Granit.Subscriptions.Endpoints/Localization/SubscriptionsEndpoints/zh.json
@@ -10,13 +10,13 @@
     "Permission:Subscriptions.Prices.Manage": "管理价格（创建版本、迁移订阅）",
     "Permission:Subscriptions.Seats.Read": "查看席位分配",
     "Permission:Subscriptions.Seats.Manage": "管理席位分配（分配、撤销）",
-    "Subscriptions.Columns.Tenant": "Tenant",
-    "Subscriptions.Columns.Plan": "Plan",
-    "Subscriptions.Columns.Status": "Status",
-    "Subscriptions.Columns.Currency": "Currency",
-    "Subscriptions.Columns.PeriodStart": "Period Start",
-    "Subscriptions.Columns.PeriodEnd": "Period End",
-    "Subscriptions.Columns.CancelAtPeriodEnd": "Cancel at Period End",
-    "Subscriptions.Columns.TrialEndsAt": "Trial Ends At"
+    "Subscriptions.Columns.Tenant": "租户",
+    "Subscriptions.Columns.Plan": "计划",
+    "Subscriptions.Columns.Status": "状态",
+    "Subscriptions.Columns.Currency": "货币",
+    "Subscriptions.Columns.PeriodStart": "周期开始",
+    "Subscriptions.Columns.PeriodEnd": "周期结束",
+    "Subscriptions.Columns.CancelAtPeriodEnd": "周期结束时取消",
+    "Subscriptions.Columns.TrialEndsAt": "试用结束时间"
   }
 }

--- a/src/Granit.Subscriptions.Endpoints/packages.lock.json
+++ b/src/Granit.Subscriptions.Endpoints/packages.lock.json
@@ -227,8 +227,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.13.22",
-        "contentHash": "MN267boY7T3AEHW1mTFDpg4KHF/oiKbox7ue5Orz6/2OeqZHYF1ZQcjBHXGSwxN+lyGSYGL9/i0IRorCYyqw3Q=="
+        "resolved": "2.14.0",
+        "contentHash": "YpcCrY+FuPrmFzThm4om8HZ0Lww9vlIQUzUcBpc2Hv4n+oY8SgvFebgBSQJgnaW6y/FgG5J6FU/71HRq/wy9uQ=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfPlanReader.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfPlanReader.cs
@@ -13,16 +13,30 @@ internal sealed class EfPlanReader(
       IPlanReader
 {
     public Task<Plan?> GetByIdAsync(PlanId id, CancellationToken cancellationToken = default) =>
-        FindByIdAsync(id.Value, cancellationToken);
+        ReadAsync(
+            async db => await Query(db)
+                .Include(p => p.Prices)
+                .FirstOrDefaultAsync(p => p.Id == id.Value, cancellationToken)
+                .ConfigureAwait(false),
+            cancellationToken);
 
     public Task<IReadOnlyList<Plan>> GetAvailablePlansAsync(CancellationToken cancellationToken = default) =>
-        ListAsync(
-            Spec.For<Plan>().Where(p => p.LifecycleStatus == WorkflowLifecycleStatus.Published),
+        ReadAsync(
+            async db =>
+            {
+                List<Plan> plans = await Query(db)
+                    .Include(p => p.Prices)
+                    .Where(p => p.LifecycleStatus == WorkflowLifecycleStatus.Published)
+                    .ToListAsync(cancellationToken)
+                    .ConfigureAwait(false);
+                return (IReadOnlyList<Plan>)plans;
+            },
             cancellationToken);
 
     public Task<Plan?> GetByExternalIdAsync(
         string providerName, string externalId, CancellationToken cancellationToken = default) =>
         ReadAsync(async db => await db.Plans
+            .Include(p => p.Prices)
             .Include(p => p.ExternalMappings)
             .FirstOrDefaultAsync(
                 p => p.ExternalMappings.Any(m => m.ProviderName == providerName && m.ExternalId == externalId),

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfPlanWriter.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfPlanWriter.cs
@@ -1,6 +1,7 @@
 using Granit.Persistence.EntityFrameworkCore;
 using Granit.Subscriptions.Domain;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Granit.Subscriptions.EntityFrameworkCore.Internal;
 
@@ -13,5 +14,29 @@ internal sealed class EfPlanWriter(
         base.AddAsync(plan, cancellationToken);
 
     Task IPlanWriter.UpdateAsync(Plan plan, CancellationToken cancellationToken) =>
-        base.UpdateAsync(plan, cancellationToken);
+        base.WriteAsync(async db =>
+        {
+            // DbSet.Update() marks the entire disconnected graph as Modified.
+            // PlanPrice entities added in memory (e.g., via Plan.AddPriceVersion)
+            // don't exist in the database yet — mark them as Added to avoid
+            // DbUpdateConcurrencyException (UPDATE targeting a non-existent row).
+            var existingPriceIds = (await db.Set<PlanPrice>()
+                .AsNoTracking()
+                .Where(p => EF.Property<Guid>(p, "PlanId") == plan.Id)
+                .Select(p => p.Id)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false))
+                .ToHashSet();
+
+            db.Set<Plan>().Update(plan);
+
+            foreach (EntityEntry<PlanPrice> entry in db.ChangeTracker.Entries<PlanPrice>())
+            {
+                if (entry.State == EntityState.Modified
+                    && !existingPriceIds.Contains(entry.Entity.Id))
+                {
+                    entry.State = EntityState.Added;
+                }
+            }
+        }, cancellationToken);
 }

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfSeatWriter.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfSeatWriter.cs
@@ -11,9 +11,10 @@ internal sealed class EfSeatWriter(
     IGuidGenerator guidGenerator,
     IClock clock) : ISeatWriter
 {
-    public async Task AssignSeatAsync(
+    public async Task<SubscriptionSeat> AssignSeatAsync(
         SubscriptionId subscriptionId,
         Guid userId,
+        int? seatLimit = null,
         CancellationToken cancellationToken = default)
     {
         await using SubscriptionsDbContext context = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
@@ -24,9 +25,10 @@ internal sealed class EfSeatWriter(
             .ConfigureAwait(false);
 
         var seat = SubscriptionSeat.Create(guidGenerator.Create(), userId, clock.Now);
-        subscription.AssignSeat(seat);
+        subscription.AssignSeat(seat, seatLimit);
 
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return seat;
     }
 
     public async Task<bool> RevokeSeatAsync(

--- a/src/Granit.Subscriptions/Diagnostics/SubscriptionsMetrics.cs
+++ b/src/Granit.Subscriptions/Diagnostics/SubscriptionsMetrics.cs
@@ -21,6 +21,9 @@ public sealed class SubscriptionsMetrics
     private readonly Counter<long> _subscriptionsExpired;
     private readonly Counter<long> _planChanges;
     private readonly Counter<long> _periodAdvances;
+    private readonly Counter<long> _priceVersionsCreated;
+    private readonly Counter<long> _priceVersionsReplaced;
+    private readonly Counter<long> _priceMigrations;
 
     /// <summary>Initializes subscription metrics using the specified meter factory.</summary>
     public SubscriptionsMetrics(IMeterFactory meterFactory)
@@ -50,6 +53,18 @@ public sealed class SubscriptionsMetrics
         _periodAdvances = meter.CreateCounter<long>(
             "granit.subscriptions.period.advanced",
             description: "Number of billing period advances.");
+
+        _priceVersionsCreated = meter.CreateCounter<long>(
+            "granit.subscriptions.price.created",
+            description: "Number of plan price versions created.");
+
+        _priceVersionsReplaced = meter.CreateCounter<long>(
+            "granit.subscriptions.price.replaced",
+            description: "Number of plan prices replaced by newer versions.");
+
+        _priceMigrations = meter.CreateCounter<long>(
+            "granit.subscriptions.price.migrated",
+            description: "Number of subscription price migrations.");
     }
 
     /// <summary>Records a subscription creation.</summary>
@@ -92,5 +107,26 @@ public sealed class SubscriptionsMetrics
     {
         var tags = new TagList { { TenantIdTag, tenantId ?? GlobalTenant } };
         _periodAdvances.Add(1, tags);
+    }
+
+    /// <summary>Records a plan price version creation.</summary>
+    public void RecordPriceCreated(string? tenantId)
+    {
+        var tags = new TagList { { TenantIdTag, tenantId ?? GlobalTenant } };
+        _priceVersionsCreated.Add(1, tags);
+    }
+
+    /// <summary>Records a plan price replacement (grandfathering).</summary>
+    public void RecordPriceReplaced(string? tenantId)
+    {
+        var tags = new TagList { { TenantIdTag, tenantId ?? GlobalTenant } };
+        _priceVersionsReplaced.Add(1, tags);
+    }
+
+    /// <summary>Records a subscription price migration.</summary>
+    public void RecordPriceMigrated(string? tenantId)
+    {
+        var tags = new TagList { { TenantIdTag, tenantId ?? GlobalTenant } };
+        _priceMigrations.Add(1, tags);
     }
 }

--- a/src/Granit.Subscriptions/ISeatWriter.cs
+++ b/src/Granit.Subscriptions/ISeatWriter.cs
@@ -1,3 +1,4 @@
+using Granit.Subscriptions.Domain;
 using Granit.Subscriptions.Domain.ValueObjects;
 
 namespace Granit.Subscriptions;
@@ -6,12 +7,14 @@ namespace Granit.Subscriptions;
 public interface ISeatWriter
 {
     /// <summary>Assigns a seat to a user within a subscription.</summary>
-    /// <exception cref="Granit.Features.Exceptions.FeatureLimitExceededException">
-    /// Thrown when the seat limit for the plan is reached.
+    /// <returns>The created seat assignment.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the user already has a seat or the seat limit is reached.
     /// </exception>
-    Task AssignSeatAsync(
+    Task<SubscriptionSeat> AssignSeatAsync(
         SubscriptionId subscriptionId,
         Guid userId,
+        int? seatLimit = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>Revokes a seat from a user within a subscription.</summary>


### PR DESCRIPTION
## Summary

Fixes the `DbUpdateConcurrencyException` reported when adding a new price version to a plan, and a family of related disconnected-graph issues discovered during a module-wide audit of `Granit.Subscriptions`.

### Breaking fix (reported bug)

`EfPlanWriter.UpdateAsync` went through `EfStoreBase.UpdateAsync` which calls `db.Set<Plan>().Update(plan)` — this marks the whole disconnected graph as `Modified`, including newly-created `PlanPrice` entities from `Plan.AddPriceVersion()`. EF then generates an `UPDATE` for rows that do not exist yet → 0 rows affected → `DbUpdateConcurrencyException`.

**Root cause fix:**
- `EfPlanWriter.UpdateAsync` (override): fetches existing `PlanPrice` IDs, then re-marks unknown entries from `Modified` → `Added`.
- `EfPlanReader.GetByIdAsync`: added `.Include(Prices)` so `AddPriceVersion` can actually find and replace the current active price (grandfathering logic was silently skipped before).

### Audit findings resolved

| Severity | Fix |
|----------|-----|
| BREAKING | Same disconnected-graph bug on `Subscription` aggregate — all 3 seat endpoints (List/Assign/Revoke) now delegate to `ISeatReader`/`ISeatWriter` which load with `.Include(Seats)` in a tracked context |
| ARCHITECTURE | `ISeatWriter.AssignSeatAsync` now accepts `seatLimit` and returns the created `SubscriptionSeat`, restoring the duplicate-user and seat-limit invariants |
| ARCHITECTURE | `GetSubscriptionById`: removed contradictory tenant guard that was blocking `AllowHostAccess()` |
| CONVENTION | `GetAvailablePlansAsync` and `GetByExternalIdAsync` now include `Prices` (plans no longer return empty price arrays) |
| CONVENTION | `UpdatePlan` missing `.ProducesValidationProblem()` — added |
| CONVENTION | `CreateSubscriptionAsync` hardcoded `AddMonths(1)` — now resolves plan's `DefaultInterval` and pins the active price |
| CONVENTION | `SeatResponse` / `SeatAssignRequest` moved to dedicated `SeatDtos.cs`; `BulkMigratePriceResponse` moved to `PriceVersioningDtos.cs` |
| IMPROVEMENT | Added `granit.subscriptions.price.{created,replaced,migrated}` OpenTelemetry counters |
| CLEANUP | `EfPlanWriter`: fully-qualified `EntityEntry<PlanPrice>` replaced by a `using` |
| CLEANUP | Localization: translated the 8 query-engine column labels in 11 cultures (`it, pt, zh, ja, ko, pl, sv, tr, cs, hi, pt-BR`) and repaired mojibake in `pt`, `ja`, `ko`, `tr` |

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings on all subscription sub-projects
- [x] `dotnet test tests/Granit.Subscriptions.Endpoints.Tests` — 8/8 passed
- [x] `dotnet test tests/Granit.Subscriptions.EntityFrameworkCore.Tests` — 4/4 passed
- [x] `dotnet test tests/Granit.Subscriptions.Wolverine.Tests` — 12/12 passed
- [x] `dotnet test tests/Granit.Subscriptions.Tests` — 108/109 passed (1 pre-existing failure unrelated to this PR)
- [ ] Manual: create plan → publish → POST `/plans/{id}/prices` → expect 201 (previously 409 Conflict)
- [ ] Manual: POST `/subscriptions/{id}/seats` with a userId already assigned → expect 409 Conflict (previously silently ignored)
- [ ] Manual: GET `/plans` as host admin → expect prices populated in response (previously empty)

## Related

Audit performed via `/audit` skill on the Subscriptions module. The bug was originally reproduced in the Showcase consumer application.
