### PR TITLE
fix(payments): normalize empty capability axes to NULL in snapshot

### DIFF
--- a/src/Granit.Payments.EntityFrameworkCore/Internal/PaymentMethodConfigurationEntityTypeConfiguration.cs
+++ b/src/Granit.Payments.EntityFrameworkCore/Internal/PaymentMethodConfigurationEntityTypeConfiguration.cs
@@ -70,24 +70,26 @@ internal sealed class PaymentMethodConfigurationEntityTypeConfiguration
             .HasConversion(boundsConverter, boundsComparer);
     }
 
+    // Empty sets / dictionaries collapse to NULL on the way to the DB — both to keep the
+    // column compact and to avoid the ambiguity between "" / {} (captured wildcard) and
+    // actually-empty provider declarations. The domain layer
+    // (PaymentMethodConfiguration.SnapshotCapability / GetCapabilitySnapshot) owns the
+    // "wildcard ↔ empty collection" semantic; these converters are purely mechanical.
+
     private static string? SetToCsv(ImmutableHashSet<string>? set) =>
-        set switch
-        {
-            null => null,
-            { Count: 0 } => string.Empty,
-            _ => string.Join(',', set.OrderBy(s => s, StringComparer.Ordinal)),
-        };
+        set is null || set.Count == 0
+            ? null
+            : string.Join(',', set.OrderBy(s => s, StringComparer.Ordinal));
 
     private static ImmutableHashSet<string>? CsvToSet(string? csv) =>
-        csv switch
-        {
-            null => null,
-            "" => [],
-            _ => [.. csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)],
-        };
+        string.IsNullOrEmpty(csv)
+            ? null
+            : [.. csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)];
 
     private static string? BoundsToJson(ImmutableDictionary<string, PaymentMethodAmountBound>? bounds) =>
-        bounds == null ? null : JsonSerializer.Serialize(bounds, JsonOptions);
+        bounds is null || bounds.Count == 0
+            ? null
+            : JsonSerializer.Serialize(bounds, JsonOptions);
 
     private static ImmutableDictionary<string, PaymentMethodAmountBound>? JsonToBounds(string? json) =>
         string.IsNullOrEmpty(json)

--- a/src/Granit.Payments/Domain/PaymentMethodConfiguration.cs
+++ b/src/Granit.Payments/Domain/PaymentMethodConfiguration.cs
@@ -85,14 +85,27 @@ public sealed class PaymentMethodConfiguration : AuditedEntity
     /// Captures the provider's current capability for this method. Called by the admin
     /// activation and resync flows.
     /// </summary>
+    /// <remarks>
+    /// Wildcard axes (empty set, empty dictionary) are stored as <see langword="null"/> to
+    /// keep the row compact and unambiguous in the DB — callers read them back as empty
+    /// collections via <see cref="GetCapabilitySnapshot"/>. <see cref="SupportedSequenceTypes"/>
+    /// is the snapshot marker: always non-null for a snapshotted record (every capability
+    /// declares at least one sequence mode), null for legacy records predating this feature.
+    /// </remarks>
     public void SnapshotCapability(PaymentMethodCapability capability)
     {
         ArgumentNullException.ThrowIfNull(capability);
 
-        SupportedCountries = [.. capability.SupportedCountries];
-        SupportedCurrencies = [.. capability.SupportedCurrencies];
+        SupportedCountries = capability.SupportedCountries.Count == 0
+            ? null
+            : [.. capability.SupportedCountries];
+        SupportedCurrencies = capability.SupportedCurrencies.Count == 0
+            ? null
+            : [.. capability.SupportedCurrencies];
         SupportedSequenceTypes = capability.SupportedSequenceTypes;
-        AmountBounds = capability.AmountBounds.ToImmutableDictionary(StringComparer.Ordinal);
+        AmountBounds = capability.AmountBounds.Count == 0
+            ? null
+            : capability.AmountBounds.ToImmutableDictionary(StringComparer.Ordinal);
     }
 
     /// <summary>Drops the capability snapshot. Typically used when detaching a provider.</summary>
