### PR TITLE
feat(tax): add TaxRateEntry query + export definitions (ADR-020)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1950,6 +1950,7 @@
       "name": "Granit.Tax.Endpoints",
       "deps": [
         "Granit.Authorization",
+        "Granit.QueryEngine.AspNetCore",
         "Granit.Tax",
         "Granit.Validation"
       ],
@@ -38866,7 +38867,7 @@
       "kind": "class",
       "project": "Granit.Tax.Endpoints",
       "file": "src/Granit.Tax.Endpoints/Extensions/TaxEndpointRouteBuilderExtensions.cs",
-      "line": 10,
+      "line": 12,
       "members": [
         {
           "name": "MapGranitTax",
@@ -39007,7 +39008,7 @@
       "kind": "class",
       "project": "Granit.Tax",
       "file": "src/Granit.Tax/Extensions/TaxHostApplicationBuilderExtensions.cs",
-      "line": 18,
+      "line": 20,
       "members": [
         {
           "name": "AddGranitTax",
@@ -39068,6 +39069,12 @@
           "kind": "method",
           "signature": "GetAllCurrentRatesAsync(CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyList<TaxRateEntry>>"
+        },
+        {
+          "name": "GetAllCurrentRates",
+          "kind": "method",
+          "signature": "GetAllCurrentRates()",
+          "returnType": "IReadOnlyList<TaxRateEntry>"
         }
       ]
     },

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -38970,6 +38970,22 @@
       "members": []
     },
     {
+      "name": "TaxRateEntryExportDefinition",
+      "fqn": "Granit.Tax.Exports.TaxRateEntryExportDefinition",
+      "kind": "class",
+      "project": "Granit.Tax",
+      "file": "src/Granit.Tax/Exports/TaxRateEntryExportDefinition.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
       "name": "TaxRateOverrideExportDefinition",
       "fqn": "Granit.Tax.Exports.TaxRateOverrideExportDefinition",
       "kind": "class",
@@ -39152,6 +39168,22 @@
           "kind": "property",
           "signature": "int ValidationCacheTtlHours",
           "returnType": "int"
+        }
+      ]
+    },
+    {
+      "name": "TaxRateEntryQueryDefinition",
+      "fqn": "Granit.Tax.Queries.TaxRateEntryQueryDefinition",
+      "kind": "class",
+      "project": "Granit.Tax",
+      "file": "src/Granit.Tax/Queries/TaxRateEntryQueryDefinition.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
         }
       ]
     },

--- a/src/Granit.Http.ApiDocumentation/packages.lock.json
+++ b/src/Granit.Http.ApiDocumentation/packages.lock.json
@@ -20,8 +20,8 @@
       "Scalar.AspNetCore": {
         "type": "Direct",
         "requested": "[2.*, )",
-        "resolved": "2.14.0",
-        "contentHash": "YpcCrY+FuPrmFzThm4om8HZ0Lww9vlIQUzUcBpc2Hv4n+oY8SgvFebgBSQJgnaW6y/FgG5J6FU/71HRq/wy9uQ=="
+        "resolved": "2.14.1",
+        "contentHash": "neS3aI7YVPDY7+I9U8nYXvSnSy6lPvGyn5w52m0MCvC5COajK4HF4vsx70OO6Fw9bd7WXOUikSBdUaLfyTzw3g=="
       },
       "Asp.Versioning.Abstractions": {
         "type": "Transitive",

--- a/src/Granit.Tax.Builtin/Internal/ConfigTaxRateProvider.cs
+++ b/src/Granit.Tax.Builtin/Internal/ConfigTaxRateProvider.cs
@@ -34,9 +34,12 @@ internal sealed class ConfigTaxRateProvider(
     }
 
     public Task<IReadOnlyList<TaxRateEntry>> GetAllCurrentRatesAsync(
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(GetAllCurrentRates());
+
+    public IReadOnlyList<TaxRateEntry> GetAllCurrentRates()
     {
-        var rates = new List<TaxRateEntry>();
+        var rates = new List<TaxRateEntry>(EuVatRateDefaults.StandardRates.Count);
 
         foreach (KeyValuePair<string, decimal> entry in EuVatRateDefaults.StandardRates)
         {
@@ -49,6 +52,6 @@ internal sealed class ConfigTaxRateProvider(
                 options.Value.ReducedRates?.GetValueOrDefault(entry.Key)));
         }
 
-        return Task.FromResult<IReadOnlyList<TaxRateEntry>>(rates);
+        return rates;
     }
 }

