### PR TITLE
refactor(auditing): rename AuditEntrySummary to AuditEntryResponse

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -4245,11 +4245,11 @@
       ]
     },
     {
-      "name": "AuditEntrySummary",
-      "fqn": "Granit.Auditing.Dtos.AuditEntrySummary",
+      "name": "AuditEntryResponse",
+      "fqn": "Granit.Auditing.Dtos.AuditEntryResponse",
       "kind": "record",
       "project": "Granit.Auditing",
-      "file": "src/Granit.Auditing/Dtos/AuditEntrySummary.cs",
+      "file": "src/Granit.Auditing/Dtos/AuditEntryResponse.cs",
       "line": 14,
       "members": []
     },

--- a/src/Granit.Auditing.Endpoints/Endpoints/AuditingReadEndpoints.cs
+++ b/src/Granit.Auditing.Endpoints/Endpoints/AuditingReadEndpoints.cs
@@ -35,7 +35,7 @@ internal static class AuditingReadEndpoints
             .WithName("GetAuditEntriesByEntity")
             .WithSummary("Returns the audit trail for a specific entity instance.")
             .WithDescription("Returns all audit log entries associated with a specific entity, identified by its CLR type name and primary key. Results are paginated and ordered by timestamp descending. Useful for displaying the full change history of a single record. Path parameters are limited to 256 characters.")
-            .Produces<PagedResult<AuditEntrySummary>>()
+            .Produces<PagedResult<AuditEntryResponse>>()
             .ProducesProblem(StatusCodes.Status400BadRequest);
 
         group.MapGet("/correlation/{correlationId}", GetByCorrelationIdAsync)
@@ -89,7 +89,7 @@ internal static class AuditingReadEndpoints
         return TypedResults.Ok(mapped);
     }
 
