### PR TITLE
fix(vault,encryption): harden crypto and credential handling

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -42223,6 +42223,12 @@
           "kind": "property",
           "signature": "int CacheSeconds",
           "returnType": "int"
+        },
+        {
+          "name": "MaxBinaryPayloadBytes",
+          "kind": "property",
+          "signature": "int MaxBinaryPayloadBytes",
+          "returnType": "int"
         }
       ]
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ et ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Security
+
+- `Granit.Vault.{HashiCorp,Azure,Aws,GoogleCloud}` — dynamic database credentials (`IDatabaseCredentialProvider.Username` / `Password`) are now stored in `byte[]` buffers and zeroized via `CryptographicOperations.ZeroMemory` on every rotation, mitigating credential residency in process memory (CWE-522 / GDPR Art. 32). Shared helper: `Granit.Vault.Internal.ZeroizingCredentialStore`.
+- `Granit.Vault.HashiCorp` — `HashiCorpSecretStore` now gates the decoded size of KV v2 `__binary` payloads before allocation, protecting the host from OOM triggered by a misconfigured or compromised vault (CWE-400 / CWE-770). New option `Vault:SecretStore:MaxBinaryPayloadBytes` (default 16 MiB).
+- `Granit.Encryption` — `AesStringEncryptionProvider` raises PBKDF2-SHA256 iterations from 100 000 to 600 000 to align with OWASP 2023. **Breaking for existing encrypted data:** payloads encrypted with the previous iteration count can no longer be decrypted. No production deployments are affected at this pre-1.0 stage; re-encrypt any persisted ciphertext before upgrading.
+
 ### Added
 
 - Initialisation du repository granit-dotnet

--- a/src/Granit.Encryption/Providers/AesStringEncryptionProvider.cs
+++ b/src/Granit.Encryption/Providers/AesStringEncryptionProvider.cs
@@ -33,7 +33,11 @@ public sealed partial class AesStringEncryptionProvider : IStringEncryptionProvi
         0x74, 0x69, 0x6F, 0x6E, 0x45, 0x6E, 0x63, 0x72
     ];
 
-    private const int KeyDerivationIterations = 100_000;
+    // PBKDF2-SHA256 iteration count — OWASP 2023 recommends ≥ 600_000 for SHA-256
+    // (https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html).
+    // Changing this value invalidates all previously encrypted data — only raise when you
+    // are willing to re-encrypt existing payloads.
+    private const int KeyDerivationIterations = 600_000;
     private const int IvSize = 16;
     private const int HmacSize = 32; // HMAC-SHA256
 

--- a/src/Granit.Vault.Aws/Services/AwsSecretsCredentialProvider.cs
+++ b/src/Granit.Vault.Aws/Services/AwsSecretsCredentialProvider.cs
@@ -4,6 +4,7 @@ using Amazon.SecretsManager.Model;
 using Granit.Diagnostics;
 using Granit.Vault.Aws.Diagnostics;
 using Granit.Vault.Aws.Options;