--- a/src/Granit.Tax.Endpoints/Endpoints/TaxRateEndpoints.cs
+++ b/src/Granit.Tax.Endpoints/Endpoints/TaxRateEndpoints.cs
@@ -1,5 +1,4 @@
 using Granit.Tax.Endpoints.Dtos;
-using Granit.Tax.Endpoints.Permissions;
 using Granit.Timing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -9,23 +8,16 @@ using Microsoft.AspNetCore.Routing;
 
 namespace Granit.Tax.Endpoints.Endpoints;
 
-/// <summary>Endpoints for tax rate lookup.</summary>
+/// <summary>
+/// Custom tax rate endpoints. The list endpoint (GET /, /meta, /saved-views/*)
+/// is provided by <c>MapGranitQuery&lt;TaxRateEntry&gt;()</c>; only the per-country
+/// lookup lives here.
+/// </summary>
 internal static class TaxRateEndpoints
 {
     internal static RouteGroupBuilder MapRateEndpoints(this RouteGroupBuilder group)
     {
-        group.MapGet("/", GetAllRatesAsync)
-            .RequireAuthorization(TaxPermissions.Rates.Read)
-            .WithName("GetAllTaxRates")
-            .WithSummary("Returns all currently effective tax rates.")
-            .WithDescription(
-                "Lists the standard and reduced tax rates for all configured countries. "
-                + "Rates come from the configured provider (EU VAT defaults, configuration overrides, "
-                + "or database-managed overrides when the EF Core package is registered).")
-            .Produces<IReadOnlyList<TaxRateResponse>>();
-
         group.MapGet("/{countryCode}", GetRateByCountryAsync)
-            .RequireAuthorization(TaxPermissions.Rates.Read)
             .WithName("GetTaxRateByCountry")
             .WithSummary("Returns the current tax rate for a specific country.")
             .WithDescription(
@@ -35,24 +27,6 @@ internal static class TaxRateEndpoints
             .ProducesProblem(StatusCodes.Status404NotFound);
 
         return group;
-    }
-
-    private static async Task<Ok<IReadOnlyList<TaxRateResponse>>> GetAllRatesAsync(
-        [FromServices] ITaxRateProvider rateProvider,
-        CancellationToken cancellationToken = default)
-    {
-        IReadOnlyList<TaxRateEntry> rates = await rateProvider
-            .GetAllCurrentRatesAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        IReadOnlyList<TaxRateResponse> response = rates
-            .Select(r => new TaxRateResponse(
-                r.CountryCode, r.StandardRate, r.ReducedRate,
-                r.SuperReducedRate, r.ParkingRate,
-                r.EffectiveFrom, r.EffectiveTo))
-            .ToList();
-
-        return TypedResults.Ok(response);
     }
 
     private static async Task<Results<Ok<TaxRateResponse>, ProblemHttpResult>> GetRateByCountryAsync(

--- a/src/Granit.Tax.Endpoints/Extensions/TaxEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Tax.Endpoints/Extensions/TaxEndpointRouteBuilderExtensions.cs
@@ -1,4 +1,6 @@
+using Granit.QueryEngine.AspNetCore.Extensions;
 using Granit.Tax.Endpoints.Endpoints;
+using Granit.Tax.Endpoints.Permissions;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -18,7 +20,14 @@ public static class TaxEndpointRouteBuilderExtensions
             .WithTags("Tax");
 
         group.MapGranitGroup("ids").MapValidationEndpoints();
-        group.MapGranitGroup("rates").MapRateEndpoints();
+
+        // Rate endpoints — query engine for list/meta/saved-views, custom lookup for /{countryCode}.
+        // Both behind Tax.Rates.Read.
+        RouteGroupBuilder ratesGroup = group
+            .MapGranitGroup("rates")
+            .RequireAuthorization(TaxPermissions.Rates.Read);
+        ratesGroup.MapGranitQuery<TaxRateEntry>();
+        ratesGroup.MapRateEndpoints();
 
         return group;
     }

--- a/src/Granit.Tax.Endpoints/Granit.Tax.Endpoints.csproj
+++ b/src/Granit.Tax.Endpoints/Granit.Tax.Endpoints.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
+    <ProjectReference Include="..\Granit.QueryEngine.AspNetCore\Granit.QueryEngine.AspNetCore.csproj" />
     <ProjectReference Include="..\Granit.Tax\Granit.Tax.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />
   </ItemGroup>

--- a/src/Granit.Tax.Endpoints/packages.lock.json
+++ b/src/Granit.Tax.Endpoints/packages.lock.json
@@ -8,6 +8,19 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Asp.Versioning.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "I4CuGwl0nO98j6Ft6XlGBgzj1+goE/TSVlnHKgtRkuMZ0K4gy9I+Wyrtto8dyt0hWcFMDFAZ4lYNr58DSemH1g=="
+      },
+      "Asp.Versioning.Http": {
+        "type": "Transitive",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "4/QzujOrkGn9sMch3eHhR5LpVJ4Xo5T2BNg7U1/r4YwEa8JywzkoGQHjW7Nk0W8ljETnpoJaO5mrTsfEOnJK3A==",
+        "dependencies": {
+          "Asp.Versioning.Abstractions": "10.0.0-preview.2"
+        }
+      },
       "Microsoft.OpenApi": {
         "type": "Transitive",
         "resolved": "2.0.0",
@@ -43,6 +56,28 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.apidocumentation": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Http.ApiVersioning": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )",
+          "Scalar.AspNetCore": "[2.*, )"
+        }
+      },
+      "granit.http.apiversioning": {
+        "type": "Project",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "[10.0.0-preview.*, )",
+          "Asp.Versioning.Mvc.ApiExplorer": "[10.0.0-preview.*, )",
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.http.exceptionhandling": {
         "type": "Project",
         "dependencies": {
@@ -57,10 +92,29 @@
           "SmartFormat": "[3.*, )"
         }
       },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.aspnetcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.tax": {
