### PR TITLE
refactor: propagate IActive.Activated rename to docs and test fixtures

### DIFF
--- a/docs-site/src/content/docs/blog/isolated-dbcontext-per-module.md
+++ b/docs-site/src/content/docs/blog/isolated-dbcontext-per-module.md
@@ -66,7 +66,7 @@ The constructor accepts `ICurrentTenant?` and `IDataFilter?` as **optional param
 The call to `modelBuilder.ApplyGranitConventions(currentTenant, dataFilter)` at the end of `OnModelCreating` is where the framework applies **global query filters** for five marker interfaces:
 
 - **`ISoftDeletable`** — filters out records where `IsDeleted == true`
-- **`IActive`** — filters out records where `IsActive == false`
+- **`IActive`** — filters out records where `Activated == false`
 - **`IProcessingRestrictable`** — filters out GDPR-restricted records
 - **`IMultiTenant`** — scopes queries to `currentTenant.Id`
 - **`IPublishable`** — filters out unpublished records

--- a/docs-site/src/content/docs/dotnet/architecture/patterns/composite.md
+++ b/docs-site/src/content/docs/dotnet/architecture/patterns/composite.md
@@ -46,7 +46,7 @@ classDiagram
     }
 
     class IActive {
-        +IsActive : bool
+        +Activated : bool
     }
 
     Entity <|-- CreationAuditedEntity
@@ -65,7 +65,7 @@ classDiagram
 | `FullAuditedEntity` | `src/Granit/Domain/FullAuditedEntity.cs` | `IsDeleted`, `DeletedAt`, `DeletedBy` (ISoftDeletable) |
 | `ISoftDeletable` | `src/Granit/Domain/ISoftDeletable.cs` | Soft delete marker |
 | `IMultiTenant` | `src/Granit/Domain/IMultiTenant.cs` | `TenantId` isolation |
-| `IActive` | `src/Granit/Domain/IActive.cs` | `IsActive` filtering |
+| `IActive` | `src/Granit/Domain/IActive.cs` | `Activated` filtering |
 
 The marker interfaces (`ISoftDeletable`, `IMultiTenant`, `IActive`) are
 composable with the inheritance hierarchy. EF Core interceptors and query

--- a/docs-site/src/content/docs/dotnet/architecture/patterns/data-filtering.md
+++ b/docs-site/src/content/docs/dotnet/architecture/patterns/data-filtering.md
@@ -15,7 +15,7 @@ by default and can be temporarily disabled via an `IDisposable` scope.
 Granit supports three filters:
 
 - `ISoftDeletable` -- `WHERE IsDeleted = false`
-- `IActive` -- `WHERE IsActive = true`
+- `IActive` -- `WHERE Activated = true`
 - `IMultiTenant` -- `WHERE TenantId = @currentTenantId`
 
 ## Diagram
@@ -25,7 +25,7 @@ flowchart TD
     Q[EF Core query] --> FB{Active filters?}
 
     FB -->|ISoftDeletable| F1["WHERE IsDeleted = false<br/>(or bypass if disabled)"]
-    FB -->|IActive| F2["WHERE IsActive = true<br/>(or bypass if disabled)"]
+    FB -->|IActive| F2["WHERE Activated = true<br/>(or bypass if disabled)"]
     FB -->|IMultiTenant| F3["WHERE TenantId = @tid<br/>(or bypass if disabled)"]
 
     F1 --> COMB["Combined expression<br/>AND"]

--- a/docs-site/src/content/docs/dotnet/architecture/patterns/expression-trees.md
+++ b/docs-site/src/content/docs/dotnet/architecture/patterns/expression-trees.md
@@ -24,7 +24,7 @@ flowchart TD
     SCAN --> CHECK{Which interfaces implemented?}
 
     CHECK -->|ISoftDeletable| E1["Expression: !e.IsDeleted<br/>or !proxy.SoftDeleteEnabled"]
-    CHECK -->|IActive| E2["Expression: e.IsActive<br/>or !proxy.ActiveEnabled"]
+    CHECK -->|IActive| E2["Expression: e.Activated<br/>or !proxy.ActiveEnabled"]
     CHECK -->|IMultiTenant| E3["Expression: e.TenantId == proxy.CurrentTenantId<br/>or !proxy.MultiTenantEnabled"]
 
     E1 --> COMBINE["Expression.AndAlso()<br/>Combine all conditions"]

