### PR TITLE
refactor(core): adopt IActive on Payment/Meter/AI and normalize to Activated

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -13068,7 +13068,7 @@
       "kind": "interface",
       "project": "Granit",
       "file": "src/Granit/Domain/IActive.cs",
-      "line": 14,
+      "line": 28,
       "members": []
     },
     {
@@ -35018,9 +35018,9 @@
           "returnType": "string"
         },
         {
-          "name": "IsActive",
+          "name": "Activated",
           "kind": "property",
-          "signature": "bool IsActive",
+          "signature": "bool Activated",
           "returnType": "bool"
         }
       ]

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -28406,7 +28406,7 @@
           "name": "Activate",
           "kind": "method",
           "signature": "Activate()",
-          "returnType": "bool IsActive { get; private set; } public ImmutableHashSet<string>? SupportedCountries { get; private set; } public ImmutableHashSet<string>? SupportedCurrencies { get; private set; } public PaymentMethodSequenceType? SupportedSequenceTypes { get; private set; } public ImmutableDictionary<string, PaymentMethodAmountBound>? AmountBounds { get; private set; } public void"
+          "returnType": "bool Activated { get; private set; } public ImmutableHashSet<string>? SupportedCountries { get; private set; } public ImmutableHashSet<string>? SupportedCurrencies { get; private set; } public PaymentMethodSequenceType? SupportedSequenceTypes { get; private set; } public ImmutableDictionary<string, PaymentMethodAmountBound>? AmountBounds { get; private set; } public void"
         },
         {
           "name": "Deactivate",

--- a/src/Granit.AI.Endpoints/Dtos/AIWorkspaceResponse.cs
+++ b/src/Granit.AI.Endpoints/Dtos/AIWorkspaceResponse.cs
@@ -12,7 +12,7 @@ namespace Granit.AI.Endpoints.Dtos;
 /// <param name="Temperature">Sampling temperature (0.0–2.0).</param>
 /// <param name="MaxOutputTokens">Maximum tokens to generate.</param>
 /// <param name="Kind">Whether this workspace is <see cref="AIWorkspaceKind.System"/> or <see cref="AIWorkspaceKind.Dynamic"/>.</param>
-/// <param name="IsActive">Whether this workspace is active.</param>
+/// <param name="Activated">Whether this workspace is active.</param>
 /// <param name="Capabilities">Model capabilities resolved from the provider catalog, or <c>null</c> if unavailable.</param>
 public sealed record AIWorkspaceResponse(
     string Name,
@@ -22,5 +22,5 @@ public sealed record AIWorkspaceResponse(
     float? Temperature,
     int? MaxOutputTokens,
     AIWorkspaceKind Kind,
-    bool IsActive,
+    bool Activated,
     AIModelCapabilities? Capabilities);

--- a/src/Granit.AI.Endpoints/Dtos/AIWorkspaceUpdateRequest.cs
+++ b/src/Granit.AI.Endpoints/Dtos/AIWorkspaceUpdateRequest.cs
@@ -8,11 +8,11 @@ namespace Granit.AI.Endpoints.Dtos;
 /// <param name="SystemPrompt">Optional system prompt.</param>
 /// <param name="Temperature">Optional sampling temperature (0.0–2.0).</param>
 /// <param name="MaxOutputTokens">Optional maximum output tokens.</param>
-/// <param name="IsActive">Whether the workspace should be active.</param>
+/// <param name="Activated">Whether the workspace should be active.</param>
 public sealed record AIWorkspaceUpdateRequest(
     string Provider,
     string Model,
     string? SystemPrompt,
     float? Temperature,
     int? MaxOutputTokens,
-    bool IsActive) : IAIWorkspaceMutableFields;
+    bool Activated) : IAIWorkspaceMutableFields;

--- a/src/Granit.AI.Endpoints/Endpoints/AIWorkspaceEndpoints.cs
+++ b/src/Granit.AI.Endpoints/Endpoints/AIWorkspaceEndpoints.cs
@@ -182,7 +182,7 @@ internal static class AIWorkspaceEndpoints
             SystemPrompt = request.SystemPrompt,
             Temperature = request.Temperature,
             MaxOutputTokens = request.MaxOutputTokens,
-            IsActive = request.IsActive,
+            Activated = request.Activated,
         };
 
         await manager.UpdateAsync(updated, cancellationToken).ConfigureAwait(false);
@@ -228,6 +228,6 @@ internal static class AIWorkspaceEndpoints
         workspace.Temperature,
         workspace.MaxOutputTokens,
         workspace.Kind,
-        workspace.IsActive,
+        workspace.Activated,
         capabilities);
 }

--- a/src/Granit.AI.EntityFrameworkCore/Entities/AIWorkspaceEntity.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Entities/AIWorkspaceEntity.cs
@@ -6,7 +6,7 @@ namespace Granit.AI.EntityFrameworkCore.Entities;
 /// <summary>
 /// EF Core entity for dynamic AI workspace configurations.
 /// </summary>
-internal sealed class AIWorkspaceEntity : AuditedEntity, IMultiTenant, ISoftDeletable
+internal sealed class AIWorkspaceEntity : AuditedEntity, IActive, IMultiTenant, ISoftDeletable
 {
     public string Name { get; set; } = string.Empty;
 
@@ -20,7 +20,7 @@ internal sealed class AIWorkspaceEntity : AuditedEntity, IMultiTenant, ISoftDele
 
     public int? MaxOutputTokens { get; set; }
 
-    public bool IsActive { get; set; } = true;
+    public bool Activated { get; set; } = true;
 
     public Guid? TenantId { get; set; }
 
@@ -40,7 +40,7 @@ internal sealed class AIWorkspaceEntity : AuditedEntity, IMultiTenant, ISoftDele
         MaxOutputTokens = MaxOutputTokens,
         Kind = AIWorkspaceKind.Dynamic,
         TenantId = TenantId,
-        IsActive = IsActive,
+        Activated = Activated,
     };
 
     public static AIWorkspaceEntity FromRecord(AIWorkspace workspace) => new()
@@ -52,6 +52,6 @@ internal sealed class AIWorkspaceEntity : AuditedEntity, IMultiTenant, ISoftDele
         Temperature = workspace.Temperature,
         MaxOutputTokens = workspace.MaxOutputTokens,
         TenantId = workspace.TenantId,
-        IsActive = workspace.IsActive,
+        Activated = workspace.Activated,
     };
 }

--- a/src/Granit.AI.EntityFrameworkCore/Internal/AIWorkspaceEntityConfiguration.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/AIWorkspaceEntityConfiguration.cs
@@ -40,7 +40,7 @@ internal sealed class AIWorkspaceEntityConfiguration : IEntityTypeConfiguration<
 
         builder.Property(e => e.MaxOutputTokens);
 
-        builder.Property(e => e.IsActive)
+        builder.Property(e => e.Activated)
             .IsRequired()
             .HasDefaultValue(true);
 

--- a/src/Granit.AI.EntityFrameworkCore/Internal/EfAIWorkspaceStore.cs
+++ b/src/Granit.AI.EntityFrameworkCore/Internal/EfAIWorkspaceStore.cs
@@ -1,5 +1,7 @@
 using Granit.AI.EntityFrameworkCore.Entities;
 using Granit.AI.Workspaces;
+using Granit.DataFiltering;
+using Granit.Domain;
 using Granit.MultiTenancy;
 using Granit.Persistence;
 using Granit.Persistence.EntityFrameworkCore;
@@ -12,12 +14,16 @@ namespace Granit.AI.EntityFrameworkCore.Internal;
 /// EF Core implementation of <see cref="IAIWorkspaceStoreReader"/> and <see cref="IAIWorkspaceStoreWriter"/>.
 /// </summary>
 /// <remarks>
-/// All reads are implicitly scoped to the current tenant via the <see cref="IMultiTenant"/>
-/// query filter applied by <c>ApplyGranitConventions</c> on <see cref="AIDbContext"/>.
+/// Reads are implicitly scoped to the current tenant via the <see cref="IMultiTenant"/> query
+/// filter applied by <c>ApplyGranitConventions</c> on <see cref="AIDbContext"/>, and filter
+/// out deactivated workspaces via the <see cref="IActive"/> filter. Admin write paths
+/// (Update, Delete) bypass the <see cref="IActive"/> filter so a deactivated workspace can
+/// still be reactivated or removed by name.
 /// </remarks>
 internal sealed class EfAIWorkspaceStore(
     IDbContextFactory<AIDbContext> contextFactory,
-    ICurrentTenant currentTenant)
+    ICurrentTenant currentTenant,
+    IDataFilter dataFilter)
     : EfStoreBase<AIWorkspaceEntity, AIDbContext>(contextFactory, currentTenant), IAIWorkspaceStoreReader, IAIWorkspaceStoreWriter
 {
     /// <inheritdoc/>
@@ -25,22 +31,29 @@ internal sealed class EfAIWorkspaceStore(
         string workspaceName,
         CancellationToken cancellationToken = default)
     {
-        AIWorkspaceEntity? entity = await FirstOrDefaultAsync(
-            w => w.Name == workspaceName, cancellationToken).ConfigureAwait(false);
+        // Admin surface — also see deactivated workspaces so they can be reactivated.
+        using (dataFilter.Disable<IActive>())
+        {
+            AIWorkspaceEntity? entity = await FirstOrDefaultAsync(
+                w => w.Name == workspaceName, cancellationToken).ConfigureAwait(false);
 
-        return entity?.ToRecord();
+            return entity?.ToRecord();
+        }
     }
 
     /// <inheritdoc/>
     public async Task<IReadOnlyList<AIWorkspace>> GetAllAsync(
         CancellationToken cancellationToken = default)
     {
-        IReadOnlyList<AIWorkspaceEntity> entities = await ListAsync(
-            Spec.For<AIWorkspaceEntity>()
-                .OrderBy(w => (object)w.Name),
-            cancellationToken).ConfigureAwait(false);
+        using (dataFilter.Disable<IActive>())
+        {
+            IReadOnlyList<AIWorkspaceEntity> entities = await ListAsync(
+                Spec.For<AIWorkspaceEntity>()
+                    .OrderBy(w => (object)w.Name),
+                cancellationToken).ConfigureAwait(false);
 
-        return entities.Select(e => e.ToRecord()).ToList();
+            return entities.Select(e => e.ToRecord()).ToList();
+        }
     }
 
     /// <inheritdoc/>
@@ -66,23 +79,26 @@ internal sealed class EfAIWorkspaceStore(
         AIWorkspace workspace,
         CancellationToken cancellationToken = default)
     {
-        await WriteAsync(async db =>
+        using (dataFilter.Disable<IActive>())
         {
-            AIWorkspaceEntity? entity = await db.Workspaces
-                .FirstOrDefaultAsync(w => w.Name == workspace.Name, cancellationToken).ConfigureAwait(false);
-
-            if (entity is null)
+            await WriteAsync(async db =>
             {
-                return;
-            }
+                AIWorkspaceEntity? entity = await db.Workspaces
+                    .FirstOrDefaultAsync(w => w.Name == workspace.Name, cancellationToken).ConfigureAwait(false);
 
-            entity.Provider = workspace.Provider;
-            entity.Model = workspace.Model;
-            entity.SystemPrompt = workspace.SystemPrompt;
-            entity.Temperature = workspace.Temperature;
-            entity.MaxOutputTokens = workspace.MaxOutputTokens;
-            entity.IsActive = workspace.IsActive;
-        }, cancellationToken).ConfigureAwait(false);
+                if (entity is null)
+                {
+                    return;
+                }
+
+                entity.Provider = workspace.Provider;
+                entity.Model = workspace.Model;
+                entity.SystemPrompt = workspace.SystemPrompt;
+                entity.Temperature = workspace.Temperature;
+                entity.MaxOutputTokens = workspace.MaxOutputTokens;
+                entity.Activated = workspace.Activated;
+            }, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     /// <inheritdoc/>
@@ -90,15 +106,18 @@ internal sealed class EfAIWorkspaceStore(
         string workspaceName,
         CancellationToken cancellationToken = default)
     {
-        await WriteAsync(async db =>
+        using (dataFilter.Disable<IActive>())
         {
-            AIWorkspaceEntity? entity = await db.Workspaces
-                .FirstOrDefaultAsync(w => w.Name == workspaceName, cancellationToken).ConfigureAwait(false);
-
-            if (entity is not null)
+            await WriteAsync(async db =>
             {
-                db.Workspaces.Remove(entity);
-            }
-        }, cancellationToken).ConfigureAwait(false);
+                AIWorkspaceEntity? entity = await db.Workspaces
+                    .FirstOrDefaultAsync(w => w.Name == workspaceName, cancellationToken).ConfigureAwait(false);
+
+                if (entity is not null)
+                {
+                    db.Workspaces.Remove(entity);
+                }
+            }, cancellationToken).ConfigureAwait(false);
+        }
     }
 }