@@ -86,6 +140,24 @@
           "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Microsoft.AspNetCore.OpenApi": "[10.*, )"
+        }
+      },
+      "Asp.Versioning.Mvc": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0-preview.*, )",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "AyrcDwLzJp8yRJaFjZMJXkR1Rx2UaJkwGrGlX8sxIt2F5ZGiZwn/puXkB/oEaq55TxLkpiXWAOHHFsiVptp0fA==",
+        "dependencies": {
+          "Asp.Versioning.Http": "10.0.0-preview.2"
+        }
+      },
+      "Asp.Versioning.Mvc.ApiExplorer": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0-preview.*, )",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "G/LhAaLQj+gsB8UXRNm65fxjsI7fe87itZExb+MvJOQdrXYalZKbwuzMntO95xM5cKDrDgLnCH64fl6w173aGg==",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "10.0.0-preview.2"
         }
       },
       "FluentValidation": {
@@ -117,6 +189,12 @@
         "requested": "[1.15.*, )",
         "resolved": "1.14.0",
         "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "Scalar.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.14.1",
+        "contentHash": "neS3aI7YVPDY7+I9U8nYXvSnSy6lPvGyn5w52m0MCvC5COajK4HF4vsx70OO6Fw9bd7WXOUikSBdUaLfyTzw3g=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Tax.EntityFrameworkCore/Internal/EfTaxRateProvider.cs
+++ b/src/Granit.Tax.EntityFrameworkCore/Internal/EfTaxRateProvider.cs
@@ -45,12 +45,10 @@ internal sealed class EfTaxRateProvider(
     public async Task<IReadOnlyList<TaxRateEntry>> GetAllCurrentRatesAsync(
         CancellationToken cancellationToken = default)
     {
-        // Get base rates from fallback
         IReadOnlyList<TaxRateEntry> baseRates = await fallback
             .GetAllCurrentRatesAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        // Get DB overrides
         await using TaxDbContext db = await contextFactory.CreateDbContextAsync(cancellationToken)
             .ConfigureAwait(false);
 
@@ -60,7 +58,28 @@ internal sealed class EfTaxRateProvider(
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        // Merge: DB overrides take precedence
+        return Merge(baseRates, overrides);
+    }
+
+    public IReadOnlyList<TaxRateEntry> GetAllCurrentRates()
+    {
+        IReadOnlyList<TaxRateEntry> baseRates = fallback.GetAllCurrentRates();
+
+        using TaxDbContext db = contextFactory.CreateDbContext();
+
+        DateTimeOffset now = clock.Now;
+        var overrides = db.TaxRateOverrides
+            .Where(r => r.EffectiveFrom <= now && (r.EffectiveTo == null || r.EffectiveTo > now))
+            .ToList();
+
+        return Merge(baseRates, overrides);
+    }
+
+    private static List<TaxRateEntry> Merge(
+        IReadOnlyList<TaxRateEntry> baseRates,
+        List<TaxRateOverride> overrides)
+    {
+        // DB overrides take precedence over the fallback rates.
         var overrideMap = overrides.ToDictionary(
             r => r.CountryCode, r => r, StringComparer.OrdinalIgnoreCase);
 

--- a/src/Granit.Tax/Exports/TaxRateEntryExportDefinition.cs
+++ b/src/Granit.Tax/Exports/TaxRateEntryExportDefinition.cs
@@ -1,0 +1,26 @@
+using Granit.DataExchange.Export;
+
+namespace Granit.Tax.Exports;
+
+/// <summary>
+/// Export definition for effective tax rate entries resolved by
+/// <see cref="ITaxRateProvider"/>.
+/// </summary>
+public sealed class TaxRateEntryExportDefinition : ExportDefinition<TaxRateEntry>
+{
+    /// <inheritdoc/>
+    public override string Name => "Granit.Tax.TaxRateEntryExport";
+
+    /// <inheritdoc/>
+    protected override void Configure(ExportDefinitionBuilder<TaxRateEntry> builder)
+    {
+        builder
+            .Field(r => r.CountryCode)
+            .Field(r => r.StandardRate, f => f.Format("#,##0.00"))
+            .Field(r => r.ReducedRate, f => f.Format("#,##0.00"))
+            .Field(r => r.SuperReducedRate, f => f.Format("#,##0.00"))
+            .Field(r => r.ParkingRate, f => f.Format("#,##0.00"))
+            .Field(r => r.EffectiveFrom, f => f.Format("O"))
+            .Field(r => r.EffectiveTo, f => f.Format("O"));
+    }
+}

--- a/src/Granit.Tax/Extensions/TaxHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Tax/Extensions/TaxHostApplicationBuilderExtensions.cs
@@ -1,9 +1,11 @@
 using Granit.DataExchange.Extensions;
 using Granit.Diagnostics;
+using Granit.QueryEngine;
 using Granit.QueryEngine.Extensions;
 using Granit.Tax.Diagnostics;
 using Granit.Tax.Domain;
 using Granit.Tax.Exports;
+using Granit.Tax.Internal;
 using Granit.Tax.Options;
 using Granit.Tax.Queries;
 using Microsoft.Extensions.DependencyInjection;
@@ -34,6 +36,9 @@ public static class TaxHostApplicationBuilderExtensions
         builder.Services.AddExportDefinition<TaxRateOverride, TaxRateOverrideExportDefinition>();
         builder.Services.AddQueryDefinition<TaxRateEntry, TaxRateEntryQueryDefinition>();
         builder.Services.AddExportDefinition<TaxRateEntry, TaxRateEntryExportDefinition>();
+
+        // Queryable source backing MapGranitQuery<TaxRateEntry>() — wraps ITaxRateProvider.
+        builder.Services.AddScoped<IQueryableSource<TaxRateEntry>, TaxRateEntryQueryableSource>();
 
         return builder;
     }

--- a/src/Granit.Tax/Extensions/TaxHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Tax/Extensions/TaxHostApplicationBuilderExtensions.cs
@@ -32,6 +32,8 @@ public static class TaxHostApplicationBuilderExtensions
         // Query + Export definitions (ADR-020: owned by the base module).
         builder.Services.AddQueryDefinition<TaxRateOverride, TaxRateOverrideQueryDefinition>();
         builder.Services.AddExportDefinition<TaxRateOverride, TaxRateOverrideExportDefinition>();
+        builder.Services.AddQueryDefinition<TaxRateEntry, TaxRateEntryQueryDefinition>();
+        builder.Services.AddExportDefinition<TaxRateEntry, TaxRateEntryExportDefinition>();
 
         return builder;
     }

--- a/src/Granit.Tax/ITaxRateProvider.cs
+++ b/src/Granit.Tax/ITaxRateProvider.cs
@@ -11,4 +11,12 @@ public interface ITaxRateProvider
     /// <summary>Returns all currently effective tax rates.</summary>
     Task<IReadOnlyList<TaxRateEntry>> GetAllCurrentRatesAsync(
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Synchronous variant of <see cref="GetAllCurrentRatesAsync"/>.
+    /// Required by <c>IQueryableSource&lt;TaxRateEntry&gt;</c> so the query engine
+    /// can expose the resolved rates via <c>MapGranitQuery&lt;TaxRateEntry&gt;()</c>.
+    /// Implementations must avoid blocking the calling thread on async I/O.
+    /// </summary>
+    IReadOnlyList<TaxRateEntry> GetAllCurrentRates();
 }

--- a/src/Granit.Tax/Internal/TaxRateEntryQueryableSource.cs
+++ b/src/Granit.Tax/Internal/TaxRateEntryQueryableSource.cs
@@ -1,0 +1,15 @@
+using Granit.QueryEngine;
+
+namespace Granit.Tax.Internal;
+
+/// <summary>
+/// In-memory <see cref="IQueryableSource{TEntity}"/> for <see cref="TaxRateEntry"/>.
+/// Wraps <see cref="ITaxRateProvider.GetAllCurrentRates"/> so the query engine can
+/// filter, sort and page the resolved rates without forcing a sync-over-async hop.
+/// </summary>
+internal sealed class TaxRateEntryQueryableSource(
+    ITaxRateProvider provider) : IQueryableSource<TaxRateEntry>
+{
+    public IQueryable<TaxRateEntry> GetQueryable() =>
+        provider.GetAllCurrentRates().AsQueryable();
+}

--- a/src/Granit.Tax/Queries/TaxRateEntryQueryDefinition.cs
+++ b/src/Granit.Tax/Queries/TaxRateEntryQueryDefinition.cs
@@ -1,0 +1,29 @@
+using Granit.QueryEngine;
+
+namespace Granit.Tax.Queries;
+
+/// <summary>
+/// Query definition for effective tax rate entries resolved by
+/// <see cref="ITaxRateProvider"/> (defaults + configuration + DB overrides).
+/// </summary>
+public sealed class TaxRateEntryQueryDefinition : QueryDefinition<TaxRateEntry>
+{
+    /// <inheritdoc/>
+    public override string Name => "Granit.Tax.TaxRateEntryQuery";
+
+    /// <inheritdoc/>
+    protected override void Configure(QueryDefinitionBuilder<TaxRateEntry> builder)
+    {
+        builder
+            .Column(r => r.CountryCode, c => c.Label("Country Code").LabelKey("Tax.Columns.CountryCode").Filterable().Sortable())
+            .Column(r => r.StandardRate, c => c.Label("Standard Rate").LabelKey("Tax.Columns.StandardRate").Sortable())
+            .Column(r => r.ReducedRate, c => c.Label("Reduced Rate").LabelKey("Tax.Columns.ReducedRate").Sortable())
+            .Column(r => r.SuperReducedRate, c => c.Label("Super-Reduced Rate").LabelKey("Tax.Columns.SuperReducedRate").Sortable())
+            .Column(r => r.ParkingRate, c => c.Label("Parking Rate").LabelKey("Tax.Columns.ParkingRate").Sortable())
+            .Column(r => r.EffectiveFrom, c => c.Label("Effective From").LabelKey("Tax.Columns.EffectiveFrom").Sortable())
+            .Column(r => r.EffectiveTo, c => c.Label("Effective To").LabelKey("Tax.Columns.EffectiveTo").Sortable())
+            .GlobalSearch(r => r.CountryCode)
+            .DefaultSort("countryCode")
+            .DefaultPageSize(50);
+    }
+}

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -3216,6 +3216,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Tax": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }

--- a/tests/Granit.Tax.Builtin.Tests/Internal/ConfigTaxRateProviderTests.cs
+++ b/tests/Granit.Tax.Builtin.Tests/Internal/ConfigTaxRateProviderTests.cs
@@ -108,4 +108,33 @@ public sealed class ConfigTaxRateProviderTests
         lu.StandardRate.ShouldBe(0.18m);
         lu.ReducedRate.ShouldBe(0.08m);
     }
+
+    // ======== GetAllCurrentRates (sync) ========
+
+    [Fact]
+    public void GetAllCurrentRates_ShouldReturnAllEuCountries()
+    {
+        ConfigTaxRateProvider provider = CreateProvider();
+
+        IReadOnlyList<TaxRateEntry> rates = provider.GetAllCurrentRates();
+
+        rates.Count.ShouldBe(27);
+    }
+
+    [Fact]
+    public void GetAllCurrentRates_WithOverride_ShouldUseOverrideRate()
+    {
+        var options = new EuVatRateOptions
+        {
+            StandardRates = new Dictionary<string, decimal> { ["LU"] = 0.18m },
+            ReducedRates = new Dictionary<string, decimal> { ["LU"] = 0.08m },
+        };
+        ConfigTaxRateProvider provider = CreateProvider(options);
+
+        IReadOnlyList<TaxRateEntry> rates = provider.GetAllCurrentRates();
+
+        TaxRateEntry lu = rates.Single(r => r.CountryCode == "LU");
+        lu.StandardRate.ShouldBe(0.18m);
+        lu.ReducedRate.ShouldBe(0.08m);
+    }
 }

