### PR TITLE
refactor(core): rename IActive.IsActive to Activated and tighten to { get; }

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -13068,7 +13068,7 @@
       "kind": "interface",
       "project": "Granit",
       "file": "src/Granit/Domain/IActive.cs",
-      "line": 14,
+      "line": 28,
       "members": []
     },
     {
@@ -35018,9 +35018,9 @@
           "returnType": "string"
         },
         {
-          "name": "IsActive",
+          "name": "Activated",
           "kind": "property",
-          "signature": "bool IsActive",
+          "signature": "bool Activated",
           "returnType": "bool"
         }
       ]

--- a/src/Granit.DataExchange.Definitions/ReferenceData/DynamicReferenceDataEntityExportDefinition.cs
+++ b/src/Granit.DataExchange.Definitions/ReferenceData/DynamicReferenceDataEntityExportDefinition.cs
@@ -28,7 +28,7 @@ public sealed class DynamicReferenceDataEntityExportDefinition : ExportDefinitio
             .Field(e => e.LabelSv)
             .Field(e => e.LabelCs)
             .Field(e => e.LabelHi)
-            .Field(e => e.IsActive)
+            .Field(e => e.Activated)
             .Field(e => e.SortOrder)
             .Field(e => e.ValidFrom, f => f.Format("O"))
             .Field(e => e.ValidTo, f => f.Format("O"))

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -248,9 +248,9 @@ public static class ModelBuilderExtensions
         {
             Expression bypass = Expression.Not(
                 Expression.Property(Expression.Constant(proxy), nameof(FilterProxy.ActiveEnabled)));
-            Expression isActive = Expression.Property(param, nameof(IActive.IsActive));
+            Expression activated = Expression.Property(param, nameof(IActive.Activated));
             builder.HasQueryFilter(GranitFilterNames.Active,
-                Expression.Lambda<Func<TEntity, bool>>(Expression.OrElse(bypass, isActive), param));
+                Expression.Lambda<Func<TEntity, bool>>(Expression.OrElse(bypass, activated), param));
         }
 
         if (typeof(IProcessingRestrictable).IsAssignableFrom(typeof(TEntity)))

--- a/src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataResponse.cs
+++ b/src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataResponse.cs
@@ -21,7 +21,7 @@ namespace Granit.ReferenceData.Endpoints.Dtos;
 /// <param name="LabelSv">Swedish display label.</param>
 /// <param name="LabelCs">Czech display label.</param>
 /// <param name="LabelHi">Hindi display label.</param>
-/// <param name="IsActive">Whether the entry is active.</param>
+/// <param name="Activated">Whether the entry is active.</param>
 /// <param name="SortOrder">Display order (lower values first).</param>
 /// <param name="ValidFrom">Optional start of validity period.</param>
 /// <param name="ValidTo">Optional end of validity period.</param>
@@ -46,7 +46,7 @@ public sealed record ReferenceDataResponse(
     string LabelSv,
     string LabelCs,
     string LabelHi,
-    bool IsActive,
+    bool Activated,
     int SortOrder,
     DateTimeOffset? ValidFrom,
     DateTimeOffset? ValidTo,

--- a/src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataUpdateRequest.cs
+++ b/src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataUpdateRequest.cs
@@ -21,7 +21,7 @@ namespace Granit.ReferenceData.Endpoints.Dtos;
 /// <param name="LabelCs">Updated Czech display label.</param>
 /// <param name="LabelHi">Updated Hindi display label.</param>
 /// <param name="SortOrder">Updated display order.</param>
-/// <param name="IsActive">Updated active status.</param>
+/// <param name="Activated">Updated active status.</param>
 /// <param name="ValidFrom">Updated start of validity period.</param>
 /// <param name="ValidTo">Updated end of validity period.</param>
 /// <param name="ParentCode">Updated parent code for hierarchical reference data.</param>
@@ -43,7 +43,7 @@ public sealed record ReferenceDataUpdateRequest(
     string LabelCs = "",
     string LabelHi = "",
     int SortOrder = 0,
-    bool IsActive = true,
+    bool Activated = true,
     DateTimeOffset? ValidFrom = null,
     DateTimeOffset? ValidTo = null,
     string? ParentCode = null,

--- a/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataAdminEndpoints.cs
+++ b/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataAdminEndpoints.cs
@@ -93,7 +93,7 @@ internal static class ReferenceDataAdminEndpoints
             ValidFrom = request.ValidFrom,
             ValidTo = request.ValidTo,
             ParentCode = request.ParentCode,
-            IsActive = true,
+            Activated = true,
         };
 
         if (request.ExtraProperties is { Count: > 0 })
@@ -139,7 +139,7 @@ internal static class ReferenceDataAdminEndpoints
         existing.LabelCs = request.LabelCs;
         existing.LabelHi = request.LabelHi;
         existing.SortOrder = request.SortOrder;
-        existing.IsActive = request.IsActive;
+        existing.Activated = request.Activated;
         existing.ValidFrom = request.ValidFrom;
         existing.ValidTo = request.ValidTo;
         existing.ParentCode = request.ParentCode;

--- a/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataDynamicEndpoints.cs
+++ b/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataDynamicEndpoints.cs
@@ -216,7 +216,7 @@ internal static class ReferenceDataDynamicEndpoints
             ValidFrom = request.ValidFrom,
             ValidTo = request.ValidTo,
             ParentCode = request.ParentCode,
-            IsActive = true,
+            Activated = true,
         };
 
         if (request.ExtraProperties is { Count: > 0 })