--- a/src/Granit.AI/Internal/DefaultAIChatClientFactory.cs
+++ b/src/Granit.AI/Internal/DefaultAIChatClientFactory.cs
@@ -26,7 +26,7 @@ internal sealed class DefaultAIChatClientFactory(
         AIWorkspace workspace = await workspaceProvider.GetAsync(name, cancellationToken).ConfigureAwait(false)
             ?? throw new AIWorkspaceNotFoundException(name);
 
-        if (!workspace.IsActive)
+        if (!workspace.Activated)
         {
             throw new AIWorkspaceNotActiveException(name);
         }

--- a/src/Granit.AI/Internal/DefaultAIEmbeddingGeneratorFactory.cs
+++ b/src/Granit.AI/Internal/DefaultAIEmbeddingGeneratorFactory.cs
@@ -26,7 +26,7 @@ internal sealed class DefaultAIEmbeddingGeneratorFactory(
         AIWorkspace workspace = await workspaceProvider.GetAsync(name, cancellationToken).ConfigureAwait(false)
             ?? throw new AIWorkspaceNotFoundException(name);
 
-        if (!workspace.IsActive)
+        if (!workspace.Activated)
         {
             throw new AIWorkspaceNotActiveException(name);
         }

--- a/src/Granit.AI/Workspaces/AIWorkspace.cs
+++ b/src/Granit.AI/Workspaces/AIWorkspace.cs
@@ -53,5 +53,5 @@ public sealed record AIWorkspace
     /// <summary>
     /// Whether this workspace is active and available for use.
     /// </summary>
-    public bool IsActive { get; init; } = true;
+    public bool Activated { get; init; } = true;
 }

--- a/src/Granit.DataExchange.Definitions/Metering/MeterDefinitionExportDefinition.cs
+++ b/src/Granit.DataExchange.Definitions/Metering/MeterDefinitionExportDefinition.cs
@@ -15,7 +15,7 @@ public sealed class MeterDefinitionExportDefinition : ExportDefinition<MeterDefi
             .Field(m => m.Unit)
             .Field(m => m.Description)
             .Field(m => m.AggregationType)
-            .Field(m => m.IsActive)
+            .Field(m => m.Activated)
             .Field(m => m.TenantId)
             .Field(m => m.CreatedAt, f => f.Format("O"))
             .Field(m => m.CreatedBy)

--- a/src/Granit.DataExchange.Definitions/MultiTenancy/TenantExportDefinition.cs
+++ b/src/Granit.DataExchange.Definitions/MultiTenancy/TenantExportDefinition.cs
@@ -15,7 +15,7 @@ public sealed class TenantExportDefinition : ExportDefinition<Tenant>
             .Field(t => t.Identifier)
             .Field(t => t.ContactEmail)
             .Field(t => t.Jurisdiction)
-            .Field(t => t.IsActive)
+            .Field(t => t.Activated)
             .Field(t => t.CustomDomain)
             .Field(t => t.IsDeleted)
             .Field(t => t.DeletedAt, f => f.Format("O"))

--- a/src/Granit.DataExchange.Definitions/ReferenceData/DynamicReferenceDataEntityExportDefinition.cs
+++ b/src/Granit.DataExchange.Definitions/ReferenceData/DynamicReferenceDataEntityExportDefinition.cs
@@ -28,7 +28,7 @@ public sealed class DynamicReferenceDataEntityExportDefinition : ExportDefinitio
             .Field(e => e.LabelSv)
             .Field(e => e.LabelCs)
             .Field(e => e.LabelHi)
-            .Field(e => e.IsActive)
+            .Field(e => e.Activated)
             .Field(e => e.SortOrder)
             .Field(e => e.ValidFrom, f => f.Format("O"))
             .Field(e => e.ValidTo, f => f.Format("O"))

--- a/src/Granit.Metering.Endpoints/Dtos/MeterDefinitionResponse.cs
+++ b/src/Granit.Metering.Endpoints/Dtos/MeterDefinitionResponse.cs
@@ -10,14 +10,14 @@ namespace Granit.Metering.Endpoints.Dtos;
 /// <param name="Unit">Unit of measure.</param>
 /// <param name="Description">Optional description.</param>
 /// <param name="AggregationType">How events are aggregated into rollups.</param>
-/// <param name="IsActive">Whether this meter accepts new events.</param>
+/// <param name="Activated">Whether this meter accepts new events.</param>
 public sealed record MeterDefinitionResponse(
     Guid Id,
     string Name,
     string Unit,
     string? Description,
     AggregationType AggregationType,
-    bool IsActive)
+    bool Activated)
 {
     internal static MeterDefinitionResponse FromEntity(MeterDefinition definition) => new(
         definition.Id,
@@ -25,5 +25,5 @@ public sealed record MeterDefinitionResponse(
         definition.Unit,
         definition.Description,
         definition.AggregationType,
-        definition.IsActive);
+        definition.Activated);
 }

--- a/src/Granit.Metering.Endpoints/Endpoints/UsageEndpoints.cs
+++ b/src/Granit.Metering.Endpoints/Endpoints/UsageEndpoints.cs
@@ -131,7 +131,7 @@ internal static class UsageEndpoints
                     statusCode: StatusCodes.Status404NotFound);
             }
 
-            if (!def.IsActive)
+            if (!def.Activated)
             {
                 return TypedResults.Problem(
                     detail: $"Meter definition '{mid}' is deactivated.",

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/EfMeterDefinitionReader.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/EfMeterDefinitionReader.cs
@@ -22,7 +22,6 @@ internal sealed class EfMeterDefinitionReader(
             .ConfigureAwait(false), cancellationToken);
 
     public Task<IReadOnlyList<MeterDefinition>> GetActiveAsync(CancellationToken cancellationToken = default) =>
-        ListAsync(
-            Spec.For<MeterDefinition>().Where(m => m.IsActive),
-            cancellationToken);
+        // IActive query filter handles the Activated = true predicate.
+        ListAsync(Spec.For<MeterDefinition>(), cancellationToken);
 }

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/MeterDefinitionConfiguration.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/MeterDefinitionConfiguration.cs
@@ -18,7 +18,7 @@ internal sealed class MeterDefinitionConfiguration : IEntityTypeConfiguration<Me
         builder.Property(e => e.Unit).HasMaxLength(50).IsRequired();
         builder.Property(e => e.Description).HasMaxLength(2000);
         builder.Property(e => e.AggregationType).IsRequired();
-        builder.Property(e => e.IsActive).IsRequired().HasDefaultValue(true);
+        builder.Property(e => e.Activated).IsRequired().HasDefaultValue(true);
 
         builder.HasIndex(e => new { e.TenantId, e.Name })
             .IsUnique()

--- a/src/Granit.Metering/Domain/MeterDefinition.cs
+++ b/src/Granit.Metering/Domain/MeterDefinition.cs
@@ -12,7 +12,7 @@ namespace Granit.Metering.Domain;
 /// Meter events are recorded against a definition and aggregated into
 /// <see cref="UsageAggregate"/> rollups by background jobs.
 /// </remarks>
-public sealed class MeterDefinition : AuditedAggregateRoot, IMultiTenant
+public sealed class MeterDefinition : AuditedAggregateRoot, IActive, IMultiTenant
 {
     private MeterDefinition() { }
 
@@ -34,7 +34,7 @@ public sealed class MeterDefinition : AuditedAggregateRoot, IMultiTenant
             Unit = unit,
             AggregationType = aggregationType,
             Description = description,
-            IsActive = true,
+            Activated = true,
         };
     }
 
@@ -51,7 +51,7 @@ public sealed class MeterDefinition : AuditedAggregateRoot, IMultiTenant
     public AggregationType AggregationType { get; private set; }
 
     /// <summary>Whether this meter accepts new events.</summary>
-    public bool IsActive { get; private set; }
+    public bool Activated { get; private set; }
 
     /// <inheritdoc/>
     public Guid? TenantId { get; private set; }
@@ -71,8 +71,8 @@ public sealed class MeterDefinition : AuditedAggregateRoot, IMultiTenant
     }
 
     /// <summary>Deactivates the meter. No new events will be accepted.</summary>
-    public void Deactivate() => IsActive = false;
+    public void Deactivate() => Activated = false;
 
     /// <summary>Reactivates the meter.</summary>
-    public void Activate() => IsActive = true;
+    public void Activate() => Activated = true;
 }

--- a/src/Granit.MultiTenancy.Endpoints/Dtos/TenantResponse.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Dtos/TenantResponse.cs
@@ -7,7 +7,7 @@ namespace Granit.MultiTenancy.Endpoints.Dtos;
 /// <param name="Name">Display name of the tenant.</param>
 /// <param name="Identifier">Unique slug/subdomain identifier.</param>
 /// <param name="ContactEmail">Optional contact email address.</param>
