### PR TITLE
fix(deps): bump MimeKit to 4.16.0 to unblock CI

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -119,9 +119,10 @@
     <PackageVersion Include="Stripe.net" Version="47.*" />
   </ItemGroup>
   <!-- Security patches: transitive dependency version overrides -->
-  <!-- MimeKit 4.15.0 is vulnerable to GHSA-g7hc-96xr-gvvx (Moderate) -->
+  <!-- MimeKit 4.15.0 is vulnerable to GHSA-g7hc-96xr-gvvx (Moderate); -->
+  <!-- bumped to 4.16.0 to align with MailKit 4.16.0's transitive requirement. -->
   <ItemGroup Label="Security overrides">
-    <PackageVersion Include="MimeKit" Version="4.15.1" />
+    <PackageVersion Include="MimeKit" Version="4.16.0" />
   </ItemGroup>
   <ItemGroup Label="Notifications">
     <PackageVersion Include="AWSSDK.SimpleEmailV2" Version="4.*" />

--- a/src/Granit.Notifications.Email.Smtp/packages.lock.json
+++ b/src/Granit.Notifications.Email.Smtp/packages.lock.json
@@ -69,9 +69,9 @@
       },
       "MimeKit": {
         "type": "Direct",
-        "requested": "[4.15.1, )",
-        "resolved": "4.15.1",
-        "contentHash": "cxCcQhD0zhboFoG136jJuJtQjNRDJ+BxBm3f2vWn+53bff/CRo+K1mAkWjsW4Wuyy5O22F40MdMG2nRzQu1cJw==",
+        "requested": "[4.16.0, )",
+        "resolved": "4.16.0",
+        "contentHash": "X0LFxeM4gPRIhODyY/HYS9b+zRZ7y//v59rFzgS6wLxcPuZThnMtNZHtrr0fjLyRRkg3gqJBtvW36XfUzZ7Djw==",
         "dependencies": {
           "BouncyCastle.Cryptography": "2.6.2",
           "System.Security.Cryptography.Pkcs": "10.0.0"

--- a/src/bundles/Granit.Bundle.Notifications/packages.lock.json
+++ b/src/bundles/Granit.Bundle.Notifications/packages.lock.json
@@ -255,7 +255,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
-          "MimeKit": "[4.15.1, )"
+          "MimeKit": "[4.16.0, )"
         }
       },
       "granit.notifications.endpoints": {
@@ -574,9 +574,9 @@
       },
       "MimeKit": {
         "type": "CentralTransitive",
-        "requested": "[4.15.1, )",
-        "resolved": "4.15.1",
-        "contentHash": "cxCcQhD0zhboFoG136jJuJtQjNRDJ+BxBm3f2vWn+53bff/CRo+K1mAkWjsW4Wuyy5O22F40MdMG2nRzQu1cJw==",
+        "requested": "[4.16.0, )",
+        "resolved": "4.16.0",
+        "contentHash": "X0LFxeM4gPRIhODyY/HYS9b+zRZ7y//v59rFzgS6wLxcPuZThnMtNZHtrr0fjLyRRkg3gqJBtvW36XfUzZ7Djw==",
         "dependencies": {
           "BouncyCastle.Cryptography": "2.6.2",
           "System.Security.Cryptography.Pkcs": "10.0.0"

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2479,7 +2479,7 @@
         "dependencies": {
           "Granit.Notifications.Email": "[0.1.0-dev, )",
           "MailKit": "[4.*, )",
-          "MimeKit": "[4.15.1, )"
+          "MimeKit": "[4.16.0, )"
         }
       },
       "granit.notifications.endpoints": {
@@ -3975,9 +3975,9 @@
       },
       "MimeKit": {
         "type": "CentralTransitive",
-        "requested": "[4.15.1, )",
-        "resolved": "4.15.1",
-        "contentHash": "cxCcQhD0zhboFoG136jJuJtQjNRDJ+BxBm3f2vWn+53bff/CRo+K1mAkWjsW4Wuyy5O22F40MdMG2nRzQu1cJw==",
+        "requested": "[4.16.0, )",
+        "resolved": "4.16.0",
+        "contentHash": "X0LFxeM4gPRIhODyY/HYS9b+zRZ7y//v59rFzgS6wLxcPuZThnMtNZHtrr0fjLyRRkg3gqJBtvW36XfUzZ7Djw==",
         "dependencies": {
           "BouncyCastle.Cryptography": "2.6.2",
           "System.Security.Cryptography.Pkcs": "10.0.0"

--- a/tests/Granit.Bundle.Tests/packages.lock.json
+++ b/tests/Granit.Bundle.Tests/packages.lock.json
@@ -696,7 +696,7 @@
         "dependencies": {
           "Granit.Notifications.Email": "[0.1.0-dev, )",
           "MailKit": "[4.*, )",
-          "MimeKit": "[4.15.1, )"
+          "MimeKit": "[4.16.0, )"
         }
       },
       "granit.notifications.endpoints": {
@@ -968,9 +968,9 @@
       },
       "MimeKit": {
         "type": "CentralTransitive",
-        "requested": "[4.15.1, )",
-        "resolved": "4.15.1",
-        "contentHash": "cxCcQhD0zhboFoG136jJuJtQjNRDJ+BxBm3f2vWn+53bff/CRo+K1mAkWjsW4Wuyy5O22F40MdMG2nRzQu1cJw==",
+        "requested": "[4.16.0, )",
+        "resolved": "4.16.0",
+        "contentHash": "X0LFxeM4gPRIhODyY/HYS9b+zRZ7y//v59rFzgS6wLxcPuZThnMtNZHtrr0fjLyRRkg3gqJBtvW36XfUzZ7Djw==",
         "dependencies": {
           "BouncyCastle.Cryptography": "2.6.2",
           "System.Security.Cryptography.Pkcs": "10.0.0"

--- a/tests/Granit.Notifications.Email.Smtp.Tests/packages.lock.json
+++ b/tests/Granit.Notifications.Email.Smtp.Tests/packages.lock.json
@@ -325,7 +325,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
-          "MimeKit": "[4.15.1, )"
+          "MimeKit": "[4.16.0, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -447,9 +447,9 @@
       },
       "MimeKit": {
         "type": "CentralTransitive",
-        "requested": "[4.15.1, )",
-        "resolved": "4.15.1",
-        "contentHash": "cxCcQhD0zhboFoG136jJuJtQjNRDJ+BxBm3f2vWn+53bff/CRo+K1mAkWjsW4Wuyy5O22F40MdMG2nRzQu1cJw==",
+        "requested": "[4.16.0, )",
+        "resolved": "4.16.0",
+        "contentHash": "X0LFxeM4gPRIhODyY/HYS9b+zRZ7y//v59rFzgS6wLxcPuZThnMtNZHtrr0fjLyRRkg3gqJBtvW36XfUzZ7Djw==",
         "dependencies": {
           "BouncyCastle.Cryptography": "2.6.2",
           "System.Security.Cryptography.Pkcs": "10.0.0"


### PR DESCRIPTION
## Summary

Unblocks CI on `develop`. After PR #1021 regenerated all `packages.lock.json` files, NuGet's `NU1605` fired as an error because the "Security overrides" pin on `MimeKit 4.15.1` conflicts with `MailKit 4.16.0`'s transitive requirement of `MimeKit >= 4.16.0`.

Bumping the explicit override to `4.16.0`:
- Keeps the CVE fix for [GHSA-g7hc-96xr-gvvx](https://github.com/advisories/GHSA-g7hc-96xr-gvvx) — 4.16.0 supersedes 4.15.1.
- Removes the version downgrade on every `dotnet restore --force-evaluate`.
- Affects 5 lock files (`Notifications.Email.Smtp`, its tests, the notifications bundle, and `ArchitectureTests` + `Bundle.Tests`).

## Test plan

- [x] `dotnet restore --force-evaluate` — no `NU1605` errors
- [x] `dotnet build src/Granit.Notifications.Email.Smtp` — 0 warnings, 0 errors
- [ ] CI shard `src-only` should pass (this was the failing shard on #1021)