@@ -267,7 +267,7 @@ internal static class ReferenceDataDynamicEndpoints
         existing.LabelCs = request.LabelCs;
         existing.LabelHi = request.LabelHi;
         existing.SortOrder = request.SortOrder;
-        existing.IsActive = request.IsActive;
+        existing.Activated = request.Activated;
         existing.ValidFrom = request.ValidFrom;
         existing.ValidTo = request.ValidTo;
         existing.ParentCode = request.ParentCode;

--- a/src/Granit.ReferenceData.Endpoints/Internal/ReferenceDataMapper.cs
+++ b/src/Granit.ReferenceData.Endpoints/Internal/ReferenceDataMapper.cs
@@ -34,7 +34,7 @@ internal static class ReferenceDataMapper
             entity.LabelSv,
             entity.LabelCs,
             entity.LabelHi,
-            entity.IsActive,
+            entity.Activated,
             entity.SortOrder,
             entity.ValidFrom,
             entity.ValidTo,

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Internal/EfCoreReferenceDataStore.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Internal/EfCoreReferenceDataStore.cs
@@ -87,7 +87,7 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
         // Active filter
         if (query.ActiveOnly)
         {
-            queryable = queryable.Where(e => e.IsActive);
+            queryable = queryable.Where(e => e.Activated);
         }
 
         // Search filter (Code or any label, case-insensitive)
@@ -272,7 +272,7 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
 
         if (entity is not null)
         {
-            entity.IsActive = isActive;
+            entity.Activated = isActive;
             await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
 
@@ -297,7 +297,7 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
         }
 
         List<TEntity> children = await queryable
-            .Where(e => e.ParentCode == parentCode && e.IsActive)
+            .Where(e => e.ParentCode == parentCode && e.Activated)
             .OrderBy(e => e.SortOrder)
             .ThenBy(e => e.Code)
             .ToListAsync(cancellationToken)

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataEntityTypeConfiguration.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataEntityTypeConfiguration.cs
@@ -6,7 +6,7 @@ namespace Granit.ReferenceData.EntityFrameworkCore.Internal;
 
 /// <summary>
 /// Base EF Core Fluent API configuration for reference data entities.
-/// Configures the common columns (Code, Label, IsActive, SortOrder, ValidFrom, ValidTo)
+/// Configures the common columns (Code, Label, Activated, SortOrder, ValidFrom, ValidTo)
 /// and the audit columns inherited from <see cref="Granit.Domain.AuditedEntity"/>.
 /// </summary>
 /// <typeparam name="TEntity">The concrete reference data entity type.</typeparam>
@@ -104,9 +104,9 @@ public abstract class ReferenceDataEntityTypeConfiguration<TEntity>
         builder.Property(e => e.LabelCs).HasMaxLength(250);
         builder.Property(e => e.LabelHi).HasMaxLength(250);
 