--- a/docs-site/src/content/docs/dotnet/architecture/patterns/marker-interface.md
+++ b/docs-site/src/content/docs/dotnet/architecture/patterns/marker-interface.md
@@ -31,7 +31,7 @@ classDiagram
 
     class IActive {
         <<marker>>
-        +IsActive : bool
+        +Activated : bool
     }
 
     class IDomainEvent {
@@ -102,15 +102,18 @@ filter -- no additional code required.
 // The entity declares its characteristics via markers
 public sealed class MedicalRecord : FullAuditedEntity, IMultiTenant, IActive
 {
-    public Guid? TenantId { get; set; }       // <- IMultiTenant
-    public bool IsActive { get; set; } = true; // <- IActive
+    public Guid? TenantId { get; set; }          // <- IMultiTenant
+    public bool Activated { get; private set; } = true; // <- IActive
+
+    public void Activate() => Activated = true;
+    public void Deactivate() => Activated = false;
     // ISoftDeletable is inherited from FullAuditedEntity
 
     public string Diagnosis { get; set; } = string.Empty;
 }
 
 // The framework detects markers and automatically applies:
-// - Query filter: WHERE IsDeleted=false AND IsActive=true AND TenantId=@tid
+// - Query filter: WHERE IsDeleted=false AND Activated=true AND TenantId=@tid
 // - Audit interceptor: CreatedAt/By, ModifiedAt/By, TenantId
 // - Soft delete interceptor: DELETE -> UPDATE IsDeleted=true
 ```

--- a/docs-site/src/content/docs/dotnet/business/reference-data.mdx
+++ b/docs-site/src/content/docs/dotnet/business/reference-data.mdx
@@ -46,7 +46,7 @@ public abstract class ReferenceDataEntity
     // Resolved at runtime via CurrentUICulture (not mapped to DB)
     public virtual string Label { get; }
 
-    public bool IsActive { get; set; }
+    public bool Activated { get; set; }
     public int SortOrder { get; set; }
     public DateTimeOffset? ValidFrom { get; set; }
     public DateTimeOffset? ValidTo { get; set; }
@@ -277,7 +277,7 @@ key-value pairs (keys max 50 chars, values max 4 000 chars).
 Both strongly-typed and dynamic reference data types automatically generate a
 `QueryDefinition` that declares:
 
-- Base columns: `Code`, `LabelEn`, `LabelFr`, `LabelNl`, `LabelDe`, `IsActive`, `SortOrder`, `ValidFrom`, `ValidTo`
+- Base columns: `Code`, `LabelEn`, `LabelFr`, `LabelNl`, `LabelDe`, `Activated`, `SortOrder`, `ValidFrom`, `ValidTo`
 - Shadow property columns declared via `MapProperty<T>()` with `isFilterable` / `isSortable`
 - Global search on `Code`, `LabelEn`, `LabelFr`
 - Default sort by `SortOrder`, then `Code`

--- a/docs-site/src/content/docs/dotnet/concepts/persistence.mdx
+++ b/docs-site/src/content/docs/dotnet/concepts/persistence.mdx
@@ -117,7 +117,7 @@ independent and individually bypassable:
 | Interface | Filter key | SQL condition |
 |-----------|------------|---------------|
 | `ISoftDeletable` | `SoftDelete` | `WHERE IsDeleted = false` |
-| `IActive` | `Active` | `WHERE IsActive = true` |
+| `IActive` | `Active` | `WHERE Activated = true` |
 | `IMultiTenant` | `MultiTenant` | `WHERE TenantId = @currentTenantId` |
 | `IProcessingRestrictable` | `ProcessingRestrictable` | `WHERE IsProcessingRestricted = false` |
 | `IPublishable` | `Publishable` | `WHERE IsPublished = true` |

--- a/docs-site/src/content/docs/dotnet/core/module-system.mdx
+++ b/docs-site/src/content/docs/dotnet/core/module-system.mdx
@@ -308,7 +308,7 @@ clauses needed.
 |-----------|----------------|-------------------|
 | `ISoftDeletable` | Hides `IsDeleted = true` | Right to erasure (Art. 17) |
 | `IMultiTenant` | Scopes to current `TenantId` | Tenant isolation |
-| `IActive` | Hides `IsActive = false` | Data minimization |
+| `IActive` | Hides `Activated = false` | Data minimization |
 | `IPublishable` | Hides `IsPublished = false` | Draft/published lifecycle |
 | `IProcessingRestrictable` | Hides `IsProcessingRestricted = true` | Right to restriction (Art. 18) |
 

--- a/docs-site/src/content/docs/dotnet/data/entity-lifecycle-events.mdx
+++ b/docs-site/src/content/docs/dotnet/data/entity-lifecycle-events.mdx
@@ -231,7 +231,7 @@ public sealed record PatientEto(
     string FirstName,
     string LastName,
     DateOnly DateOfBirth,
-    bool IsActive);
+    bool Activated);
 
 // ❌ BAD — lazy-loaded navigation, not serializable
 public sealed record PatientEto(

--- a/docs-site/src/content/docs/dotnet/data/query-filters.mdx
+++ b/docs-site/src/content/docs/dotnet/data/query-filters.mdx
@@ -13,7 +13,7 @@ without affecting the others.
 | Interface | Filter key (`GranitFilterNames`) | Filter expression | Default |
 |-----------|----------------------------------|------------------|---------|
 | `ISoftDeletable` | `SoftDelete` | `!e.IsDeleted` | Enabled |
-| `IActive` | `Active` | `e.IsActive` | Enabled |
+| `IActive` | `Active` | `e.Activated` | Enabled |
 | `IProcessingRestrictable` | `ProcessingRestrictable` | `!e.IsProcessingRestricted` | Enabled |
 | `IMultiTenant` | `MultiTenant` | `e.TenantId == currentTenant.Id` | Enabled |
 | `IPublishable` | `Publishable` | `e.IsPublished` | Enabled |

--- a/docs-site/src/content/docs/dotnet/guides/use-reference-data.mdx
+++ b/docs-site/src/content/docs/dotnet/guides/use-reference-data.mdx
@@ -36,7 +36,7 @@ dotnet add package Granit.ReferenceData.Endpoints
 <TabItem label="Strongly-typed (subclass)">
 
 Every reference data type inherits from `ReferenceDataEntity`, which provides
-`Code`, 14 label properties, `Label` (culture-resolved), `IsActive`, `SortOrder`,
+`Code`, 14 label properties, `Label` (culture-resolved), `Activated`, `SortOrder`,
 `ValidFrom`, `ValidTo`, `ExtraPropertiesJson`, and `ParentCode`.
 
 Add domain-specific properties to the subclass:
@@ -76,7 +76,7 @@ fallback: fr-CA resolves to `LabelFr`, en-GB to `LabelEn`, pt-BR to `LabelPt`.
 
 Create a configuration class inheriting from `ReferenceDataEntityTypeConfiguration<T>`.
 The base class configures the primary key, unique index on `Code`, label columns,
-audit columns, and the `IsActive` filter.
+audit columns, and the `Activated` filter.
 
 ```csharp
 namespace MyApp.Persistence;

--- a/docs-site/src/content/docs/dotnet/infrastructure/multi-tenancy/resolvers.mdx
+++ b/docs-site/src/content/docs/dotnet/infrastructure/multi-tenancy/resolvers.mdx
@@ -66,7 +66,7 @@ The resolver returns `null` when:
 - `DomainTemplate` is not configured (disabled)
 - The host doesn't match the template pattern
 - No tenant with the extracted identifier exists
-- The matched tenant is inactive (`IsActive = false`)
+- The matched tenant is inactive (`Activated = false`)
 
 :::note
 The domain resolver requires `ITenantReader`, provided by

--- a/docs-site/src/content/docs/dotnet/saas/metering.mdx
+++ b/docs-site/src/content/docs/dotnet/saas/metering.mdx
@@ -225,7 +225,7 @@ Table prefix: `metering_` (configurable via `GranitMeteringDbProperties.DbTableP
 | `Name` | varchar(200) | Meter display name |
 | `Unit` | varchar(50) | Unit of measure |
 | `AggregationType` | int | Sum/Max/Count/Last |
-| `IsActive` | bool | Accepts new events |
+| `Activated` | bool | Accepts new events |
 | `TenantId` | GUID? | Multi-tenant isolation |
 
 ### metering_meter_events

--- a/docs-site/src/content/docs/dotnet/saas/payments/availability.mdx
+++ b/docs-site/src/content/docs/dotnet/saas/payments/availability.mdx
@@ -42,7 +42,7 @@ and a **hot checkout path**:
     paym_payment_method_configurations (DB)
     • SupportedCountries, SupportedCurrencies
     • SupportedSequenceTypes, AmountBounds
-    • IsActive
+    • Activated
                              │
                              │ GET /methods/available — hot, checkout
                              ▼

--- a/src/Granit.ReferenceData.Endpoints/Internal/ReferenceDataSchemaExampleProvider.cs
+++ b/src/Granit.ReferenceData.Endpoints/Internal/ReferenceDataSchemaExampleProvider.cs
@@ -38,7 +38,7 @@ internal sealed class ReferenceDataSchemaExampleProvider : ISchemaExampleProvide
                 ["labelIt"] = Europa,
                 ["labelPt"] = Europa,
                 ["sortOrder"] = 1,
-                ["isActive"] = true,
+                ["activated"] = true,
             },
         };
 }

--- a/tests/Granit.Auditing.EntityFrameworkCore.Tests/Internal/ChangeTrackingCaptureServiceTests.cs
+++ b/tests/Granit.Auditing.EntityFrameworkCore.Tests/Internal/ChangeTrackingCaptureServiceTests.cs
@@ -652,7 +652,7 @@ public sealed class ChangeTrackingCaptureServiceTests : IDisposable
         // Arrange
         _options.EnablePropertyTracking = true;
         ChangeTrackingCaptureService service = CreateService();
-        _dbContext.Add(new TypedEntity { Id = 1, IsActive = true });
+        _dbContext.Add(new TypedEntity { Id = 1, Activated = true });
 
         // Act
         service.Capture(_dbContext);
@@ -662,7 +662,7 @@ public sealed class ChangeTrackingCaptureServiceTests : IDisposable
         await _publisher.Received(1).PublishAsync(
             Arg.Is<AuditingBatch>(b =>
                 b.EntityChanges[0].PropertyChanges.Any(p =>
-                    p.PropertyName == "IsActive" && p.NewValue == "True")),
+                    p.PropertyName == "Activated" && p.NewValue == "True")),
             Arg.Any<CancellationToken>());
     }
 
@@ -877,7 +877,7 @@ public sealed class ChangeTrackingCaptureServiceTests : IDisposable
     {
         public int Id { get; set; }
         public Guid GuidProp { get; set; }
-        public bool IsActive { get; set; }
+        public bool Activated { get; set; }
         public int IntProp { get; set; }
     }
 

--- a/tests/Granit.DataExchange.Excel.Tests/ClosedXmlExportWriterTests.cs
+++ b/tests/Granit.DataExchange.Excel.Tests/ClosedXmlExportWriterTests.cs
@@ -471,12 +471,12 @@ public sealed class ClosedXmlExportWriterTests
         // Arrange
         List<ExportFieldDescriptor> fields =
         [
-            new("IsActive", "Boolean", null, null, 0, false),
+            new("Activated", "Boolean", null, null, 0, false),
         ];
 
         List<IReadOnlyDictionary<string, object?>> rows =
         [
-            new Dictionary<string, object?> { ["IsActive"] = value },
+            new Dictionary<string, object?> { ["Activated"] = value },
         ];
 
         using MemoryStream stream = new();

--- a/tests/Granit.DataExchange.Tests/Export/ExportPropertyFilterTests.cs
+++ b/tests/Granit.DataExchange.Tests/Export/ExportPropertyFilterTests.cs
@@ -17,7 +17,7 @@ public sealed class ExportPropertyFilterTests
         fields.ShouldContain(f => f.PropertyPath == "Name" && f.ClrTypeName == "String");
         fields.ShouldContain(f => f.PropertyPath == "Age" && f.ClrTypeName == "Int32");
         fields.ShouldContain(f => f.PropertyPath == "Id" && f.ClrTypeName == "Guid");
-        fields.ShouldContain(f => f.PropertyPath == "IsActive" && f.ClrTypeName == "Boolean");
+        fields.ShouldContain(f => f.PropertyPath == "Activated" && f.ClrTypeName == "Boolean");
         fields.ShouldContain(f => f.PropertyPath == "CreatedAt" && f.ClrTypeName == "DateTimeOffset");
         fields.ShouldContain(f => f.PropertyPath == "BirthDate" && f.ClrTypeName == "DateOnly");
         fields.ShouldContain(f => f.PropertyPath == "Amount" && f.ClrTypeName == "Decimal");
@@ -169,7 +169,7 @@ public sealed class ExportPropertyFilterTests
         public Guid Id { get; set; }
         public string Name { get; set; } = string.Empty;
         public int Age { get; set; }
-        public bool IsActive { get; set; }
+        public bool Activated { get; set; }
         public DateTimeOffset CreatedAt { get; set; }
         public DateOnly BirthDate { get; set; }
         public decimal Amount { get; set; }

--- a/tests/Granit.DataExchange.Tests/Export/ReflectionExportDefinitionTests.cs
+++ b/tests/Granit.DataExchange.Tests/Export/ReflectionExportDefinitionTests.cs
@@ -56,7 +56,7 @@ public sealed class ReflectionExportDefinitionTests
         fields.Count.ShouldBe(3);
         fields.ShouldContain(f => f.PropertyPath == "Id");
         fields.ShouldContain(f => f.PropertyPath == "Name");
-        fields.ShouldContain(f => f.PropertyPath == "IsActive");
+        fields.ShouldContain(f => f.PropertyPath == "Activated");
     }
 
     [Fact]
@@ -80,7 +80,7 @@ public sealed class ReflectionExportDefinitionTests
     {
         public Guid Id { get; set; }
         public string Name { get; set; } = string.Empty;
-        public bool IsActive { get; set; }
+        public bool Activated { get; set; }
         public List<string> Tags { get; set; } = []; // excluded (collection)
     }
 }

--- a/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/TenantEntityTypeConfigurationTests.cs
+++ b/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/TenantEntityTypeConfigurationTests.cs
@@ -75,14 +75,14 @@ public sealed class TenantEntityTypeConfigurationTests
     }
 
     [Fact]
-    public void Model_IsActive_IsRequired()
+    public void Model_Activated_IsRequired()
     {
         using MultiTenancyDbContext ctx = CreateInMemory();
         IEntityType entityType = ctx.Model.FindEntityType(typeof(Tenant))!;
 
-        IProperty isActive = entityType.FindProperty(nameof(Tenant.Activated))!;
+        IProperty activated = entityType.FindProperty(nameof(Tenant.Activated))!;
 
-        isActive.IsNullable.ShouldBeFalse();
+        activated.IsNullable.ShouldBeFalse();
     }
 
     [Fact]

--- a/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/TenantTests.cs
+++ b/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/TenantTests.cs
@@ -110,7 +110,7 @@ public sealed class TenantTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void Deactivate_SetsIsActiveFalse()
+    public void Deactivate_SetsActivatedFalse()
     {
         var tenant = Tenant.Create(Guid.NewGuid(), "Acme", "acme");
         tenant.ClearDomainEvents();
@@ -147,7 +147,7 @@ public sealed class TenantTests
     }
 
     [Fact]
-    public void Activate_AfterDeactivate_SetsIsActiveTrue()
+    public void Activate_AfterDeactivate_SetsActivatedTrue()
     {
         var tenant = Tenant.Create(Guid.NewGuid(), "Acme", "acme");
         tenant.Deactivate();

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/FilterExpressionBuilderTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/FilterExpressionBuilderTests.cs
@@ -162,13 +162,13 @@ public sealed class FilterExpressionBuilderTests
     [Fact]
     public void Eq_on_bool()
     {
-        FilterCriteria criteria = new("IsActive", FilterOperator.Eq, "true");
+        FilterCriteria criteria = new("Activated", FilterOperator.Eq, "true");
 
         Expression<Func<TestProduct, bool>>? expr = FilterExpressionBuilder.Build<TestProduct>(criteria);
 
         Func<TestProduct, bool> compiled = expr!.Compile();
-        compiled(new TestProduct { Name = "A", IsActive = true }).ShouldBeTrue();
-        compiled(new TestProduct { Name = "B", IsActive = false }).ShouldBeFalse();
+        compiled(new TestProduct { Name = "A", Activated = true }).ShouldBeTrue();
+        compiled(new TestProduct { Name = "B", Activated = false }).ShouldBeFalse();
     }
 
     [Fact]
@@ -245,7 +245,7 @@ public sealed class TestProduct
     public string Name { get; set; } = string.Empty;
     public int Price { get; set; }
     public decimal Amount { get; set; }
-    public bool IsActive { get; set; }
+    public bool Activated { get; set; }
     public ProductCategory Category { get; set; }
     public DateTimeOffset? CreatedAt { get; set; }
 }

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryEngineAdditionalTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryEngineAdditionalTests.cs
@@ -21,12 +21,12 @@ public sealed class QueryEngineAdditionalTests : IAsyncLifetime
                 .Column(p => p.Name, c => c.Label("Name").Sortable().Filterable())
                 .Column(p => p.Price, c => c.Label("Price").Sortable().Filterable())
                 .Column(p => p.Category, c => c.Label("Category").Filterable())
-                .Column(p => p.IsActive, c => c.Label("Active").Filterable().Visible(false))
+                .Column(p => p.Activated, c => c.Label("Active").Filterable().Visible(false))
                 .GlobalSearch(p => p.Name)
                 .DateFilter(p => p.CreatedAt, DatePeriod.ThisMonth)
                 .AllowGroupBy(p => p.Category)
                 .Aggregate(p => p.Price, AggregateFunction.Sum, "totalPrice")
-                .QuickFilter("Active", p => p.IsActive, isDefault: true)
+                .QuickFilter("Active", p => p.Activated, isDefault: true)
                 .SupportsCursorPagination(p => p.Id)
                 .DefaultPageSize(10)
                 .MaxPageSize(50)
@@ -42,11 +42,11 @@ public sealed class QueryEngineAdditionalTests : IAsyncLifetime
         _db = new TestDbContext(options);
 
         _db.Products.AddRange(
-            new TestProduct { Id = Guid.NewGuid(), Name = "Laptop", Price = 1000, IsActive = true, Category = ProductCategory.Electronics },
-            new TestProduct { Id = Guid.NewGuid(), Name = "Novel", Price = 15, IsActive = true, Category = ProductCategory.Books },
-            new TestProduct { Id = Guid.NewGuid(), Name = "T-Shirt", Price = 25, IsActive = false, Category = ProductCategory.Clothing },
-            new TestProduct { Id = Guid.NewGuid(), Name = "Phone", Price = 800, IsActive = true, Category = ProductCategory.Electronics },
-            new TestProduct { Id = Guid.NewGuid(), Name = "Headset", Price = 200, IsActive = true, Category = ProductCategory.Electronics });
+            new TestProduct { Id = Guid.NewGuid(), Name = "Laptop", Price = 1000, Activated = true, Category = ProductCategory.Electronics },
+            new TestProduct { Id = Guid.NewGuid(), Name = "Novel", Price = 15, Activated = true, Category = ProductCategory.Books },
+            new TestProduct { Id = Guid.NewGuid(), Name = "T-Shirt", Price = 25, Activated = false, Category = ProductCategory.Clothing },
+            new TestProduct { Id = Guid.NewGuid(), Name = "Phone", Price = 800, Activated = true, Category = ProductCategory.Electronics },
+            new TestProduct { Id = Guid.NewGuid(), Name = "Headset", Price = 200, Activated = true, Category = ProductCategory.Electronics });
 
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
     }
@@ -197,7 +197,7 @@ public sealed class QueryEngineAdditionalTests : IAsyncLifetime
 
         QueryMetadata metadata = engine.GetMetadata();
 
-        ColumnDefinition activeCol = metadata.Columns.First(c => c.Name == "IsActive");
+        ColumnDefinition activeCol = metadata.Columns.First(c => c.Name == "Activated");
         activeCol.IsVisible.ShouldBeFalse();
     }
 
@@ -261,6 +261,6 @@ public sealed class QueryEngineAdditionalTests : IAsyncLifetime
         protected override void Configure(QueryDefinitionBuilder<TestProduct> builder) =>
             builder
                 .Column(p => p.Name, c => c.Sortable())
-                .FilterGroup("Status", g => g.Preset("Active", p => p.IsActive));
+                .FilterGroup("Status", g => g.Preset("Active", p => p.Activated));
     }
 }

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryEngineProjectionTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryEngineProjectionTests.cs
@@ -47,11 +47,11 @@ public sealed class QueryEngineProjectionTests : IAsyncLifetime
         _db = new TestDbContext(options);
 
         _db.Products.AddRange(
-            new TestProduct { Id = Guid.NewGuid(), Name = "Laptop", Price = 1000, IsActive = true, Category = ProductCategory.Electronics },
-            new TestProduct { Id = Guid.NewGuid(), Name = "Novel", Price = 15, IsActive = true, Category = ProductCategory.Books },
-            new TestProduct { Id = Guid.NewGuid(), Name = "T-Shirt", Price = 25, IsActive = true, Category = ProductCategory.Clothing },
-            new TestProduct { Id = Guid.NewGuid(), Name = "Phone", Price = 800, IsActive = true, Category = ProductCategory.Electronics },
-            new TestProduct { Id = Guid.NewGuid(), Name = "Headset", Price = 200, IsActive = true, Category = ProductCategory.Electronics });
+            new TestProduct { Id = Guid.NewGuid(), Name = "Laptop", Price = 1000, Activated = true, Category = ProductCategory.Electronics },
+            new TestProduct { Id = Guid.NewGuid(), Name = "Novel", Price = 15, Activated = true, Category = ProductCategory.Books },
+            new TestProduct { Id = Guid.NewGuid(), Name = "T-Shirt", Price = 25, Activated = true, Category = ProductCategory.Clothing },
+            new TestProduct { Id = Guid.NewGuid(), Name = "Phone", Price = 800, Activated = true, Category = ProductCategory.Electronics },
+            new TestProduct { Id = Guid.NewGuid(), Name = "Headset", Price = 200, Activated = true, Category = ProductCategory.Electronics });
 
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
     }

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryEngineStreamTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryEngineStreamTests.cs
@@ -34,11 +34,11 @@ public sealed class QueryEngineStreamTests : IAsyncLifetime
         _db = new TestDbContext(options);
 
         _db.Products.AddRange(
-            new TestProduct { Id = Guid.NewGuid(), Name = "Laptop", Price = 1000, IsActive = true, Category = ProductCategory.Electronics },
-            new TestProduct { Id = Guid.NewGuid(), Name = "Novel", Price = 15, IsActive = true, Category = ProductCategory.Books },
-            new TestProduct { Id = Guid.NewGuid(), Name = "T-Shirt", Price = 25, IsActive = true, Category = ProductCategory.Clothing },
-            new TestProduct { Id = Guid.NewGuid(), Name = "Phone", Price = 800, IsActive = true, Category = ProductCategory.Electronics },
-            new TestProduct { Id = Guid.NewGuid(), Name = "Headset", Price = 200, IsActive = true, Category = ProductCategory.Electronics });
+            new TestProduct { Id = Guid.NewGuid(), Name = "Laptop", Price = 1000, Activated = true, Category = ProductCategory.Electronics },
+            new TestProduct { Id = Guid.NewGuid(), Name = "Novel", Price = 15, Activated = true, Category = ProductCategory.Books },
+            new TestProduct { Id = Guid.NewGuid(), Name = "T-Shirt", Price = 25, Activated = true, Category = ProductCategory.Clothing },
+            new TestProduct { Id = Guid.NewGuid(), Name = "Phone", Price = 800, Activated = true, Category = ProductCategory.Electronics },
+            new TestProduct { Id = Guid.NewGuid(), Name = "Headset", Price = 200, Activated = true, Category = ProductCategory.Electronics });
 
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
     }

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryEngineTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryEngineTests.cs
@@ -40,11 +40,11 @@ public sealed class QueryEngineTests : IAsyncLifetime
         _db = new TestDbContext(options);
 
         _db.Products.AddRange(
-            new TestProduct { Id = Guid.NewGuid(), Name = "Laptop", Price = 1000, IsActive = true, Category = ProductCategory.Electronics },
-            new TestProduct { Id = Guid.NewGuid(), Name = "Novel", Price = 15, IsActive = true, Category = ProductCategory.Books },
-            new TestProduct { Id = Guid.NewGuid(), Name = "T-Shirt", Price = 25, IsActive = true, Category = ProductCategory.Clothing },
-            new TestProduct { Id = Guid.NewGuid(), Name = "Phone", Price = 800, IsActive = true, Category = ProductCategory.Electronics },
-            new TestProduct { Id = Guid.NewGuid(), Name = "Headset", Price = 200, IsActive = true, Category = ProductCategory.Electronics });
+            new TestProduct { Id = Guid.NewGuid(), Name = "Laptop", Price = 1000, Activated = true, Category = ProductCategory.Electronics },
+            new TestProduct { Id = Guid.NewGuid(), Name = "Novel", Price = 15, Activated = true, Category = ProductCategory.Books },
+            new TestProduct { Id = Guid.NewGuid(), Name = "T-Shirt", Price = 25, Activated = true, Category = ProductCategory.Clothing },
+            new TestProduct { Id = Guid.NewGuid(), Name = "Phone", Price = 800, Activated = true, Category = ProductCategory.Electronics },
+            new TestProduct { Id = Guid.NewGuid(), Name = "Headset", Price = 200, Activated = true, Category = ProductCategory.Electronics });
 
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
     }
@@ -217,7 +217,7 @@ public sealed class QueryEngineTests : IAsyncLifetime
             new QueryRequest(),
             TestContext.Current.CancellationToken);
 
-        result.Items.ShouldAllBe(p => p.IsActive);
+        result.Items.ShouldAllBe(p => p.Activated);
         result.TotalCount.ShouldBe(5); // All test products are active
     }
 
@@ -233,7 +233,7 @@ public sealed class QueryEngineTests : IAsyncLifetime
             new QueryRequest { QuickFilters = ["Expensive", "Active"] },
             TestContext.Current.CancellationToken);
 
-        result.Items.ShouldAllBe(p => p.Price >= 500 && p.IsActive);
+        result.Items.ShouldAllBe(p => p.Price >= 500 && p.Activated);
     }
 
     [Fact]
@@ -280,7 +280,7 @@ public sealed class QueryEngineTests : IAsyncLifetime
             builder
                 .Column(p => p.Name, c => c.Label("Name").Sortable().Filterable())
                 .Column(p => p.Price, c => c.Label("Price").Sortable().Filterable())
-                .QuickFilter("Active", "Actifs uniquement", p => p.IsActive, isDefault: true)
+                .QuickFilter("Active", "Actifs uniquement", p => p.Activated, isDefault: true)
                 .QuickFilter("Expensive", p => p.Price >= 500)
                 .DefaultPageSize(10)
                 .MaxPageSize(50);

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryableFilterAdditionalTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryableFilterAdditionalTests.cs
@@ -25,13 +25,13 @@ public sealed class ApplyQuickFiltersTests
     public void ApplyQuickFilters_applies_default_when_none_specified()
     {
         QueryDefinitionBuilder<TestProduct> builder = new();
-        builder.QuickFilter("Active", p => p.IsActive, isDefault: true);
+        builder.QuickFilter("Active", p => p.Activated, isDefault: true);
         builder.QuickFilter("Expensive", p => p.Price >= 500);
 
         List<TestProduct> source =
         [
-            new() { Name = "A", IsActive = true, Price = 100 },
-            new() { Name = "B", IsActive = false, Price = 100 },
+            new() { Name = "A", Activated = true, Price = 100 },
+            new() { Name = "B", Activated = false, Price = 100 },
         ];
 
         var result = source.AsQueryable()
@@ -46,12 +46,12 @@ public sealed class ApplyQuickFiltersTests
     public void ApplyQuickFilters_applies_empty_list_uses_defaults()
     {
         QueryDefinitionBuilder<TestProduct> builder = new();
-        builder.QuickFilter("Active", p => p.IsActive, isDefault: true);
+        builder.QuickFilter("Active", p => p.Activated, isDefault: true);
 
         List<TestProduct> source =
         [
-            new() { Name = "A", IsActive = true },
-            new() { Name = "B", IsActive = false },
+            new() { Name = "A", Activated = true },
+            new() { Name = "B", Activated = false },
         ];
 
         var result = source.AsQueryable()
@@ -66,13 +66,13 @@ public sealed class ApplyQuickFiltersTests
     public void ApplyQuickFilters_applies_explicit_filter()
     {
         QueryDefinitionBuilder<TestProduct> builder = new();
-        builder.QuickFilter("Active", p => p.IsActive, isDefault: true);
+        builder.QuickFilter("Active", p => p.Activated, isDefault: true);
         builder.QuickFilter("Expensive", p => p.Price >= 500);
 
         List<TestProduct> source =
         [
-            new() { Name = "A", IsActive = true, Price = 100 },
-            new() { Name = "B", IsActive = true, Price = 600 },
+            new() { Name = "A", Activated = true, Price = 100 },
+            new() { Name = "B", Activated = true, Price = 600 },
         ];
 
         var result = source.AsQueryable()
@@ -87,14 +87,14 @@ public sealed class ApplyQuickFiltersTests
     public void ApplyQuickFilters_AND_semantics_for_multiple()
     {
         QueryDefinitionBuilder<TestProduct> builder = new();
-        builder.QuickFilter("Active", p => p.IsActive);
+        builder.QuickFilter("Active", p => p.Activated);
         builder.QuickFilter("Expensive", p => p.Price >= 500);
 
         List<TestProduct> source =
         [
-            new() { Name = "A", IsActive = true, Price = 100 },
-            new() { Name = "B", IsActive = true, Price = 600 },
-            new() { Name = "C", IsActive = false, Price = 600 },
+            new() { Name = "A", Activated = true, Price = 100 },
+            new() { Name = "B", Activated = true, Price = 600 },
+            new() { Name = "C", Activated = false, Price = 600 },
         ];
 
         var result = source.AsQueryable()
@@ -109,12 +109,12 @@ public sealed class ApplyQuickFiltersTests
     public void ApplyQuickFilters_case_insensitive_name_matching()
     {
         QueryDefinitionBuilder<TestProduct> builder = new();
-        builder.QuickFilter("Active", p => p.IsActive);
+        builder.QuickFilter("Active", p => p.Activated);
 
         List<TestProduct> source =
         [
-            new() { Name = "A", IsActive = true },
-            new() { Name = "B", IsActive = false },
+            new() { Name = "A", Activated = true },
+            new() { Name = "B", Activated = false },
         ];
 
         var result = source.AsQueryable()
@@ -128,12 +128,12 @@ public sealed class ApplyQuickFiltersTests
     public void ApplyQuickFilters_unknown_filter_name_is_ignored()
     {
         QueryDefinitionBuilder<TestProduct> builder = new();
-        builder.QuickFilter("Active", p => p.IsActive);
+        builder.QuickFilter("Active", p => p.Activated);
 
         List<TestProduct> source =
         [
-            new() { Name = "A", IsActive = true },
-            new() { Name = "B", IsActive = false },
+            new() { Name = "A", Activated = true },
+            new() { Name = "B", Activated = false },
         ];
 
         var result = source.AsQueryable()
@@ -152,13 +152,13 @@ public sealed class ApplyPresetsAdditionalTests
     {
         QueryDefinitionBuilder<TestProduct> builder = new();
         builder.FilterGroup("Status", g => g
-            .Preset("Active", p => p.IsActive, isDefault: true)
-            .Preset("Inactive", p => !p.IsActive));
+            .Preset("Active", p => p.Activated, isDefault: true)
+            .Preset("Inactive", p => !p.Activated));
 
         List<TestProduct> source =
         [
-            new() { Name = "A", IsActive = true },
-            new() { Name = "B", IsActive = false },
+            new() { Name = "A", Activated = true },
+            new() { Name = "B", Activated = false },
         ];
 
         var result = source.AsQueryable()
@@ -176,13 +176,13 @@ public sealed class ApplyPresetsAdditionalTests
     {
         QueryDefinitionBuilder<TestProduct> builder = new();
         builder.FilterGroup("Status", g => g
-            .Preset("Active", p => p.IsActive)
-            .Preset("Inactive", p => !p.IsActive));
+            .Preset("Active", p => p.Activated)
+            .Preset("Inactive", p => !p.Activated));
 
         List<TestProduct> source =
         [
-            new() { Name = "A", IsActive = true },
-            new() { Name = "B", IsActive = false },
+            new() { Name = "A", Activated = true },
+            new() { Name = "B", Activated = false },
         ];
 
         // No defaults set, no explicit presets
@@ -198,9 +198,9 @@ public sealed class ApplyPresetsAdditionalTests
     {
         QueryDefinitionBuilder<TestProduct> builder = new();
         builder.FilterGroup("Status", g => g
-            .Preset("Active", p => p.IsActive));
+            .Preset("Active", p => p.Activated));
 
-        List<TestProduct> source = [new() { Name = "A", IsActive = true }];
+        List<TestProduct> source = [new() { Name = "A", Activated = true }];
 
         Dictionary<string, string> presets = new() { ["NonExistentGroup"] = "Active" };
 
@@ -216,12 +216,12 @@ public sealed class ApplyPresetsAdditionalTests
     {
         QueryDefinitionBuilder<TestProduct> builder = new();
         builder.FilterGroup("Status", g => g
-            .Preset("Active", p => p.IsActive));
+            .Preset("Active", p => p.Activated));
 
         List<TestProduct> source =
         [
-            new() { Name = "A", IsActive = true },
-            new() { Name = "B", IsActive = false },
+            new() { Name = "A", Activated = true },
+            new() { Name = "B", Activated = false },
         ];
 
         Dictionary<string, string> presets = new() { ["Status"] = "NonExistent" };

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryableGroupByExtensionsTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryableGroupByExtensionsTests.cs
@@ -18,9 +18,9 @@ public sealed class QueryableGroupByExtensionsTests : IAsyncLifetime
             builder
                 .Column(p => p.Name, c => c.Label("Name"))
                 .Column(p => p.Category, c => c.Label("Category"))
-                .Column(p => p.IsActive, c => c.Label("Active"))
+                .Column(p => p.Activated, c => c.Label("Active"))
                 .AllowGroupBy(p => p.Category)
-                .AllowGroupBy(p => p.IsActive);
+                .AllowGroupBy(p => p.Activated);
     }
 
     public async ValueTask InitializeAsync()
@@ -32,11 +32,11 @@ public sealed class QueryableGroupByExtensionsTests : IAsyncLifetime
         _db = new TestDbContext(options);
 
         _db.Products.AddRange(
-            new TestProduct { Id = Guid.NewGuid(), Name = "Laptop", Price = 1000, IsActive = true, Category = ProductCategory.Electronics },
-            new TestProduct { Id = Guid.NewGuid(), Name = "Phone", Price = 800, IsActive = true, Category = ProductCategory.Electronics },
-            new TestProduct { Id = Guid.NewGuid(), Name = "Headset", Price = 200, IsActive = false, Category = ProductCategory.Electronics },
-            new TestProduct { Id = Guid.NewGuid(), Name = "Novel", Price = 15, IsActive = true, Category = ProductCategory.Books },
-            new TestProduct { Id = Guid.NewGuid(), Name = "T-Shirt", Price = 25, IsActive = true, Category = ProductCategory.Clothing });
+            new TestProduct { Id = Guid.NewGuid(), Name = "Laptop", Price = 1000, Activated = true, Category = ProductCategory.Electronics },
+            new TestProduct { Id = Guid.NewGuid(), Name = "Phone", Price = 800, Activated = true, Category = ProductCategory.Electronics },
+            new TestProduct { Id = Guid.NewGuid(), Name = "Headset", Price = 200, Activated = false, Category = ProductCategory.Electronics },
+            new TestProduct { Id = Guid.NewGuid(), Name = "Novel", Price = 15, Activated = true, Category = ProductCategory.Books },
+            new TestProduct { Id = Guid.NewGuid(), Name = "T-Shirt", Price = 25, Activated = true, Category = ProductCategory.Clothing });
 
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
     }
@@ -72,7 +72,7 @@ public sealed class QueryableGroupByExtensionsTests : IAsyncLifetime
 
         GroupedResult<TestProduct> result = await engine.ExecuteGroupedAsync(
             _db.Products.AsQueryable(),
-            new QueryRequest { GroupBy = "IsActive" },
+            new QueryRequest { GroupBy = "Activated" },
             TestContext.Current.CancellationToken);
 
         result.Groups.Count.ShouldBe(2);

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryablePaginationExtensionsTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryablePaginationExtensionsTests.cs
@@ -18,11 +18,11 @@ public sealed class QueryablePaginationExtensionsTests : IAsyncLifetime
         _db = new TestDbContext(options);
 
         _db.Products.AddRange(
-            new TestProduct { Id = Guid.NewGuid(), Name = "A", Price = 10, IsActive = true, Category = ProductCategory.Electronics },
-            new TestProduct { Id = Guid.NewGuid(), Name = "B", Price = 20, IsActive = true, Category = ProductCategory.Books },
-            new TestProduct { Id = Guid.NewGuid(), Name = "C", Price = 30, IsActive = true, Category = ProductCategory.Clothing },
-            new TestProduct { Id = Guid.NewGuid(), Name = "D", Price = 40, IsActive = true, Category = ProductCategory.Electronics },
-            new TestProduct { Id = Guid.NewGuid(), Name = "E", Price = 50, IsActive = true, Category = ProductCategory.Electronics });
+            new TestProduct { Id = Guid.NewGuid(), Name = "A", Price = 10, Activated = true, Category = ProductCategory.Electronics },
+            new TestProduct { Id = Guid.NewGuid(), Name = "B", Price = 20, Activated = true, Category = ProductCategory.Books },
+            new TestProduct { Id = Guid.NewGuid(), Name = "C", Price = 30, Activated = true, Category = ProductCategory.Clothing },
+            new TestProduct { Id = Guid.NewGuid(), Name = "D", Price = 40, Activated = true, Category = ProductCategory.Electronics },
+            new TestProduct { Id = Guid.NewGuid(), Name = "E", Price = 50, Activated = true, Category = ProductCategory.Electronics });
 
         await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
     }

--- a/tests/Granit.ReferenceData.Endpoints.Tests/ReferenceDataSchemaExampleProviderTests.cs
+++ b/tests/Granit.ReferenceData.Endpoints.Tests/ReferenceDataSchemaExampleProviderTests.cs
@@ -58,12 +58,12 @@ public sealed class ReferenceDataSchemaExampleProviderTests
     }
 
     [Fact]
-    public void GetExamples_UpdateRequest_HasIsActiveProperty()
+    public void GetExamples_UpdateRequest_HasActivatedProperty()
     {
         IReadOnlyDictionary<Type, JsonNode> examples = _provider.GetExamples();
         JsonNode updateExample = examples[typeof(ReferenceDataUpdateRequest)];
 
-        updateExample["isActive"]!.GetValue<bool>().ShouldBeTrue();
+        updateExample["activated"]!.GetValue<bool>().ShouldBeTrue();
     }
 
     [Fact]

--- a/tests/Granit.ReferenceData.Endpoints.Tests/ReferenceDataUpdateRequestTests.cs
+++ b/tests/Granit.ReferenceData.Endpoints.Tests/ReferenceDataUpdateRequestTests.cs
@@ -43,7 +43,7 @@ public sealed class ReferenceDataUpdateRequestTests
     }
 
     [Fact]
-    public void Default_IsActive_Is_True()
+    public void Default_Activated_Is_True()
     {
         ReferenceDataUpdateRequest request = new("Belgium");
 

--- a/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEntityTypeConfigurationTests.cs
+++ b/tests/Granit.ReferenceData.EntityFrameworkCore.Tests/ReferenceDataEntityTypeConfigurationTests.cs
@@ -104,13 +104,13 @@ public sealed class ReferenceDataEntityTypeConfigurationTests
     }
 
     [Fact]
-    public void IsActive_Has_Index()
+    public void Activated_Has_Index()
     {
         IEntityType entityType = GetEntityType();
-        IProperty isActive = entityType.FindProperty(nameof(TestEntity.Activated))!;
+        IProperty activated = entityType.FindProperty(nameof(TestEntity.Activated))!;
 
         IIndex? index = entityType.GetIndexes()
-            .FirstOrDefault(i => i.Properties.Count == 1 && i.Properties[0] == isActive);
+            .FirstOrDefault(i => i.Properties.Count == 1 && i.Properties[0] == activated);
 
         index.ShouldNotBeNull();
     }

--- a/tests/Granit.ReferenceData.Tests/ReferenceDataEntityTests.cs
+++ b/tests/Granit.ReferenceData.Tests/ReferenceDataEntityTests.cs
@@ -28,7 +28,7 @@ public sealed class ReferenceDataEntityTests
     }
 
     [Fact]
-    public void Default_IsActive_Is_True()
+    public void Default_Activated_Is_True()
     {
         TestEntity entity = new();
 

--- a/tests/Granit.Templating.Endpoints.Tests/TemplatingEndpointsTests.cs
+++ b/tests/Granit.Templating.Endpoints.Tests/TemplatingEndpointsTests.cs
@@ -1572,7 +1572,7 @@ public sealed class TemplatingEndpointsTests : IAsyncDisposable
     {
         public string ContextName => "test";
 
-        public object Resolve() => new { FirstName = "John", Age = 42, IsActive = true };
+        public object Resolve() => new { FirstName = "John", Age = 42, Activated = true };
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

Follow-up cleanup to #1033 (IActive rename) and #1034 (entity adoption). Propagates the `IsActive` → `Activated` rename to documentation and test fixtures that were not covered by those PRs, and fixes one latent bug discovered along the way.

## Changes

### Documentation (14 pages)
SQL conditions, Mermaid diagrams, column lists, code examples:
- `concepts/persistence.mdx`, `architecture/patterns/{marker-interface,data-filtering,expression-trees,composite}.md`
- `data/{query-filters,entity-lifecycle-events}.mdx`, `core/module-system.mdx`
- `business/reference-data.mdx`, `guides/use-reference-data.mdx`
- `infrastructure/multi-tenancy/resolvers.mdx`, `saas/metering.mdx`, `saas/payments/availability.mdx`
- `blog/isolated-dbcontext-per-module.md`

### Bug fix
- **`ReferenceDataSchemaExampleProvider`**: OpenAPI example emitted JSON key `"isActive"` but the DTO `ReferenceDataUpdateRequest.Activated` serializes as camelCase `"activated"`. Example payloads would not round-trip through the API.

### Test fixtures
- Renamed `IsActive` property on local test helpers: `TestProduct` (8 files), `TestEntity`, `TypedEntity`, `SimpleEntity`
- Aligned test method names: `Default_IsActive_Is_True` → `Default_Activated_Is_True`, `IsActive_Has_Index` → `Activated_Has_Index`, `Deactivate_SetsIsActiveFalse` → `Deactivate_SetsActivatedFalse`, etc.

### Scope notes
- **Not renamed**: `IGlobalPrivacyControlSignal.IsActive(HttpContext)` (predicate method, natural English `is active`), `AuditedEntityInterceptorTests.SaveChangesAsync_MultiTenant_OnAdd_SetsTenantId_WhenTenantIsActive` (test scenario prose).

## Test plan

- [x] `dotnet build` passes for all touched projects
- [x] `dotnet test tests/Granit.QueryEngine.EntityFrameworkCore.Tests` — 184 passed
- [x] `dotnet test tests/Granit.ReferenceData.Endpoints.Tests` — 124 passed
- [x] `dotnet format --verify-no-changes` clean on `Granit.ReferenceData.Endpoints`
- [ ] Full CI run