### PR TITLE
refactor(subscriptions): rename PlanPrice.IsActive to IsCurrent

### DIFF
--- a/src/Granit.DataExchange.Definitions/Subscriptions/PlanPriceExportDefinition.cs
+++ b/src/Granit.DataExchange.Definitions/Subscriptions/PlanPriceExportDefinition.cs
@@ -17,6 +17,6 @@ public sealed class PlanPriceExportDefinition : ExportDefinition<PlanPrice>
             .Field(p => p.EffectiveFrom, f => f.Format("O"))
             .Field(p => p.ReplacedByPriceId)
             .Field(p => p.ReplacedAt, f => f.Format("O"))
-            .Field(p => p.IsActive);
+            .Field(p => p.IsCurrent);
     }
 }

--- a/src/Granit.Subscriptions.Endpoints/Dtos/PlanResponse.cs
+++ b/src/Granit.Subscriptions.Endpoints/Dtos/PlanResponse.cs
@@ -36,11 +36,11 @@ public sealed record PlanPriceResponse(
     string Currency,
     string Interval,
     DateTimeOffset EffectiveFrom,
-    bool IsActive,
+    bool IsCurrent,
     Guid? ReplacedByPriceId = null,
     DateTimeOffset? ReplacedAt = null)
 {
     internal static PlanPriceResponse FromEntity(PlanPrice price) =>
         new(price.Id, price.Amount, price.Currency, price.Interval.ToString(),
-            price.EffectiveFrom, price.IsActive, price.ReplacedByPriceId, price.ReplacedAt);
+            price.EffectiveFrom, price.IsCurrent, price.ReplacedByPriceId, price.ReplacedAt);
 }

--- a/src/Granit.Subscriptions.Endpoints/Endpoints/SubscriptionEndpoints.cs
+++ b/src/Granit.Subscriptions.Endpoints/Endpoints/SubscriptionEndpoints.cs
@@ -150,7 +150,7 @@ internal static class SubscriptionEndpoints
         };
 
         // Pin to the current active price for the requested currency and default interval.
-        PlanPrice? activePrice = plan.GetActivePrice(request.Currency, plan.DefaultInterval);
+        PlanPrice? currentPrice = plan.GetCurrentPrice(request.Currency, plan.DefaultInterval);
 
         var sub = Subscription.Create(
             guidGenerator.Create(),
@@ -159,7 +159,7 @@ internal static class SubscriptionEndpoints
             request.Currency,
             new SubscriptionPeriod(now, periodEnd, BillingCycleAnchor: now),
             trialEndsAt: request.TrialEndsAt,
-            planPriceId: activePrice?.Id);
+            planPriceId: currentPrice?.Id);
 
         await writer.AddAsync(sub, cancellationToken).ConfigureAwait(false);
 

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfPricingResolver.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/EfPricingResolver.cs
@@ -53,6 +53,6 @@ internal sealed class EfPricingResolver(IPlanReader planReader) : IPricingResolv
         }
 
         // Dynamic resolution: return the current active price for (currency, interval)
-        return plan.GetActivePrice(currency, interval);
+        return plan.GetCurrentPrice(currency, interval);
     }
 }

--- a/src/Granit.Subscriptions.EntityFrameworkCore/Internal/PlanPriceConfiguration.cs
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/Internal/PlanPriceConfiguration.cs
@@ -22,8 +22,8 @@ internal sealed class PlanPriceConfiguration : IEntityTypeConfiguration<PlanPric
 
         builder.HasIndex(e => new { e.ReplacedByPriceId })
             .HasFilter("\"ReplacedByPriceId\" IS NULL")
-            .HasDatabaseName($"ix_{GranitSubscriptionsDbProperties.DbTablePrefix}plan_prices_active");
+            .HasDatabaseName($"ix_{GranitSubscriptionsDbProperties.DbTablePrefix}plan_prices_current");
 
-        builder.Ignore(e => e.IsActive);
+        builder.Ignore(e => e.IsCurrent);
     }
 }

--- a/src/Granit.Subscriptions/Domain/Plan.cs
+++ b/src/Granit.Subscriptions/Domain/Plan.cs
@@ -132,7 +132,7 @@ public sealed class Plan : AuditedAggregateRoot, IWorkflowStateful
 
         PlanPrice? currentPrice = _prices
             .FirstOrDefault(p =>
-                p.IsActive
+                p.IsCurrent
                 && string.Equals(p.Currency, newPrice.Currency, StringComparison.OrdinalIgnoreCase)
                 && p.Interval == newPrice.Interval);
 
@@ -199,10 +199,10 @@ public sealed class Plan : AuditedAggregateRoot, IWorkflowStateful
         LifecycleStatus = WorkflowLifecycleStatus.Archived;
     }
 
-    /// <summary>Returns the current active price for the given currency and interval, or <c>null</c>.</summary>
-    public PlanPrice? GetActivePrice(string currency, BillingInterval interval) =>
+    /// <summary>Returns the current price for the given currency and interval (not replaced), or <c>null</c>.</summary>
+    public PlanPrice? GetCurrentPrice(string currency, BillingInterval interval) =>
         _prices.FirstOrDefault(p =>
-            p.IsActive
+            p.IsCurrent
             && string.Equals(p.Currency, currency, StringComparison.OrdinalIgnoreCase)
             && p.Interval == interval);
 