-    private static async Task<Results<Ok<PagedResult<AuditEntrySummary>>, ProblemHttpResult>> GetByEntityAsync(
+    private static async Task<Results<Ok<PagedResult<AuditEntryResponse>>, ProblemHttpResult>> GetByEntityAsync(
         string entityType,
         string entityId,
         [FromQuery] int? page,
@@ -114,8 +114,8 @@ internal static class AuditingReadEndpoints
                 cancellationToken)
             .ConfigureAwait(false);
 
-        PagedResult<AuditEntrySummary> mapped = new(
-            result.Items.Select(AuditingResponseMapper.ToSummary).ToList(),
+        PagedResult<AuditEntryResponse> mapped = new(
+            result.Items.Select(AuditingResponseMapper.ToSummaryResponse).ToList(),
             result.TotalCount,
             result.HasMore);
 

--- a/src/Granit.Auditing.Endpoints/Internal/AuditingResponseMapper.cs
+++ b/src/Granit.Auditing.Endpoints/Internal/AuditingResponseMapper.cs
@@ -10,7 +10,7 @@ namespace Granit.Auditing.Endpoints.Internal;
 internal static class AuditingResponseMapper
 {
     /// <summary>Maps to the summary projection used by per-entity list lookups.</summary>
-    public static AuditEntrySummary ToSummary(AuditEntry entry) =>
+    public static AuditEntryResponse ToSummaryResponse(AuditEntry entry) =>
         new(
             entry.Id,
             entry.Timestamp,

--- a/src/Granit.Auditing.Endpoints/Internal/AuditingSchemaExampleProvider.cs
+++ b/src/Granit.Auditing.Endpoints/Internal/AuditingSchemaExampleProvider.cs
@@ -14,7 +14,7 @@ internal sealed class AuditingSchemaExampleProvider : ISchemaExampleProvider
     public IReadOnlyDictionary<Type, JsonNode> GetExamples() =>
         new Dictionary<Type, JsonNode>
         {
-            [typeof(AuditEntrySummary)] = new JsonObject
+            [typeof(AuditEntryResponse)] = new JsonObject
             {
                 ["id"] = "b3f7a1c2-9d4e-4f8a-b6c5-1e2d3f4a5b6c",
                 ["timestamp"] = "2026-03-17T10:15:30+00:00",

--- a/src/Granit.Auditing/Dtos/AuditEntryResponse.cs
+++ b/src/Granit.Auditing/Dtos/AuditEntryResponse.cs
@@ -11,7 +11,7 @@ namespace Granit.Auditing.Dtos;
 /// the list view — it is only exposed via the detail endpoint. <c>EntityChangeCount</c>
 /// is computed server-side via a SQL subquery on <c>AuditEntityChange</c>.
 /// </remarks>
-public sealed record AuditEntrySummary(
+public sealed record AuditEntryResponse(
     Guid Id,
     DateTimeOffset Timestamp,
     string UserId,

--- a/src/Granit.Auditing/Queries/AuditEntryQueryDefinition.cs
+++ b/src/Granit.Auditing/Queries/AuditEntryQueryDefinition.cs
@@ -28,7 +28,7 @@ public sealed class AuditEntryQueryDefinition : QueryDefinition<AuditEntry>
             .DateFilter(e => e.Timestamp)
             .DefaultSort("-timestamp")
             .DefaultPageSize(25)
-            .ProjectTo(e => new AuditEntrySummary(
+            .ProjectTo(e => new AuditEntryResponse(
                 e.Id,
                 e.Timestamp,
                 e.UserId,

--- a/tests/Granit.Auditing.Endpoints.Tests/Internal/AuditingResponseMapperAdditionalTests.cs
+++ b/tests/Granit.Auditing.Endpoints.Tests/Internal/AuditingResponseMapperAdditionalTests.cs
@@ -10,7 +10,7 @@ namespace Granit.Auditing.Endpoints.Tests.Internal;
 public sealed class AuditingResponseMapperAdditionalTests
 {
     [Fact]
-    public void ToSummary_WithEmptyEntityChanges_ReturnsZeroCount()
+    public void ToSummaryResponse_WithEmptyEntityChanges_ReturnsZeroCount()
     {
         AuditEntry entry = new()
         {
@@ -20,13 +20,13 @@ public sealed class AuditingResponseMapperAdditionalTests
             Category = AuditCategory.DataMutation,
         };
 
-        AuditEntrySummary response = AuditingResponseMapper.ToSummary(entry);
+        AuditEntryResponse response = AuditingResponseMapper.ToSummaryResponse(entry);
 
         response.EntityChangeCount.ShouldBe(0);
     }
 
     [Fact]
-    public void ToSummary_WithMultipleEntityChanges_CountsCorrectly()
+    public void ToSummaryResponse_WithMultipleEntityChanges_CountsCorrectly()
     {
         AuditEntry entry = new()
         {
@@ -42,13 +42,13 @@ public sealed class AuditingResponseMapperAdditionalTests
             ],
         };
 
-        AuditEntrySummary response = AuditingResponseMapper.ToSummary(entry);
+        AuditEntryResponse response = AuditingResponseMapper.ToSummaryResponse(entry);
 
         response.EntityChangeCount.ShouldBe(3);
     }
 
     [Fact]
-    public void ToSummary_PreservesCategoryEnum()
+    public void ToSummaryResponse_PreservesCategoryEnum()
     {
         AuditEntry entry = new()
         {
@@ -58,7 +58,7 @@ public sealed class AuditingResponseMapperAdditionalTests
             Category = AuditCategory.ConfigurationChange,
         };
 
-        AuditEntrySummary response = AuditingResponseMapper.ToSummary(entry);
+        AuditEntryResponse response = AuditingResponseMapper.ToSummaryResponse(entry);
 
         response.Category.ShouldBe(AuditCategory.ConfigurationChange);
     }

--- a/tests/Granit.Auditing.Endpoints.Tests/Internal/AuditingResponseMapperTests.cs
+++ b/tests/Granit.Auditing.Endpoints.Tests/Internal/AuditingResponseMapperTests.cs
@@ -10,7 +10,7 @@ namespace Granit.Auditing.Endpoints.Tests.Internal;
 public sealed class AuditingResponseMapperTests
 {
     [Fact]
-    public void ToSummary_MapsAllFields()
+    public void ToSummaryResponse_MapsAllFields()
     {
         // Arrange
         var tenantId = Guid.NewGuid();
@@ -36,7 +36,7 @@ public sealed class AuditingResponseMapperTests
         };
 
         // Act
-        AuditEntrySummary response = AuditingResponseMapper.ToSummary(entry);
+        AuditEntryResponse response = AuditingResponseMapper.ToSummaryResponse(entry);
 
         // Assert
         response.Id.ShouldBe(entry.Id);

--- a/tests/Granit.Auditing.Endpoints.Tests/Internal/AuditingSchemaExampleProviderTests.cs
+++ b/tests/Granit.Auditing.Endpoints.Tests/Internal/AuditingSchemaExampleProviderTests.cs
@@ -16,7 +16,7 @@ public sealed class AuditingSchemaExampleProviderTests
 
         IReadOnlyDictionary<Type, JsonNode> examples = provider.GetExamples();
 
-        examples.ShouldContainKey(typeof(AuditEntrySummary));
+        examples.ShouldContainKey(typeof(AuditEntryResponse));
     }
 
     [Fact]
@@ -35,7 +35,7 @@ public sealed class AuditingSchemaExampleProviderTests
         AuditingSchemaExampleProvider provider = new();
         IReadOnlyDictionary<Type, JsonNode> examples = provider.GetExamples();
 
-        JsonNode entryExample = examples[typeof(AuditEntrySummary)];
+        JsonNode entryExample = examples[typeof(AuditEntryResponse)];
         JsonObject obj = entryExample.AsObject();
 
         obj["id"].ShouldNotBeNull();


### PR DESCRIPTION
## Summary

Framework DTO naming convention is `*Response` (`AIChatResponse`, `ApiKeyResponse`, `AuditEntryDetailResponse`, etc.). `AuditEntrySummary` introduced in #1047 was the only outlier.

Rename `AuditEntrySummary` → `AuditEntryResponse`. The pair now reads:

| DTO | Returned by |
| --- | ----------- |
| `AuditEntryResponse` (base module) | `GET /` (query engine), `GET /entity/{type}/{id}` |
| `AuditEntryDetailResponse` (Endpoints) | `GET /{id}`, `GET /correlation/{id}` |

Also renames the mapper method `ToSummary` → `ToSummaryResponse` so both sibling mappers follow the same suffix (`ToSummaryResponse` / `ToDetailResponse`).

## Test plan

- [x] `dotnet build` clean
- [x] Auditing tests: 88 + 33 + 125 = 246 passing