### PR TITLE
refactor(vault): audit cleanups + SecretMetadata + shared health check

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -41759,6 +41759,15 @@
       ]
     },
     {
+      "name": "SecretStoreActivityTags",
+      "fqn": "Granit.Vault.Diagnostics.SecretStoreActivityTags",
+      "kind": "class",
+      "project": "Granit.Vault",
+      "file": "src/Granit.Vault/Diagnostics/SecretStoreActivityTags.cs",
+      "line": 8,
+      "members": []
+    },
+    {
       "name": "VaultMetrics",
       "fqn": "Granit.Vault.Diagnostics.VaultMetrics",
       "kind": "class",
@@ -41893,7 +41902,7 @@
       "kind": "class",
       "project": "Granit.Vault",
       "file": "src/Granit.Vault/Extensions/SecretStoreServiceCollectionExtensions.cs",
-      "line": 16,
+      "line": 18,
       "members": []
     },
     {
@@ -42234,8 +42243,24 @@
         {
           "name": "FromString",
           "kind": "method",
-          "signature": "FromString(string name, string value, string? version = null, string? contentType = null, DateTimeOffset? createdAt = null, DateTimeOffset? expiresOn = null, DateTimeOffset? notBefore = null, IReadOnlyDictionary<string, string>? tags = null)",
+          "signature": "FromString(string name, string value, SecretMetadata? metadata = null)",
           "returnType": "SecretDescriptor"
+        }
+      ]
+    },
+    {
+      "name": "SecretMetadata",
+      "fqn": "Granit.Vault.SecretMetadata",
+      "kind": "record",
+      "project": "Granit.Vault",
+      "file": "src/Granit.Vault/SecretMetadata.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new()",
+          "returnType": "SecretMetadata Empty { get; } ="
         }
       ]
     },

--- a/src/Granit.Vault.Aws/Services/AwsSecretStore.cs
+++ b/src/Granit.Vault.Aws/Services/AwsSecretStore.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Amazon.SecretsManager;
 using Amazon.SecretsManager.Model;
 using Granit.Vault.Aws.Diagnostics;
+using Granit.Vault.Diagnostics;
 using Granit.Vault.Exceptions;
 using Microsoft.Extensions.Logging;
 
@@ -46,53 +47,47 @@ internal sealed partial class AwsSecretStore(
         catch (ResourceNotFoundException ex)
         {
             activity?.SetStatus(ActivityStatusCode.Error, "not_found");
+            activity?.SetTag(SecretStoreActivityTags.Outcome, "not_found");
             throw new SecretNotFoundException(request.Name, request.Version?.Identifier, ex);
         }
         catch (AmazonSecretsManagerException ex) when (IsAccessDenied(ex))
         {
             activity?.SetStatus(ActivityStatusCode.Error, "denied");
+            activity?.SetTag(SecretStoreActivityTags.Outcome, "denied");
             LogAccessDenied(logger, request.Name);
             throw new SecretAccessDeniedException(request.Name, ex);
         }
         catch (AmazonSecretsManagerException ex) when (IsTransient(ex))
         {
             activity?.SetStatus(ActivityStatusCode.Error, "transient");
+            activity?.SetTag(SecretStoreActivityTags.Outcome, "transient");
             throw new SecretVaultTransientException(
                 request.Name,
                 $"Transient AWS Secrets Manager failure ({ex.ErrorCode}).",
                 ex);
         }
 
+        activity?.SetTag(SecretStoreActivityTags.Outcome, "ok");
         DateTimeOffset? createdAt = response.CreatedDate is { } created
             ? new DateTimeOffset(DateTime.SpecifyKind(created, DateTimeKind.Utc))
             : null;
 
+        var metadata = new SecretMetadata(Version: response.VersionId, CreatedAt: createdAt);
+
         if (response.SecretBinary is { } binaryStream)
         {
-            byte[] bytes = ToArray(binaryStream);
-            return SecretDescriptor.FromBinary(
-                request.Name,
-                bytes,
-                version: response.VersionId,
-                createdAt: createdAt);
+            // MemoryStream is always seekable; rewind defensively in case the SDK returned a
+            // stream that was already consumed by a deserializer up the call chain.
+            if (binaryStream.Position != 0)
+            {
+                binaryStream.Position = 0;
+            }
+
+            return SecretDescriptor.FromBinary(request.Name, binaryStream.ToArray(), metadata);
         }
 
         string stringValue = response.SecretString ?? string.Empty;
-        return SecretDescriptor.FromString(
-            request.Name,
-            stringValue,
-            version: response.VersionId,
-            createdAt: createdAt);
-    }
-
-    private static byte[] ToArray(MemoryStream stream)
-    {
-        if (stream.Position != 0 && stream.CanSeek)
-        {
-            stream.Position = 0;
-        }
-
-        return stream.ToArray();
+        return SecretDescriptor.FromString(request.Name, stringValue, metadata);
     }
 
     private static bool IsAccessDenied(AmazonSecretsManagerException ex) =>

