### PR TITLE
feat(payments): provider catalog + capability snapshot + runtime availability filter

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -29053,6 +29053,38 @@
       ]
     },
     {
+      "name": "PaymentProviderHealthCheck",
+      "fqn": "Granit.Payments.HealthChecks.PaymentProviderHealthCheck",
+      "kind": "class",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/HealthChecks/PaymentProviderHealthCheck.cs",
+      "line": 29,
+      "members": [
+        {
+          "name": "CheckHealthAsync",
+          "kind": "method",
+          "signature": "CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)",
+          "returnType": "Task<HealthCheckResult>"
+        }
+      ]
+    },
+    {
+      "name": "PaymentProviderHealthCheckBuilderExtensions",
+      "fqn": "Granit.Payments.HealthChecks.PaymentProviderHealthCheckBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/HealthChecks/PaymentProviderHealthCheckBuilderExtensions.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "AddGranitPaymentProviderHealthCheck",
+          "kind": "method",
+          "signature": "AddGranitPaymentProviderHealthCheck(this IHealthChecksBuilder builder, string providerName)",
+          "returnType": "IHealthChecksBuilder"
+        }
+      ]
+    },
+    {
       "name": "IAutoChargeService",
       "fqn": "Granit.Payments.IAutoChargeService",
       "kind": "interface",
@@ -29468,7 +29500,7 @@
       "kind": "class",
       "project": "Granit.Payments.Mollie",
       "file": "src/Granit.Payments.Mollie/GranitPaymentsMollieModule.cs",
-      "line": 13,
+      "line": 14,
       "members": [
         {
           "name": "ConfigureServices",
@@ -29701,7 +29733,7 @@
       "kind": "class",
       "project": "Granit.Payments.SepaDirectDebit.Builtin",
       "file": "src/Granit.Payments.SepaDirectDebit.Builtin/GranitPaymentsSepaDirectDebitBuiltinModule.cs",
-      "line": 11,
+      "line": 12,
       "members": [
         {
           "name": "ConfigureServices",
@@ -30136,7 +30168,7 @@
       "kind": "class",
       "project": "Granit.Payments.SepaTransfer",
       "file": "src/Granit.Payments.SepaTransfer/GranitPaymentsSepaTransferModule.cs",
-      "line": 13,
+      "line": 14,
       "members": [
         {
           "name": "ConfigureServices",
@@ -30224,7 +30256,7 @@
       "kind": "class",
       "project": "Granit.Payments.Stripe",
       "file": "src/Granit.Payments.Stripe/GranitPaymentsStripeModule.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "ConfigureServices",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -29479,22 +29479,6 @@
       ]
     },
     {
-      "name": "IPaymentMethodAvailabilityFilter",
-      "fqn": "Granit.Payments.Internal.IPaymentMethodAvailabilityFilter",
-      "kind": "interface",
-      "project": "Granit.Payments",
-      "file": "src/Granit.Payments/Internal/IPaymentMethodAvailabilityFilter.cs",
-      "line": 9,
-      "members": [
-        {
-          "name": "IsAvailable",
-          "kind": "method",
-          "signature": "IsAvailable(PaymentMethodCapability capability, PaymentAvailabilityContext context)",
-          "returnType": "bool"
-        }
-      ]
-    },
-    {
       "name": "GranitPaymentsMollieModule",
       "fqn": "Granit.Payments.Mollie.GranitPaymentsMollieModule",
       "kind": "class",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -28129,7 +28129,7 @@
       "kind": "record",
       "project": "Granit.Payments",
       "file": "src/Granit.Payments/Contracts/PaymentAvailableMethod.cs",
-      "line": 6,
+      "line": 11,
       "members": []
     },
     {
@@ -28701,7 +28701,7 @@
       "kind": "record",
       "project": "Granit.Payments.Endpoints",
       "file": "src/Granit.Payments.Endpoints/Dtos/PaymentMethodResponse.cs",
-      "line": 21,
+      "line": 30,
       "members": []
     },
     {
@@ -29315,7 +29315,7 @@
         {
           "name": "GetAvailableProvidersAsync",
           "kind": "method",
-          "signature": "GetAvailableProvidersAsync(Guid tenantId, CancellationToken cancellationToken = default)",
+          "signature": "GetAvailableProvidersAsync(Guid tenantId, PaymentAvailabilityContext? context = null, CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyList<PaymentAvailableMethod>>"
         }
       ]

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -28388,7 +28388,7 @@
       "kind": "class",
       "project": "Granit.Payments",
       "file": "src/Granit.Payments/Domain/PaymentMethodConfiguration.cs",
-      "line": 17,
+      "line": 25,
       "members": [
         {
           "name": "Activate",
@@ -28406,12 +28406,18 @@
           "name": "Activate",
           "kind": "method",
           "signature": "Activate()",
-          "returnType": "bool IsActive { get; private set; } public void"
+          "returnType": "bool IsActive { get; private set; } public ImmutableHashSet<string>? SupportedCountries { get; private set; } public ImmutableHashSet<string>? SupportedCurrencies { get; private set; } public PaymentMethodSequenceType? SupportedSequenceTypes { get; private set; } public ImmutableDictionary<string, PaymentMethodAmountBound>? AmountBounds { get; private set; } public void"
         },
         {
           "name": "Deactivate",
           "kind": "method",
           "signature": "Deactivate()",
+          "returnType": "void"
+        },
+        {
+          "name": "SnapshotCapability",
+          "kind": "method",
+          "signature": "SnapshotCapability(PaymentMethodCapability capability)",
           "returnType": "void"
         }
       ]

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -28165,7 +28165,23 @@
       "kind": "record",
       "project": "Granit.Payments",
       "file": "src/Granit.Payments/Contracts/PaymentMethodCapability.cs",
-      "line": 17,
+      "line": 18,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(SupportedCountries: ImmutableHashSet<string>.Empty, SupportedCurrencies: ImmutableHashSet<string>.Empty, SupportedSequenceTypes: PaymentMethodSequenceType.OneOff | PaymentMethodSequenceType.First | PaymentMethodSequenceType.Recurring, AmountBounds: ImmutableDictionary<string, PaymentMethodAmountBound>.Empty)",
+          "returnType": "PaymentMethodCapability Wildcard { get; } ="
+        }
+      ]
+    },
+    {
+      "name": "PaymentMethodCatalogEntry",
+      "fqn": "Granit.Payments.Contracts.PaymentMethodCatalogEntry",
+      "kind": "record",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/Contracts/PaymentMethodCatalogEntry.cs",
+      "line": 18,
       "members": []
     },
     {
@@ -29171,10 +29187,16 @@
       "line": 6,
       "members": [
         {
+          "name": "GetCatalogAsync",
+          "kind": "method",
+          "signature": "GetCatalogAsync(CancellationToken cancellationToken = default)",
+          "returnType": "string Name { get; } IReadOnlyList<PaymentMethodDescriptor> SupportedMethods { get; } Task<IReadOnlyList<PaymentMethodCatalogEntry>>"
+        },
+        {
           "name": "ChargeAsync",
           "kind": "method",
           "signature": "ChargeAsync(PaymentChargeRequest request, CancellationToken cancellationToken = default)",
-          "returnType": "string Name { get; } IReadOnlyList<PaymentMethodDescriptor> SupportedMethods { get; } Task<PaymentProviderChargeResult>"
+          "returnType": "Task<PaymentProviderChargeResult>"
         },
         {
           "name": "RefundAsync",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -28115,6 +28115,15 @@
       "members": []
     },
     {
+      "name": "PaymentAvailabilityContext",
+      "fqn": "Granit.Payments.Contracts.PaymentAvailabilityContext",
+      "kind": "record",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/Contracts/PaymentAvailabilityContext.cs",
+      "line": 15,
+      "members": []
+    },
+    {
       "name": "PaymentAvailableMethod",
       "fqn": "Granit.Payments.Contracts.PaymentAvailableMethod",
       "kind": "record",
@@ -28148,6 +28157,15 @@
       "project": "Granit.Payments",
       "file": "src/Granit.Payments/Contracts/PaymentCheckoutSessionRequest.cs",
       "line": 4,
+      "members": []
+    },
+    {
+      "name": "PaymentMethodCapability",
+      "fqn": "Granit.Payments.Contracts.PaymentMethodCapability",
+      "kind": "record",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/Contracts/PaymentMethodCapability.cs",
+      "line": 17,
       "members": []
     },
     {
@@ -28331,6 +28349,15 @@
       ]
     },
     {
+      "name": "PaymentMethodAmountBound",
+      "fqn": "Granit.Payments.Domain.PaymentMethodAmountBound",
+      "kind": "record",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/Domain/PaymentMethodAmountBound.cs",
+      "line": 9,
+      "members": []
+    },
+    {
       "name": "PaymentMethodCategory",
       "fqn": "Granit.Payments.Domain.PaymentMethodCategory",
       "kind": "enum",
@@ -28372,6 +28399,15 @@
           "returnType": "void"
         }
       ]
+    },
+    {
+      "name": "PaymentMethodSequenceType",
+      "fqn": "Granit.Payments.Domain.PaymentMethodSequenceType",
+      "kind": "enum",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/Domain/PaymentMethodSequenceType.cs",
+      "line": 14,
+      "members": []
     },
     {
       "name": "PaymentMethods",
@@ -29299,6 +29335,22 @@
           "kind": "method",
           "signature": "ProcessAsync(ProcessWebhookCommand command, CancellationToken cancellationToken)",
           "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "IPaymentMethodAvailabilityFilter",
+      "fqn": "Granit.Payments.Internal.IPaymentMethodAvailabilityFilter",
+      "kind": "interface",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/Internal/IPaymentMethodAvailabilityFilter.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "IsAvailable",
+          "kind": "method",
+          "signature": "IsAvailable(PaymentMethodCapability capability, PaymentAvailabilityContext context)",
+          "returnType": "bool"
         }
       ]
     },

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -28705,6 +28705,15 @@
       "members": []
     },
     {
+      "name": "PaymentCatalogMethod",
+      "fqn": "Granit.Payments.Endpoints.Dtos.PaymentCatalogMethod",
+      "kind": "record",
+      "project": "Granit.Payments.Endpoints",
+      "file": "src/Granit.Payments.Endpoints/Dtos/PaymentMethodConfigurationDtos.cs",
+      "line": 30,
+      "members": []
+    },
+    {
       "name": "PaymentChargeRequest",
       "fqn": "Granit.Payments.Endpoints.Dtos.PaymentChargeRequest",
       "kind": "record",
@@ -28741,12 +28750,30 @@
       "members": []
     },
     {
+      "name": "PaymentMethodAmountBoundResponse",
+      "fqn": "Granit.Payments.Endpoints.Dtos.PaymentMethodAmountBoundResponse",
+      "kind": "record",
+      "project": "Granit.Payments.Endpoints",
+      "file": "src/Granit.Payments.Endpoints/Dtos/PaymentMethodConfigurationDtos.cs",
+      "line": 58,
+      "members": []
+    },
+    {
+      "name": "PaymentMethodCapabilityResponse",
+      "fqn": "Granit.Payments.Endpoints.Dtos.PaymentMethodCapabilityResponse",
+      "kind": "record",
+      "project": "Granit.Payments.Endpoints",
+      "file": "src/Granit.Payments.Endpoints/Dtos/PaymentMethodConfigurationDtos.cs",
+      "line": 48,
+      "members": []
+    },
+    {
       "name": "PaymentMethodConfigurationItem",
       "fqn": "Granit.Payments.Endpoints.Dtos.PaymentMethodConfigurationItem",
       "kind": "record",
       "project": "Granit.Payments.Endpoints",
       "file": "src/Granit.Payments.Endpoints/Dtos/PaymentMethodConfigurationDtos.cs",
-      "line": 6,
+      "line": 11,
       "members": []
     },
     {
@@ -28759,12 +28786,21 @@
       "members": []
     },
     {
+      "name": "PaymentProviderCatalogResponse",
+      "fqn": "Granit.Payments.Endpoints.Dtos.PaymentProviderCatalogResponse",
+      "kind": "record",
+      "project": "Granit.Payments.Endpoints",
+      "file": "src/Granit.Payments.Endpoints/Dtos/PaymentMethodConfigurationDtos.cs",
+      "line": 39,
+      "members": []
+    },
+    {
       "name": "PaymentProviderConfigurationResponse",
       "fqn": "Granit.Payments.Endpoints.Dtos.PaymentProviderConfigurationResponse",
       "kind": "record",
       "project": "Granit.Payments.Endpoints",
       "file": "src/Granit.Payments.Endpoints/Dtos/PaymentMethodConfigurationDtos.cs",
-      "line": 13,
+      "line": 19,
       "members": []
     },
     {
@@ -29104,7 +29140,7 @@
       "kind": "interface",
       "project": "Granit.Payments",
       "file": "src/Granit.Payments/IPaymentMethodConfigurationWriter.cs",
-      "line": 6,
+      "line": 7,
       "members": [
         {
           "name": "AddAsync",
@@ -29129,6 +29165,18 @@
           "kind": "method",
           "signature": "UpsertActivationAsync(Guid newId, string providerName, string methodType, bool isActive, CancellationToken cancellationToken = default)",
           "returnType": "Task"
+        },
+        {
+          "name": "UpsertActivationWithSnapshotAsync",
+          "kind": "method",
+          "signature": "UpsertActivationWithSnapshotAsync(Guid newId, string providerName, string methodType, PaymentMethodCapability capability, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UpdateCapabilitySnapshotAsync",
+          "kind": "method",
+          "signature": "UpdateCapabilitySnapshotAsync(string providerName, string methodType, PaymentMethodCapability capability, CancellationToken cancellationToken = default)",
+          "returnType": "Task<bool>"
         }
       ]
     },

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -28417,6 +28417,38 @@
       ]
     },
     {
+      "name": "PaymentMethodCountries",
+      "fqn": "Granit.Payments.Domain.PaymentMethodCountries",
+      "kind": "class",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/Domain/PaymentMethodCountries.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(StringComparer.Ordinal, \"AT\", \"BE\", \"BG\", \"CY\", \"CZ\", \"DE\", \"DK\", \"EE\", \"ES\", \"FI\", \"FR\", \"GR\", \"HR\", \"HU\", \"IE\", \"IT\", \"LT\", \"LU\", \"LV\", \"MT\", \"NL\", \"PL\", \"PT\", \"RO\", \"SE\", \"SI\", \"SK\", \"IS\", \"LI\", \"NO\", \"CH\", \"GB\", \"AD\", \"MC\", \"SM\", \"VA\")",
+          "returnType": "ImmutableHashSet<string> SepaZone { get; } = ImmutableHashSet."
+        }
+      ]
+    },
+    {
+      "name": "PaymentMethodCurrencies",
+      "fqn": "Granit.Payments.Domain.PaymentMethodCurrencies",
+      "kind": "class",
+      "project": "Granit.Payments",
+      "file": "src/Granit.Payments/Domain/PaymentMethodCurrencies.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(StringComparer.Ordinal, \"EUR\")",
+          "returnType": "ImmutableHashSet<string> EurOnly { get; } = ImmutableHashSet."
+        }
+      ]
+    },
+    {
       "name": "PaymentMethodSequenceType",
       "fqn": "Granit.Payments.Domain.PaymentMethodSequenceType",
       "kind": "enum",

--- a/docs-site/src/content/docs/dotnet/saas/payments/availability.mdx
+++ b/docs-site/src/content/docs/dotnet/saas/payments/availability.mdx
@@ -1,0 +1,268 @@
+---
+title: "Availability & provider catalog"
+description: Provider-driven method catalogue, capability snapshots on PaymentMethodConfiguration, and runtime filtering of GET /methods/available by country, currency, amount, and sequence type.
+sidebar:
+  label: Availability
+  order: 2
+---
+
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
+
+## Why filter at all
+
+Without availability filtering, the checkout shows every activated method regardless
+of whether the provider will actually accept the charge. The symptoms:
+
+- A Belgian EUR checkout offers **iDEAL** — NL-only — and the provider rejects the
+  charge at the last click.
+- A 0.50 € cart offers **Klarna** — which has a ~10 € floor — and the customer hits
+  an inscrutable rejection after entering their details.
+- A recurring subscription checkout proposes a **OneOff** method — the setup flow
+  fails mid-way with no mandate.
+
+Each of these is a UX failure *caused by the back-end proposing a method the
+provider does not support*. The fix is to honour the provider's availability rules
+before the method reaches the checkout UI.
+
+## Design — two paths, one source of truth
+
+Providers themselves know the truth (Mollie exposes `GET /v2/methods`, Stripe exposes
+`payment_method_configurations`). Granit splits the work into a **cold admin path**
+and a **hot checkout path**:
+
+```text
+    Provider API (Mollie /v2/methods, Stripe /payment_method_configs)
+                             │
+                             │ GetCatalogAsync() — cold, admin only
+                             ▼
+    Admin UI — activate method + refresh catalogue
+                             │
+                             │ snapshot capability
+                             ▼
+    paym_payment_method_configurations (DB)
+    • SupportedCountries, SupportedCurrencies
+    • SupportedSequenceTypes, AmountBounds
+    • IsActive
+                             │
+                             │ GET /methods/available — hot, checkout
+                             ▼
+    IPaymentMethodAvailabilityFilter (pure)
+       capability snapshot ∩ request context
+```
+
+- **Admin path**: when an admin activates a method, the provider's current catalogue
+  is fetched live and the capability is captured as a snapshot on the activation
+  record. Newly added provider methods appear in the admin UI automatically — no
+  Granit release required.
+- **Hot path**: `GET /methods/available` reads only the DB snapshot plus the request
+  context. Zero latency on the provider, offline-capable, deterministic.
+
+<Aside type="note" title="No tightening overrides">
+The admin cannot *further* restrict a method beyond what the provider declares.
+The capability snapshot is the contract. If you need a Granit-level restriction
+(sanctioned countries, tenant-specific lockdown) that is stricter than the provider
+dashboard, that is a separate feature and not yet built.
+</Aside>
+
+## Capability shape
+
+A `PaymentMethodCapability` carries four independent axes:
+
+```csharp
+public sealed record PaymentMethodCapability(
+    IReadOnlySet<string> SupportedCountries,
+    IReadOnlySet<string> SupportedCurrencies,
+    PaymentMethodSequenceType SupportedSequenceTypes,
+    IReadOnlyDictionary<string, PaymentMethodAmountBound> AmountBounds);
+```
+
+| Axis | Semantics | Wildcard |
+|------|-----------|----------|
+| `SupportedCountries` | ISO-3166 alpha-2 codes (upper) | empty set = global |
+| `SupportedCurrencies` | ISO-4217 alpha-3 codes (upper) | empty set = all |
+| `SupportedSequenceTypes` | `[Flags]` — `OneOff` / `First` / `Recurring` | must be non-zero |
+| `AmountBounds` | per-currency `(CurrencyCode, Min?, Max?)` | empty dict = no bounds |
+
+The sequence axis mirrors Mollie's `sequenceType`: **OneOff** for standalone
+payments, **First** for the initial payment of a mandate-backed sequence,
+**Recurring** for subsequent off-session charges. The filter does not chain modes
+automatically — a caller that needs mandate setup requests `First`, later charges
+request `Recurring`.
+
+## Provider catalogue
+
+Each provider implements `GetCatalogAsync` and declares the real capability per
+method. The shipped providers maintain a static catalogue in code:
+
+```csharp
+// Excerpt from MollieCatalog.cs
+new(PaymentMethods.Bancontact, PaymentMethodCategory.BankRedirect, "Bancontact",
+    new(Set("BE"), PaymentMethodCurrencies.EurOnly,
+        PaymentMethodSequenceType.OneOff | PaymentMethodSequenceType.First, NoBounds)),
+
+new(PaymentMethods.Klarna, PaymentMethodCategory.BuyNowPayLater, "Klarna",
+    new(
+        Set("AT", "BE", "CH", "CZ", "DE", "DK", "ES", "FI", "FR", "GB", "IE",
+            "IT", "NL", "NO", "PL", "PT", "SE", "US"),
+        Set("EUR", "GBP", "SEK", "DKK", "NOK", "CHF", "USD"),
+        PaymentMethodSequenceType.OneOff,
+        Bounds(
+            ("EUR", 1m, 10_000m),
+            ("GBP", 1m, 10_000m),
+            ("SEK", 10m, 100_000m),
+            ("DKK", 10m, 75_000m)))),
+```
+
+Shared constants live in `PaymentMethodCountries.SepaZone` and
+`PaymentMethodCurrencies.EurOnly` so SEPA-constrained methods align across
+providers.
+
+<Aside type="tip" title="Why static, not a live API call">
+Mollie's `/v2/methods` endpoint does not expose per-method country lists or stable
+sequence type flags, and the data is extremely stable in practice (iDEAL will not
+stop being NL-only). Bounds and pricing can drift, so a future iteration can
+replace these static catalogues with live calls. The interface is already async
+to support that transition without touching consumers.
+</Aside>
+
+## Admin workflow
+
+Three admin endpoints cover the activation lifecycle. All three require
+`Payments.Configuration.Manage`.
+
+### 1. Browse the live catalogue
+
+```http
+GET /api/payments/configuration/catalog?providerName=mollie
+```
+
+Calls `IPaymentProvider.GetCatalogAsync` on the named provider and cross-references
+with the existing activation records. Each entry reports `isActive` and
+`hasSnapshot`, so the admin UI can distinguish **not activated**, **activated (no
+snapshot yet)**, and **activated with snapshot**.
+
+Returns `404` when the provider is not registered in DI.
+
+### 2. Activate and snapshot
+
+```http
+POST /api/payments/configuration/{providerName}/{methodType}/activate
+```
+
+Refetches the provider catalogue, extracts the entry matching `methodType`, calls
+`PaymentMethodConfiguration.SnapshotCapability(capability)`, and persists. Race-safe
+on the unique `(ProviderName, MethodType)` index — concurrent activations converge.
+
+Returns `400` if the provider no longer offers the requested method (the method
+was removed from the provider's dashboard).
+
+### 3. Resync an existing activation
+
+```http
+POST /api/payments/configuration/{providerName}/{methodType}/resync
+```
+
+Overwrites the capability snapshot with the current provider catalogue — used to
+propagate provider-side changes (added countries, updated bounds) without a
+deactivate / reactivate cycle. Returns `404` when no activation record exists.
+
+## Runtime filtering
+
+The hot path reads the DB snapshot and intersects it with the request context:
+
+```http
+GET /api/payments/methods/available?country=BE&currency=EUR&amount=25&sequenceType=oneoff
+```
+
+| Query param | Validation | Default |
+|-------------|-----------|---------|
+| `country` | `^[A-Z]{2}$`, case-insensitive | no country filter |
+| `currency` | `^[A-Z]{3}$`, case-insensitive | no currency filter |
+| `amount` | decimal ≥ 0 | no amount filter |
+| `sequenceType` | `oneoff` / `first` / `recurring` (case-insensitive) | `oneoff` |
+
+A malformed value returns `400 ProblemDetails` before any store read. Any absent
+axis is treated as a wildcard on that axis.
+
+The response carries the capability snapshot alongside each available method, so
+the front-end can render tooltips ("Klarna requires ≥ 1 €"), country badges
+("available in BE only"), and hide impossible combinations without a second
+round-trip:
+
+```json
+[
+  {
+    "methodType": "bancontact",
+    "category": "BankRedirect",
+    "providerName": "mollie",
+    "displayLabel": "Bancontact",
+    "capability": {
+      "supportedCountries": ["BE"],
+      "supportedCurrencies": ["EUR"],
+      "supportedSequenceTypes": ["oneoff", "first"],
+      "amountBounds": []
+    }
+  }
+]
+```
+
+## Filtering semantics
+
+The filter is a pure predicate (`IPaymentMethodAvailabilityFilter`) that rejects a
+method when *any* axis fails. Sequence type uses a **bitwise containment** test —
+`(capability.SupportedSequenceTypes & requested) == requested` — meaning:
+
+- A caller requesting `Recurring` against a method that supports only `OneOff` is
+  **rejected**. Mandate setup flows are chained explicitly by the caller; the
+  filter does not synthesise a `First` step.
+- A caller requesting `First` against a method that supports `OneOff | First` is
+  accepted.
+- A caller requesting `OneOff` against a method that supports
+  `First | Recurring` is **rejected** — mandate-based methods typically cannot
+  accept a one-shot charge.
+
+Amount bounds apply **only** when the request currency matches a declared bound.
+A Klarna capability with `{EUR: (1, 10000)}` offers no constraint on a GBP
+request, because Klarna exposes its GBP bound separately. An absent bound means
+unrestricted for that currency.
+
+## Backward compatibility
+
+`PaymentMethodConfiguration` rows created before snapshotting existed have
+`SupportedCountries` / `SupportedCurrencies` / `SupportedSequenceTypes` /
+`AmountBounds` all `NULL`. The resolver treats this as **wildcard** — the legacy
+record is returned regardless of context. An admin `POST /resync` populates the
+snapshot and the record starts being filtered properly.
+
+## EF persistence
+
+Snapshot columns are additive and nullable. Host applications running
+`dotnet ef migrations add` on the `PaymentsDbContext` pick up the new columns
+automatically:
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `SupportedCountries` | `nvarchar(512)` | CSV, sorted |
+| `SupportedCurrencies` | `nvarchar(256)` | CSV, sorted |
+| `SupportedSequenceTypes` | `int` | flags |
+| `AmountBounds` | JSON | per-currency `{min?, max?}` dictionary |
+
+The `ValueComparer` for the immutable sets uses `SetEquals` for equality and
+returns the same reference for the snapshot — immutable collections do not need to
+be deep-copied for change tracking.
+
+## What's intentionally not built
+
+- **Admin tightening overrides** — YAGNI until a concrete cross-cutting restriction
+  (sanctioned countries, tenant lockdown) is on the table. Provider dashboards
+  already cover most merchant-level restrictions.
+- **`ITenantInfo.CountryCode`** — the country at checkout is a transactional
+  attribute, not a tenant-global one. It comes from the invoice's
+  [`BillingAddress.Country`](/dotnet/saas/invoicing/) and is passed through the
+  query string.
+- **Self-healing snapshot on provider rejection** — a reactive resync triggered by
+  `ChargeAsync` rejecting on capability grounds (e.g., Mollie returning
+  `amount_too_high` after lowering the Klarna bound). Considered for a later
+  iteration; in the meantime an admin `POST /resync` catches drift manually.
+- **Periodic background resync** — same rationale; add when observed drift becomes
+  a pain point.

--- a/docs-site/src/content/docs/dotnet/saas/payments/index.mdx
+++ b/docs-site/src/content/docs/dotnet/saas/payments/index.mdx
@@ -6,12 +6,25 @@ sidebar:
   order: 3
 ---
 
-import { Tabs, TabItem, FileTree } from "@astrojs/starlight/components";
+import { FileTree, LinkCard, CardGrid } from "@astrojs/starlight/components";
 
 Granit.Payments provides provider-agnostic payment processing with a **multi-provider
 per tenant** model. A single tenant can route Card payments to Stripe, iDEAL to Mollie,
 and bank transfers to SEPA — all simultaneously. No card data ever touches Granit
 (hosted payment pages only, PCI DSS compliant).
+
+<CardGrid>
+  <LinkCard
+    title="Providers"
+    description="IPaymentProvider contract, Stripe implementation, Mollie, SEPA Transfer, SEPA Direct Debit. How to wire a new provider."
+    href="/dotnet/saas/payments/providers/"
+  />
+  <LinkCard
+    title="Availability & provider catalog"
+    description="Provider-driven method catalogue, capability snapshots, and runtime filtering by country / currency / amount / sequence type."
+    href="/dotnet/saas/payments/availability/"
+  />
+</CardGrid>
 
 ## Package structure
 
@@ -21,10 +34,10 @@ and bank transfers to SEPA — all simultaneously. No card data ever touches Gra
   - Granit.Payments.Endpoints Checkout, payment methods, webhooks (AllowAnonymous + signature)
   - Granit.Payments.Wolverine InvoiceFinalizedHandler (auto-charge), webhook dispatch
   - Granit.Payments.Stripe Stripe provider (PaymentIntent API, Checkout, WebhookVerifier)
-  - Granit.Payments.Mollie Mollie EU-sovereign provider (Phase 2)
+  - Granit.Payments.Mollie Mollie EU-sovereign provider
   - Granit.Payments.Notifications Payment lifecycle notifications (5 types)
-  - Granit.Payments.SepaTransfer Bank transfer + reconciliation (Phase 2)
-  - Granit.Payments.SepaDirectDebit Mandate management + SDD collection (Phase 2)
+  - Granit.Payments.SepaTransfer Bank transfer + reconciliation
+  - Granit.Payments.SepaDirectDebit Mandate management + SDD collection
 </FileTree>
 
 ## Payment transaction FSM
@@ -54,10 +67,21 @@ stateDiagram-v2
 ```csharp
 public interface IPaymentProviderResolver
 {
-    IPaymentProvider Resolve(Guid tenantId, PaymentMethodType methodType);
-    IReadOnlyList<AvailablePaymentMethod> GetAvailableProviders(Guid tenantId);
+    Task<IPaymentProvider> ResolveAsync(Guid tenantId, string methodType,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<PaymentAvailableMethod>> GetAvailableProvidersAsync(
+        Guid tenantId,
+        PaymentAvailabilityContext? context = null,
+        CancellationToken cancellationToken = default);
 }
 ```
+
+The resolver reads the active `PaymentMethodConfiguration` records and returns the
+methods each registered `IPaymentProvider` can handle. Passing a
+`PaymentAvailabilityContext` filters the result against the capability snapshot
+captured at activation time — see
+[Availability & provider catalog](/dotnet/saas/payments/availability/).
 
 Configuration per tenant:
 
@@ -156,69 +180,24 @@ changes between the original payment and a retry 14 days later.
 ## Checkout flow
 
 ```csharp
-// 1. Customer selects payment method type
-var methods = providerResolver.GetAvailableProviders(tenantId);
-// → [Card (Stripe), BankTransfer (SEPA), iDEAL (Mollie)]
+// 1. Customer selects a payment method type — filtered by context
+var context = new PaymentAvailabilityContext(
+    CountryCode: "BE",
+    CurrencyCode: "EUR",
+    Amount: 25m,
+    SequenceType: PaymentMethodSequenceType.OneOff);
 
-// 2. Resolve provider for selected method
-var provider = providerResolver.Resolve(tenantId, PaymentMethodType.Card);
+var methods = await resolver.GetAvailableProvidersAsync(tenantId, context, ct);
+// → only methods whose capability snapshot accepts (BE, EUR, 25€, OneOff)
 
-// 3. Create checkout session (hosted page)
+// 2. Resolve the provider for the selected method
+var provider = await resolver.ResolveAsync(tenantId, "card", ct);
+
+// 3. Create a checkout session (hosted page)
 var session = await checkoutFactory.CreateAsync(
     invoiceId, amount, currency, returnUrl, ct);
 // → { Url: "https://checkout.stripe.com/...", SessionId: "cs_xxx" }
 ```
-
-## Stripe implementation
-
-`Granit.Payments.Stripe` provides a full implementation using the Stripe.net SDK
-and the PaymentIntent API:
-
-| Class | Stripe API | Purpose |
-|-------|-----------|---------|
-| `StripePaymentProvider` | PaymentIntent | Charge, refund, status check |
-| `StripeCheckoutSessionFactory` | Checkout Session | Hosted payment pages |
-| `StripePaymentMethodManager` | Customer + PaymentMethod | List, attach, detach |
-| `StripeWebhookVerifier` | EventUtility | HMAC-SHA256 signature validation |
-
-### StripeClientFactory (no static config)
-
-`StripeConfiguration.ApiKey` is **never used** (global static, unsafe for multi-tenant).
-Instead, `StripeClientFactory` creates an `IStripeClient` per request via `IHttpClientFactory`:
-
-```csharp
-// DI registration (in GranitPaymentsStripeModule)
-services.AddScoped<IStripeClient>(sp =>
-    sp.GetRequiredService<StripeClientFactory>().Create());
-```
-
-This enables future Stripe Connect (per-tenant API keys) and integrates with
-`IHttpClientFactory` lifecycle (pooling, logging, resilience policies).
-
-### Provider customer mapping
-
-`ProviderCustomerMapping` maps Granit TenantId → provider customer ID (e.g., `cus_xxx`).
-Generic entity reusable by any provider (Stripe, Mollie). Auto-created on first
-`AttachAsync()` call.
-
-### Configuration
-
-```json
-{
-  "Payments": {
-    "Stripe": {
-      "SecretKey": "sk_test_xxx",
-      "WebhookSecret": "whsec_xxx",
-      "PublishableKey": "pk_test_xxx"
-    }
-  }
-}
-```
-
-### Amount conversion
-
-`StripeAmountConverter` handles zero-decimal currencies (JPY, KRW, VND, etc.)
-automatically — Stripe uses cents for EUR/USD but major units for JPY.
 
 ## Notifications
 
@@ -242,15 +221,26 @@ automatically — Stripe uses cents for EUR/USD but major units for JPY.
 | POST | `/api/payments/refund` | `Payments.Refunds.Execute` |
 | POST | `/api/payments/checkout` | `Payments.Charges.Execute` |
 | GET | `/api/payments/methods` | `Payments.Methods.Read` |
+| GET | `/api/payments/methods/available` | `Payments.Methods.Read` |
 | POST | `/api/payments/methods` | `Payments.Methods.Manage` |
 | DELETE | `/api/payments/methods/{id}` | `Payments.Methods.Manage` |
+| GET | `/api/payments/configuration` | `Payments.Configuration.Manage` |
+| GET | `/api/payments/configuration/catalog` | `Payments.Configuration.Manage` |
+| POST | `/api/payments/configuration/{p}/{m}/activate` | `Payments.Configuration.Manage` |
+| POST | `/api/payments/configuration/{p}/{m}/deactivate` | `Payments.Configuration.Manage` |
+| POST | `/api/payments/configuration/{p}/{m}/resync` | `Payments.Configuration.Manage` |
 | POST | `/api/payments/webhooks/{provider}` | `[AllowAnonymous]` |
 
 Charge and checkout endpoints use `Granit.Http.Idempotency` (`[Idempotent]`)
-to prevent double charges.
+to prevent double charges. Configuration endpoints (activate / deactivate / resync) are
+also idempotent. The `/methods/available` endpoint accepts
+`?country=&currency=&amount=&sequenceType=` query params — details in
+[Availability & provider catalog](/dotnet/saas/payments/availability/).
 
 ## See also
 
+- [Providers](/dotnet/saas/payments/providers/) — `IPaymentProvider` contract, Stripe, Mollie, SEPA
+- [Availability & provider catalog](/dotnet/saas/payments/availability/) — method catalog, capability snapshots, runtime filtering
 - [SaaS Overview](/dotnet/saas/) — ecosystem architecture and choreography
 - [Invoicing](/dotnet/saas/invoicing/) — invoice lifecycle and partial payments
 - [Subscriptions](/dotnet/saas/subscriptions/) — billing cycle orchestration

--- a/docs-site/src/content/docs/dotnet/saas/payments/providers.mdx
+++ b/docs-site/src/content/docs/dotnet/saas/payments/providers.mdx
@@ -1,0 +1,192 @@
+---
+title: "Providers — Stripe, Mollie, SEPA"
+description: Provider abstraction layer, built-in providers (Stripe, Mollie, SEPA Transfer, SEPA Direct Debit), and how to add a new one.
+sidebar:
+  label: Providers
+  order: 1
+---
+
+import { FileTree, Aside } from "@astrojs/starlight/components";
+
+Each payment integration implements the same `IPaymentProvider` contract. The host
+decides which providers to register, the admin decides which methods on each provider
+to activate, and the runtime resolves a concrete provider per (tenant, method) at
+charge time.
+
+## The `IPaymentProvider` contract
+
+```csharp
+public interface IPaymentProvider
+{
+    string Name { get; }
+
+    IReadOnlyList<PaymentMethodDescriptor> SupportedMethods { get; }
+
+    Task<IReadOnlyList<PaymentMethodCatalogEntry>> GetCatalogAsync(
+        CancellationToken cancellationToken = default);
+
+    Task<PaymentProviderChargeResult> ChargeAsync(
+        PaymentChargeRequest request, CancellationToken cancellationToken = default);
+
+    Task<PaymentProviderRefundResult> RefundAsync(
+        PaymentRefundRequest request, CancellationToken cancellationToken = default);
+
+    Task<PaymentProviderStatus> GetStatusAsync(
+        string providerTransactionId, CancellationToken cancellationToken = default);
+}
+```
+
+- `SupportedMethods` — the fixed list of method identifiers this provider can handle,
+  used primarily by the admin listing endpoint (one row per method).
+- `GetCatalogAsync` — **live** catalogue including capability metadata
+  (countries, currencies, amount bounds, sequence types). Called by the admin
+  activation flow to snapshot the capability onto `PaymentMethodConfiguration`.
+  See [Availability & provider catalog](/dotnet/saas/payments/availability/).
+- `ChargeAsync` / `RefundAsync` / `GetStatusAsync` — the charge lifecycle. Providers
+  map their native API responses into `ProviderChargeStatus` and `RefundStatus` via
+  small mapper helpers.
+
+Providers also typically ship an `I{Provider}WebhookVerifier` (signature validation)
+and an `I{Provider}PaymentMethodManager` (attach / detach saved methods) — see each
+provider's section below.
+
+## Stripe (`Granit.Payments.Stripe`)
+
+Full implementation using the Stripe.NET SDK and the **PaymentIntent API**
+(not the legacy Charges API). Covers the European surface plus Alipay / WeChat Pay
+for merchants with China exposure.
+
+| Class | Stripe API | Purpose |
+|-------|-----------|---------|
+| `StripePaymentProvider` | PaymentIntent | Charge, refund, status check, catalog |
+| `StripeCheckoutSessionFactory` | Checkout Session | Hosted payment pages |
+| `StripePaymentMethodManager` | Customer + PaymentMethod | List, attach, detach |
+| `StripeWebhookVerifier` | EventUtility | HMAC-SHA256 signature validation |
+| `StripeCatalog` | — | Static capability catalogue (countries, bounds, sequences) |
+
+### `StripeClientFactory` (no static config)
+
+`StripeConfiguration.ApiKey` is **never used** (global static, unsafe for
+multi-tenant). `StripeClientFactory` creates an `IStripeClient` per request via
+`IHttpClientFactory`:
+
+```csharp
+// DI registration (in GranitPaymentsStripeModule)
+services.AddScoped<IStripeClient>(sp =>
+    sp.GetRequiredService<StripeClientFactory>().Create());
+```
+
+This enables future Stripe Connect (per-tenant API keys) and integrates with
+`IHttpClientFactory` lifecycle (pooling, logging, resilience policies).
+
+### Provider customer mapping
+
+`ProviderCustomerMapping` maps Granit `TenantId` → provider customer ID
+(`cus_xxx` on Stripe, `cst_xxx` on Mollie). It's a generic entity reusable by any
+provider — `Granit.Payments` owns the abstraction, provider packages create and
+read rows through it. Auto-created on the first `AttachAsync()` call.
+
+### Amount conversion
+
+`StripeAmountConverter` handles **zero-decimal currencies** (JPY, KRW, VND, …)
+automatically — Stripe uses cents for EUR/USD but major units for JPY. The
+converter also handles three-decimal currencies (BHD, JOD, KWD) and the
+special-case KRW that Stripe treats as zero-decimal even though ISO-4217 is
+ambiguous.
+
+### Configuration
+
+```json
+{
+  "Payments": {
+    "Stripe": {
+      "SecretKey": "sk_test_xxx",
+      "WebhookSecret": "whsec_xxx",
+      "PublishableKey": "pk_test_xxx"
+    }
+  }
+}
+```
+
+## Mollie (`Granit.Payments.Mollie`)
+
+EU-sovereign provider. Mollie's strength over Stripe is direct support for Belgian
+local methods (Belfius, KBC), Nordic banking (Trustly), vouchers (Paysafecard), and
+BNPL variants that Stripe does not expose in the same account surface.
+
+| Class | Mollie API | Purpose |
+|-------|-----------|---------|
+| `MolliePaymentProvider` | Payments API | Charge, refund, status check, catalog |
+| `MollieCheckoutSessionFactory` | Payments API | Hosted payment pages |
+| `MolliePaymentMethodManager` | Customers + Mandates | Mandate setup for recurring |
+| `MollieWebhookVerifier` | Payment polling | ID-based verification (no signature) |
+| `MollieCatalog` | — | Static capability catalogue |
+
+<Aside>
+Mollie webhooks are unsigned — the provider pushes the payment ID and the client
+re-fetches the payment status from the Mollie API. The webhook verifier records the
+event id and delegates status determination to `GetStatusAsync`.
+</Aside>
+
+### Configuration
+
+```json
+{
+  "Payments": {
+    "Mollie": {
+      "ApiKey": "test_xxx"
+    }
+  }
+}
+```
+
+## SEPA Direct Debit (`Granit.Payments.SepaDirectDebit.Builtin`)
+
+Self-hosted SEPA Direct Debit — no external gateway. Creates a collection in
+`Processing` state; reconciliation from a CAMT.053 bank statement import moves the
+transaction to `Succeeded` or `Failed`.
+
+Use case: you have a banking relationship with IBAN / BIC, you issue SDD mandates
+yourself, and you want to keep the entire flow on-premises (no Cloud Act exposure
+for the payment data).
+
+Requires a PAIN.008 batch generator (provided — `Pain008Generator`) and an upstream
+CAMT.053 import path (`Granit.Payments.SepaTransfer` ships a parser shared between
+SDD and SCT).
+
+## SEPA Transfer (`Granit.Payments.SepaTransfer`)
+
+Bank transfers with structured reference reconciliation. The charge returns a
+pending transaction with a structured reference that the payer includes in their
+transfer. The reconciliation processor matches incoming CAMT.053 entries against
+open transactions by reference + amount, promoting `Processing` → `Succeeded`.
+
+| Component | Purpose |
+|-----------|---------|
+| `SepaTransferPaymentProvider` | Charge returns pending tx with reference; refund is manual |
+| `SepaTransferCheckoutSessionFactory` | Hosted page showing IBAN + reference |
+| `StructuredReferenceGenerator` | Belgian OGM-VCS / SEPA RF reference formats |
+| `Camt053Parser` | Parses `camt.053.001.xx` account statements |
+| `DefaultBankReconciliationProcessor` | Matches CAMT entries to open transactions |
+
+## Adding a new provider
+
+The shortest viable provider:
+
+1. Create `Granit.Payments.{ProviderName}` with a `Granit{ProviderName}Module`.
+2. Implement `IPaymentProvider` — `Name`, `SupportedMethods`, `GetCatalogAsync`,
+   `ChargeAsync`, `RefundAsync`, `GetStatusAsync`.
+3. Implement `IPaymentWebhookVerifier` keyed on the provider name.
+4. Register the provider via `services.AddScoped<IPaymentProvider, …>()` and the
+   verifier via `AddScoped<IPaymentWebhookVerifier, …>()`.
+5. Maintain a `{Provider}Catalog` static class with the real capability metadata
+   (countries, currencies, bounds, sequence types). Don't return wildcard in
+   production — the availability filter won't filter anything meaningful.
+
+If the provider supports saved methods, also implement `IPaymentMethodManager` for
+attach / detach. If the provider needs per-request credentials (e.g., Stripe Connect,
+Mollie Partner), inject an `IHttpClientFactory` and mint clients per scope.
+
+See [Availability & provider catalog](/dotnet/saas/payments/availability/) for
+how the capability data plugs into the runtime filtering on
+`GET /methods/available`.

--- a/docs-site/src/content/docs/dotnet/saas/payments/providers.mdx
+++ b/docs-site/src/content/docs/dotnet/saas/payments/providers.mdx
@@ -169,6 +169,37 @@ open transactions by reference + amount, promoting `Processing` → `Succeeded`.
 | `Camt053Parser` | Parses `camt.053.001.xx` account statements |
 | `DefaultBankReconciliationProcessor` | Matches CAMT entries to open transactions |
 
+## Health check
+
+Every provider ships a readiness probe that calls `GetCatalogAsync` — one hit covers
+authentication, reachability and response parsing, and the API-backed providers
+already cache the catalogue 60 s so K8s probes do not hammer the provider.
+
+Register it from the provider module:
+
+```csharp
+context.Services.AddHealthChecks()
+    .AddGranitPaymentProviderHealthCheck("mollie");
+```
+
+The registration produces a check named `payments-mollie`, tagged `readiness`
+and `payments`, with `HealthStatus.Degraded` as the failure status so a single
+misbehaving provider does not cascade a `/ready` outage. Mapping:
+
+| Outcome | Status |
+|---------|--------|
+| Catalog returned ≥ 1 method | `Healthy` |
+| Catalog empty (auth OK, nothing to offer) | `Degraded` |
+| `OperationCanceledException` (5 s timeout) | `Unhealthy` — `timed out` |
+| `UnauthorizedAccessException` | `Unhealthy` — `auth failed` |
+| Any other exception | `Unhealthy` — `unreachable: {ExceptionType}` |
+
+Error messages contain **only** the provider name and the exception type name —
+URLs, API keys and tokens are never exposed, matching the convention from
+`HttpServiceHealthCheckBase`. Static-catalogue providers (SEPA Transfer, SEPA
+Direct Debit) are trivially `Healthy`; the check is still registered to keep the
+readiness surface uniform at zero cost.
+
 ## Adding a new provider
 
 The shortest viable provider:
@@ -179,7 +210,9 @@ The shortest viable provider:
 3. Implement `IPaymentWebhookVerifier` keyed on the provider name.
 4. Register the provider via `services.AddScoped<IPaymentProvider, …>()` and the
    verifier via `AddScoped<IPaymentWebhookVerifier, …>()`.
-5. Maintain a `{Provider}Catalog` static class with the real capability metadata
+5. Register the readiness probe via
+   `services.AddHealthChecks().AddGranitPaymentProviderHealthCheck(name)`.
+6. Maintain a `{Provider}Catalog` static class with the real capability metadata
    (countries, currencies, bounds, sequence types). Don't return wildcard in
    production — the availability filter won't filter anything meaningful.
 

--- a/src/Granit.Payments.Endpoints/Dtos/PaymentMethodConfigurationDtos.cs
+++ b/src/Granit.Payments.Endpoints/Dtos/PaymentMethodConfigurationDtos.cs
@@ -3,13 +3,59 @@ using Granit.Payments.Domain;
 namespace Granit.Payments.Endpoints.Dtos;
 
 /// <summary>A single payment method declared by a provider, with its activation state.</summary>
+/// <param name="MethodType">Stable method identifier (e.g., <c>card</c>, <c>bancontact</c>).</param>
+/// <param name="DisplayLabel">Localized display label for the checkout UI.</param>
+/// <param name="Category">Grouping category for the checkout UI.</param>
+/// <param name="IsActive">Whether the method is currently active on the platform.</param>
+/// <param name="CapabilitySnapshot">Last-captured capability snapshot, or <see langword="null"/> when no snapshot has been taken yet.</param>
 public sealed record PaymentMethodConfigurationItem(
     string MethodType,
     string DisplayLabel,
     PaymentMethodCategory Category,
-    bool IsActive);
+    bool IsActive,
+    PaymentMethodCapabilityResponse? CapabilitySnapshot);
 
 /// <summary>All methods declared by a single provider, with their activation state.</summary>
 public sealed record PaymentProviderConfigurationResponse(
     string ProviderName,
     IReadOnlyList<PaymentMethodConfigurationItem> Methods);
+
+/// <summary>A single provider catalog entry fetched live from the provider.</summary>
+/// <param name="MethodType">Stable method identifier.</param>
+/// <param name="Category">Grouping category for the checkout UI.</param>
+/// <param name="DisplayLabel">Provider-native display label (caller can still localize).</param>
+/// <param name="Capability">Live capability metadata reported by the provider.</param>
+/// <param name="IsActive">Whether the method is currently active on the platform.</param>
+/// <param name="HasSnapshot">Whether the activation record already carries a capability snapshot.</param>
+public sealed record PaymentCatalogMethod(
+    string MethodType,
+    PaymentMethodCategory Category,
+    string DisplayLabel,
+    PaymentMethodCapabilityResponse Capability,
+    bool IsActive,
+    bool HasSnapshot);
+
+/// <summary>Catalog response for a single provider.</summary>
+public sealed record PaymentProviderCatalogResponse(
+    string ProviderName,
+    IReadOnlyList<PaymentCatalogMethod> Methods);
+
+/// <summary>API-facing shape of <see cref="Contracts.PaymentMethodCapability"/>.</summary>
+/// <param name="SupportedCountries">ISO-3166 alpha-2 codes. Empty = global.</param>
+/// <param name="SupportedCurrencies">ISO-4217 alpha-3 codes. Empty = all.</param>
+/// <param name="SupportedSequenceTypes">Sequence mode names: <c>oneoff</c>, <c>first</c>, <c>recurring</c>.</param>
+/// <param name="AmountBounds">Per-currency amount bounds.</param>
+public sealed record PaymentMethodCapabilityResponse(
+    IReadOnlyList<string> SupportedCountries,
+    IReadOnlyList<string> SupportedCurrencies,
+    IReadOnlyList<string> SupportedSequenceTypes,
+    IReadOnlyList<PaymentMethodAmountBoundResponse> AmountBounds);
+
+/// <summary>API-facing shape of <see cref="Domain.PaymentMethodAmountBound"/>.</summary>
+/// <param name="CurrencyCode">ISO-4217 alpha-3 code.</param>
+/// <param name="MinAmount">Minimum accepted amount, or <see langword="null"/> for no floor.</param>
+/// <param name="MaxAmount">Maximum accepted amount, or <see langword="null"/> for no ceiling.</param>
+public sealed record PaymentMethodAmountBoundResponse(
+    string CurrencyCode,
+    decimal? MinAmount,
+    decimal? MaxAmount);

--- a/src/Granit.Payments.Endpoints/Dtos/PaymentMethodResponse.cs
+++ b/src/Granit.Payments.Endpoints/Dtos/PaymentMethodResponse.cs
@@ -18,8 +18,18 @@ public sealed record PaymentMethodResponse(
 /// <summary>
 /// Available payment method that a tenant can use, as reported by the provider.
 /// </summary>
+/// <param name="MethodType">Stable method identifier.</param>
+/// <param name="Category">Grouping category for the checkout UI.</param>
+/// <param name="ProviderName">Provider that will process charges for this method.</param>
+/// <param name="DisplayLabel">Localized display label.</param>
+/// <param name="Capability">
+/// Capability snapshot for this method (countries, currencies, bounds, sequence types).
+/// <see langword="null"/> when the method was activated before snapshotting was introduced —
+/// callers should treat null as wildcard.
+/// </param>
 public sealed record PaymentAvailableMethodResponse(
     string MethodType,
     PaymentMethodCategory Category,
     string ProviderName,
-    string DisplayLabel);
+    string DisplayLabel,
+    PaymentMethodCapabilityResponse? Capability);

--- a/src/Granit.Payments.Endpoints/Endpoints/PaymentMethodConfigurationEndpoints.cs
+++ b/src/Granit.Payments.Endpoints/Endpoints/PaymentMethodConfigurationEndpoints.cs
@@ -1,5 +1,6 @@
 using Granit.Authorization.Extensions;
 using Granit.Guids;
+using Granit.Http.Idempotency.Attributes;
 using Granit.Payments.Contracts;
 using Granit.Payments.Domain;
 using Granit.Payments.Endpoints.Dtos;
@@ -46,6 +47,7 @@ internal static class PaymentMethodConfigurationEndpoints
             .Produces<PaymentMethodConfigurationItem>()
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithMetadata(new IdempotentAttribute { Required = false })
             .RequireAuthorization(PaymentsPermissions.Configuration.Manage)
             .AllowHostAccess();
 
@@ -58,6 +60,7 @@ internal static class PaymentMethodConfigurationEndpoints
             .Produces<PaymentMethodConfigurationItem>()
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithMetadata(new IdempotentAttribute { Required = false })
             .RequireAuthorization(PaymentsPermissions.Configuration.Manage)
             .AllowHostAccess();
 

--- a/src/Granit.Payments.Endpoints/Endpoints/PaymentMethodConfigurationEndpoints.cs
+++ b/src/Granit.Payments.Endpoints/Endpoints/PaymentMethodConfigurationEndpoints.cs
@@ -31,19 +31,32 @@ internal static class PaymentMethodConfigurationEndpoints
             .WithDescription(
                 "Returns the fused view of all payment methods supported by registered IPaymentProvider "
                 + "instances, grouped by provider. Each method shows its localized display label, category "
-                + "and current activation state. Use the /{provider}/{method}/activate and /deactivate "
-                + "endpoints to toggle a method.")
+                + "and current activation state plus the capability snapshot captured at activation time.")
             .Produces<IReadOnlyList<PaymentProviderConfigurationResponse>>()