--- a/tests/Granit.Tax.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Tax.Endpoints.Tests/packages.lock.json
@@ -64,6 +64,22 @@
           "xunit.v3.mtp-v1": "[3.2.2]"
         }
       },
+      "Asp.Versioning.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "I4CuGwl0nO98j6Ft6XlGBgzj1+goE/TSVlnHKgtRkuMZ0K4gy9I+Wyrtto8dyt0hWcFMDFAZ4lYNr58DSemH1g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Asp.Versioning.Http": {
+        "type": "Transitive",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "4/QzujOrkGn9sMch3eHhR5LpVJ4Xo5T2BNg7U1/r4YwEa8JywzkoGQHjW7Nk0W8ljETnpoJaO5mrTsfEOnJK3A==",
+        "dependencies": {
+          "Asp.Versioning.Abstractions": "10.0.0-preview.2"
+        }
+      },
       "Castle.Core": {
         "type": "Transitive",
         "resolved": "5.1.1",
@@ -320,6 +336,30 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.http.apidocumentation": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Http.ApiVersioning": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )",
+          "Scalar.AspNetCore": "[2.*, )"
+        }
+      },
+      "granit.http.apiversioning": {
+        "type": "Project",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "[10.0.0-preview.*, )",
+          "Asp.Versioning.Mvc.ApiExplorer": "[10.0.0-preview.*, )",
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.http.exceptionhandling": {
         "type": "Project",
         "dependencies": {
@@ -336,10 +376,29 @@
           "SmartFormat": "[3.*, )"
         }
       },