-/// <param name="IsActive">Whether the tenant is active.</param>
+/// <param name="Activated">Whether the tenant is active.</param>
 /// <param name="Jurisdiction">Privacy regulation code or ISO country code, or <c>null</c>.</param>
 /// <param name="CreatedAt">Timestamp when the tenant was created.</param>
 public sealed record TenantResponse(
@@ -15,6 +15,6 @@ public sealed record TenantResponse(
     string Name,
     string Identifier,
     string? ContactEmail,
-    bool IsActive,
+    bool Activated,
     string? Jurisdiction,
     DateTimeOffset CreatedAt);

--- a/src/Granit.MultiTenancy.Endpoints/Extensions/MultiTenancyEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Extensions/MultiTenancyEndpointRouteBuilderExtensions.cs
@@ -230,7 +230,7 @@ public static class MultiTenancyEndpointRouteBuilderExtensions
     // -------------------------------------------------------------------------
 
     private static TenantResponse ToResponse(TenantData data) =>
-        new(data.Id, data.Name, data.Identifier, data.ContactEmail, data.IsActive, data.Jurisdiction, data.CreatedAt);
+        new(data.Id, data.Name, data.Identifier, data.ContactEmail, data.Activated, data.Jurisdiction, data.CreatedAt);
 
     private static ProblemHttpResult TenantNotFound(Guid id) =>
         TypedResults.Problem(

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Entities/Tenant.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Entities/Tenant.cs
@@ -27,7 +27,7 @@ public sealed class Tenant : FullAuditedAggregateRoot, ITenantInfo
     public string? Jurisdiction { get; private set; }
 
     /// <summary>Whether the tenant is active and can be resolved by the middleware.</summary>
-    public bool IsActive { get; private set; } = true;
+    public bool Activated { get; private set; } = true;
 
     /// <summary>
     /// Optional custom domain for this tenant (e.g., <c>"app.acme-corp.com"</c>).
@@ -71,7 +71,7 @@ public sealed class Tenant : FullAuditedAggregateRoot, ITenantInfo
             Identifier = identifier,
             ContactEmail = contactEmail,
             Jurisdiction = jurisdiction,
-            IsActive = true,
+            Activated = true,
         };
 
         tenant.AddDomainEvent(new TenantCreatedEvent(id, name, identifier));
@@ -121,12 +121,12 @@ public sealed class Tenant : FullAuditedAggregateRoot, ITenantInfo
     /// </summary>
     public void Activate()
     {
-        if (IsActive)
+        if (Activated)
         {
             return;
         }
 
-        IsActive = true;
+        Activated = true;
         AddDomainEvent(new TenantActivatedEvent(Id));
     }
 
@@ -136,12 +136,12 @@ public sealed class Tenant : FullAuditedAggregateRoot, ITenantInfo
     /// </summary>
     public void Deactivate()
     {
-        if (!IsActive)
+        if (!Activated)
         {
             return;
         }
 
-        IsActive = false;
+        Activated = false;
         AddDomainEvent(new TenantDeactivatedEvent(Id));
     }
 }

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/EfCoreTenantEnumerator.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/EfCoreTenantEnumerator.cs
@@ -42,7 +42,7 @@ internal sealed class EfCoreTenantEnumerator(IServiceScopeFactory scopeFactory) 
             yield break;
         }
 
-        foreach (TenantData tenant in tenants.Where(static t => t.IsActive))
+        foreach (TenantData tenant in tenants.Where(static t => t.Activated))
         {
             yield return tenant.Id;
         }

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/EfCoreTenantStore.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/EfCoreTenantStore.cs
@@ -166,7 +166,7 @@ internal sealed partial class EfCoreTenantStore(
     // -------------------------------------------------------------------------
 
     private static TenantData ToData(Tenant tenant) =>
-        new(tenant.Id, tenant.Name, tenant.Identifier, tenant.ContactEmail, tenant.IsActive, tenant.Jurisdiction, tenant.CreatedAt, tenant.CustomDomain);
+        new(tenant.Id, tenant.Name, tenant.Identifier, tenant.ContactEmail, tenant.Activated, tenant.Jurisdiction, tenant.CreatedAt, tenant.CustomDomain);
 
     // -------------------------------------------------------------------------
     // Logging

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/TenantEntityTypeConfiguration.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Internal/TenantEntityTypeConfiguration.cs
@@ -33,7 +33,7 @@ internal sealed class TenantEntityTypeConfiguration : IEntityTypeConfiguration<T
         builder.Property(e => e.Jurisdiction)
                .HasMaxLength(16);
 
-        builder.Property(e => e.IsActive)
+        builder.Property(e => e.Activated)
                .IsRequired();
 
         builder.Property(e => e.CustomDomain)

--- a/src/Granit.MultiTenancy/Resolvers/CustomDomainTenantResolver.cs
+++ b/src/Granit.MultiTenancy/Resolvers/CustomDomainTenantResolver.cs
@@ -51,7 +51,7 @@ public sealed class CustomDomainTenantResolver(
             .FindByCustomDomainAsync(host, cancellationToken)
             .ConfigureAwait(false);
 
-        if (tenant is null || !tenant.IsActive)
+        if (tenant is null || !tenant.Activated)
         {
             return null;
         }

--- a/src/Granit.MultiTenancy/Resolvers/DomainTenantResolver.cs
+++ b/src/Granit.MultiTenancy/Resolvers/DomainTenantResolver.cs
@@ -47,7 +47,7 @@ public sealed class DomainTenantResolver(
             .FindByIdentifierAsync(identifier, cancellationToken)
             .ConfigureAwait(false);
 
-        if (tenant is null || !tenant.IsActive)
+        if (tenant is null || !tenant.Activated)
         {
             return null;
         }

--- a/src/Granit.MultiTenancy/Stores/TenantData.cs
+++ b/src/Granit.MultiTenancy/Stores/TenantData.cs
@@ -9,7 +9,7 @@ namespace Granit.MultiTenancy.Stores;
 /// <param name="Name">Display name of the tenant.</param>
 /// <param name="Identifier">Unique slug/subdomain identifier.</param>
 /// <param name="ContactEmail">Optional contact email address.</param>
-/// <param name="IsActive">Whether the tenant is active.</param>
+/// <param name="Activated">Whether the tenant is active.</param>
 /// <param name="Jurisdiction">Privacy regulation code or ISO country code, or <c>null</c>.</param>
 /// <param name="CreatedAt">Timestamp when the tenant was created.</param>
 /// <param name="CustomDomain">Optional custom domain for outbound URL generation (e.g., <c>"app.acme-corp.com"</c>).</param>
@@ -18,7 +18,7 @@ public sealed record TenantData(
     string Name,
     string Identifier,
     string? ContactEmail,
-    bool IsActive,
+    bool Activated,
     string? Jurisdiction,
     DateTimeOffset CreatedAt,
     string? CustomDomain = null);

--- a/src/Granit.Payments.Endpoints/Dtos/PaymentMethodConfigurationDtos.cs
+++ b/src/Granit.Payments.Endpoints/Dtos/PaymentMethodConfigurationDtos.cs
@@ -6,13 +6,13 @@ namespace Granit.Payments.Endpoints.Dtos;
 /// <param name="MethodType">Stable method identifier (e.g., <c>card</c>, <c>bancontact</c>).</param>
 /// <param name="DisplayLabel">Localized display label for the checkout UI.</param>
 /// <param name="Category">Grouping category for the checkout UI.</param>
-/// <param name="IsActive">Whether the method is currently active on the platform.</param>
+/// <param name="Activated">Whether the method is currently active on the platform.</param>
 /// <param name="CapabilitySnapshot">Last-captured capability snapshot, or <see langword="null"/> when no snapshot has been taken yet.</param>
 public sealed record PaymentMethodConfigurationItem(
     string MethodType,
     string DisplayLabel,
     PaymentMethodCategory Category,
-    bool IsActive,
+    bool Activated,
     PaymentMethodCapabilityResponse? CapabilitySnapshot);
 
 /// <summary>All methods declared by a single provider, with their activation state.</summary>
@@ -25,14 +25,14 @@ public sealed record PaymentProviderConfigurationResponse(
 /// <param name="Category">Grouping category for the checkout UI.</param>
 /// <param name="DisplayLabel">Provider-native display label (caller can still localize).</param>
 /// <param name="Capability">Live capability metadata reported by the provider.</param>
-/// <param name="IsActive">Whether the method is currently active on the platform.</param>
+/// <param name="Activated">Whether the method is currently active on the platform.</param>
 /// <param name="HasSnapshot">Whether the activation record already carries a capability snapshot.</param>
 public sealed record PaymentCatalogMethod(
     string MethodType,
     PaymentMethodCategory Category,
     string DisplayLabel,
     PaymentMethodCapabilityResponse Capability,
-    bool IsActive,
+    bool Activated,
     bool HasSnapshot);
 
 /// <summary>Catalog response for a single provider.</summary>

--- a/src/Granit.Payments.Endpoints/Endpoints/PaymentMethodConfigurationEndpoints.cs
+++ b/src/Granit.Payments.Endpoints/Endpoints/PaymentMethodConfigurationEndpoints.cs
@@ -125,7 +125,7 @@ internal static class PaymentMethodConfigurationEndpoints
                     MethodType: descriptor.MethodType,
                     DisplayLabel: PaymentMethodLabelResolver.Resolve(localizer, descriptor.MethodType),
                     Category: descriptor.Category,
-                    IsActive: config?.IsActive ?? false,
+                    Activated: config?.Activated ?? false,
                     CapabilitySnapshot: PaymentMethodCapabilityMapper.ToResponseOrNull(snapshot)));
             }
 
@@ -175,7 +175,7 @@ internal static class PaymentMethodConfigurationEndpoints
                 Category: entry.Category,
                 DisplayLabel: entry.DisplayLabel,
                 Capability: PaymentMethodCapabilityMapper.ToResponse(entry.Capability),
-                IsActive: config?.IsActive ?? false,
+                Activated: config?.Activated ?? false,
                 HasSnapshot: config?.GetCapabilitySnapshot() is not null));
         }
 
@@ -232,7 +232,7 @@ internal static class PaymentMethodConfigurationEndpoints
             MethodType: entry.MethodType,
             DisplayLabel: PaymentMethodLabelResolver.Resolve(localizer, entry.MethodType),
             Category: entry.Category,
-            IsActive: true,
+            Activated: true,
             CapabilitySnapshot: PaymentMethodCapabilityMapper.ToResponse(entry.Capability)));
     }
 
@@ -287,7 +287,7 @@ internal static class PaymentMethodConfigurationEndpoints
             MethodType: descriptor.MethodType,
             DisplayLabel: PaymentMethodLabelResolver.Resolve(localizer, descriptor.MethodType),
             Category: descriptor.Category,
-            IsActive: false,
+            Activated: false,
             CapabilitySnapshot: PaymentMethodCapabilityMapper.ToResponseOrNull(config?.GetCapabilitySnapshot())));
     }
 
@@ -348,7 +348,7 @@ internal static class PaymentMethodConfigurationEndpoints
             MethodType: entry.MethodType,
             DisplayLabel: PaymentMethodLabelResolver.Resolve(localizer, entry.MethodType),
             Category: entry.Category,