--- a/src/Granit.Vault.Aws/packages.lock.json
+++ b/src/Granit.Vault.Aws/packages.lock.json
@@ -179,7 +179,8 @@
         "dependencies": {
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Encryption": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.*, )"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {

--- a/src/Granit.Vault.Azure/Services/AzureSecretStore.cs
+++ b/src/Granit.Vault.Azure/Services/AzureSecretStore.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Azure;
 using Azure.Security.KeyVault.Secrets;
 using Granit.Vault.Azure.Diagnostics;
+using Granit.Vault.Diagnostics;
 using Granit.Vault.Exceptions;
 using Microsoft.Extensions.Logging;
 
@@ -43,52 +44,48 @@ internal sealed partial class AzureSecretStore(
         catch (RequestFailedException ex) when (ex.Status == 404)
         {
             activity?.SetStatus(ActivityStatusCode.Error, "not_found");
+            activity?.SetTag(SecretStoreActivityTags.Outcome, "not_found");
             throw new SecretNotFoundException(request.Name, request.Version?.Identifier, ex);
         }
         catch (RequestFailedException ex) when (ex.Status is 401 or 403)
         {
             activity?.SetStatus(ActivityStatusCode.Error, "denied");
+            activity?.SetTag(SecretStoreActivityTags.Outcome, "denied");
             LogAccessDenied(logger, request.Name);
             throw new SecretAccessDeniedException(request.Name, ex);
         }
         catch (RequestFailedException ex) when (IsTransient(ex.Status))
         {
             activity?.SetStatus(ActivityStatusCode.Error, "transient");
+            activity?.SetTag(SecretStoreActivityTags.Outcome, "transient");
             throw new SecretVaultTransientException(
                 request.Name,
                 $"Transient Azure Key Vault failure (HTTP {ex.Status}).",
                 ex);
         }
 
+        activity?.SetTag(SecretStoreActivityTags.Outcome, "ok");
         KeyVaultSecret secret = response.Value;
         SecretProperties props = secret.Properties;
         IReadOnlyDictionary<string, string>? tags = props.Tags is { Count: > 0 }
             ? new Dictionary<string, string>(props.Tags)
             : null;
 
+        var metadata = new SecretMetadata(
+            Version: props.Version,
+            ContentType: props.ContentType,
+            CreatedAt: props.CreatedOn,
+            ExpiresOn: props.ExpiresOn,
+            NotBefore: props.NotBefore,
+            Tags: tags);
+
         if (string.Equals(props.ContentType, OctetStreamContentType, StringComparison.OrdinalIgnoreCase))
         {
             byte[] bytes = Convert.FromBase64String(secret.Value);
-            return SecretDescriptor.FromBinary(
-                request.Name,
-                bytes,
-                version: props.Version,
-                contentType: props.ContentType,
-                createdAt: props.CreatedOn,
-                expiresOn: props.ExpiresOn,
-                notBefore: props.NotBefore,
-                tags: tags);
+            return SecretDescriptor.FromBinary(request.Name, bytes, metadata);
         }
 
-        return SecretDescriptor.FromString(
-            request.Name,
-            secret.Value,
-            version: props.Version,
-            contentType: props.ContentType,
-            createdAt: props.CreatedOn,
-            expiresOn: props.ExpiresOn,
-            notBefore: props.NotBefore,
-            tags: tags);
+        return SecretDescriptor.FromString(request.Name, secret.Value, metadata);
     }
 
     private static bool IsTransient(int status) =>

--- a/src/Granit.Vault.Azure/packages.lock.json
+++ b/src/Granit.Vault.Azure/packages.lock.json
@@ -245,7 +245,8 @@
         "dependencies": {
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Encryption": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.*, )"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {

--- a/src/Granit.Vault.GoogleCloud/Services/GoogleCloudSecretStore.cs
+++ b/src/Granit.Vault.GoogleCloud/Services/GoogleCloudSecretStore.cs
@@ -1,5 +1,8 @@
 using System.Diagnostics;
+using System.Text;
 using Google.Cloud.SecretManager.V1;
+using Google.Protobuf;
+using Granit.Vault.Diagnostics;
 using Granit.Vault.Exceptions;
 using Granit.Vault.GoogleCloud.Diagnostics;
 using Granit.Vault.GoogleCloud.Options;
@@ -59,30 +62,55 @@ internal sealed partial class GoogleCloudSecretStore(
         catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)
         {
             activity?.SetStatus(ActivityStatusCode.Error, "not_found");
+            activity?.SetTag(SecretStoreActivityTags.Outcome, "not_found");
             throw new SecretNotFoundException(request.Name, request.Version?.Identifier, ex);
         }
         catch (RpcException ex) when (ex.StatusCode is StatusCode.PermissionDenied or StatusCode.Unauthenticated)
         {
             activity?.SetStatus(ActivityStatusCode.Error, "denied");
+            activity?.SetTag(SecretStoreActivityTags.Outcome, "denied");
             LogAccessDenied(logger, request.Name);
             throw new SecretAccessDeniedException(request.Name, ex);
         }
         catch (RpcException ex) when (IsTransient(ex.StatusCode))
         {
             activity?.SetStatus(ActivityStatusCode.Error, "transient");
+            activity?.SetTag(SecretStoreActivityTags.Outcome, "transient");
             throw new SecretVaultTransientException(
                 request.Name,
                 $"Transient GCP Secret Manager failure ({ex.StatusCode}).",
                 ex);
         }
 
-        byte[] bytes = response.Payload.Data.ToByteArray();
-        string? resolvedVersion = ExtractVersion(response.Name);
+        activity?.SetTag(SecretStoreActivityTags.Outcome, "ok");
+        ByteString payload = response.Payload.Data;
+        var metadata = new SecretMetadata(Version: ExtractVersion(response.Name));
 
-        return SecretDescriptor.FromBinary(
-            request.Name,
-            bytes,
-            version: resolvedVersion);
+        // GCP payloads are always binary natively. When the body is valid UTF-8 and no binary
+        // content type is hinted, surface the payload as StringValue so consumers of text
+        // secrets don't have to call AsString(). Callers who explicitly want raw bytes
+        // (certificates, binary blobs) use AsBytes() regardless of which facet is set.
+        if (TryDecodeUtf8(payload, out string? text))
+        {
+            return SecretDescriptor.FromString(request.Name, text!, metadata);
+        }
+
+        return SecretDescriptor.FromBinary(request.Name, payload.ToByteArray(), metadata);
+    }
+
+    private static bool TryDecodeUtf8(ByteString payload, out string? text)
+    {
+        try
+        {
+            var decoder = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+            text = decoder.GetString(payload.Span);
+            return true;
+        }
+        catch (DecoderFallbackException)
+        {
+            text = null;
+            return false;
+        }
     }
 
     private SecretVersionName BuildVersionName(SecretRequest request)

--- a/src/Granit.Vault.GoogleCloud/packages.lock.json
+++ b/src/Granit.Vault.GoogleCloud/packages.lock.json
@@ -319,7 +319,8 @@
         "dependencies": {
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Encryption": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.*, )"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {

--- a/src/Granit.Vault.HashiCorp/Services/HashiCorpSecretStore.cs
+++ b/src/Granit.Vault.HashiCorp/Services/HashiCorpSecretStore.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Net;
+using Granit.Vault.Diagnostics;
 using Granit.Vault.Exceptions;
 using Granit.Vault.HashiCorp.Diagnostics;
 using Granit.Vault.HashiCorp.Options;
@@ -67,24 +68,28 @@ internal sealed partial class HashiCorpSecretStore(
         catch (VaultApiException ex) when (ex.HttpStatusCode == HttpStatusCode.NotFound)
         {
             activity?.SetStatus(ActivityStatusCode.Error, "not_found");
+            activity?.SetTag(SecretStoreActivityTags.Outcome, "not_found");
             throw new SecretNotFoundException(request.Name, request.Version?.Identifier, ex);
         }
         catch (VaultApiException ex) when (
             ex.HttpStatusCode is HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized)
         {
             activity?.SetStatus(ActivityStatusCode.Error, "denied");
+            activity?.SetTag(SecretStoreActivityTags.Outcome, "denied");
             LogAccessDenied(logger, request.Name);
             throw new SecretAccessDeniedException(request.Name, ex);
         }
         catch (VaultApiException ex) when (IsTransient(ex.HttpStatusCode))
         {
             activity?.SetStatus(ActivityStatusCode.Error, "transient");
+            activity?.SetTag(SecretStoreActivityTags.Outcome, "transient");
             throw new SecretVaultTransientException(
                 request.Name,
                 $"Transient HashiCorp Vault failure (HTTP {(int)ex.HttpStatusCode}).",
                 ex);
         }
 
+        activity?.SetTag(SecretStoreActivityTags.Outcome, "ok");
         IDictionary<string, object> data = secret.Data.Data;
         string? resolvedVersion = secret.Data.Metadata?.Version.ToString(CultureInfo.InvariantCulture);
         DateTimeOffset? createdAt = TryParseIso(secret.Data.Metadata?.CreatedTime);
@@ -95,9 +100,10 @@ internal sealed partial class HashiCorpSecretStore(
             return SecretDescriptor.FromBinary(
                 request.Name,
                 bytes,
-                version: resolvedVersion,
-                contentType: "application/octet-stream",
-                createdAt: createdAt);
+                new SecretMetadata(
+                    Version: resolvedVersion,
+                    ContentType: "application/octet-stream",
+                    CreatedAt: createdAt));
         }
 
         string stringValue = data.TryGetValue(ValueKey, out object? valueRaw) && valueRaw is not null
@@ -107,8 +113,7 @@ internal sealed partial class HashiCorpSecretStore(
         return SecretDescriptor.FromString(
             request.Name,
             stringValue,
-            version: resolvedVersion,
-            createdAt: createdAt);
+            new SecretMetadata(Version: resolvedVersion, CreatedAt: createdAt));
     }
 
     private static int? ParseVersion(SecretRequest request)

--- a/src/Granit.Vault.HashiCorp/packages.lock.json
+++ b/src/Granit.Vault.HashiCorp/packages.lock.json
@@ -162,7 +162,8 @@
         "dependencies": {
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Encryption": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.*, )"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {

--- a/src/Granit.Vault/Diagnostics/SecretStoreActivityTags.cs
+++ b/src/Granit.Vault/Diagnostics/SecretStoreActivityTags.cs
@@ -1,0 +1,16 @@
+namespace Granit.Vault.Diagnostics;
+
+/// <summary>
+/// Provider-agnostic <see cref="System.Diagnostics.Activity"/> tag keys used by
+/// <c>ISecretStore</c> implementations. Provider-specific tags live on each
+/// provider's own <c>Vault*ActivitySource.Tags</c> class.
+/// </summary>
+public static class SecretStoreActivityTags
+{
+    /// <summary>
+    /// Canonical outcome tag. Matches the <c>outcome</c> dimension of the
+    /// <c>granit.vault.secret.read</c> counter: <c>ok</c> | <c>not_found</c>
+    /// | <c>denied</c> | <c>transient</c> | <c>error</c>.
+    /// </summary>
+    public const string Outcome = "secret.outcome";
+}

--- a/src/Granit.Vault/Extensions/SecretStoreServiceCollectionExtensions.cs
+++ b/src/Granit.Vault/Extensions/SecretStoreServiceCollectionExtensions.cs
@@ -1,8 +1,10 @@
 using Granit.Vault.Diagnostics;
+using Granit.Vault.HealthChecks;
 using Granit.Vault.Internal;
 using Granit.Vault.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ZiggyCreatures.Caching.Fusion;
@@ -38,12 +40,17 @@ public static class SecretStoreServiceCollectionExtensions
 
         // Self-sufficient registration: ensure VaultMetrics and SecretStoreOptions are available
         // even when the extension is called outside the GranitVaultModule pipeline (e.g. tests
-        // that stand up a ServiceCollection manually).
+        // that stand up a ServiceCollection manually). Idempotent — GranitVaultModule may have
+        // registered SecretStoreOptions already, so guard against a second BindConfiguration.
         services.TryAddSingleton<VaultMetrics>();
-        services
-            .AddOptions<SecretStoreOptions>()
-            .BindConfiguration(SecretStoreOptions.SectionName)
-            .ValidateDataAnnotations();
+
+        if (!services.Any(d => d.ServiceType == typeof(IConfigureOptions<SecretStoreOptions>)))
+        {
+            services
+                .AddOptions<SecretStoreOptions>()
+                .BindConfiguration(SecretStoreOptions.SectionName)
+                .ValidateDataAnnotations();
+        }
 
         services.AddSingleton<TStore>();
 
@@ -72,5 +79,32 @@ public static class SecretStoreServiceCollectionExtensions
         });
 
         return services;
+    }
+
+    /// <summary>
+    /// Adds a provider-agnostic health check that reads the canary secret named in
+    /// <see cref="SecretStoreOptions.HealthCheckSecretName"/>. When the option is not set,
+    /// the check is a no-op and reports <see cref="HealthStatus.Healthy"/>.
+    /// </summary>
+    /// <param name="builder">Health-checks builder.</param>
+    /// <param name="name">Check name (default: <c>"vault-secret-store"</c>).</param>
+    /// <param name="failureStatus">Status on failure (default: <see cref="HealthStatus.Unhealthy"/>).</param>
+    /// <param name="timeout">Timeout (default: 10 seconds).</param>
+    public static IHealthChecksBuilder AddGranitSecretStoreHealthCheck(
+        this IHealthChecksBuilder builder,
+        string name = "vault-secret-store",
+        HealthStatus? failureStatus = null,
+        TimeSpan? timeout = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Services.TryAddSingleton<SecretStoreHealthCheck>();
+
+        return builder.Add(new HealthCheckRegistration(
+            name,
+            sp => sp.GetRequiredService<SecretStoreHealthCheck>(),
+            failureStatus,
+            ["readiness", "startup"],
+            timeout ?? TimeSpan.FromSeconds(10)));
     }
 }

--- a/src/Granit.Vault/Granit.Vault.csproj
+++ b/src/Granit.Vault/Granit.Vault.csproj
@@ -8,6 +8,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Granit.Vault.Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Granit.Vault/HealthChecks/SecretStoreHealthCheck.cs
+++ b/src/Granit.Vault/HealthChecks/SecretStoreHealthCheck.cs
@@ -1,0 +1,58 @@
+using Granit.Vault.Exceptions;
+using Granit.Vault.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Vault.HealthChecks;
+
+/// <summary>
+/// Provider-agnostic health check that reads a canary secret through
+/// <see cref="ISecretStore"/>. Detects permission regressions, provider outages and
+/// misconfiguration that the existing connectivity health checks (which call
+/// provider-specific endpoints like <c>sys/health</c> or <c>DescribeKey</c>) may miss.
+/// </summary>
+/// <remarks>
+/// Enabled only when <see cref="SecretStoreOptions.HealthCheckSecretName"/> is set —
+/// otherwise the check returns <see cref="HealthStatus.Healthy"/> with a "not configured"
+/// description so adopters who do not use the feature aren't forced to wire a canary.
+/// </remarks>
+internal sealed class SecretStoreHealthCheck(
+    ISecretStore secretStore,
+    IOptions<SecretStoreOptions> options) : IHealthCheck
+{
+    /// <inheritdoc />
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        string? canary = options.Value.HealthCheckSecretName;
+        if (string.IsNullOrWhiteSpace(canary))
+        {
+            return HealthCheckResult.Healthy("SecretStore canary not configured (Vault:SecretStore:HealthCheckSecretName).");
+        }
+
+        try
+        {
+            _ = await secretStore.GetSecretAsync(SecretRequest.Latest(canary), cancellationToken).ConfigureAwait(false);
+            return HealthCheckResult.Healthy("SecretStore canary retrieved successfully.");
+        }
+        catch (SecretNotFoundException)
+        {
+            return HealthCheckResult.Unhealthy(
+                "SecretStore canary not found. Verify Vault:SecretStore:HealthCheckSecretName is provisioned in the vault.");
+        }
+        catch (SecretAccessDeniedException)
+        {
+            return HealthCheckResult.Unhealthy(
+                "SecretStore canary access denied. Verify the application principal has read permission.");
+        }
+        catch (SecretVaultTransientException)
+        {
+            return HealthCheckResult.Degraded("SecretStore is reporting a transient failure.");
+        }
+        catch (SecretVaultException ex)
+        {
+            return HealthCheckResult.Unhealthy("SecretStore returned an error.", ex);
+        }
+    }
+}

--- a/src/Granit.Vault/Internal/CachedSecretStore.cs
+++ b/src/Granit.Vault/Internal/CachedSecretStore.cs
@@ -1,4 +1,3 @@
-using Granit.MultiTenancy;
 using Granit.Vault.Diagnostics;
 using Granit.Vault.Exceptions;
 using Granit.Vault.Options;
@@ -45,7 +44,7 @@ internal sealed partial class CachedSecretStore(
         ArgumentNullException.ThrowIfNull(request);
 
         string cacheKey = BuildCacheKey(request);
-        string? tenantId = ResolveTenantId();
+        string? tenantId = SecretStoreDiagnostics.ResolveTenantId(serviceProvider);
 
         MaybeValue<SecretDescriptor> cached = await cache
             .TryGetAsync<SecretDescriptor>(cacheKey, token: cancellationToken)
@@ -63,24 +62,9 @@ internal sealed partial class CachedSecretStore(
         {
             descriptor = await inner.GetSecretAsync(request, cancellationToken).ConfigureAwait(false);
         }
-        catch (SecretNotFoundException)
+        catch (SecretVaultException ex)
         {
-            metrics.RecordSecretRead(tenantId, providerName, outcome: "not_found", cached: false);
-            throw;
-        }
-        catch (SecretAccessDeniedException)
-        {
-            metrics.RecordSecretRead(tenantId, providerName, outcome: "denied", cached: false);
-            throw;
-        }
-        catch (SecretVaultTransientException)
-        {
-            metrics.RecordSecretRead(tenantId, providerName, outcome: "transient", cached: false);
-            throw;
-        }
-        catch (SecretVaultException)
-        {
-            metrics.RecordSecretRead(tenantId, providerName, outcome: "error", cached: false);
+            SecretStoreDiagnostics.RecordAndThrow(metrics, tenantId, providerName, cached: false, ex);
             throw;
         }
 
@@ -110,12 +94,6 @@ internal sealed partial class CachedSecretStore(
         }
 
         return true;
-    }
-
-    private string? ResolveTenantId()
-    {
-        var currentTenant = serviceProvider.GetService(typeof(ICurrentTenant)) as ICurrentTenant;
-        return currentTenant?.IsAvailable == true ? currentTenant.Id?.ToString() : null;
     }
 
     private string BuildCacheKey(SecretRequest request) =>

--- a/src/Granit.Vault/Internal/ProviderTaggingSecretStore.cs
+++ b/src/Granit.Vault/Internal/ProviderTaggingSecretStore.cs
@@ -1,4 +1,3 @@
-using Granit.MultiTenancy;
 using Granit.Vault.Diagnostics;
 using Granit.Vault.Exceptions;
 
@@ -23,7 +22,7 @@ internal sealed class ProviderTaggingSecretStore(
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        string? tenantId = ResolveTenantId();
+        string? tenantId = SecretStoreDiagnostics.ResolveTenantId(serviceProvider);
 
         try
         {
@@ -31,31 +30,10 @@ internal sealed class ProviderTaggingSecretStore(
             metrics.RecordSecretRead(tenantId, providerName, outcome: "ok", cached: false);
             return descriptor;
         }
-        catch (SecretNotFoundException)
+        catch (SecretVaultException ex)
         {
-            metrics.RecordSecretRead(tenantId, providerName, outcome: "not_found", cached: false);
+            SecretStoreDiagnostics.RecordAndThrow(metrics, tenantId, providerName, cached: false, ex);
             throw;
         }
-        catch (SecretAccessDeniedException)
-        {
-            metrics.RecordSecretRead(tenantId, providerName, outcome: "denied", cached: false);
-            throw;
-        }
-        catch (SecretVaultTransientException)
-        {
-            metrics.RecordSecretRead(tenantId, providerName, outcome: "transient", cached: false);
-            throw;
-        }
-        catch (SecretVaultException)
-        {
-            metrics.RecordSecretRead(tenantId, providerName, outcome: "error", cached: false);
-            throw;
-        }
-    }
-
-    private string? ResolveTenantId()
-    {
-        var currentTenant = serviceProvider.GetService(typeof(ICurrentTenant)) as ICurrentTenant;
-        return currentTenant?.IsAvailable == true ? currentTenant.Id?.ToString() : null;
     }
 }

--- a/src/Granit.Vault/Internal/SecretStoreDiagnostics.cs
+++ b/src/Granit.Vault/Internal/SecretStoreDiagnostics.cs
@@ -1,0 +1,63 @@
+using Granit.MultiTenancy;
+using Granit.Vault.Diagnostics;
+using Granit.Vault.Exceptions;
+
+namespace Granit.Vault.Internal;
+
+/// <summary>
+/// Shared diagnostics helpers used by <see cref="CachedSecretStore"/> and
+/// <see cref="ProviderTaggingSecretStore"/>. Centralises tenant resolution and
+/// exception-to-outcome mapping so the two decorators stay in lockstep.
+/// </summary>
+internal static class SecretStoreDiagnostics
+{
+    /// <summary>
+    /// Resolves the current tenant id, or <c>null</c> when no tenant is active.
+    /// Safe to call when <see cref="ICurrentTenant"/> is not registered — returns <c>null</c>.
+    /// </summary>
+    internal static string? ResolveTenantId(IServiceProvider serviceProvider)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+
+        var currentTenant = serviceProvider.GetService(typeof(ICurrentTenant)) as ICurrentTenant;
+        return currentTenant?.IsAvailable == true ? currentTenant.Id?.ToString() : null;
+    }
+
+    /// <summary>
+    /// Maps a <see cref="SecretVaultException"/> (or subtype) to its canonical outcome tag
+    /// used by the <c>granit.vault.secret.read</c> counter.
+    /// Returns <c>null</c> if the exception is not part of the vault taxonomy — the
+    /// counter must not be emitted in that case (unknown failure, not vault-attributable).
+    /// </summary>
+    internal static string? TryMapOutcome(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        return exception switch
+        {
+            SecretNotFoundException => "not_found",
+            SecretAccessDeniedException => "denied",
+            SecretVaultTransientException => "transient",
+            SecretVaultException => "error",
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Records an outcome if the exception belongs to the vault taxonomy, then rethrows.
+    /// Factored out so both decorators share an identical observe-then-throw path.
+    /// </summary>
+    internal static void RecordAndThrow(
+        VaultMetrics metrics,
+        string? tenantId,
+        string providerName,
+        bool cached,
+        Exception exception)
+    {
+        string? outcome = TryMapOutcome(exception);
+        if (outcome is not null)
+        {
+            metrics.RecordSecretRead(tenantId, providerName, outcome, cached);
+        }
+    }
+}

--- a/src/Granit.Vault/Options/SecretStoreOptions.cs
+++ b/src/Granit.Vault/Options/SecretStoreOptions.cs
@@ -27,4 +27,12 @@ public sealed class SecretStoreOptions
     /// </summary>
     [Range(1024, 10_485_760)]
     public int MaxCachedBinarySizeBytes { get; set; } = 64 * 1024;
+
+    /// <summary>
+    /// Optional canary secret name used by <c>AddGranitSecretStoreHealthCheck()</c>.
+    /// When <c>null</c> or empty, the health check is a no-op — use a dedicated non-critical,
+    /// read-only secret (e.g. <c>healthcheck/probe</c>) specifically for liveness probing;
+    /// NEVER reuse a business secret here.
+    /// </summary>
+    public string? HealthCheckSecretName { get; set; }
 }

--- a/src/Granit.Vault/SecretDescriptor.cs
+++ b/src/Granit.Vault/SecretDescriptor.cs
@@ -53,56 +53,42 @@ public sealed record SecretDescriptor
     /// <summary>True when the payload is binary — use <see cref="BinaryValue"/> / <see cref="AsBytes"/>.</summary>
     public bool IsBinary => BinaryValue is not null;
 
-    /// <summary>Builds a descriptor for a text secret.</summary>
-    public static SecretDescriptor FromString(
-        string name,
-        string value,
-        string? version = null,
-        string? contentType = null,
-        DateTimeOffset? createdAt = null,
-        DateTimeOffset? expiresOn = null,
-        DateTimeOffset? notBefore = null,
-        IReadOnlyDictionary<string, string>? tags = null)
+    /// <summary>Builds a descriptor for a text secret. Pass <see cref="SecretMetadata.Empty"/> when no metadata is available.</summary>
+    public static SecretDescriptor FromString(string name, string value, SecretMetadata? metadata = null)
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
         ArgumentNullException.ThrowIfNull(value);
 
+        metadata ??= SecretMetadata.Empty;
         return new SecretDescriptor
         {
             Name = name,
             StringValue = value,
-            Version = version,
-            ContentType = contentType,
-            CreatedAt = createdAt,
-            ExpiresOn = expiresOn,
-            NotBefore = notBefore,
-            Tags = tags,
+            Version = metadata.Version,
+            ContentType = metadata.ContentType,
+            CreatedAt = metadata.CreatedAt,
+            ExpiresOn = metadata.ExpiresOn,
+            NotBefore = metadata.NotBefore,
+            Tags = metadata.Tags,
         };
     }
 
-    /// <summary>Builds a descriptor for a binary secret.</summary>
-    public static SecretDescriptor FromBinary(
-        string name,
-        ReadOnlyMemory<byte> value,
-        string? version = null,
-        string? contentType = null,
-        DateTimeOffset? createdAt = null,
-        DateTimeOffset? expiresOn = null,
-        DateTimeOffset? notBefore = null,
-        IReadOnlyDictionary<string, string>? tags = null)
+    /// <summary>Builds a descriptor for a binary secret. Pass <see cref="SecretMetadata.Empty"/> when no metadata is available.</summary>
+    public static SecretDescriptor FromBinary(string name, ReadOnlyMemory<byte> value, SecretMetadata? metadata = null)
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
 
+        metadata ??= SecretMetadata.Empty;
         return new SecretDescriptor
         {
             Name = name,
             BinaryValue = value,
-            Version = version,
-            ContentType = contentType,
-            CreatedAt = createdAt,
-            ExpiresOn = expiresOn,
-            NotBefore = notBefore,
-            Tags = tags,
+            Version = metadata.Version,
+            ContentType = metadata.ContentType,
+            CreatedAt = metadata.CreatedAt,
+            ExpiresOn = metadata.ExpiresOn,
+            NotBefore = metadata.NotBefore,
+            Tags = metadata.Tags,
         };
     }
 