+using Granit.Vault.Internal;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -20,19 +21,18 @@ internal sealed partial class AwsSecretsCredentialProvider(
     ILogger<AwsSecretsCredentialProvider> logger) : BackgroundService, IDatabaseCredentialProvider
 {
     private readonly AwsVaultOptions _options = options.Value;
+    private readonly ZeroizingCredentialStore _store = new();
 
-    private volatile string _username = string.Empty;
-    private volatile string _password = string.Empty;
     private volatile string _versionId = string.Empty;
 
     /// <inheritdoc />
-    public string Username => _username;
+    public string Username => _store.Username;
 
     /// <inheritdoc />
-    public string Password => _password;
+    public string Password => _store.Password;
 
     /// <inheritdoc />
-    public bool IsReady => !string.IsNullOrEmpty(_username);
+    public bool IsReady => _store.IsReady;
 
     /// <inheritdoc />
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -111,11 +111,13 @@ internal sealed partial class AwsSecretsCredentialProvider(
         using var doc = JsonDocument.Parse(response.SecretString);
         JsonElement root = doc.RootElement;
 
-        _username = root.GetProperty("username").GetString() ?? string.Empty;
-        _password = root.GetProperty("password").GetString() ?? string.Empty;
+        string username = root.GetProperty("username").GetString() ?? string.Empty;
+        string password = root.GetProperty("password").GetString() ?? string.Empty;
+
+        _store.Apply(username, password);
         _versionId = response.VersionId;
 
-        LogCredentialsObtained(LogRedaction.Username(_username), _versionId);
+        LogCredentialsObtained(LogRedaction.Username(username), _versionId);
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Starting AWS Secrets Manager credential manager")]

--- a/src/Granit.Vault.Azure/Services/AzureSecretsCredentialProvider.cs
+++ b/src/Granit.Vault.Azure/Services/AzureSecretsCredentialProvider.cs
@@ -3,6 +3,7 @@ using Azure.Security.KeyVault.Secrets;
 using Granit.Diagnostics;
 using Granit.Vault.Azure.Diagnostics;
 using Granit.Vault.Azure.Options;
+using Granit.Vault.Internal;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -19,19 +20,18 @@ internal sealed partial class AzureSecretsCredentialProvider(
     ILogger<AzureSecretsCredentialProvider> logger) : BackgroundService, IDatabaseCredentialProvider
 {
     private readonly AzureKeyVaultOptions _options = options.Value;
+    private readonly ZeroizingCredentialStore _store = new();
 
-    private volatile string _username = string.Empty;
-    private volatile string _password = string.Empty;
     private volatile string _version = string.Empty;
 
     /// <inheritdoc />
-    public string Username => _username;
+    public string Username => _store.Username;
 
     /// <inheritdoc />
-    public string Password => _password;
+    public string Password => _store.Password;
 
     /// <inheritdoc />
-    public bool IsReady => !string.IsNullOrEmpty(_username);
+    public bool IsReady => _store.IsReady;
 
     /// <inheritdoc />
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -105,11 +105,13 @@ internal sealed partial class AzureSecretsCredentialProvider(
         using var doc = JsonDocument.Parse(secret.Value);
         JsonElement root = doc.RootElement;
 
-        _username = root.GetProperty("username").GetString() ?? string.Empty;
-        _password = root.GetProperty("password").GetString() ?? string.Empty;
+        string username = root.GetProperty("username").GetString() ?? string.Empty;
+        string password = root.GetProperty("password").GetString() ?? string.Empty;
+
+        _store.Apply(username, password);
         _version = secret.Properties.Version ?? string.Empty;
 
-        LogCredentialsObtained(LogRedaction.Username(_username), _version);
+        LogCredentialsObtained(LogRedaction.Username(username), _version);
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Starting Azure Key Vault Secrets credential manager")]

--- a/src/Granit.Vault.GoogleCloud/Services/SecretManagerCredentialProvider.cs
+++ b/src/Granit.Vault.GoogleCloud/Services/SecretManagerCredentialProvider.cs
@@ -3,6 +3,7 @@ using Google.Cloud.SecretManager.V1;
 using Granit.Diagnostics;
 using Granit.Vault.GoogleCloud.Diagnostics;
 using Granit.Vault.GoogleCloud.Options;
+using Granit.Vault.Internal;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -19,19 +20,18 @@ internal sealed partial class SecretManagerCredentialProvider(
     ILogger<SecretManagerCredentialProvider> logger) : BackgroundService, IDatabaseCredentialProvider
 {
     private readonly GoogleCloudVaultOptions _options = options.Value;
+    private readonly ZeroizingCredentialStore _store = new();
 
-    private volatile string _username = string.Empty;
-    private volatile string _password = string.Empty;
     private volatile string _versionName = string.Empty;
 
     /// <inheritdoc />
-    public string Username => _username;
+    public string Username => _store.Username;
 
     /// <inheritdoc />
-    public string Password => _password;
+    public string Password => _store.Password;
 
     /// <inheritdoc />
-    public bool IsReady => !string.IsNullOrEmpty(_username);
+    public bool IsReady => _store.IsReady;
 
     /// <inheritdoc />
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -109,11 +109,13 @@ internal sealed partial class SecretManagerCredentialProvider(
         using var doc = JsonDocument.Parse(secretPayload);
         JsonElement root = doc.RootElement;
 
-        _username = root.GetProperty("username").GetString() ?? string.Empty;
-        _password = root.GetProperty("password").GetString() ?? string.Empty;
+        string username = root.GetProperty("username").GetString() ?? string.Empty;
+        string password = root.GetProperty("password").GetString() ?? string.Empty;
+
+        _store.Apply(username, password);
         _versionName = response.Name;
 
-        LogCredentialsObtained(LogRedaction.Username(_username), _versionName);
+        LogCredentialsObtained(LogRedaction.Username(username), _versionName);
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Starting Secret Manager credential manager")]

--- a/src/Granit.Vault.HashiCorp/Services/HashiCorpSecretStore.cs
+++ b/src/Granit.Vault.HashiCorp/Services/HashiCorpSecretStore.cs
@@ -5,6 +5,7 @@ using Granit.Vault.Diagnostics;
 using Granit.Vault.Exceptions;
 using Granit.Vault.HashiCorp.Diagnostics;
 using Granit.Vault.HashiCorp.Options;
+using Granit.Vault.Options;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using VaultSharp;
@@ -36,12 +37,14 @@ namespace Granit.Vault.HashiCorp.Services;
 internal sealed partial class HashiCorpSecretStore(
     IVaultClient vaultClient,
     IOptions<HashiCorpVaultOptions> options,
+    IOptions<SecretStoreOptions> secretStoreOptions,
     ILogger<HashiCorpSecretStore> logger) : ISecretStore
 {
     private const string BinaryKey = "__binary";
     private const string ValueKey = "value";
 
     private readonly string _mountPoint = options.Value.KvMountPoint;
+    private readonly int _maxBinaryPayloadBytes = secretStoreOptions.Value.MaxBinaryPayloadBytes;
 
     /// <inheritdoc />
     public async Task<SecretDescriptor> GetSecretAsync(
@@ -96,6 +99,17 @@ internal sealed partial class HashiCorpSecretStore(
 
         if (data.TryGetValue(BinaryKey, out object? binaryRaw) && binaryRaw is string base64)
         {
+            // Gate the decoded size BEFORE allocating (CWE-400). Base64 decodes to ~3/4 of
+            // its input length; compute the upper bound from the string length alone.
+            long estimatedBytes = (long)base64.Length * 3 / 4;
+            if (estimatedBytes > _maxBinaryPayloadBytes)
+            {
+                throw new SecretVaultConfigurationException(
+                    "Vault:Secret:BinaryTooLarge",
+                    $"Secret '{request.Name}' binary payload ({estimatedBytes} bytes) exceeds " +
+                    $"SecretStoreOptions.MaxBinaryPayloadBytes ({_maxBinaryPayloadBytes}).");
+            }
+
             byte[] bytes = Convert.FromBase64String(base64);
             return SecretDescriptor.FromBinary(
                 request.Name,

--- a/src/Granit.Vault.HashiCorp/Services/VaultCredentialLeaseManager.cs
+++ b/src/Granit.Vault.HashiCorp/Services/VaultCredentialLeaseManager.cs
@@ -1,5 +1,6 @@
 using Granit.Diagnostics;
 using Granit.Vault.HashiCorp.Options;
+using Granit.Vault.Internal;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -20,15 +21,14 @@ internal sealed partial class VaultCredentialLeaseManager(
     ILogger<VaultCredentialLeaseManager> logger) : BackgroundService, IDatabaseCredentialProvider
 {
     private readonly HashiCorpVaultOptions _options = options.Value;
+    private readonly ZeroizingCredentialStore _store = new();
 
-    private volatile string _username = string.Empty;
-    private volatile string _password = string.Empty;
     private volatile string _leaseId = string.Empty;
     private volatile int _leaseDurationSeconds;
 
-    public string Username => _username;
-    public string Password => _password;
-    public bool IsReady => !string.IsNullOrEmpty(_username);
+    public string Username => _store.Username;
+    public string Password => _store.Password;
+    public bool IsReady => _store.IsReady;
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -70,12 +70,11 @@ internal sealed partial class VaultCredentialLeaseManager(
             _options.DatabaseRoleName,
             mountPoint: _options.DatabaseMountPoint).WaitAsync(cancellationToken).ConfigureAwait(false);
 
-        _username = secret.Data.Username;
-        _password = secret.Data.Password;
+        _store.Apply(secret.Data.Username, secret.Data.Password);
         _leaseId = secret.LeaseId;
         _leaseDurationSeconds = secret.LeaseDurationSeconds;
 
-        LogCredentialsObtained(logger, LogRedaction.Username(_username), _leaseDurationSeconds);
+        LogCredentialsObtained(logger, LogRedaction.Username(secret.Data.Username), _leaseDurationSeconds);
     }
 
     private async Task RenewLeaseAsync(CancellationToken cancellationToken)

--- a/src/Granit.Vault/Granit.Vault.csproj
+++ b/src/Granit.Vault/Granit.Vault.csproj
@@ -13,6 +13,10 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.Vault.Tests" />
+    <InternalsVisibleTo Include="Granit.Vault.Aws" />
+    <InternalsVisibleTo Include="Granit.Vault.Azure" />
+    <InternalsVisibleTo Include="Granit.Vault.GoogleCloud" />
+    <InternalsVisibleTo Include="Granit.Vault.HashiCorp" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 

--- a/src/Granit.Vault/Internal/ZeroizingCredentialStore.cs
+++ b/src/Granit.Vault/Internal/ZeroizingCredentialStore.cs
@@ -1,0 +1,64 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Granit.Vault.Internal;
+
+/// <summary>
+/// Holds dynamic database credentials as <see cref="byte"/> arrays and zeroizes the
+/// previous buffers whenever new credentials are applied. Mitigates credential
+/// residency in process memory after rotation (CWE-522 / GDPR Art. 32).
+/// </summary>
+/// <remarks>
+/// <para>
+/// .NET strings are immutable and cannot be securely erased. Keeping credentials in
+/// <c>byte[]</c> lets us wipe the previous generation via
+/// <see cref="CryptographicOperations.ZeroMemory(Span{byte})"/> the moment a rotation
+/// completes. Transient string copies produced by <see cref="Username"/> /
+/// <see cref="Password"/> reads are short-lived and scoped to the consumer.
+/// </para>
+/// <para>
+/// Thread-safety: readers use <see cref="Volatile.Read(ref byte[])"/>; writers swap
+/// via <see cref="Interlocked.Exchange{T}(ref T, T)"/> then zeroize the old buffer.
+/// Callers are expected to be single-writer (the credential background service).
+/// </para>
+/// </remarks>
+internal sealed class ZeroizingCredentialStore
+{
+    private byte[] _username = [];
+    private byte[] _password = [];
+
+    public string Username
+    {
+        get
+        {
+            byte[] bytes = Volatile.Read(ref _username);
+            return bytes.Length == 0 ? string.Empty : Encoding.UTF8.GetString(bytes);
+        }
+    }
+
+    public string Password
+    {
+        get
+        {
+            byte[] bytes = Volatile.Read(ref _password);
+            return bytes.Length == 0 ? string.Empty : Encoding.UTF8.GetString(bytes);
+        }
+    }
+
+    public bool IsReady => Volatile.Read(ref _username).Length > 0;
+
+    public void Apply(string username, string password)
+    {
+        ArgumentNullException.ThrowIfNull(username);
+        ArgumentNullException.ThrowIfNull(password);
+
+        byte[] newUsername = Encoding.UTF8.GetBytes(username);
+        byte[] newPassword = Encoding.UTF8.GetBytes(password);
+
+        byte[] oldUsername = Interlocked.Exchange(ref _username, newUsername);
+        byte[] oldPassword = Interlocked.Exchange(ref _password, newPassword);
+
+        CryptographicOperations.ZeroMemory(oldUsername);
+        CryptographicOperations.ZeroMemory(oldPassword);
+    }
+}

--- a/src/Granit.Vault/Options/SecretStoreOptions.cs
+++ b/src/Granit.Vault/Options/SecretStoreOptions.cs
@@ -29,6 +29,17 @@ public sealed class SecretStoreOptions
     public int MaxCachedBinarySizeBytes { get; set; } = 64 * 1024;
 
     /// <summary>
+    /// Hard upper bound on the decoded size (bytes) of a secret payload returned by a
+    /// provider. Payloads above this threshold are rejected with
+    /// <see cref="Exceptions.SecretVaultConfigurationException"/> before any allocation,
+    /// protecting the host from OOM triggered by a misconfigured or compromised vault
+    /// (CWE-400 / CWE-770). Default: 16 MiB — generous for PFX bundles and CA chains,
+    /// orders of magnitude below process memory limits.
+    /// </summary>
+    [Range(4096, 134_217_728)]
+    public int MaxBinaryPayloadBytes { get; set; } = 16 * 1024 * 1024;
+
+    /// <summary>
     /// Optional canary secret name used by <c>AddGranitSecretStoreHealthCheck()</c>.
     /// When <c>null</c> or empty, the health check is a no-op — use a dedicated non-critical,
     /// read-only secret (e.g. <c>healthcheck/probe</c>) specifically for liveness probing;

--- a/tests/Granit.Vault.HashiCorp.Tests/HashiCorpSecretStoreTests.cs
+++ b/tests/Granit.Vault.HashiCorp.Tests/HashiCorpSecretStoreTests.cs
@@ -45,9 +45,13 @@ public sealed class HashiCorpSecretStoreTests
             KvMountPoint = "secret",
         });
 
+        IOptions<Granit.Vault.Options.SecretStoreOptions> secretStoreOptions =
+            Microsoft.Extensions.Options.Options.Create(new Granit.Vault.Options.SecretStoreOptions());
+
         _concrete = new HashiCorpSecretStore(
             _vaultClient,
             options,
+            secretStoreOptions,
             NullLogger<HashiCorpSecretStore>.Instance);
         _sut = _concrete;
     }
@@ -93,6 +97,38 @@ public sealed class HashiCorpSecretStoreTests
         descriptor.BinaryValue!.Value.ToArray().ShouldBe(payload);
         descriptor.StringValue.ShouldBeNull();
         descriptor.ContentType.ShouldBe("application/octet-stream");
+    }
+
+    [Fact]
+    public async Task GetSecretAsync_WhenBinaryPayloadExceedsMaxBytes_ThrowsConfigurationException()
+    {
+        // Build a SecretStore with a tight 4 KiB ceiling (minimum allowed by options validation).
+        IOptions<HashiCorpVaultOptions> options = Microsoft.Extensions.Options.Options.Create(new HashiCorpVaultOptions
+        {
+            KvMountPoint = "secret",
+        });
+        IOptions<Granit.Vault.Options.SecretStoreOptions> tightOptions = Microsoft.Extensions.Options.Options.Create(
+            new Granit.Vault.Options.SecretStoreOptions { MaxBinaryPayloadBytes = 4096 });
+
+        var sut = new HashiCorpSecretStore(
+            _vaultClient,
+            options,
+            tightOptions,
+            NullLogger<HashiCorpSecretStore>.Instance);
+
+        // 8 KiB of random bytes → 10.7 KB base64 string, decodes to 8 KB > 4 KB cap.
+        byte[] oversized = new byte[8192];
+        Random.Shared.NextBytes(oversized);
+
+        _kvV2.ReadSecretAsync("huge/blob", null, "secret")
+            .Returns(Task.FromResult(CreateSecret(
+                data: new Dictionary<string, object> { ["__binary"] = Convert.ToBase64String(oversized) },
+                version: 1)));
+
+        SecretVaultConfigurationException ex = await Should.ThrowAsync<SecretVaultConfigurationException>(
+            () => sut.GetSecretAsync(SecretRequest.Latest("huge/blob"), TestContext.Current.CancellationToken));
+
+        ex.ErrorCode.ShouldBe("Vault:Secret:BinaryTooLarge");
     }
 
     [Fact]

--- a/tests/Granit.Vault.Tests/Internal/ZeroizingCredentialStoreTests.cs
+++ b/tests/Granit.Vault.Tests/Internal/ZeroizingCredentialStoreTests.cs
@@ -1,0 +1,81 @@
+using Granit.Vault.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Vault.Tests.Internal;
+
+public class ZeroizingCredentialStoreTests
+{
+    [Fact]
+    public void IsReady_IsFalseBeforeFirstApply()
+    {
+        var store = new ZeroizingCredentialStore();
+
+        store.IsReady.ShouldBeFalse();
+        store.Username.ShouldBe(string.Empty);
+        store.Password.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void Apply_ExposesCredentialsAndMarksReady()
+    {
+        var store = new ZeroizingCredentialStore();
+
+        store.Apply("alice", "s3cr3t");
+
+        store.IsReady.ShouldBeTrue();
+        store.Username.ShouldBe("alice");
+        store.Password.ShouldBe("s3cr3t");
+    }
+
+    [Fact]
+    public void Apply_OnRotation_ReturnsLatestCredentials()
+    {
+        var store = new ZeroizingCredentialStore();
+
+        store.Apply("v1-user", "v1-pass");
+        store.Apply("v2-user", "v2-pass");
+
+        store.Username.ShouldBe("v2-user");
+        store.Password.ShouldBe("v2-pass");
+    }
+
+    [Fact]
+    public void Apply_ThrowsWhenUsernameIsNull()
+    {
+        var store = new ZeroizingCredentialStore();
+
+        Should.Throw<ArgumentNullException>(() => store.Apply(null!, "p"));
+    }
+
+    [Fact]
+    public void Apply_ThrowsWhenPasswordIsNull()
+    {
+        var store = new ZeroizingCredentialStore();
+
+        Should.Throw<ArgumentNullException>(() => store.Apply("u", null!));
+    }
+
+    [Fact]
+    public void Apply_AcceptsEmptyStrings()
+    {
+        var store = new ZeroizingCredentialStore();
+
+        store.Apply(string.Empty, string.Empty);
+
+        store.IsReady.ShouldBeFalse();
+        store.Username.ShouldBe(string.Empty);
+        store.Password.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void Username_DecodesUtf8()
+    {
+        var store = new ZeroizingCredentialStore();
+
+        store.Apply("ÆgirOdin", "Pøss");
+
+        store.Username.ShouldBe("ÆgirOdin");
+        store.Password.ShouldBe("Pøss");
+    }
+}


### PR DESCRIPTION
## Summary

Addresses three findings from the `/security audit Granit.Vault.*` run (no CVE filed — pre-1.0 framework, internal audit):

- **VULN-201** (MEDIUM, CWE-522): dynamic DB credentials were kept in unzeroized `volatile string` fields, leaving every rotation generation on the managed heap until GC. Introduce `Granit.Vault.Internal.ZeroizingCredentialStore` — credentials live in `byte[]`, previous buffer is overwritten via `CryptographicOperations.ZeroMemory` on every rotation. All four providers (HashiCorp, Azure, AWS, GCP) now share it.
- **VULN-202** (LOW, CWE-400): `HashiCorpSecretStore` decoded KV v2 `__binary` via `Convert.FromBase64String` with no length gate — a malicious vault could trigger OOM. Add `Vault:SecretStore:MaxBinaryPayloadBytes` (default 16 MiB, range 4 KiB – 128 MiB). Oversized payloads are rejected with `SecretVaultConfigurationException("Vault:Secret:BinaryTooLarge")` before any allocation.
- **INFO-204**: `AesStringEncryptionProvider` PBKDF2-SHA256 iterations raised from 100 000 → 600 000 to match OWASP 2023. **Breaking for any existing ciphertext** — re-encrypt before upgrading (documented in CHANGELOG).

## Why

The security audit flagged credential residency after rotation as the highest residual risk for Granit.Vault (impacts GDPR Art. 32 "appropriate technical measures"). The base64 gate is defense-in-depth against a hostile/misconfigured vault. The PBKDF2 bump is a cheap one-line hardening that's trivial now and painful later.

## Test plan

- [x] `dotnet build` — all six touched projects green
- [x] `dotnet test tests/Granit.Vault.Tests` — 43 passed (incl. 7 new `ZeroizingCredentialStoreTests`)
- [x] `dotnet test tests/Granit.Vault.HashiCorp.Tests` — 86 passed (incl. new `GetSecretAsync_WhenBinaryPayloadExceedsMaxBytes_ThrowsConfigurationException`)
- [x] `dotnet test tests/Granit.Vault.{Azure,Aws,GoogleCloud}.Tests` — all green
- [x] `dotnet test tests/Granit.Encryption.Tests` — 118 passed
- [x] `dotnet test tests/Granit.ArchitectureTests --filter Vault` — 9 passed
- [x] `dotnet format --verify-no-changes` — clean on all touched projects

## Follow-ups

None blocking — the remaining residual risk from the audit (transient plaintext during `RewrapAsync` on non-HashiCorp providers) is inherent to managed .NET crypto APIs without a `ReadOnlyMemory<byte>` contract. Tracked as a strategic item in the audit report.