-            IsActive: existing.IsActive,
+            Activated: existing.Activated,
             CapabilitySnapshot: PaymentMethodCapabilityMapper.ToResponse(entry.Capability)));
     }
 

--- a/src/Granit.Payments.EntityFrameworkCore/Internal/EfPaymentMethodConfigurationStore.cs
+++ b/src/Granit.Payments.EntityFrameworkCore/Internal/EfPaymentMethodConfigurationStore.cs
@@ -1,3 +1,5 @@
+using Granit.DataFiltering;
+using Granit.Domain;
 using Granit.Payments.Contracts;
 using Granit.Payments.Domain;
 using Microsoft.EntityFrameworkCore;
@@ -5,8 +7,20 @@ using Microsoft.EntityFrameworkCore;
 namespace Granit.Payments.EntityFrameworkCore.Internal;
 
 /// <summary>EF Core store for host-level payment method configurations.</summary>
+/// <remarks>
+/// <para>
+/// <see cref="PaymentMethodConfiguration"/> implements <see cref="IActive"/>, so the
+/// EF Core global query filter hides deactivated rows by default. The <em>reads</em>
+/// that must see both active and inactive records (admin listing, race-safe upsert,
+/// resync) bypass the filter with
+/// <see cref="IDataFilter.Disable{TFilterMarker}"/>. The hot-path
+/// <see cref="GetActiveAsync"/> relies on the filter and carries no manual
+/// <c>.Where(c => c.Activated)</c>.
+/// </para>
+/// </remarks>
 internal sealed class EfPaymentMethodConfigurationStore(
-    IDbContextFactory<PaymentsDbContext> contextFactory)
+    IDbContextFactory<PaymentsDbContext> contextFactory,
+    IDataFilter dataFilter)
     : IPaymentMethodConfigurationReader, IPaymentMethodConfigurationWriter
 {
     // ── Reader (AsNoTracking for all reads) ─────────────────────────────
@@ -17,10 +31,13 @@ internal sealed class EfPaymentMethodConfigurationStore(
         await using PaymentsDbContext db = await contextFactory
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
-        return await db.PaymentMethodConfigurations
-            .AsNoTracking()
-            .OrderBy(c => c.ProviderName).ThenBy(c => c.MethodType)
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
+        using (dataFilter.Disable<IActive>())
+        {
+            return await db.PaymentMethodConfigurations
+                .AsNoTracking()
+                .OrderBy(c => c.ProviderName).ThenBy(c => c.MethodType)
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 
     public async Task<IReadOnlyList<PaymentMethodConfiguration>> GetActiveAsync(
@@ -29,9 +46,9 @@ internal sealed class EfPaymentMethodConfigurationStore(
         await using PaymentsDbContext db = await contextFactory
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
+        // IActive query filter handles the Activated = true predicate.
         return await db.PaymentMethodConfigurations
             .AsNoTracking()
-            .Where(c => c.IsActive)
             .OrderBy(c => c.ProviderName).ThenBy(c => c.MethodType)
             .ToListAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -42,10 +59,13 @@ internal sealed class EfPaymentMethodConfigurationStore(
         await using PaymentsDbContext db = await contextFactory
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
-        return await db.PaymentMethodConfigurations
-            .AsNoTracking()
-            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken)
-            .ConfigureAwait(false);
+        using (dataFilter.Disable<IActive>())
+        {
+            return await db.PaymentMethodConfigurations
+                .AsNoTracking()
+                .FirstOrDefaultAsync(c => c.Id == id, cancellationToken)
+                .ConfigureAwait(false);
+        }
     }
 
     public async Task<PaymentMethodConfiguration?> FindAsync(
@@ -54,12 +74,15 @@ internal sealed class EfPaymentMethodConfigurationStore(
         await using PaymentsDbContext db = await contextFactory
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
-        return await db.PaymentMethodConfigurations
-            .AsNoTracking()
-            .FirstOrDefaultAsync(
-                c => c.ProviderName == providerName && c.MethodType == methodType,
-                cancellationToken)
-            .ConfigureAwait(false);
+        using (dataFilter.Disable<IActive>())
+        {
+            return await db.PaymentMethodConfigurations
+                .AsNoTracking()
+                .FirstOrDefaultAsync(
+                    c => c.ProviderName == providerName && c.MethodType == methodType,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
     }
 
     // ── Writer ──────────────────────────────────────────────────────────
@@ -104,56 +127,59 @@ internal sealed class EfPaymentMethodConfigurationStore(
         await using PaymentsDbContext db = await contextFactory
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
-        PaymentMethodConfiguration? existing = await db.PaymentMethodConfigurations
-            .FirstOrDefaultAsync(
-                c => c.ProviderName == providerName && c.MethodType == methodType,
-                cancellationToken).ConfigureAwait(false);
-
-        if (existing is null)
+        using (dataFilter.Disable<IActive>())
         {
-            var created = PaymentMethodConfiguration
-                .Activate(newId, providerName, methodType);
+            PaymentMethodConfiguration? existing = await db.PaymentMethodConfigurations
+                .FirstOrDefaultAsync(
+                    c => c.ProviderName == providerName && c.MethodType == methodType,
+                    cancellationToken).ConfigureAwait(false);
 
-            if (!isActive)
+            if (existing is null)
             {
-                created.Deactivate();
-            }
+                var created = PaymentMethodConfiguration
+                    .Activate(newId, providerName, methodType);
 
-            db.PaymentMethodConfigurations.Add(created);
-
-            try
-            {
-                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-                return;
-            }
-            catch (DbUpdateException)
-            {
-                // Concurrent POST won the race — fall through to read + update.
-                db.PaymentMethodConfigurations.Remove(created);
-                db.ChangeTracker.Clear();
-
-                existing = await db.PaymentMethodConfigurations
-                    .FirstOrDefaultAsync(
-                        c => c.ProviderName == providerName && c.MethodType == methodType,
-                        cancellationToken).ConfigureAwait(false);
-
-                if (existing is null)
+                if (!isActive)
                 {
-                    throw;
+                    created.Deactivate();
+                }
+
+                db.PaymentMethodConfigurations.Add(created);
+
+                try
+                {
+                    await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                    return;
+                }
+                catch (DbUpdateException)
+                {
+                    // Concurrent POST won the race — fall through to read + update.
+                    db.PaymentMethodConfigurations.Remove(created);
+                    db.ChangeTracker.Clear();
+
+                    existing = await db.PaymentMethodConfigurations
+                        .FirstOrDefaultAsync(
+                            c => c.ProviderName == providerName && c.MethodType == methodType,
+                            cancellationToken).ConfigureAwait(false);
+
+                    if (existing is null)
+                    {
+                        throw;
+                    }
                 }
             }
-        }
 
-        if (isActive)
-        {
-            existing.Activate();
-        }
-        else
-        {
-            existing.Deactivate();
-        }
+            if (isActive)
+            {
+                existing.Activate();
+            }
+            else
+            {
+                existing.Deactivate();
+            }
 
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 
     public async Task UpsertActivationWithSnapshotAsync(
@@ -168,44 +194,47 @@ internal sealed class EfPaymentMethodConfigurationStore(
         await using PaymentsDbContext db = await contextFactory
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
-        PaymentMethodConfiguration? existing = await db.PaymentMethodConfigurations
-            .FirstOrDefaultAsync(
-                c => c.ProviderName == providerName && c.MethodType == methodType,
-                cancellationToken).ConfigureAwait(false);
-
-        if (existing is null)
+        using (dataFilter.Disable<IActive>())
         {
-            var created = PaymentMethodConfiguration.Activate(newId, providerName, methodType);
-            created.SnapshotCapability(capability);
+            PaymentMethodConfiguration? existing = await db.PaymentMethodConfigurations
+                .FirstOrDefaultAsync(
+                    c => c.ProviderName == providerName && c.MethodType == methodType,
+                    cancellationToken).ConfigureAwait(false);
 
-            db.PaymentMethodConfigurations.Add(created);
-
-            try
+            if (existing is null)
             {
-                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-                return;
-            }
-            catch (DbUpdateException)
-            {
-                db.PaymentMethodConfigurations.Remove(created);
-                db.ChangeTracker.Clear();
+                var created = PaymentMethodConfiguration.Activate(newId, providerName, methodType);
+                created.SnapshotCapability(capability);
 
-                existing = await db.PaymentMethodConfigurations
-                    .FirstOrDefaultAsync(
-                        c => c.ProviderName == providerName && c.MethodType == methodType,
-                        cancellationToken).ConfigureAwait(false);
+                db.PaymentMethodConfigurations.Add(created);
 
-                if (existing is null)
+                try
                 {
-                    throw;
+                    await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                    return;
+                }
+                catch (DbUpdateException)
+                {
+                    db.PaymentMethodConfigurations.Remove(created);
+                    db.ChangeTracker.Clear();
+
+                    existing = await db.PaymentMethodConfigurations
+                        .FirstOrDefaultAsync(
+                            c => c.ProviderName == providerName && c.MethodType == methodType,
+                            cancellationToken).ConfigureAwait(false);
+
+                    if (existing is null)
+                    {
+                        throw;
+                    }
                 }
             }
+
+            existing.Activate();
+            existing.SnapshotCapability(capability);
+
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
-
-        existing.Activate();
-        existing.SnapshotCapability(capability);
-
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<bool> UpdateCapabilitySnapshotAsync(
@@ -219,18 +248,21 @@ internal sealed class EfPaymentMethodConfigurationStore(
         await using PaymentsDbContext db = await contextFactory
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
-        PaymentMethodConfiguration? existing = await db.PaymentMethodConfigurations
-            .FirstOrDefaultAsync(
-                c => c.ProviderName == providerName && c.MethodType == methodType,
-                cancellationToken).ConfigureAwait(false);
-
-        if (existing is null)
+        using (dataFilter.Disable<IActive>())
         {
-            return false;
-        }
+            PaymentMethodConfiguration? existing = await db.PaymentMethodConfigurations
+                .FirstOrDefaultAsync(
+                    c => c.ProviderName == providerName && c.MethodType == methodType,
+                    cancellationToken).ConfigureAwait(false);
 
-        existing.SnapshotCapability(capability);
-        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-        return true;
+            if (existing is null)
+            {
+                return false;
+            }
+
+            existing.SnapshotCapability(capability);
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            return true;
+        }
     }
 }

--- a/src/Granit.Payments.EntityFrameworkCore/Internal/PaymentMethodConfigurationEntityTypeConfiguration.cs
+++ b/src/Granit.Payments.EntityFrameworkCore/Internal/PaymentMethodConfigurationEntityTypeConfiguration.cs
@@ -24,7 +24,7 @@ internal sealed class PaymentMethodConfigurationEntityTypeConfiguration
 
         builder.Property(e => e.MethodType).HasMaxLength(64).IsRequired();
         builder.Property(e => e.ProviderName).HasMaxLength(64).IsRequired();
-        builder.Property(e => e.IsActive).IsRequired().HasDefaultValue(true);
+        builder.Property(e => e.Activated).IsRequired().HasDefaultValue(true);
 
         ConfigureCapabilitySnapshot(builder);
 

--- a/src/Granit.Payments/Domain/PaymentMethodConfiguration.cs
+++ b/src/Granit.Payments/Domain/PaymentMethodConfiguration.cs
@@ -22,7 +22,7 @@ namespace Granit.Payments.Domain;
 /// deterministic, offline-capable, and does not hit the provider on every request.
 /// </para>
 /// </remarks>
-public sealed class PaymentMethodConfiguration : AuditedEntity
+public sealed class PaymentMethodConfiguration : AuditedEntity, IActive
 {
     private PaymentMethodConfiguration() { }
 
@@ -37,7 +37,7 @@ public sealed class PaymentMethodConfiguration : AuditedEntity
             Id = id,
             ProviderName = providerName,
             MethodType = methodType,
-            IsActive = true,
+            Activated = true,
         };
     }
 
@@ -48,7 +48,7 @@ public sealed class PaymentMethodConfiguration : AuditedEntity
     public string ProviderName { get; private set; } = string.Empty;
 
     /// <summary>Whether this method is currently active for the platform.</summary>
-    public bool IsActive { get; private set; }
+    public bool Activated { get; private set; }
 
     /// <summary>
     /// Snapshot of the countries supported by the provider for this method.
@@ -76,10 +76,10 @@ public sealed class PaymentMethodConfiguration : AuditedEntity
     public ImmutableDictionary<string, PaymentMethodAmountBound>? AmountBounds { get; private set; }
 
     /// <summary>Marks this method as active for the platform.</summary>
-    public void Activate() => IsActive = true;
+    public void Activate() => Activated = true;
 
     /// <summary>Marks this method as inactive (tenants will no longer see it).</summary>
-    public void Deactivate() => IsActive = false;
+    public void Deactivate() => Activated = false;
 
     /// <summary>
     /// Captures the provider's current capability for this method. Called by the admin

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -248,9 +248,9 @@ public static class ModelBuilderExtensions
         {
             Expression bypass = Expression.Not(
                 Expression.Property(Expression.Constant(proxy), nameof(FilterProxy.ActiveEnabled)));
-            Expression isActive = Expression.Property(param, nameof(IActive.IsActive));
+            Expression activated = Expression.Property(param, nameof(IActive.Activated));
             builder.HasQueryFilter(GranitFilterNames.Active,
-                Expression.Lambda<Func<TEntity, bool>>(Expression.OrElse(bypass, isActive), param));
+                Expression.Lambda<Func<TEntity, bool>>(Expression.OrElse(bypass, activated), param));
         }
 
         if (typeof(IProcessingRestrictable).IsAssignableFrom(typeof(TEntity)))

--- a/src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataResponse.cs
+++ b/src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataResponse.cs
@@ -21,7 +21,7 @@ namespace Granit.ReferenceData.Endpoints.Dtos;
 /// <param name="LabelSv">Swedish display label.</param>
 /// <param name="LabelCs">Czech display label.</param>
 /// <param name="LabelHi">Hindi display label.</param>
-/// <param name="IsActive">Whether the entry is active.</param>
+/// <param name="Activated">Whether the entry is active.</param>
 /// <param name="SortOrder">Display order (lower values first).</param>
 /// <param name="ValidFrom">Optional start of validity period.</param>
 /// <param name="ValidTo">Optional end of validity period.</param>
@@ -46,7 +46,7 @@ public sealed record ReferenceDataResponse(
     string LabelSv,
     string LabelCs,
     string LabelHi,
-    bool IsActive,
+    bool Activated,
     int SortOrder,
     DateTimeOffset? ValidFrom,
     DateTimeOffset? ValidTo,

--- a/src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataUpdateRequest.cs
+++ b/src/Granit.ReferenceData.Endpoints/Dtos/ReferenceDataUpdateRequest.cs
@@ -21,7 +21,7 @@ namespace Granit.ReferenceData.Endpoints.Dtos;
 /// <param name="LabelCs">Updated Czech display label.</param>
 /// <param name="LabelHi">Updated Hindi display label.</param>
 /// <param name="SortOrder">Updated display order.</param>
-/// <param name="IsActive">Updated active status.</param>
+/// <param name="Activated">Updated active status.</param>
 /// <param name="ValidFrom">Updated start of validity period.</param>
 /// <param name="ValidTo">Updated end of validity period.</param>
 /// <param name="ParentCode">Updated parent code for hierarchical reference data.</param>
@@ -43,7 +43,7 @@ public sealed record ReferenceDataUpdateRequest(
     string LabelCs = "",
     string LabelHi = "",
     int SortOrder = 0,
-    bool IsActive = true,
+    bool Activated = true,
     DateTimeOffset? ValidFrom = null,
     DateTimeOffset? ValidTo = null,
     string? ParentCode = null,

--- a/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataAdminEndpoints.cs
+++ b/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataAdminEndpoints.cs
@@ -93,7 +93,7 @@ internal static class ReferenceDataAdminEndpoints
             ValidFrom = request.ValidFrom,
             ValidTo = request.ValidTo,
             ParentCode = request.ParentCode,
-            IsActive = true,
+            Activated = true,
         };
 
         if (request.ExtraProperties is { Count: > 0 })
@@ -139,7 +139,7 @@ internal static class ReferenceDataAdminEndpoints
         existing.LabelCs = request.LabelCs;
         existing.LabelHi = request.LabelHi;
         existing.SortOrder = request.SortOrder;
-        existing.IsActive = request.IsActive;
+        existing.Activated = request.Activated;
         existing.ValidFrom = request.ValidFrom;
         existing.ValidTo = request.ValidTo;
         existing.ParentCode = request.ParentCode;

--- a/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataDynamicEndpoints.cs
+++ b/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataDynamicEndpoints.cs
@@ -216,7 +216,7 @@ internal static class ReferenceDataDynamicEndpoints
             ValidFrom = request.ValidFrom,
             ValidTo = request.ValidTo,
             ParentCode = request.ParentCode,
-            IsActive = true,
+            Activated = true,
         };
 
         if (request.ExtraProperties is { Count: > 0 })
@@ -267,7 +267,7 @@ internal static class ReferenceDataDynamicEndpoints
         existing.LabelCs = request.LabelCs;
         existing.LabelHi = request.LabelHi;
         existing.SortOrder = request.SortOrder;
-        existing.IsActive = request.IsActive;
+        existing.Activated = request.Activated;
         existing.ValidFrom = request.ValidFrom;
         existing.ValidTo = request.ValidTo;
         existing.ParentCode = request.ParentCode;

--- a/src/Granit.ReferenceData.Endpoints/Internal/ReferenceDataMapper.cs
+++ b/src/Granit.ReferenceData.Endpoints/Internal/ReferenceDataMapper.cs
@@ -34,7 +34,7 @@ internal static class ReferenceDataMapper
             entity.LabelSv,
             entity.LabelCs,
             entity.LabelHi,
-            entity.IsActive,
+            entity.Activated,
             entity.SortOrder,
             entity.ValidFrom,
             entity.ValidTo,

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Internal/EfCoreReferenceDataStore.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Internal/EfCoreReferenceDataStore.cs
@@ -87,7 +87,7 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
         // Active filter
         if (query.ActiveOnly)
         {
-            queryable = queryable.Where(e => e.IsActive);
+            queryable = queryable.Where(e => e.Activated);
         }
 
         // Search filter (Code or any label, case-insensitive)
@@ -272,7 +272,7 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
 
         if (entity is not null)
         {
-            entity.IsActive = isActive;
+            entity.Activated = isActive;
             await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
 
@@ -297,7 +297,7 @@ internal sealed class EfCoreReferenceDataStore<TEntity, TDbContext>(
         }
 
         List<TEntity> children = await queryable
-            .Where(e => e.ParentCode == parentCode && e.IsActive)
+            .Where(e => e.ParentCode == parentCode && e.Activated)
             .OrderBy(e => e.SortOrder)
             .ThenBy(e => e.Code)
             .ToListAsync(cancellationToken)

--- a/src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataEntityTypeConfiguration.cs
+++ b/src/Granit.ReferenceData.EntityFrameworkCore/Internal/ReferenceDataEntityTypeConfiguration.cs
@@ -6,7 +6,7 @@ namespace Granit.ReferenceData.EntityFrameworkCore.Internal;
 
 /// <summary>
 /// Base EF Core Fluent API configuration for reference data entities.
-/// Configures the common columns (Code, Label, IsActive, SortOrder, ValidFrom, ValidTo)
+/// Configures the common columns (Code, Label, Activated, SortOrder, ValidFrom, ValidTo)
 /// and the audit columns inherited from <see cref="Granit.Domain.AuditedEntity"/>.
 /// </summary>
 /// <typeparam name="TEntity">The concrete reference data entity type.</typeparam>
@@ -104,9 +104,9 @@ public abstract class ReferenceDataEntityTypeConfiguration<TEntity>
         builder.Property(e => e.LabelCs).HasMaxLength(250);
         builder.Property(e => e.LabelHi).HasMaxLength(250);
 
-        // IsActive — indexed for global query filter performance
-        builder.HasIndex(e => e.IsActive)
-               .HasDatabaseName($"ix_{_tableName}_is_active");
+        // Activated — indexed for global query filter performance
+        builder.HasIndex(e => e.Activated)
+               .HasDatabaseName($"ix_{_tableName}_activated");
 
         // SortOrder
         builder.Property(e => e.SortOrder)

--- a/src/Granit.ReferenceData/Domain/ReferenceDataEntity.cs
+++ b/src/Granit.ReferenceData/Domain/ReferenceDataEntity.cs
@@ -20,7 +20,7 @@ namespace Granit.ReferenceData.Domain;
 /// Derived entities can override <see cref="Label"/> for custom resolution logic.
 /// </para>
 /// <para>
-/// Soft activation/deactivation is controlled by <see cref="IsActive"/>. Deactivated entries
+/// Soft activation/deactivation is controlled by <see cref="Activated"/>. Deactivated entries
 /// are filtered out by the EF Core global query filter unless explicitly disabled.
 /// </para>
 /// <para>
@@ -118,7 +118,7 @@ public abstract class ReferenceDataEntity : AuditedEntity, IActive, IHasExtraPro
     };
 
     /// <inheritdoc/>
-    public bool IsActive { get; set; } = true;
+    public bool Activated { get; set; } = true;
 
     /// <summary>
     /// Display order for UI sorting. Lower values appear first. Default is 0.

--- a/src/Granit.ReferenceData/Internal/GenericReferenceDataQueryDefinition.cs
+++ b/src/Granit.ReferenceData/Internal/GenericReferenceDataQueryDefinition.cs
@@ -6,7 +6,7 @@ namespace Granit.ReferenceData.Internal;
 /// <summary>
 /// Auto-generated <see cref="QueryDefinition{TEntity}"/> for strongly-typed reference data
 /// entity types. Declares the same base columns as <see cref="ReferenceDataQueryDefinition"/>
-/// (Code, Labels, IsActive, SortOrder, ValidFrom, ValidTo) for any <typeparamref name="TEntity"/>
+/// (Code, Labels, Activated, SortOrder, ValidFrom, ValidTo) for any <typeparamref name="TEntity"/>
 /// inheriting from <see cref="ReferenceDataEntity"/>.
 /// </summary>
 internal sealed class GenericReferenceDataQueryDefinition<TEntity>
@@ -26,7 +26,7 @@ internal sealed class GenericReferenceDataQueryDefinition<TEntity>
             .Column(e => e.LabelNl, c => c.Label("Label (NL)").Filterable())
             .Column(e => e.LabelDe, c => c.Label("Label (DE)").Filterable())
             .Column(e => e.LabelHi, c => c.Label("Label (HI)").Filterable())
-            .Column(e => e.IsActive, c => c.Label("Active").Filterable())
+            .Column(e => e.Activated, c => c.Label("Active").Filterable())
             .Column(e => e.SortOrder, c => c.Label("Sort Order").Sortable())
             .Column(e => e.ValidFrom, c => c.Label("Valid From").Filterable().Sortable())
             .Column(e => e.ValidTo, c => c.Label("Valid To").Filterable().Sortable())

--- a/src/Granit.ReferenceData/Internal/ReferenceDataQueryDefinition.cs
+++ b/src/Granit.ReferenceData/Internal/ReferenceDataQueryDefinition.cs
@@ -6,7 +6,7 @@ namespace Granit.ReferenceData.Internal;
 
 /// <summary>
 /// Auto-generated <see cref="QueryDefinition{TEntity}"/> for a dynamically registered
-/// reference data type. Declares base columns (Code, Labels, IsActive, SortOrder, ValidFrom,
+/// reference data type. Declares base columns (Code, Labels, Activated, SortOrder, ValidFrom,
 /// ValidTo) plus any Shadow Property columns from <see cref="ReferenceDataExtensionOptions"/>.
 /// </summary>
 internal sealed class ReferenceDataQueryDefinition(
@@ -28,7 +28,7 @@ internal sealed class ReferenceDataQueryDefinition(
             .Column(e => e.LabelNl, c => c.Label("Label (NL)").Filterable())
             .Column(e => e.LabelDe, c => c.Label("Label (DE)").Filterable())
             .Column(e => e.LabelHi, c => c.Label("Label (HI)").Filterable())
-            .Column(e => e.IsActive, c => c.Label("Active").Filterable())
+            .Column(e => e.Activated, c => c.Label("Active").Filterable())
             .Column(e => e.SortOrder, c => c.Label("Sort Order").Sortable())
             .Column(e => e.ValidFrom, c => c.Label("Valid From").Filterable().Sortable())
             .Column(e => e.ValidTo, c => c.Label("Valid To").Filterable().Sortable());

--- a/src/Granit/Domain/IActive.cs
+++ b/src/Granit/Domain/IActive.cs
@@ -1,18 +1,32 @@
 namespace Granit.Domain;
 
 /// <summary>
-/// Interface for entities with an active/inactive status.
-/// When <see cref="IsActive"/> is <c>false</c>, the entity is excluded from standard
-/// queries by the EF Core global query filter registered by
-/// <c>ModelBuilderExtensions.ApplyGranitConventions()</c> (WHERE IsActive = true).
+/// Marker interface for entities that expose an on/off activation flag and should be
+/// hidden from standard queries when deactivated.
 /// </summary>
 /// <remarks>
-/// Opt-in: only entities explicitly implementing this interface are filtered.
-/// The filter can be bypassed at runtime via
+/// <para>
+/// When <see cref="Activated"/> is <c>false</c>, the entity is excluded from standard
+/// queries by the EF Core global query filter registered by
+/// <c>ModelBuilderExtensions.ApplyGranitConventions()</c> (<c>WHERE Activated = true</c>).
+/// Admin code paths that need to see deactivated rows disable the filter via
 /// <c>IDataFilter.Disable&lt;IActive&gt;()</c>.
+/// </para>
+/// <para>
+/// The interface requires only a getter — implementers may expose a public setter
+/// (CRUD / reference-data style) or encapsulate mutation via behavior methods with a
+/// private setter (DDD aggregate style). The query filter only reads the value; no
+/// framework code mutates <see cref="Activated"/> through the interface.
+/// </para>
+/// <para>
+/// The past-participle naming (<em>Activated</em>) pairs with the conventional
+/// <c>Activate()</c> / <c>Deactivate()</c> behavior methods found on DDD aggregates and
+/// mirrors the bare-participle convention used in the Identity subsystem
+/// (<c>IIdentityUser.Enabled</c>).
+/// </para>
 /// </remarks>
 public interface IActive
 {
-    /// <summary>Indicates whether the entity is active and visible in standard queries.</summary>
-    bool IsActive { get; set; }
+    /// <summary>Indicates whether the entity is currently active and visible in standard queries.</summary>
+    bool Activated { get; }
 }

--- a/tests/Granit.AI.EntityFrameworkCore.Tests/EfAIWorkspaceStoreTests.cs
+++ b/tests/Granit.AI.EntityFrameworkCore.Tests/EfAIWorkspaceStoreTests.cs
@@ -1,6 +1,7 @@
 using Granit.AI.EntityFrameworkCore.Entities;
 using Granit.AI.EntityFrameworkCore.Internal;
 using Granit.AI.Workspaces;
+using Granit.DataFiltering;
 using Granit.MultiTenancy;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
@@ -19,8 +20,10 @@ public sealed class EfAIWorkspaceStoreTests : IAsyncDisposable
             .UseInMemoryDatabase($"ai-test-{Guid.NewGuid()}")
             .Options;
 
-        _factory = new TestDbContextFactory(options);
-        _store = new EfAIWorkspaceStore(_factory, Substitute.For<ICurrentTenant>());
+        // Share the DataFilter between the DbContext (for query-filter bypass) and the store.
+        DataFilter sharedFilter = new();
+        _factory = new TestDbContextFactory(options, sharedFilter);
+        _store = new EfAIWorkspaceStore(_factory, Substitute.For<ICurrentTenant>(), sharedFilter);
     }
 
     public async ValueTask DisposeAsync()
@@ -34,7 +37,7 @@ public sealed class EfAIWorkspaceStoreTests : IAsyncDisposable
         Name = name,
         Provider = "OpenAI",
         Model = "gpt-4o",
-        IsActive = true,
+        Activated = true,
     };
 
     [Fact]
@@ -62,19 +65,19 @@ public sealed class EfAIWorkspaceStoreTests : IAsyncDisposable
     [Fact]
     public async Task FindAsync_ReturnsInactiveWorkspace()
     {
-        await _store.CreateAsync(CreateWorkspace() with { IsActive = false }, TestContext.Current.CancellationToken);
+        await _store.CreateAsync(CreateWorkspace() with { Activated = false }, TestContext.Current.CancellationToken);
 
         AIWorkspace? result = await _store.FindAsync("test-ws", TestContext.Current.CancellationToken);
 
         result.ShouldNotBeNull();
-        result.IsActive.ShouldBeFalse();
+        result.Activated.ShouldBeFalse();
     }
 
     [Fact]
     public async Task GetAllAsync_ReturnsActiveAndInactiveWorkspaces()
     {
         await _store.CreateAsync(CreateWorkspace("active"), TestContext.Current.CancellationToken);
-        await _store.CreateAsync(CreateWorkspace("inactive") with { IsActive = false }, TestContext.Current.CancellationToken);
+        await _store.CreateAsync(CreateWorkspace("inactive") with { Activated = false }, TestContext.Current.CancellationToken);
 
         IReadOnlyList<AIWorkspace> results = await _store.GetAllAsync(TestContext.Current.CancellationToken);
 
@@ -113,11 +116,12 @@ public sealed class EfAIWorkspaceStoreTests : IAsyncDisposable
     /// <summary>
     /// Simple factory wrapping InMemory options for testing.
     /// </summary>
-    private sealed class TestDbContextFactory(DbContextOptions<AIDbContext> options) : IDbContextFactory<AIDbContext>
+    private sealed class TestDbContextFactory(DbContextOptions<AIDbContext> options, IDataFilter dataFilter)
+        : IDbContextFactory<AIDbContext>
     {
-        public AIDbContext CreateDbContext() => new(options);
+        public AIDbContext CreateDbContext() => new(options, dataFilter: dataFilter);
 
         public Task<AIDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
-            Task.FromResult(new AIDbContext(options));
+            Task.FromResult(new AIDbContext(options, dataFilter: dataFilter));
     }
 }

--- a/tests/Granit.Metering.Tests/MeterDefinitionTests.cs
+++ b/tests/Granit.Metering.Tests/MeterDefinitionTests.cs
@@ -17,7 +17,7 @@ public sealed class MeterDefinitionTests
         meter.Unit.ShouldBe("requests");
         meter.AggregationType.ShouldBe(AggregationType.Sum);
         meter.Description.ShouldBe("HTTP requests");
-        meter.IsActive.ShouldBeTrue();
+        meter.Activated.ShouldBeTrue();
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public sealed class MeterDefinitionTests
 
         meter.Deactivate();
 
-        meter.IsActive.ShouldBeFalse();
+        meter.Activated.ShouldBeFalse();
     }
 
     [Fact]
@@ -67,7 +67,7 @@ public sealed class MeterDefinitionTests
 
         meter.Activate();
 
-        meter.IsActive.ShouldBeTrue();
+        meter.Activated.ShouldBeTrue();
     }
 
     [Fact]

--- a/tests/Granit.MultiTenancy.Endpoints.Tests/Dtos/TenantResponseTests.cs
+++ b/tests/Granit.MultiTenancy.Endpoints.Tests/Dtos/TenantResponseTests.cs
@@ -18,7 +18,7 @@ public sealed class TenantResponseTests
         response.Name.ShouldBe("Acme Corp");
         response.Identifier.ShouldBe("acme-corp");
         response.ContactEmail.ShouldBe("admin@acme.com");
-        response.IsActive.ShouldBeTrue();
+        response.Activated.ShouldBeTrue();
         response.Jurisdiction.ShouldBe("BE");
         response.CreatedAt.ShouldBe(createdAt);
     }

--- a/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/MultiTenancyDbContextTests.cs
+++ b/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/MultiTenancyDbContextTests.cs
@@ -46,6 +46,6 @@ public sealed class MultiTenancyDbContextTests
         loaded.Name.ShouldBe("Acme Corp");
         loaded.Identifier.ShouldBe("acme-corp");
         loaded.ContactEmail.ShouldBe("admin@acme.com");
-        loaded.IsActive.ShouldBeTrue();
+        loaded.Activated.ShouldBeTrue();
     }
 }

--- a/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/TenantEntityTypeConfigurationTests.cs
+++ b/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/TenantEntityTypeConfigurationTests.cs
@@ -80,7 +80,7 @@ public sealed class TenantEntityTypeConfigurationTests
         using MultiTenancyDbContext ctx = CreateInMemory();
         IEntityType entityType = ctx.Model.FindEntityType(typeof(Tenant))!;
 
-        IProperty isActive = entityType.FindProperty(nameof(Tenant.IsActive))!;
+        IProperty isActive = entityType.FindProperty(nameof(Tenant.Activated))!;
 
         isActive.IsNullable.ShouldBeFalse();
     }

--- a/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/TenantTests.cs
+++ b/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/TenantTests.cs
@@ -25,7 +25,7 @@ public sealed class TenantTests
         tenant.Name.ShouldBe("Acme Corp");
         tenant.Identifier.ShouldBe("acme-corp");
         tenant.ContactEmail.ShouldBe("admin@acme.com");
-        tenant.IsActive.ShouldBeTrue();
+        tenant.Activated.ShouldBeTrue();
         tenant.Jurisdiction.ShouldBeNull();
     }
 
@@ -117,7 +117,7 @@ public sealed class TenantTests
 
         tenant.Deactivate();
 
-        tenant.IsActive.ShouldBeFalse();
+        tenant.Activated.ShouldBeFalse();
     }
 
     [Fact]