@@ -109,20 +122,22 @@ public sealed class PaymentMethodConfiguration : AuditedEntity
     /// captured yet. A null return means the runtime filter should treat this record as
     /// wildcard on every axis.
     /// </summary>
+    /// <remarks>
+    /// The presence of a snapshot is determined by <see cref="SupportedSequenceTypes"/> —
+    /// the other axes may legitimately be null (stored that way when the provider declares
+    /// wildcard / no bounds) and are hydrated back to empty collections here.
+    /// </remarks>
     public PaymentMethodCapability? GetCapabilitySnapshot()
     {
-        if (SupportedCountries is null
-            || SupportedCurrencies is null
-            || SupportedSequenceTypes is null
-            || AmountBounds is null)
+        if (SupportedSequenceTypes is null)
         {
             return null;
         }
 
         return new PaymentMethodCapability(
-            SupportedCountries,
-            SupportedCurrencies,
+            SupportedCountries ?? [],
+            SupportedCurrencies ?? [],
             SupportedSequenceTypes.Value,
-            AmountBounds);
+            AmountBounds ?? ImmutableDictionary<string, PaymentMethodAmountBound>.Empty);
     }
 }

--- a/tests/Granit.Payments.Tests/Domain/PaymentMethodConfigurationSnapshotTests.cs
+++ b/tests/Granit.Payments.Tests/Domain/PaymentMethodConfigurationSnapshotTests.cs
@@ -1,0 +1,115 @@
+using System.Collections.Immutable;
+using Granit.Payments.Contracts;
+using Granit.Payments.Domain;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Payments.Tests.Domain;
+
+public sealed class PaymentMethodConfigurationSnapshotTests
+{
+    private static PaymentMethodConfiguration NewConfig() =>
+        PaymentMethodConfiguration.Activate(Guid.NewGuid(), "mollie", "bancontact");
+
+    [Fact]
+    public void SnapshotCapability_WithAllWildcards_StoresNulls()
+    {
+        PaymentMethodConfiguration config = NewConfig();
+
+        config.SnapshotCapability(PaymentMethodCapability.Wildcard);
+
+        // Empty axes collapse to null; sequence marker is preserved
+        config.SupportedCountries.ShouldBeNull();
+        config.SupportedCurrencies.ShouldBeNull();
+        config.AmountBounds.ShouldBeNull();
+        config.SupportedSequenceTypes.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void SnapshotCapability_WithPopulatedAxes_StoresValues()
+    {
+        PaymentMethodConfiguration config = NewConfig();
+        PaymentMethodCapability capability = new(
+            SupportedCountries: ImmutableHashSet.Create("BE", "NL"),
+            SupportedCurrencies: ImmutableHashSet.Create("EUR"),
+            SupportedSequenceTypes: PaymentMethodSequenceType.OneOff | PaymentMethodSequenceType.First,
+            AmountBounds: new Dictionary<string, PaymentMethodAmountBound>
+            {
+                ["EUR"] = new("EUR", 1m, 10_000m),
+            });
+
+        config.SnapshotCapability(capability);
+
+        config.SupportedCountries.ShouldBe(["BE", "NL"], ignoreOrder: true);
+        config.SupportedCurrencies.ShouldBe(["EUR"]);
+        config.AmountBounds.ShouldNotBeNull();
+        config.AmountBounds["EUR"].MinAmount.ShouldBe(1m);
+    }
+
+    [Fact]
+    public void GetCapabilitySnapshot_WithWildcardsPersisted_HydratesToEmptyCollections()
+    {
+        PaymentMethodConfiguration config = NewConfig();
+        config.SnapshotCapability(PaymentMethodCapability.Wildcard);
+
+        PaymentMethodCapability? snapshot = config.GetCapabilitySnapshot();
+
+        snapshot.ShouldNotBeNull();
+        snapshot!.SupportedCountries.Count.ShouldBe(0);
+        snapshot.SupportedCurrencies.Count.ShouldBe(0);
+        snapshot.AmountBounds.Count.ShouldBe(0);
+        snapshot.SupportedSequenceTypes.ShouldBe(PaymentMethodCapability.Wildcard.SupportedSequenceTypes);
+    }
+
+    [Fact]
+    public void GetCapabilitySnapshot_ReturnsNull_ForLegacyRecordWithoutSnapshot()
+    {
+        PaymentMethodConfiguration config = NewConfig();
+        // Fresh Activate — never snapshotted
+
+        PaymentMethodCapability? snapshot = config.GetCapabilitySnapshot();
+
+        snapshot.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Snapshot_RoundTrip_PreservesValues()
+    {
+        PaymentMethodCapability original = new(
+            SupportedCountries: ImmutableHashSet.Create("BE", "NL", "FR"),
+            SupportedCurrencies: ImmutableHashSet.Create("EUR", "GBP"),
+            SupportedSequenceTypes: PaymentMethodSequenceType.First | PaymentMethodSequenceType.Recurring,
+            AmountBounds: new Dictionary<string, PaymentMethodAmountBound>
+            {
+                ["EUR"] = new("EUR", 10m, 10_000m),
+                ["GBP"] = new("GBP", 8m, 8_000m),
+            });
+
+        PaymentMethodConfiguration config = NewConfig();
+        config.SnapshotCapability(original);
+
+        PaymentMethodCapability? roundTripped = config.GetCapabilitySnapshot();
+
+        roundTripped.ShouldNotBeNull();
+        roundTripped!.SupportedCountries.ShouldBe(original.SupportedCountries, ignoreOrder: true);
+        roundTripped.SupportedCurrencies.ShouldBe(original.SupportedCurrencies, ignoreOrder: true);
+        roundTripped.SupportedSequenceTypes.ShouldBe(original.SupportedSequenceTypes);
+        roundTripped.AmountBounds["EUR"].MinAmount.ShouldBe(10m);
+        roundTripped.AmountBounds["GBP"].MaxAmount.ShouldBe(8_000m);
+    }
+
+    [Fact]
+    public void ClearCapability_ResetsAllAxesToNull()
+    {
+        PaymentMethodConfiguration config = NewConfig();
+        config.SnapshotCapability(PaymentMethodCapability.Wildcard);
+
+        config.ClearCapability();
+
+        config.SupportedCountries.ShouldBeNull();
+        config.SupportedCurrencies.ShouldBeNull();
+        config.SupportedSequenceTypes.ShouldBeNull();
+        config.AmountBounds.ShouldBeNull();
+        config.GetCapabilitySnapshot().ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up fix on PR #1031. Empty capability axes were persisting as `""` / `""` / `{}` in the DB — visually noisy and ambiguous against future deltas. This PR normalizes them to `NULL`, with no wire-format impact.

- `PaymentMethodConfiguration.SnapshotCapability` collapses empty `SupportedCountries` / `SupportedCurrencies` / `AmountBounds` to `null`
- `GetCapabilitySnapshot` now uses `SupportedSequenceTypes` as the snapshot marker (always non-null for a snapshotted record — every capability declares at least one sequence mode); the other axes hydrate back to empty collections
- EF converters mirror the normalization defensively on write (any path that assigns `ImmutableHashSet.Empty` or `ImmutableDictionary.Empty` still persists as NULL)
- 6 new unit tests in `PaymentMethodConfigurationSnapshotTests` cover wildcard → nulls, populated → values, null hydration, legacy record absence, round-trip, and clear

## Test plan

- [x] `dotnet build Granit.slnx` — 0 errors
- [x] `dotnet test tests/Granit.Payments.Tests` — 100 tests (94 previous + 6 new)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 111 tests
- [x] `dotnet format --verify-no-changes` clean on all touched projects
- [ ] Host smoke (after rebase onto develop):
  - `POST /configuration/Mollie/card/activate` → row has `SupportedCountries=NULL`, `SupportedCurrencies=NULL`, `AmountBounds=NULL`, `SupportedSequenceTypes=7`
  - `POST /configuration/Mollie/klarna/activate` → `AmountBounds` contains `{"EUR":{...}, "GBP":{...}, ...}`
  - `GET /configuration/` returns empty arrays for wildcard axes (mapper hydrates)

## No schema change

Columns are already nullable (introduced in PR #1031). Hosts do **not** need a new EF migration. Existing rows written with `""` / `{}` still round-trip correctly — the EF converter treats `""` and `NULL` identically on read.