--- a/src/Granit.Vault/SecretMetadata.cs
+++ b/src/Granit.Vault/SecretMetadata.cs
@@ -1,0 +1,26 @@
+namespace Granit.Vault;
+
+/// <summary>
+/// Provider-exposed metadata attached to a secret. All fields are nullable because
+/// not every provider surfaces every piece of information.
+/// </summary>
+/// <param name="Version">Provider-specific version identifier (integer for HashiCorp KV v2,
+/// UUID for Azure, GUID for AWS, numeric / "latest" for GCP).</param>
+/// <param name="ContentType">Media type hint — <c>"application/octet-stream"</c> signals
+/// a binary payload, any other value is informational. Primarily set by Azure Key Vault.</param>
+/// <param name="CreatedAt">Creation timestamp. HashiCorp, Azure, AWS expose it; GCP does not.</param>
+/// <param name="ExpiresOn">Expiration timestamp. Azure Key Vault exposes this natively —
+/// consumers can use it to schedule proactive rotations (e.g. mTLS certificate reload).</param>
+/// <param name="NotBefore">"Not before" timestamp. Azure Key Vault only.</param>
+/// <param name="Tags">Provider-exposed key/value labels. Azure and AWS support user-defined tags.</param>
+public sealed record SecretMetadata(
+    string? Version = null,
+    string? ContentType = null,
+    DateTimeOffset? CreatedAt = null,
+    DateTimeOffset? ExpiresOn = null,
+    DateTimeOffset? NotBefore = null,
+    IReadOnlyDictionary<string, string>? Tags = null)
+{
+    /// <summary>Empty metadata — all fields null. Convenience constant for providers that expose nothing.</summary>
+    public static SecretMetadata Empty { get; } = new();
+}