@@ -155,7 +155,7 @@ public sealed class TenantTests
 
         tenant.Activate();
 
-        tenant.IsActive.ShouldBeTrue();
+        tenant.Activated.ShouldBeTrue();
     }
 
     [Fact]

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/ModelBuilderExtensionsTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/ModelBuilderExtensionsTests.cs
@@ -196,8 +196,8 @@ public sealed class ModelBuilderExtensionsTests
         await using TestDbContextWithActive context = CreateContextWithActive();
         await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
 
-        context.ActiveEntities.Add(new TestActiveEntity { Name = "Active", IsActive = true });
-        context.ActiveEntities.Add(new TestActiveEntity { Name = "Inactive", IsActive = false });
+        context.ActiveEntities.Add(new TestActiveEntity { Name = "Active", Activated = true });
+        context.ActiveEntities.Add(new TestActiveEntity { Name = "Inactive", Activated = false });
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
@@ -215,8 +215,8 @@ public sealed class ModelBuilderExtensionsTests
         await using TestDbContextWithActive context = CreateContextWithActive();
         await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
 
-        context.ActiveEntities.Add(new TestActiveEntity { Name = "Active", IsActive = true });
-        context.ActiveEntities.Add(new TestActiveEntity { Name = "Inactive", IsActive = false });
+        context.ActiveEntities.Add(new TestActiveEntity { Name = "Active", Activated = true });
+        context.ActiveEntities.Add(new TestActiveEntity { Name = "Inactive", Activated = false });
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         // Act
@@ -275,11 +275,11 @@ public sealed class ModelBuilderExtensionsTests
 
         var compiled = (Func<TestActiveWithFilter, bool>)filter!.Compile();
 
