### PR TITLE
chore(deps): bump dompurify to >=3.4.0 (GHSA-39q2-94rc-95cp)

### DIFF
--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -38,6 +38,7 @@
       "sharp"
     ],
     "overrides": {
+      "dompurify": ">=3.4.0",
       "fast-xml-parser": ">=5.5.7",
       "lodash-es": ">=4.18.0",
       "picomatch": ">=4.0.4",

--- a/docs-site/pnpm-lock.yaml
+++ b/docs-site/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  dompurify: '>=3.4.0'
   fast-xml-parser: '>=5.5.7'
   lodash-es: '>=4.18.0'
   picomatch: '>=4.0.4'
@@ -1444,8 +1445,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -4201,7 +4202,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.3.3:
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -5047,7 +5048,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.3.3
+      dompurify: 3.4.0
       katex: 0.16.45
       khroma: 2.1.0
       lodash-es: 4.18.1


### PR DESCRIPTION
## Summary

Closes Dependabot alert #17 (moderate, [GHSA-39q2-94rc-95cp](https://github.com/advisories/GHSA-39q2-94rc-95cp)).

DOMPurify <= 3.3.3 has a bypass in `ADD_TAGS` that lets attacker-controlled markup evade `FORBID_TAGS` via JS short-circuit evaluation. We don't use DOMPurify directly — it arrives as a transitive dep of `mermaid@11.14.0` (diagram rendering in the docs site). Patched in 3.4.0.

Applied the same fix pattern already in place for four other transitive bumps: add an entry to `docs-site/package.json` `pnpm.overrides` forcing `>=3.4.0`, regenerate `pnpm-lock.yaml`.

## Test plan

- [x] `pnpm install` — lockfile resolves to `dompurify@3.4.0` in both places it appears
- [x] `npx astro build` — 391 pages built, all internal links valid, no errors
- [ ] Dependabot closes alert #17 automatically once this lands on `develop`