+            .RequireAuthorization(PaymentsPermissions.Configuration.Manage)
+            .AllowHostAccess();
+
+        config.MapGet("/catalog", GetCatalogAsync)
+            .WithName("GetPaymentProviderCatalog")
+            .WithSummary("Returns the live catalog of a specific provider with activation state.")
+            .WithDescription(
+                "Calls IPaymentProvider.GetCatalogAsync on the named provider and cross-references the "
+                + "result with the current activation records. Use this endpoint to power admin UIs where "
+                + "new provider methods should appear automatically (before any activation has snapshotted "
+                + "them). Returns 404 if the provider is not registered.")
+            .Produces<PaymentProviderCatalogResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(PaymentsPermissions.Configuration.Manage)
             .AllowHostAccess();
 
         config.MapPost("/{providerName}/{methodType}/activate", ActivateAsync)
             .WithName("ActivatePaymentMethodConfiguration")
-            .WithSummary("Activates a payment method for the platform.")
+            .WithSummary("Activates a payment method for the platform and snapshots its capability.")
             .WithDescription(
-                "Marks the method declared by the given provider as active. Idempotent: calling on an "
-                + "already-active method returns 200 OK with no change. Returns 404 if the provider is "
-                + "not registered, 400 if the provider does not declare the given method type.")
+                "Marks the method declared by the given provider as active and captures its current "
+                + "capability (countries, currencies, amount bounds, sequence types) on the activation "
+                + "record. Idempotent. Returns 404 if the provider is not registered, 400 if the provider "
+                + "no longer offers the given method type.")
             .Produces<PaymentMethodConfigurationItem>()
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
@@ -56,7 +69,21 @@ internal static class PaymentMethodConfigurationEndpoints
             .WithSummary("Deactivates a payment method for the platform.")
             .WithDescription(
                 "Marks the method as inactive. Tenants will no longer see it in GET /methods/available. "
-                + "Idempotent: calling on an already-inactive (or never-activated) method returns 200 OK.")
+                + "The capability snapshot is preserved so a future reactivation does not require a re-sync.")
+            .Produces<PaymentMethodConfigurationItem>()
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithMetadata(new IdempotentAttribute { Required = false })
+            .RequireAuthorization(PaymentsPermissions.Configuration.Manage)
+            .AllowHostAccess();
+
+        config.MapPost("/{providerName}/{methodType}/resync", ResyncAsync)
+            .WithName("ResyncPaymentMethodConfiguration")
+            .WithSummary("Re-fetches the provider catalog and updates the capability snapshot.")
+            .WithDescription(
+                "Calls IPaymentProvider.GetCatalogAsync and overwrites the capability snapshot on the "
+                + "existing activation record. Use this to propagate provider-side changes (added "
+                + "countries, updated amount bounds) without deactivating/reactivating the method.")
             .Produces<PaymentMethodConfigurationItem>()
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
@@ -80,78 +107,44 @@ internal static class PaymentMethodConfigurationEndpoints
         IReadOnlyList<PaymentMethodConfiguration> configs = await reader
             .GetAllAsync(cancellationToken).ConfigureAwait(false);
 