-        // IsActive — indexed for global query filter performance
-        builder.HasIndex(e => e.IsActive)
-               .HasDatabaseName($"ix_{_tableName}_is_active");
+        // Activated — indexed for global query filter performance
+        builder.HasIndex(e => e.Activated)
+               .HasDatabaseName($"ix_{_tableName}_activated");
 
         // SortOrder
         builder.Property(e => e.SortOrder)

--- a/src/Granit.ReferenceData/Domain/ReferenceDataEntity.cs
+++ b/src/Granit.ReferenceData/Domain/ReferenceDataEntity.cs
@@ -20,7 +20,7 @@ namespace Granit.ReferenceData.Domain;
 /// Derived entities can override <see cref="Label"/> for custom resolution logic.
 /// </para>
 /// <para>
-/// Soft activation/deactivation is controlled by <see cref="IsActive"/>. Deactivated entries
+/// Soft activation/deactivation is controlled by <see cref="Activated"/>. Deactivated entries
 /// are filtered out by the EF Core global query filter unless explicitly disabled.
 /// </para>
 /// <para>
@@ -118,7 +118,7 @@ public abstract class ReferenceDataEntity : AuditedEntity, IActive, IHasExtraPro
     };
 
     /// <inheritdoc/>
-    public bool IsActive { get; set; } = true;
+    public bool Activated { get; set; } = true;
 
     /// <summary>
     /// Display order for UI sorting. Lower values appear first. Default is 0.

--- a/src/Granit.ReferenceData/Internal/GenericReferenceDataQueryDefinition.cs
+++ b/src/Granit.ReferenceData/Internal/GenericReferenceDataQueryDefinition.cs
@@ -6,7 +6,7 @@ namespace Granit.ReferenceData.Internal;
 /// <summary>
 /// Auto-generated <see cref="QueryDefinition{TEntity}"/> for strongly-typed reference data
 /// entity types. Declares the same base columns as <see cref="ReferenceDataQueryDefinition"/>
-/// (Code, Labels, IsActive, SortOrder, ValidFrom, ValidTo) for any <typeparamref name="TEntity"/>
+/// (Code, Labels, Activated, SortOrder, ValidFrom, ValidTo) for any <typeparamref name="TEntity"/>
 /// inheriting from <see cref="ReferenceDataEntity"/>.
 /// </summary>
 internal sealed class GenericReferenceDataQueryDefinition<TEntity>
@@ -26,7 +26,7 @@ internal sealed class GenericReferenceDataQueryDefinition<TEntity>
             .Column(e => e.LabelNl, c => c.Label("Label (NL)").Filterable())
             .Column(e => e.LabelDe, c => c.Label("Label (DE)").Filterable())
             .Column(e => e.LabelHi, c => c.Label("Label (HI)").Filterable())
-            .Column(e => e.IsActive, c => c.Label("Active").Filterable())
+            .Column(e => e.Activated, c => c.Label("Active").Filterable())
             .Column(e => e.SortOrder, c => c.Label("Sort Order").Sortable())
             .Column(e => e.ValidFrom, c => c.Label("Valid From").Filterable().Sortable())
             .Column(e => e.ValidTo, c => c.Label("Valid To").Filterable().Sortable())

--- a/src/Granit.ReferenceData/Internal/ReferenceDataQueryDefinition.cs
+++ b/src/Granit.ReferenceData/Internal/ReferenceDataQueryDefinition.cs
@@ -6,7 +6,7 @@ namespace Granit.ReferenceData.Internal;
 
 /// <summary>
 /// Auto-generated <see cref="QueryDefinition{TEntity}"/> for a dynamically registered