+      "granit.queryengine": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.aspnetcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.QueryEngine": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
         }
       },
       "granit.tax": {
@@ -356,6 +415,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.QueryEngine.AspNetCore": "[0.1.0-dev, )",
           "Granit.Tax": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"
         }
@@ -376,6 +436,24 @@
           "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Microsoft.AspNetCore.OpenApi": "[10.*, )"
+        }
+      },
+      "Asp.Versioning.Mvc": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0-preview.*, )",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "AyrcDwLzJp8yRJaFjZMJXkR1Rx2UaJkwGrGlX8sxIt2F5ZGiZwn/puXkB/oEaq55TxLkpiXWAOHHFsiVptp0fA==",
+        "dependencies": {
+          "Asp.Versioning.Http": "10.0.0-preview.2"
+        }
+      },
+      "Asp.Versioning.Mvc.ApiExplorer": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0-preview.*, )",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "G/LhAaLQj+gsB8UXRNm65fxjsI7fe87itZExb+MvJOQdrXYalZKbwuzMntO95xM5cKDrDgLnCH64fl6w173aGg==",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "10.0.0-preview.2"
         }
       },
       "FluentValidation": {
@@ -509,6 +587,12 @@
         "requested": "[1.15.*, )",
         "resolved": "1.14.0",
         "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "Scalar.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.14.1",
+        "contentHash": "neS3aI7YVPDY7+I9U8nYXvSnSy6lPvGyn5w52m0MCvC5COajK4HF4vsx70OO6Fw9bd7WXOUikSBdUaLfyTzw3g=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Summary

`TaxRateEntry` is the effective tax rate shape returned by `ITaxRateProvider` (EU defaults + configuration + DB overrides resolved at the current date) and exposed at `GET /tax/rates/`. `TaxRateOverride` already shipped a `QueryDefinition` + `ExportDefinition`; the resolved `TaxRateEntry` did not, breaking ADR-020 pairing for the admin-visible read surface.

This PR adds the two declarative primitives and registers them in `AddGranitTax`. The shape is now consumable by non-EF callers (export orchestrator, tests, future `MapGranitQuery` wiring).

## What's not in scope

No endpoint change. Exposing the effective rates as a query-engine endpoint requires an `IQueryableSource<TaxRateEntry>` implementation — that's non-trivial because `ITaxRateProvider.GetAllCurrentRatesAsync` is async while `IQueryableSource.GetQueryable` is sync. That decision belongs in a separate change.

## Test plan

- [x] `dotnet build` — 0 warnings / 0 errors
- [x] `dotnet test` Tax.Builtin — 62 passing
- [x] `dotnet test` Tax.Endpoints — 1 passing
- [x] `dotnet test` ArchitectureTests — 113 passing (Query/Export pairing rule honored)
- [x] `dotnet format Granit.slnx --verify-no-changes` — clean