-        compiled(new TestActiveWithFilter { IsActive = false }).ShouldBeFalse("inactive must be filtered");
-        compiled(new TestActiveWithFilter { IsActive = true }).ShouldBeTrue("active must pass");
+        compiled(new TestActiveWithFilter { Activated = false }).ShouldBeFalse("inactive must be filtered");
+        compiled(new TestActiveWithFilter { Activated = true }).ShouldBeTrue("active must pass");
 
         SharedDataFilter.SetEnabled<IActive>(false);
-        compiled(new TestActiveWithFilter { IsActive = false }).ShouldBeTrue("inactive must pass when filter disabled");
+        compiled(new TestActiveWithFilter { Activated = false }).ShouldBeTrue("inactive must pass when filter disabled");
 
         SharedDataFilter.SetEnabled<IActive>(true);
     }
@@ -753,7 +753,7 @@ internal sealed class TestActiveEntity : IActive
 {
     public int Id { get; set; }
     public string Name { get; set; } = string.Empty;
-    public bool IsActive { get; set; }
+    public bool Activated { get; set; }
 }
 
 internal sealed class TestSoftDeleteWithFilter : ISoftDeletable
@@ -767,7 +767,7 @@ internal sealed class TestSoftDeleteWithFilter : ISoftDeletable
 internal sealed class TestActiveWithFilter : IActive
 {
     public int Id { get; set; }
-    public bool IsActive { get; set; }
+    public bool Activated { get; set; }
 }
 
 internal sealed class TestCombinedEntity : ISoftDeletable, IMultiTenant