-/// reference data type. Declares base columns (Code, Labels, IsActive, SortOrder, ValidFrom,
+/// reference data type. Declares base columns (Code, Labels, Activated, SortOrder, ValidFrom,
 /// ValidTo) plus any Shadow Property columns from <see cref="ReferenceDataExtensionOptions"/>.
 /// </summary>
 internal sealed class ReferenceDataQueryDefinition(
@@ -28,7 +28,7 @@ internal sealed class ReferenceDataQueryDefinition(
             .Column(e => e.LabelNl, c => c.Label("Label (NL)").Filterable())
             .Column(e => e.LabelDe, c => c.Label("Label (DE)").Filterable())
             .Column(e => e.LabelHi, c => c.Label("Label (HI)").Filterable())
-            .Column(e => e.IsActive, c => c.Label("Active").Filterable())
+            .Column(e => e.Activated, c => c.Label("Active").Filterable())
             .Column(e => e.SortOrder, c => c.Label("Sort Order").Sortable())
             .Column(e => e.ValidFrom, c => c.Label("Valid From").Filterable().Sortable())
             .Column(e => e.ValidTo, c => c.Label("Valid To").Filterable().Sortable());

--- a/src/Granit/Domain/IActive.cs
+++ b/src/Granit/Domain/IActive.cs
@@ -1,18 +1,32 @@
 namespace Granit.Domain;
 
 /// <summary>
-/// Interface for entities with an active/inactive status.
-/// When <see cref="IsActive"/> is <c>false</c>, the entity is excluded from standard
-/// queries by the EF Core global query filter registered by
-/// <c>ModelBuilderExtensions.ApplyGranitConventions()</c> (WHERE IsActive = true).
+/// Marker interface for entities that expose an on/off activation flag and should be
+/// hidden from standard queries when deactivated.
 /// </summary>
 /// <remarks>
-/// Opt-in: only entities explicitly implementing this interface are filtered.
-/// The filter can be bypassed at runtime via
+/// <para>
+/// When <see cref="Activated"/> is <c>false</c>, the entity is excluded from standard
+/// queries by the EF Core global query filter registered by
+/// <c>ModelBuilderExtensions.ApplyGranitConventions()</c> (<c>WHERE Activated = true</c>).
+/// Admin code paths that need to see deactivated rows disable the filter via
 /// <c>IDataFilter.Disable&lt;IActive&gt;()</c>.
+/// </para>
+/// <para>
+/// The interface requires only a getter — implementers may expose a public setter
+/// (CRUD / reference-data style) or encapsulate mutation via behavior methods with a
+/// private setter (DDD aggregate style). The query filter only reads the value; no
+/// framework code mutates <see cref="Activated"/> through the interface.
+/// </para>
+/// <para>
+/// The past-participle naming (<em>Activated</em>) pairs with the conventional
+/// <c>Activate()</c> / <c>Deactivate()</c> behavior methods found on DDD aggregates and
+/// mirrors the bare-participle convention used in the Identity subsystem
+/// (<c>IIdentityUser.Enabled</c>).
+/// </para>
 /// </remarks>
 public interface IActive
 {
-    /// <summary>Indicates whether the entity is active and visible in standard queries.</summary>
-    bool IsActive { get; set; }
+    /// <summary>Indicates whether the entity is currently active and visible in standard queries.</summary>
+    bool Activated { get; }
 }

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/ModelBuilderExtensionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/ModelBuilderExtensionsTests.cs
@@ -196,8 +196,8 @@ public sealed class ModelBuilderExtensionsTests
         await using TestDbContextWithActive context = CreateContextWithActive();
         await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
 
-        context.ActiveEntities.Add(new TestActiveEntity { Name = "Active", IsActive = true });
-        context.ActiveEntities.Add(new TestActiveEntity { Name = "Inactive", IsActive = false });
+        context.ActiveEntities.Add(new TestActiveEntity { Name = "Active", Activated = true });
+        context.ActiveEntities.Add(new TestActiveEntity { Name = "Inactive", Activated = false });
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
@@ -215,8 +215,8 @@ public sealed class ModelBuilderExtensionsTests
         await using TestDbContextWithActive context = CreateContextWithActive();
         await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
 
-        context.ActiveEntities.Add(new TestActiveEntity { Name = "Active", IsActive = true });
-        context.ActiveEntities.Add(new TestActiveEntity { Name = "Inactive", IsActive = false });
+        context.ActiveEntities.Add(new TestActiveEntity { Name = "Active", Activated = true });
+        context.ActiveEntities.Add(new TestActiveEntity { Name = "Inactive", Activated = false });
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
@@ -275,11 +275,11 @@ public sealed class ModelBuilderExtensionsTests
 
         var compiled = (Func<TestActiveWithFilter, bool>)filter!.Compile();
 
-        compiled(new TestActiveWithFilter { IsActive = false }).ShouldBeFalse("inactive must be filtered");
-        compiled(new TestActiveWithFilter { IsActive = true }).ShouldBeTrue("active must pass");
+        compiled(new TestActiveWithFilter { Activated = false }).ShouldBeFalse("inactive must be filtered");
+        compiled(new TestActiveWithFilter { Activated = true }).ShouldBeTrue("active must pass");
 
         SharedDataFilter.SetEnabled<IActive>(false);
-        compiled(new TestActiveWithFilter { IsActive = false }).ShouldBeTrue("inactive must pass when filter disabled");
+        compiled(new TestActiveWithFilter { Activated = false }).ShouldBeTrue("inactive must pass when filter disabled");
 
         SharedDataFilter.SetEnabled<IActive>(true);
     }
@@ -753,7 +753,7 @@ internal sealed class TestActiveEntity : IActive
 {
     public int Id { get; set; }
     public string Name { get; set; } = string.Empty;
-    public bool IsActive { get; set; }
+    public bool Activated { get; set; }
 }
 
 internal sealed class TestSoftDeleteWithFilter : ISoftDeletable
@@ -767,7 +767,7 @@ internal sealed class TestSoftDeleteWithFilter : ISoftDeletable
 internal sealed class TestActiveWithFilter : IActive
 {
     public int Id { get; set; }
-    public bool IsActive { get; set; }
+    public bool Activated { get; set; }
 }
 
 internal sealed class TestCombinedEntity : ISoftDeletable, IMultiTenant

--- a/tests/Granit.ReferenceData.Endpoints.Tests/Internal/ReferenceDataMapperTests.cs
+++ b/tests/Granit.ReferenceData.Endpoints.Tests/Internal/ReferenceDataMapperTests.cs
@@ -35,7 +35,7 @@ public sealed class ReferenceDataMapperTests
             LabelKo = "벨기에",
             LabelSv = "Belgien",
             LabelCs = "Belgie",
-            IsActive = true,
+            Activated = true,
             SortOrder = 5,
             ValidFrom = validFrom,
             ValidTo = validTo,
@@ -60,7 +60,7 @@ public sealed class ReferenceDataMapperTests
         response.LabelKo.ShouldBe("벨기에");
         response.LabelSv.ShouldBe("Belgien");
         response.LabelCs.ShouldBe("Belgie");
-        response.IsActive.ShouldBeTrue();
+        response.Activated.ShouldBeTrue();
         response.SortOrder.ShouldBe(5);
         response.ValidFrom.ShouldBe(validFrom);
         response.ValidTo.ShouldBe(validTo);

--- a/tests/Granit.ReferenceData.Endpoints.Tests/ReferenceDataEndpointsTests.cs
+++ b/tests/Granit.ReferenceData.Endpoints.Tests/ReferenceDataEndpointsTests.cs
@@ -356,7 +356,7 @@ public sealed class ReferenceDataEndpointsTests : IAsyncDisposable
             builder
                 .Column(e => e.Code, c => c.Label("Code").Filterable().Sortable())
                 .Column(e => e.LabelEn, c => c.Label("Label (EN)").Filterable().Sortable())
-                .Column(e => e.IsActive, c => c.Label("Active").Filterable())
+                .Column(e => e.Activated, c => c.Label("Active").Filterable())
                 .GlobalSearch(e => e.Code, e => e.LabelEn)
                 .DefaultSort("Code");
         }