--- a/src/Granit.Subscriptions/Domain/PlanPrice.cs
+++ b/src/Granit.Subscriptions/Domain/PlanPrice.cs
@@ -42,8 +42,12 @@ public sealed class PlanPrice : Entity
     /// <summary>When this price was replaced by a newer version. Null if still current.</summary>
     public DateTimeOffset? ReplacedAt { get; private set; }
 
-    /// <summary>Whether this price is the current active version (not replaced).</summary>
-    public bool IsActive => ReplacedByPriceId is null;
+    /// <summary>
+    /// Whether this price is the current version in the timeline (not replaced by a newer
+    /// version). Computed from <see cref="ReplacedByPriceId"/> — there is no backing column
+    /// and no admin toggle; the state flips only when <see cref="MarkReplaced"/> runs.
+    /// </summary>
+    public bool IsCurrent => ReplacedByPriceId is null;
 
     /// <summary>Marks this price as replaced by a newer version.</summary>
     internal void MarkReplaced(Guid replacedByPriceId, DateTimeOffset replacedAt)

--- a/tests/Granit.Subscriptions.Tests/PlanTests.cs
+++ b/tests/Granit.Subscriptions.Tests/PlanTests.cs
@@ -92,7 +92,7 @@ public sealed class PlanTests
         replaced.ShouldBeNull();
         plan.Prices.Count.ShouldBe(1);
         plan.Prices[0].Amount.ShouldBe(29.99m);
-        plan.Prices[0].IsActive.ShouldBeTrue();
+        plan.Prices[0].IsCurrent.ShouldBeTrue();
     }
 
     [Fact]
@@ -106,12 +106,12 @@ public sealed class PlanTests
 
         replaced.ShouldNotBeNull();
         replaced!.Amount.ShouldBe(29.99m);
-        replaced.IsActive.ShouldBeFalse();
+        replaced.IsCurrent.ShouldBeFalse();
         replaced.ReplacedByPriceId.ShouldBe(newPrice.Id);
         replaced.ReplacedAt.ShouldBe(now);
 
         plan.Prices.Count.ShouldBe(2);
-        plan.GetActivePrice("EUR", BillingInterval.Monthly)!.Amount.ShouldBe(39.99m);
+        plan.GetCurrentPrice("EUR", BillingInterval.Monthly)!.Amount.ShouldBe(39.99m);
     }
 
     [Fact]
@@ -137,8 +137,8 @@ public sealed class PlanTests
 
         replaced.ShouldBeNull();
         plan.Prices.Count.ShouldBe(2);
-        plan.GetActivePrice("EUR", BillingInterval.Monthly)!.Amount.ShouldBe(29.99m);
-        plan.GetActivePrice("USD", BillingInterval.Monthly)!.Amount.ShouldBe(34.99m);
+        plan.GetCurrentPrice("EUR", BillingInterval.Monthly)!.Amount.ShouldBe(29.99m);
+        plan.GetCurrentPrice("USD", BillingInterval.Monthly)!.Amount.ShouldBe(34.99m);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Rename `PlanPrice.IsActive` to `IsCurrent` and the paired accessor `Plan.GetActivePrice` to `GetCurrentPrice`. The "Active" naming conflicted with the post-participle convention established in #1033 / #1034 for aggregate toggles (`Activated` on `PaymentMethodConfiguration`, `MeterDefinition`, `Tenant`, `AIWorkspace`) — a reader could reasonably expect `PlanPrice` to have an admin toggle when it does not.

`PlanPrice.IsActive` was a **computed property** deriving from `ReplacedByPriceId`:
- no backing column (EF `Ignore`)
- no admin toggle, no `Activate()` / `Deactivate()` method
- state flips only when `MarkReplaced` runs

`IsCurrent` describes the actual semantic — "this is the current version in the replacement timeline" — without suggesting a toggle.

## Changes

- `PlanPrice.IsActive` → `IsCurrent`
- `Plan.GetActivePrice(currency, interval)` → `GetCurrentPrice(currency, interval)`
- EF index name `ix_{prefix}_plan_prices_active` → `ix_{prefix}_plan_prices_current`
- `PlanPriceResponse.IsActive` → `IsCurrent` (DTO breaking)
- Call-sites in `EfPricingResolver`, `SubscriptionEndpoints`, `PlanPriceExportDefinition`, `PlanTests`

## Non-breaking on DB

No column rename — the property has always been computed and ignored by EF. Only the index name changes (additive migration regenerates the index under the new name).

## Test plan

- [x] `dotnet build Granit.slnx` — 0 errors
- [x] `dotnet test tests/Granit.Subscriptions.Tests/PlanTests.cs` — all passing for plan price versioning scenarios
- [x] `dotnet format --verify-no-changes` clean on touched projects

Note: `DefaultSubscriptionReactivationServiceTests.TryReactivateAsync_PastDueSubscription_ShouldActivateAndResetDunning` fails on `develop` as well (pre-existing bug: test mocks `GetActiveForTenantAsync` but service calls `GetPastDueForTenantAsync`). Not touched by this rename.

## SDK impact

Front-end consumers (`PlanPriceResponse` JSON) must rename the key `isActive` → `isCurrent`. Version bump minor on `@granit/subscriptions` when applicable.