-        var activeByKey = configs.ToDictionary(
+        var configsByKey = configs.ToDictionary(
             c => (c.ProviderName, c.MethodType),
-            c => c.IsActive,
+            c => c,
             new ProviderMethodKeyComparer());
 
-        var response = providers
-            .Select(p => new PaymentProviderConfigurationResponse(
-                p.Name,
-                p.SupportedMethods
-                    .Select(d => new PaymentMethodConfigurationItem(
-                        d.MethodType,
-                        PaymentMethodLabelResolver.Resolve(localizer, d.MethodType),
-                        d.Category,
-                        activeByKey.TryGetValue((p.Name, d.MethodType), out bool active) && active))
-                    .ToList()))
-            .OrderBy(g => g.ProviderName)
-            .ToList();
+        List<PaymentProviderConfigurationResponse> response = [];
+        foreach (IPaymentProvider provider in providers.OrderBy(p => p.Name, StringComparer.Ordinal))
+        {
+            List<PaymentMethodConfigurationItem> methods = [];
+            foreach (PaymentMethodDescriptor descriptor in provider.SupportedMethods)
+            {
+                configsByKey.TryGetValue((provider.Name, descriptor.MethodType), out PaymentMethodConfiguration? config);
+                PaymentMethodCapability? snapshot = config?.GetCapabilitySnapshot();
+
+                methods.Add(new PaymentMethodConfigurationItem(
+                    MethodType: descriptor.MethodType,
+                    DisplayLabel: PaymentMethodLabelResolver.Resolve(localizer, descriptor.MethodType),
+                    Category: descriptor.Category,
+                    IsActive: config?.IsActive ?? false,
+                    CapabilitySnapshot: PaymentMethodCapabilityMapper.ToResponseOrNull(snapshot)));
+            }
+
+            response.Add(new PaymentProviderConfigurationResponse(provider.Name, methods));
+        }
 
         return TypedResults.Ok<IReadOnlyList<PaymentProviderConfigurationResponse>>(response);
     }
 
     // -------------------------------------------------------------------------
-    // POST /{provider}/{method}/activate
+    // GET /catalog?providerName=
     // -------------------------------------------------------------------------
 
-    private static Task<Results<Ok<PaymentMethodConfigurationItem>, ProblemHttpResult>> ActivateAsync(
-        string providerName,
-        string methodType,
+    private static async Task<Results<Ok<PaymentProviderCatalogResponse>, ProblemHttpResult>> GetCatalogAsync(
+        [FromQuery] string providerName,
         [FromServices] IEnumerable<IPaymentProvider> providers,
         [FromServices] IPaymentMethodConfigurationReader reader,
-        [FromServices] IPaymentMethodConfigurationWriter writer,
-        [FromServices] IGuidGenerator guidGenerator,
-        [FromServices] IStringLocalizer<PaymentsEndpointsLocalizationResource> localizer,
-        [FromServices] IFusionCache cache,
-        CancellationToken cancellationToken) =>
-        ToggleAsync(providerName, methodType, activate: true,
-            providers, reader, writer, guidGenerator, localizer, cache, cancellationToken);
-
-    // -------------------------------------------------------------------------
-    // POST /{provider}/{method}/deactivate
-    // -------------------------------------------------------------------------
-
-    private static Task<Results<Ok<PaymentMethodConfigurationItem>, ProblemHttpResult>> DeactivateAsync(
-        string providerName,
-        string methodType,
-        [FromServices] IEnumerable<IPaymentProvider> providers,
-        [FromServices] IPaymentMethodConfigurationReader reader,
-        [FromServices] IPaymentMethodConfigurationWriter writer,
-        [FromServices] IGuidGenerator guidGenerator,
-        [FromServices] IStringLocalizer<PaymentsEndpointsLocalizationResource> localizer,
-        [FromServices] IFusionCache cache,
-        CancellationToken cancellationToken) =>
-        ToggleAsync(providerName, methodType, activate: false,
-            providers, reader, writer, guidGenerator, localizer, cache, cancellationToken);
-
-    // -------------------------------------------------------------------------
-    // Shared toggle logic
-    // -------------------------------------------------------------------------
-
-    private static async Task<Results<Ok<PaymentMethodConfigurationItem>, ProblemHttpResult>> ToggleAsync(
-        string providerName,
-        string methodType,
-        bool activate,
-        [FromServices] IEnumerable<IPaymentProvider> providers,
-        [FromServices] IPaymentMethodConfigurationReader reader,
-        [FromServices] IPaymentMethodConfigurationWriter writer,
-        [FromServices] IGuidGenerator guidGenerator,
-        [FromServices] IStringLocalizer<PaymentsEndpointsLocalizationResource> localizer,
-        [FromServices] IFusionCache cache,
         CancellationToken cancellationToken)
     {
-        // 1. Validate provider exists in DI
         IPaymentProvider? provider = providers
             .FirstOrDefault(p => p.Name.Equals(providerName, StringComparison.OrdinalIgnoreCase));
 
@@ -162,7 +155,112 @@ internal static class PaymentMethodConfigurationEndpoints
                 detail: $"Payment provider '{providerName}' is not registered.");
         }
 