--- a/tests/Granit.ReferenceData.Endpoints.Tests/ReferenceDataUpdateRequestTests.cs
+++ b/tests/Granit.ReferenceData.Endpoints.Tests/ReferenceDataUpdateRequestTests.cs
@@ -47,7 +47,7 @@ public sealed class ReferenceDataUpdateRequestTests
     {
         ReferenceDataUpdateRequest request = new("Belgium");
 
-        request.IsActive.ShouldBeTrue();
+        request.Activated.ShouldBeTrue();
     }
 
     [Fact]
@@ -86,14 +86,14 @@ public sealed class ReferenceDataUpdateRequestTests
             LabelSv: "Belgien",
             LabelCs: "Belgie",
             SortOrder: 10,
-            IsActive: false,
+            Activated: false,
             ValidFrom: now,
             ValidTo: now.AddYears(1));
 
         request.LabelFr.ShouldBe("Belgique");
         request.LabelCs.ShouldBe("Belgie");
         request.SortOrder.ShouldBe(10);
-        request.IsActive.ShouldBeFalse();
+        request.Activated.ShouldBeFalse();
         request.ValidFrom.ShouldBe(now);
         request.ValidTo.ShouldBe(now.AddYears(1));
     }

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreAdditionalTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreAdditionalTests.cs
@@ -78,7 +78,7 @@ public sealed class EfCoreReferenceDataStoreAdditionalTests
             Code = code,
             LabelEn = label,
             LabelFr = labelFr,