--- a/src/Granit.Vault/packages.lock.json
+++ b/src/Granit.Vault/packages.lock.json
@@ -14,6 +14,18 @@
         "resolved": "10.0.6",
         "contentHash": "w+dX4SIr1X9yegX2yX2dU1XtP4JAUVNdvOG/Evn+H+ndn96YzfIPX52FALXChrRNWFR9l77FQyg1mB7WQo6iOA=="
       },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.6",
+        "contentHash": "G6AVN2vs66Gu8IkB2FwsVJRpIkkTmPJ+NmAUH7+N+VGGI6qK38OXMZLipjCaOYdj2DW6ge2IIXdwZjhNJefD0w==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Options": "10.0.6"
+        }
+      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "10.0.6",
@@ -27,6 +39,28 @@
         "type": "Transitive",
         "resolved": "10.0.6",
         "contentHash": "a7bA7IT3ngIgcOMb/2MVH5CcfSxUCeQ6QXWS1Vt6oFpzLTH3U1+J2Xtc64Uw3whX9akYG8eR/UQeEzxo64zZLg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.6"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "L98Xe5C+xyKytLNLiEyQ0rcY8GNXAeAn1xKsE0YDxPx/mXBYYtRoj8pC2cnbSFQUlOzBkyO90ivMSV22SRETFg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Options": "10.0.6"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "ChhUF6HVSz9DwBgTyHtWbGzH8kWMbEFS7gqrqBnZQhHJFFK7L1k5BX7UCiIHiCap5HEDS6bZYks79JK4c+H0GQ=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "iU/lPyrjHVA4jJ7Bl/VpXvgsAD4qJWc4oPSVJjMBeZjmv7IIo8wBKxnOUoXdZcSCUJ6MeBMs3WpXNfncO7OzRg==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "10.0.6"
         }
