### PR TITLE
feat(identity): add SupportsGroupManagement capability flag

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -16456,7 +16456,7 @@
       "kind": "record",
       "project": "Granit.Identity.Endpoints",
       "file": "src/Granit.Identity.Endpoints/Dtos/IdentityProviderCapabilitiesResponse.cs",
-      "line": 14,
+      "line": 15,
       "members": []
     },
     {

--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@
   <a href="https://sonarcloud.io/summary/new_code?id=granit-fx_granit-dotnet"><img src="https://sonarcloud.io/api/project_badges/measure?project=granit-fx_granit-dotnet&metric=alert_status" alt="Quality Gate Status"></a>
   <a href="https://sonarcloud.io/summary/new_code?id=granit-fx_granit-dotnet"><img src="https://sonarcloud.io/api/project_badges/measure?project=granit-fx_granit-dotnet&metric=coverage" alt="Coverage"></a>
   <a href="https://github.com/granit-fx/granit-dotnet/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="License"></a>
+  <a href="https://www.bestpractices.dev/projects/12585"><img src="https://www.bestpractices.dev/projects/12585/badge" alt="OpenSSF Best Practices"></a>
 </p>
 
 ---
 
 Granit is a rock-solid, production-ready modular framework for .NET and React.
 Built as a Modular Monolith with zero compromises on Developer Experience.
-It provides **217 NuGet packages** organized as independent modules,
+It provides **273 NuGet packages** organized as independent modules,
 compliant with **GDPR/ISO 27001** requirements.
 
 **📖 Full documentation: [granit-fx.dev](https://granit-fx.dev)**
@@ -71,7 +72,7 @@ dotnet add package Granit
 
 # Add the modules you need
 dotnet add package Granit.Persistence
-dotnet add package Granit.Users
+dotnet add package Granit.Identity
 dotnet add package Granit.Observability
 ```
 
@@ -89,7 +90,7 @@ app.Run();
 // MyAppModule.cs
 [DependsOn(
     typeof(GranitPersistenceModule),
-    typeof(),
+    typeof(GranitIdentityModule),
     typeof(GranitObservabilityModule))]
 public sealed class MyAppModule : GranitModule
 {

--- a/src/Granit.Identity.Endpoints/Dtos/IdentityProviderCapabilitiesResponse.cs
+++ b/src/Granit.Identity.Endpoints/Dtos/IdentityProviderCapabilitiesResponse.cs
@@ -11,6 +11,7 @@ namespace Granit.Identity.Endpoints.Dtos;
 /// <param name="MaxCustomAttributes">Maximum number of custom attributes (0 if not supported).</param>
 /// <param name="SupportsCredentialVerification">Whether the provider supports credential verification.</param>
 /// <param name="SupportsUserCreation">Whether the provider supports user creation.</param>
+/// <param name="SupportsGroupManagement">Whether tenant admins can create, update, and delete groups via the API.</param>
 public sealed record IdentityProviderCapabilitiesResponse(
     string ProviderName,
     bool SupportsIndividualSessionTermination,
@@ -19,4 +20,5 @@ public sealed record IdentityProviderCapabilitiesResponse(
     bool SupportsCustomAttributes,
     int MaxCustomAttributes,
     bool SupportsCredentialVerification,
-    bool SupportsUserCreation);
+    bool SupportsUserCreation,
+    bool SupportsGroupManagement);

--- a/src/Granit.Identity.Endpoints/Endpoints/IdentityCapabilitiesEndpoints.cs
+++ b/src/Granit.Identity.Endpoints/Endpoints/IdentityCapabilitiesEndpoints.cs
@@ -33,5 +33,6 @@ internal static class IdentityCapabilitiesEndpoints
             capabilities.SupportsCustomAttributes,
             capabilities.MaxCustomAttributes,
             capabilities.SupportsCredentialVerification,
-            capabilities.SupportsUserCreation));
+            capabilities.SupportsUserCreation,
+            capabilities.SupportsGroupManagement));
 }

--- a/src/Granit.Identity.Federated.Cognito/Internal/CognitoIdentityProviderCapabilities.cs
+++ b/src/Granit.Identity.Federated.Cognito/Internal/CognitoIdentityProviderCapabilities.cs
@@ -36,5 +36,14 @@ internal sealed class CognitoIdentityProviderCapabilities : IIdentityProviderCap
     public bool SupportsUserCreation => true;
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// Cognito supports group CRUD via the AWS SDK, but groups are pool-scoped (not
+    /// tenant-scoped) — CRUD cannot be safely exposed in a shared-pool multi-tenant
+    /// deployment. Reported as <see langword="false"/> pending the dedicated work item
+    /// (see <c>docs/framework/identity/group-management.md</c>).
+    /// </remarks>
+    public bool SupportsGroupManagement => false;
+
+    /// <inheritdoc/>
     public bool IsLocalStore => false;
 }

--- a/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProviderCapabilities.cs
+++ b/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProviderCapabilities.cs
@@ -44,5 +44,14 @@ internal sealed class EntraIdIdentityProviderCapabilities : IIdentityProviderCap
     public bool SupportsUserCreation => true;
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// EntraID supports group CRUD via Microsoft Graph, but tenant-admin-facing endpoints
+    /// are not yet exposed in Granit. In a shared-directory deployment, group CRUD cannot
+    /// be safely isolated per SaaS tenant. Reported as <see langword="false"/> pending the
+    /// dedicated work item (see <c>docs/framework/identity/group-management.md</c>).
+    /// </remarks>
+    public bool SupportsGroupManagement => false;
+
+    /// <inheritdoc/>
     public bool IsLocalStore => false;
 }

--- a/src/Granit.Identity.Federated.GoogleCloud/Internal/GoogleCloudIdentityProviderCapabilities.cs
+++ b/src/Granit.Identity.Federated.GoogleCloud/Internal/GoogleCloudIdentityProviderCapabilities.cs
@@ -30,5 +30,9 @@ internal sealed class GoogleCloudIdentityProviderCapabilities : IIdentityProvide
     public bool SupportsUserCreation => true;
 
     /// <inheritdoc />
+    /// <remarks>Firebase Auth has no group concept — group management is never supported.</remarks>
+    public bool SupportsGroupManagement => false;
+
+    /// <inheritdoc />
     public bool IsLocalStore => false;
 }

--- a/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProviderCapabilities.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProviderCapabilities.cs
@@ -30,5 +30,13 @@ internal sealed class KeycloakIdentityProviderCapabilities : IIdentityProviderCa
     public bool SupportsUserCreation => true;
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// Keycloak natively supports group CRUD via the Admin REST API, but Granit does not yet
+    /// expose tenant-admin-facing endpoints. Reported as <see langword="false"/> until the
+    /// feature ships (see <c>docs/framework/identity/group-management.md</c>).
+    /// </remarks>
+    public bool SupportsGroupManagement => false;
+
+    /// <inheritdoc/>
     public bool IsLocalStore => false;
 }

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetIdentityProviderCapabilities.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/AspNetIdentityProviderCapabilities.cs
@@ -32,5 +32,13 @@ internal sealed class AspNetIdentityProviderCapabilities : IIdentityProviderCapa
     public bool SupportsUserCreation => true;
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// The local store supports group CRUD natively (via <c>OpenIddictGroupStore</c>), but
+    /// tenant-admin-facing endpoints are not yet exposed. Reported as <see langword="false"/>
+    /// pending the dedicated work item (see <c>docs/framework/identity/group-management.md</c>).
+    /// </remarks>
+    public bool SupportsGroupManagement => false;
+
+    /// <inheritdoc/>
     public bool IsLocalStore => true;
 }

--- a/src/Granit.Identity/IIdentityProviderCapabilities.cs
+++ b/src/Granit.Identity/IIdentityProviderCapabilities.cs
@@ -35,6 +35,18 @@ public interface IIdentityProviderCapabilities
     bool SupportsUserCreation { get; }
 
     /// <summary>
+    /// Whether tenant admins can create, update, and delete groups via the API.
+    /// </summary>
+    /// <remarks>
+    /// Currently <see langword="false"/> for every provider — group lifecycle management
+    /// is handled by the identity provider's admin console (Keycloak, EntraID, Cognito) or
+    /// is unsupported (Firebase). The capability is exposed so the frontend can hide the
+    /// "manage groups" menu while the feature is scoped. See
+    /// <c>docs/framework/identity/group-management.md</c> for the roadmap.
+    /// </remarks>
+    bool SupportsGroupManagement { get; }
+
+    /// <summary>
     /// Whether users are stored locally in the application database.
     /// </summary>
     /// <remarks>

--- a/src/Granit.Identity/Internal/NullIdentityProviderCapabilities.cs
+++ b/src/Granit.Identity/Internal/NullIdentityProviderCapabilities.cs
@@ -31,5 +31,8 @@ internal sealed class NullIdentityProviderCapabilities : IIdentityProviderCapabi
     public bool SupportsUserCreation => false;
 
     /// <inheritdoc/>
+    public bool SupportsGroupManagement => false;
+
+    /// <inheritdoc/>
     public bool IsLocalStore => false;
 }

--- a/tests/Granit.Identity.Endpoints.Tests/Dtos/IdentityDtoTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/Dtos/IdentityDtoTests.cs
@@ -88,7 +88,8 @@ public sealed class IdentityDtoTests
             SupportsCustomAttributes: true,
             MaxCustomAttributes: 100,
             SupportsCredentialVerification: true,
-            SupportsUserCreation: true);
+            SupportsUserCreation: true,
+            SupportsGroupManagement: false);
 
         response.ProviderName.ShouldBe("Keycloak");
         response.SupportsIndividualSessionTermination.ShouldBeTrue();
@@ -98,6 +99,7 @@ public sealed class IdentityDtoTests
         response.MaxCustomAttributes.ShouldBe(100);
         response.SupportsCredentialVerification.ShouldBeTrue();
         response.SupportsUserCreation.ShouldBeTrue();
+        response.SupportsGroupManagement.ShouldBeFalse();
     }
 
     // ──── IdentityPasswordChangedAtResponse ────

--- a/tests/Granit.Identity.Federated.Cognito.Tests/CognitoIdentityProviderCapabilitiesTests.cs
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/CognitoIdentityProviderCapabilitiesTests.cs
@@ -41,6 +41,10 @@ public sealed class CognitoIdentityProviderCapabilitiesTests
         _capabilities.SupportsUserCreation.ShouldBeTrue();
 
     [Fact]
+    public void SupportsGroupManagement_ReturnsFalse() =>
+        _capabilities.SupportsGroupManagement.ShouldBeFalse();
+
+    [Fact]
     public void Implements_IIdentityProviderCapabilities() =>
         _capabilities.ShouldBeAssignableTo<IIdentityProviderCapabilities>();
 }

--- a/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdIdentityProviderCapabilitiesTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdIdentityProviderCapabilitiesTests.cs
@@ -44,6 +44,10 @@ public sealed class EntraIdIdentityProviderCapabilitiesTests
         _capabilities.SupportsUserCreation.ShouldBeTrue();
 
     [Fact]
+    public void SupportsGroupManagement_ReturnsFalse() =>
+        _capabilities.SupportsGroupManagement.ShouldBeFalse();
+
+    [Fact]
     public void ImplementsIIdentityProviderCapabilities() =>
         _capabilities.ShouldBeAssignableTo<IIdentityProviderCapabilities>();
 

--- a/tests/Granit.Identity.Federated.GoogleCloud.Tests/GoogleCloudIdentityProviderCapabilitiesTests.cs
+++ b/tests/Granit.Identity.Federated.GoogleCloud.Tests/GoogleCloudIdentityProviderCapabilitiesTests.cs
@@ -39,4 +39,8 @@ public sealed class GoogleCloudIdentityProviderCapabilitiesTests
     [Fact]
     public void SupportsUserCreation_IsTrue() =>
         _sut.SupportsUserCreation.ShouldBeTrue();
+
+    [Fact]
+    public void SupportsGroupManagement_IsFalse() =>
+        _sut.SupportsGroupManagement.ShouldBeFalse();
 }

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakIdentityProviderCapabilitiesTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakIdentityProviderCapabilitiesTests.cs
@@ -44,6 +44,10 @@ public sealed class KeycloakIdentityProviderCapabilitiesTests
         _capabilities.SupportsUserCreation.ShouldBeTrue();
 
     [Fact]
+    public void SupportsGroupManagement_ReturnsFalse() =>
+        _capabilities.SupportsGroupManagement.ShouldBeFalse();
+
+    [Fact]
     public void ImplementsIIdentityProviderCapabilities() =>
         _capabilities.ShouldBeAssignableTo<IIdentityProviderCapabilities>();
 

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/Internal/AspNetIdentityProviderCapabilitiesTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/Internal/AspNetIdentityProviderCapabilitiesTests.cs
@@ -43,4 +43,8 @@ public sealed class AspNetIdentityProviderCapabilitiesTests
     [Fact]
     public void MaxCustomAttributes_IsIntMaxValue() =>
         _sut.MaxCustomAttributes.ShouldBe(int.MaxValue);
+
+    [Fact]
+    public void SupportsGroupManagement_IsFalse() =>
+        _sut.SupportsGroupManagement.ShouldBeFalse();
 }

--- a/tests/Granit.Identity.Tests/IdentityProviderCapabilitiesTests.cs
+++ b/tests/Granit.Identity.Tests/IdentityProviderCapabilitiesTests.cs
@@ -43,6 +43,10 @@ public sealed class IdentityProviderCapabilitiesTests
         _capabilities.SupportsUserCreation.ShouldBeFalse();
 
     [Fact]
+    public void SupportsGroupManagement_ReturnsFalse() =>
+        _capabilities.SupportsGroupManagement.ShouldBeFalse();
+
+    [Fact]
     public void ImplementsIIdentityProviderCapabilities() =>
         _capabilities.ShouldBeAssignableTo<IIdentityProviderCapabilities>();
 


### PR DESCRIPTION
## Summary

- Adds a new `SupportsGroupManagement` capability on `IIdentityProviderCapabilities` so the frontend can hide group-management UI until the feature is rolled out.
- All current providers (Cognito, EntraID, Google Cloud, Keycloak, ASP.NET Identity, Null) return `false` — group lifecycle remains delegated to each provider's admin console.
- Propagates the new flag through `IdentityProviderCapabilitiesResponse` and `IdentityCapabilitiesEndpoints`.

## Test plan

- [x] `dotnet build src/Granit.Identity` — 0 warnings, 0 errors
- [x] `dotnet format src/Granit.Identity --verify-no-changes` — clean
- [x] All 7 affected test projects pass (848 tests total: Identity, Identity.Endpoints, Federated.Cognito/EntraId/GoogleCloud/Keycloak, Local.AspNetIdentity)