-            IsActive = isActive,
+            Activated = isActive,
             SortOrder = sortOrder,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "seed",
@@ -279,7 +279,7 @@ public sealed class EfCoreReferenceDataStoreAdditionalTests
             Id = Guid.NewGuid(),
             Code = "BE",
             LabelEn = "Belgium (duplicate)",
-            IsActive = true,
+            Activated = true,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "test",
         }, TestContext.Current.CancellationToken));
@@ -293,7 +293,7 @@ public sealed class EfCoreReferenceDataStoreAdditionalTests
     public async Task CreateAsync_DuplicateCode_InactiveRecord_IsNoOp()
     {
         // This is the exact scenario seen in production: seeder runs a second time,
-        // the existing record has IsActive=false (bypassed by the query filter in
+        // the existing record has Activated=false (bypassed by the query filter in
         // GetByCodeAsync), so the seeder calls CreateAsync which must not throw 23505.
         string db = Guid.NewGuid().ToString();
         await SeedAsync(db, "BE", "Belgium", isActive: false, cancellationToken: TestContext.Current.CancellationToken);
@@ -305,7 +305,7 @@ public sealed class EfCoreReferenceDataStoreAdditionalTests
             Id = Guid.NewGuid(),
             Code = "BE",
             LabelEn = "Belgium",
-            IsActive = true,
+            Activated = true,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "test",
         }, TestContext.Current.CancellationToken));
@@ -323,13 +323,13 @@ public sealed class EfCoreReferenceDataStoreAdditionalTests
 
         EfCoreReferenceDataStore<TestEntity, TestDbContext> store = CreateStore(db);
 
-        // Should succeed even though the record is filtered out by IsActive=false
+        // Should succeed even though the record is filtered out by Activated=false
         await store.SetActiveAsync("BE", true, TestContext.Current.CancellationToken);
 
         PagedResult<TestEntity> result = await store.GetAllAsync(
             cancellationToken: TestContext.Current.CancellationToken);
 
-        result.Items.ShouldContain(e => e.Code == "BE" && e.IsActive);
+        result.Items.ShouldContain(e => e.Code == "BE" && e.Activated);
     }
 
     // -------------------------------------------------------------------------
@@ -356,7 +356,7 @@ public sealed class EfCoreReferenceDataStoreAdditionalTests
             Id = Guid.NewGuid(),
             Code = "BE",
             LabelEn = "Belgium",
-            IsActive = true,
+            Activated = true,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "test",
         };

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreConcurrencyTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreConcurrencyTests.cs
@@ -71,7 +71,7 @@ public sealed class EfCoreReferenceDataStoreConcurrencyTests : IAsyncLifetime
                     Id = Guid.NewGuid(),
                     Code = code,
                     LabelEn = "Concurrent winner",
-                    IsActive = true,
+                    Activated = true,
                     SortOrder = 0,
                     CreatedAt = DateTimeOffset.UtcNow,
                     CreatedBy = "race",
@@ -143,7 +143,7 @@ public sealed class EfCoreReferenceDataStoreConcurrencyTests : IAsyncLifetime
             Id = Guid.NewGuid(),
             Code = "RACE",
             LabelEn = "Loser",
-            IsActive = true,
+            Activated = true,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "test",
         }, TestContext.Current.CancellationToken));
@@ -168,7 +168,7 @@ public sealed class EfCoreReferenceDataStoreConcurrencyTests : IAsyncLifetime
             Id = Guid.NewGuid(),
             Code = "VALID",
             LabelEn = "Valid",
-            IsActive = true,
+            Activated = true,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "test",
         }, TestContext.Current.CancellationToken);

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreTests.cs
@@ -76,7 +76,7 @@ public sealed class EfCoreReferenceDataStoreTests
             Id = Guid.NewGuid(),
             Code = code,
             LabelEn = label,
-            IsActive = isActive,
+            Activated = isActive,
             SortOrder = sortOrder,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "seed",
