### PR TITLE
docs(blog): add observability, testcontainers, cqrs articles + Mermaid conversions

### DIFF
--- a/docs-site/src/content/docs/blog/cqrs-without-mediatr-how-granit-uses-wolverine.mdx
+++ b/docs-site/src/content/docs/blog/cqrs-without-mediatr-how-granit-uses-wolverine.mdx
@@ -1,0 +1,254 @@
+---
+title: "CQRS Without MediatR: How Granit Uses Wolverine"
+date: 2026-04-21
+authors:
+  - jfmeyers
+tags:
+  - architecture
+  - messaging
+  - best-practice
+  - deep-dive
+description: "MediatR is in-process only — no outbox, no retry, no transport. Wolverine is the CQRS bus most teams actually need. Here is how Granit uses it."
+excerpt: >
+  MediatR is in-process only — no outbox, no retry, no transport. Wolverine is
+  the CQRS bus most teams actually need. Here is how Granit uses it.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+For a decade, "CQRS in .NET" meant one thing: install MediatR, sprinkle `IRequestHandler<T>` everywhere, marvel at how clean the controllers look. It became reflex. New project, new MediatR.
+
+Then production hits. Your "send invoice email" command runs *inside* the HTTP transaction. The DB commit succeeds, the SMTP call times out, the user sees a 500. You add a retry loop. You add a try/catch. You add a `BackgroundService` that polls a `pending_email` table you wrote yourself. Six months later you've reinvented half a message bus, badly.
+
+The problem is that **MediatR is not a mediator for CQRS** — it's an in-process function dispatcher. The thing you actually need is a **message bus with a transactional outbox**. That's what `Granit.Wolverine` gives you, and this article shows exactly how.
+
+## What MediatR is, and isn't
+
+MediatR routes a `request` object to a handler in the same call stack, in the same thread, in the same transaction. That is its entire feature set. It is roughly 400 lines of code wrapped around `IServiceProvider.GetRequiredService<>`.
+
+Things MediatR does **not** do:
+
+- Persist messages to survive a process crash
+- Retry transient failures with backoff
+- Dispatch work *after* the database transaction commits
+- Schedule work for later
+- Send messages between services or even between modules
+- Provide a dead-letter queue for poison messages
+- Propagate tenant, user or trace context across async boundaries
+
+That list is exactly the list of things you need the moment a CQRS command does anything besides "write one row and return". Email, webhook, queued report, "create user → provision tenant", anything cross-module — MediatR doesn't help. You bolt on Hangfire, Quartz, a SQL polling service, a `Channel<T>`, a custom outbox table. By the time it's done, your "lightweight mediator" has five dependencies and a maintenance owner.
+
+## What you actually want
+
+Most CQRS commands need three properties together:
+
+1. **Atomic with the data.** If the row commits, the side effect must happen. If the row rolls back, the side effect must not.
+2. **Durable.** A pod kill mid-handler must not lose the message.
+3. **Async from the caller.** The HTTP request returns 202 immediately; the side effect runs after the transaction.
+
+That triple is the **transactional outbox** pattern. The side effect (`SendInvoiceEmailCommand`) is written to an `outbox` table inside the *same* `SaveChanges` as the business row. After commit, a separate worker reads the outbox and dispatches. If the worker crashes, the message is still on disk — it gets picked up next time.
+
+You can build this. You shouldn't. Wolverine ships it.
+
+## Wolverine in 30 seconds
+
+[Wolverine](https://wolverinefx.net/) is a MIT-licensed message bus and command runtime by Jeremy D. Miller (the author of StructureMap and Marten). In Granit it's wrapped in two packages:
+
+| Package                       | Role                                                  |
+| ----------------------------- | ----------------------------------------------------- |
+| `Granit.Wolverine`            | Bus, routing, context propagation, FluentValidation   |
+| `Granit.Wolverine.Postgresql` | PostgreSQL outbox + transport (no broker required)    |
+
+A single `[DependsOn(typeof(GranitWolverinePostgresqlModule))]` on your app module wires:
+
+- A **PostgreSQL outbox** that lives in your existing app database
+- **PostgreSQL as the transport itself** — no RabbitMQ, no Kafka, no broker pod to operate
+- **Convention-based handler discovery** — no `IRequestHandler<T>` interface to implement
+- **FluentValidation** as bus middleware — invalid commands skip handlers and go straight to the error queue
+- **Tenant + user + W3C trace context** propagation across async message processing
+
+```json title="appsettings.json"
+{
+  "Wolverine": {
+    "MaxRetryAttempts": 3,
+    "RetryDelays": ["00:00:05", "00:00:30", "00:05:00"]
+  },
+  "WolverinePostgresql": {
+    "TransportConnectionString": "Host=db;Database=myapp;Username=app;Password=..."
+  }
+}
+```
+
+## A handler, the Granit way
+
+Wolverine handlers don't implement an interface. They are plain classes with a `Handle` method, discovered by convention from any assembly marked `[assembly: WolverineHandlerModule]`.
+
+```csharp title="DischargePatientHandler.cs"
+public class DischargePatientHandler
+{
+    public static IEnumerable<object> Handle(
+        DischargePatientCommand command,
+        PatientDbContext db)
+    {
+        var patient = db.Patients.Find(command.PatientId)
+            ?? throw new EntityNotFoundException(typeof(Patient), command.PatientId);
+
+        patient.Discharge();
+
+        // Local — same transaction, in-process queue
+        yield return new PatientDischargedOccurred(patient.Id, patient.BedId);
+
+        // Distributed — persisted in the outbox, dispatched post-commit
+        yield return new BedReleasedEvent(
+            patient.BedId, patient.WardId, DateTimeOffset.UtcNow);
+    }
+}
+```
+
+Three things to notice:
+
+1. **No interface.** No `IRequestHandler<DischargePatientCommand, Unit>`. No `Mediator.Send(...)` plumbing.
+2. **`yield return` for fan-out.** The handler returns a sequence of follow-up messages. Wolverine writes all of them to the outbox **inside the same `SaveChanges`**. Atomic by construction.
+3. **Two message kinds, two transports.** `IDomainEvent` runs in-process on a local queue. `IIntegrationEvent` (the `*Eto`) goes through the durable outbox. Same syntax, different guarantees.
+
+<Aside type="caution" title="Handler visibility — Granit convention">
+Handlers must be `public class` (non-static) with `public static Handle` methods. Wolverine discovers types via `Assembly.ExportedTypes`; `public static class` is skipped unless decorated with `[WolverineHandler]`, and `internal` is invisible. Don't use either — see [coding standards](/contributing/coding-standards/).
+</Aside>
+
+## What happens when you call the bus
+
+Here is the full lifecycle of a single command. Every box is something Wolverine does for you — and that you'd be reimplementing with MediatR.
+
+```mermaid
+sequenceDiagram
+    participant Endpoint as HTTP endpoint
+    participant Bus as IMessageBus
+    participant Validator as FluentValidation<br/>middleware
+    participant Handler
+    participant DB as PostgreSQL<br/>(business + outbox)
+    participant Worker as Outbox dispatcher
+    participant Next as Downstream handler
+
+    Endpoint->>Bus: PublishAsync(DischargePatientCommand)
+    Bus->>Validator: AbstractValidator<T>?
+    alt invalid
+        Validator-->>Bus: ValidationException
+        Bus-->>Endpoint: 400 (no retry, no DLQ)
+    else valid
+        Validator->>Handler: Handle(cmd, dbContext)
+        Handler->>DB: UPDATE patients
+        Handler->>DB: INSERT outbox(BedReleasedEvent)
+        Handler->>DB: COMMIT (atomic)
+        Bus-->>Endpoint: 202 Accepted
+        DB->>Worker: notify
+        Worker->>Next: dispatch BedReleasedEvent
+        Next-->>Worker: ACK
+        Worker->>DB: DELETE from outbox
+    end
+```
+
+The HTTP request returns the moment the database commits. Everything past that arrow is async, durable, and retried automatically with the configured backoff (`5s → 30s → 5min`, then dead-letter). MediatR can't draw this diagram — half the boxes don't exist for it.
+
+## Domain events vs integration events
+
+Granit splits messages into two clearly named buckets, enforced by architecture tests:
+
+|             | Domain event                      | Integration event              |
+| ----------- | --------------------------------- | ------------------------------ |
+| Suffix      | `*Event` (`IDomainEvent`)         | `*Eto`  (`IIntegrationEvent`)  |
+| Scope       | In-process, same transaction      | Cross-module, durable          |
+| Transport   | Local in-memory queue             | PostgreSQL outbox → transport  |
+| Lifetime    | Lives and dies with the request   | Survives crashes, broker hops  |
+| Example     | `PatientDischargedOccurred`       | `BedReleasedEto`               |
+
+```csharp
+public sealed record PatientDischargedOccurred(
+    Guid PatientId, Guid BedId) : IDomainEvent;
+
+public sealed record BedReleasedEto(
+    Guid BedId, Guid WardId, DateTimeOffset ReleasedAt) : IIntegrationEvent;
+```
+
+The two-bucket discipline is **the** thing MediatR users miss. Without it, every `IRequest` is implicitly synchronous. With it, you make the durability cost visible at the type level. Anyone reading the code knows what survives a kill -9 and what doesn't.
+
+## The validation pipeline you don't write
+
+Wolverine runs FluentValidation as **bus middleware**, before the handler ever sees the message:
+
+```csharp title="DischargePatientCommandValidator.cs"
+public class DischargePatientCommandValidator
+    : AbstractValidator<DischargePatientCommand>
+{
+    public DischargePatientCommandValidator()
+    {
+        RuleFor(x => x.PatientId).NotEmpty();
+    }
+}
+```
+
+Invalid messages **bypass retries** and go straight to the error queue — retrying a malformed command is just burning CPU. Other exceptions follow the configured backoff. With MediatR you'd write a `ValidationBehavior<TRequest, TResponse>`, register it in the right order, and hope nobody adds a behavior that wraps it incorrectly. With Wolverine, validators are picked up by `[assembly: WolverineHandlerModule]` discovery — same convention as handlers.
+
+## Context that survives async boundaries
+
+A command published in an HTTP request runs in some background thread minutes later. The handler still needs to know *who* sent it (for `AuditedEntity.CreatedBy`), *which tenant* (for query filters), and *which trace* (for Tempo). Wolverine moves all three through the message envelope automatically.
+
+```mermaid
+sequenceDiagram
+    participant HTTP as HTTP request
+    participant Out as OutgoingMiddleware
+    participant Env as Message envelope
+    participant In as Incoming behaviors
+    participant Handler
+
+    HTTP->>Out: TenantId, UserId, traceparent
+    Out->>Env: X-Tenant-Id, X-User-Id, traceparent
+    Env-->>In: read headers
+    In->>Handler: ICurrentTenant, ICurrentUserService, Activity.Current
+```
+
+The result: `AuditedEntityInterceptor` writes the correct `CreatedBy` even from a Wolverine handler running 12 hours after the original request. Every span the handler emits joins the original trace in Grafana Tempo. None of this is in MediatR's mandate; you'd own the wiring.
+
+## Why PostgreSQL-as-transport instead of RabbitMQ
+
+The single most underrated decision in Wolverine is that **the outbox table can also be the transport**. You write a row in the outbox, the dispatcher picks it up, and that's the entire wire. No broker pod, no AMQP credentials, no extra alert rules. For most applications below 10k messages/sec, this is a permanent answer. When you outgrow it, Wolverine speaks RabbitMQ and Azure Service Bus too — same handler code, different transport binding.
+
+Compared to the usual MediatR-plus-something stack:
+
+| Concern                  | MediatR + handcraft   | MediatR + MassTransit | Granit.Wolverine     |
+| ------------------------ | --------------------- | --------------------- | -------------------- |
+| In-process mediator      | Yes                   | Yes                   | Yes                  |
+| Transactional outbox     | DIY                   | Yes (config-heavy)    | Yes (default)        |
+| Transport without broker | DIY                   | No                    | PostgreSQL native    |
+| Retry + DLQ              | DIY                   | Yes                   | Yes                  |
+| Scheduled messages       | Hangfire/Quartz       | Yes                   | Yes (Cronos)         |
+| FluentValidation pipe    | Custom behavior       | Third-party           | Built in             |
+| Tenant + user propagation| DIY                   | Possible              | Built in             |
+| Operational footprint    | App + cron + table    | App + RabbitMQ        | App + Postgres       |
+
+## When MediatR is still the right call
+
+This is not a hit piece. MediatR is excellent at exactly one thing — **synchronous in-process dispatch** — and there are codebases where that is enough:
+
+- A small monolith where every command is "validate → write → return", with no side effects
+- A library where you want internal CQRS without imposing infrastructure on consumers
+- A team that genuinely does not need durability and never will
+
+For everything else — anything that sends an email, hits a third party, fans out across modules, or must survive a redeploy — you want a real bus. `Granit.Wolverine` is what that looks like when the framework owns the boilerplate.
+
+## Takeaways
+
+- **MediatR is an in-process function dispatcher**, not a CQRS infrastructure. Most production CQRS needs an outbox, retries, scheduling and a transport — none of which MediatR provides.
+- **Wolverine is the CQRS bus most teams reinvent badly.** Outbox, transport, retries, DLQ, scheduling and validation in one MIT package.
+- **PostgreSQL is the transport.** No broker pod, no AMQP, no extra ops. Same database that holds your business data.
+- **Domain events vs integration events** is a type-level contract: `*Event` is in-process, `*Eto` is durable. Suffix discipline is enforced by architecture tests.
+- **Handlers stay plain.** No `IRequestHandler<T>`. Convention discovery via `[assembly: WolverineHandlerModule]`. Side effects via `yield return`.
+- **Tenant, user and trace context travel with the message** — your audit trail and your Grafana traces stay correct across async boundaries.
+
+## Further reading
+
+- [Wolverine — Messaging & Command Bus for .NET](/dotnet/infrastructure/wolverine-messaging/) — full module reference
+- [ADR-005 — Wolverine + Cronos](/dotnet/architecture/adr/005-wolverine-cronos/) — why Wolverine, why not MediatR/MassTransit/NServiceBus
+- [Mediator Pattern — In-Process Command Routing](/dotnet/architecture/patterns/mediator/) — the pattern as Granit applies it
+- [Command Pattern — CQRS & Wolverine Handlers](/dotnet/architecture/patterns/command/) — the handler convention in detail
+- [Observability in .NET 10](/blog/observability-dotnet-10-serilog-opentelemetry-grafana/) — how trace context flows from HTTP to Wolverine handler
+- [Don't Mock the Database](/blog/dont-mock-the-database-use-testcontainers/) — what your handler tests should actually exercise

--- a/docs-site/src/content/docs/blog/dont-mock-the-database-use-testcontainers.mdx
+++ b/docs-site/src/content/docs/blog/dont-mock-the-database-use-testcontainers.mdx
@@ -1,0 +1,217 @@
+---
+title: "Don't Mock the Database — Use Testcontainers Instead"
+date: 2026-04-19
+authors:
+  - jfmeyers
+tags:
+  - best-practice
+  - testing
+  - persistence
+description: "EF Core InMemory and SQLite lie about PostgreSQL. Use Testcontainers to run ephemeral real databases in your integration tests — zero mocks, zero surprises in prod."
+excerpt: >
+  EF Core InMemory and SQLite lie about PostgreSQL. Use Testcontainers to run
+  ephemeral real databases in your integration tests — zero mocks, zero
+  surprises in prod.
+---
+
+Your tests are green. All 4,812 of them. Coverage is 87 %. You deploy to staging. The very first query against PostgreSQL throws `42883: operator does not exist: jsonb @> text`. Two hours later you learn that `EF Core InMemory` silently accepted a query the real database rejects.
+
+The test suite lied. **It was mocking reality.**
+
+## The problem
+
+Integration tests need to exercise the full persistence stack: EF Core migrations, FK constraints, transactions, JSONB operators, partial indexes, multi-tenant global query filters, the Wolverine outbox pattern. None of that works the same — and some of it doesn't work at all — on `UseInMemoryDatabase` or SQLite.
+
+The cost of the mismatch shows up in production, not in CI.
+
+## The bad practice
+
+You probably have this somewhere in your test project:
+
+```csharp title="OrderRepositoryTests.cs — Don't do this"
+public sealed class OrderRepositoryTests
+{
+    private readonly AppDbContext _db;
+
+    public OrderRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _db = new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task FindByMetadata_MatchesJsonbFilter()
+    {
+        // This test passes locally. It will never pass against PostgreSQL.
+        var match = await _db.Orders
+            .Where(o => EF.Functions.JsonContains(o.Metadata, "{\"vip\":true}"))
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        match.ShouldHaveSingleItem();
+    }
+}
+```
+
+Everything that makes this test a lie:
+
+- **`UseInMemoryDatabase` is not a database.** It's a LINQ-to-objects evaluator. No SQL is ever generated. No migration is ever applied. Your production query plan is irrelevant here.
+- **JSONB operators are a fiction.** `JsonContains`, `@>`, `->>` — all silently no-op or throw. SQLite has the same gap.
+- **FK constraints don't fire.** Inserting an orphan row succeeds in InMemory, fails in Postgres.
+- **Transactions are a stub.** `BeginTransactionAsync` returns a fake that doesn't serialize anything.
+- **Global query filters behave differently.** The InMemory provider has known divergences with named filters, multi-tenant predicates, and soft-delete interceptors.
+
+You are testing an abstraction layer, not your database. When staging fails, the test suite has no idea why.
+
+## The good practice
+
+Spin up an **ephemeral PostgreSQL container**, apply migrations, run the test, tear it down. One `IAsyncLifetime`, one NuGet package, real SQL.
+
+```csharp title="OrdersFixture.cs"
+using Testcontainers.PostgreSql;
+
+public sealed class OrdersFixture : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder()
+        .WithImage("postgres:17-alpine")
+        .WithDatabase("orders_test")
+        .WithUsername("test")
+        .WithPassword("test")
+        .Build();
+
+    public string ConnectionString => _postgres.GetConnectionString();
+
+    public async ValueTask InitializeAsync()
+    {
+        await _postgres.StartAsync();
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseNpgsql(ConnectionString)
+            .Options;
+
+        await using var db = new AppDbContext(options);
+        await db.Database.MigrateAsync();
+    }
+
+    public ValueTask DisposeAsync() => _postgres.DisposeAsync();
+}
+```
+
+```csharp title="OrderRepositoryTests.cs — Do this"
+public sealed class OrderRepositoryTests(OrdersFixture fixture)
+    : IClassFixture<OrdersFixture>
+{
+    private AppDbContext CreateContext() =>
+        new(new DbContextOptionsBuilder<AppDbContext>()
+            .UseNpgsql(fixture.ConnectionString)
+            .Options);
+
+    [Fact]
+    public async Task FindByMetadata_MatchesJsonbFilter()
+    {
+        // Arrange
+        await using var db = CreateContext();
+        db.Orders.Add(new Order { Metadata = """{ "vip": true }""" });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        var match = await db.Orders
+            .Where(o => EF.Functions.JsonContains(o.Metadata, """{ "vip": true }"""))
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        match.ShouldHaveSingleItem();
+    }
+}
+```
+
+This test either passes against a real Postgres or tells you exactly how your production query is broken. No third option.
+
+## The fixture lifecycle
+
+`IAsyncLifetime` + `IClassFixture<T>` gives you one container per test class, shared across facts, torn down when the class is done:
+
+```mermaid
+sequenceDiagram
+    participant xUnit
+    participant Fixture as OrdersFixture
+    participant Docker
+    participant PG as PostgreSQL 17
+    participant Test as Test method
+
+    xUnit->>Fixture: InitializeAsync()
+    Fixture->>Docker: start postgres:17-alpine
+    Docker->>PG: boot
+    PG-->>Fixture: ready
+    Fixture->>PG: MigrateAsync()
+    PG-->>Fixture: schema applied
+
+    loop every [Fact] in the class
+        xUnit->>Test: run
+        Test->>PG: real SQL
+        PG-->>Test: real rows
+    end
+
+    xUnit->>Fixture: DisposeAsync()
+    Fixture->>Docker: stop + remove container
+```
+
+The 3–5 s cost lives in the first arrow. Everything after it is network-local SQL against a throwaway database that nobody else can see.
+
+## What you get back
+
+| Concern                       | InMemory / SQLite    | Testcontainers          |
+| ----------------------------- | -------------------- | ----------------------- |
+| EF Core migrations            | Skipped              | Applied end-to-end      |
+| JSONB / `@>` / `->>`          | No-op or throws      | Real PostgreSQL         |
+| FK constraints                | Ignored              | Enforced                |
+| Transactions & isolation      | Stubbed              | Real MVCC               |
+| Global query filters          | Partial divergence   | Exact production parity |
+| Wolverine outbox tables       | Not created          | Real `mt_*` schema      |
+| Per-test isolation            | Per-context          | Per-container           |
+| Startup cost                  | 0 ms                 | ~3–5 s (once per class) |
+| Docker required               | No                   | Yes (CI + dev)          |
+
+The `~3–5 s` startup is the only honest downside. You pay it once per test class via `IClassFixture<T>` (or once per collection via `ICollectionFixture<T>`), not once per test.
+
+## Why it matters
+
+Three incidents out of four that masquerade as "weird behaviour in prod" are a test that never reproduced prod. The classic shapes:
+
+1. **Broken migration.** A new column is `NOT NULL` without a default. InMemory doesn't care. The first real insert in staging fails.
+2. **Silent query downgrade.** EF Core translates your LINQ to client-side evaluation against InMemory. In Postgres it fails, or worse, changes meaning.
+3. **Isolation bug.** A global query filter or soft-delete interceptor behaves differently against the InMemory provider. Data that should be hidden leaks in tests — or data that should be visible is missing.
+
+Testcontainers kills all three categories at the PR stage.
+
+<aside>
+**On the cost.** "But 3 seconds per fixture!" — yes, and it runs in parallel across test classes. A Granit integration suite with ~40 fixtures starts ~40 containers concurrently and completes in under a minute on a laptop. CI runners have Docker-in-Docker. The cost is real but small, and the alternative is finding the bug in production.
+</aside>
+
+## Decision rule
+
+Use Testcontainers when any of these is true — and that covers most of the surface area:
+
+- The test exercises a **`DbContext`, a query, a migration or an interceptor**.
+- The test depends on **PostgreSQL-specific features** (JSONB, `gen_random_uuid`, partial indexes, `CITEXT`, transactional DDL).
+- The test validates **Wolverine** messaging, the outbox, or Postgres-based persistence.
+- The test asserts on **multi-tenant isolation** or any global query filter.
+
+Keep `FakeTimeProvider`, `NSubstitute` and regular unit tests for pure business logic — services with no `DbContext`, domain invariants, value objects. Those don't need a container.
+
+## Takeaways
+
+- **`EF Core InMemory` and SQLite do not test your database.** They test an abstraction that lies about it.
+- **Real bugs live in real SQL.** JSONB, FKs, transactions, global filters all diverge silently on in-memory providers.
+- **Testcontainers runs PostgreSQL as a first-class test dependency** — ephemeral, isolated, reproducible in CI.
+- **Amortize startup with `IClassFixture<T>`.** ~3–5 s per fixture, parallel across classes, once per run.
+- **Mocks go on the seams, not on the database.** Mock `IClock`, `ICurrentUserService`, `IVaultClient`. Never `DbContext`.
+
+## Further reading
+
+- [Testing Guide — xUnit, Shouldly, NSubstitute, Testcontainers](/contributing/testing-guide/) — full Granit test conventions
+- [ADR-007 — Testcontainers](/dotnet/architecture/adr/007-testcontainers/) — why in-memory was rejected
+- [Persistence — Isolated DbContexts & migrations](/dotnet/data/persistence/) — the stack your tests must exercise
+- [Stop Using DateTime.Now](/blog/stop-using-datetime-now/) — the other half: mock time, not the database
+- [Isolated DbContext per Module](/blog/isolated-dbcontext-per-module/) — why each module's tests need their own schema

--- a/docs-site/src/content/docs/blog/idempotency-keys-why-every-post-should-be-retry-safe.mdx
+++ b/docs-site/src/content/docs/blog/idempotency-keys-why-every-post-should-be-retry-safe.mdx
@@ -56,20 +56,33 @@ All three produce the same symptom: **duplicate side effects**. The fix is the s
 
 `Granit.Http.Idempotency` implements the full Stripe-style idempotency pattern as ASP.NET Core middleware. The state machine has three states:
 
-```text
-Request arrives
-    │
-    ├─ Key absent ──────────────> Execute normally (no idempotency)
-    │
-    └─ Key present
-         │
-         ├─ State: Absent ─────> SET NX (acquire lock) ──> Execute ──> Cache response
-         │
-         ├─ State: InProgress ─> Return 409 Conflict + Retry-After header
-         │
-         └─ State: Completed ──> Verify payload hash
-                                    ├─ Match ──> Return cached response (replay)
-                                    └─ Mismatch ─> Return 422 (key reuse with different body)
+```mermaid
+flowchart TD
+    Start([Request arrives])
+    HasKey{Idempotency-Key<br/>header present?}
+    Normal[Execute normally<br/>no idempotency]
+    State{Cached state?}
+    Absent[SET NX — acquire lock<br/>Execute handler<br/>Cache response]
+    InProgress[Return 409 Conflict<br/>+ Retry-After header]
+    Completed{Payload hash<br/>matches?}
+    Replay[Return cached response<br/>replay]
+    Mismatch[Return 422<br/>key reuse, different body]
+
+    Start --> HasKey
+    HasKey -- no --> Normal
+    HasKey -- yes --> State
+    State -- Absent --> Absent
+    State -- InProgress --> InProgress
+    State -- Completed --> Completed
+    Completed -- match --> Replay
+    Completed -- mismatch --> Mismatch
+
+    style Start fill:#e8f0ff,stroke:#1f4e8c,color:#0b1c38
+    style Normal fill:#e2f5e2,stroke:#1a7a1a,color:#0b3a0b
+    style Absent fill:#e2f5e2,stroke:#1a7a1a,color:#0b3a0b
+    style InProgress fill:#fff4e0,stroke:#a15c00,color:#3a2000
+    style Replay fill:#e2f5e2,stroke:#1a7a1a,color:#0b3a0b
+    style Mismatch fill:#fde2e2,stroke:#a31515,color:#3a0000
 ```
 
 ### Mark an endpoint as idempotent

--- a/docs-site/src/content/docs/blog/observability-dotnet-10-serilog-opentelemetry-grafana.mdx
+++ b/docs-site/src/content/docs/blog/observability-dotnet-10-serilog-opentelemetry-grafana.mdx
@@ -1,0 +1,320 @@
+---
+title: "Observability in .NET 10: Serilog + OpenTelemetry to Grafana"
+date: 2026-04-17
+authors:
+  - jfmeyers
+tags:
+  - observability
+  - best-practice
+  - architecture
+  - compliance
+description: "Wire Serilog, OpenTelemetry and the Grafana LGTM stack into a .NET 10 app in one call. Structured logs, distributed traces, metrics — all OTLP, all sovereign."
+excerpt: >
+  Wire Serilog, OpenTelemetry and the Grafana LGTM stack into a .NET 10 app in
+  one call. Structured logs, distributed traces, metrics — all OTLP, all
+  sovereign.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+You ship to production. A customer reports that "placing an order hangs sometimes". You open your log platform: ten thousand lines of unstructured text, no correlation ID, no user context, no trace. You switch to APM: the request disappears the moment it hits the message bus. You open your metrics dashboard: CPU is green, latency is green, nothing is obviously wrong.
+
+This is the cost of bolt-on observability. **Three signals, three vendors, three formats, no correlation.** And if any of those vendors stores your telemetry outside the EU, you just bought yourself a GDPR problem on top of the debugging one.
+
+This article shows how `Granit.Observability` wires **Serilog**, **OpenTelemetry** and the **Grafana LGTM stack** (Loki, Grafana, Tempo, Mimir) into a .NET 10 app with a single `AddGranitObservability()` call — OTLP-native, sovereignty-compliant, and with logs, traces and metrics correlated by the same `TraceId`.
+
+## The three signals, and why they must share an ID
+
+Modern observability rests on three pillars, standardized by the CNCF:
+
+| Signal     | Question it answers                     | Stored in     |
+| ---------- | --------------------------------------- | ------------- |
+| **Logs**   | What happened (discrete events)?        | Loki          |
+| **Traces** | Where did time go (causal chain)?       | Tempo         |
+| **Metrics**| How much, how often (aggregates)?       | Mimir         |
+
+Any one of these alone is a guessing game. Logs without traces can't tell you that the 800 ms latency came from a Wolverine handler three hops away. Traces without logs tell you *where* the slow span is but not *why*. Metrics tell you the SLO is breached but not *which* request breached it.
+
+The missing glue is a **shared correlation ID**. In OpenTelemetry, that's the `TraceId` — a 16-byte hex string propagated through the W3C `traceparent` header. If every log line, every span and every exception carries it, you can pivot from a Grafana alert → Mimir panel → Tempo waterfall → Loki log line in four clicks.
+
+That is exactly what the LGTM stack + `Granit.Observability` gives you.
+
+## Why Serilog *and* OpenTelemetry?
+
+OpenTelemetry now has a logs signal of its own. So why keep Serilog?
+
+Two reasons:
+
+1. **Enrichment ergonomics.** Serilog's fluent API, namespace-scoped level overrides, destructuring operators (`@`) and enrichers (`WithMachineName`, `WithTenantId`, `WithUserId`) are still ahead of `Microsoft.Extensions.Logging`.
+2. **OTLP sink.** `Serilog.Sinks.OpenTelemetry` ships every Serilog event to an OTLP collector as a proper log record — same wire format as traces and metrics. You get Serilog's authoring ergonomics *and* OTel's unified transport.
+
+<Aside type="note">
+This is the trade-off formalized in [ADR-001](/dotnet/architecture/adr/001-observability/). Application Insights and Datadog were rejected on **data sovereignty** grounds (US Cloud Act), and `Microsoft.Extensions.Logging + OpenTelemetry` was rejected on enrichment flexibility.
+</Aside>
+
+## The OTLP pipeline
+
+Every signal travels the same path: **application → OTLP gRPC → OpenTelemetry Collector → backend**.
+
+```mermaid
+flowchart LR
+    App["ASP.NET Core App"]
+    Serilog["Serilog<br/>(WriteTo.OpenTelemetry)"]
+    OTel["OpenTelemetry SDK<br/>(traces + metrics)"]
+    Collector["OpenTelemetry Collector<br/>OTLP :4317"]
+    Loki[("Loki<br/>logs")]
+    Tempo[("Tempo<br/>traces")]
+    Mimir[("Mimir<br/>metrics")]
+    Grafana["Grafana"]
+
+    App --> Serilog
+    App --> OTel
+    Serilog -- OTLP gRPC --> Collector
+    OTel -- OTLP gRPC --> Collector
+    Collector --> Loki
+    Collector --> Tempo
+    Collector --> Mimir
+    Loki --> Grafana
+    Tempo --> Grafana
+    Mimir --> Grafana
+
+    style App fill:#e8f0ff,stroke:#1f4e8c,color:#0b1c38
+    style Collector fill:#fff4e0,stroke:#a15c00,color:#3a2000
+    style Loki fill:#fde2e2,stroke:#a31515,color:#3a0000
+    style Tempo fill:#e2f5e2,stroke:#1a7a1a,color:#0b3a0b
+    style Mimir fill:#ece2fd,stroke:#5a2aa0,color:#1f0b3a
+    style Grafana fill:#fff1c2,stroke:#8a6b00,color:#3a2e00
+```
+
+The collector is the single chokepoint: it batches, retries, redacts, tenant-routes, and fans out. Your app only ever speaks OTLP to `localhost:4317` (or a sidecar). Swap the backend — Elasticsearch, Jaeger, self-hosted Mimir, whatever — and the app doesn't change.
+
+## Day one — one call, done
+
+`Granit.Observability` hides all the wiring behind a single extension:
+
+```csharp title="Program.cs"
+var builder = WebApplication.CreateBuilder(args);
+builder.AddGranitObservability();
+
+var app = builder.Build();
+app.Run();
+```
+
+And a single config block:
+
+```json title="appsettings.Production.json"
+{
+  "Observability": {
+    "ServiceName": "orders-api",
+    "ServiceVersion": "1.4.0",
+    "ServiceNamespace": "acme",
+    "Environment": "production",
+    "OtlpEndpoint": "http://otel-collector.monitoring:4317",
+    "EnableTracing": true,
+    "EnableMetrics": true
+  }
+}
+```
+
+That single call registers:
+
+- Serilog with a **console sink** (dev) and an **OTLP sink** (prod → Loki)
+- OpenTelemetry **tracing** with ASP.NET Core, `HttpClient` and EF Core instrumentations
+- OpenTelemetry **metrics** with ASP.NET Core and `HttpClient` instrumentations
+- Resource attributes `service.name`, `service.version`, `service.namespace`, `deployment.environment` attached to every signal
+
+Health check endpoints (`/health/*`) are filtered out so they don't flood Tempo with noise.
+
+## Automatic log enrichment — the ISO 27001 angle
+
+Every log entry emitted by a Granit app is automatically enriched with the following properties — no manual instrumentation required:
+
+| Property          | Source                  | Why it matters                                      |
+| ----------------- | ----------------------- | --------------------------------------------------- |
+| `ServiceName`     | `ObservabilityOptions`  | Routing in Loki                                     |
+| `ServiceVersion`  | `ObservabilityOptions`  | Correlate bugs with deployments                     |
+| `Environment`     | `ObservabilityOptions`  | `production` vs `staging` dashboards                |
+| `TenantId`        | `ICurrentTenant`        | Multi-tenancy isolation in queries                  |
+| `UserId`          | `ICurrentUserService`   | **Mandatory for ISO 27001 A.12.4 audit trail**      |
+| `TraceId`         | `Activity.Current`      | Pivot from log → trace                              |
+| `SpanId`          | `Activity.Current`      | Pivot from log → exact span                         |
+| `MachineName`     | Environment             | Pod name in Kubernetes                              |
+
+<Aside type="caution" title="ISO 27001 audit trail">
+`UserId` and `TenantId` enrichment is **not optional**. ISO 27001 A.12.4 requires every data-access event to be attributable to a specific user and tenant. `Granit.Observability` adds these automatically from `ICurrentUserService` and `ICurrentTenant` — remove that enrichment and you fail the audit.
+</Aside>
+
+## Distributed traces that cross async boundaries
+
+The hardest part of distributed tracing isn't the HTTP call — it's the **async boundary**. An HTTP request publishes a Wolverine message to the outbox. A worker picks it up 400 ms later. Does the worker's work appear on the original trace?
+
+With `Granit.Observability` + `Granit.Wolverine`, **yes** — automatically.
+
+**Sender side** — `OutgoingContextMiddleware` captures `Activity.Current.Id` (the W3C `traceparent`) and injects it into the envelope headers alongside `TenantId` and `UserId`.
+
+**Receiver side** — `TraceContextBehavior` reads `traceparent`, parses it with `ActivityContext.TryParse()`, and starts a `wolverine.message.handle` bridge activity with the original trace as parent.
+
+The result in Tempo:
+
+```mermaid
+gantt
+    title Single trace — HTTP → Wolverine → EF Core
+    dateFormat x
+    axisFormat %L ms
+
+    section HTTP
+    POST /api/orders               :http, 0, 64
+
+    section App
+    PublishAsync OrderPlacedEvent  :pub,  2, 4
+
+    section Wolverine
+    OrderPlacedHandler             :hdl,  14, 62
+
+    section EF Core
+    INSERT orders                  :ins,  18, 27
+    Commit transaction             :cmt,  58, 61
+```
+
+One trace, one ID, spanning HTTP + message bus + database. That is what you need to answer "where did the 800 ms go?".
+
+## Adding your own spans — the soft-dependency pattern
+
+Every Granit module that does significant I/O declares a dedicated `ActivitySource` in a `Diagnostics/` folder. Here's the recipe for your own module:
+
+```csharp title="Diagnostics/InventoryActivitySource.cs"
+internal static class InventoryActivitySource
+{
+    internal const string Name = "Acme.Inventory";
+    internal static readonly ActivitySource Source = new(Name);
+    internal const string CheckStock = "inventory.check-stock";
+}
+```
+
+Register it once during DI setup:
+
+```csharp title="InventoryModule.cs"
+public static IServiceCollection AddInventory(this IServiceCollection services)
+{
+    GranitActivitySourceRegistry.Register(InventoryActivitySource.Name);
+    return services;
+}
+```
+
+Then instrument the I/O:
+
+```csharp title="InventoryService.cs"
+public async Task<int> CheckStockAsync(Guid productId, CancellationToken ct)
+{
+    using var activity = InventoryActivitySource.Source.StartActivity(
+        InventoryActivitySource.CheckStock);
+
+    activity?.SetTag("inventory.product_id", productId.ToString());
+
+    var stock = await _db.Stock
+        .Where(s => s.ProductId == productId)
+        .Select(s => s.Quantity)
+        .FirstOrDefaultAsync(ct);
+
+    activity?.SetTag("inventory.stock_level", stock);
+    return stock;
+}
+```
+
+Two properties make this pattern **soft-dependent** on `Granit.Observability`:
+
+1. **Registry-based discovery.** `AddGranitObservability()` iterates `GranitActivitySourceRegistry` and calls `AddSource()` for each registered name — no module needs to reference the observability package.
+2. **Null-tolerant API.** If no OTel listener is attached (e.g., a unit test or an app that doesn't install `Granit.Observability`), `StartActivity()` returns `null` and every `activity?.SetTag(...)` becomes a free no-op.
+
+Modules stay observability-agnostic. The observability package lights them up at startup.
+
+## PII redaction — mandatory, enforced by architecture tests
+
+A log line saying `User john.doe@acme.com reset their password` is a GDPR Article 5 violation the moment it lands in Loki. A span tag `email=john.doe@acme.com` is worse — metric cardinality explodes and the tag value survives in Mimir for weeks.
+
+`Granit.Diagnostics.LogRedaction` gives you redaction helpers that make the safe path the easy path:
+
+```csharp title="PasswordResetService.cs"
+using Granit.Diagnostics;
+
+_logger.LogPasswordResetRequested(LogRedaction.Email(user.Email));
+activity?.SetTag("user.email_domain", LogRedaction.EmailDomain(user.Email));
+```
+
+| Helper                 | Input                    | Output                 |
+| ---------------------- | ------------------------ | ---------------------- |
+| `Email(string)`        | `john.doe@acme.com`      | `joh***@acme.com`      |
+| `EmailDomain(string)`  | `john.doe@acme.com`      | `acme.com`             |
+| `Phone(string)`        | `+33612345678`           | `+336*****78`          |
+| `Token(string)`        | `dLkj3FDmAbCdEfGh`       | `dLkj...fGh`           |
+| `IpAddress(string)`    | `192.168.1.42`           | `192.168.1.***`        |
+| `HashPrefix(string)`   | *(any)*                  | `a1b2c3d4`             |
+
+Two architecture tests back this up:
+
+- `LoggerMessagePiiConventionTests` — scans every `[LoggerMessage]` template for parameter names matching PII patterns (`email`, `phone`, `ip`, `token`…) and fails the build if the value isn't wrapped in `LogRedaction`.
+- `ActivitySourcePiiConventionTests` — same check on `*ActivitySource.cs` tag constants.
+
+The result: **you cannot merge code that leaks PII to Loki or Tempo**. It simply fails to build.
+
+## Querying the stack
+
+Once telemetry lands in the LGTM backends, Grafana is your single pane:
+
+**LogQL — all errors for one user, one tenant, in the last hour:**
+
+```text
+{service_name="orders-api", environment="production"}
+  | json
+  | Level = "Error"
+  | TenantId = "d3f9..."
+  | UserId   = "a2b7..."
+```
+
+**TraceQL — all traces slower than 1 s hitting the orders module:**
+
+```text
+{ resource.service.name = "orders-api" && duration > 1s }
+```
+
+**PromQL — p95 latency of the orders endpoint, 5-minute window:**
+
+```text
+histogram_quantile(0.95,
+  sum by (le, route) (
+    rate(http_server_request_duration_seconds_bucket{
+      service_name="orders-api", route="/api/orders"
+    }[5m])
+  )
+)
+```
+
+In Grafana, configure a **data source correlation** between Loki and Tempo on the `TraceId` field. Clicking a log line then opens the matching trace — the full HTTP → message bus → database chain — in one click.
+
+## Data sovereignty, for free
+
+This stack happens to solve a compliance problem most teams discover too late:
+
+- **All three backends run on your own infrastructure** (Kubernetes, European cloud, air-gapped datacenter — your call).
+- **No telemetry leaves the EU.** No US Cloud Act exposure. No variable SaaS bill.
+- **OTLP is a CNCF standard.** If you ever want to move off Grafana, you flip the collector's exporters and your app doesn't know.
+
+Compare that to a SaaS APM where your logs, traces and every customer interaction land on US infrastructure by default. GDPR and ISO 27001 treat that as a cross-border data transfer — you need SCCs, DPIAs, and a very patient legal team.
+
+## Takeaways
+
+- **Three signals, one ID.** Logs, traces and metrics are only useful together — the shared `TraceId` is the glue.
+- **Serilog + OpenTelemetry beats either alone.** Serilog for authoring, OTel for transport. One OTLP pipe to the Grafana LGTM stack.
+- **One call sets it all up.** `builder.AddGranitObservability()` configures sinks, instrumentations, enrichers and the activity-source registry.
+- **Async boundaries are the trap.** `Granit.Wolverine` propagates `traceparent` across the outbox so HTTP → message handler is a single trace.
+- **PII redaction is non-negotiable.** `LogRedaction` + architecture tests make it impossible to merge a leak.
+- **Self-hosted LGTM keeps you sovereign.** No Cloud Act, no vendor lock-in, no per-GB surprise bill.
+
+## Further reading
+
+- [Observability — Serilog & OpenTelemetry](/dotnet/core/observability/) — full module reference
+- [Observability — Grafana LGTM & OpenTelemetry](/dotnet/operations/observability/) — production setup, alert rules, dashboards
+- [Set Up End-to-End Tracing](/dotnet/guides/end-to-end-tracing/) — step-by-step tracing across Wolverine
+- [ADR-001 — Serilog + OpenTelemetry](/dotnet/architecture/adr/001-observability/) — why this stack was chosen
+- [Stop Using DateTime.Now](/blog/stop-using-datetime-now/) — another injectable building block
+- [LoggerMessage over string interpolation](/blog/loggermessage-over-string-interpolation/) — the logging primitive this article leans on

--- a/docs-site/src/content/docs/blog/secrets-management-with-hashicorp-vault-in-dotnet-10.mdx
+++ b/docs-site/src/content/docs/blog/secrets-management-with-hashicorp-vault-in-dotnet-10.mdx
@@ -74,16 +74,31 @@ The module is **disabled in Development** — no local Vault instance required. 
 
 `VaultCredentialLeaseManager` is a `BackgroundService` that manages the full credential lifecycle:
 
-```text
-Pod starts
-    │
-    ├─ GET database/creds/readwrite ──> Vault returns username, password, lease ID, TTL
-    │
-    ├─ At 75% of TTL ─────────────────> Renew lease (POST sys/leases/renew)
-    │                                       ├─ Success ──> Update TTL, schedule next renewal
-    │                                       └─ Failure ──> Obtain fresh credentials (step 1)
-    │
-    └─ Pod stops ──────────────────────> Revoke lease (PUT sys/leases/revoke)
+```mermaid
+sequenceDiagram
+    participant Pod as .NET pod
+    participant Mgr as VaultCredentialLeaseManager
+    participant Vault as HashiCorp Vault
+    participant DB as PostgreSQL
+
+    Pod->>Mgr: startup
+    Mgr->>Vault: GET database/creds/readwrite
+    Vault-->>Mgr: username, password, lease ID, TTL
+    Mgr->>DB: open connection with issued credentials
+
+    loop At 75% of TTL
+        Mgr->>Vault: POST sys/leases/renew
+        alt renew succeeds
+            Vault-->>Mgr: updated TTL
+        else renew fails
+            Mgr->>Vault: GET database/creds/readwrite (fresh)
+            Vault-->>Mgr: new username, password, lease
+        end
+    end
+
+    Pod->>Mgr: shutdown
+    Mgr->>Vault: PUT sys/leases/revoke
+    Vault-->>DB: drop user
 ```
 
 The service implements `IDatabaseCredentialProvider`:


### PR DESCRIPTION
## Summary

Adds three new blog articles and converts two existing posts' ASCII diagrams to Mermaid.

### New posts (published dates)

| Date | Title | Format |
| ---- | ----- | ------ |
| 2026-04-17 | Observability in .NET 10: Serilog + OpenTelemetry to Grafana | deep-dive (~1940 w) |
| 2026-04-19 | Don't Mock the Database — Use Testcontainers Instead | best-practice (~1230 w) |
| 2026-04-21 | CQRS Without MediatR: How Granit Uses Wolverine | deep-dive (~1930 w) |

### Converted to Mermaid (.md → .mdx)

- `idempotency-keys-why-every-post-should-be-retry-safe` — state machine (`flowchart TD`)
- `secrets-management-with-hashicorp-vault-in-dotnet-10` — lease renewal (`sequenceDiagram`)

### Diagrams

5 Mermaid blocks total across the three new posts, plus the 2 converted ones. Explicit dark-mode `style` directives on every colored node.

### Content accuracy

All Granit APIs, options and conventions verified against `Granit.Observability`, `Granit.Wolverine`, `Granit.Testing` docs and ADR-001/005/007. No invented types.

## Test plan

- [x] `cd docs-site && npx astro build` — 397 pages, 0 errors
- [x] `starlight-links-validator` — all internal links valid
- [x] All 5 Mermaid blocks render (astro-mermaid transforms reported)
- [ ] Review rendered posts on preview deployment
- [ ] Confirm dark-mode readability for colored Mermaid nodes