@@ -102,6 +136,19 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration": "10.0.6",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.6"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.6",
+        "contentHash": "x3C8tgsX+xWvV5u76LFm24/U7sSnCRjuudBkbFsMV/DIqCA85te7YGg6dpa7lBToDhi4Lry9E7Arpy0laUw5AQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.6",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.6"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {

--- a/tests/Granit.ArchitectureTests/VaultConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/VaultConventionTests.cs
@@ -3,7 +3,12 @@ using ArchUnitNET.Domain;
 using ArchUnitNET.Fluent;
 using ArchUnitNET.xUnit;
 using Granit.Vault;
+using Granit.Vault.Aws;
+using Granit.Vault.Azure;
 using Granit.Vault.Exceptions;
+using Granit.Vault.GoogleCloud;
+using Granit.Vault.HashiCorp;
+using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using Xunit;
 using static ArchUnitNET.Fluent.ArchRuleDefinition;
@@ -17,6 +22,17 @@ namespace Granit.ArchitectureTests;
 public sealed class VaultConventionTests
 {
     private static readonly ArchUnitNET.Domain.Architecture Architecture = GranitArchitecture.Instance;
+
+    // Force-load every provider assembly so reflection-based scans below (and the
+    // AppDomain.CurrentDomain.GetAssemblies() call in the TryGetSecretAsync check)
+    // find the concrete store types without depending on xUnit test ordering.
+    private static readonly System.Reflection.Assembly[] ProviderAssemblies =
+    [
+        typeof(GranitVaultHashiCorpModule).Assembly,
+        typeof(GranitVaultAzureModule).Assembly,
+        typeof(GranitVaultAwsModule).Assembly,
+        typeof(GranitVaultGoogleCloudModule).Assembly,
+    ];
 
     private static readonly IObjectProvider<Class> ConcreteSecretStores =
         Classes().That().ImplementInterface(typeof(ISecretStore))
@@ -91,10 +107,9 @@ public sealed class VaultConventionTests
         // Default interface method on ISecretStore centralises the anti-footgun contract:
         // only SecretNotFoundException → null; every other failure bubbles. Providers must
         // NOT reimplement it, or they risk swallowing 403/503 under the guise of "missing".
-        Type[] concrete = typeof(ISecretStore).Assembly.GetTypes()
-            .Concat(AppDomain.CurrentDomain.GetAssemblies()
-                .Where(a => a.GetName().Name!.StartsWith("Granit.Vault.", StringComparison.Ordinal))
-                .SelectMany(a => a.GetTypes()))
+        Type[] concrete = ProviderAssemblies
+            .Append(typeof(ISecretStore).Assembly)
+            .SelectMany(a => a.GetTypes())
             .Distinct()
             .Where(t => t.IsClass && !t.IsAbstract && typeof(ISecretStore).IsAssignableFrom(t))
             .ToArray();
@@ -135,6 +150,33 @@ public sealed class VaultConventionTests
         rendered.ShouldNotContain("super-sensitive-token-value",
             Case.Sensitive,
             "SecretDescriptor.ToString() must redact the payload to protect against logger sinks that ignore [SensitiveData]");
+    }
+
+    [Fact]
+    public void Every_vault_provider_module_should_register_an_ISecretStore()
+    {
+        // Scans each Granit.Vault.{Provider} assembly for a public `AddGranitVault{Provider}`
+        // extension method on IServiceCollection, invokes it, and asserts that an
+        // `ISecretStore` binding exists afterwards. This is the structural guarantee that
+        // the provider wired up the shared `AddGranitSecretStore<T>` helper.
+        foreach (System.Reflection.Assembly providerAssembly in ProviderAssemblies)
+        {
+            MethodInfo? addMethod = providerAssembly.GetTypes()
+                .Where(t => t.IsAbstract && t.IsSealed && t.IsPublic && t.Name.EndsWith("ServiceCollectionExtensions", StringComparison.Ordinal))
+                .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static))
+                .FirstOrDefault(m => m.Name.StartsWith("AddGranitVault", StringComparison.Ordinal)
+                    && m.GetParameters() is { Length: 1 } p
+                    && p[0].ParameterType == typeof(IServiceCollection));
+
+            addMethod.ShouldNotBeNull(
+                $"{providerAssembly.GetName().Name} must expose an AddGranitVault* extension on IServiceCollection");
+
+            ServiceCollection services = [];
+            addMethod!.Invoke(obj: null, parameters: [services]);
+
+            services.Any(d => d.ServiceType == typeof(ISecretStore)).ShouldBeTrue(
+                $"{providerAssembly.GetName().Name}.{addMethod.Name} must register an ISecretStore implementation");
+        }
     }
 
     [Fact]