@@ -147,7 +147,7 @@ public sealed class EfCoreReferenceDataStoreTests
             cancellationToken: TestContext.Current.CancellationToken);
 
         result.TotalCount.ShouldBe(1);
-        result.Items.ShouldAllBe(e => e.IsActive);
+        result.Items.ShouldAllBe(e => e.Activated);
     }
 
     [Fact]
@@ -277,7 +277,7 @@ public sealed class EfCoreReferenceDataStoreTests
             Id = Guid.NewGuid(),
             Code = "DE",
             LabelEn = "Germany",
-            IsActive = true,
+            Activated = true,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "test",
         };
@@ -332,7 +332,7 @@ public sealed class EfCoreReferenceDataStoreTests
             new ReferenceDataQuery(ActiveOnly: false),
             TestContext.Current.CancellationToken);
 
-        result.Items.ShouldContain(e => e.Code == "BE" && !e.IsActive);
+        result.Items.ShouldContain(e => e.Code == "BE" && !e.Activated);
     }
 
     [Fact]
@@ -347,7 +347,7 @@ public sealed class EfCoreReferenceDataStoreTests
         PagedResult<TestEntity> result = await store.GetAllAsync(
             cancellationToken: TestContext.Current.CancellationToken);
 
-        result.Items.ShouldContain(e => e.Code == "BE" && e.IsActive);
+        result.Items.ShouldContain(e => e.Code == "BE" && e.Activated);
     }
 
     // -------------------------------------------------------------------------
@@ -379,7 +379,7 @@ public sealed class EfCoreReferenceDataStoreTests
             Id = Guid.NewGuid(),
             Code = "DE",
             LabelEn = "Germany",
-            IsActive = true,
+            Activated = true,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "test",
         }, TestContext.Current.CancellationToken);

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEntityTypeConfigurationAdditionalTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEntityTypeConfigurationAdditionalTests.cs
@@ -122,19 +122,19 @@ public sealed class ReferenceDataEntityTypeConfigurationAdditionalTests
     }
 
     // -------------------------------------------------------------------------