-        // 2. Validate method is declared by the provider
+        IReadOnlyList<PaymentMethodCatalogEntry> catalog = await provider
+            .GetCatalogAsync(cancellationToken).ConfigureAwait(false);
+
+        IReadOnlyList<PaymentMethodConfiguration> allConfigs = await reader
+            .GetAllAsync(cancellationToken).ConfigureAwait(false);
+
+        var configsForProvider = allConfigs
+            .Where(c => c.ProviderName.Equals(provider.Name, StringComparison.OrdinalIgnoreCase))
+            .ToDictionary(c => c.MethodType, c => c, StringComparer.OrdinalIgnoreCase);
+
+        List<PaymentCatalogMethod> methods = [];
+        foreach (PaymentMethodCatalogEntry entry in catalog)
+        {
+            configsForProvider.TryGetValue(entry.MethodType, out PaymentMethodConfiguration? config);
+
+            methods.Add(new PaymentCatalogMethod(
+                MethodType: entry.MethodType,
+                Category: entry.Category,
+                DisplayLabel: entry.DisplayLabel,
+                Capability: PaymentMethodCapabilityMapper.ToResponse(entry.Capability),
+                IsActive: config?.IsActive ?? false,
+                HasSnapshot: config?.GetCapabilitySnapshot() is not null));
+        }
+
+        return TypedResults.Ok(new PaymentProviderCatalogResponse(provider.Name, methods));
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /{provider}/{method}/activate
+    // -------------------------------------------------------------------------
+
+    private static async Task<Results<Ok<PaymentMethodConfigurationItem>, ProblemHttpResult>> ActivateAsync(
+        string providerName,
+        string methodType,
+        [FromServices] IEnumerable<IPaymentProvider> providers,
+        [FromServices] IPaymentMethodConfigurationWriter writer,
+        [FromServices] IGuidGenerator guidGenerator,
+        [FromServices] IStringLocalizer<PaymentsEndpointsLocalizationResource> localizer,
+        [FromServices] IFusionCache cache,
+        CancellationToken cancellationToken)
+    {
+        IPaymentProvider? provider = providers
+            .FirstOrDefault(p => p.Name.Equals(providerName, StringComparison.OrdinalIgnoreCase));
+
+        if (provider is null)
+        {
+            return TypedResults.Problem(
+                statusCode: StatusCodes.Status404NotFound,
+                detail: $"Payment provider '{providerName}' is not registered.");
+        }
+
+        IReadOnlyList<PaymentMethodCatalogEntry> catalog = await provider
+            .GetCatalogAsync(cancellationToken).ConfigureAwait(false);
+
+        PaymentMethodCatalogEntry? entry = catalog
+            .FirstOrDefault(e => e.MethodType.Equals(methodType, StringComparison.OrdinalIgnoreCase));
+
+        if (entry is null)
+        {
+            return TypedResults.Problem(
+                statusCode: StatusCodes.Status400BadRequest,
+                detail: $"Provider '{providerName}' does not currently offer method type '{methodType}'.");
+        }
+
+        await writer.UpsertActivationWithSnapshotAsync(
+            guidGenerator.Create(),
+            provider.Name,
+            entry.MethodType,
+            entry.Capability,
+            cancellationToken).ConfigureAwait(false);
+
+        await cache.RemoveAsync(ResolverCacheKey, token: cancellationToken).ConfigureAwait(false);
+
+        return TypedResults.Ok(new PaymentMethodConfigurationItem(
+            MethodType: entry.MethodType,
+            DisplayLabel: PaymentMethodLabelResolver.Resolve(localizer, entry.MethodType),
+            Category: entry.Category,
+            IsActive: true,
+            CapabilitySnapshot: PaymentMethodCapabilityMapper.ToResponse(entry.Capability)));
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /{provider}/{method}/deactivate
+    // -------------------------------------------------------------------------
+
+    private static async Task<Results<Ok<PaymentMethodConfigurationItem>, ProblemHttpResult>> DeactivateAsync(
+        string providerName,
+        string methodType,
+        [FromServices] IEnumerable<IPaymentProvider> providers,
+        [FromServices] IPaymentMethodConfigurationReader reader,
+        [FromServices] IPaymentMethodConfigurationWriter writer,
+        [FromServices] IGuidGenerator guidGenerator,
+        [FromServices] IStringLocalizer<PaymentsEndpointsLocalizationResource> localizer,
+        [FromServices] IFusionCache cache,
+        CancellationToken cancellationToken)
+    {
+        IPaymentProvider? provider = providers
+            .FirstOrDefault(p => p.Name.Equals(providerName, StringComparison.OrdinalIgnoreCase));
+
+        if (provider is null)
+        {
+            return TypedResults.Problem(
+                statusCode: StatusCodes.Status404NotFound,
+                detail: $"Payment provider '{providerName}' is not registered.");
+        }
+
         PaymentMethodDescriptor? descriptor = provider.SupportedMethods
             .FirstOrDefault(d => d.MethodType.Equals(methodType, StringComparison.OrdinalIgnoreCase));
 
@@ -173,25 +271,85 @@ internal static class PaymentMethodConfigurationEndpoints
                 detail: $"Provider '{providerName}' does not support method type '{methodType}'.");
         }
 
-        // 3. Race-safe upsert — the store handles DbUpdateException internally
         await writer.UpsertActivationAsync(
             guidGenerator.Create(),
             provider.Name,
             descriptor.MethodType,
-            activate,
+            isActive: false,
             cancellationToken).ConfigureAwait(false);
 
-        // 4. Proactive cache invalidation — tenants see the change immediately
         await cache.RemoveAsync(ResolverCacheKey, token: cancellationToken).ConfigureAwait(false);
 
-        // 5. Return the merged view for this method
-        var item = new PaymentMethodConfigurationItem(
-            descriptor.MethodType,
-            PaymentMethodLabelResolver.Resolve(localizer, descriptor.MethodType),
-            descriptor.Category,
-            activate);
+        PaymentMethodConfiguration? config = await reader
+            .FindAsync(provider.Name, descriptor.MethodType, cancellationToken).ConfigureAwait(false);
 
-        return TypedResults.Ok(item);
+        return TypedResults.Ok(new PaymentMethodConfigurationItem(
+            MethodType: descriptor.MethodType,
+            DisplayLabel: PaymentMethodLabelResolver.Resolve(localizer, descriptor.MethodType),
+            Category: descriptor.Category,
+            IsActive: false,
+            CapabilitySnapshot: PaymentMethodCapabilityMapper.ToResponseOrNull(config?.GetCapabilitySnapshot())));
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /{provider}/{method}/resync
+    // -------------------------------------------------------------------------
+
+    private static async Task<Results<Ok<PaymentMethodConfigurationItem>, ProblemHttpResult>> ResyncAsync(
+        string providerName,
+        string methodType,
+        [FromServices] IEnumerable<IPaymentProvider> providers,
+        [FromServices] IPaymentMethodConfigurationReader reader,
+        [FromServices] IPaymentMethodConfigurationWriter writer,
+        [FromServices] IStringLocalizer<PaymentsEndpointsLocalizationResource> localizer,
+        [FromServices] IFusionCache cache,
+        CancellationToken cancellationToken)
+    {
+        IPaymentProvider? provider = providers
+            .FirstOrDefault(p => p.Name.Equals(providerName, StringComparison.OrdinalIgnoreCase));
+
+        if (provider is null)
+        {
+            return TypedResults.Problem(
+                statusCode: StatusCodes.Status404NotFound,
+                detail: $"Payment provider '{providerName}' is not registered.");
+        }
+
+        PaymentMethodConfiguration? existing = await reader
+            .FindAsync(provider.Name, methodType, cancellationToken).ConfigureAwait(false);
+
+        if (existing is null)
+        {
+            return TypedResults.Problem(
+                statusCode: StatusCodes.Status404NotFound,
+                detail: $"No configuration exists for '{providerName}'/'{methodType}'. Activate it first.");
+        }
+
+        IReadOnlyList<PaymentMethodCatalogEntry> catalog = await provider
+            .GetCatalogAsync(cancellationToken).ConfigureAwait(false);
+
+        PaymentMethodCatalogEntry? entry = catalog
+            .FirstOrDefault(e => e.MethodType.Equals(methodType, StringComparison.OrdinalIgnoreCase));
+
+        if (entry is null)
+        {
+            return TypedResults.Problem(
+                statusCode: StatusCodes.Status400BadRequest,
+                detail: $"Provider '{providerName}' no longer offers method type '{methodType}'.");
+        }
+
+        await writer.UpdateCapabilitySnapshotAsync(
+            provider.Name, entry.MethodType, entry.Capability, cancellationToken)
+            .ConfigureAwait(false);
+
+        await cache.RemoveAsync(ResolverCacheKey, token: cancellationToken).ConfigureAwait(false);
+
+        return TypedResults.Ok(new PaymentMethodConfigurationItem(
+            MethodType: entry.MethodType,
+            DisplayLabel: PaymentMethodLabelResolver.Resolve(localizer, entry.MethodType),
+            Category: entry.Category,
+            IsActive: existing.IsActive,
+            CapabilitySnapshot: PaymentMethodCapabilityMapper.ToResponse(entry.Capability)));
     }
 
     private sealed class ProviderMethodKeyComparer : IEqualityComparer<(string Provider, string Method)>

--- a/src/Granit.Payments.Endpoints/Endpoints/PaymentMethodEndpoints.cs
+++ b/src/Granit.Payments.Endpoints/Endpoints/PaymentMethodEndpoints.cs
@@ -34,12 +34,16 @@ internal static class PaymentMethodEndpoints
 
         group.MapGet("/methods/available", GetAvailableAsync)
             .WithName("GetAvailablePaymentMethods")
-            .WithSummary("Lists payment methods available for the current tenant.")
+            .WithSummary("Lists payment methods available for the current tenant and request context.")
             .WithDescription(
-                "Returns the payment methods that the tenant can use based on the configured "
-                + "providers. This includes method types, categories, and display labels as "
-                + "reported by the active payment providers.")
+                "Returns the payment methods that the tenant can use, filtered against the request "
+                + "context (billing country, currency, amount, sequence type). Each method returns its "
+                + "capability snapshot so the front-end can render explanatory UI "
+                + "(e.g., 'available in BE only', Klarna amount bounds). Query params are optional: an "
+                + "absent axis skips filtering on that axis. Returns 400 for malformed country/currency/"
+                + "amount/sequenceType values.")
             .Produces<IReadOnlyList<PaymentAvailableMethodResponse>>()
+            .ProducesProblem(StatusCodes.Status400BadRequest)
             .RequireAuthorization(PaymentsPermissions.Methods.Read)
             .AllowHostAccess();
 
@@ -89,26 +93,40 @@ internal static class PaymentMethodEndpoints
         return TypedResults.Ok(response);
     }
 
-    private static async Task<Ok<IReadOnlyList<PaymentAvailableMethodResponse>>> GetAvailableAsync(
+    private static async Task<Results<Ok<IReadOnlyList<PaymentAvailableMethodResponse>>, ProblemHttpResult>> GetAvailableAsync(
         [FromServices] IPaymentProviderResolver resolver,
         [FromServices] ICurrentTenant currentTenant,
         [FromServices] IStringLocalizer<PaymentsEndpointsLocalizationResource> localizer,
+        [FromQuery] string? country,
+        [FromQuery] string? currency,
+        [FromQuery] decimal? amount,
+        [FromQuery] string? sequenceType,
         CancellationToken cancellationToken)
     {
+        PaymentAvailabilityContext? context =
+            PaymentAvailabilityContextParser.TryParse(country, currency, amount, sequenceType, out string? error);
+
+        if (error is not null)
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status400BadRequest, detail: error);
+        }
+
         Guid tenantId = currentTenant.Id ?? Guid.Empty;
 
-        IReadOnlyList<PaymentAvailableMethod> available =
-            await resolver.GetAvailableProvidersAsync(tenantId, cancellationToken).ConfigureAwait(false);
+        IReadOnlyList<PaymentAvailableMethod> available = await resolver
+            .GetAvailableProvidersAsync(tenantId, context, cancellationToken)
+            .ConfigureAwait(false);
 
         IReadOnlyList<PaymentAvailableMethodResponse> response = available
             .Select(a => new PaymentAvailableMethodResponse(
                 a.MethodType,
                 a.Category,
                 a.ProviderName,
-                PaymentMethodLabelResolver.Resolve(localizer, a.MethodType)))
+                PaymentMethodLabelResolver.Resolve(localizer, a.MethodType),
+                PaymentMethodCapabilityMapper.ToResponseOrNull(a.Capability)))
             .ToList();
 
-        return TypedResults.Ok(response);
+        return TypedResults.Ok<IReadOnlyList<PaymentAvailableMethodResponse>>(response);
     }
 
     private static async Task<Results<Created<PaymentMethodResponse>, ProblemHttpResult>> AttachAsync(

--- a/src/Granit.Payments.Endpoints/Internal/PaymentAvailabilityContextParser.cs
+++ b/src/Granit.Payments.Endpoints/Internal/PaymentAvailabilityContextParser.cs
@@ -1,0 +1,88 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Granit.Payments.Contracts;
+using Granit.Payments.Domain;
+
+namespace Granit.Payments.Endpoints.Internal;
+
+/// <summary>
+/// Parses and validates the <c>GET /methods/available</c> query parameters into a
+/// <see cref="PaymentAvailabilityContext"/>.
+/// </summary>
+internal static partial class PaymentAvailabilityContextParser
+{
+    [GeneratedRegex("^[A-Z]{2}$", RegexOptions.CultureInvariant, 50)]
+    private static partial Regex CountryRegex();
+
+    [GeneratedRegex("^[A-Z]{3}$", RegexOptions.CultureInvariant, 50)]
+    private static partial Regex CurrencyRegex();
+
+    /// <summary>
+    /// Builds a <see cref="PaymentAvailabilityContext"/> from raw query values, returning
+    /// <see langword="null"/> when no axis is set. Writes a human-readable reason into
+    /// <paramref name="error"/> when any axis is malformed.
+    /// </summary>
+    public static PaymentAvailabilityContext? TryParse(
+        string? country,
+        string? currency,
+        decimal? amount,
+        string? sequenceType,
+        out string? error)
+    {
+        error = null;
+
+        string? normalizedCountry = null;
+        if (!string.IsNullOrWhiteSpace(country))
+        {
+            normalizedCountry = country.Trim().ToUpperInvariant();
+            if (!CountryRegex().IsMatch(normalizedCountry))
+            {
+                error = $"'{country}' is not a valid ISO-3166 alpha-2 country code.";
+                return null;
+            }
+        }
+
+        string? normalizedCurrency = null;
+        if (!string.IsNullOrWhiteSpace(currency))
+        {
+            normalizedCurrency = currency.Trim().ToUpperInvariant();
+            if (!CurrencyRegex().IsMatch(normalizedCurrency))
+            {
+                error = $"'{currency}' is not a valid ISO-4217 alpha-3 currency code.";
+                return null;
+            }
+        }
+
+        if (amount is < 0m)
+        {
+            error = $"amount must be non-negative (received {amount.Value.ToString(CultureInfo.InvariantCulture)}).";
+            return null;
+        }
+
+        PaymentMethodSequenceType sequence = PaymentMethodSequenceType.OneOff;
+        if (!string.IsNullOrWhiteSpace(sequenceType))
+        {
+            sequence = sequenceType.Trim().ToLowerInvariant() switch
+            {
+                "oneoff" => PaymentMethodSequenceType.OneOff,
+                "first" => PaymentMethodSequenceType.First,
+                "recurring" => PaymentMethodSequenceType.Recurring,
+                _ => PaymentMethodSequenceType.None,
+            };
+
+            if (sequence == PaymentMethodSequenceType.None)
+            {
+                error = $"'{sequenceType}' is not a valid sequence type (expected: oneoff, first, recurring).";
+                return null;
+            }
+        }
+
+        if (normalizedCountry is null && normalizedCurrency is null && amount is null
+            && string.IsNullOrWhiteSpace(sequenceType))
+        {
+            return null;
+        }
+
+        return new PaymentAvailabilityContext(normalizedCountry, normalizedCurrency, amount, sequence);
+    }
+}

--- a/src/Granit.Payments.Endpoints/Internal/PaymentMethodCapabilityMapper.cs
+++ b/src/Granit.Payments.Endpoints/Internal/PaymentMethodCapabilityMapper.cs
@@ -1,0 +1,54 @@
+using Granit.Payments.Contracts;
+using Granit.Payments.Domain;
+using Granit.Payments.Endpoints.Dtos;
+
+namespace Granit.Payments.Endpoints.Internal;
+
+/// <summary>
+/// Maps between <see cref="PaymentMethodCapability"/> (domain) and
+/// <see cref="PaymentMethodCapabilityResponse"/> (API surface).
+/// </summary>
+internal static class PaymentMethodCapabilityMapper
+{
+    public static PaymentMethodCapabilityResponse ToResponse(PaymentMethodCapability capability)
+    {
+        ArgumentNullException.ThrowIfNull(capability);
+
+        return new PaymentMethodCapabilityResponse(
+            SupportedCountries: [.. capability.SupportedCountries.OrderBy(c => c, StringComparer.Ordinal)],
+            SupportedCurrencies: [.. capability.SupportedCurrencies.OrderBy(c => c, StringComparer.Ordinal)],
+            SupportedSequenceTypes: FlagsToNames(capability.SupportedSequenceTypes),
+            AmountBounds:
+            [
+                .. capability.AmountBounds
+                    .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+                    .Select(kv => new PaymentMethodAmountBoundResponse(
+                        kv.Value.CurrencyCode, kv.Value.MinAmount, kv.Value.MaxAmount)),
+            ]);
+    }
+
+    public static PaymentMethodCapabilityResponse? ToResponseOrNull(PaymentMethodCapability? capability) =>
+        capability is null ? null : ToResponse(capability);
+
+    private static List<string> FlagsToNames(PaymentMethodSequenceType flags)
+    {
+        List<string> names = new(3);
+
+        if (flags.HasFlag(PaymentMethodSequenceType.OneOff))
+        {
+            names.Add("oneoff");
+        }
+
+        if (flags.HasFlag(PaymentMethodSequenceType.First))
+        {
+            names.Add("first");
+        }
+
+        if (flags.HasFlag(PaymentMethodSequenceType.Recurring))
+        {
+            names.Add("recurring");
+        }
+
+        return names;
+    }
+}

--- a/src/Granit.Payments.EntityFrameworkCore/Internal/EfPaymentMethodConfigurationStore.cs
+++ b/src/Granit.Payments.EntityFrameworkCore/Internal/EfPaymentMethodConfigurationStore.cs
@@ -1,3 +1,4 @@
+using Granit.Payments.Contracts;
 using Granit.Payments.Domain;
 using Microsoft.EntityFrameworkCore;
 
@@ -153,5 +154,83 @@ internal sealed class EfPaymentMethodConfigurationStore(
         }
 
         await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task UpsertActivationWithSnapshotAsync(
+        Guid newId,
+        string providerName,
+        string methodType,
+        PaymentMethodCapability capability,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(capability);
+
+        await using PaymentsDbContext db = await contextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        PaymentMethodConfiguration? existing = await db.PaymentMethodConfigurations
+            .FirstOrDefaultAsync(
+                c => c.ProviderName == providerName && c.MethodType == methodType,
+                cancellationToken).ConfigureAwait(false);
+
+        if (existing is null)
+        {
+            var created = PaymentMethodConfiguration.Activate(newId, providerName, methodType);
+            created.SnapshotCapability(capability);
+
+            db.PaymentMethodConfigurations.Add(created);
+
+            try
+            {
+                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                return;
+            }
+            catch (DbUpdateException)
+            {
+                db.PaymentMethodConfigurations.Remove(created);
+                db.ChangeTracker.Clear();
+
+                existing = await db.PaymentMethodConfigurations
+                    .FirstOrDefaultAsync(
+                        c => c.ProviderName == providerName && c.MethodType == methodType,
+                        cancellationToken).ConfigureAwait(false);
+
+                if (existing is null)
+                {
+                    throw;
+                }
+            }
+        }
+
+        existing.Activate();
+        existing.SnapshotCapability(capability);
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<bool> UpdateCapabilitySnapshotAsync(
+        string providerName,
+        string methodType,
+        PaymentMethodCapability capability,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(capability);
+
+        await using PaymentsDbContext db = await contextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        PaymentMethodConfiguration? existing = await db.PaymentMethodConfigurations
+            .FirstOrDefaultAsync(
+                c => c.ProviderName == providerName && c.MethodType == methodType,
+                cancellationToken).ConfigureAwait(false);
+
+        if (existing is null)
+        {
+            return false;
+        }
+
+        existing.SnapshotCapability(capability);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return true;
     }
 }

--- a/src/Granit.Payments.EntityFrameworkCore/Internal/PaymentMethodConfigurationEntityTypeConfiguration.cs
+++ b/src/Granit.Payments.EntityFrameworkCore/Internal/PaymentMethodConfigurationEntityTypeConfiguration.cs
@@ -1,12 +1,19 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using Granit.Payments.Contracts;
 using Granit.Payments.Domain;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Granit.Payments.EntityFrameworkCore.Internal;
 
 internal sealed class PaymentMethodConfigurationEntityTypeConfiguration
     : IEntityTypeConfiguration<PaymentMethodConfiguration>
 {
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
     public void Configure(EntityTypeBuilder<PaymentMethodConfiguration> builder)
     {
         builder.ToTable(
@@ -19,8 +26,72 @@ internal sealed class PaymentMethodConfigurationEntityTypeConfiguration
         builder.Property(e => e.ProviderName).HasMaxLength(64).IsRequired();
         builder.Property(e => e.IsActive).IsRequired().HasDefaultValue(true);
 
+        ConfigureCapabilitySnapshot(builder);
+
         builder.HasIndex(e => new { e.ProviderName, e.MethodType })
             .IsUnique()
             .HasDatabaseName($"uq_{GranitPaymentsDbProperties.DbTablePrefix}method_configs_provider_method");
     }
+
+    private static void ConfigureCapabilitySnapshot(EntityTypeBuilder<PaymentMethodConfiguration> builder)
+    {
+        ValueConverter<ImmutableHashSet<string>?, string?> setConverter = new(
+            v => SetToCsv(v),
+            v => CsvToSet(v));
+
+        ValueComparer<ImmutableHashSet<string>?> setComparer = new(
+            (l, r) => ReferenceEquals(l, r) || (l != null && r != null && l.SetEquals(r)),
+            v => v == null ? 0 : v.Aggregate(0, (h, c) => HashCode.Combine(h, c)),
+            v => v);
+
+        builder.Property(e => e.SupportedCountries)
+            .HasConversion(setConverter, setComparer)
+            .HasMaxLength(512);
+
+        builder.Property(e => e.SupportedCurrencies)
+            .HasConversion(setConverter, setComparer)
+            .HasMaxLength(256);
+
+        builder.Property(e => e.SupportedSequenceTypes)
+            .HasConversion<int?>();
+
+        ValueConverter<ImmutableDictionary<string, PaymentMethodAmountBound>?, string?> boundsConverter = new(
+            v => BoundsToJson(v),
+            v => JsonToBounds(v));
+
+        ValueComparer<ImmutableDictionary<string, PaymentMethodAmountBound>?> boundsComparer = new(
+            (l, r) => ReferenceEquals(l, r) || (l != null && r != null
+                && l.Count == r.Count
+                && l.All(kv => r.ContainsKey(kv.Key) && kv.Value == r[kv.Key])),
+            v => v == null ? 0 : v.Aggregate(0, (h, kv) => HashCode.Combine(h, kv.Key, kv.Value)),
+            v => v);
+
+        builder.Property(e => e.AmountBounds)
+            .HasConversion(boundsConverter, boundsComparer);
+    }
+
+    private static string? SetToCsv(ImmutableHashSet<string>? set) =>
+        set switch
+        {
+            null => null,
+            { Count: 0 } => string.Empty,
+            _ => string.Join(',', set.OrderBy(s => s, StringComparer.Ordinal)),
+        };
+
+    private static ImmutableHashSet<string>? CsvToSet(string? csv) =>
+        csv switch
+        {
+            null => null,
+            "" => [],
+            _ => [.. csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)],
+        };
+
+    private static string? BoundsToJson(ImmutableDictionary<string, PaymentMethodAmountBound>? bounds) =>
+        bounds == null ? null : JsonSerializer.Serialize(bounds, JsonOptions);
+
+    private static ImmutableDictionary<string, PaymentMethodAmountBound>? JsonToBounds(string? json) =>
+        string.IsNullOrEmpty(json)
+            ? null
+            : JsonSerializer.Deserialize<Dictionary<string, PaymentMethodAmountBound>>(json, JsonOptions)
+                ?.ToImmutableDictionary(StringComparer.Ordinal);
 }

--- a/src/Granit.Payments.Mollie/GranitPaymentsMollieModule.cs
+++ b/src/Granit.Payments.Mollie/GranitPaymentsMollieModule.cs
@@ -1,4 +1,5 @@
 using Granit.Modularity;
+using Granit.Payments.HealthChecks;
 using Granit.Payments.Mollie.Internal;
 using Granit.Payments.Mollie.Options;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,5 +38,7 @@ public sealed class GranitPaymentsMollieModule : GranitModule
         context.Services.AddScoped<ICheckoutSessionFactory, MollieCheckoutSessionFactory>();
         context.Services.AddSingleton<IPaymentMethodManager, MolliePaymentMethodManager>();
         context.Services.AddScoped<IPaymentWebhookVerifier, MollieWebhookVerifier>();
+
+        context.Services.AddHealthChecks().AddGranitPaymentProviderHealthCheck("mollie");
     }
 }