--- a/tests/Granit.Vault.Aws.Tests/AwsSecretStoreTests.cs
+++ b/tests/Granit.Vault.Aws.Tests/AwsSecretStoreTests.cs
@@ -45,7 +45,8 @@ public sealed class AwsSecretStoreTests
         descriptor.IsBinary.ShouldBeFalse();
         descriptor.Version.ShouldBe("11111111-2222-3333-4444-555555555555");
         descriptor.CreatedAt.ShouldNotBeNull();
-        descriptor.CreatedAt.Value.Year.ShouldBe(2026);
+        DateTimeOffset createdAt = descriptor.CreatedAt!.Value;
+        createdAt.Year.ShouldBe(2026);
     }
 
     [Fact]

--- a/tests/Granit.Vault.Aws.Tests/packages.lock.json
+++ b/tests/Granit.Vault.Aws.Tests/packages.lock.json
@@ -384,7 +384,8 @@
         "dependencies": {
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Encryption": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.*, )"
         }
       },
       "granit.vault.aws": {

--- a/tests/Granit.Vault.Azure.Tests/packages.lock.json
+++ b/tests/Granit.Vault.Azure.Tests/packages.lock.json
@@ -382,7 +382,8 @@
         "dependencies": {
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Encryption": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.*, )"
         }
       },
       "granit.vault.azure": {

--- a/tests/Granit.Vault.GoogleCloud.Tests/GoogleCloudSecretStoreTests.cs
+++ b/tests/Granit.Vault.GoogleCloud.Tests/GoogleCloudSecretStoreTests.cs
@@ -40,7 +40,10 @@ public sealed class GoogleCloudSecretStoreTests
     [Fact]
     public async Task GetSecretAsync_WithShortName_BuildsLatestVersionName()
     {
-        byte[] payload = [0x10, 0x20, 0x30];
+        // Invalid UTF-8 prefix (0xFF 0xFE is not a valid UTF-8 start sequence) forces
+        // the binary facet — proves the short-name/latest path works independently of
+        // the UTF-8 heuristic.
+        byte[] payload = [0xFF, 0xFE, 0xFD];
         _client.AccessSecretVersionAsync(
                 Arg.Is<SecretVersionName>(v => v.ProjectId == TestProject
                     && v.SecretId == "api-key"
@@ -58,6 +61,23 @@ public sealed class GoogleCloudSecretStoreTests
         descriptor.IsBinary.ShouldBeTrue();
         descriptor.BinaryValue!.Value.ToArray().ShouldBe(payload);
         descriptor.Version.ShouldBe("42");
+    }
+
+    [Fact]
+    public async Task GetSecretAsync_WithUtf8Payload_ReturnsStringFacet()
+    {
+        _client.AccessSecretVersionAsync(Arg.Any<SecretVersionName>(), Arg.Any<CancellationToken>())
+            .Returns(new AccessSecretVersionResponse
+            {
+                Name = $"projects/{TestProject}/secrets/api-key/versions/1",
+                Payload = new SecretPayload { Data = ByteString.CopyFromUtf8("super-token") },
+            });
+
+        SecretDescriptor descriptor = await _sut.GetSecretAsync(
+            SecretRequest.Latest("api-key"), TestContext.Current.CancellationToken);
+
+        descriptor.StringValue.ShouldBe("super-token");
+        descriptor.IsBinary.ShouldBeFalse();
     }
 
     [Fact]
@@ -94,7 +114,8 @@ public sealed class GoogleCloudSecretStoreTests
         SecretDescriptor descriptor = await _sut.GetSecretAsync(
             SecretRequest.Latest(resource), TestContext.Current.CancellationToken);
 
-        descriptor.BinaryValue.ShouldNotBeNull();
+        // "ok" is valid UTF-8 → store prefers StringValue facet (heuristic).
+        descriptor.StringValue.ShouldBe("ok");
     }
 
     [Fact]

--- a/tests/Granit.Vault.GoogleCloud.Tests/packages.lock.json
+++ b/tests/Granit.Vault.GoogleCloud.Tests/packages.lock.json
@@ -496,7 +496,8 @@
         "dependencies": {
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Encryption": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.*, )"
         }
       },
       "granit.vault.googlecloud": {

--- a/tests/Granit.Vault.HashiCorp.Tests/HashiCorpSecretStoreTests.cs
+++ b/tests/Granit.Vault.HashiCorp.Tests/HashiCorpSecretStoreTests.cs
@@ -71,7 +71,8 @@ public sealed class HashiCorpSecretStoreTests
         descriptor.IsBinary.ShouldBeFalse();
         descriptor.Version.ShouldBe("3");
         descriptor.CreatedAt.ShouldNotBeNull();
-        descriptor.CreatedAt.Value.Year.ShouldBe(2026);
+        DateTimeOffset createdAt = descriptor.CreatedAt!.Value;
+        createdAt.Year.ShouldBe(2026);
     }
 
     [Fact]
@@ -211,7 +212,7 @@ public sealed class HashiCorpSecretStoreTests
             .Returns(async _ =>
             {
                 await Task.Delay(TimeSpan.FromSeconds(10), cts.Token);
-                return CreateSecret(new Dictionary<string, object>(), version: 1);
+                return CreateSecret([], version: 1);
             });
 
         await Should.ThrowAsync<OperationCanceledException>(async () =>

--- a/tests/Granit.Vault.HashiCorp.Tests/packages.lock.json
+++ b/tests/Granit.Vault.HashiCorp.Tests/packages.lock.json
@@ -331,7 +331,8 @@
         "dependencies": {
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Encryption": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.*, )"
         }
       },
       "granit.vault.hashicorp": {

--- a/tests/Granit.Vault.Tests/HealthChecks/SecretStoreHealthCheckTests.cs
+++ b/tests/Granit.Vault.Tests/HealthChecks/SecretStoreHealthCheckTests.cs
@@ -1,0 +1,111 @@
+using Granit.Vault;
+using Granit.Vault.Exceptions;
+using Granit.Vault.HealthChecks;
+using Granit.Vault.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Vault.Tests.HealthChecks;
+
+public sealed class SecretStoreHealthCheckTests
+{
+    private readonly ISecretStore _store = Substitute.For<ISecretStore>();
+
+    [Fact]
+    public async Task CheckHealthAsync_WhenCanaryNotConfigured_ReportsHealthy()
+    {
+        SecretStoreHealthCheck sut = Build(canary: null);
+
+        HealthCheckResult result = await sut.CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+        result.Description!.ShouldContain("not configured");
+        await _store.DidNotReceive().GetSecretAsync(Arg.Any<SecretRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_WhenCanaryRetrieved_ReportsHealthy()
+    {
+        _store.GetSecretAsync(Arg.Any<SecretRequest>(), Arg.Any<CancellationToken>())
+            .Returns(SecretDescriptor.FromString("healthcheck/probe", "alive"));
+
+        SecretStoreHealthCheck sut = Build(canary: "healthcheck/probe");
+
+        HealthCheckResult result = await sut.CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_WhenCanaryNotFound_ReportsUnhealthy()
+    {
+        _store.GetSecretAsync(Arg.Any<SecretRequest>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new SecretNotFoundException("healthcheck/probe"));
+
+        SecretStoreHealthCheck sut = Build(canary: "healthcheck/probe");
+
+        HealthCheckResult result = await sut.CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Description!.ShouldContain("not found");
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_WhenAccessDenied_ReportsUnhealthy()
+    {
+        _store.GetSecretAsync(Arg.Any<SecretRequest>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new SecretAccessDeniedException("healthcheck/probe"));
+
+        SecretStoreHealthCheck sut = Build(canary: "healthcheck/probe");
+
+        HealthCheckResult result = await sut.CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Description!.ShouldContain("access denied", Case.Insensitive);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_WhenTransient_ReportsDegraded()
+    {
+        _store.GetSecretAsync(Arg.Any<SecretRequest>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new SecretVaultTransientException("healthcheck/probe", "503"));
+
+        SecretStoreHealthCheck sut = Build(canary: "healthcheck/probe");
+
+        HealthCheckResult result = await sut.CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Degraded);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_WhenConfigError_ReportsUnhealthyWithException()
+    {
+        var cause = new SecretVaultConfigurationException("Vault:Test", "bad config");
+        _store.GetSecretAsync(Arg.Any<SecretRequest>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(cause);
+
+        SecretStoreHealthCheck sut = Build(canary: "healthcheck/probe");
+
+        HealthCheckResult result = await sut.CheckHealthAsync(
+            new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Exception.ShouldBe(cause);
+    }
+
+    private SecretStoreHealthCheck Build(string? canary)
+    {
+        IOptions<SecretStoreOptions> options = Microsoft.Extensions.Options.Options.Create(
+            new SecretStoreOptions { HealthCheckSecretName = canary });
+        return new SecretStoreHealthCheck(_store, options);
+    }
+}

--- a/tests/Granit.Vault.Tests/packages.lock.json
+++ b/tests/Granit.Vault.Tests/packages.lock.json
@@ -152,6 +152,28 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
         }
       },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "L98Xe5C+xyKytLNLiEyQ0rcY8GNXAeAn1xKsE0YDxPx/mXBYYtRoj8pC2cnbSFQUlOzBkyO90ivMSV22SRETFg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Options": "10.0.6"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "ChhUF6HVSz9DwBgTyHtWbGzH8kWMbEFS7gqrqBnZQhHJFFK7L1k5BX7UCiIHiCap5HEDS6bZYks79JK4c+H0GQ=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.6",
+        "contentHash": "iU/lPyrjHVA4jJ7Bl/VpXvgsAD4qJWc4oPSVJjMBeZjmv7IIo8wBKxnOUoXdZcSCUJ6MeBMs3WpXNfncO7OzRg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.6"
+        }
+      },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
         "resolved": "10.0.6",
@@ -363,7 +385,8 @@
         "dependencies": {
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Encryption": "[0.1.0-dev, )",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.*, )"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {
@@ -403,6 +426,31 @@
         "requested": "[10.*, )",
         "resolved": "10.0.6",
         "contentHash": "w+dX4SIr1X9yegX2yX2dU1XtP4JAUVNdvOG/Evn+H+ndn96YzfIPX52FALXChrRNWFR9l77FQyg1mB7WQo6iOA=="
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.6",
+        "contentHash": "G6AVN2vs66Gu8IkB2FwsVJRpIkkTmPJ+NmAUH7+N+VGGI6qK38OXMZLipjCaOYdj2DW6ge2IIXdwZjhNJefD0w==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Options": "10.0.6"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.6",
+        "contentHash": "x3C8tgsX+xWvV5u76LFm24/U7sSnCRjuudBkbFsMV/DIqCA85te7YGg6dpa7lBToDhi4Lry9E7Arpy0laUw5AQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.6",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.6"
+        }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Summary

Follow-up to PR #1024 — addresses the framework audit, SonarQube, and Copilot review findings on the `ISecretStore` introduction. Pure cleanup: no breaking changes, no API surface change for consumers.

### Audit fixes

- **CLEANUP-1** — Shared `SecretStoreDiagnostics` helper (ResolveTenantId + outcome mapping) consumed by both `CachedSecretStore` and `ProviderTaggingSecretStore`. Removes the duplicated catch-ladder.
- **CLEANUP-2** — `AddGranitSecretStore<T>` guards against a second `SecretStoreOptions` BindConfiguration when the module already registered it.
- **IMP-3 (GCP)** — UTF-8 heuristic: when the Secret Manager payload is valid UTF-8 and no binary content type is hinted, surface it as `StringValue` instead of `BinaryValue`. Binary consumers keep using `AsBytes()`.
- **IMP-4** — New `SecretStoreActivityTags.Outcome` constant (`"secret.outcome"`) used by all 4 provider spans — values match the `outcome` dimension of the `granit.vault.secret.read` counter (`ok | not_found | denied | transient | error`).
- **IMP-5** — Provider-agnostic `SecretStoreHealthCheck` that reads an optional canary (`Vault:SecretStore:HealthCheckSecretName`) through `ISecretStore`. Maps outcomes to `Healthy / Unhealthy / Degraded`; no-op when the canary is not configured. Wired via `AddGranitSecretStoreHealthCheck()` on `IHealthChecksBuilder` (readiness + startup tags, 10 s timeout). **One shared class for all 4 providers** instead of 4 parallel ones.
- **IMP-6** — AWS: kept the defensive `MemoryStream` rewind, dropped the redundant `CanSeek` check.
- **IMP-7** — `VaultConventionTests` now force-loads the 4 provider assemblies via `typeof(GranitVault*Module).Assembly` — removes the implicit reliance on xUnit test ordering to populate `AppDomain.CurrentDomain.GetAssemblies()`.
- **IMP-8** — New arch test `Every_vault_provider_module_should_register_an_ISecretStore` invokes each provider's `AddGranitVault*` extension and asserts an `ISecretStore` binding is produced — catches accidental DI regressions.

### Sonar / Copilot

- **brain-overload** on `SecretDescriptor.FromString` / `FromBinary` (8 params > 7): new `SecretMetadata` record wrapping Version / ContentType / CreatedAt / ExpiresOn / NotBefore / Tags. Factories drop to 3 params. The 4 provider stores build a `SecretMetadata` once and pass it through. `SecretDescriptor` flat properties are unchanged — public ergonomics preserved.
- **nullable dereference** on `descriptor.CreatedAt.Value.Year` (AWS + HashiCorp tests): extract into a non-null local via `DateTimeOffset createdAt = descriptor.CreatedAt!.Value;`.
- **Collection initialization** at `HashiCorpSecretStoreTests:L215`: `new Dictionary<string, object>()` → `[]` (collection expression).

## Test plan

- [x] 368 vault tests passing (was 361):
  - `Granit.Vault.Tests`: 36 (was 30 — +6 health check)
  - `Granit.Vault.HashiCorp.Tests`: 85
  - `Granit.Vault.Azure.Tests`: 83
  - `Granit.Vault.Aws.Tests`: 80
  - `Granit.Vault.GoogleCloud.Tests`: 84 (was 83 — +1 UTF-8 facet)
- [x] 9 architecture tests passing (was 8 — +1 DI assertion).
- [x] `dotnet format --verify-no-changes` clean on all touched projects.
- [x] `dotnet build` clean — 0 warnings, 0 errors.
- [ ] CI pipeline green on `security` and `architecture` shards.
- [ ] Manual: spin up a host with `AddGranitVault{Provider}()` + `AddHealthChecks().AddGranitSecretStoreHealthCheck()`, verify canary-unset returns Healthy and canary-misconfigured returns Unhealthy.

## Follow-ups still deferred

- Doc-only PR to split `vault-encryption.mdx` (~680 lines) into a `vault/` folder with 5 dedicated pages (overview, encryption, secrets, credentials, providers). Discussed on #1024.