-    // IsActive index has expected name
+    // Activated index has expected name
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void IsActive_Index_HasExpectedDatabaseName()
+    public void Activated_Index_HasExpectedDatabaseName()
     {
         IEntityType entityType = GetEntityType();
-        IProperty isActive = entityType.FindProperty(nameof(TestEntity.IsActive))!;
+        IProperty activated = entityType.FindProperty(nameof(TestEntity.Activated))!;
 
         IIndex? index = entityType.GetIndexes()
-            .FirstOrDefault(i => i.Properties.Count == 1 && i.Properties[0] == isActive);
+            .FirstOrDefault(i => i.Properties.Count == 1 && i.Properties[0] == activated);
 
         index.ShouldNotBeNull();
-        index!.GetDatabaseName().ShouldBe("ix_ref_test_entities_is_active");
+        index!.GetDatabaseName().ShouldBe("ix_ref_test_entities_activated");
     }
 }

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEntityTypeConfigurationTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEntityTypeConfigurationTests.cs
@@ -107,7 +107,7 @@ public sealed class ReferenceDataEntityTypeConfigurationTests
     public void IsActive_Has_Index()
     {
         IEntityType entityType = GetEntityType();
-        IProperty isActive = entityType.FindProperty(nameof(TestEntity.IsActive))!;
+        IProperty isActive = entityType.FindProperty(nameof(TestEntity.Activated))!;
 
         IIndex? index = entityType.GetIndexes()
             .FirstOrDefault(i => i.Properties.Count == 1 && i.Properties[0] == isActive);

--- a/tests/Granit.ReferenceData.Tests/ReferenceDataEntityAdditionalTests.cs
+++ b/tests/Granit.ReferenceData.Tests/ReferenceDataEntityAdditionalTests.cs
@@ -54,9 +54,9 @@ public sealed class ReferenceDataEntityAdditionalTests
     [Fact]
     public void IsActive_CanBeSetToFalse()
     {
-        TestEntity entity = new() { IsActive = false };
+        TestEntity entity = new() { Activated = false };
 
-        entity.IsActive.ShouldBeFalse();
+        entity.Activated.ShouldBeFalse();
     }
 
     [Fact]

--- a/tests/Granit.ReferenceData.Tests/ReferenceDataEntityTests.cs
+++ b/tests/Granit.ReferenceData.Tests/ReferenceDataEntityTests.cs
@@ -32,7 +32,7 @@ public sealed class ReferenceDataEntityTests
     {
         TestEntity entity = new();
 
-        entity.IsActive.ShouldBeTrue();
+        entity.Activated.ShouldBeTrue();
     }
 
     [Fact]
@@ -253,7 +253,7 @@ public sealed class ReferenceDataEntityTests
             LabelKo = "벨기에",
             LabelSv = "Belgien",
             LabelCs = "Belgie",
-            IsActive = false,
+            Activated = false,
             SortOrder = 42,
             ValidFrom = now,
             ValidTo = now.AddYears(1)
@@ -274,7 +274,7 @@ public sealed class ReferenceDataEntityTests
         entity.LabelKo.ShouldBe("벨기에");
         entity.LabelSv.ShouldBe("Belgien");
         entity.LabelCs.ShouldBe("Belgie");
-        entity.IsActive.ShouldBeFalse();
+        entity.Activated.ShouldBeFalse();
         entity.SortOrder.ShouldBe(42);
         entity.ValidFrom.ShouldBe(now);
         entity.ValidTo.ShouldBe(now.AddYears(1));


### PR DESCRIPTION
## Summary

Framework-level rename on `IActive` to enable clean adoption on DDD aggregate roots and align with the bare-participle naming already used in the Identity subsystem.

- `IActive.IsActive { get; set; }` → `IActive.Activated { get; }` (interface tightened to getter-only; renaming drops the redundant `Is` prefix on a boolean adjective and pairs the state name with the imperative method `Activate`)
- `ReferenceDataEntity.IsActive` → `Activated` (the only existing implementer — `public set` stays, still satisfies the `{ get; }` contract)
- Query filter expression in `ModelBuilderExtensions.ApplyGranitConventions` updated to `nameof(IActive.Activated)`
- EF index rename on reference data tables: `ix_{table}_is_active` → `ix_{table}_activated`
- DTO surface rename: `ReferenceDataUpdateRequest.IsActive` / `ReferenceDataResponse.IsActive` → `Activated` — **breaking change on the reference-data admin API**, hosts will need a column rename migration on every reference data table

## Why now

Aggregate roots like `PaymentMethodConfiguration`, `MeterDefinition`, `AIWorkspaceEntity` all have a `private set IsActive` with manual `.Where(x.IsActive)` in their stores because the current `IActive` forces `public set` — breaking the DDD encapsulation contract. Tightening the interface to getter-only unlocks adoption on those aggregates in follow-up PRs, gains the global query filter (safety on hot checkout paths), and normalizes the naming.

## Test plan

- [x] `dotnet build Granit.slnx` — 0 errors
- [x] `dotnet test tests/Granit.Persistence.EntityFrameworkCore.Tests` — 307 tests
- [x] `dotnet test tests/Granit.ReferenceData.Tests` — 85 tests
- [x] `dotnet test tests/Granit.ReferenceData.EntityFrameworkCore.Tests` — 73 tests (index name assertion updated)
- [x] `dotnet test tests/Granit.ReferenceData.Endpoints.Tests` — 124 tests
- [x] `dotnet test tests/Granit.ArchitectureTests` — 111 tests
- [x] `dotnet format --verify-no-changes` clean on every touched project

## Migration notes for hosts

- Generate a migration on every `DbContext` that includes a reference data table — EF will produce `RenameColumn("IsActive", "Activated")` + `RenameIndex("ix_{table}_is_active", "ix_{table}_activated")` per table. Additive, safe, no data migration.
- Front-end consumers (admin UIs) reading/writing `ReferenceDataUpdateRequest` / `ReferenceDataResponse` must rename the JSON key `isActive` → `activated`.

## Follow-ups (not in this PR)

- PR-2: adopt `IActive` on `PaymentMethodConfiguration`, `MeterDefinition`, `AIWorkspaceEntity` (each renames its `IsActive` → `Activated`, drops manual `.Where`, adds `IDataFilter.Disable<IActive>()` on admin paths)
- PR-3: rename `Tenant.IsActive` → `Activated` (architecturally kept out of the global filter)
- Optional: normalize `BackgroundJobDefinition.IsEnabled` (stays bare but no interface)