--- a/tests/Granit.ReferenceData.Endpoints.Tests/Internal/ReferenceDataMapperTests.cs
+++ b/tests/Granit.ReferenceData.Endpoints.Tests/Internal/ReferenceDataMapperTests.cs
@@ -35,7 +35,7 @@ public sealed class ReferenceDataMapperTests
             LabelKo = "벨기에",
             LabelSv = "Belgien",
             LabelCs = "Belgie",
-            IsActive = true,
+            Activated = true,
             SortOrder = 5,
             ValidFrom = validFrom,
             ValidTo = validTo,
@@ -60,7 +60,7 @@ public sealed class ReferenceDataMapperTests
         response.LabelKo.ShouldBe("벨기에");
         response.LabelSv.ShouldBe("Belgien");
         response.LabelCs.ShouldBe("Belgie");
-        response.IsActive.ShouldBeTrue();
+        response.Activated.ShouldBeTrue();
         response.SortOrder.ShouldBe(5);
         response.ValidFrom.ShouldBe(validFrom);
         response.ValidTo.ShouldBe(validTo);

--- a/tests/Granit.ReferenceData.Endpoints.Tests/ReferenceDataEndpointsTests.cs
+++ b/tests/Granit.ReferenceData.Endpoints.Tests/ReferenceDataEndpointsTests.cs
@@ -356,7 +356,7 @@ public sealed class ReferenceDataEndpointsTests : IAsyncDisposable
             builder
                 .Column(e => e.Code, c => c.Label("Code").Filterable().Sortable())
                 .Column(e => e.LabelEn, c => c.Label("Label (EN)").Filterable().Sortable())
-                .Column(e => e.IsActive, c => c.Label("Active").Filterable())
+                .Column(e => e.Activated, c => c.Label("Active").Filterable())
                 .GlobalSearch(e => e.Code, e => e.LabelEn)
                 .DefaultSort("Code");
         }

--- a/tests/Granit.ReferenceData.Endpoints.Tests/ReferenceDataUpdateRequestTests.cs
+++ b/tests/Granit.ReferenceData.Endpoints.Tests/ReferenceDataUpdateRequestTests.cs
@@ -47,7 +47,7 @@ public sealed class ReferenceDataUpdateRequestTests
     {
         ReferenceDataUpdateRequest request = new("Belgium");
 
-        request.IsActive.ShouldBeTrue();
+        request.Activated.ShouldBeTrue();
     }
 
     [Fact]
@@ -86,14 +86,14 @@ public sealed class ReferenceDataUpdateRequestTests
             LabelSv: "Belgien",
             LabelCs: "Belgie",
             SortOrder: 10,
-            IsActive: false,
+            Activated: false,
             ValidFrom: now,
             ValidTo: now.AddYears(1));
 
         request.LabelFr.ShouldBe("Belgique");
         request.LabelCs.ShouldBe("Belgie");
         request.SortOrder.ShouldBe(10);
-        request.IsActive.ShouldBeFalse();
+        request.Activated.ShouldBeFalse();
         request.ValidFrom.ShouldBe(now);
         request.ValidTo.ShouldBe(now.AddYears(1));
     }

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreAdditionalTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreAdditionalTests.cs
@@ -78,7 +78,7 @@ public sealed class EfCoreReferenceDataStoreAdditionalTests
             Code = code,
             LabelEn = label,
             LabelFr = labelFr,
-            IsActive = isActive,
+            Activated = isActive,
             SortOrder = sortOrder,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "seed",
@@ -279,7 +279,7 @@ public sealed class EfCoreReferenceDataStoreAdditionalTests
             Id = Guid.NewGuid(),
             Code = "BE",
             LabelEn = "Belgium (duplicate)",
-            IsActive = true,
+            Activated = true,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "test",
         }, TestContext.Current.CancellationToken));
@@ -293,7 +293,7 @@ public sealed class EfCoreReferenceDataStoreAdditionalTests
     public async Task CreateAsync_DuplicateCode_InactiveRecord_IsNoOp()
     {
         // This is the exact scenario seen in production: seeder runs a second time,
-        // the existing record has IsActive=false (bypassed by the query filter in
+        // the existing record has Activated=false (bypassed by the query filter in
         // GetByCodeAsync), so the seeder calls CreateAsync which must not throw 23505.
         string db = Guid.NewGuid().ToString();
         await SeedAsync(db, "BE", "Belgium", isActive: false, cancellationToken: TestContext.Current.CancellationToken);
@@ -305,7 +305,7 @@ public sealed class EfCoreReferenceDataStoreAdditionalTests
             Id = Guid.NewGuid(),
             Code = "BE",
             LabelEn = "Belgium",
-            IsActive = true,
+            Activated = true,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "test",
         }, TestContext.Current.CancellationToken));
@@ -323,13 +323,13 @@ public sealed class EfCoreReferenceDataStoreAdditionalTests
 
         EfCoreReferenceDataStore<TestEntity, TestDbContext> store = CreateStore(db);
 
-        // Should succeed even though the record is filtered out by IsActive=false
+        // Should succeed even though the record is filtered out by Activated=false
         await store.SetActiveAsync("BE", true, TestContext.Current.CancellationToken);
 
         PagedResult<TestEntity> result = await store.GetAllAsync(
             cancellationToken: TestContext.Current.CancellationToken);
 
-        result.Items.ShouldContain(e => e.Code == "BE" && e.IsActive);
+        result.Items.ShouldContain(e => e.Code == "BE" && e.Activated);
     }
 
     // -------------------------------------------------------------------------
@@ -356,7 +356,7 @@ public sealed class EfCoreReferenceDataStoreAdditionalTests
             Id = Guid.NewGuid(),
             Code = "BE",
             LabelEn = "Belgium",
-            IsActive = true,
+            Activated = true,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "test",
         };

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreConcurrencyTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreConcurrencyTests.cs
@@ -71,7 +71,7 @@ public sealed class EfCoreReferenceDataStoreConcurrencyTests : IAsyncLifetime
                     Id = Guid.NewGuid(),
                     Code = code,
                     LabelEn = "Concurrent winner",
-                    IsActive = true,
+                    Activated = true,
                     SortOrder = 0,
                     CreatedAt = DateTimeOffset.UtcNow,
                     CreatedBy = "race",