--- a/src/Granit.Payments.Mollie/Internal/MollieCatalog.cs
+++ b/src/Granit.Payments.Mollie/Internal/MollieCatalog.cs
@@ -1,0 +1,140 @@
+using System.Collections.Immutable;
+using Granit.Payments.Contracts;
+using Granit.Payments.Domain;
+
+namespace Granit.Payments.Mollie.Internal;
+
+/// <summary>
+/// Static catalog of Mollie payment methods with their capability metadata.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mollie's <c>GET /v2/methods</c> endpoint does not expose per-method country lists,
+/// so we maintain them here from the Mollie documentation. Amount bounds come from
+/// Mollie's public method reference — a future iteration can replace this with a live
+/// call to <c>IMethodClient.GetMethodListAsync(include: "pricing")</c> to pick up
+/// bound updates automatically.
+/// </para>
+/// <para>
+/// Source: <c>https://docs.mollie.com/reference/v2/methods-api/list-methods</c> and
+/// per-method documentation pages (checked April 2026).
+/// </para>
+/// </remarks>
+internal static class MollieCatalog
+{
+    private static readonly ImmutableDictionary<string, PaymentMethodAmountBound> NoBounds =
+        ImmutableDictionary<string, PaymentMethodAmountBound>.Empty;
+
+    private static readonly ImmutableHashSet<string> GlobalCurrencies =
+        ImmutableHashSet<string>.Empty;
+
+    private static readonly ImmutableHashSet<string> Global =
+        ImmutableHashSet<string>.Empty;
+
+    private const PaymentMethodSequenceType AllSequences =
+        PaymentMethodSequenceType.OneOff | PaymentMethodSequenceType.First | PaymentMethodSequenceType.Recurring;
+
+    /// <summary>Ordered catalog entries covering Mollie's European surface.</summary>
+    public static IReadOnlyList<PaymentMethodCatalogEntry> Entries { get; } =
+    [
+        // Cards — global, all currencies, all sequences
+        new(PaymentMethods.Card, PaymentMethodCategory.Card, "Card", new(Global, GlobalCurrencies, AllSequences, NoBounds)),
+
+        // Bank redirects — typically OneOff | First (mandate setup possible), per-country
+        new(PaymentMethods.Bancontact, PaymentMethodCategory.BankRedirect, "Bancontact",
+            new(Set("BE"), PaymentMethodCurrencies.EurOnly,
+                PaymentMethodSequenceType.OneOff | PaymentMethodSequenceType.First, NoBounds)),
+
+        new(PaymentMethods.Ideal, PaymentMethodCategory.BankRedirect, "iDEAL",
+            new(Set("NL"), PaymentMethodCurrencies.EurOnly,
+                PaymentMethodSequenceType.OneOff | PaymentMethodSequenceType.First, NoBounds)),
+
+        new(PaymentMethods.Eps, PaymentMethodCategory.BankRedirect, "EPS",
+            new(Set("AT"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceType.OneOff, NoBounds)),
+
+        new(PaymentMethods.Giropay, PaymentMethodCategory.BankRedirect, "Giropay",
+            new(Set("DE"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceType.OneOff, NoBounds)),
+
+        new(PaymentMethods.Przelewy24, PaymentMethodCategory.BankRedirect, "Przelewy24",
+            new(Set("PL"), Set("PLN", "EUR"), PaymentMethodSequenceType.OneOff, NoBounds)),
+
+        new(PaymentMethods.Twint, PaymentMethodCategory.BankRedirect, "TWINT",
+            new(Set("CH"), Set("CHF"), PaymentMethodSequenceType.OneOff, NoBounds)),
+
+        new(PaymentMethods.Trustly, PaymentMethodCategory.BankRedirect, "Trustly",
+            new(Set("SE", "FI", "EE", "LV", "LT", "DK", "NO", "GB"), GlobalCurrencies,
+                PaymentMethodSequenceType.OneOff, NoBounds)),
+
+        new(PaymentMethods.MyBank, PaymentMethodCategory.BankRedirect, "MyBank",
+            new(Set("IT"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceType.OneOff, NoBounds)),
+
+        new(PaymentMethods.Belfius, PaymentMethodCategory.BankRedirect, "Belfius Pay Button",
+            new(Set("BE"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceType.OneOff, NoBounds)),
+
+        new(PaymentMethods.Kbc, PaymentMethodCategory.BankRedirect, "KBC/CBC Payment Button",
+            new(Set("BE"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceType.OneOff, NoBounds)),
+
+        // Bank transfer — SEPA zone, EUR, OneOff
+        new(PaymentMethods.BankTransfer, PaymentMethodCategory.BankTransfer, "Bank transfer",
+            new(PaymentMethodCountries.SepaZone, PaymentMethodCurrencies.EurOnly,
+                PaymentMethodSequenceType.OneOff, NoBounds)),
+
+        // SEPA Direct Debit — mandate-based, First | Recurring
+        new(PaymentMethods.SepaDebit, PaymentMethodCategory.BankDebit, "SEPA Direct Debit",
+            new(PaymentMethodCountries.SepaZone, PaymentMethodCurrencies.EurOnly,
+                PaymentMethodSequenceType.First | PaymentMethodSequenceType.Recurring, NoBounds)),
+
+        // Wallets — global
+        new(PaymentMethods.ApplePay, PaymentMethodCategory.Wallet, "Apple Pay",
+            new(Global, GlobalCurrencies, AllSequences, NoBounds)),
+
+        new(PaymentMethods.PayPal, PaymentMethodCategory.Wallet, "PayPal",
+            new(Global, GlobalCurrencies, AllSequences, NoBounds)),
+
+        // BNPL — country list plus amount bounds (Mollie docs, April 2026)
+        new(PaymentMethods.Klarna, PaymentMethodCategory.BuyNowPayLater, "Klarna",
+            new(
+                Set("AT", "BE", "CH", "CZ", "DE", "DK", "ES", "FI", "FR", "GB", "IE", "IT", "NL", "NO", "PL", "PT", "SE", "US"),
+                Set("EUR", "GBP", "SEK", "DKK", "NOK", "CHF", "USD"),
+                PaymentMethodSequenceType.OneOff,
+                Bounds(
+                    ("EUR", 1m, 10_000m),
+                    ("GBP", 1m, 10_000m),
+                    ("SEK", 10m, 100_000m),
+                    ("DKK", 10m, 75_000m),
+                    ("NOK", 10m, 100_000m),
+                    ("CHF", 1m, 10_000m),
+                    ("USD", 1m, 10_000m)))),
+
+        new(PaymentMethods.Riverty, PaymentMethodCategory.BuyNowPayLater, "Riverty",
+            new(
+                Set("AT", "CH", "DE", "NL"),
+                Set("EUR", "CHF"),
+                PaymentMethodSequenceType.OneOff,
+                Bounds(
+                    ("EUR", 5m, 1_500m),
+                    ("CHF", 5m, 1_500m)))),
+
+        // Vouchers — country-specific
+        new(PaymentMethods.Paysafecard, PaymentMethodCategory.Voucher, "Paysafecard",
+            new(Global, Set("EUR", "USD"), PaymentMethodSequenceType.OneOff,
+                Bounds(("EUR", 1m, 1_000m), ("USD", 1m, 1_000m)))),
+    ];
+
+    private static ImmutableHashSet<string> Set(params string[] values) =>
+        ImmutableHashSet.Create(StringComparer.Ordinal, values);
+
+    private static ImmutableDictionary<string, PaymentMethodAmountBound> Bounds(
+        params (string Currency, decimal Min, decimal Max)[] entries)
+    {
+        ImmutableDictionary<string, PaymentMethodAmountBound>.Builder builder =
+            ImmutableDictionary.CreateBuilder<string, PaymentMethodAmountBound>(StringComparer.Ordinal);
+
+        foreach ((string currency, decimal min, decimal max) in entries)
+        {
+            builder.Add(currency, new PaymentMethodAmountBound(currency, min, max));
+        }
+
+        return builder.ToImmutable();
+    }
+}

--- a/src/Granit.Payments.Mollie/Internal/MolliePaymentProvider.cs
+++ b/src/Granit.Payments.Mollie/Internal/MolliePaymentProvider.cs
@@ -59,17 +59,14 @@ internal sealed partial class MolliePaymentProvider(
     ];
 
     /// <inheritdoc/>
-    public Task<IReadOnlyList<PaymentMethodCatalogEntry>> GetCatalogAsync(CancellationToken cancellationToken = default)
-    {
-        // TODO(phase-2b): call IMethodClient.GetMethodListAsync(include: "pricing") and
-        // map pricing / min / max / countries / sequenceType into real capabilities.
-        IReadOnlyList<PaymentMethodCatalogEntry> catalog =
-        [
-            .. SupportedMethods.Select(m => new PaymentMethodCatalogEntry(
-                m.MethodType, m.Category, m.MethodType, PaymentMethodCapability.Wildcard)),
-        ];
-        return Task.FromResult(catalog);
-    }
+    /// <remarks>
+    /// Returns a static catalog curated from the Mollie documentation
+    /// (<see cref="MollieCatalog"/>). A future enhancement can call
+    /// <c>IMethodClient.GetMethodListAsync(include: "pricing")</c> to pick up
+    /// account-level toggles and up-to-date bounds.
+    /// </remarks>
+    public Task<IReadOnlyList<PaymentMethodCatalogEntry>> GetCatalogAsync(CancellationToken cancellationToken = default) =>
+        Task.FromResult(MollieCatalog.Entries);
 
     /// <inheritdoc/>
     public async Task<PaymentProviderChargeResult> ChargeAsync(

--- a/src/Granit.Payments.Mollie/Internal/MolliePaymentProvider.cs
+++ b/src/Granit.Payments.Mollie/Internal/MolliePaymentProvider.cs
@@ -59,6 +59,19 @@ internal sealed partial class MolliePaymentProvider(
     ];
 
     /// <inheritdoc/>
+    public Task<IReadOnlyList<PaymentMethodCatalogEntry>> GetCatalogAsync(CancellationToken cancellationToken = default)
+    {
+        // TODO(phase-2b): call IMethodClient.GetMethodListAsync(include: "pricing") and
+        // map pricing / min / max / countries / sequenceType into real capabilities.
+        IReadOnlyList<PaymentMethodCatalogEntry> catalog =
+        [
+            .. SupportedMethods.Select(m => new PaymentMethodCatalogEntry(
+                m.MethodType, m.Category, m.MethodType, PaymentMethodCapability.Wildcard)),
+        ];
+        return Task.FromResult(catalog);
+    }
+
+    /// <inheritdoc/>
     public async Task<PaymentProviderChargeResult> ChargeAsync(
         PaymentChargeRequest request, CancellationToken cancellationToken = default)
     {

--- a/src/Granit.Payments.SepaDirectDebit.Builtin/GranitPaymentsSepaDirectDebitBuiltinModule.cs
+++ b/src/Granit.Payments.SepaDirectDebit.Builtin/GranitPaymentsSepaDirectDebitBuiltinModule.cs
@@ -1,4 +1,5 @@
 using Granit.Modularity;
+using Granit.Payments.HealthChecks;
 using Granit.Payments.SepaDirectDebit.Builtin.Internal;
 using Granit.Payments.SepaDirectDebit.Builtin.Options;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,5 +22,7 @@ public sealed class GranitPaymentsSepaDirectDebitBuiltinModule : GranitModule
         context.Services.TryAddScoped<IDirectDebitProvider, BuiltinDirectDebitProvider>();
         context.Services.TryAddScoped<ICollectionFileGenerator, Pain008Generator>();
         context.Services.AddScoped<IPaymentProvider, SepaDirectDebitPaymentProvider>();
+
+        context.Services.AddHealthChecks().AddGranitPaymentProviderHealthCheck("sepa-direct-debit");
     }
 }

--- a/src/Granit.Payments.SepaDirectDebit.Builtin/Internal/SepaDirectDebitPaymentProvider.cs
+++ b/src/Granit.Payments.SepaDirectDebit.Builtin/Internal/SepaDirectDebitPaymentProvider.cs
@@ -23,6 +23,17 @@ internal sealed partial class SepaDirectDebitPaymentProvider(
     ];
 
     /// <inheritdoc/>
+    public Task<IReadOnlyList<PaymentMethodCatalogEntry>> GetCatalogAsync(CancellationToken cancellationToken = default)
+    {
+        // TODO(phase-2b): declare real capabilities — SEPA zone countries, {EUR}, First|Recurring.
+        IReadOnlyList<PaymentMethodCatalogEntry> catalog =
+        [
+            new(PaymentMethods.SepaDebit, PaymentMethodCategory.BankDebit, "SEPA Direct Debit", PaymentMethodCapability.Wildcard),
+        ];
+        return Task.FromResult(catalog);
+    }
+
+    /// <inheritdoc/>
     public Task<PaymentProviderChargeResult> ChargeAsync(
         PaymentChargeRequest request, CancellationToken cancellationToken = default)
     {

--- a/src/Granit.Payments.SepaDirectDebit.Builtin/Internal/SepaDirectDebitPaymentProvider.cs
+++ b/src/Granit.Payments.SepaDirectDebit.Builtin/Internal/SepaDirectDebitPaymentProvider.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Granit.Guids;
 using Granit.Payments.Contracts;
 using Granit.Payments.Domain;
@@ -25,10 +26,17 @@ internal sealed partial class SepaDirectDebitPaymentProvider(
     /// <inheritdoc/>
     public Task<IReadOnlyList<PaymentMethodCatalogEntry>> GetCatalogAsync(CancellationToken cancellationToken = default)
     {
-        // TODO(phase-2b): declare real capabilities — SEPA zone countries, {EUR}, First|Recurring.
         IReadOnlyList<PaymentMethodCatalogEntry> catalog =
         [
-            new(PaymentMethods.SepaDebit, PaymentMethodCategory.BankDebit, "SEPA Direct Debit", PaymentMethodCapability.Wildcard),
+            new(
+                MethodType: PaymentMethods.SepaDebit,
+                Category: PaymentMethodCategory.BankDebit,
+                DisplayLabel: "SEPA Direct Debit",
+                Capability: new PaymentMethodCapability(
+                    SupportedCountries: PaymentMethodCountries.SepaZone,
+                    SupportedCurrencies: PaymentMethodCurrencies.EurOnly,
+                    SupportedSequenceTypes: PaymentMethodSequenceType.First | PaymentMethodSequenceType.Recurring,
+                    AmountBounds: ImmutableDictionary<string, PaymentMethodAmountBound>.Empty)),
         ];
         return Task.FromResult(catalog);
     }

--- a/src/Granit.Payments.SepaTransfer/GranitPaymentsSepaTransferModule.cs
+++ b/src/Granit.Payments.SepaTransfer/GranitPaymentsSepaTransferModule.cs
@@ -1,4 +1,5 @@
 using Granit.Modularity;
+using Granit.Payments.HealthChecks;
 using Granit.Payments.SepaTransfer.Internal;
 using Granit.Payments.SepaTransfer.Options;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,5 +28,7 @@ public sealed class GranitPaymentsSepaTransferModule : GranitModule
 
         // Register CAMT.053 parser
         context.Services.AddSingleton<IBankStatementParser, Camt053Parser>();
+
+        context.Services.AddHealthChecks().AddGranitPaymentProviderHealthCheck("sepa-transfer");
     }
 }

--- a/src/Granit.Payments.SepaTransfer/Internal/SepaTransferPaymentProvider.cs
+++ b/src/Granit.Payments.SepaTransfer/Internal/SepaTransferPaymentProvider.cs
@@ -28,6 +28,17 @@ internal sealed partial class SepaTransferPaymentProvider(
     ];
 
     /// <inheritdoc/>
+    public Task<IReadOnlyList<PaymentMethodCatalogEntry>> GetCatalogAsync(CancellationToken cancellationToken = default)
+    {
+        // TODO(phase-2b): declare real capabilities — SEPA zone countries, {EUR}, OneOff.
+        IReadOnlyList<PaymentMethodCatalogEntry> catalog =
+        [
+            new(PaymentMethods.BankTransfer, PaymentMethodCategory.BankTransfer, "SEPA Transfer", PaymentMethodCapability.Wildcard),
+        ];
+        return Task.FromResult(catalog);
+    }
+
+    /// <inheritdoc/>
     public Task<PaymentProviderChargeResult> ChargeAsync(
         PaymentChargeRequest request, CancellationToken cancellationToken = default)
     {

--- a/src/Granit.Payments.SepaTransfer/Internal/SepaTransferPaymentProvider.cs
+++ b/src/Granit.Payments.SepaTransfer/Internal/SepaTransferPaymentProvider.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Granit.Guids;
 using Granit.Payments.Contracts;
 using Granit.Payments.Domain;
@@ -30,10 +31,17 @@ internal sealed partial class SepaTransferPaymentProvider(
     /// <inheritdoc/>
     public Task<IReadOnlyList<PaymentMethodCatalogEntry>> GetCatalogAsync(CancellationToken cancellationToken = default)
     {
-        // TODO(phase-2b): declare real capabilities — SEPA zone countries, {EUR}, OneOff.
         IReadOnlyList<PaymentMethodCatalogEntry> catalog =
         [
-            new(PaymentMethods.BankTransfer, PaymentMethodCategory.BankTransfer, "SEPA Transfer", PaymentMethodCapability.Wildcard),
+            new(
+                MethodType: PaymentMethods.BankTransfer,
+                Category: PaymentMethodCategory.BankTransfer,
+                DisplayLabel: "SEPA Transfer",
+                Capability: new PaymentMethodCapability(
+                    SupportedCountries: PaymentMethodCountries.SepaZone,
+                    SupportedCurrencies: PaymentMethodCurrencies.EurOnly,
+                    SupportedSequenceTypes: PaymentMethodSequenceType.OneOff,
+                    AmountBounds: ImmutableDictionary<string, PaymentMethodAmountBound>.Empty)),
         ];
         return Task.FromResult(catalog);
     }

--- a/src/Granit.Payments.Stripe/GranitPaymentsStripeModule.cs
+++ b/src/Granit.Payments.Stripe/GranitPaymentsStripeModule.cs
@@ -1,6 +1,7 @@
 using Granit.Http.Resilience;
 using Granit.Http.Resilience.Extensions;
 using Granit.Modularity;
+using Granit.Payments.HealthChecks;
 using Granit.Payments.Stripe.Internal;
 using Granit.Payments.Stripe.Options;
 using Microsoft.Extensions.DependencyInjection;
@@ -31,5 +32,7 @@ public sealed class GranitPaymentsStripeModule : GranitModule
         context.Services.AddScoped<ICheckoutSessionFactory, StripeCheckoutSessionFactory>();
         context.Services.AddScoped<IPaymentMethodManager, StripePaymentMethodManager>();
         context.Services.AddScoped<IPaymentWebhookVerifier, StripeWebhookVerifier>();
+
+        context.Services.AddHealthChecks().AddGranitPaymentProviderHealthCheck("stripe");
     }
 }

--- a/src/Granit.Payments.Stripe/Internal/StripeCatalog.cs
+++ b/src/Granit.Payments.Stripe/Internal/StripeCatalog.cs
@@ -1,0 +1,135 @@
+using System.Collections.Immutable;
+using Granit.Payments.Contracts;
+using Granit.Payments.Domain;
+
+namespace Granit.Payments.Stripe.Internal;
+
+/// <summary>
+/// Static catalog of Stripe payment methods with their capability metadata.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Sourced from Stripe's payment method support matrix
+/// (<c>https://docs.stripe.com/payments/payment-methods/payment-method-support</c>,
+/// checked April 2026). Country lists are restricted to the European surface we actively
+/// support; Stripe's full catalog spans additional regions not wired into Granit yet.
+/// </para>
+/// <para>
+/// A future enhancement can call <c>PaymentMethodConfigurationService.GetAsync()</c> to
+/// honor the merchant's current dashboard toggles (<c>display_preference.value == "on"</c>)
+/// and override these defaults dynamically.
+/// </para>
+/// </remarks>
+internal static class StripeCatalog
+{
+    private static readonly ImmutableDictionary<string, PaymentMethodAmountBound> NoBounds =
+        ImmutableDictionary<string, PaymentMethodAmountBound>.Empty;
+
+    private static readonly ImmutableHashSet<string> GlobalCurrencies = ImmutableHashSet<string>.Empty;
+    private static readonly ImmutableHashSet<string> Global = ImmutableHashSet<string>.Empty;
+
+    private const PaymentMethodSequenceType AllSequences =
+        PaymentMethodSequenceType.OneOff | PaymentMethodSequenceType.First | PaymentMethodSequenceType.Recurring;
+
+    /// <summary>Ordered catalog covering Stripe's European surface.</summary>
+    public static IReadOnlyList<PaymentMethodCatalogEntry> Entries { get; } =
+    [
+        new(PaymentMethods.Card, PaymentMethodCategory.Card, "Card",
+            new(Global, GlobalCurrencies, AllSequences, NoBounds)),
+
+        new(PaymentMethods.Bancontact, PaymentMethodCategory.BankRedirect, "Bancontact",
+            new(Set("BE"), PaymentMethodCurrencies.EurOnly,
+                PaymentMethodSequenceType.OneOff | PaymentMethodSequenceType.First, NoBounds)),
+
+        new(PaymentMethods.Ideal, PaymentMethodCategory.BankRedirect, "iDEAL",
+            new(Set("NL"), PaymentMethodCurrencies.EurOnly,
+                PaymentMethodSequenceType.OneOff | PaymentMethodSequenceType.First, NoBounds)),
+
+        new(PaymentMethods.Eps, PaymentMethodCategory.BankRedirect, "EPS",
+            new(Set("AT"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceType.OneOff, NoBounds)),
+
+        new(PaymentMethods.Giropay, PaymentMethodCategory.BankRedirect, "Giropay",
+            new(Set("DE"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceType.OneOff, NoBounds)),
+
+        new(PaymentMethods.Przelewy24, PaymentMethodCategory.BankRedirect, "Przelewy24",
+            new(Set("PL"), Set("PLN", "EUR"), PaymentMethodSequenceType.OneOff, NoBounds)),
+
+        new(PaymentMethods.Blik, PaymentMethodCategory.BankRedirect, "BLIK",
+            new(Set("PL"), Set("PLN"), PaymentMethodSequenceType.OneOff, NoBounds)),
+
+        new(PaymentMethods.Twint, PaymentMethodCategory.BankRedirect, "TWINT",
+            new(Set("CH"), Set("CHF"), PaymentMethodSequenceType.OneOff, NoBounds)),
+
+        new(PaymentMethods.Trustly, PaymentMethodCategory.BankRedirect, "Trustly",
+            new(Set("SE", "FI", "EE", "LV", "LT", "DK", "NO", "GB"), GlobalCurrencies,
+                PaymentMethodSequenceType.OneOff, NoBounds)),
+
+        new(PaymentMethods.MyBank, PaymentMethodCategory.BankRedirect, "MyBank",
+            new(Set("IT"), PaymentMethodCurrencies.EurOnly, PaymentMethodSequenceType.OneOff, NoBounds)),
+
+        new(PaymentMethods.BankTransfer, PaymentMethodCategory.BankTransfer, "Bank transfer",
+            new(PaymentMethodCountries.SepaZone, PaymentMethodCurrencies.EurOnly,
+                PaymentMethodSequenceType.OneOff, NoBounds)),
+
+        new(PaymentMethods.SepaDebit, PaymentMethodCategory.BankDebit, "SEPA Direct Debit",
+            new(PaymentMethodCountries.SepaZone, PaymentMethodCurrencies.EurOnly,
+                PaymentMethodSequenceType.First | PaymentMethodSequenceType.Recurring, NoBounds)),
+
+        new(PaymentMethods.ApplePay, PaymentMethodCategory.Wallet, "Apple Pay",
+            new(Global, GlobalCurrencies, AllSequences, NoBounds)),
+
+        new(PaymentMethods.GooglePay, PaymentMethodCategory.Wallet, "Google Pay",
+            new(Global, GlobalCurrencies, AllSequences, NoBounds)),
+
+        new(PaymentMethods.PayPal, PaymentMethodCategory.Wallet, "PayPal",
+            new(Global, GlobalCurrencies, AllSequences, NoBounds)),
+
+        new(PaymentMethods.Alipay, PaymentMethodCategory.Wallet, "Alipay",
+            new(Set("CN", "HK", "SG"), Set("CNY", "USD", "EUR", "GBP", "HKD", "SGD"),
+                PaymentMethodSequenceType.OneOff, NoBounds)),
+
+        new(PaymentMethods.WechatPay, PaymentMethodCategory.Wallet, "WeChat Pay",
+            new(Set("CN", "HK"), Set("CNY", "USD", "EUR", "GBP", "HKD"),
+                PaymentMethodSequenceType.OneOff, NoBounds)),
+
+        new(PaymentMethods.Klarna, PaymentMethodCategory.BuyNowPayLater, "Klarna",
+            new(
+                Set("AT", "BE", "CH", "CZ", "DE", "DK", "ES", "FI", "FR", "GB", "IE", "IT", "NL", "NO", "PL", "PT", "SE", "US"),
+                Set("EUR", "GBP", "SEK", "DKK", "NOK", "CHF", "USD"),
+                PaymentMethodSequenceType.OneOff,
+                Bounds(
+                    ("EUR", 1m, 10_000m),
+                    ("GBP", 1m, 10_000m),
+                    ("SEK", 10m, 100_000m),
+                    ("DKK", 10m, 75_000m),
+                    ("NOK", 10m, 100_000m),
+                    ("CHF", 1m, 10_000m),
+                    ("USD", 1m, 10_000m)))),
+
+        new(PaymentMethods.Riverty, PaymentMethodCategory.BuyNowPayLater, "Afterpay/Clearpay",
+            new(
+                Set("AT", "CH", "DE", "NL"),
+                Set("EUR", "CHF"),
+                PaymentMethodSequenceType.OneOff,
+                Bounds(
+                    ("EUR", 5m, 1_500m),
+                    ("CHF", 5m, 1_500m)))),
+    ];
+
+    private static ImmutableHashSet<string> Set(params string[] values) =>
+        ImmutableHashSet.Create(StringComparer.Ordinal, values);
+
+    private static ImmutableDictionary<string, PaymentMethodAmountBound> Bounds(
+        params (string Currency, decimal Min, decimal Max)[] entries)
+    {
+        ImmutableDictionary<string, PaymentMethodAmountBound>.Builder builder =
+            ImmutableDictionary.CreateBuilder<string, PaymentMethodAmountBound>(StringComparer.Ordinal);
+
+        foreach ((string currency, decimal min, decimal max) in entries)
+        {
+            builder.Add(currency, new PaymentMethodAmountBound(currency, min, max));
+        }
+
+        return builder.ToImmutable();
+    }
+}

--- a/src/Granit.Payments.Stripe/Internal/StripePaymentProvider.cs
+++ b/src/Granit.Payments.Stripe/Internal/StripePaymentProvider.cs
@@ -56,18 +56,14 @@ internal sealed partial class StripePaymentProvider(
     ];
 
     /// <inheritdoc/>
-    public Task<IReadOnlyList<PaymentMethodCatalogEntry>> GetCatalogAsync(CancellationToken cancellationToken = default)
-    {
-        // TODO(phase-2b): call PaymentMethodConfigurationService to honor the merchant's
-        // active payment method configuration (display_preference.value == "on") and map
-        // real capabilities.
-        IReadOnlyList<PaymentMethodCatalogEntry> catalog =
-        [
-            .. SupportedMethods.Select(m => new PaymentMethodCatalogEntry(
-                m.MethodType, m.Category, m.MethodType, PaymentMethodCapability.Wildcard)),
-        ];
-        return Task.FromResult(catalog);
-    }
+    /// <remarks>
+    /// Returns a static catalog curated from Stripe's payment method support matrix
+    /// (<see cref="StripeCatalog"/>). A future enhancement can call
+    /// <c>PaymentMethodConfigurationService.GetAsync()</c> to honor the merchant's
+    /// dashboard toggles dynamically.
+    /// </remarks>
+    public Task<IReadOnlyList<PaymentMethodCatalogEntry>> GetCatalogAsync(CancellationToken cancellationToken = default) =>
+        Task.FromResult(StripeCatalog.Entries);
 
     /// <inheritdoc/>
     public async Task<PaymentProviderChargeResult> ChargeAsync(

--- a/src/Granit.Payments.Stripe/Internal/StripePaymentProvider.cs
+++ b/src/Granit.Payments.Stripe/Internal/StripePaymentProvider.cs
@@ -56,6 +56,20 @@ internal sealed partial class StripePaymentProvider(
     ];
 
     /// <inheritdoc/>
+    public Task<IReadOnlyList<PaymentMethodCatalogEntry>> GetCatalogAsync(CancellationToken cancellationToken = default)
+    {
+        // TODO(phase-2b): call PaymentMethodConfigurationService to honor the merchant's
+        // active payment method configuration (display_preference.value == "on") and map
+        // real capabilities.
+        IReadOnlyList<PaymentMethodCatalogEntry> catalog =
+        [
+            .. SupportedMethods.Select(m => new PaymentMethodCatalogEntry(
+                m.MethodType, m.Category, m.MethodType, PaymentMethodCapability.Wildcard)),
+        ];
+        return Task.FromResult(catalog);
+    }
+
+    /// <inheritdoc/>
     public async Task<PaymentProviderChargeResult> ChargeAsync(
         PaymentChargeRequest request, CancellationToken cancellationToken = default)
     {

--- a/src/Granit.Payments/Contracts/PaymentAvailabilityContext.cs
+++ b/src/Granit.Payments/Contracts/PaymentAvailabilityContext.cs
@@ -1,0 +1,19 @@
+using Granit.Payments.Domain;
+
+namespace Granit.Payments.Contracts;
+
+/// <summary>
+/// Request context used to filter available payment methods at checkout.
+/// </summary>
+/// <remarks>
+/// Any axis set to <see langword="null"/> is treated as a wildcard on that axis (no filter).
+/// </remarks>
+/// <param name="CountryCode">ISO-3166 alpha-2 code (upper-case), typically the billing country.</param>
+/// <param name="CurrencyCode">ISO-4217 alpha-3 code (upper-case), the transaction currency.</param>
+/// <param name="Amount">Transaction amount in <paramref name="CurrencyCode"/>.</param>
+/// <param name="SequenceType">Intended sequence mode for this transaction.</param>
+public sealed record PaymentAvailabilityContext(
+    string? CountryCode,
+    string? CurrencyCode,
+    decimal? Amount,
+    PaymentMethodSequenceType SequenceType = PaymentMethodSequenceType.OneOff);

--- a/src/Granit.Payments/Contracts/PaymentAvailableMethod.cs
+++ b/src/Granit.Payments/Contracts/PaymentAvailableMethod.cs
@@ -3,6 +3,14 @@ using Granit.Payments.Domain;
 namespace Granit.Payments.Contracts;
 
 /// <summary>Available payment method for checkout UI.</summary>
+/// <param name="MethodType">Stable method identifier.</param>
+/// <param name="Category">Grouping category for the checkout UI.</param>
+/// <param name="ProviderName">Provider that will process charges for this method.</param>
+/// <param name="DisplayLabel">Raw method type — callers localize via <c>IStringLocalizer</c>.</param>
+/// <param name="Capability">Capability snapshot, or <see langword="null"/> when no snapshot is available.</param>
 public sealed record PaymentAvailableMethod(
-    string MethodType, PaymentMethodCategory Category,
-    string ProviderName, string DisplayLabel);
+    string MethodType,
+    PaymentMethodCategory Category,
+    string ProviderName,
+    string DisplayLabel,
+    PaymentMethodCapability? Capability);

--- a/src/Granit.Payments/Contracts/PaymentMethodCapability.cs
+++ b/src/Granit.Payments/Contracts/PaymentMethodCapability.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Granit.Payments.Domain;
 
 namespace Granit.Payments.Contracts;
@@ -18,4 +19,17 @@ public sealed record PaymentMethodCapability(
     IReadOnlySet<string> SupportedCountries,
     IReadOnlySet<string> SupportedCurrencies,
     PaymentMethodSequenceType SupportedSequenceTypes,
-    IReadOnlyDictionary<string, PaymentMethodAmountBound> AmountBounds);
+    IReadOnlyDictionary<string, PaymentMethodAmountBound> AmountBounds)
+{
+    /// <summary>
+    /// Capability with no country/currency/amount constraints and all sequence modes allowed.
+    /// Use when the real capability is unknown or being deferred to a later phase.
+    /// </summary>
+    public static PaymentMethodCapability Wildcard { get; } = new(
+        SupportedCountries: ImmutableHashSet<string>.Empty,
+        SupportedCurrencies: ImmutableHashSet<string>.Empty,
+        SupportedSequenceTypes: PaymentMethodSequenceType.OneOff
+            | PaymentMethodSequenceType.First
+            | PaymentMethodSequenceType.Recurring,
+        AmountBounds: ImmutableDictionary<string, PaymentMethodAmountBound>.Empty);
+}

--- a/src/Granit.Payments/Contracts/PaymentMethodCapability.cs
+++ b/src/Granit.Payments/Contracts/PaymentMethodCapability.cs
@@ -1,0 +1,21 @@
+using Granit.Payments.Domain;
+
+namespace Granit.Payments.Contracts;
+
+/// <summary>
+/// Availability metadata declared by a payment method.
+/// </summary>
+/// <remarks>
+/// Empty <see cref="SupportedCountries"/> or <see cref="SupportedCurrencies"/> means
+/// <em>wildcard</em> (no constraint on that axis). An empty <see cref="AmountBounds"/>
+/// dictionary means the method has no per-currency bounds (e.g., cards, wallets).
+/// </remarks>
+/// <param name="SupportedCountries">ISO-3166 alpha-2 codes (upper-case). Empty = global.</param>
+/// <param name="SupportedCurrencies">ISO-4217 alpha-3 codes (upper-case). Empty = all.</param>
+/// <param name="SupportedSequenceTypes">Supported sequence modes (flags). Must include at least one mode.</param>
+/// <param name="AmountBounds">Per-currency amount bounds. Keys are ISO-4217 upper-case.</param>
+public sealed record PaymentMethodCapability(
+    IReadOnlySet<string> SupportedCountries,
+    IReadOnlySet<string> SupportedCurrencies,
+    PaymentMethodSequenceType SupportedSequenceTypes,
+    IReadOnlyDictionary<string, PaymentMethodAmountBound> AmountBounds);

--- a/src/Granit.Payments/Contracts/PaymentMethodCatalogEntry.cs
+++ b/src/Granit.Payments/Contracts/PaymentMethodCatalogEntry.cs
@@ -1,0 +1,22 @@
+using Granit.Payments.Domain;
+
+namespace Granit.Payments.Contracts;
+
+/// <summary>
+/// Describes a payment method as seen by a provider at a given point in time.
+/// </summary>
+/// <remarks>
+/// Returned by <see cref="IPaymentProvider.GetCatalogAsync"/>. The admin activation flow
+/// uses this shape to populate the capability snapshot on
+/// <c>PaymentMethodConfiguration</c>. The runtime filter operates against the persisted
+/// snapshot, never against the live catalog.
+/// </remarks>
+/// <param name="MethodType">Stable method identifier (e.g., <c>card</c>, <c>bancontact</c>).</param>
+/// <param name="Category">Grouping category for the checkout UI.</param>
+/// <param name="DisplayLabel">Provider-native label (English by default). Callers may still localize via <c>IStringLocalizer</c>.</param>
+/// <param name="Capability">Availability metadata for this method.</param>
+public sealed record PaymentMethodCatalogEntry(
+    string MethodType,
+    PaymentMethodCategory Category,
+    string DisplayLabel,
+    PaymentMethodCapability Capability);

--- a/src/Granit.Payments/Domain/PaymentMethodAmountBound.cs
+++ b/src/Granit.Payments/Domain/PaymentMethodAmountBound.cs
@@ -1,0 +1,12 @@
+namespace Granit.Payments.Domain;
+
+/// <summary>
+/// Amount bounds declared by a payment method for a specific currency.
+/// </summary>
+/// <param name="CurrencyCode">ISO-4217 alpha-3 code, upper-case (e.g., <c>EUR</c>).</param>
+/// <param name="MinAmount">Minimum accepted amount, or <see langword="null"/> for no floor.</param>
+/// <param name="MaxAmount">Maximum accepted amount, or <see langword="null"/> for no ceiling.</param>
+public sealed record PaymentMethodAmountBound(
+    string CurrencyCode,
+    decimal? MinAmount,
+    decimal? MaxAmount);

--- a/src/Granit.Payments/Domain/PaymentMethodConfiguration.cs
+++ b/src/Granit.Payments/Domain/PaymentMethodConfiguration.cs
@@ -1,4 +1,6 @@
+using System.Collections.Immutable;
 using Granit.Domain;
+using Granit.Payments.Contracts;
 
 namespace Granit.Payments.Domain;
 
@@ -8,10 +10,16 @@ namespace Granit.Payments.Domain;
 /// </summary>
 /// <remarks>
 /// <para>
-/// This is a slim toggle entity — only <see cref="ProviderName"/>, <see cref="MethodType"/>
-/// and <see cref="IsActive"/> are persisted. The display label and category are derived
-/// at runtime from the corresponding <c>IPaymentProvider.SupportedMethods</c> descriptor
-/// (category) and from <c>IStringLocalizer</c> (localized display label).
+/// The display label and category are derived at runtime from the corresponding
+/// <c>IPaymentProvider</c> catalog (category) and from <c>IStringLocalizer</c>
+/// (localized display label).
+/// </para>
+/// <para>
+/// When admins activate a method they also snapshot the provider's declared
+/// <see cref="PaymentMethodCapability"/> onto this record via
+/// <see cref="SnapshotCapability"/>. The runtime availability filter reads this
+/// snapshot — never the live provider catalog — so the hot checkout path is
+/// deterministic, offline-capable, and does not hit the provider on every request.
 /// </para>
 /// </remarks>
 public sealed class PaymentMethodConfiguration : AuditedEntity
@@ -42,9 +50,79 @@ public sealed class PaymentMethodConfiguration : AuditedEntity
     /// <summary>Whether this method is currently active for the platform.</summary>
     public bool IsActive { get; private set; }
 
+    /// <summary>
+    /// Snapshot of the countries supported by the provider for this method.
+    /// <see langword="null"/> when no snapshot has been captured yet (legacy record);
+    /// an empty set means the method is supported globally.
+    /// </summary>
+    public ImmutableHashSet<string>? SupportedCountries { get; private set; }
+
+    /// <summary>
+    /// Snapshot of the currencies supported by the provider for this method.
+    /// <see langword="null"/> when no snapshot has been captured yet; empty = all currencies.
+    /// </summary>
+    public ImmutableHashSet<string>? SupportedCurrencies { get; private set; }
+
+    /// <summary>
+    /// Snapshot of the sequence modes supported by the provider for this method.
+    /// <see langword="null"/> when no snapshot has been captured yet.
+    /// </summary>
+    public PaymentMethodSequenceType? SupportedSequenceTypes { get; private set; }
+
+    /// <summary>
+    /// Snapshot of the per-currency amount bounds declared by the provider for this method.
+    /// <see langword="null"/> when no snapshot has been captured yet; empty dictionary = no bounds.
+    /// </summary>
+    public ImmutableDictionary<string, PaymentMethodAmountBound>? AmountBounds { get; private set; }
+
     /// <summary>Marks this method as active for the platform.</summary>
     public void Activate() => IsActive = true;
 
     /// <summary>Marks this method as inactive (tenants will no longer see it).</summary>
     public void Deactivate() => IsActive = false;
+
+    /// <summary>
+    /// Captures the provider's current capability for this method. Called by the admin
+    /// activation and resync flows.
+    /// </summary>
+    public void SnapshotCapability(PaymentMethodCapability capability)
+    {
+        ArgumentNullException.ThrowIfNull(capability);
+
+        SupportedCountries = [.. capability.SupportedCountries];
+        SupportedCurrencies = [.. capability.SupportedCurrencies];
+        SupportedSequenceTypes = capability.SupportedSequenceTypes;
+        AmountBounds = capability.AmountBounds.ToImmutableDictionary(StringComparer.Ordinal);
+    }
+
+    /// <summary>Drops the capability snapshot. Typically used when detaching a provider.</summary>
+    public void ClearCapability()
+    {
+        SupportedCountries = null;
+        SupportedCurrencies = null;
+        SupportedSequenceTypes = null;
+        AmountBounds = null;
+    }
+
+    /// <summary>
+    /// Returns the current capability snapshot, or <see langword="null"/> when none has been
+    /// captured yet. A null return means the runtime filter should treat this record as
+    /// wildcard on every axis.
+    /// </summary>
+    public PaymentMethodCapability? GetCapabilitySnapshot()
+    {
+        if (SupportedCountries is null
+            || SupportedCurrencies is null
+            || SupportedSequenceTypes is null
+            || AmountBounds is null)
+        {
+            return null;
+        }
+
+        return new PaymentMethodCapability(
+            SupportedCountries,
+            SupportedCurrencies,
+            SupportedSequenceTypes.Value,
+            AmountBounds);
+    }
 }

--- a/src/Granit.Payments/Domain/PaymentMethodCountries.cs
+++ b/src/Granit.Payments/Domain/PaymentMethodCountries.cs
@@ -1,0 +1,26 @@
+using System.Collections.Immutable;
+
+namespace Granit.Payments.Domain;
+
+/// <summary>
+/// Well-known country sets shared across payment method capability declarations.
+/// </summary>
+public static class PaymentMethodCountries
+{
+    /// <summary>
+    /// SEPA zone as of 2026: EU-27 plus EEA (IS, LI, NO), Switzerland, United Kingdom,
+    /// and the micro-states (Monaco, San Marino, Andorra, Vatican City).
+    /// </summary>
+    public static ImmutableHashSet<string> SepaZone { get; } = ImmutableHashSet.Create(
+        StringComparer.Ordinal,
+        // EU-27
+        "AT", "BE", "BG", "CY", "CZ", "DE", "DK", "EE", "ES", "FI",
+        "FR", "GR", "HR", "HU", "IE", "IT", "LT", "LU", "LV", "MT",
+        "NL", "PL", "PT", "RO", "SE", "SI", "SK",
+        // EEA
+        "IS", "LI", "NO",
+        // Switzerland + UK
+        "CH", "GB",
+        // Micro-states
+        "AD", "MC", "SM", "VA");
+}

--- a/src/Granit.Payments/Domain/PaymentMethodCurrencies.cs
+++ b/src/Granit.Payments/Domain/PaymentMethodCurrencies.cs
@@ -1,0 +1,13 @@
+using System.Collections.Immutable;
+
+namespace Granit.Payments.Domain;
+
+/// <summary>
+/// Well-known currency sets shared across payment method capability declarations.
+/// </summary>
+public static class PaymentMethodCurrencies
+{
+    /// <summary>Single-currency set: EUR. Used by SEPA-constrained methods.</summary>
+    public static ImmutableHashSet<string> EurOnly { get; } =
+        ImmutableHashSet.Create(StringComparer.Ordinal, "EUR");
+}

--- a/src/Granit.Payments/Domain/PaymentMethodSequenceType.cs
+++ b/src/Granit.Payments/Domain/PaymentMethodSequenceType.cs
@@ -1,0 +1,27 @@
+namespace Granit.Payments.Domain;
+
+/// <summary>
+/// Payment sequence modes, aligned with Mollie's <c>sequenceType</c> semantics.
+/// </summary>
+/// <remarks>
+/// Callers request a single mode per operation. The availability filter matches a method
+/// if its <see cref="PaymentMethodCapability.SupportedSequenceTypes"/> includes the requested
+/// mode via bit test. Callers are responsible for chaining modes across a subscription
+/// lifecycle (<see cref="First"/> to set up a mandate, then <see cref="Recurring"/> for
+/// subsequent charges) — the filter does not infer this sequencing.
+/// </remarks>
+[Flags]
+public enum PaymentMethodSequenceType
+{
+    /// <summary>No sequence declared. Invalid on a capability; used only as a sentinel.</summary>
+    None = 0,
+
+    /// <summary>Single payment with no stored mandate.</summary>
+    OneOff = 1,
+
+    /// <summary>Initial payment that establishes a mandate for later recurring charges.</summary>
+    First = 2,
+
+    /// <summary>Subsequent off-session payment using a previously established mandate.</summary>
+    Recurring = 4,
+}

--- a/src/Granit.Payments/Extensions/PaymentsHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Payments/Extensions/PaymentsHostApplicationBuilderExtensions.cs
@@ -21,6 +21,7 @@ public static class PaymentsHostApplicationBuilderExtensions
         GranitActivitySourceRegistry.Register(PaymentsActivitySource.Name);
 
         builder.Services.TryAddScoped<IPaymentProviderResolver, DefaultPaymentProviderResolver>();
+        builder.Services.TryAddSingleton<IPaymentMethodAvailabilityFilter, DefaultPaymentMethodAvailabilityFilter>();
 
         return builder;
     }

--- a/src/Granit.Payments/HealthChecks/PaymentProviderHealthCheck.cs
+++ b/src/Granit.Payments/HealthChecks/PaymentProviderHealthCheck.cs
@@ -1,0 +1,65 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Granit.Payments.HealthChecks;
+
+/// <summary>
+/// Readiness probe for a single <see cref="IPaymentProvider"/>. Calls
+/// <see cref="IPaymentProvider.GetCatalogAsync"/> with a short timeout — a single
+/// call covers authentication, reachability, and response parsing in one hit.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Status mapping:
+/// </para>
+/// <list type="bullet">
+///   <item><see cref="HealthCheckResult.Healthy"/> when the catalog returns at least one entry.</item>
+///   <item><see cref="HealthCheckResult.Degraded"/> when the catalog is empty (auth OK, but nothing to offer).</item>
+///   <item><see cref="HealthCheckResult.Unhealthy"/> on timeout, <see cref="UnauthorizedAccessException"/>, or any other exception.</item>
+/// </list>
+/// <para>
+/// Security: error messages expose only the provider name and the exception type name —
+/// never URLs, API keys, or tokens. Follows the same convention as
+/// <c>HttpServiceHealthCheckBase</c>.
+/// </para>
+/// <para>
+/// Built-in providers with a static catalog (SEPA Transfer, SEPA Direct Debit) are always
+/// Healthy — registering the check for them is cheap and keeps the surface uniform.
+/// </para>
+/// </remarks>
+public sealed class PaymentProviderHealthCheck(
+    IPaymentProvider provider,
+    TimeProvider timeProvider) : IHealthCheck
+{
+    private static readonly TimeSpan s_timeout = TimeSpan.FromSeconds(5);
+
+    /// <inheritdoc/>
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var timeoutCts = new CancellationTokenSource(s_timeout, timeProvider);
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+            IReadOnlyList<Contracts.PaymentMethodCatalogEntry> catalog = await provider
+                .GetCatalogAsync(linkedCts.Token)
+                .ConfigureAwait(false);
+
+            return catalog.Count == 0
+                ? HealthCheckResult.Degraded($"{provider.Name} catalog empty")
+                : HealthCheckResult.Healthy();
+        }
+        catch (OperationCanceledException)
+        {
+            return HealthCheckResult.Unhealthy($"{provider.Name} health check timed out");
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return HealthCheckResult.Unhealthy($"{provider.Name} auth failed");
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy($"{provider.Name} unreachable: {ex.GetType().Name}");
+        }
+    }
+}

--- a/src/Granit.Payments/HealthChecks/PaymentProviderHealthCheckBuilderExtensions.cs
+++ b/src/Granit.Payments/HealthChecks/PaymentProviderHealthCheckBuilderExtensions.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Granit.Payments.HealthChecks;
+
+/// <summary>
+/// Registers <see cref="PaymentProviderHealthCheck"/> for a single
+/// <see cref="IPaymentProvider"/> identified by name.
+/// </summary>
+public static class PaymentProviderHealthCheckBuilderExtensions
+{
+    /// <summary>
+    /// Adds a <see cref="PaymentProviderHealthCheck"/> named
+    /// <c>payments-{providerName}</c>, tagged <c>readiness</c> and <c>payments</c>, with
+    /// <see cref="HealthStatus.Degraded"/> as the failure status so a single misbehaving
+    /// provider does not cascade a <c>/ready</c> outage.
+    /// </summary>
+    /// <param name="builder">The health-checks builder to register on.</param>
+    /// <param name="providerName">
+    /// Provider <see cref="IPaymentProvider.Name"/> — matched case-insensitively against the
+    /// providers registered in DI.
+    /// </param>
+    public static IHealthChecksBuilder AddGranitPaymentProviderHealthCheck(
+        this IHealthChecksBuilder builder, string providerName)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerName);
+
+        return builder.Add(new HealthCheckRegistration(
+            $"payments-{providerName}",
+            sp => new PaymentProviderHealthCheck(
+                ResolveProvider(sp, providerName),
+                sp.GetRequiredService<TimeProvider>()),
+            failureStatus: HealthStatus.Degraded,
+            tags: ["readiness", "payments"]));
+    }
+
+    private static IPaymentProvider ResolveProvider(IServiceProvider sp, string providerName) =>
+        sp.GetServices<IPaymentProvider>()
+            .FirstOrDefault(p => p.Name.Equals(providerName, StringComparison.OrdinalIgnoreCase))
+            ?? throw new InvalidOperationException(
+                $"No IPaymentProvider named '{providerName}' is registered in DI.");
+}

--- a/src/Granit.Payments/IPaymentMethodConfigurationWriter.cs
+++ b/src/Granit.Payments/IPaymentMethodConfigurationWriter.cs
@@ -1,3 +1,4 @@
+using Granit.Payments.Contracts;
 using Granit.Payments.Domain;
 
 namespace Granit.Payments;
@@ -24,5 +25,26 @@ public interface IPaymentMethodConfigurationWriter
         string providerName,
         string methodType,
         bool isActive,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Upserts a configuration as active, capturing the provider's capability snapshot in the
+    /// same transaction. Race-safe on insert (same semantics as <see cref="UpsertActivationAsync"/>).
+    /// </summary>
+    Task UpsertActivationWithSnapshotAsync(
+        Guid newId,
+        string providerName,
+        string methodType,
+        PaymentMethodCapability capability,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates the capability snapshot on an existing configuration. Returns
+    /// <see langword="false"/> when no configuration exists for (providerName, methodType).
+    /// </summary>
+    Task<bool> UpdateCapabilitySnapshotAsync(
+        string providerName,
+        string methodType,
+        PaymentMethodCapability capability,
         CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Payments/IPaymentProvider.cs
+++ b/src/Granit.Payments/IPaymentProvider.cs
@@ -15,6 +15,18 @@ public interface IPaymentProvider
     /// </summary>
     IReadOnlyList<PaymentMethodDescriptor> SupportedMethods { get; }
 
+    /// <summary>
+    /// Fetches the live catalog of methods from the provider, with capability metadata
+    /// (supported countries, currencies, amount bounds, sequence types).
+    /// </summary>
+    /// <remarks>
+    /// Called by the admin activation flow to snapshot capability into
+    /// <c>PaymentMethodConfiguration</c>. External-API-backed providers (Mollie, Stripe)
+    /// should honor the provider's current account state (enabled methods in the provider
+    /// dashboard). Built-in providers (SEPA) return a static catalog.
+    /// </remarks>
+    Task<IReadOnlyList<PaymentMethodCatalogEntry>> GetCatalogAsync(CancellationToken cancellationToken = default);
+
     /// <summary>Initiates a charge.</summary>
     Task<PaymentProviderChargeResult> ChargeAsync(PaymentChargeRequest request, CancellationToken cancellationToken = default);
 

--- a/src/Granit.Payments/IPaymentProviderResolver.cs
+++ b/src/Granit.Payments/IPaymentProviderResolver.cs
@@ -12,7 +12,14 @@ public interface IPaymentProviderResolver
     Task<IPaymentProvider> ResolveAsync(Guid tenantId, string methodType,
         CancellationToken cancellationToken = default);
 
-    /// <summary>Returns all available payment methods for a tenant (for checkout UI).</summary>
-    Task<IReadOnlyList<PaymentAvailableMethod>> GetAvailableProvidersAsync(Guid tenantId,
+    /// <summary>
+    /// Returns all available payment methods for a tenant (for checkout UI). When
+    /// <paramref name="context"/> is non-null, methods whose capability snapshot does not
+    /// satisfy the context (country / currency / amount / sequence) are filtered out.
+    /// Null context returns the unfiltered set.
+    /// </summary>
+    Task<IReadOnlyList<PaymentAvailableMethod>> GetAvailableProvidersAsync(
+        Guid tenantId,
+        PaymentAvailabilityContext? context = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Payments/Internal/DefaultPaymentMethodAvailabilityFilter.cs
+++ b/src/Granit.Payments/Internal/DefaultPaymentMethodAvailabilityFilter.cs
@@ -1,0 +1,66 @@
+using Granit.Payments.Contracts;
+using Granit.Payments.Domain;
+
+namespace Granit.Payments.Internal;
+
+/// <summary>
+/// Default <see cref="IPaymentMethodAvailabilityFilter"/>. Intersects a capability with a
+/// request context across four axes: country, currency, amount, and sequence type.
+/// </summary>
+/// <remarks>
+/// Empty sets / empty bounds dictionaries are treated as wildcards. Null axes on the
+/// context are not filtered.
+///
+/// <para>
+/// Sequence type matching uses a bitwise containment test:
+/// <c>(capability.SupportedSequenceTypes &amp; context.SequenceType) == context.SequenceType</c>.
+/// A caller requesting <see cref="PaymentMethodSequenceType.Recurring"/> against a method
+/// that supports only <see cref="PaymentMethodSequenceType.OneOff"/> is rejected; the filter
+/// does not infer mandate-setup chains.
+/// </para>
+/// </remarks>
+internal sealed class DefaultPaymentMethodAvailabilityFilter : IPaymentMethodAvailabilityFilter
+{
+    public bool IsAvailable(PaymentMethodCapability capability, PaymentAvailabilityContext context)
+    {
+        ArgumentNullException.ThrowIfNull(capability);
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (context.CountryCode is { Length: > 0 } country
+            && capability.SupportedCountries.Count > 0
+            && !capability.SupportedCountries.Contains(country))
+        {
+            return false;
+        }
+
+        if (context.CurrencyCode is { Length: > 0 } currency
+            && capability.SupportedCurrencies.Count > 0
+            && !capability.SupportedCurrencies.Contains(currency))
+        {
+            return false;
+        }
+
+        if (context.SequenceType != PaymentMethodSequenceType.None
+            && (capability.SupportedSequenceTypes & context.SequenceType) != context.SequenceType)
+        {
+            return false;
+        }
+
+        if (context.Amount is { } amount
+            && context.CurrencyCode is { Length: > 0 } boundsCurrency
+            && capability.AmountBounds.TryGetValue(boundsCurrency, out PaymentMethodAmountBound? bound))
+        {
+            if (bound.MinAmount is { } min && amount < min)
+            {
+                return false;
+            }
+
+            if (bound.MaxAmount is { } max && amount > max)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Granit.Payments/Internal/DefaultPaymentProviderResolver.cs
+++ b/src/Granit.Payments/Internal/DefaultPaymentProviderResolver.cs
@@ -7,12 +7,13 @@ namespace Granit.Payments.Internal;
 /// <summary>
 /// Default <see cref="IPaymentProviderResolver"/> that cross-references activated
 /// <see cref="PaymentMethodConfiguration"/> records with registered
-/// <see cref="IPaymentProvider"/> instances (and their <c>SupportedMethods</c> descriptors).
+/// <see cref="IPaymentProvider"/> instances, and applies the availability filter
+/// against the persisted capability snapshot on each record.
 /// </summary>
 /// <remarks>
 /// Active configurations are cached in <see cref="IFusionCache"/> for 5 minutes.
 /// The cache is proactively invalidated by the configuration endpoints on every
-/// activate/deactivate, so tenants see changes immediately.
+/// activate / deactivate / resync, so tenants see changes immediately.
 ///
 /// <para>
 /// Display labels are returned as the raw <c>MethodType</c> identifier. Callers
@@ -23,6 +24,7 @@ namespace Granit.Payments.Internal;
 internal sealed class DefaultPaymentProviderResolver(
     IPaymentMethodConfigurationReader configReader,
     IEnumerable<IPaymentProvider> providers,
+    IPaymentMethodAvailabilityFilter availabilityFilter,
     IFusionCache cache) : IPaymentProviderResolver
 {
     private const string CacheKey = "granit:payments:active-configs";
@@ -59,7 +61,9 @@ internal sealed class DefaultPaymentProviderResolver(
 
     /// <inheritdoc/>
     public async Task<IReadOnlyList<PaymentAvailableMethod>> GetAvailableProvidersAsync(
-        Guid tenantId, CancellationToken cancellationToken = default)
+        Guid tenantId,
+        PaymentAvailabilityContext? context = null,
+        CancellationToken cancellationToken = default)
     {
         IReadOnlyList<PaymentMethodConfiguration> configs =
             await GetActiveConfigsCachedAsync(cancellationToken).ConfigureAwait(false);
@@ -86,10 +90,24 @@ internal sealed class DefaultPaymentProviderResolver(
                 continue;
             }
 
+            PaymentMethodCapability? snapshot = config.GetCapabilitySnapshot();
+
+            // Filter: when a context is supplied AND a snapshot exists, apply it.
+            // No snapshot = legacy record, treated as wildcard (no filtering).
+            if (context is not null && snapshot is not null
+                && !availabilityFilter.IsAvailable(snapshot, context))
+            {
+                continue;
+            }
+
             // Note: DisplayLabel is returned as the raw method type. The caller
             // (endpoint) localizes via IStringLocalizer.
             result.Add(new PaymentAvailableMethod(
-                descriptor.MethodType, descriptor.Category, provider.Name, descriptor.MethodType));
+                descriptor.MethodType,
+                descriptor.Category,
+                provider.Name,
+                descriptor.MethodType,
+                snapshot));
         }
 
         return result;

--- a/src/Granit.Payments/Internal/IPaymentMethodAvailabilityFilter.cs
+++ b/src/Granit.Payments/Internal/IPaymentMethodAvailabilityFilter.cs
@@ -6,7 +6,7 @@ namespace Granit.Payments.Internal;
 /// Pure predicate evaluating whether a <see cref="PaymentMethodCapability"/> satisfies
 /// a <see cref="PaymentAvailabilityContext"/>.
 /// </summary>
-public interface IPaymentMethodAvailabilityFilter
+internal interface IPaymentMethodAvailabilityFilter
 {
     /// <summary>
     /// Returns <see langword="true"/> when every non-null axis of <paramref name="context"/>

--- a/src/Granit.Payments/Internal/IPaymentMethodAvailabilityFilter.cs
+++ b/src/Granit.Payments/Internal/IPaymentMethodAvailabilityFilter.cs
@@ -1,0 +1,16 @@
+using Granit.Payments.Contracts;
+
+namespace Granit.Payments.Internal;
+
+/// <summary>
+/// Pure predicate evaluating whether a <see cref="PaymentMethodCapability"/> satisfies
+/// a <see cref="PaymentAvailabilityContext"/>.
+/// </summary>
+public interface IPaymentMethodAvailabilityFilter
+{
+    /// <summary>
+    /// Returns <see langword="true"/> when every non-null axis of <paramref name="context"/>
+    /// is compatible with <paramref name="capability"/>.
+    /// </summary>
+    bool IsAvailable(PaymentMethodCapability capability, PaymentAvailabilityContext context);
+}

--- a/tests/Granit.Payments.Endpoints.Tests/Internal/PaymentAvailabilityContextParserTests.cs
+++ b/tests/Granit.Payments.Endpoints.Tests/Internal/PaymentAvailabilityContextParserTests.cs
@@ -1,0 +1,111 @@
+using Granit.Payments.Contracts;
+using Granit.Payments.Domain;
+using Granit.Payments.Endpoints.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Payments.Endpoints.Tests.Internal;
+
+public sealed class PaymentAvailabilityContextParserTests
+{
+    [Fact]
+    public void AllAxesNull_ReturnsNullContextAndNoError()
+    {
+        PaymentAvailabilityContext? context = PaymentAvailabilityContextParser
+            .TryParse(country: null, currency: null, amount: null, sequenceType: null, out string? error);
+
+        context.ShouldBeNull();
+        error.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Country_NormalizedToUppercase()
+    {
+        PaymentAvailabilityContext? context = PaymentAvailabilityContextParser
+            .TryParse(country: "be", currency: null, amount: null, sequenceType: null, out string? error);
+
+        error.ShouldBeNull();
+        context!.CountryCode.ShouldBe("BE");
+    }
+
+    [Fact]
+    public void Country_InvalidLength_Rejected()
+    {
+        PaymentAvailabilityContext? context = PaymentAvailabilityContextParser
+            .TryParse(country: "BEL", currency: null, amount: null, sequenceType: null, out string? error);
+
+        context.ShouldBeNull();
+        error.ShouldNotBeNull();
+        error.ShouldContain("ISO-3166");
+    }
+
+    [Fact]
+    public void Currency_InvalidLength_Rejected()
+    {
+        PaymentAvailabilityContext? context = PaymentAvailabilityContextParser
+            .TryParse(country: null, currency: "EU", amount: null, sequenceType: null, out string? error);
+
+        context.ShouldBeNull();
+        error.ShouldNotBeNull();
+        error.ShouldContain("ISO-4217");
+    }
+
+    [Fact]
+    public void Amount_Negative_Rejected()
+    {
+        PaymentAvailabilityContext? context = PaymentAvailabilityContextParser
+            .TryParse(country: null, currency: null, amount: -1m, sequenceType: null, out string? error);
+
+        context.ShouldBeNull();
+        error.ShouldNotBeNull();
+        error.ShouldContain("non-negative");
+    }
+
+    [Theory]
+    [InlineData("oneoff", PaymentMethodSequenceType.OneOff)]
+    [InlineData("First", PaymentMethodSequenceType.First)]
+    [InlineData("RECURRING", PaymentMethodSequenceType.Recurring)]
+    public void SequenceType_CaseInsensitive(string input, PaymentMethodSequenceType expected)
+    {
+        PaymentAvailabilityContext? context = PaymentAvailabilityContextParser
+            .TryParse(country: null, currency: null, amount: null, sequenceType: input, out string? error);
+
+        error.ShouldBeNull();
+        context!.SequenceType.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void SequenceType_Unknown_Rejected()
+    {
+        PaymentAvailabilityContext? context = PaymentAvailabilityContextParser
+            .TryParse(country: null, currency: null, amount: null, sequenceType: "weekly", out string? error);
+
+        context.ShouldBeNull();
+        error.ShouldNotBeNull();
+        error.ShouldContain("sequence type");
+    }
+
+    [Fact]
+    public void AllAxesValid_ReturnsPopulatedContext()
+    {
+        PaymentAvailabilityContext? context = PaymentAvailabilityContextParser
+            .TryParse(country: "BE", currency: "EUR", amount: 25m, sequenceType: "oneoff", out string? error);
+
+        error.ShouldBeNull();
+        context.ShouldNotBeNull();
+        context!.CountryCode.ShouldBe("BE");
+        context.CurrencyCode.ShouldBe("EUR");
+        context.Amount.ShouldBe(25m);
+        context.SequenceType.ShouldBe(PaymentMethodSequenceType.OneOff);
+    }
+
+    [Fact]
+    public void SequenceTypeAbsent_DefaultsToOneOff_WhenOtherAxisSet()
+    {
+        PaymentAvailabilityContext? context = PaymentAvailabilityContextParser
+            .TryParse(country: "BE", currency: null, amount: null, sequenceType: null, out string? error);
+
+        error.ShouldBeNull();
+        context!.SequenceType.ShouldBe(PaymentMethodSequenceType.OneOff);
+    }
+}

--- a/tests/Granit.Payments.Tests/HealthChecks/PaymentProviderHealthCheckTests.cs
+++ b/tests/Granit.Payments.Tests/HealthChecks/PaymentProviderHealthCheckTests.cs
@@ -1,0 +1,114 @@
+using Granit.Payments;
+using Granit.Payments.Contracts;
+using Granit.Payments.Domain;
+using Granit.Payments.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Payments.Tests.HealthChecks;
+
+public sealed class PaymentProviderHealthCheckTests
+{
+    private const string ProviderName = "contoso";
+    private const string ApiKey = "sk_live_ultra_secret";
+
+    private readonly IPaymentProvider _provider = Substitute.For<IPaymentProvider>();
+    private readonly PaymentProviderHealthCheck _check;
+
+    public PaymentProviderHealthCheckTests()
+    {
+        _provider.Name.Returns(ProviderName);
+        _check = new PaymentProviderHealthCheck(_provider, TimeProvider.System);
+    }
+
+    private static PaymentMethodCatalogEntry Entry(string methodType) =>
+        new(methodType, PaymentMethodCategory.Card, methodType, PaymentMethodCapability.Wildcard);
+
+    private Task<HealthCheckResult> InvokeAsync() =>
+        _check.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+    [Fact]
+    public async Task NonEmptyCatalog_IsHealthy()
+    {
+        _provider.GetCatalogAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<PaymentMethodCatalogEntry>>([Entry("card")]));
+
+        HealthCheckResult result = await InvokeAsync();
+
+        result.Status.ShouldBe(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task EmptyCatalog_IsDegraded()
+    {
+        _provider.GetCatalogAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<PaymentMethodCatalogEntry>>([]));
+
+        HealthCheckResult result = await InvokeAsync();
+
+        result.Status.ShouldBe(HealthStatus.Degraded);
+        result.Description.ShouldNotBeNull();
+        result.Description.ShouldContain(ProviderName);
+        result.Description.ShouldContain("empty");
+    }
+
+    [Fact]
+    public async Task UnauthorizedAccess_IsUnhealthyWithAuthMessage()
+    {
+        _provider.GetCatalogAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new UnauthorizedAccessException("invalid API key " + ApiKey));
+
+        HealthCheckResult result = await InvokeAsync();
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Description.ShouldNotBeNull();
+        result.Description.ShouldContain("auth failed");
+        result.Description.ShouldNotContain(ApiKey, Case.Sensitive);
+    }
+
+    [Fact]
+    public async Task OperationCanceled_IsUnhealthyWithTimeoutMessage()
+    {
+        _provider.GetCatalogAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException());
+
+        HealthCheckResult result = await InvokeAsync();
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Description.ShouldNotBeNull();
+        result.Description.ShouldContain("timed out");
+    }
+
+    [Fact]
+    public async Task GenericException_IsUnhealthyExposingOnlyTypeName()
+    {
+        _provider.GetCatalogAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("connection refused to https://api.contoso.com/v1/methods"));
+
+        HealthCheckResult result = await InvokeAsync();
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Description.ShouldNotBeNull();
+        result.Description.ShouldContain("unreachable");
+        result.Description.ShouldContain(nameof(HttpRequestException));
+        result.Description.ShouldNotContain("api.contoso.com", Case.Insensitive);
+        result.Description.ShouldNotContain("connection refused", Case.Insensitive);
+    }
+
+    [Fact]
+    public async Task ErrorMessages_NeverExposeApiKeyFragment()
+    {
+        _provider.GetCatalogAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException($"bearer {ApiKey} rejected"));
+
+        HealthCheckResult result = await InvokeAsync();
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Description.ShouldNotBeNull();
+        result.Description.ShouldNotContain(ApiKey, Case.Sensitive);
+        result.Description.ShouldNotContain("sk_live", Case.Insensitive);
+    }
+}

--- a/tests/Granit.Payments.Tests/Internal/DefaultPaymentMethodAvailabilityFilterTests.cs
+++ b/tests/Granit.Payments.Tests/Internal/DefaultPaymentMethodAvailabilityFilterTests.cs
@@ -1,0 +1,220 @@
+using System.Collections.Immutable;
+using Granit.Payments.Contracts;
+using Granit.Payments.Domain;
+using Granit.Payments.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Payments.Tests.Internal;
+
+public sealed class DefaultPaymentMethodAvailabilityFilterTests
+{
+    private static readonly PaymentMethodCapability Wildcard = new(
+        SupportedCountries: ImmutableHashSet<string>.Empty,
+        SupportedCurrencies: ImmutableHashSet<string>.Empty,
+        SupportedSequenceTypes: PaymentMethodSequenceType.OneOff
+            | PaymentMethodSequenceType.First
+            | PaymentMethodSequenceType.Recurring,
+        AmountBounds: ImmutableDictionary<string, PaymentMethodAmountBound>.Empty);
+
+    private readonly DefaultPaymentMethodAvailabilityFilter _filter = new();
+
+    [Fact]
+    public void Wildcards_AlwaysAvailable() =>
+        _filter.IsAvailable(Wildcard, new PaymentAvailabilityContext("BE", "EUR", 25m)).ShouldBeTrue();
+
+    [Fact]
+    public void EmptyContext_IgnoresAllAxes() =>
+        _filter.IsAvailable(
+                Wildcard,
+                new PaymentAvailabilityContext(null, null, null, PaymentMethodSequenceType.None))
+            .ShouldBeTrue();
+
+    [Fact]
+    public void Country_OutsideSupportedSet_Rejected()
+    {
+        PaymentMethodCapability bancontact = Wildcard with { SupportedCountries = ImmutableHashSet.Create("BE") };
+
+        _filter.IsAvailable(bancontact, new PaymentAvailabilityContext("NL", null, null)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Country_InsideSupportedSet_Accepted()
+    {
+        PaymentMethodCapability bancontact = Wildcard with { SupportedCountries = ImmutableHashSet.Create("BE") };
+
+        _filter.IsAvailable(bancontact, new PaymentAvailabilityContext("BE", null, null)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Country_NullContext_TreatedAsWildcard()
+    {
+        PaymentMethodCapability bancontact = Wildcard with { SupportedCountries = ImmutableHashSet.Create("BE") };
+
+        _filter.IsAvailable(bancontact, new PaymentAvailabilityContext(null, null, null)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Currency_OutsideSupportedSet_Rejected()
+    {
+        PaymentMethodCapability sepa = Wildcard with { SupportedCurrencies = ImmutableHashSet.Create("EUR") };
+
+        _filter.IsAvailable(sepa, new PaymentAvailabilityContext(null, "USD", null)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SequenceType_RequestedRecurring_AgainstOneOffOnly_Rejected()
+    {
+        PaymentMethodCapability oneOffOnly = Wildcard with { SupportedSequenceTypes = PaymentMethodSequenceType.OneOff };
+
+        _filter.IsAvailable(
+                oneOffOnly,
+                new PaymentAvailabilityContext(null, null, null, PaymentMethodSequenceType.Recurring))
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SequenceType_RequestedRecurring_AgainstFirstAndRecurring_Accepted()
+    {
+        PaymentMethodCapability sepa = Wildcard with
+        {
+            SupportedSequenceTypes = PaymentMethodSequenceType.First | PaymentMethodSequenceType.Recurring,
+        };
+
+        _filter.IsAvailable(
+                sepa,
+                new PaymentAvailabilityContext(null, null, null, PaymentMethodSequenceType.Recurring))
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SequenceType_RequestedFirst_AgainstOneOffAndFirst_Accepted()
+    {
+        PaymentMethodCapability bancontact = Wildcard with
+        {
+            SupportedSequenceTypes = PaymentMethodSequenceType.OneOff | PaymentMethodSequenceType.First,
+        };
+
+        _filter.IsAvailable(
+                bancontact,
+                new PaymentAvailabilityContext(null, null, null, PaymentMethodSequenceType.First))
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SequenceType_None_BypassesCheck()
+    {
+        PaymentMethodCapability sepa = Wildcard with
+        {
+            SupportedSequenceTypes = PaymentMethodSequenceType.First | PaymentMethodSequenceType.Recurring,
+        };
+
+        _filter.IsAvailable(
+                sepa,
+                new PaymentAvailabilityContext(null, null, null, PaymentMethodSequenceType.None))
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Amount_BelowMinimum_Rejected()
+    {
+        PaymentMethodCapability klarna = Wildcard with
+        {
+            AmountBounds = new Dictionary<string, PaymentMethodAmountBound>
+            {
+                ["EUR"] = new("EUR", MinAmount: 10m, MaxAmount: 10_000m),
+            },
+        };
+
+        _filter.IsAvailable(klarna, new PaymentAvailabilityContext(null, "EUR", 5m)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Amount_AboveMaximum_Rejected()
+    {
+        PaymentMethodCapability klarna = Wildcard with
+        {
+            AmountBounds = new Dictionary<string, PaymentMethodAmountBound>
+            {
+                ["EUR"] = new("EUR", MinAmount: 10m, MaxAmount: 10_000m),
+            },
+        };
+
+        _filter.IsAvailable(klarna, new PaymentAvailabilityContext(null, "EUR", 12_000m)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Amount_WithinBounds_Accepted()
+    {
+        PaymentMethodCapability klarna = Wildcard with
+        {
+            AmountBounds = new Dictionary<string, PaymentMethodAmountBound>
+            {
+                ["EUR"] = new("EUR", MinAmount: 10m, MaxAmount: 10_000m),
+            },
+        };
+
+        _filter.IsAvailable(klarna, new PaymentAvailabilityContext(null, "EUR", 25m)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Amount_CurrencyMismatch_NoBoundApplied()
+    {
+        PaymentMethodCapability klarnaEurOnly = Wildcard with
+        {
+            AmountBounds = new Dictionary<string, PaymentMethodAmountBound>
+            {
+                ["EUR"] = new("EUR", MinAmount: 10m, MaxAmount: 10_000m),
+            },
+        };
+
+        // Request in GBP — no bound defined for GBP, filter does not enforce
+        _filter.IsAvailable(klarnaEurOnly, new PaymentAvailabilityContext(null, "GBP", 5m)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Amount_OnlyMinSet_NoCeiling()
+    {
+        PaymentMethodCapability method = Wildcard with
+        {
+            AmountBounds = new Dictionary<string, PaymentMethodAmountBound>
+            {
+                ["EUR"] = new("EUR", MinAmount: 10m, MaxAmount: null),
+            },
+        };
+
+        _filter.IsAvailable(method, new PaymentAvailabilityContext(null, "EUR", 9m)).ShouldBeFalse();
+        _filter.IsAvailable(method, new PaymentAvailabilityContext(null, "EUR", 1_000_000m)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AllAxes_IntersectionRejectsOnAnyFailure()
+    {
+        PaymentMethodCapability method = new(
+            SupportedCountries: ImmutableHashSet.Create("BE", "NL"),
+            SupportedCurrencies: ImmutableHashSet.Create("EUR"),
+            SupportedSequenceTypes: PaymentMethodSequenceType.OneOff,
+            AmountBounds: new Dictionary<string, PaymentMethodAmountBound>
+            {
+                ["EUR"] = new("EUR", 1m, 500m),
+            });
+
+        // All axes OK
+        _filter.IsAvailable(method, new PaymentAvailabilityContext("BE", "EUR", 50m)).ShouldBeTrue();
+
+        // Country fails
+        _filter.IsAvailable(method, new PaymentAvailabilityContext("DE", "EUR", 50m)).ShouldBeFalse();
+
+        // Currency fails
+        _filter.IsAvailable(method, new PaymentAvailabilityContext("BE", "USD", 50m)).ShouldBeFalse();
+
+        // Amount fails
+        _filter.IsAvailable(method, new PaymentAvailabilityContext("BE", "EUR", 1000m)).ShouldBeFalse();
+
+        // Sequence fails
+        _filter.IsAvailable(
+                method,
+                new PaymentAvailabilityContext("BE", "EUR", 50m, PaymentMethodSequenceType.Recurring))
+            .ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Provider-driven payment method availability, in four phases stacked on top of PR #1030 (provider-declared descriptors + i18n labels, already merged):

1. **Phase 1** — Pure domain: `PaymentMethodSequenceType` (Mollie-aligned flags), `PaymentMethodAmountBound`, `PaymentMethodCapability`, `PaymentAvailabilityContext`, and a `IPaymentMethodAvailabilityFilter` that intersects capability ∩ request across country / currency / amount / sequence type.
2. **Phase 2** — Provider catalog: `IPaymentProvider.GetCatalogAsync()`, real capability metadata for Mollie / Stripe / SEPA (countries, currencies, bounds, sequence types). `PaymentMethodConfiguration` persists a capability snapshot at activation. New admin endpoints:
   - `GET /configuration/catalog?providerName=…` — live catalogue + activation state
   - `POST /configuration/{p}/{m}/activate` — now snapshots the capability
   - `POST /configuration/{p}/{m}/resync` — re-fetch + update snapshot
3. **Phase 3** — Runtime filtering on `GET /methods/available?country=&currency=&amount=&sequenceType=`. Response now carries the capability snapshot so the front-end can render bound tooltips / country badges without a second round-trip.
4. **Health checks** — new `PaymentProviderHealthCheck` (readiness probe) using `GetCatalogAsync` as the liveness signal. Registered per provider, tagged `readiness, payments`, `Degraded` as failureStatus to avoid cascading a `/ready` outage. Error messages never expose URLs/keys.
5. **Docs** — split `payments.mdx` into a folder: `index` (overview), `providers` (contract + Stripe/Mollie/SEPA + how-to add), `availability` (new chapter with the Phase 1-3 work end-to-end).

Intentional non-goals (flagged in docs): admin tightening overrides (YAGNI, provider dashboards already cover this), `ITenantInfo.CountryCode` (country at checkout is transactional, from `BillingAddress`), self-healing snapshot on provider rejection, periodic background resync.

## Test plan

- [x] `dotnet build Granit.slnx` — 0 errors
- [x] `dotnet test tests/Granit.Payments.Tests` — 94 tests, including 16 filter tests and 6 health-check tests with secret-leak assertions
- [x] `dotnet test tests/Granit.Payments.EntityFrameworkCore.Tests` — 4 tests
- [x] `dotnet test tests/Granit.Payments.Endpoints.Tests` — 18 tests, including 11 query parser tests
- [x] `dotnet format --verify-no-changes` clean on all touched projects
- [ ] Host showcase smoke:
   - `GET /api/payments/configuration/catalog?providerName=mollie` returns the live catalogue
   - `POST /api/payments/configuration/Mollie/bancontact/activate` snapshots `{countries:["BE"], currencies:["EUR"], …}`
   - `GET /methods/available?country=BE&currency=EUR&amount=25&sequenceType=oneoff` excludes iDEAL, keeps Bancontact / Klarna
   - `GET /methods/available?country=BE&currency=EUR&amount=5` drops Klarna (< 10 €)
   - `/ready` includes `payments-mollie`, `payments-stripe`, `payments-sepa-direct-debit`, `payments-sepa-transfer`
- [ ] Host generates the additive EF migration on its `PaymentsDbContext` rebuild

## Migration notes for hosts

Four new nullable columns are added to `paym_payment_method_configurations`:
`SupportedCountries` (CSV nvarchar(512)), `SupportedCurrencies` (CSV nvarchar(256)),
`SupportedSequenceTypes` (int), `AmountBounds` (JSON). Host projects should run
`dotnet ef migrations add AddPaymentMethodConfigurationCapability` on their
`PaymentsDbContext`. Existing rows keep all four columns `NULL`; the runtime
resolver treats that as wildcard until an admin triggers `POST /resync` on each
activation.