@@ -143,7 +143,7 @@ public sealed class EfCoreReferenceDataStoreConcurrencyTests : IAsyncLifetime
             Id = Guid.NewGuid(),
             Code = "RACE",
             LabelEn = "Loser",
-            IsActive = true,
+            Activated = true,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "test",
         }, TestContext.Current.CancellationToken));
@@ -168,7 +168,7 @@ public sealed class EfCoreReferenceDataStoreConcurrencyTests : IAsyncLifetime
             Id = Guid.NewGuid(),
             Code = "VALID",
             LabelEn = "Valid",
-            IsActive = true,
+            Activated = true,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "test",
         }, TestContext.Current.CancellationToken);

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/EfCoreReferenceDataStoreTests.cs
@@ -76,7 +76,7 @@ public sealed class EfCoreReferenceDataStoreTests
             Id = Guid.NewGuid(),
             Code = code,
             LabelEn = label,
-            IsActive = isActive,
+            Activated = isActive,
             SortOrder = sortOrder,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "seed",
@@ -147,7 +147,7 @@ public sealed class EfCoreReferenceDataStoreTests
             cancellationToken: TestContext.Current.CancellationToken);
 
         result.TotalCount.ShouldBe(1);
-        result.Items.ShouldAllBe(e => e.IsActive);
+        result.Items.ShouldAllBe(e => e.Activated);
     }
 
     [Fact]
@@ -277,7 +277,7 @@ public sealed class EfCoreReferenceDataStoreTests
             Id = Guid.NewGuid(),
             Code = "DE",
             LabelEn = "Germany",
-            IsActive = true,
+            Activated = true,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "test",
         };
@@ -332,7 +332,7 @@ public sealed class EfCoreReferenceDataStoreTests
             new ReferenceDataQuery(ActiveOnly: false),
             TestContext.Current.CancellationToken);
 
-        result.Items.ShouldContain(e => e.Code == "BE" && !e.IsActive);
+        result.Items.ShouldContain(e => e.Code == "BE" && !e.Activated);
     }
 
     [Fact]
@@ -347,7 +347,7 @@ public sealed class EfCoreReferenceDataStoreTests
         PagedResult<TestEntity> result = await store.GetAllAsync(
             cancellationToken: TestContext.Current.CancellationToken);
 
-        result.Items.ShouldContain(e => e.Code == "BE" && e.IsActive);
+        result.Items.ShouldContain(e => e.Code == "BE" && e.Activated);
     }
 
     // -------------------------------------------------------------------------
@@ -379,7 +379,7 @@ public sealed class EfCoreReferenceDataStoreTests
             Id = Guid.NewGuid(),
             Code = "DE",
             LabelEn = "Germany",
-            IsActive = true,
+            Activated = true,
             CreatedAt = DateTimeOffset.UtcNow,
             CreatedBy = "test",
         }, TestContext.Current.CancellationToken);

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEntityTypeConfigurationAdditionalTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEntityTypeConfigurationAdditionalTests.cs
@@ -122,19 +122,19 @@ public sealed class ReferenceDataEntityTypeConfigurationAdditionalTests
     }
 
     // -------------------------------------------------------------------------
-    // IsActive index has expected name
+    // Activated index has expected name
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void IsActive_Index_HasExpectedDatabaseName()
+    public void Activated_Index_HasExpectedDatabaseName()
     {
         IEntityType entityType = GetEntityType();
-        IProperty isActive = entityType.FindProperty(nameof(TestEntity.IsActive))!;
+        IProperty activated = entityType.FindProperty(nameof(TestEntity.Activated))!;
 
         IIndex? index = entityType.GetIndexes()
-            .FirstOrDefault(i => i.Properties.Count == 1 && i.Properties[0] == isActive);
+            .FirstOrDefault(i => i.Properties.Count == 1 && i.Properties[0] == activated);
 
         index.ShouldNotBeNull();
-        index!.GetDatabaseName().ShouldBe("ix_ref_test_entities_is_active");
+        index!.GetDatabaseName().ShouldBe("ix_ref_test_entities_activated");
     }
 }

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEntityTypeConfigurationTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEntityTypeConfigurationTests.cs
@@ -107,7 +107,7 @@ public sealed class ReferenceDataEntityTypeConfigurationTests
     public void IsActive_Has_Index()
     {
         IEntityType entityType = GetEntityType();
-        IProperty isActive = entityType.FindProperty(nameof(TestEntity.IsActive))!;
+        IProperty isActive = entityType.FindProperty(nameof(TestEntity.Activated))!;
 
         IIndex? index = entityType.GetIndexes()
             .FirstOrDefault(i => i.Properties.Count == 1 && i.Properties[0] == isActive);

--- a/tests/Granit.ReferenceData.Tests/ReferenceDataEntityAdditionalTests.cs
+++ b/tests/Granit.ReferenceData.Tests/ReferenceDataEntityAdditionalTests.cs
@@ -54,9 +54,9 @@ public sealed class ReferenceDataEntityAdditionalTests
     [Fact]
     public void IsActive_CanBeSetToFalse()
     {
-        TestEntity entity = new() { IsActive = false };
+        TestEntity entity = new() { Activated = false };
 
-        entity.IsActive.ShouldBeFalse();
+        entity.Activated.ShouldBeFalse();
     }
 
     [Fact]

--- a/tests/Granit.ReferenceData.Tests/ReferenceDataEntityTests.cs
+++ b/tests/Granit.ReferenceData.Tests/ReferenceDataEntityTests.cs
@@ -32,7 +32,7 @@ public sealed class ReferenceDataEntityTests
     {
         TestEntity entity = new();
 
-        entity.IsActive.ShouldBeTrue();
+        entity.Activated.ShouldBeTrue();
     }
 
     [Fact]
@@ -253,7 +253,7 @@ public sealed class ReferenceDataEntityTests
             LabelKo = "벨기에",
             LabelSv = "Belgien",
             LabelCs = "Belgie",
-            IsActive = false,
+            Activated = false,
             SortOrder = 42,
             ValidFrom = now,
             ValidTo = now.AddYears(1)
@@ -274,7 +274,7 @@ public sealed class ReferenceDataEntityTests
         entity.LabelKo.ShouldBe("벨기에");
         entity.LabelSv.ShouldBe("Belgien");
         entity.LabelCs.ShouldBe("Belgie");
-        entity.IsActive.ShouldBeFalse();
+        entity.Activated.ShouldBeFalse();
         entity.SortOrder.ShouldBe(42);
         entity.ValidFrom.ShouldBe(now);
         entity.ValidTo.ShouldBe(now.AddYears(1));


### PR DESCRIPTION
## Summary

Stacked on top of #1033. Adopts the relaxed `IActive` on three aggregate roots that
currently carry a `private set IsActive` with a manual `.Where(x.IsActive)` in their
stores, renames each property to `Activated` (post-participle paired with
`Activate()` / `Deactivate()` behavior methods), and normalizes `Tenant` to the same
naming without opting into `IActive` (architecturally out).

### Changes per aggregate

- **`PaymentMethodConfiguration`** — implements `IActive`, `IsActive` → `Activated`. `GetActiveAsync` drops its manual `.Where` (filter handles it). Admin paths (`GetAllAsync`, `GetByIdAsync`, `FindAsync`, `UpsertActivationAsync`, `UpsertActivationWithSnapshotAsync`, `UpdateCapabilitySnapshotAsync`) bypass `IActive` via `IDataFilter.Disable<IActive>()` so deactivated rows stay visible for reactivation / resync / race-safe upsert.
- **`MeterDefinition`** — implements `IActive`, `IsActive` → `Activated`. `EfMeterDefinitionReader.GetActiveAsync` drops its manual spec predicate.
- **`AIWorkspaceEntity`** — implements `IActive`, `IsActive` → `Activated`. `EfAIWorkspaceStore` gains an `IDataFilter` dependency; admin-surface reads (`FindAsync`, `GetAllAsync`) and writes (`UpdateAsync`, `DeleteAsync`) bypass the filter so deactivated workspaces can still be listed, reactivated, or deleted by name. Domain record `AIWorkspace.IsActive` renamed too.
- **`Tenant`** — `IsActive` → `Activated` for naming consistency (no interface adoption). Callers updated: entity config, EF stores (`EfCoreTenantStore`, `EfCoreTenantEnumerator`), domain resolvers (`DomainTenantResolver`, `CustomDomainTenantResolver`), `TenantData` record, `TenantResponse` DTO, endpoint mappers, export definition.

### DTO / API surface impact

- `PaymentMethodConfigurationItem.IsActive` → `Activated`
- `PaymentCatalogMethod.IsActive` → `Activated`
- `MeterDefinitionResponse.IsActive` → `Activated`
- `AIWorkspaceResponse.IsActive` → `Activated`
- `AIWorkspaceUpdateRequest.IsActive` → `Activated`
- `TenantResponse.IsActive` → `Activated`

Front-end consumers (admin UIs, SDK) must rename the JSON key `isActive` → `activated` on these DTOs.

### Test infrastructure

`EfAIWorkspaceStoreTests` — the `TestDbContextFactory` now shares the same
`DataFilter` instance with both the DbContext and the store under test. Without
this, `IDataFilter.Disable<IActive>()` has no effect because the query filter
captures a different `FilterProxy` reference.

## Test plan

- [x] `dotnet build Granit.slnx` — 0 errors
- [x] `dotnet test tests/Granit.Payments.Tests` — 94 tests
- [x] `dotnet test tests/Granit.Payments.EntityFrameworkCore.Tests` — 4 tests
- [x] `dotnet test tests/Granit.Payments.Endpoints.Tests` — 18 tests
- [x] `dotnet test tests/Granit.Metering.Tests` — 37 tests
- [x] `dotnet test tests/Granit.Metering.EntityFrameworkCore.Tests` — 4 tests
- [x] `dotnet test tests/Granit.AI.EntityFrameworkCore.Tests` — 8 tests
- [x] `dotnet test tests/Granit.MultiTenancy.Tests` — 93 tests
- [x] `dotnet test tests/Granit.MultiTenancy.EntityFrameworkCore.Tests` — 33 tests
- [x] `dotnet test tests/Granit.MultiTenancy.Endpoints.Tests` — 36 tests
- [x] `dotnet test tests/Granit.ArchitectureTests` — 111 tests
- [x] `dotnet format --verify-no-changes` clean on all touched projects

## Migration notes for hosts

Generate EF migrations on any `DbContext` that includes `PaymentMethodConfiguration`,
`MeterDefinition`, `AIWorkspaceEntity`, or `Tenant` — EF will produce
`RenameColumn("IsActive", "Activated")` per affected table. Additive, safe,
no data migration.

## Non-goals

- `BackgroundJobDefinition.IsEnabled` stays — semantic fits the bare `Enabled`
  convention. Can be normalized in a follow-up if desired.
- `NotificationPreference.IsEnabled`, `UserCacheEntry.Enabled`, computed
  `PlanPrice.IsActive`, `GranitUser.Enabled` — different semantics, kept as-is.
