### PR TITLE
feat(authz): MultiTenancySide + ABP-style multi-provider grants

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -6502,13 +6502,19 @@
       "kind": "class",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/Extensions/HostAccessEndpointExtensions.cs",
-      "line": 10,
+      "line": 11,
       "members": [
         {
           "name": "AllowHostAccess",
           "kind": "method",
           "signature": "AllowHostAccess(this RouteHandlerBuilder builder)",
           "returnType": "RouteHandlerBuilder"
+        },
+        {
+          "name": "AllowHostAccess",
+          "kind": "method",
+          "signature": "AllowHostAccess(this RouteGroupBuilder group)",
+          "returnType": "RouteGroupBuilder"
         }
       ]
     },
@@ -9826,7 +9832,7 @@
       "kind": "class",
       "project": "Granit.CustomerBalance.Endpoints",
       "file": "src/Granit.CustomerBalance.Endpoints/Extensions/CustomerBalanceEndpointRouteBuilderExtensions.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "MapGranitCustomerBalance",
@@ -39539,7 +39545,7 @@
       "kind": "class",
       "project": "Granit.Tax.Endpoints",
       "file": "src/Granit.Tax.Endpoints/Extensions/TaxEndpointRouteBuilderExtensions.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "MapGranitTax",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -6264,7 +6264,7 @@
       "kind": "class",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/Domain/PermissionGrant.cs",
-      "line": 10,
+      "line": 22,
       "members": [
         {
           "name": "Name",
@@ -6273,9 +6273,15 @@
           "returnType": "string"
         },
         {
-          "name": "RoleName",
+          "name": "ProviderName",
           "kind": "property",
-          "signature": "string RoleName",
+          "signature": "string ProviderName",
+          "returnType": "string"
+        },
+        {
+          "name": "ProviderKey",
+          "kind": "property",
+          "signature": "string ProviderKey",
           "returnType": "string"
         }
       ]
@@ -6430,7 +6436,7 @@
       "kind": "class",
       "project": "Granit.Authorization.EntityFrameworkCore",
       "file": "src/Granit.Authorization.EntityFrameworkCore/GranitAuthorizationDbProperties.cs",
-      "line": 13,
+      "line": 20,
       "members": [
         {
           "name": "DbTablePrefix",
@@ -6455,7 +6461,7 @@
       "kind": "record",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/Events/PermissionGrantChangedEvent.cs",
-      "line": 15,
+      "line": 17,
       "members": []
     },
     {
@@ -6616,42 +6622,42 @@
       "kind": "interface",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/IPermissionGrantStore.cs",
-      "line": 9,
+      "line": 10,
       "members": [
         {
           "name": "IsGrantedAsync",
           "kind": "method",
-          "signature": "IsGrantedAsync(string roleName, string permissionName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "signature": "IsGrantedAsync(string providerName, string providerKey, string permissionName, Guid? tenantId, CancellationToken cancellationToken = default)",
           "returnType": "Task<bool>"
         },
         {
           "name": "GetGrantedPermissionsAsync",
           "kind": "method",
-          "signature": "GetGrantedPermissionsAsync(string roleName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "signature": "GetGrantedPermissionsAsync(string providerName, string providerKey, Guid? tenantId, CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyList<string>>"
         },
         {
           "name": "GetGrantedAsync",
           "kind": "method",
-          "signature": "GetGrantedAsync(string roleName, IReadOnlyList<string> permissionNames, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "signature": "GetGrantedAsync(string providerName, string providerKey, IReadOnlyList<string> permissionNames, Guid? tenantId, CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyList<string>>"
         },
         {
-          "name": "GetGrantedRolesAsync",
+          "name": "GetGranteesAsync",
           "kind": "method",
-          "signature": "GetGrantedRolesAsync(string permissionName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "signature": "GetGranteesAsync(string providerName, string permissionName, Guid? tenantId, CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyList<string>>"
         },
         {
           "name": "GrantAsync",
           "kind": "method",
-          "signature": "GrantAsync(string permissionName, string roleName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "signature": "GrantAsync(string providerName, string providerKey, string permissionName, Guid? tenantId, CancellationToken cancellationToken = default)",
           "returnType": "Task<bool>"
         },
         {
           "name": "RevokeAsync",
           "kind": "method",
-          "signature": "RevokeAsync(string permissionName, string roleName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "signature": "RevokeAsync(string providerName, string providerKey, string permissionName, Guid? tenantId, CancellationToken cancellationToken = default)",
           "returnType": "Task<bool>"
         }
       ]
@@ -6678,24 +6684,24 @@
       "kind": "interface",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/IPermissionManagerReader.cs",
-      "line": 7,
+      "line": 8,
       "members": [
         {
           "name": "IsGrantedAsync",
           "kind": "method",
-          "signature": "IsGrantedAsync(string permissionName, string roleName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "signature": "IsGrantedAsync(string permissionName, string providerName, string providerKey, Guid? tenantId, CancellationToken cancellationToken = default)",
           "returnType": "Task<bool>"
         },
         {
           "name": "GetGrantedPermissionsAsync",
           "kind": "method",
-          "signature": "GetGrantedPermissionsAsync(string roleName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "signature": "GetGrantedPermissionsAsync(string providerName, string providerKey, Guid? tenantId, CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyList<string>>"
         },
         {
-          "name": "GetGrantedRolesAsync",
+          "name": "GetGranteesAsync",
           "kind": "method",
-          "signature": "GetGrantedRolesAsync(string permissionName, Guid? tenantId, CancellationToken cancellationToken = default)",
+          "signature": "GetGranteesAsync(string providerName, string permissionName, Guid? tenantId, CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyList<string>>"
         }
       ]
@@ -6706,12 +6712,12 @@
       "kind": "interface",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/IPermissionManagerWriter.cs",
-      "line": 8,
+      "line": 10,
       "members": [
         {
           "name": "SetAsync",
           "kind": "method",
-          "signature": "SetAsync(string permissionName, string roleName, Guid? tenantId, bool isGranted, CancellationToken cancellationToken = default)",
+          "signature": "SetAsync(string permissionName, string providerName, string providerKey, Guid? tenantId, bool isGranted, CancellationToken cancellationToken = default)",
           "returnType": "Task"
         }
       ]

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -6617,6 +6617,22 @@
       ]
     },
     {
+      "name": "IPermissionGrantProvider",
+      "fqn": "Granit.Authorization.IPermissionGrantProvider",
+      "kind": "interface",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/IPermissionGrantProvider.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "GetProviderKeys",
+          "kind": "method",
+          "signature": "GetProviderKeys(PermissionGrantLookupContext context)",
+          "returnType": "string Name { get; } IReadOnlyList<string>"
+        }
+      ]
+    },
+    {
       "name": "IPermissionGrantStore",
       "fqn": "Granit.Authorization.IPermissionGrantStore",
       "kind": "interface",
@@ -6760,6 +6776,15 @@
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/PermissionDefinition.cs",
       "line": 13,
+      "members": []
+    },
+    {
+      "name": "PermissionGrantLookupContext",
+      "fqn": "Granit.Authorization.PermissionGrantLookupContext",
+      "kind": "record",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/PermissionGrantLookupContext.cs",
+      "line": 10,
       "members": []
     },
     {
@@ -42117,6 +42142,12 @@
           "kind": "property",
           "signature": "Guid? ApiKeyId",
           "returnType": "Guid?"
+        },
+        {
+          "name": "ClientId",
+          "kind": "property",
+          "signature": "string? ClientId",
+          "returnType": "string?"
         }
       ]
     },

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -6657,6 +6657,22 @@
       ]
     },
     {
+      "name": "IPermissionGrantValidator",
+      "fqn": "Granit.Authorization.IPermissionGrantValidator",
+      "kind": "interface",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/IPermissionGrantValidator.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "ValidateAsync",
+          "kind": "method",
+          "signature": "ValidateAsync(PermissionGrantValidationContext context, CancellationToken cancellationToken = default)",
+          "returnType": "ValueTask<PermissionGrantValidationResult>"
+        }
+      ]
+    },
+    {
       "name": "IPermissionManagerReader",
       "fqn": "Granit.Authorization.IPermissionManagerReader",
       "kind": "interface",
@@ -6701,6 +6717,15 @@
       ]
     },
     {
+      "name": "MultiTenancySide",
+      "fqn": "Granit.Authorization.MultiTenancySide",
+      "kind": "enum",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/MultiTenancySide.cs",
+      "line": 14,
+      "members": []
+    },
+    {
       "name": "GranitAuthorizationOptions",
       "fqn": "Granit.Authorization.Options.GranitAuthorizationOptions",
       "kind": "class",
@@ -6728,7 +6753,25 @@
       "kind": "record",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/PermissionDefinition.cs",
-      "line": 6,
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "PermissionGrantProviderNames",
+      "fqn": "Granit.Authorization.PermissionGrantProviderNames",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/PermissionGrantProviderNames.cs",
+      "line": 12,
+      "members": []
+    },
+    {
+      "name": "PermissionGrantValidationContext",
+      "fqn": "Granit.Authorization.PermissionGrantValidationContext",
+      "kind": "record",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/PermissionGrantValidationContext.cs",
+      "line": 15,
       "members": []
     },
     {
@@ -6760,7 +6803,7 @@
         {
           "name": "AddPermission",
           "kind": "method",
-          "signature": "AddPermission(string name, LocalizableString? displayName = null)",
+          "signature": "AddPermission(string name, LocalizableString? displayName = null, MultiTenancySide multiTenancySide = MultiTenancySide.Both)",
           "returnType": "PermissionDefinition"
         }
       ]
@@ -6778,6 +6821,28 @@
           "kind": "property",
           "signature": "string Name",
           "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "struct",
+      "fqn": "Granit.Authorization.struct",
+      "kind": "record",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/PermissionGrantValidationResult.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(true, null, null)",
+          "returnType": "PermissionGrantValidationResult Success { get; } ="
+        },
+        {
+          "name": "Reject",
+          "kind": "method",
+          "signature": "Reject(string reasonCode, string? reasonMessage = null)",
+          "returnType": "PermissionGrantValidationResult"
         }
       ]
     },
@@ -7806,6 +7871,12 @@
           "kind": "property",
           "signature": "string EffectiveErrorRedirectPath",
           "returnType": "string"
+        },
+        {
+          "name": "UsePushedAuthorizationRequests",
+          "kind": "property",
+          "signature": "bool UsePushedAuthorizationRequests",
+          "returnType": "bool"
         }
       ]
     },

--- a/docs-site/src/content/docs/dotnet/security/authorization-multitenancy-side.mdx
+++ b/docs-site/src/content/docs/dotnet/security/authorization-multitenancy-side.mdx
@@ -1,0 +1,191 @@
+---
+title: "Authorization — Host/Tenant scope & multi-provider grants"
+description: Tag permissions as Host, Tenant, or Both; grant them to roles, users, or OIDC clients. The checker enforces the scope at check time and follows a specific-wins-over-generic evaluation order.
+sidebar:
+  order: 4
+  label: Host/Tenant & multi-provider
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+## Why this matters
+
+A SaaS application almost always carries two kinds of authorization concerns:
+
+- **Host-level concerns** — managing tenants, reading cross-tenant audit logs, rotating
+  platform-wide secrets. Relevant only in an admin context where no tenant is active.
+- **Tenant-level concerns** — reading invoices, updating customers, approving
+  workflows. Only meaningful inside a specific tenant's scope.
+
+Without an explicit marker, nothing stops an operator from granting `Tenants.Manage` to
+a tenant user or from issuing a tenant-scoped check for an inherently host-level
+permission. Granit 2026.05 adds two aligned features that close this gap:
+
+1. A **`MultiTenancySide`** tag on every `PermissionDefinition` (`Host`, `Tenant`, `Both`).
+2. A **multi-provider grant model** (role / user / OIDC client) with a deterministic
+   evaluation order.
+
+Multi-tenancy remains optional: consumers that do not reference
+`Granit.MultiTenancy` keep their current behavior — the absent module resolves to a
+`NullTenantContext`, which is always "host-side" from the checker's point of view.
+
+## `MultiTenancySide`
+
+```csharp title="MyModulePermissionDefinitionProvider.cs"
+group.AddPermission(
+    MyPermissions.Tenants.Manage,
+    L("Permission:MyModule.Tenants.Manage"),
+    MultiTenancySide.Host);
+
+group.AddPermission(
+    MyPermissions.Invoices.Delete,
+    L("Permission:MyModule.Invoices.Delete"),
+    MultiTenancySide.Tenant);
+
+group.AddPermission(
+    MyPermissions.Profile.Read,
+    L("Permission:MyModule.Profile.Read")); // default = Both
+```
+
+The `MultiTenancySide` property on the definition is consulted by
+`IPermissionChecker.IsGrantedAsync` **before** any store lookup:
+
+- Permission is `Host` and `ICurrentTenant.IsAvailable == true` → denied, no DB hit.
+- Permission is `Tenant` and `ICurrentTenant.IsAvailable == false` → denied, no DB hit.
+- Otherwise, normal grant evaluation proceeds.
+
+At grant time, the built-in
+`MultiTenancySidePermissionGrantValidator` refuses to persist a grant whose
+`TenantId` contradicts the permission's side:
+
+| Permission side | Accepted `TenantId` on grant |
+| --- | --- |
+| `Host` | `null` only (host-level grant) |
+| `Tenant` | non-null only (tenant-scoped grant) |
+| `Both` | any |
+
+Custom validators can compose on top of the default chain via
+`TryAddEnumerable<IPermissionGrantValidator>` for domain-specific rules (e.g. reject
+if the target role does not exist in the IdP).
+
+<Aside type="tip">
+The architecture test suite only enforces that every permission has a side explicitly
+declared if you opt in — the default `Both` is always accepted. Tagging obvious
+Host-sided permissions (platform admin, tenant provisioning) closes the most common
+privilege-escalation holes without boiling the ocean.
+</Aside>
+
+## Grant providers (ABP-style)
+
+Grants are no longer role-only. A `PermissionGrant` row now carries:
+
+```csharp
+public sealed class PermissionGrant : AuditedEntity, IMultiTenant
+{
+    public string Name { get; init; }         // "Invoices.Delete"
+    public string ProviderName { get; init; } // "R" | "U" | "C"
+    public string ProviderKey { get; init; }  // role name | user id | client id
+    public Guid?  TenantId    { get; set; }   // null = host-level grant
+}
+```
+
+The storage lives in the **host schema** (aligned with Identity and OpenIddict), so a
+host admin user without a tenant can receive grants on the same footing as a
+tenant-scoped user.
+
+The canonical provider names are defined once and reused everywhere:
+
+```csharp
+public static class PermissionGrantProviderNames
+{
+    public const string Role   = "R";
+    public const string User   = "U";
+    public const string Client = "C";
+}
+```
+
+### Evaluation order
+
+Registered providers are consulted in the order they are added to the DI container.
+The default order is **specific → generic**:
+
+```text
+User (U)  ──▶  Role (R)  ──▶  Client (C)
+```
+
+A user-level grant short-circuits role and client lookups; a role-level grant
+short-circuits the client lookup. This ordering is deliberate:
+
+- It matches the principle of least surprise — explicit user permissions win.
+- It prepares a future `Deny` semantic where the most specific entry takes precedence.
+
+### Writing a custom provider
+
+A provider is a read-only projection of the current principal — it does not run the
+actual grant query (the shared `IPermissionGrantStore` handles persistence and caching).
+
+```csharp title="OrganizationPermissionGrantProvider.cs"
+internal sealed class OrganizationPermissionGrantProvider : IPermissionGrantProvider
+{
+    public string Name => "O";
+
+    public IReadOnlyList<string> GetProviderKeys(PermissionGrantLookupContext context) =>
+        // Organization id is surfaced by a custom ICurrentUserService extension;
+        // or consume IHttpContextAccessor / custom claims here.
+        OrganizationResolver.Resolve(context) is { } orgId ? [orgId] : [];
+}
+```
+
+```csharp title="Program.cs"
+builder.Services.TryAddEnumerable(
+    ServiceDescriptor.Singleton<IPermissionGrantProvider, OrganizationPermissionGrantProvider>());
+```
+
+### Granting permissions
+
+The HTTP endpoints under `POST/DELETE /api/authorization/roles/{role}/{permission}`
+still target roles. Lower-level consumers can grant to users or clients via
+`IPermissionManagerWriter.SetAsync`:
+
+```csharp
+await permissionManagerWriter.SetAsync(
+    permissionName: "Invoices.Delete",
+    providerName:  PermissionGrantProviderNames.User,
+    providerKey:   userId.ToString(),
+    tenantId:      currentTenant.Id,
+    isGranted:     true);
+```
+
+The writer runs the `IPermissionGrantValidator` chain before persisting — including
+the built-in side validator.
+
+## Cache key layout
+
+Cache keys are scoped by `(tenantId, providerName, providerKey, permissionName)` so
+that a role named `"alice"` and a user with id `"alice"` never collide:
+
+```text
+perm:{tenantId|"global"}:{providerName}:{providerKey}:{permissionName}
+```
+
+Cache invalidation (`PermissionCacheInvalidationHandler`) uses the exact same key
+layout, driven by the updated `PermissionGrantChangedEvent`.
+
+## Storage placement
+
+The `PermissionGrant` table lives in the **host schema** reached via
+`GranitDbDefaults.HostDbSchema` (with fallback to `DbSchema` for shared-database
+setups). Wire it from the host context:
+
+```csharp title="AppHostDbContext.cs"
+protected override void OnModelCreating(ModelBuilder modelBuilder)
+{
+    base.OnModelCreating(modelBuilder);
+    modelBuilder.ConfigureOpenIddictModule();
+    modelBuilder.ConfigureAuthorizationModule(); // new: grants are host-level
+}
+```
+
+Tenant-scoped grants simply carry the target `TenantId`; host-level grants have
+`TenantId == null`. A single table, a single migration — no per-tenant duplication of
+authorization state.

--- a/src/Granit.AI.Endpoints/Permissions/AIPermissionDefinitionProvider.cs
+++ b/src/Granit.AI.Endpoints/Permissions/AIPermissionDefinitionProvider.cs
@@ -39,26 +39,31 @@ internal sealed class AIPermissionDefinitionProvider : IPermissionDefinitionProv
         group.AddPermission(
             AIPermissions.Workspaces.Read,
             LocalizableString.Create<AIEndpointsLocalizationResource>(
-                "Permission:AI.Workspaces.Read"));
+                "Permission:AI.Workspaces.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             AIPermissions.Workspaces.Manage,
             LocalizableString.Create<AIEndpointsLocalizationResource>(
-                "Permission:AI.Workspaces.Manage"));
+                "Permission:AI.Workspaces.Manage"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             AIPermissions.Usage.Read,
             LocalizableString.Create<AIEndpointsLocalizationResource>(
-                "Permission:AI.Usage.Read"));
+                "Permission:AI.Usage.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             AIPermissions.Chat.Execute,
             LocalizableString.Create<AIEndpointsLocalizationResource>(
-                "Permission:AI.Chat.Execute"));
+                "Permission:AI.Chat.Execute"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             AIPermissions.Embeddings.Execute,
             LocalizableString.Create<AIEndpointsLocalizationResource>(
-                "Permission:AI.Embeddings.Execute"));
+                "Permission:AI.Embeddings.Execute"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.Auditing.Endpoints/Permissions/AuditingPermissionDefinitionProvider.cs
+++ b/src/Granit.Auditing.Endpoints/Permissions/AuditingPermissionDefinitionProvider.cs
@@ -18,14 +18,20 @@ internal sealed class AuditingPermissionDefinitionProvider : IPermissionDefiniti
             LocalizableString.Create<AuditingEndpointsLocalizationResource>(
                 "PermissionGroup:Auditing"));
 
+        // Reading audit entries is meaningful in both scopes: a tenant admin reads the
+        // tenant's entries; a host admin reads cross-tenant entries.
         group.AddPermission(
             AuditingPermissions.AuditEntries.Read,
             LocalizableString.Create<AuditingEndpointsLocalizationResource>(
-                "Permission:Auditing.AuditEntries.Read"));
+                "Permission:Auditing.AuditEntries.Read"),
+            MultiTenancySide.Both);
 
+        // Managing (pruning, redacting) audit entries is an infrastructure concern and
+        // should not be delegated to tenant admins — mis-use could break compliance trails.
         group.AddPermission(
             AuditingPermissions.AuditEntries.Manage,
             LocalizableString.Create<AuditingEndpointsLocalizationResource>(
-                "Permission:Auditing.AuditEntries.Manage"));
+                "Permission:Auditing.AuditEntries.Manage"),
+            MultiTenancySide.Host);
     }
 }

--- a/src/Granit.Authentication.ApiKeys.Endpoints/Permissions/ApiKeyPermissionDefinitionProvider.cs
+++ b/src/Granit.Authentication.ApiKeys.Endpoints/Permissions/ApiKeyPermissionDefinitionProvider.cs
@@ -20,26 +20,31 @@ internal sealed class ApiKeyPermissionDefinitionProvider : IPermissionDefinition
         group.AddPermission(
             ApiKeyPermissions.Keys.Read,
             LocalizableString.Create<ApiKeysEndpointsLocalizationResource>(
-                "Permission:AuthenticationApiKeys.Keys.Read"));
+                "Permission:AuthenticationApiKeys.Keys.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             ApiKeyPermissions.Keys.Create,
             LocalizableString.Create<ApiKeysEndpointsLocalizationResource>(
-                "Permission:AuthenticationApiKeys.Keys.Create"));
+                "Permission:AuthenticationApiKeys.Keys.Create"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             ApiKeyPermissions.Keys.Revoke,
             LocalizableString.Create<ApiKeysEndpointsLocalizationResource>(
-                "Permission:AuthenticationApiKeys.Keys.Revoke"));
+                "Permission:AuthenticationApiKeys.Keys.Revoke"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             ApiKeyPermissions.Keys.Rotate,
             LocalizableString.Create<ApiKeysEndpointsLocalizationResource>(
-                "Permission:AuthenticationApiKeys.Keys.Rotate"));
+                "Permission:AuthenticationApiKeys.Keys.Rotate"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             ApiKeyPermissions.Keys.UpdateScopes,
             LocalizableString.Create<ApiKeysEndpointsLocalizationResource>(
-                "Permission:AuthenticationApiKeys.Keys.UpdateScopes"));
+                "Permission:AuthenticationApiKeys.Keys.UpdateScopes"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.Authorization.Endpoints/Endpoints/PermissionGrantEndpoints.cs
+++ b/src/Granit.Authorization.Endpoints/Endpoints/PermissionGrantEndpoints.cs
@@ -15,6 +15,11 @@ namespace Granit.Authorization.Endpoints.Endpoints;
 /// <summary>
 /// Admin endpoints for viewing and managing role → permission grants.
 /// </summary>
+/// <remarks>
+/// These endpoints operate on the role provider (<c>"R"</c>) of the underlying ABP-style
+/// grant model. Endpoints targeting user-level (<c>"U"</c>) or OIDC-client-level (<c>"C"</c>)
+/// grants can be added in sibling modules without changing this route surface.
+/// </remarks>
 internal static partial class PermissionGrantEndpoints
 {
     /// <summary>
@@ -69,7 +74,8 @@ internal static partial class PermissionGrantEndpoints
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
 
         IReadOnlyList<string> permissions = await permissionManagerReader
-            .GetGrantedPermissionsAsync(roleName, tenantId, cancellationToken)
+            .GetGrantedPermissionsAsync(
+                PermissionGrantProviderNames.Role, roleName, tenantId, cancellationToken)
             .ConfigureAwait(false);
 
         return TypedResults.Ok(new PermissionGrantResponse(roleName, permissions));
@@ -113,7 +119,13 @@ internal static partial class PermissionGrantEndpoints
 
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
 
-        await permissionManagerWriter.SetAsync(permissionName, roleName, tenantId, isGranted: true, cancellationToken)
+        await permissionManagerWriter.SetAsync(
+                permissionName,
+                PermissionGrantProviderNames.Role,
+                roleName,
+                tenantId,
+                isGranted: true,
+                cancellationToken)
             .ConfigureAwait(false);
 
         return TypedResults.NoContent();
@@ -157,7 +169,13 @@ internal static partial class PermissionGrantEndpoints
 
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
 
-        await permissionManagerWriter.SetAsync(permissionName, roleName, tenantId, isGranted: false, cancellationToken)
+        await permissionManagerWriter.SetAsync(
+                permissionName,
+                PermissionGrantProviderNames.Role,
+                roleName,
+                tenantId,
+                isGranted: false,
+                cancellationToken)
             .ConfigureAwait(false);
 
         return TypedResults.NoContent();

--- a/src/Granit.Authorization.Endpoints/Permissions/AuthorizationEndpointsPermissionDefinitionProvider.cs
+++ b/src/Granit.Authorization.Endpoints/Permissions/AuthorizationEndpointsPermissionDefinitionProvider.cs
@@ -20,11 +20,13 @@ internal sealed class AuthorizationEndpointsPermissionDefinitionProvider : IPerm
         group.AddPermission(
             AuthorizationEndpointsPermissions.Definitions.Read,
             LocalizableString.Create<AuthorizationEndpointsLocalizationResource>(
-                "Permission:Authorization.Definitions.Read"));
+                "Permission:Authorization.Definitions.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             AuthorizationEndpointsPermissions.Grants.Manage,
             LocalizableString.Create<AuthorizationEndpointsLocalizationResource>(
-                "Permission:Authorization.Grants.Manage"));
+                "Permission:Authorization.Grants.Manage"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.Authorization.EntityFrameworkCore/DbContext/PermissionGrantModelBuilderExtensions.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/DbContext/PermissionGrantModelBuilderExtensions.cs
@@ -10,9 +10,10 @@ public static class PermissionGrantModelBuilderExtensions
     /// Applies all entity configurations for the Granit Authorization module.
     /// </summary>
     /// <remarks>
-    /// Configures the <see cref="PermissionGrant"/> entity: table name, column constraints,
-    /// and unique composite index on (TenantId, Name, RoleName).
-    /// Call this from <c>OnModelCreating</c> in the host application's DbContext.
+    /// Configures the <see cref="PermissionGrant"/> entity: host-level table name, column
+    /// constraints, and unique composite index on
+    /// <c>(TenantId, ProviderName, ProviderKey, Name)</c>. Call this from
+    /// <c>OnModelCreating</c> in the host application's DbContext.
     /// </remarks>
     public static ModelBuilder ConfigureAuthorizationModule(this ModelBuilder builder)
     {
@@ -23,10 +24,11 @@ public static class PermissionGrantModelBuilderExtensions
                 GranitAuthorizationDbProperties.DbSchema);
             entity.HasKey(e => e.Id);
             entity.Property(e => e.Name).HasMaxLength(256).IsRequired();
-            entity.Property(e => e.RoleName).HasMaxLength(256).IsRequired();
-            entity.HasIndex(e => new { e.TenantId, e.Name, e.RoleName })
+            entity.Property(e => e.ProviderName).HasMaxLength(8).IsRequired();
+            entity.Property(e => e.ProviderKey).HasMaxLength(256).IsRequired();
+            entity.HasIndex(e => new { e.TenantId, e.ProviderName, e.ProviderKey, e.Name })
                   .IsUnique()
-                  .HasDatabaseName($"uq_{GranitAuthorizationDbProperties.DbTablePrefix}permission_grants_tenant_name_role");
+                  .HasDatabaseName($"uq_{GranitAuthorizationDbProperties.DbTablePrefix}permission_grants_tenant_provider_key_name");
         });
 
         return builder;

--- a/src/Granit.Authorization.EntityFrameworkCore/GranitAuthorizationDbProperties.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/GranitAuthorizationDbProperties.cs
@@ -6,9 +6,16 @@ namespace Granit.Authorization.EntityFrameworkCore;
 /// Provides configurable table-naming properties for the Authorization EF Core module.
 /// </summary>
 /// <remarks>
+/// <para>
+/// Authorization grants are host-level: they may target host users (<c>TenantId == null</c>)
+/// or tenant-scoped users (<c>TenantId</c> set), but the storage itself always lives in the
+/// host schema alongside Identity and OpenIddict — per the ABP-aligned topology.
+/// </para>
+/// <para>
 /// <b>Important:</b> Set these properties at application startup, before
 /// <c>ConfigureServices</c> completes. EF Core caches the compiled model
 /// after first use — later mutations have no effect.
+/// </para>
 /// </remarks>
 public static class GranitAuthorizationDbProperties
 {
@@ -21,12 +28,14 @@ public static class GranitAuthorizationDbProperties
     private static bool _dbSchemaExplicitlySet;
 
     /// <summary>
-    /// Database schema for tenant-level tables.
-    /// Falls back to <see cref="GranitDbDefaults.DbSchema"/> when not explicitly set.
+    /// Database schema for authorization tables. Host-level storage:
+    /// falls back to <see cref="GranitDbDefaults.HostDbSchema"/> when not explicitly set,
+    /// then to <see cref="GranitDbDefaults.DbSchema"/> as a final fallback for
+    /// shared-database deployments.
     /// </summary>
     public static string? DbSchema
     {
-        get => _dbSchemaExplicitlySet ? _dbSchema : GranitDbDefaults.DbSchema;
+        get => _dbSchemaExplicitlySet ? _dbSchema : GranitDbDefaults.HostDbSchema ?? GranitDbDefaults.DbSchema;
         set { _dbSchema = value; _dbSchemaExplicitlySet = true; }
     }
 }

--- a/src/Granit.Authorization.EntityFrameworkCore/Stores/EfCorePermissionGrantStore.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/Stores/EfCorePermissionGrantStore.cs
@@ -19,62 +19,78 @@ internal sealed class EfCorePermissionGrantStore<TContext>(
 {
     /// <inheritdoc />
     public Task<bool> IsGrantedAsync(
-        string roleName,
+        string providerName,
+        string providerKey,
         string permissionName,
         Guid? tenantId,
         CancellationToken cancellationToken = default) =>
         context.PermissionGrants
             .AsNoTracking()
             .AnyAsync(
-                g => g.TenantId == tenantId && g.Name == permissionName && g.RoleName == roleName,
+                g => g.TenantId == tenantId
+                    && g.Name == permissionName
+                    && g.ProviderName == providerName
+                    && g.ProviderKey == providerKey,
                 cancellationToken);
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<string>> GetGrantedPermissionsAsync(
-        string roleName,
+        string providerName,
+        string providerKey,
         Guid? tenantId,
         CancellationToken cancellationToken = default) =>
         await context.PermissionGrants
             .AsNoTracking()
-            .Where(g => g.TenantId == tenantId && g.RoleName == roleName)
+            .Where(g => g.TenantId == tenantId
+                && g.ProviderName == providerName
+                && g.ProviderKey == providerKey)
             .Select(g => g.Name)
             .ToListAsync(cancellationToken).ConfigureAwait(false);
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<string>> GetGrantedAsync(
-        string roleName,
+        string providerName,
+        string providerKey,
         IReadOnlyList<string> permissionNames,
         Guid? tenantId,
         CancellationToken cancellationToken = default) =>
         await context.PermissionGrants
             .AsNoTracking()
             .Where(g => g.TenantId == tenantId
-                && g.RoleName == roleName
+                && g.ProviderName == providerName
+                && g.ProviderKey == providerKey
                 && permissionNames.Contains(g.Name))
             .Select(g => g.Name)
             .ToListAsync(cancellationToken).ConfigureAwait(false);
 
     /// <inheritdoc />
-    public async Task<IReadOnlyList<string>> GetGrantedRolesAsync(
+    public async Task<IReadOnlyList<string>> GetGranteesAsync(
+        string providerName,
         string permissionName,
         Guid? tenantId,
         CancellationToken cancellationToken = default) =>
         await context.PermissionGrants
             .AsNoTracking()
-            .Where(g => g.TenantId == tenantId && g.Name == permissionName)
-            .Select(g => g.RoleName)
+            .Where(g => g.TenantId == tenantId
+                && g.Name == permissionName
+                && g.ProviderName == providerName)
+            .Select(g => g.ProviderKey)
             .ToListAsync(cancellationToken).ConfigureAwait(false);
 
     /// <inheritdoc />
     public async Task<bool> GrantAsync(
+        string providerName,
+        string providerKey,
         string permissionName,
-        string roleName,
         Guid? tenantId,
         CancellationToken cancellationToken = default)
     {
         bool exists = await context.PermissionGrants
             .AnyAsync(
-                g => g.TenantId == tenantId && g.Name == permissionName && g.RoleName == roleName,
+                g => g.TenantId == tenantId
+                    && g.Name == permissionName
+                    && g.ProviderName == providerName
+                    && g.ProviderKey == providerKey,
                 cancellationToken).ConfigureAwait(false);
 
         if (exists)
@@ -86,7 +102,8 @@ internal sealed class EfCorePermissionGrantStore<TContext>(
         {
             Id = guidGenerator.Create(),
             Name = permissionName,
-            RoleName = roleName,
+            ProviderName = providerName,
+            ProviderKey = providerKey,
             TenantId = tenantId
         });
 
@@ -106,14 +123,18 @@ internal sealed class EfCorePermissionGrantStore<TContext>(
 
     /// <inheritdoc />
     public async Task<bool> RevokeAsync(
+        string providerName,
+        string providerKey,
         string permissionName,
-        string roleName,
         Guid? tenantId,
         CancellationToken cancellationToken = default)
     {
         PermissionGrant? existing = await context.PermissionGrants
             .FirstOrDefaultAsync(
-                g => g.TenantId == tenantId && g.Name == permissionName && g.RoleName == roleName,
+                g => g.TenantId == tenantId
+                    && g.Name == permissionName
+                    && g.ProviderName == providerName
+                    && g.ProviderKey == providerKey,
                 cancellationToken).ConfigureAwait(false);
 
         if (existing is null)

--- a/src/Granit.Authorization/Cache/PermissionCacheInvalidationHandler.cs
+++ b/src/Granit.Authorization/Cache/PermissionCacheInvalidationHandler.cs
@@ -25,7 +25,7 @@ namespace Granit.Authorization.Cache;
 public class PermissionCacheInvalidationHandler
 {
     /// <summary>
-    /// Invalidates the cached permission grant entry for the changed role and tenant scope.
+    /// Invalidates the cached permission grant entry for the changed grantee and tenant scope.
     /// </summary>
     public static async Task HandleAsync(
         PermissionGrantChangedEvent @event,
@@ -33,7 +33,7 @@ public class PermissionCacheInvalidationHandler
         CancellationToken cancellationToken)
     {
         string key = PermissionChecker.BuildCacheKey(
-            @event.TenantId, @event.RoleName, @event.PermissionName);
+            @event.TenantId, @event.ProviderName, @event.ProviderKey, @event.PermissionName);
 
         if (@event.IsGranted)
         {

--- a/src/Granit.Authorization/Domain/PermissionGrant.cs
+++ b/src/Granit.Authorization/Domain/PermissionGrant.cs
@@ -3,20 +3,38 @@ using Granit.Domain;
 namespace Granit.Authorization.Domain;
 
 /// <summary>
-/// Represents an explicit grant of a permission to a role within a tenant.
-/// RBAC strict: no UserId column — permissions are assigned to roles, never to individual users.
-/// Audited via <see cref="AuditedEntity"/> interceptor (CreatedAt, CreatedBy, ModifiedAt, ModifiedBy).
+/// Represents an explicit grant of a permission to a grantee (role, user, or OIDC client)
+/// scoped to a tenant (or host if <see cref="TenantId"/> is <see langword="null"/>).
 /// </summary>
+/// <remarks>
+/// <para>
+/// ABP-style multi-provider model: <see cref="ProviderName"/> identifies the grantee kind
+/// (<c>"R"</c> for role, <c>"U"</c> for user, <c>"C"</c> for OIDC client) and
+/// <see cref="ProviderKey"/> holds the provider-specific identifier (role name, user id,
+/// client id). Extension points may introduce additional providers (organization, group,
+/// geography) without schema changes.
+/// </para>
+/// <para>
+/// Audited via <see cref="AuditedEntity"/> interceptor (CreatedAt, CreatedBy, ModifiedAt,
+/// ModifiedBy). Unique index covers <c>(TenantId, ProviderName, ProviderKey, Name)</c>.
+/// </para>
+/// </remarks>
 public sealed class PermissionGrant : AuditedEntity, IMultiTenant
 {
-    /// <summary>Permission name, e.g. "Invoices.Delete". Max 256 characters.</summary>
+    /// <summary>Permission name, e.g. <c>"Invoices.Delete"</c>. Max 256 characters.</summary>
     public string Name { get; init; } = string.Empty;
 
     /// <summary>
-    /// Role name from the identity provider (Keycloak realm role, ASP.NET Core Identity role, etc.).
-    /// Max 256 characters.
+    /// Provider identifier for the grantee. Use <see cref="PermissionGrantProviderNames"/>
+    /// constants: <c>"R"</c> (role), <c>"U"</c> (user), <c>"C"</c> (OIDC client). Max 8 characters.
     /// </summary>
-    public string RoleName { get; init; } = string.Empty;
+    public string ProviderName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Provider-specific grantee key: role name for <c>"R"</c>, user id for <c>"U"</c>,
+    /// OIDC <c>client_id</c> for <c>"C"</c>. Max 256 characters.
+    /// </summary>
+    public string ProviderKey { get; init; } = string.Empty;
 
     /// <summary>Tenant scope. Null means the grant applies at the host (cross-tenant) level.</summary>
     /// <remarks>Keeps <c>set</c> to satisfy <see cref="IMultiTenant"/> interceptor injection.</remarks>

--- a/src/Granit.Authorization/Events/PermissionGrantChangedEvent.cs
+++ b/src/Granit.Authorization/Events/PermissionGrantChangedEvent.cs
@@ -1,19 +1,22 @@
 namespace Granit.Authorization.Events;
 
 /// <summary>
-/// Raised when a permission grant is created or revoked for a role.
+/// Raised when a permission grant is created or revoked for a grantee (role, user, or
+/// OIDC client).
 /// </summary>
 /// <remarks>
 /// Consumed by <see cref="Cache.PermissionCacheInvalidationHandler"/> to remove the stale
 /// entry from <see cref="Caching.ICacheService{PermissionGrantCacheItem}"/>.
-/// Publish this event after any <see cref="Abstractions.IPermissionManagerWriter"/> mutation.
+/// Publish this event after any <see cref="IPermissionManagerWriter"/> mutation.
 /// </remarks>
 /// <param name="PermissionName">The permission that was granted or revoked.</param>
-/// <param name="RoleName">The role whose grant changed.</param>
-/// <param name="TenantId">The tenant scope, or <c>null</c> for a global change.</param>
+/// <param name="ProviderName">Provider identifier for the grantee (<c>"R"</c>, <c>"U"</c>, <c>"C"</c>).</param>
+/// <param name="ProviderKey">Provider-specific key (role name, user id, client id).</param>
+/// <param name="TenantId">The tenant scope, or <c>null</c> for a host-level change.</param>
 /// <param name="IsGranted">Whether the permission was granted (<c>true</c>) or revoked (<c>false</c>).</param>
 public sealed record PermissionGrantChangedEvent(
     string PermissionName,
-    string RoleName,
+    string ProviderName,
+    string ProviderKey,
     Guid? TenantId,
     bool IsGranted);

--- a/src/Granit.Authorization/Exports/PermissionGrantExportDefinition.cs
+++ b/src/Granit.Authorization/Exports/PermissionGrantExportDefinition.cs
@@ -12,7 +12,8 @@ public sealed class PermissionGrantExportDefinition : ExportDefinition<Permissio
         builder
             .IncludeId()
             .Field(p => p.Name)
-            .Field(p => p.RoleName)
+            .Field(p => p.ProviderName)
+            .Field(p => p.ProviderKey)
             .Field(p => p.TenantId)
             .Field(p => p.CreatedAt, f => f.Format("O"))
             .Field(p => p.CreatedBy)

--- a/src/Granit.Authorization/Extensions/AuthorizationServiceCollectionExtensions.cs
+++ b/src/Granit.Authorization/Extensions/AuthorizationServiceCollectionExtensions.cs
@@ -38,6 +38,9 @@ public static class AuthorizationServiceCollectionExtensions
         services.AddScoped<IPermissionManagerReader, PermissionManager>();
         services.AddScoped<IPermissionManagerWriter, PermissionManager>();
 
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            IPermissionGrantValidator, MultiTenancySidePermissionGrantValidator>());
+
         services.AddSingleton<IAuthorizationPolicyProvider, DynamicPermissionPolicyProvider>();
         services.AddScoped<IAuthorizationHandler, PermissionAuthorizationHandler>();
 

--- a/src/Granit.Authorization/Extensions/AuthorizationServiceCollectionExtensions.cs
+++ b/src/Granit.Authorization/Extensions/AuthorizationServiceCollectionExtensions.cs
@@ -41,6 +41,17 @@ public static class AuthorizationServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IPermissionGrantValidator, MultiTenancySidePermissionGrantValidator>());
 
+        // Grant providers evaluated in the order below: specific → generic.
+        // A user-level grant short-circuits role and client checks; a role-level grant
+        // short-circuits the client check. This ordering also prepares a future "Deny"
+        // semantic where the most specific grant wins.
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            IPermissionGrantProvider, UserPermissionGrantProvider>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            IPermissionGrantProvider, RolePermissionGrantProvider>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            IPermissionGrantProvider, ClientPermissionGrantProvider>());
+
         services.AddSingleton<IAuthorizationPolicyProvider, DynamicPermissionPolicyProvider>();
         services.AddScoped<IAuthorizationHandler, PermissionAuthorizationHandler>();
 

--- a/src/Granit.Authorization/Extensions/HostAccessEndpointExtensions.cs
+++ b/src/Granit.Authorization/Extensions/HostAccessEndpointExtensions.cs
@@ -1,6 +1,7 @@
 using Granit.Authorization.Filters;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 
 namespace Granit.Authorization.Extensions;
 
@@ -30,4 +31,15 @@ public static class HostAccessEndpointExtensions
     public static RouteHandlerBuilder AllowHostAccess(
         this RouteHandlerBuilder builder) =>
         builder.AddEndpointFilter(new RequireHostContextEndpointFilter());
+
+    /// <summary>
+    /// Marks every endpoint in the route group as accessible from host context. Equivalent
+    /// to calling <see cref="AllowHostAccess(RouteHandlerBuilder)"/> on each handler.
+    /// </summary>
+    public static RouteGroupBuilder AllowHostAccess(
+        this RouteGroupBuilder group)
+    {
+        group.AddEndpointFilter(new RequireHostContextEndpointFilter());
+        return group;
+    }
 }

--- a/src/Granit.Authorization/IPermissionGrantProvider.cs
+++ b/src/Granit.Authorization/IPermissionGrantProvider.cs
@@ -1,0 +1,28 @@
+namespace Granit.Authorization;
+
+/// <summary>
+/// Extracts the grantee identifiers that the permission checker should consult for a given
+/// principal. Registered via <c>TryAddEnumerable</c>; evaluated by <c>PermissionChecker</c>
+/// in the order they are registered (specific → generic: User, Role, Client).
+/// </summary>
+/// <remarks>
+/// Providers are deliberately read-only projections of a <see cref="PermissionGrantLookupContext"/>.
+/// They do not execute grant lookups themselves; the shared <see cref="IPermissionGrantStore"/>
+/// handles persistence and the shared cache handles memoization. A custom provider only needs
+/// to decide which keys to look up (role names, org ids, geography codes, etc.).
+/// </remarks>
+public interface IPermissionGrantProvider
+{
+    /// <summary>
+    /// Provider identifier written into <see cref="Domain.PermissionGrant.ProviderName"/>.
+    /// Use <see cref="PermissionGrantProviderNames"/> constants for the built-in providers.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Returns the provider keys to consult for the current principal. An empty list means
+    /// the provider has nothing to contribute (e.g. anonymous user for the user provider).
+    /// Multiple keys (typical for roles) are queried one-by-one until any grants the permission.
+    /// </summary>
+    IReadOnlyList<string> GetProviderKeys(PermissionGrantLookupContext context);
+}

--- a/src/Granit.Authorization/IPermissionGrantStore.cs
+++ b/src/Granit.Authorization/IPermissionGrantStore.cs
@@ -1,7 +1,8 @@
 namespace Granit.Authorization;
 
 /// <summary>
-/// Data access layer for permission grants.
+/// Data access layer for permission grants. Operates on the ABP-style
+/// <c>(providerName, providerKey, permissionName, tenantId)</c> tuple.
 /// Called by <see cref="IPermissionChecker"/> (read) and <c>PermissionManager</c> (read/write).
 /// Default implementation is <c>NullPermissionGrantStore</c> (always false, writes are no-ops).
 /// Override with <c>Granit.Authorization.EntityFrameworkCore</c> for persistence.
@@ -9,57 +10,65 @@ namespace Granit.Authorization;
 public interface IPermissionGrantStore
 {
     /// <summary>
-    /// Returns true if the specified role has been explicitly granted the permission in the given tenant.
+    /// Returns <see langword="true"/> if the specified grantee has been explicitly granted
+    /// <paramref name="permissionName"/> in the given tenant.
     /// </summary>
     Task<bool> IsGrantedAsync(
-        string roleName,
+        string providerName,
+        string providerKey,
         string permissionName,
         Guid? tenantId,
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Returns all permission names explicitly granted to the role in the given tenant.
+    /// Returns all permission names explicitly granted to the grantee in the given tenant.
     /// </summary>
     Task<IReadOnlyList<string>> GetGrantedPermissionsAsync(
-        string roleName,
+        string providerName,
+        string providerKey,
         Guid? tenantId,
         CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns the subset of <paramref name="permissionNames"/> that are explicitly granted
-    /// to the role in the given tenant. Filters with a single <c>WHERE IN</c> clause.
+    /// to the grantee in the given tenant. Filters with a single <c>WHERE IN</c> clause.
     /// </summary>
     Task<IReadOnlyList<string>> GetGrantedAsync(
-        string roleName,
+        string providerName,
+        string providerKey,
         IReadOnlyList<string> permissionNames,
         Guid? tenantId,
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Returns all role names that have been explicitly granted the permission in the given tenant.
+    /// Returns all grantee keys of the specified <paramref name="providerName"/> that have
+    /// been explicitly granted <paramref name="permissionName"/> in the given tenant.
     /// </summary>
-    Task<IReadOnlyList<string>> GetGrantedRolesAsync(
+    Task<IReadOnlyList<string>> GetGranteesAsync(
+        string providerName,
         string permissionName,
         Guid? tenantId,
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Creates a permission grant for the specified role in the given tenant.
-    /// Returns true if the grant was created, false if it already existed (idempotent).
+    /// Creates a permission grant for the specified grantee in the given tenant.
+    /// Returns <see langword="true"/> if the grant was created, <see langword="false"/> if it already existed (idempotent).
     /// </summary>
     Task<bool> GrantAsync(
+        string providerName,
+        string providerKey,
         string permissionName,
-        string roleName,
         Guid? tenantId,
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Removes a permission grant for the specified role in the given tenant.
-    /// Returns true if the grant was removed, false if it did not exist (idempotent).
+    /// Removes a permission grant for the specified grantee in the given tenant.
+    /// Returns <see langword="true"/> if the grant was removed, <see langword="false"/> if it did not exist (idempotent).
     /// </summary>
     Task<bool> RevokeAsync(
+        string providerName,
+        string providerKey,
         string permissionName,
-        string roleName,
         Guid? tenantId,
         CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Authorization/IPermissionGrantValidator.cs
+++ b/src/Granit.Authorization/IPermissionGrantValidator.cs
@@ -1,0 +1,21 @@
+namespace Granit.Authorization;
+
+/// <summary>
+/// Validates a permission grant before it is written to the store.
+/// Multiple validators compose via <c>TryAddEnumerable</c> + fail-fast evaluation.
+/// </summary>
+/// <remarks>
+/// Built-in validators rejected can be augmented by consumers (e.g. forbid granting a
+/// permission to a role that does not exist in the current identity provider).
+/// </remarks>
+public interface IPermissionGrantValidator
+{
+    /// <summary>
+    /// Validates the grant. Return <see cref="PermissionGrantValidationResult.Success"/> to
+    /// accept, or <see cref="PermissionGrantValidationResult.Reject"/> with a machine-readable
+    /// reason code to refuse.
+    /// </summary>
+    ValueTask<PermissionGrantValidationResult> ValidateAsync(
+        PermissionGrantValidationContext context,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Authorization/IPermissionManagerReader.cs
+++ b/src/Granit.Authorization/IPermissionManagerReader.cs
@@ -1,26 +1,33 @@
 namespace Granit.Authorization;
 
 /// <summary>
-/// Read-only service for querying role → permission grants.
+/// Read-only service for querying grant state via the ABP-style
+/// <c>(providerName, providerKey)</c> tuple.
 /// Available only when <c>Granit.Authorization.EntityFrameworkCore</c> is registered.
 /// </summary>
 public interface IPermissionManagerReader
 {
-    /// <summary>Returns true if the role has been explicitly granted the permission.</summary>
+    /// <summary>Returns true if the grantee has been explicitly granted the permission.</summary>
     Task<bool> IsGrantedAsync(
         string permissionName,
-        string roleName,
+        string providerName,
+        string providerKey,
         Guid? tenantId,
         CancellationToken cancellationToken = default);
 
-    /// <summary>Returns all permission names explicitly granted to the role in the given tenant.</summary>
+    /// <summary>Returns all permission names explicitly granted to the grantee in the given tenant.</summary>
     Task<IReadOnlyList<string>> GetGrantedPermissionsAsync(
-        string roleName,
+        string providerName,
+        string providerKey,
         Guid? tenantId,
         CancellationToken cancellationToken = default);
 
-    /// <summary>Returns all role names that have been explicitly granted the permission in the given tenant.</summary>
-    Task<IReadOnlyList<string>> GetGrantedRolesAsync(
+    /// <summary>
+    /// Returns all grantee keys of the specified <paramref name="providerName"/> that have been
+    /// explicitly granted <paramref name="permissionName"/> in the given tenant.
+    /// </summary>
+    Task<IReadOnlyList<string>> GetGranteesAsync(
+        string providerName,
         string permissionName,
         Guid? tenantId,
         CancellationToken cancellationToken = default);

--- a/src/Granit.Authorization/IPermissionManagerWriter.cs
+++ b/src/Granit.Authorization/IPermissionManagerWriter.cs
@@ -1,22 +1,26 @@
 namespace Granit.Authorization;
 
 /// <summary>
-/// Administrative service for mutating role → permission grants.
-/// Each call to <see cref="SetAsync"/> emits an ISO 27001 audit log entry and invalidates the cache.
+/// Administrative service for mutating grants in the ABP-style
+/// <c>(providerName, providerKey)</c> model.
+/// Each call to <see cref="SetAsync"/> runs the <see cref="IPermissionGrantValidator"/> chain
+/// (for additions), emits an ISO 27001 audit log entry, and invalidates the cache.
 /// Available only when <c>Granit.Authorization.EntityFrameworkCore</c> is registered.
 /// </summary>
 public interface IPermissionManagerWriter
 {
     /// <summary>
-    /// Grants or revokes a permission for a role within a tenant.
+    /// Grants or revokes a permission for a grantee within a tenant.
     /// No-op if the current state already matches <paramref name="isGranted"/>.
     /// </summary>
     /// <exception cref="InvalidOperationException">
-    /// Thrown if <paramref name="permissionName"/> has not been declared.
+    /// Thrown if <paramref name="permissionName"/> has not been declared, or if any
+    /// <see cref="IPermissionGrantValidator"/> rejects the grant.
     /// </exception>
     Task SetAsync(
         string permissionName,
-        string roleName,
+        string providerName,
+        string providerKey,
         Guid? tenantId,
         bool isGranted,
         CancellationToken cancellationToken = default);

--- a/src/Granit.Authorization/MultiTenancySide.cs
+++ b/src/Granit.Authorization/MultiTenancySide.cs
@@ -1,0 +1,24 @@
+namespace Granit.Authorization;
+
+/// <summary>
+/// Scope of a permission relative to the host/tenant boundary.
+/// </summary>
+/// <remarks>
+/// Evaluated by <see cref="IPermissionChecker"/> before grant lookup, using <c>ICurrentTenant</c>
+/// (soft dependency on <c>Granit.MultiTenancy</c>). When the multi-tenancy module is absent, the
+/// current tenant is never available and only <see cref="Host"/> / <see cref="Both"/> permissions
+/// are grantable — consumers without multi-tenancy simply don't declare <see cref="Tenant"/>
+/// permissions, so the behavior remains coherent.
+/// </remarks>
+[Flags]
+public enum MultiTenancySide
+{
+    /// <summary>Permission is grantable only when no tenant context is active (host-level admin, cross-tenant operations).</summary>
+    Host = 1 << 0,
+
+    /// <summary>Permission is grantable only when a tenant context is active (per-tenant operations).</summary>
+    Tenant = 1 << 1,
+
+    /// <summary>Permission is grantable in both host and tenant contexts. Default for legacy permissions.</summary>
+    Both = Host | Tenant,
+}

--- a/src/Granit.Authorization/PermissionDefinition.cs
+++ b/src/Granit.Authorization/PermissionDefinition.cs
@@ -3,4 +3,15 @@ using Granit.Localization;
 namespace Granit.Authorization;
 
 /// <summary>Defines a single permission that can be granted to a role.</summary>
-public sealed record PermissionDefinition(string Name, LocalizableString? DisplayName, string GroupName);
+/// <param name="Name">Unique permission name, e.g. <c>"Invoices.Delete"</c>.</param>
+/// <param name="DisplayName">Optional localizable label for admin UIs.</param>
+/// <param name="GroupName">Name of the group this permission belongs to.</param>
+/// <param name="MultiTenancySide">
+/// Tenant/host scope of the permission. Defaults to <see cref="MultiTenancySide.Both"/> for
+/// backwards compatibility with existing permission declarations.
+/// </param>
+public sealed record PermissionDefinition(
+    string Name,
+    LocalizableString? DisplayName,
+    string GroupName,
+    MultiTenancySide MultiTenancySide = MultiTenancySide.Both);

--- a/src/Granit.Authorization/PermissionGrantLookupContext.cs
+++ b/src/Granit.Authorization/PermissionGrantLookupContext.cs
@@ -1,0 +1,13 @@
+namespace Granit.Authorization;
+
+/// <summary>
+/// Immutable projection of the current principal consumed by
+/// <see cref="IPermissionGrantProvider"/> implementations.
+/// </summary>
+/// <param name="UserId">Subject (<c>sub</c>) claim value, or <see langword="null"/> for anonymous.</param>
+/// <param name="Roles">Role claims associated with the principal (never <see langword="null"/>, possibly empty).</param>
+/// <param name="ClientId">OIDC <c>client_id</c> claim value, or <see langword="null"/> when absent.</param>
+public sealed record PermissionGrantLookupContext(
+    string? UserId,
+    IReadOnlyList<string> Roles,
+    string? ClientId);

--- a/src/Granit.Authorization/PermissionGrantProviderNames.cs
+++ b/src/Granit.Authorization/PermissionGrantProviderNames.cs
@@ -1,0 +1,22 @@
+namespace Granit.Authorization;
+
+/// <summary>
+/// Canonical provider names identifying the grantee of a <see cref="Domain.PermissionGrant"/>.
+/// Kept short for compact storage — single-char letters match ABP's convention.
+/// </summary>
+/// <remarks>
+/// Extend this type with additional providers (e.g. <c>"O"</c> for organization, <c>"G"</c> for
+/// AD group) as custom <see cref="IPermissionGrantValidator"/> and grant manager extensions
+/// evolve.
+/// </remarks>
+public static class PermissionGrantProviderNames
+{
+    /// <summary>Provider name for role-based grants: <c>ProviderKey</c> holds the role name.</summary>
+    public const string Role = "R";
+
+    /// <summary>Provider name for user-based grants: <c>ProviderKey</c> holds the user's <c>sub</c> (GUID or opaque id).</summary>
+    public const string User = "U";
+
+    /// <summary>Provider name for OIDC client-based grants: <c>ProviderKey</c> holds the <c>client_id</c>.</summary>
+    public const string Client = "C";
+}

--- a/src/Granit.Authorization/PermissionGrantValidationContext.cs
+++ b/src/Granit.Authorization/PermissionGrantValidationContext.cs
@@ -1,0 +1,20 @@
+namespace Granit.Authorization;
+
+/// <summary>
+/// Context passed to each <see cref="IPermissionGrantValidator"/> when evaluating a grant
+/// before it is persisted.
+/// </summary>
+/// <param name="PermissionName">The permission being granted (e.g. <c>"Invoices.Delete"</c>).</param>
+/// <param name="ProviderName">Provider identifier for the grantee: <c>"R"</c> (role), <c>"U"</c> (user), <c>"C"</c> (OIDC client).</param>
+/// <param name="ProviderKey">Provider-specific key: role name, user id, or client id.</param>
+/// <param name="TenantId">
+/// Target tenant scope. <see langword="null"/> means the grant is host-level (cross-tenant
+/// or infrastructure-level).
+/// </param>
+/// <param name="Definition">The resolved permission definition (includes <see cref="MultiTenancySide"/>).</param>
+public sealed record PermissionGrantValidationContext(
+    string PermissionName,
+    string ProviderName,
+    string ProviderKey,
+    Guid? TenantId,
+    PermissionDefinition Definition);

--- a/src/Granit.Authorization/PermissionGrantValidationResult.cs
+++ b/src/Granit.Authorization/PermissionGrantValidationResult.cs
@@ -1,0 +1,20 @@
+namespace Granit.Authorization;
+
+/// <summary>
+/// Outcome of an <see cref="IPermissionGrantValidator"/> evaluation.
+/// </summary>
+public readonly record struct PermissionGrantValidationResult(
+    bool IsValid,
+    string? ReasonCode,
+    string? ReasonMessage)
+{
+    /// <summary>Accept the grant.</summary>
+    public static PermissionGrantValidationResult Success { get; } = new(true, null, null);
+
+    /// <summary>
+    /// Reject the grant with a machine-readable <paramref name="reasonCode"/> and an optional
+    /// human-readable <paramref name="reasonMessage"/> (server-side logs, not exposed to the client).
+    /// </summary>
+    public static PermissionGrantValidationResult Reject(string reasonCode, string? reasonMessage = null) =>
+        new(false, reasonCode, reasonMessage);
+}

--- a/src/Granit.Authorization/PermissionGroup.cs
+++ b/src/Granit.Authorization/PermissionGroup.cs
@@ -17,9 +17,12 @@ public sealed class PermissionGroup(string name, LocalizableString? displayName 
     public IReadOnlyList<PermissionDefinition> Permissions => _permissions.AsReadOnly();
 
     /// <summary>Adds a permission to this group and returns its definition.</summary>
-    public PermissionDefinition AddPermission(string name, LocalizableString? displayName = null)
+    public PermissionDefinition AddPermission(
+        string name,
+        LocalizableString? displayName = null,
+        MultiTenancySide multiTenancySide = MultiTenancySide.Both)
     {
-        PermissionDefinition definition = new(name, displayName, Name);
+        PermissionDefinition definition = new(name, displayName, Name, multiTenancySide);
         _permissions.Add(definition);
         return definition;
     }

--- a/src/Granit.Authorization/Queries/PermissionGrantQueryDefinition.cs
+++ b/src/Granit.Authorization/Queries/PermissionGrantQueryDefinition.cs
@@ -18,10 +18,11 @@ public sealed class PermissionGrantQueryDefinition : QueryDefinition<PermissionG
         builder
             .Column(p => p.TenantId, c => c.Label("Tenant").LabelKey("Authorization.Columns.Tenant").Filterable().Sortable())
             .Column(p => p.Name, c => c.Label("Permission").LabelKey("Authorization.Columns.Permission").Filterable().Sortable())
-            .Column(p => p.RoleName, c => c.Label("Role").LabelKey("Authorization.Columns.Role").Filterable().Sortable())
+            .Column(p => p.ProviderName, c => c.Label("Provider").LabelKey("Authorization.Columns.Provider").Filterable().Sortable())
+            .Column(p => p.ProviderKey, c => c.Label("Grantee").LabelKey("Authorization.Columns.Grantee").Filterable().Sortable())
             .Column(p => p.CreatedAt, c => c.Label("Created At").LabelKey("Authorization.Columns.CreatedAt").Sortable())
             .Column(p => p.ModifiedAt, c => c.Label("Modified At").LabelKey("Authorization.Columns.ModifiedAt").Sortable())
-            .GlobalSearch(p => p.Name, p => p.RoleName)
+            .GlobalSearch(p => p.Name, p => p.ProviderKey)
             .DateFilter(p => p.CreatedAt)
             .DefaultSort("-createdAt")
             .DefaultPageSize(25);

--- a/src/Granit.Authorization/Services/ClientPermissionGrantProvider.cs
+++ b/src/Granit.Authorization/Services/ClientPermissionGrantProvider.cs
@@ -1,0 +1,20 @@
+namespace Granit.Authorization.Services;
+
+/// <summary>
+/// Grants evaluated against the OIDC <c>client_id</c> of the current principal. Evaluated
+/// last in the default order: client-wide grants are the coarsest level of authorization
+/// and should not shadow user- or role-specific grants.
+/// </summary>
+/// <remarks>
+/// Typical use: machine-to-machine callers authenticated via client credentials, where no
+/// user or role claims are present but the client itself is trusted for a set of permissions.
+/// </remarks>
+internal sealed class ClientPermissionGrantProvider : IPermissionGrantProvider
+{
+    /// <inheritdoc />
+    public string Name => PermissionGrantProviderNames.Client;
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> GetProviderKeys(PermissionGrantLookupContext context) =>
+        string.IsNullOrEmpty(context.ClientId) ? [] : [context.ClientId];
+}

--- a/src/Granit.Authorization/Services/MultiTenancySidePermissionGrantValidator.cs
+++ b/src/Granit.Authorization/Services/MultiTenancySidePermissionGrantValidator.cs
@@ -1,0 +1,38 @@
+namespace Granit.Authorization.Services;
+
+/// <summary>
+/// Rejects permission grants whose target scope contradicts the permission's declared
+/// <see cref="MultiTenancySide"/>:
+/// <list type="bullet">
+/// <item><see cref="MultiTenancySide.Host"/> permissions must be granted with <c>TenantId == null</c>.</item>
+/// <item><see cref="MultiTenancySide.Tenant"/> permissions must be granted with a non-null <c>TenantId</c>.</item>
+/// <item><see cref="MultiTenancySide.Both"/> permissions are accepted regardless.</item>
+/// </list>
+/// Registered by default via <c>GranitAuthorizationModule</c>.
+/// </summary>
+internal sealed class MultiTenancySidePermissionGrantValidator : IPermissionGrantValidator
+{
+    /// <inheritdoc />
+    public ValueTask<PermissionGrantValidationResult> ValidateAsync(
+        PermissionGrantValidationContext context,
+        CancellationToken cancellationToken = default)
+    {
+        MultiTenancySide side = context.Definition.MultiTenancySide;
+
+        if (!side.HasFlag(MultiTenancySide.Host) && context.TenantId is null)
+        {
+            return ValueTask.FromResult(PermissionGrantValidationResult.Reject(
+                "side_host_forbidden",
+                $"Permission '{context.PermissionName}' is Tenant-only; host-level grant (TenantId == null) refused."));
+        }
+
+        if (!side.HasFlag(MultiTenancySide.Tenant) && context.TenantId is not null)
+        {
+            return ValueTask.FromResult(PermissionGrantValidationResult.Reject(
+                "side_tenant_forbidden",
+                $"Permission '{context.PermissionName}' is Host-only; tenant-scoped grant refused."));
+        }
+
+        return ValueTask.FromResult(PermissionGrantValidationResult.Success);
+    }
+}

--- a/src/Granit.Authorization/Services/NullPermissionGrantStore.cs
+++ b/src/Granit.Authorization/Services/NullPermissionGrantStore.cs
@@ -16,54 +16,60 @@ internal sealed partial class NullPermissionGrantStore(
 
     /// <inheritdoc />
     public Task<bool> IsGrantedAsync(
-        string roleName,
+        string providerName,
+        string providerKey,
         string permissionName,
         Guid? tenantId,
         CancellationToken cancellationToken = default) => Task.FromResult(false);
 
     /// <inheritdoc />
     public Task<IReadOnlyList<string>> GetGrantedPermissionsAsync(
-        string roleName,
+        string providerName,
+        string providerKey,
         Guid? tenantId,
         CancellationToken cancellationToken = default) => Task.FromResult(Empty);
 
     /// <inheritdoc />
     public Task<IReadOnlyList<string>> GetGrantedAsync(
-        string roleName,
+        string providerName,
+        string providerKey,
         IReadOnlyList<string> permissionNames,
         Guid? tenantId,
         CancellationToken cancellationToken = default) => Task.FromResult(Empty);
 
     /// <inheritdoc />
-    public Task<IReadOnlyList<string>> GetGrantedRolesAsync(
+    public Task<IReadOnlyList<string>> GetGranteesAsync(
+        string providerName,
         string permissionName,
         Guid? tenantId,
         CancellationToken cancellationToken = default) => Task.FromResult(Empty);
 
     /// <inheritdoc />
     public Task<bool> GrantAsync(
+        string providerName,
+        string providerKey,
         string permissionName,
-        string roleName,
         Guid? tenantId,
         CancellationToken cancellationToken = default)
     {
-        LogWriteDiscarded("Grant", permissionName, roleName);
+        LogWriteDiscarded("Grant", permissionName, providerName, providerKey);
         return Task.FromResult(false);
     }
 
     /// <inheritdoc />
     public Task<bool> RevokeAsync(
+        string providerName,
+        string providerKey,
         string permissionName,
-        string roleName,
         Guid? tenantId,
         CancellationToken cancellationToken = default)
     {
-        LogWriteDiscarded("Revoke", permissionName, roleName);
+        LogWriteDiscarded("Revoke", permissionName, providerName, providerKey);
         return Task.FromResult(false);
     }
 
     [LoggerMessage(Level = LogLevel.Warning,
-        Message = "NullPermissionGrantStore is active — {Operation} for permission={PermissionName} role={RoleName} was discarded. " +
+        Message = "NullPermissionGrantStore is active — {Operation} for permission={PermissionName} provider={ProviderName} key={ProviderKey} was discarded. " +
                   "Register Granit.Authorization.EntityFrameworkCore for persistence.")]
-    private partial void LogWriteDiscarded(string operation, string permissionName, string roleName);
+    private partial void LogWriteDiscarded(string operation, string permissionName, string providerName, string providerKey);
 }

--- a/src/Granit.Authorization/Services/PermissionChecker.cs
+++ b/src/Granit.Authorization/Services/PermissionChecker.cs
@@ -74,12 +74,14 @@ internal sealed class PermissionChecker(
         foreach (string role in roles)
         {
             PermissionGrantCacheItem result = await cache.GetOrSetAsync<PermissionGrantCacheItem>(
-                BuildCacheKey(tenantId, role, permissionName),
+                BuildCacheKey(tenantId, PermissionGrantProviderNames.Role, role, permissionName),
                 async (_, ct) =>
                 {
                     metrics.RecordCacheMiss(tenantIdStr);
                     return new PermissionGrantCacheItem(
-                        await grantStore.IsGrantedAsync(role, permissionName, tenantId, ct).ConfigureAwait(false));
+                        await grantStore.IsGrantedAsync(
+                            PermissionGrantProviderNames.Role, role, permissionName, tenantId, ct)
+                        .ConfigureAwait(false));
                 },
                 new FusionCacheEntryOptions { Duration = opts.CacheDuration },
                 token: cancellationToken).ConfigureAwait(false);
@@ -179,7 +181,7 @@ internal sealed class PermissionChecker(
         foreach (string role in roles)
         {
             MaybeValue<PermissionGrantCacheItem> cached = await cache.TryGetAsync<PermissionGrantCacheItem>(
-                BuildCacheKey(tenantId, role, permissionName),
+                BuildCacheKey(tenantId, PermissionGrantProviderNames.Role, role, permissionName),
                 token: cancellationToken).ConfigureAwait(false);
 
             if (cached.HasValue)
@@ -210,7 +212,7 @@ internal sealed class PermissionChecker(
         foreach (string role in roles)
         {
             IReadOnlyList<string> roleGrants = await grantStore.GetGrantedAsync(
-                role, uncached, tenantId, cancellationToken).ConfigureAwait(false);
+                PermissionGrantProviderNames.Role, role, uncached, tenantId, cancellationToken).ConfigureAwait(false);
 
             foreach (string perm in roleGrants)
             {
@@ -222,7 +224,7 @@ internal sealed class PermissionChecker(
             {
                 bool isGranted = roleGrants.Contains(perm);
                 await cache.SetAsync(
-                    BuildCacheKey(tenantId, role, perm),
+                    BuildCacheKey(tenantId, PermissionGrantProviderNames.Role, role, perm),
                     new PermissionGrantCacheItem(isGranted),
                     entryOptions,
                     token: cancellationToken).ConfigureAwait(false);
@@ -230,8 +232,13 @@ internal sealed class PermissionChecker(
         }
     }
 
-    internal static string BuildCacheKey(Guid? tenantId, string roleName, string permissionName) =>
-        $"perm:{tenantId?.ToString() ?? "global"}:{roleName}:{permissionName}";
+    /// <summary>
+    /// Builds the cache key for a permission check. Scopes the cache by tenant, provider and
+    /// provider key so that grants to a user and grants to a role of the same textual key
+    /// (unlikely but possible) never collide.
+    /// </summary>
+    internal static string BuildCacheKey(Guid? tenantId, string providerName, string providerKey, string permissionName) =>
+        $"perm:{tenantId?.ToString() ?? "global"}:{providerName}:{providerKey}:{permissionName}";
 
     // Side enforcement: a Host-sided permission is only grantable when no tenant is active;
     // a Tenant-sided one only when a tenant is active. Both-sided permissions pass in any context.

--- a/src/Granit.Authorization/Services/PermissionChecker.cs
+++ b/src/Granit.Authorization/Services/PermissionChecker.cs
@@ -54,7 +54,8 @@ internal sealed class PermissionChecker(
             return true;
         }
 
-        if (!definitionManager.Exists(permissionName))
+        PermissionDefinition? definition = definitionManager.Find(permissionName);
+        if (definition is null)
         {
             throw new InvalidOperationException(
                 $"Permission '{permissionName}' is not defined. Register it via IPermissionDefinitionProvider.");
@@ -63,6 +64,12 @@ internal sealed class PermissionChecker(
         // Explicit IsAvailable check per soft-dependency contract (NullTenantContext returns null).
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
         string tenantIdStr = tenantId?.ToString() ?? "global";
+
+        if (!IsCompatibleWithCurrentSide(definition, currentTenant))
+        {
+            metrics.RecordCheckDenied(tenantIdStr);
+            return false;
+        }
 
         foreach (string role in roles)
         {
@@ -141,7 +148,13 @@ internal sealed class PermissionChecker(
 
         foreach (string permissionName in permissionNames)
         {
-            if (!definitionManager.Exists(permissionName))
+            PermissionDefinition? definition = definitionManager.Find(permissionName);
+            if (definition is null)
+            {
+                continue;
+            }
+
+            if (!IsCompatibleWithCurrentSide(definition, currentTenant))
             {
                 continue;
             }
@@ -219,4 +232,14 @@ internal sealed class PermissionChecker(
 
     internal static string BuildCacheKey(Guid? tenantId, string roleName, string permissionName) =>
         $"perm:{tenantId?.ToString() ?? "global"}:{roleName}:{permissionName}";
+
+    // Side enforcement: a Host-sided permission is only grantable when no tenant is active;
+    // a Tenant-sided one only when a tenant is active. Both-sided permissions pass in any context.
+    // When Granit.MultiTenancy is absent, NullTenantContext.IsAvailable is always false — so
+    // Tenant-sided permissions are uniformly denied, which is consistent: a consumer without
+    // multi-tenancy should not declare Tenant-sided permissions in the first place.
+    internal static bool IsCompatibleWithCurrentSide(PermissionDefinition definition, ICurrentTenant currentTenant) =>
+        currentTenant.IsAvailable
+            ? definition.MultiTenancySide.HasFlag(MultiTenancySide.Tenant)
+            : definition.MultiTenancySide.HasFlag(MultiTenancySide.Host);
 }

--- a/src/Granit.Authorization/Services/PermissionChecker.cs
+++ b/src/Granit.Authorization/Services/PermissionChecker.cs
@@ -9,21 +9,24 @@ using ZiggyCreatures.Caching.Fusion;
 namespace Granit.Authorization.Services;
 
 /// <summary>
-/// Scoped permission checker implementing the full RBAC verification pipeline:
+/// Scoped permission checker implementing the full verification pipeline:
 /// <list type="number">
 /// <item>Not authenticated → denied</item>
 /// <item>AlwaysAllow (dev/test, authenticated users only) → granted</item>
 /// <item>AdminRole bypass (root of trust, case-insensitive) → granted without DB</item>
 /// <item>Permission undefined → <see cref="InvalidOperationException"/></item>
-/// <item>For each role: cache hit or store query; any true → granted</item>
+/// <item>Permission's <see cref="MultiTenancySide"/> incompatible with current tenant context → denied</item>
+/// <item>For each registered <see cref="IPermissionGrantProvider"/> (default order: User, Role, Client),
+///   query each of the provider's keys through cache / store. First positive match wins (fail-fast).</item>
 /// </list>
-/// Cache key format: <c>perm:{tenantId|"global"}:{roleName}:{permissionName}</c>
+/// Cache key format: <c>perm:{tenantId|"global"}:{providerName}:{providerKey}:{permissionName}</c>
 /// </summary>
 internal sealed class PermissionChecker(
     ICurrentUserService currentUserService,
     ICurrentTenant currentTenant,
     IPermissionDefinitionManager definitionManager,
     IPermissionGrantStore grantStore,
+    IEnumerable<IPermissionGrantProvider> grantProviders,
     IFusionCache cache,
     AuthorizationMetrics metrics,
     IOptions<GranitAuthorizationOptions> options) : IPermissionChecker
@@ -71,24 +74,30 @@ internal sealed class PermissionChecker(
             return false;
         }
 
-        foreach (string role in roles)
-        {
-            PermissionGrantCacheItem result = await cache.GetOrSetAsync<PermissionGrantCacheItem>(
-                BuildCacheKey(tenantId, PermissionGrantProviderNames.Role, role, permissionName),
-                async (_, ct) =>
-                {
-                    metrics.RecordCacheMiss(tenantIdStr);
-                    return new PermissionGrantCacheItem(
-                        await grantStore.IsGrantedAsync(
-                            PermissionGrantProviderNames.Role, role, permissionName, tenantId, ct)
-                        .ConfigureAwait(false));
-                },
-                new FusionCacheEntryOptions { Duration = opts.CacheDuration },
-                token: cancellationToken).ConfigureAwait(false);
+        PermissionGrantLookupContext lookup = BuildLookupContext(currentUserService, roles);
 
-            if (result.IsGranted)
+        foreach (IPermissionGrantProvider provider in grantProviders)
+        {
+            IReadOnlyList<string> providerKeys = provider.GetProviderKeys(lookup);
+            foreach (string providerKey in providerKeys)
             {
-                return true;
+                PermissionGrantCacheItem result = await cache.GetOrSetAsync<PermissionGrantCacheItem>(
+                    BuildCacheKey(tenantId, provider.Name, providerKey, permissionName),
+                    async (_, ct) =>
+                    {
+                        metrics.RecordCacheMiss(tenantIdStr);
+                        return new PermissionGrantCacheItem(
+                            await grantStore.IsGrantedAsync(
+                                provider.Name, providerKey, permissionName, tenantId, ct)
+                            .ConfigureAwait(false));
+                    },
+                    new FusionCacheEntryOptions { Duration = opts.CacheDuration },
+                    token: cancellationToken).ConfigureAwait(false);
+
+                if (result.IsGranted)
+                {
+                    return true;
+                }
             }
         }
 
@@ -122,26 +131,28 @@ internal sealed class PermissionChecker(
         }
 
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
+        PermissionGrantLookupContext lookup = BuildLookupContext(currentUserService, roles);
 
         (HashSet<string> granted, List<string> uncached) = await PartitionCachedPermissionsAsync(
-            permissionNames, roles, tenantId, cancellationToken).ConfigureAwait(false);
+            permissionNames, lookup, tenantId, cancellationToken).ConfigureAwait(false);
 
         if (uncached.Count == 0)
         {
             return [.. granted];
         }
 
-        await QueryAndCachePermissionsAsync(uncached, roles, tenantId, granted, opts, cancellationToken)
+        await QueryAndCachePermissionsAsync(uncached, lookup, tenantId, granted, opts, cancellationToken)
             .ConfigureAwait(false);
 
         return [.. granted];
     }
 
-    // Walks each (permission, role) pair and splits them into cached-grants vs. uncached.
-    // A permission is added to 'uncached' at most once, even if several roles miss the cache.
+    // Walks each (permission, provider, key) triplet and splits them into cached-grants
+    // vs. uncached. A permission is added to 'uncached' at most once, even if several
+    // provider keys miss the cache.
     private async Task<(HashSet<string> Granted, List<string> Uncached)> PartitionCachedPermissionsAsync(
         IReadOnlyList<string> permissionNames,
-        IReadOnlyList<string> roles,
+        PermissionGrantLookupContext lookup,
         Guid? tenantId,
         CancellationToken cancellationToken)
     {
@@ -161,7 +172,7 @@ internal sealed class PermissionChecker(
                 continue;
             }
 
-            await PartitionPermissionAsync(permissionName, roles, tenantId, granted, uncached, cancellationToken)
+            await PartitionPermissionAsync(permissionName, lookup, tenantId, granted, uncached, cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -170,7 +181,7 @@ internal sealed class PermissionChecker(
 
     private async Task PartitionPermissionAsync(
         string permissionName,
-        IReadOnlyList<string> roles,
+        PermissionGrantLookupContext lookup,
         Guid? tenantId,
         HashSet<string> granted,
         List<string> uncached,
@@ -178,56 +189,63 @@ internal sealed class PermissionChecker(
     {
         bool uncachedRecorded = false;
 
-        foreach (string role in roles)
+        foreach (IPermissionGrantProvider provider in grantProviders)
         {
-            MaybeValue<PermissionGrantCacheItem> cached = await cache.TryGetAsync<PermissionGrantCacheItem>(
-                BuildCacheKey(tenantId, PermissionGrantProviderNames.Role, role, permissionName),
-                token: cancellationToken).ConfigureAwait(false);
+            foreach (string providerKey in provider.GetProviderKeys(lookup))
+            {
+                MaybeValue<PermissionGrantCacheItem> cached = await cache.TryGetAsync<PermissionGrantCacheItem>(
+                    BuildCacheKey(tenantId, provider.Name, providerKey, permissionName),
+                    token: cancellationToken).ConfigureAwait(false);
 
-            if (cached.HasValue)
-            {
-                if (cached.Value.IsGranted)
+                if (cached.HasValue)
                 {
-                    granted.Add(permissionName);
-                    uncachedRecorded = true; // no need to requery; cache is authoritative for this pair
+                    if (cached.Value.IsGranted)
+                    {
+                        granted.Add(permissionName);
+                        uncachedRecorded = true; // cache is authoritative for this pair
+                    }
                 }
-            }
-            else if (!uncachedRecorded)
-            {
-                uncached.Add(permissionName);
-                uncachedRecorded = true;
+                else if (!uncachedRecorded)
+                {
+                    uncached.Add(permissionName);
+                    uncachedRecorded = true;
+                }
             }
         }
     }
 
-    // Batch-query the store for all uncached permissions per role, then populate the cache.
+    // Batch-query the store for all uncached permissions per (provider, key), then populate the cache.
     private async Task QueryAndCachePermissionsAsync(
         List<string> uncached,
-        IReadOnlyList<string> roles,
+        PermissionGrantLookupContext lookup,
         Guid? tenantId,
         HashSet<string> granted,
         GranitAuthorizationOptions opts,
         CancellationToken cancellationToken)
     {
-        foreach (string role in roles)
+        FusionCacheEntryOptions entryOptions = new() { Duration = opts.CacheDuration };
+
+        foreach (IPermissionGrantProvider provider in grantProviders)
         {
-            IReadOnlyList<string> roleGrants = await grantStore.GetGrantedAsync(
-                PermissionGrantProviderNames.Role, role, uncached, tenantId, cancellationToken).ConfigureAwait(false);
-
-            foreach (string perm in roleGrants)
+            foreach (string providerKey in provider.GetProviderKeys(lookup))
             {
-                granted.Add(perm);
-            }
+                IReadOnlyList<string> granteeGrants = await grantStore.GetGrantedAsync(
+                    provider.Name, providerKey, uncached, tenantId, cancellationToken).ConfigureAwait(false);
 
-            FusionCacheEntryOptions entryOptions = new() { Duration = opts.CacheDuration };
-            foreach (string perm in uncached)
-            {
-                bool isGranted = roleGrants.Contains(perm);
-                await cache.SetAsync(
-                    BuildCacheKey(tenantId, PermissionGrantProviderNames.Role, role, perm),
-                    new PermissionGrantCacheItem(isGranted),
-                    entryOptions,
-                    token: cancellationToken).ConfigureAwait(false);
+                foreach (string perm in granteeGrants)
+                {
+                    granted.Add(perm);
+                }
+
+                foreach (string perm in uncached)
+                {
+                    bool isGranted = granteeGrants.Contains(perm);
+                    await cache.SetAsync(
+                        BuildCacheKey(tenantId, provider.Name, providerKey, perm),
+                        new PermissionGrantCacheItem(isGranted),
+                        entryOptions,
+                        token: cancellationToken).ConfigureAwait(false);
+                }
             }
         }
     }
@@ -249,4 +267,9 @@ internal sealed class PermissionChecker(
         currentTenant.IsAvailable
             ? definition.MultiTenancySide.HasFlag(MultiTenancySide.Tenant)
             : definition.MultiTenancySide.HasFlag(MultiTenancySide.Host);
+
+    private static PermissionGrantLookupContext BuildLookupContext(
+        ICurrentUserService currentUserService,
+        IReadOnlyList<string> roles) =>
+        new(currentUserService.UserId, roles, currentUserService.ClientId);
 }

--- a/src/Granit.Authorization/Services/PermissionManager.cs
+++ b/src/Granit.Authorization/Services/PermissionManager.cs
@@ -7,11 +7,13 @@ namespace Granit.Authorization.Services;
 /// <summary>
 /// Domain service implementing <see cref="IPermissionManagerReader"/> and <see cref="IPermissionManagerWriter"/>.
 /// Delegates data access to <see cref="IPermissionGrantStore"/> and provides business logic:
-/// permission definition validation, event-driven cache invalidation, and ISO 27001 audit logging.
+/// permission definition validation, grant validation chain, event-driven cache invalidation,
+/// and ISO 27001 audit logging.
 /// </summary>
 internal sealed partial class PermissionManager(
     IPermissionGrantStore grantStore,
     IPermissionDefinitionManager definitionManager,
+    IEnumerable<IPermissionGrantValidator> grantValidators,
     ILocalEventBus eventBus,
     ILogger<PermissionManager> logger)
     : IPermissionManagerReader, IPermissionManagerWriter
@@ -24,10 +26,35 @@ internal sealed partial class PermissionManager(
         bool isGranted,
         CancellationToken cancellationToken = default)
     {
-        if (!definitionManager.Exists(permissionName))
+        PermissionDefinition? definition = definitionManager.Find(permissionName);
+        if (definition is null)
         {
             throw new InvalidOperationException(
                 $"Permission '{permissionName}' is not defined. Register it via IPermissionDefinitionProvider.");
+        }
+
+        // Validators only gate additions. Revocations must always be possible so that a
+        // grant previously made under relaxed rules can still be removed after a policy change.
+        if (isGranted)
+        {
+            PermissionGrantValidationContext validationContext = new(
+                permissionName,
+                PermissionGrantProviderNames.Role,
+                roleName,
+                tenantId,
+                definition);
+
+            foreach (IPermissionGrantValidator validator in grantValidators)
+            {
+                PermissionGrantValidationResult result = await validator
+                    .ValidateAsync(validationContext, cancellationToken).ConfigureAwait(false);
+
+                if (!result.IsValid)
+                {
+                    throw new InvalidOperationException(
+                        $"Grant rejected ({result.ReasonCode}): {result.ReasonMessage}");
+                }
+            }
         }
 
         bool changed = isGranted

--- a/src/Granit.Authorization/Services/PermissionManager.cs
+++ b/src/Granit.Authorization/Services/PermissionManager.cs
@@ -21,7 +21,8 @@ internal sealed partial class PermissionManager(
     /// <inheritdoc />
     public async Task SetAsync(
         string permissionName,
-        string roleName,
+        string providerName,
+        string providerKey,
         Guid? tenantId,
         bool isGranted,
         CancellationToken cancellationToken = default)
@@ -39,8 +40,8 @@ internal sealed partial class PermissionManager(
         {
             PermissionGrantValidationContext validationContext = new(
                 permissionName,
-                PermissionGrantProviderNames.Role,
-                roleName,
+                providerName,
+                providerKey,
                 tenantId,
                 definition);
 
@@ -58,9 +59,9 @@ internal sealed partial class PermissionManager(
         }
 
         bool changed = isGranted
-            ? await grantStore.GrantAsync(permissionName, roleName, tenantId, cancellationToken)
+            ? await grantStore.GrantAsync(providerName, providerKey, permissionName, tenantId, cancellationToken)
                 .ConfigureAwait(false)
-            : await grantStore.RevokeAsync(permissionName, roleName, tenantId, cancellationToken)
+            : await grantStore.RevokeAsync(providerName, providerKey, permissionName, tenantId, cancellationToken)
                 .ConfigureAwait(false);
 
         if (!changed)
@@ -71,36 +72,40 @@ internal sealed partial class PermissionManager(
         // Event-driven cache invalidation — consumed by PermissionCacheInvalidationHandler.
         // Decoupled from the store so other modules can react to permission changes.
         await eventBus.PublishAsync(
-            new PermissionGrantChangedEvent(permissionName, roleName, tenantId, isGranted),
+            new PermissionGrantChangedEvent(permissionName, providerName, providerKey, tenantId, isGranted),
             cancellationToken).ConfigureAwait(false);
 
         // ISO 27001 audit trail: emitted as structured log → Serilog → OTLP → Loki (3-year retention)
-        // RGPD: no personal data — only role name, permission name, tenant scope
-        LogPermissionChange(isGranted ? "Granted" : "Revoked", permissionName, roleName, tenantId);
+        // RGPD: no personal data — only provider key, permission name, tenant scope
+        LogPermissionChange(
+            isGranted ? "Granted" : "Revoked", permissionName, providerName, providerKey, tenantId);
     }
 
     /// <inheritdoc />
     public Task<bool> IsGrantedAsync(
         string permissionName,
-        string roleName,
+        string providerName,
+        string providerKey,
         Guid? tenantId,
         CancellationToken cancellationToken = default) =>
-        grantStore.IsGrantedAsync(roleName, permissionName, tenantId, cancellationToken);
+        grantStore.IsGrantedAsync(providerName, providerKey, permissionName, tenantId, cancellationToken);
 
     /// <inheritdoc />
     public Task<IReadOnlyList<string>> GetGrantedPermissionsAsync(
-        string roleName,
+        string providerName,
+        string providerKey,
         Guid? tenantId,
         CancellationToken cancellationToken = default) =>
-        grantStore.GetGrantedPermissionsAsync(roleName, tenantId, cancellationToken);
+        grantStore.GetGrantedPermissionsAsync(providerName, providerKey, tenantId, cancellationToken);
 
     /// <inheritdoc />
-    public Task<IReadOnlyList<string>> GetGrantedRolesAsync(
+    public Task<IReadOnlyList<string>> GetGranteesAsync(
+        string providerName,
         string permissionName,
         Guid? tenantId,
         CancellationToken cancellationToken = default) =>
-        grantStore.GetGrantedRolesAsync(permissionName, tenantId, cancellationToken);
+        grantStore.GetGranteesAsync(providerName, permissionName, tenantId, cancellationToken);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "[AUDIT] Permission {Change}: permission={PermissionName} role={RoleName} tenantId={TenantId}")]
-    private partial void LogPermissionChange(string change, string permissionName, string roleName, Guid? tenantId);
+    [LoggerMessage(Level = LogLevel.Information, Message = "[AUDIT] Permission {Change}: permission={PermissionName} provider={ProviderName} key={ProviderKey} tenantId={TenantId}")]
+    private partial void LogPermissionChange(string change, string permissionName, string providerName, string providerKey, Guid? tenantId);
 }

--- a/src/Granit.Authorization/Services/RolePermissionGrantProvider.cs
+++ b/src/Granit.Authorization/Services/RolePermissionGrantProvider.cs
@@ -1,0 +1,16 @@
+namespace Granit.Authorization.Services;
+
+/// <summary>
+/// Grants evaluated against the role claims of the current principal. Second in the
+/// evaluation order (after user, before client): a role-level grant is more specific than
+/// a client-level grant but less specific than an explicit user grant.
+/// </summary>
+internal sealed class RolePermissionGrantProvider : IPermissionGrantProvider
+{
+    /// <inheritdoc />
+    public string Name => PermissionGrantProviderNames.Role;
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> GetProviderKeys(PermissionGrantLookupContext context) =>
+        context.Roles;
+}

--- a/src/Granit.Authorization/Services/UserPermissionGrantProvider.cs
+++ b/src/Granit.Authorization/Services/UserPermissionGrantProvider.cs
@@ -1,0 +1,15 @@
+namespace Granit.Authorization.Services;
+
+/// <summary>
+/// Grants evaluated against the <c>sub</c> (user id) of the current principal. Evaluated
+/// first because a user-specific grant is more specific than any role- or client-level grant.
+/// </summary>
+internal sealed class UserPermissionGrantProvider : IPermissionGrantProvider
+{
+    /// <inheritdoc />
+    public string Name => PermissionGrantProviderNames.User;
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> GetProviderKeys(PermissionGrantLookupContext context) =>
+        string.IsNullOrEmpty(context.UserId) ? [] : [context.UserId];
+}

--- a/src/Granit.BackgroundJobs.Endpoints/Permissions/BackgroundJobsPermissionDefinitionProvider.cs
+++ b/src/Granit.BackgroundJobs.Endpoints/Permissions/BackgroundJobsPermissionDefinitionProvider.cs
@@ -36,14 +36,22 @@ internal sealed class BackgroundJobsPermissionDefinitionProvider : IPermissionDe
             LocalizableString.Create<BackgroundJobsEndpointsLocalizationResource>(
                 "PermissionGroup:BackgroundJobs"));
 
+        // Host-only: the Wolverine scheduler is a single instance per application, jobs
+        // are registered globally via [RecurringJob] with kebab-case names unique across
+        // the whole app (e.g. "blob-storage-orphan-cleanup", "privacy-export-expiration").
+        // Their state and controls are cross-tenant by construction — exposing trigger /
+        // pause / cancel to a tenant would leak other tenants' activity and let one tenant
+        // interrupt work scheduled for others. Reading the job list has the same leak.
         group.AddPermission(
             BackgroundJobsPermissions.Jobs.Read,
             LocalizableString.Create<BackgroundJobsEndpointsLocalizationResource>(
-                "Permission:BackgroundJobs.Jobs.Read"));
+                "Permission:BackgroundJobs.Jobs.Read"),
+            MultiTenancySide.Host);
 
         group.AddPermission(
             BackgroundJobsPermissions.Jobs.Manage,
             LocalizableString.Create<BackgroundJobsEndpointsLocalizationResource>(
-                "Permission:BackgroundJobs.Jobs.Manage"));
+                "Permission:BackgroundJobs.Jobs.Manage"),
+            MultiTenancySide.Host);
     }
 }

--- a/src/Granit.BlobStorage.Endpoints/Permissions/BlobStoragePermissionDefinitionProvider.cs
+++ b/src/Granit.BlobStorage.Endpoints/Permissions/BlobStoragePermissionDefinitionProvider.cs
@@ -20,11 +20,13 @@ internal sealed class BlobStoragePermissionDefinitionProvider : IPermissionDefin
         group.AddPermission(
             BlobStoragePermissions.Administration.Read,
             LocalizableString.Create<BlobStorageEndpointsLocalizationResource>(
-                "Permission:BlobStorage.Administration.Read"));
+                "Permission:BlobStorage.Administration.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             BlobStoragePermissions.Administration.Manage,
             LocalizableString.Create<BlobStorageEndpointsLocalizationResource>(
-                "Permission:BlobStorage.Administration.Manage"));
+                "Permission:BlobStorage.Administration.Manage"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.CustomerBalance.Endpoints/Extensions/CustomerBalanceEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Extensions/CustomerBalanceEndpointRouteBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Authorization.Extensions;
 using Granit.CustomerBalance.Endpoints.Dtos;
 using Granit.CustomerBalance.Endpoints.Internal;
 using Granit.CustomerBalance.Endpoints.Permissions;
@@ -26,7 +27,8 @@ public static class CustomerBalanceEndpointRouteBuilderExtensions
                 "Returns the current credit balance for the authenticated tenant in the specified currency. "
                 + "Returns zero balance if no account exists for that currency.")
             .Produces<CustomerBalanceResponse>()
-            .RequireAuthorization(CustomerBalancePermissions.Accounts.Read);
+            .RequireAuthorization(CustomerBalancePermissions.Accounts.Read)
+            .AllowHostAccess();
 
         group.MapGet("/transactions", ListTransactionsEndpoint.HandleAsync)
             .WithName("ListBalanceTransactions")
@@ -36,7 +38,8 @@ public static class CustomerBalanceEndpointRouteBuilderExtensions
                 + "Ordered by creation date descending (most recent first). "
                 + "Each entry shows the transaction type, amount, source, and optional reference.")
             .Produces<IReadOnlyList<BalanceTransactionResponse>>()
-            .RequireAuthorization(CustomerBalancePermissions.Transactions.Read);
+            .RequireAuthorization(CustomerBalancePermissions.Transactions.Read)
+            .AllowHostAccess();
 
         group.MapPost("/balance/credit", AdminCreditEndpoint.HandleAsync)
             .WithName("AddAdminCredit")
@@ -48,7 +51,8 @@ public static class CustomerBalanceEndpointRouteBuilderExtensions
             .Produces<CustomerBalanceResponse>()
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status400BadRequest)
-            .RequireAuthorization(CustomerBalancePermissions.Credits.Manage);
+            .RequireAuthorization(CustomerBalancePermissions.Credits.Manage)
+            .AllowHostAccess();
 
         return group;
     }

--- a/src/Granit.CustomerBalance.Endpoints/Permissions/CustomerBalancePermissionDefinitionProvider.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Permissions/CustomerBalancePermissionDefinitionProvider.cs
@@ -13,14 +13,20 @@ internal sealed class CustomerBalancePermissionDefinitionProvider : IPermissionD
             LocalizableString.Create<CustomerBalanceEndpointsLocalizationResource>(
                 "PermissionGroup:CustomerBalance"));
 
+        // Both-sided: the host tracks balances of its tenants (credit issuance, write-offs)
+        // while tenants see their own balance and transactions. Consumers whose tenants bill
+        // their own customers can tighten these to Tenant in their own provider.
         group.AddPermission(CustomerBalancePermissions.Accounts.Read,
             LocalizableString.Create<CustomerBalanceEndpointsLocalizationResource>(
-                "Permission:CustomerBalance.Accounts.Read"));
+                "Permission:CustomerBalance.Accounts.Read"),
+            MultiTenancySide.Both);
         group.AddPermission(CustomerBalancePermissions.Transactions.Read,
             LocalizableString.Create<CustomerBalanceEndpointsLocalizationResource>(
-                "Permission:CustomerBalance.Transactions.Read"));
+                "Permission:CustomerBalance.Transactions.Read"),
+            MultiTenancySide.Both);
         group.AddPermission(CustomerBalancePermissions.Credits.Manage,
             LocalizableString.Create<CustomerBalanceEndpointsLocalizationResource>(
-                "Permission:CustomerBalance.Credits.Manage"));
+                "Permission:CustomerBalance.Credits.Manage"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.DataExchange.Endpoints/Permissions/DataExchangePermissionDefinitionProvider.cs
+++ b/src/Granit.DataExchange.Endpoints/Permissions/DataExchangePermissionDefinitionProvider.cs
@@ -39,21 +39,25 @@ internal sealed class DataExchangePermissionDefinitionProvider : IPermissionDefi
         group.AddPermission(
             DataExchangePermissions.Imports.Read,
             LocalizableString.Create<DataExchangeEndpointsLocalizationResource>(
-                "Permission:DataExchange.Imports.Read"));
+                "Permission:DataExchange.Imports.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             DataExchangePermissions.Imports.Execute,
             LocalizableString.Create<DataExchangeEndpointsLocalizationResource>(
-                "Permission:DataExchange.Imports.Execute"));
+                "Permission:DataExchange.Imports.Execute"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             DataExchangePermissions.Exports.Read,
             LocalizableString.Create<DataExchangeEndpointsLocalizationResource>(
-                "Permission:DataExchange.Exports.Read"));
+                "Permission:DataExchange.Exports.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             DataExchangePermissions.Exports.Execute,
             LocalizableString.Create<DataExchangeEndpointsLocalizationResource>(
-                "Permission:DataExchange.Exports.Execute"));
+                "Permission:DataExchange.Exports.Execute"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.Diagnostics.Endpoints/Permissions/DiagnosticsPermissionDefinitionProvider.cs
+++ b/src/Granit.Diagnostics.Endpoints/Permissions/DiagnosticsPermissionDefinitionProvider.cs
@@ -18,9 +18,11 @@ internal sealed class DiagnosticsPermissionDefinitionProvider : IPermissionDefin
             LocalizableString.Create<DiagnosticsEndpointsLocalizationResource>(
                 "PermissionGroup:Diagnostics"));
 
+        // Platform observability is host-level: metrics and health expose cross-tenant state.
         group.AddPermission(
             DiagnosticsPermissions.Monitoring.Read,
             LocalizableString.Create<DiagnosticsEndpointsLocalizationResource>(
-                "Permission:Diagnostics.Monitoring.Read"));
+                "Permission:Diagnostics.Monitoring.Read"),
+            MultiTenancySide.Host);
     }
 }

--- a/src/Granit.Features.Endpoints/Permissions/FeaturesPermissionDefinitionProvider.cs
+++ b/src/Granit.Features.Endpoints/Permissions/FeaturesPermissionDefinitionProvider.cs
@@ -17,14 +17,20 @@ internal sealed class FeaturesPermissionDefinitionProvider : IPermissionDefiniti
             LocalizableString.Create<FeaturesEndpointsLocalizationResource>(
                 "PermissionGroup:Features"));
 
+        // Reading flag values is legitimate in either context (a tenant reads the effective
+        // values for its own scope).
         group.AddPermission(
             FeaturesPermissions.Flags.Read,
             LocalizableString.Create<FeaturesEndpointsLocalizationResource>(
-                "Permission:Features.Flags.Read"));
+                "Permission:Features.Flags.Read"),
+            MultiTenancySide.Both);
 
+        // Defining/toggling feature flags is a platform concern — tenant-level overrides,
+        // if needed, warrant a dedicated permission rather than reusing this one.
         group.AddPermission(
             FeaturesPermissions.Flags.Manage,
             LocalizableString.Create<FeaturesEndpointsLocalizationResource>(
-                "Permission:Features.Flags.Manage"));
+                "Permission:Features.Flags.Manage"),
+            MultiTenancySide.Host);
     }
 }

--- a/src/Granit.Identity.Endpoints/Permissions/IdentityPermissionDefinitionProvider.cs
+++ b/src/Granit.Identity.Endpoints/Permissions/IdentityPermissionDefinitionProvider.cs
@@ -21,60 +21,71 @@ internal sealed class IdentityPermissionDefinitionProvider : IPermissionDefiniti
         group.AddPermission(
             IdentityPermissions.Users.Read,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
-                "Permission:Identity.Users.Read"));
+                "Permission:Identity.Users.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             IdentityPermissions.Users.Manage,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
-                "Permission:Identity.Users.Manage"));
+                "Permission:Identity.Users.Manage"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             IdentityPermissions.Users.Sync,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
-                "Permission:Identity.Users.Sync"));
+                "Permission:Identity.Users.Sync"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             IdentityPermissions.Users.Delete,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
-                "Permission:Identity.Users.Delete"));
+                "Permission:Identity.Users.Delete"),
+            MultiTenancySide.Both);
 
         // Roles
         group.AddPermission(
             IdentityPermissions.Roles.Read,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
-                "Permission:Identity.Roles.Read"));
+                "Permission:Identity.Roles.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             IdentityPermissions.Roles.Manage,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
-                "Permission:Identity.Roles.Manage"));
+                "Permission:Identity.Roles.Manage"),
+            MultiTenancySide.Both);
 
         // Groups
         group.AddPermission(
             IdentityPermissions.Groups.Read,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
-                "Permission:Identity.Groups.Read"));
+                "Permission:Identity.Groups.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             IdentityPermissions.Groups.Manage,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
-                "Permission:Identity.Groups.Manage"));
+                "Permission:Identity.Groups.Manage"),
+            MultiTenancySide.Both);
 
         // Sessions
         group.AddPermission(
             IdentityPermissions.Sessions.Read,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
-                "Permission:Identity.Sessions.Read"));
+                "Permission:Identity.Sessions.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             IdentityPermissions.Sessions.Manage,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
-                "Permission:Identity.Sessions.Manage"));
+                "Permission:Identity.Sessions.Manage"),
+            MultiTenancySide.Both);
 
         // Passwords
         group.AddPermission(
             IdentityPermissions.Passwords.Manage,
             LocalizableString.Create<IdentityEndpointsLocalizationResource>(
-                "Permission:Identity.Passwords.Manage"));
+                "Permission:Identity.Passwords.Manage"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.Identity.Local.Endpoints/Permissions/IdentityLocalPermissionDefinitionProvider.cs
+++ b/src/Granit.Identity.Local.Endpoints/Permissions/IdentityLocalPermissionDefinitionProvider.cs
@@ -18,9 +18,12 @@ internal sealed class IdentityLocalPermissionDefinitionProvider : IPermissionDef
             LocalizableString.Create<IdentityLocalEndpointsLocalizationResource>(
                 "PermissionGroup:IdentityLocal"));
 
+        // Impersonation is a highly privileged "break glass" capability intended for platform
+        // support / investigations — cross-tenant by design. Restrict to the host side.
         group.AddPermission(
             IdentityLocalPermissions.Users.Impersonate,
             LocalizableString.Create<IdentityLocalEndpointsLocalizationResource>(
-                "Permission:IdentityLocal.Users.Impersonate"));
+                "Permission:IdentityLocal.Users.Impersonate"),
+            MultiTenancySide.Host);
     }
 }

--- a/src/Granit.Invoicing.Endpoints/Endpoints/InvoiceEndpoints.cs
+++ b/src/Granit.Invoicing.Endpoints/Endpoints/InvoiceEndpoints.cs
@@ -52,7 +52,8 @@ internal static class InvoiceEndpoints
             .Produces<InvoiceResponse>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesValidationProblem()
-            .RequireAuthorization(InvoicingPermissions.Invoices.Manage);
+            .RequireAuthorization(InvoicingPermissions.Invoices.Manage)
+            .AllowHostAccess();
 
         return group;
     }

--- a/src/Granit.Invoicing.Endpoints/Permissions/InvoicingPermissionDefinitionProvider.cs
+++ b/src/Granit.Invoicing.Endpoints/Permissions/InvoicingPermissionDefinitionProvider.cs
@@ -12,15 +12,24 @@ internal sealed class InvoicingPermissionDefinitionProvider : IPermissionDefinit
             InvoicingPermissions.GroupName,
             LocalizableString.Create<InvoicingEndpointsLocalizationResource>("PermissionGroup:Invoicing"));
 
+        // Both-sided: in a SaaS, the host issues invoices to its tenants (host side), and
+        // each tenant consults/downloads those invoices from inside its own scope (tenant
+        // side). Consumers who run a pure B2B flow — a tenant billing its own customers —
+        // can tighten these to Tenant-only in their own permission provider.
         group.AddPermission(InvoicingPermissions.Invoices.Read,
-            LocalizableString.Create<InvoicingEndpointsLocalizationResource>("Permission:Invoicing.Invoices.Read"));
+            LocalizableString.Create<InvoicingEndpointsLocalizationResource>("Permission:Invoicing.Invoices.Read"),
+            MultiTenancySide.Both);
         group.AddPermission(InvoicingPermissions.Invoices.Manage,
-            LocalizableString.Create<InvoicingEndpointsLocalizationResource>("Permission:Invoicing.Invoices.Manage"));
+            LocalizableString.Create<InvoicingEndpointsLocalizationResource>("Permission:Invoicing.Invoices.Manage"),
+            MultiTenancySide.Both);
         group.AddPermission(InvoicingPermissions.Invoices.Download,
-            LocalizableString.Create<InvoicingEndpointsLocalizationResource>("Permission:Invoicing.Invoices.Download"));
+            LocalizableString.Create<InvoicingEndpointsLocalizationResource>("Permission:Invoicing.Invoices.Download"),
+            MultiTenancySide.Both);
         group.AddPermission(InvoicingPermissions.CreditNotes.Read,
-            LocalizableString.Create<InvoicingEndpointsLocalizationResource>("Permission:Invoicing.CreditNotes.Read"));
+            LocalizableString.Create<InvoicingEndpointsLocalizationResource>("Permission:Invoicing.CreditNotes.Read"),
+            MultiTenancySide.Both);
         group.AddPermission(InvoicingPermissions.CreditNotes.Manage,
-            LocalizableString.Create<InvoicingEndpointsLocalizationResource>("Permission:Invoicing.CreditNotes.Manage"));
+            LocalizableString.Create<InvoicingEndpointsLocalizationResource>("Permission:Invoicing.CreditNotes.Manage"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.Localization.Endpoints/Permissions/LocalizationOverridesPermissionDefinitionProvider.cs
+++ b/src/Granit.Localization.Endpoints/Permissions/LocalizationOverridesPermissionDefinitionProvider.cs
@@ -39,11 +39,13 @@ internal sealed class LocalizationOverridesPermissionDefinitionProvider : IPermi
         group.AddPermission(
             LocalizationOverridesPermissions.Overrides.Read,
             LocalizableString.Create<LocalizationEndpointsLocalizationResource>(
-                "Permission:Localization.Overrides.Read"));
+                "Permission:Localization.Overrides.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             LocalizationOverridesPermissions.Overrides.Manage,
             LocalizableString.Create<LocalizationEndpointsLocalizationResource>(
-                "Permission:Localization.Overrides.Manage"));
+                "Permission:Localization.Overrides.Manage"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.Mcp.Server/Permissions/McpPermissionDefinitionProvider.cs
+++ b/src/Granit.Mcp.Server/Permissions/McpPermissionDefinitionProvider.cs
@@ -17,22 +17,27 @@ internal sealed class McpPermissionDefinitionProvider : IPermissionDefinitionPro
 
         group.AddPermission(
             McpPermissions.Server.Access,
-            LocalizableString.Create<McpServerLocalizationResource>("Permission:Mcp.Server.Access"));
+            LocalizableString.Create<McpServerLocalizationResource>("Permission:Mcp.Server.Access"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             McpPermissions.Tools.Read,
-            LocalizableString.Create<McpServerLocalizationResource>("Permission:Mcp.Tools.Read"));
+            LocalizableString.Create<McpServerLocalizationResource>("Permission:Mcp.Tools.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             McpPermissions.Tools.Execute,
-            LocalizableString.Create<McpServerLocalizationResource>("Permission:Mcp.Tools.Execute"));
+            LocalizableString.Create<McpServerLocalizationResource>("Permission:Mcp.Tools.Execute"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             McpPermissions.Resources.Read,
-            LocalizableString.Create<McpServerLocalizationResource>("Permission:Mcp.Resources.Read"));
+            LocalizableString.Create<McpServerLocalizationResource>("Permission:Mcp.Resources.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             McpPermissions.Prompts.Read,
-            LocalizableString.Create<McpServerLocalizationResource>("Permission:Mcp.Prompts.Read"));
+            LocalizableString.Create<McpServerLocalizationResource>("Permission:Mcp.Prompts.Read"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.Metering.Endpoints/Permissions/MeteringPermissionDefinitionProvider.cs
+++ b/src/Granit.Metering.Endpoints/Permissions/MeteringPermissionDefinitionProvider.cs
@@ -14,12 +14,16 @@ internal sealed class MeteringPermissionDefinitionProvider : IPermissionDefiniti
                 "PermissionGroup:Metering"));
 
         group.AddPermission(MeteringPermissions.Meters.Read,
-            LocalizableString.Create<MeteringEndpointsLocalizationResource>("Permission:Metering.Meters.Read"));
+            LocalizableString.Create<MeteringEndpointsLocalizationResource>("Permission:Metering.Meters.Read"),
+            MultiTenancySide.Both);
         group.AddPermission(MeteringPermissions.Meters.Manage,
-            LocalizableString.Create<MeteringEndpointsLocalizationResource>("Permission:Metering.Meters.Manage"));
+            LocalizableString.Create<MeteringEndpointsLocalizationResource>("Permission:Metering.Meters.Manage"),
+            MultiTenancySide.Both);
         group.AddPermission(MeteringPermissions.Usage.Read,
-            LocalizableString.Create<MeteringEndpointsLocalizationResource>("Permission:Metering.Usage.Read"));
+            LocalizableString.Create<MeteringEndpointsLocalizationResource>("Permission:Metering.Usage.Read"),
+            MultiTenancySide.Both);
         group.AddPermission(MeteringPermissions.Usage.Record,
-            LocalizableString.Create<MeteringEndpointsLocalizationResource>("Permission:Metering.Usage.Record"));
+            LocalizableString.Create<MeteringEndpointsLocalizationResource>("Permission:Metering.Usage.Record"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.MultiTenancy.Endpoints/Permissions/MultiTenancyPermissionDefinitionProvider.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Permissions/MultiTenancyPermissionDefinitionProvider.cs
@@ -17,24 +17,29 @@ internal sealed class MultiTenancyPermissionDefinitionProvider : IPermissionDefi
             LocalizableString.Create<MultiTenancyEndpointsLocalizationResource>(
                 "PermissionGroup:MultiTenancy"));
 
+        // Managing tenants is inherently cross-tenant and can only be authorized in the host context.
         group.AddPermission(
             MultiTenancyPermissions.Tenants.Read,
             LocalizableString.Create<MultiTenancyEndpointsLocalizationResource>(
-                "Permission:MultiTenancy.Tenants.Read"));
+                "Permission:MultiTenancy.Tenants.Read"),
+            MultiTenancySide.Host);
 
         group.AddPermission(
             MultiTenancyPermissions.Tenants.Create,
             LocalizableString.Create<MultiTenancyEndpointsLocalizationResource>(
-                "Permission:MultiTenancy.Tenants.Create"));
+                "Permission:MultiTenancy.Tenants.Create"),
+            MultiTenancySide.Host);
 
         group.AddPermission(
             MultiTenancyPermissions.Tenants.Update,
             LocalizableString.Create<MultiTenancyEndpointsLocalizationResource>(
-                "Permission:MultiTenancy.Tenants.Update"));
+                "Permission:MultiTenancy.Tenants.Update"),
+            MultiTenancySide.Host);
 
         group.AddPermission(
             MultiTenancyPermissions.Tenants.Manage,
             LocalizableString.Create<MultiTenancyEndpointsLocalizationResource>(
-                "Permission:MultiTenancy.Tenants.Manage"));
+                "Permission:MultiTenancy.Tenants.Manage"),
+            MultiTenancySide.Host);
     }
 }

--- a/src/Granit.Notifications.Endpoints/Permissions/NotificationPermissionDefinitionProvider.cs
+++ b/src/Granit.Notifications.Endpoints/Permissions/NotificationPermissionDefinitionProvider.cs
@@ -39,11 +39,13 @@ internal sealed class NotificationPermissionDefinitionProvider : IPermissionDefi
         group.AddPermission(
             NotificationPermissions.UserNotifications.Read,
             LocalizableString.Create<NotificationsEndpointsLocalizationResource>(
-                "Permission:Notifications.UserNotifications.Read"));
+                "Permission:Notifications.UserNotifications.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             NotificationPermissions.UserNotifications.Manage,
             LocalizableString.Create<NotificationsEndpointsLocalizationResource>(
-                "Permission:Notifications.UserNotifications.Manage"));
+                "Permission:Notifications.UserNotifications.Manage"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.OpenIddict.Endpoints/Permissions/OpenIddictPermissionDefinitionProvider.cs
+++ b/src/Granit.OpenIddict.Endpoints/Permissions/OpenIddictPermissionDefinitionProvider.cs
@@ -19,38 +19,48 @@ internal sealed class OpenIddictPermissionDefinitionProvider : IPermissionDefini
             LocalizableString.Create<OpenIddictEndpointsLocalizationResource>(
                 "PermissionGroup:OpenIddict"));
 
-        // OIDC Applications
+        // OIDC Applications — GranitOpenIddictApplication is IMultiTenant: apps can be
+        // tenant-scoped or host-level, so management permissions are valid in either context.
         group.AddPermission(
             OpenIddictPermissions.Applications.Read,
             LocalizableString.Create<OpenIddictEndpointsLocalizationResource>(
-                "Permission:OpenIddict.Applications.Read"));
+                "Permission:OpenIddict.Applications.Read"),
+            MultiTenancySide.Both);
         group.AddPermission(
             OpenIddictPermissions.Applications.Manage,
             LocalizableString.Create<OpenIddictEndpointsLocalizationResource>(
-                "Permission:OpenIddict.Applications.Manage"));
+                "Permission:OpenIddict.Applications.Manage"),
+            MultiTenancySide.Both);
         group.AddPermission(
             OpenIddictPermissions.Applications.Rotate,
             LocalizableString.Create<OpenIddictEndpointsLocalizationResource>(
-                "Permission:OpenIddict.Applications.Rotate"));
+                "Permission:OpenIddict.Applications.Rotate"),
+            MultiTenancySide.Both);
 
-        // OIDC Scopes
+        // OIDC Scopes — scopes are a global OAuth primitive by spec (RFC 6749 §3.3):
+        // they identify capabilities, not resource ownership. Managing them is host-level.
         group.AddPermission(
             OpenIddictPermissions.Scopes.Read,
             LocalizableString.Create<OpenIddictEndpointsLocalizationResource>(
-                "Permission:OpenIddict.Scopes.Read"));
+                "Permission:OpenIddict.Scopes.Read"),
+            MultiTenancySide.Host);
         group.AddPermission(
             OpenIddictPermissions.Scopes.Manage,
             LocalizableString.Create<OpenIddictEndpointsLocalizationResource>(
-                "Permission:OpenIddict.Scopes.Manage"));
+                "Permission:OpenIddict.Scopes.Manage"),
+            MultiTenancySide.Host);
 
-        // OIDC Authorizations
+        // OIDC Authorizations — live authorizations can belong to a tenant user or a host
+        // admin; the permission must be usable in both contexts.
         group.AddPermission(
             OpenIddictPermissions.Authorizations.Read,
             LocalizableString.Create<OpenIddictEndpointsLocalizationResource>(
-                "Permission:OpenIddict.Authorizations.Read"));
+                "Permission:OpenIddict.Authorizations.Read"),
+            MultiTenancySide.Both);
         group.AddPermission(
             OpenIddictPermissions.Authorizations.Revoke,
             LocalizableString.Create<OpenIddictEndpointsLocalizationResource>(
-                "Permission:OpenIddict.Authorizations.Revoke"));
+                "Permission:OpenIddict.Authorizations.Revoke"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.Payments.Endpoints/Endpoints/PaymentMethodEndpoints.cs
+++ b/src/Granit.Payments.Endpoints/Endpoints/PaymentMethodEndpoints.cs
@@ -59,7 +59,8 @@ internal static class PaymentMethodEndpoints
             .Produces<PaymentMethodResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .RequireAuthorization(PaymentsPermissions.Methods.Manage);
+            .RequireAuthorization(PaymentsPermissions.Methods.Manage)
+            .AllowHostAccess();
 
         group.MapDelete("/methods/{id:guid}", DetachAsync)
             .WithName("DetachPaymentMethod")
@@ -70,7 +71,8 @@ internal static class PaymentMethodEndpoints
             .WithMetadata(new IdempotentAttribute())
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .RequireAuthorization(PaymentsPermissions.Methods.Manage);
+            .RequireAuthorization(PaymentsPermissions.Methods.Manage)
+            .AllowHostAccess();
 
         return group;
     }

--- a/src/Granit.Payments.Endpoints/Endpoints/TransactionEndpoints.cs
+++ b/src/Granit.Payments.Endpoints/Endpoints/TransactionEndpoints.cs
@@ -53,7 +53,8 @@ internal static class TransactionEndpoints
             .WithMetadata(new IdempotentAttribute())
             .Produces(StatusCodes.Status202Accepted)
             .ProducesValidationProblem()
-            .RequireAuthorization(PaymentsPermissions.Charges.Execute);
+            .RequireAuthorization(PaymentsPermissions.Charges.Execute)
+            .AllowHostAccess();
 
         group.MapPost("/refund", RefundAsync)
             .WithName("RequestPaymentRefund")
@@ -67,7 +68,8 @@ internal static class TransactionEndpoints
             .Produces(StatusCodes.Status202Accepted)
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .RequireAuthorization(PaymentsPermissions.Refunds.Execute);
+            .RequireAuthorization(PaymentsPermissions.Refunds.Execute)
+            .AllowHostAccess();
 
         group.MapPost("/checkout", CheckoutAsync)
             .WithName("CreateCheckoutSession")
@@ -80,7 +82,8 @@ internal static class TransactionEndpoints
             .Produces<PaymentCheckoutSessionResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .RequireAuthorization(PaymentsPermissions.Charges.Execute);
+            .RequireAuthorization(PaymentsPermissions.Charges.Execute)
+            .AllowHostAccess();
 
         return group;
     }

--- a/src/Granit.Payments.Endpoints/Permissions/PaymentsPermissionDefinitionProvider.cs
+++ b/src/Granit.Payments.Endpoints/Permissions/PaymentsPermissionDefinitionProvider.cs
@@ -12,17 +12,27 @@ internal sealed class PaymentsPermissionDefinitionProvider : IPermissionDefiniti
             PaymentsPermissions.GroupName,
             LocalizableString.Create<PaymentsEndpointsLocalizationResource>("PermissionGroup:Payments"));
 
+        // Both-sided: the host executes charges and refunds on behalf of tenants (SaaS
+        // collection flow) while tenants must be able to inspect their own transactions
+        // and manage their stored payment methods. Consumers running a tenant-only
+        // merchant flow can tighten these to Tenant in their own provider.
         group.AddPermission(PaymentsPermissions.Transactions.Read,
-            LocalizableString.Create<PaymentsEndpointsLocalizationResource>("Permission:Payments.Transactions.Read"));
+            LocalizableString.Create<PaymentsEndpointsLocalizationResource>("Permission:Payments.Transactions.Read"),
+            MultiTenancySide.Both);
         group.AddPermission(PaymentsPermissions.Charges.Execute,
-            LocalizableString.Create<PaymentsEndpointsLocalizationResource>("Permission:Payments.Charges.Execute"));
+            LocalizableString.Create<PaymentsEndpointsLocalizationResource>("Permission:Payments.Charges.Execute"),
+            MultiTenancySide.Both);
         group.AddPermission(PaymentsPermissions.Refunds.Execute,
-            LocalizableString.Create<PaymentsEndpointsLocalizationResource>("Permission:Payments.Refunds.Execute"));
+            LocalizableString.Create<PaymentsEndpointsLocalizationResource>("Permission:Payments.Refunds.Execute"),
+            MultiTenancySide.Both);
         group.AddPermission(PaymentsPermissions.Methods.Read,
-            LocalizableString.Create<PaymentsEndpointsLocalizationResource>("Permission:Payments.Methods.Read"));
+            LocalizableString.Create<PaymentsEndpointsLocalizationResource>("Permission:Payments.Methods.Read"),
+            MultiTenancySide.Both);
         group.AddPermission(PaymentsPermissions.Methods.Manage,
-            LocalizableString.Create<PaymentsEndpointsLocalizationResource>("Permission:Payments.Methods.Manage"));
+            LocalizableString.Create<PaymentsEndpointsLocalizationResource>("Permission:Payments.Methods.Manage"),
+            MultiTenancySide.Both);
         group.AddPermission(PaymentsPermissions.Configuration.Manage,
-            LocalizableString.Create<PaymentsEndpointsLocalizationResource>("Permission:Payments.Configuration.Manage"));
+            LocalizableString.Create<PaymentsEndpointsLocalizationResource>("Permission:Payments.Configuration.Manage"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.Privacy.Endpoints/Permissions/PrivacyPermissionDefinitionProvider.cs
+++ b/src/Granit.Privacy.Endpoints/Permissions/PrivacyPermissionDefinitionProvider.cs
@@ -21,26 +21,31 @@ internal sealed class PrivacyPermissionDefinitionProvider : IPermissionDefinitio
         group.AddPermission(
             PrivacyPermissions.Export.Execute,
             LocalizableString.Create<PrivacyEndpointsLocalizationResource>(
-                "Permission:Privacy.Export.Execute"));
+                "Permission:Privacy.Export.Execute"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             PrivacyPermissions.Deletion.Execute,
             LocalizableString.Create<PrivacyEndpointsLocalizationResource>(
-                "Permission:Privacy.Deletion.Execute"));
+                "Permission:Privacy.Deletion.Execute"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             PrivacyPermissions.Purposes.Read,
             LocalizableString.Create<PrivacyEndpointsLocalizationResource>(
-                "Permission:Privacy.Purposes.Read"));
+                "Permission:Privacy.Purposes.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             PrivacyPermissions.Agreements.Read,
             LocalizableString.Create<PrivacyEndpointsLocalizationResource>(
-                "Permission:Privacy.Agreements.Read"));
+                "Permission:Privacy.Agreements.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             PrivacyPermissions.Agreements.Create,
             LocalizableString.Create<PrivacyEndpointsLocalizationResource>(
-                "Permission:Privacy.Agreements.Create"));
+                "Permission:Privacy.Agreements.Create"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.ReferenceData.Endpoints/Permissions/ReferenceDataPermissionDefinitionProvider.cs
+++ b/src/Granit.ReferenceData.Endpoints/Permissions/ReferenceDataPermissionDefinitionProvider.cs
@@ -25,11 +25,13 @@ internal sealed class ReferenceDataPermissionDefinitionProvider : IPermissionDef
         group.AddPermission(
             ReferenceDataPermissions.Entries.Read,
             LocalizableString.Create<ReferenceDataEndpointsLocalizationResource>(
-                "Permission:ReferenceData.Entries.Read"));
+                "Permission:ReferenceData.Entries.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             ReferenceDataPermissions.Entries.Manage,
             LocalizableString.Create<ReferenceDataEndpointsLocalizationResource>(
-                "Permission:ReferenceData.Entries.Manage"));
+                "Permission:ReferenceData.Entries.Manage"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.Scheduling.Endpoints/Permissions/SchedulingPermissionDefinitionProvider.cs
+++ b/src/Granit.Scheduling.Endpoints/Permissions/SchedulingPermissionDefinitionProvider.cs
@@ -21,11 +21,13 @@ internal sealed class SchedulingPermissionDefinitionProvider : IPermissionDefini
         group.AddPermission(
             SchedulingPermissions.Actions.Read,
             LocalizableString.Create<SchedulingEndpointsLocalizationResource>(
-                "Permission:Scheduling.Actions.Read"));
+                "Permission:Scheduling.Actions.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             SchedulingPermissions.Actions.Manage,
             LocalizableString.Create<SchedulingEndpointsLocalizationResource>(
-                "Permission:Scheduling.Actions.Manage"));
+                "Permission:Scheduling.Actions.Manage"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.Settings.Endpoints/Permissions/SettingsPermissionDefinitionProvider.cs
+++ b/src/Granit.Settings.Endpoints/Permissions/SettingsPermissionDefinitionProvider.cs
@@ -17,24 +17,31 @@ internal sealed class SettingsPermissionDefinitionProvider : IPermissionDefiniti
             LocalizableString.Create<SettingsEndpointsLocalizationResource>(
                 "PermissionGroup:Settings"));
 
+        // Global settings live at the host level by design — the permission name itself
+        // advertises the scope.
         group.AddPermission(
             SettingsPermissions.Global.Read,
             LocalizableString.Create<SettingsEndpointsLocalizationResource>(
-                "Permission:Settings.Global.Read"));
+                "Permission:Settings.Global.Read"),
+            MultiTenancySide.Host);
 
         group.AddPermission(
             SettingsPermissions.Global.Manage,
             LocalizableString.Create<SettingsEndpointsLocalizationResource>(
-                "Permission:Settings.Global.Manage"));
+                "Permission:Settings.Global.Manage"),
+            MultiTenancySide.Host);
 
+        // Tenant settings are only meaningful inside a tenant context.
         group.AddPermission(
             SettingsPermissions.Tenant.Read,
             LocalizableString.Create<SettingsEndpointsLocalizationResource>(
-                "Permission:Settings.Tenant.Read"));
+                "Permission:Settings.Tenant.Read"),
+            MultiTenancySide.Tenant);
 
         group.AddPermission(
             SettingsPermissions.Tenant.Manage,
             LocalizableString.Create<SettingsEndpointsLocalizationResource>(
-                "Permission:Settings.Tenant.Manage"));
+                "Permission:Settings.Tenant.Manage"),
+            MultiTenancySide.Tenant);
     }
 }

--- a/src/Granit.Subscriptions.Endpoints/Endpoints/SeatEndpoints.cs
+++ b/src/Granit.Subscriptions.Endpoints/Endpoints/SeatEndpoints.cs
@@ -1,3 +1,4 @@
+using Granit.Authorization.Extensions;
 using Granit.Http.Idempotency.Attributes;
 using Granit.MultiTenancy;
 using Granit.Subscriptions.Domain;
@@ -23,7 +24,8 @@ internal static class SeatEndpoints
             .Produces<IReadOnlyList<SeatResponse>>()
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .RequireAuthorization(SubscriptionsPermissions.Seats.Read);
+            .RequireAuthorization(SubscriptionsPermissions.Seats.Read)
+            .AllowHostAccess();
 
         group.MapPost("/subscriptions/{id:guid}/seats", AssignSeatAsync)
             .WithName("AssignSeat")
@@ -34,7 +36,8 @@ internal static class SeatEndpoints
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict)
-            .RequireAuthorization(SubscriptionsPermissions.Seats.Manage);
+            .RequireAuthorization(SubscriptionsPermissions.Seats.Manage)
+            .AllowHostAccess();
 
         group.MapDelete("/subscriptions/{id:guid}/seats/{userId:guid}", RevokeSeatAsync)
             .WithName("RevokeSeat")
@@ -44,7 +47,8 @@ internal static class SeatEndpoints
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .RequireAuthorization(SubscriptionsPermissions.Seats.Manage);
+            .RequireAuthorization(SubscriptionsPermissions.Seats.Manage)
+            .AllowHostAccess();
 
         return group;
     }

--- a/src/Granit.Subscriptions.Endpoints/Endpoints/SubscriptionEndpoints.cs
+++ b/src/Granit.Subscriptions.Endpoints/Endpoints/SubscriptionEndpoints.cs
@@ -28,7 +28,8 @@ internal static class SubscriptionEndpoints
             .Produces<SubscriptionResponse>()
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .RequireAuthorization(SubscriptionsPermissions.Subscriptions.Read);
+            .RequireAuthorization(SubscriptionsPermissions.Subscriptions.Read)
+            .AllowHostAccess();
 
         group.MapGet("/subscriptions/{id:guid}", GetSubscriptionByIdAsync)
             .WithName("GetSubscriptionById")
@@ -48,7 +49,8 @@ internal static class SubscriptionEndpoints
             .Produces<SubscriptionResponse>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesValidationProblem()
-            .RequireAuthorization(SubscriptionsPermissions.Subscriptions.Manage);
+            .RequireAuthorization(SubscriptionsPermissions.Subscriptions.Manage)
+            .AllowHostAccess();
 
         group.MapPost("/subscriptions/{id:guid}/cancel", CancelSubscriptionAsync)
             .WithName("CancelSubscription")
@@ -58,7 +60,8 @@ internal static class SubscriptionEndpoints
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict)
-            .RequireAuthorization(SubscriptionsPermissions.Subscriptions.Manage);
+            .RequireAuthorization(SubscriptionsPermissions.Subscriptions.Manage)
+            .AllowHostAccess();
 
         group.MapPost("/subscriptions/{id:guid}/change-plan", ChangePlanAsync)
             .WithName("ChangeSubscriptionPlan")
@@ -69,7 +72,8 @@ internal static class SubscriptionEndpoints
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict)
-            .RequireAuthorization(SubscriptionsPermissions.Subscriptions.Manage);
+            .RequireAuthorization(SubscriptionsPermissions.Subscriptions.Manage)
+            .AllowHostAccess();
 
         return group;
     }

--- a/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissionDefinitionProvider.cs
+++ b/src/Granit.Subscriptions.Endpoints/Permissions/SubscriptionsPermissionDefinitionProvider.cs
@@ -13,21 +13,33 @@ internal sealed class SubscriptionsPermissionDefinitionProvider : IPermissionDef
             LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>(
                 "PermissionGroup:Subscriptions"));
 
+        // Plans and Prices are the SaaS catalog: they are authored at the host level only.
         group.AddPermission(SubscriptionsPermissions.Plans.Read,
-            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Plans.Read"));
+            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Plans.Read"),
+            MultiTenancySide.Host);
         group.AddPermission(SubscriptionsPermissions.Plans.Manage,
-            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Plans.Manage"));
-        group.AddPermission(SubscriptionsPermissions.Subscriptions.Read,
-            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Subscriptions.Read"));
-        group.AddPermission(SubscriptionsPermissions.Subscriptions.Manage,
-            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Subscriptions.Manage"));
+            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Plans.Manage"),
+            MultiTenancySide.Host);
         group.AddPermission(SubscriptionsPermissions.Prices.Read,
-            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Prices.Read"));
+            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Prices.Read"),
+            MultiTenancySide.Host);
         group.AddPermission(SubscriptionsPermissions.Prices.Manage,
-            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Prices.Manage"));
+            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Prices.Manage"),
+            MultiTenancySide.Host);
+
+        // Subscriptions and Seats: the host provisions and adjusts tenant subscriptions,
+        // and each tenant also needs to see/manage its own plan and seats. Both-sided.
+        group.AddPermission(SubscriptionsPermissions.Subscriptions.Read,
+            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Subscriptions.Read"),
+            MultiTenancySide.Both);
+        group.AddPermission(SubscriptionsPermissions.Subscriptions.Manage,
+            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Subscriptions.Manage"),
+            MultiTenancySide.Both);
         group.AddPermission(SubscriptionsPermissions.Seats.Read,
-            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Seats.Read"));
+            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Seats.Read"),
+            MultiTenancySide.Both);
         group.AddPermission(SubscriptionsPermissions.Seats.Manage,
-            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Seats.Manage"));
+            LocalizableString.Create<SubscriptionsEndpointsLocalizationResource>("Permission:Subscriptions.Seats.Manage"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.Tax.Endpoints/Endpoints/TaxValidationEndpoints.cs
+++ b/src/Granit.Tax.Endpoints/Endpoints/TaxValidationEndpoints.cs
@@ -1,3 +1,4 @@
+using Granit.Authorization.Extensions;
 using Granit.Tax.Endpoints.Dtos;
 using Granit.Tax.Endpoints.Permissions;
 using Microsoft.AspNetCore.Builder;
@@ -15,6 +16,7 @@ internal static class TaxValidationEndpoints
     {
         group.MapPost("/validate", ValidateAsync)
             .RequireAuthorization(TaxPermissions.Validations.Execute)
+            .AllowHostAccess()
             .WithName("ValidateTaxId")
             .WithSummary("Validates a tax ID online against the relevant tax authority.")
             .WithDescription(

--- a/src/Granit.Tax.Endpoints/Extensions/TaxEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Tax.Endpoints/Extensions/TaxEndpointRouteBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Authorization.Extensions;
 using Granit.QueryEngine.AspNetCore.Extensions;
 using Granit.Tax.Endpoints.Endpoints;
 using Granit.Tax.Endpoints.Permissions;
@@ -25,7 +26,8 @@ public static class TaxEndpointRouteBuilderExtensions
         // Both behind Tax.Rates.Read.
         RouteGroupBuilder ratesGroup = group
             .MapGranitGroup("rates")
-            .RequireAuthorization(TaxPermissions.Rates.Read);
+            .RequireAuthorization(TaxPermissions.Rates.Read)
+            .AllowHostAccess();
         ratesGroup.MapGranitQuery<TaxRateEntry>();
         ratesGroup.MapRateEndpoints();
 

--- a/src/Granit.Tax.Endpoints/Permissions/TaxPermissionDefinitionProvider.cs
+++ b/src/Granit.Tax.Endpoints/Permissions/TaxPermissionDefinitionProvider.cs
@@ -12,13 +12,19 @@ internal sealed class TaxPermissionDefinitionProvider : IPermissionDefinitionPro
             TaxPermissions.GroupName,
             LocalizableString.Create<TaxEndpointsLocalizationResource>("PermissionGroup:Tax"));
 
+        // Both-sided: tax rules apply to SaaS invoicing of tenants (host) AND to the
+        // tenant's own billing flow (tenant). Validations run from either context.
         group.AddPermission(TaxPermissions.Rates.Read,
-            LocalizableString.Create<TaxEndpointsLocalizationResource>("Permission:Tax.Rates.Read"));
+            LocalizableString.Create<TaxEndpointsLocalizationResource>("Permission:Tax.Rates.Read"),
+            MultiTenancySide.Both);
         group.AddPermission(TaxPermissions.Rates.Manage,
-            LocalizableString.Create<TaxEndpointsLocalizationResource>("Permission:Tax.Rates.Manage"));
+            LocalizableString.Create<TaxEndpointsLocalizationResource>("Permission:Tax.Rates.Manage"),
+            MultiTenancySide.Both);
         group.AddPermission(TaxPermissions.Validations.Read,
-            LocalizableString.Create<TaxEndpointsLocalizationResource>("Permission:Tax.Validations.Read"));
+            LocalizableString.Create<TaxEndpointsLocalizationResource>("Permission:Tax.Validations.Read"),
+            MultiTenancySide.Both);
         group.AddPermission(TaxPermissions.Validations.Execute,
-            LocalizableString.Create<TaxEndpointsLocalizationResource>("Permission:Tax.Validations.Execute"));
+            LocalizableString.Create<TaxEndpointsLocalizationResource>("Permission:Tax.Validations.Execute"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.Templating.Endpoints/Permissions/TemplatingPermissionDefinitionProvider.cs
+++ b/src/Granit.Templating.Endpoints/Permissions/TemplatingPermissionDefinitionProvider.cs
@@ -23,21 +23,25 @@ internal sealed class TemplatingPermissionDefinitionProvider : IPermissionDefini
         group.AddPermission(
             TemplatingPermissions.Templates.Read,
             LocalizableString.Create<TemplatingEndpointsLocalizationResource>(
-                "Permission:Templating.Templates.Read"));
+                "Permission:Templating.Templates.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             TemplatingPermissions.Templates.Manage,
             LocalizableString.Create<TemplatingEndpointsLocalizationResource>(
-                "Permission:Templating.Templates.Manage"));
+                "Permission:Templating.Templates.Manage"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             TemplatingPermissions.Categories.Read,
             LocalizableString.Create<TemplatingEndpointsLocalizationResource>(
-                "Permission:Templating.Categories.Read"));
+                "Permission:Templating.Categories.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             TemplatingPermissions.Categories.Manage,
             LocalizableString.Create<TemplatingEndpointsLocalizationResource>(
-                "Permission:Templating.Categories.Manage"));
+                "Permission:Templating.Categories.Manage"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.Timeline.Endpoints/Permissions/TimelinePermissionDefinitionProvider.cs
+++ b/src/Granit.Timeline.Endpoints/Permissions/TimelinePermissionDefinitionProvider.cs
@@ -20,26 +20,31 @@ internal sealed class TimelinePermissionDefinitionProvider : IPermissionDefiniti
         group.AddPermission(
             TimelinePermissions.Entries.Read,
             LocalizableString.Create<TimelineEndpointsLocalizationResource>(
-                "Permission:Timeline.Entries.Read"));
+                "Permission:Timeline.Entries.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             TimelinePermissions.Entries.Create,
             LocalizableString.Create<TimelineEndpointsLocalizationResource>(
-                "Permission:Timeline.Entries.Create"));
+                "Permission:Timeline.Entries.Create"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             TimelinePermissions.Entries.Manage,
             LocalizableString.Create<TimelineEndpointsLocalizationResource>(
-                "Permission:Timeline.Entries.Manage"));
+                "Permission:Timeline.Entries.Manage"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             TimelinePermissions.InternalNotes.Read,
             LocalizableString.Create<TimelineEndpointsLocalizationResource>(
-                "Permission:Timeline.InternalNotes.Read"));
+                "Permission:Timeline.InternalNotes.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             TimelinePermissions.Followers.Manage,
             LocalizableString.Create<TimelineEndpointsLocalizationResource>(
-                "Permission:Timeline.Followers.Manage"));
+                "Permission:Timeline.Followers.Manage"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.Webhooks.Endpoints/Permissions/WebhooksPermissionDefinitionProvider.cs
+++ b/src/Granit.Webhooks.Endpoints/Permissions/WebhooksPermissionDefinitionProvider.cs
@@ -39,11 +39,13 @@ internal sealed class WebhooksPermissionDefinitionProvider : IPermissionDefiniti
         group.AddPermission(
             WebhooksPermissions.Subscriptions.Read,
             LocalizableString.Create<WebhooksEndpointsLocalizationResource>(
-                "Permission:Webhooks.Subscriptions.Read"));
+                "Permission:Webhooks.Subscriptions.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             WebhooksPermissions.Subscriptions.Manage,
             LocalizableString.Create<WebhooksEndpointsLocalizationResource>(
-                "Permission:Webhooks.Subscriptions.Manage"));
+                "Permission:Webhooks.Subscriptions.Manage"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.Workflow.Endpoints/Permissions/WorkflowPermissionDefinitionProvider.cs
+++ b/src/Granit.Workflow.Endpoints/Permissions/WorkflowPermissionDefinitionProvider.cs
@@ -25,16 +25,19 @@ internal sealed class WorkflowPermissionDefinitionProvider : IPermissionDefiniti
         group.AddPermission(
             WorkflowPermissions.History.Read,
             LocalizableString.Create<WorkflowEndpointsLocalizationResource>(
-                "Permission:Workflow.History.Read"));
+                "Permission:Workflow.History.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             WorkflowPermissions.Transitions.Read,
             LocalizableString.Create<WorkflowEndpointsLocalizationResource>(
-                "Permission:Workflow.Transitions.Read"));
+                "Permission:Workflow.Transitions.Read"),
+            MultiTenancySide.Both);
 
         group.AddPermission(
             WorkflowPermissions.Transitions.Execute,
             LocalizableString.Create<WorkflowEndpointsLocalizationResource>(
-                "Permission:Workflow.Transitions.Execute"));
+                "Permission:Workflow.Transitions.Execute"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.Workflow.Notifications/Internal/IdentityApproverResolver.cs
+++ b/src/Granit.Workflow.Notifications/Internal/IdentityApproverResolver.cs
@@ -14,7 +14,7 @@ namespace Granit.Workflow.Notifications.Internal;
 /// Resolution flow:
 /// <list type="number">
 ///   <item>
-///     <see cref="IPermissionManagerReader.GetGrantedRolesAsync"/> retrieves role names
+///     <see cref="IPermissionManagerReader.GetGranteesAsync"/> retrieves role names
 ///     granted the required permission (from the authorization database).
 ///   </item>
 ///   <item>
@@ -37,8 +37,9 @@ internal sealed partial class IdentityApproverResolver(
     {
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
 
-        IReadOnlyList<string> roles = await permissionManagerReader.GetGrantedRolesAsync(
-            requiredPermission, tenantId, cancellationToken).ConfigureAwait(false);
+        IReadOnlyList<string> roles = await permissionManagerReader.GetGranteesAsync(
+            PermissionGrantProviderNames.Role, requiredPermission, tenantId, cancellationToken)
+            .ConfigureAwait(false);
 
         if (roles.Count == 0)
         {

--- a/src/Granit/Users/ICurrentUserService.cs
+++ b/src/Granit/Users/ICurrentUserService.cs
@@ -53,4 +53,15 @@ public interface ICurrentUserService
     /// API key identifier when authenticated via API key, <c>null</c> otherwise.
     /// </summary>
     Guid? ApiKeyId => null;
+
+    /// <summary>
+    /// OIDC <c>client_id</c> of the calling application, <c>null</c> when unavailable
+    /// (e.g. local dev hosts without an IDP, or tests).
+    /// </summary>
+    /// <remarks>
+    /// Used by <c>ClientPermissionGrantProvider</c> (Granit.Authorization) to resolve
+    /// client-level permission grants. Default implementation returns <c>null</c> so
+    /// existing <see cref="ICurrentUserService"/> impls remain source-compatible.
+    /// </remarks>
+    string? ClientId => null;
 }

--- a/tests/Granit.Authorization.Endpoints.Tests/AuthorizationEndpointsTests.cs
+++ b/tests/Granit.Authorization.Endpoints.Tests/AuthorizationEndpointsTests.cs
@@ -197,7 +197,7 @@ public sealed class AuthorizationEndpointsTests : IAsyncDisposable
     public async Task GetRolePermissions_WithAdminRole_Returns200()
     {
         // Arrange
-        _permissionManagerReader.GetGrantedPermissionsAsync("editor", null, Arg.Any<CancellationToken>())
+        _permissionManagerReader.GetGrantedPermissionsAsync("R", "editor", null, Arg.Any<CancellationToken>())
             .Returns(["Invoices.Read", "Invoices.Create"]);
 
         // Act
@@ -247,7 +247,7 @@ public sealed class AuthorizationEndpointsTests : IAsyncDisposable
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
         await _permissionManagerWriter.Received(1).SetAsync(
-            "Invoices.Read", "editor", null, true, Arg.Any<CancellationToken>());
+            "Invoices.Read", "R", "editor", null, true, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -300,7 +300,7 @@ public sealed class AuthorizationEndpointsTests : IAsyncDisposable
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
         await _permissionManagerWriter.Received(1).SetAsync(
-            "Invoices.Read", "editor", null, false, Arg.Any<CancellationToken>());
+            "Invoices.Read", "R", "editor", null, false, Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Granit.Authorization.EntityFrameworkCore.Tests/EfCorePermissionGrantStoreTests.cs
+++ b/tests/Granit.Authorization.EntityFrameworkCore.Tests/EfCorePermissionGrantStoreTests.cs
@@ -3,10 +3,14 @@
 // =============================================================================
 // Vérifie que le store :
 //   - Retourne true pour un grant existant
-//   - Retourne false si le rôle, la permission ou le tenant ne correspond pas
+//   - Retourne false si le grantee (ProviderName/ProviderKey), la permission ou le tenant
+//     ne correspondent pas
 //   - Gère correctement les grants à portée globale (TenantId null)
+// Les grants sont scopés via le tuple ABP-style (ProviderName, ProviderKey) où
+// ProviderName="R" identifie un grantee de type rôle.
 // =============================================================================
 
+using Granit.Authorization;
 using Granit.Authorization.Domain;
 using Granit.Authorization.EntityFrameworkCore.DbContext;
 using Granit.Authorization.EntityFrameworkCore.Stores;
@@ -19,137 +23,130 @@ namespace Granit.Authorization.EntityFrameworkCore.Tests;
 
 public sealed class EfCorePermissionGrantStoreTests
 {
+    private const string R = PermissionGrantProviderNames.Role;
     private static readonly Guid TenantA = Guid.NewGuid();
     private static readonly Guid TenantB = Guid.NewGuid();
 
     [Fact]
     public async Task IsGrantedAsync_MatchingGrant_ReturnsTrue()
     {
-        // Arrange
         await using TestDbContext context = CreateContext();
         await SeedAsync(context, "accountant", "Invoices.Delete", TenantA);
         EfCorePermissionGrantStore<TestDbContext> store = new(context, new SimpleGuidGenerator());
 
-        // Act
-        bool result = await store.IsGrantedAsync("accountant", "Invoices.Delete", TenantA, TestContext.Current.CancellationToken);
+        bool result = await store.IsGrantedAsync(R, "accountant", "Invoices.Delete", TenantA, TestContext.Current.CancellationToken);
 
-        // Assert
         result.ShouldBeTrue();
     }
 
     [Fact]
     public async Task IsGrantedAsync_DifferentRole_ReturnsFalse()
     {
-        // Arrange
         await using TestDbContext context = CreateContext();
         await SeedAsync(context, "accountant", "Invoices.Delete", TenantA);
         EfCorePermissionGrantStore<TestDbContext> store = new(context, new SimpleGuidGenerator());
 
-        // Act
-        bool result = await store.IsGrantedAsync("reader", "Invoices.Delete", TenantA, TestContext.Current.CancellationToken);
+        bool result = await store.IsGrantedAsync(R, "reader", "Invoices.Delete", TenantA, TestContext.Current.CancellationToken);
 
-        // Assert
         result.ShouldBeFalse();
     }
 
     [Fact]
     public async Task IsGrantedAsync_DifferentPermission_ReturnsFalse()
     {
-        // Arrange
         await using TestDbContext context = CreateContext();
         await SeedAsync(context, "accountant", "Invoices.Delete", TenantA);
         EfCorePermissionGrantStore<TestDbContext> store = new(context, new SimpleGuidGenerator());
 
-        // Act
-        bool result = await store.IsGrantedAsync("accountant", "Invoices.Read", TenantA, TestContext.Current.CancellationToken);
+        bool result = await store.IsGrantedAsync(R, "accountant", "Invoices.Read", TenantA, TestContext.Current.CancellationToken);
 
-        // Assert
         result.ShouldBeFalse();
     }
 
     [Fact]
     public async Task IsGrantedAsync_DifferentTenant_ReturnsFalse()
     {
-        // Arrange
         await using TestDbContext context = CreateContext();
         await SeedAsync(context, "accountant", "Invoices.Delete", TenantA);
         EfCorePermissionGrantStore<TestDbContext> store = new(context, new SimpleGuidGenerator());
 
-        // Act
-        bool result = await store.IsGrantedAsync("accountant", "Invoices.Delete", TenantB, TestContext.Current.CancellationToken);
+        bool result = await store.IsGrantedAsync(R, "accountant", "Invoices.Delete", TenantB, TestContext.Current.CancellationToken);
 
-        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task IsGrantedAsync_DifferentProvider_ReturnsFalse()
+    {
+        await using TestDbContext context = CreateContext();
+        await SeedAsync(context, "accountant", "Invoices.Delete", TenantA);
+        EfCorePermissionGrantStore<TestDbContext> store = new(context, new SimpleGuidGenerator());
+
+        // Same textual key but a different provider — must not match.
+        bool result = await store.IsGrantedAsync(
+            PermissionGrantProviderNames.User, "accountant", "Invoices.Delete", TenantA,
+            TestContext.Current.CancellationToken);
+
         result.ShouldBeFalse();
     }
 
     [Fact]
     public async Task IsGrantedAsync_GlobalGrant_NullTenantMatches()
     {
-        // Arrange
         await using TestDbContext context = CreateContext();
         await SeedAsync(context, "admin", "System.Configure", tenantId: null);
         EfCorePermissionGrantStore<TestDbContext> store = new(context, new SimpleGuidGenerator());
 
-        // Act
-        bool result = await store.IsGrantedAsync("admin", "System.Configure", tenantId: null, TestContext.Current.CancellationToken);
+        bool result = await store.IsGrantedAsync(
+            R, "admin", "System.Configure", tenantId: null, TestContext.Current.CancellationToken);
 
-        // Assert
         result.ShouldBeTrue();
     }
 
     [Fact]
     public async Task IsGrantedAsync_GlobalGrantDoesNotMatchTenant_ReturnsFalse()
     {
-        // Arrange
         await using TestDbContext context = CreateContext();
         await SeedAsync(context, "admin", "System.Configure", tenantId: null);
         EfCorePermissionGrantStore<TestDbContext> store = new(context, new SimpleGuidGenerator());
 
-        // Act — tenant-scoped query should not match the global (null) grant
-        bool result = await store.IsGrantedAsync("admin", "System.Configure", TenantA, TestContext.Current.CancellationToken);
+        bool result = await store.IsGrantedAsync(R, "admin", "System.Configure", TenantA, TestContext.Current.CancellationToken);
 
-        // Assert
         result.ShouldBeFalse();
     }
 
     // --- GetGrantedPermissionsAsync ---
 
     [Fact]
-    public async Task GetGrantedPermissionsAsync_ReturnsPermissionsForRole()
+    public async Task GetGrantedPermissionsAsync_ReturnsPermissionsForGrantee()
     {
-        // Arrange
         await using TestDbContext context = CreateContext();
         await SeedAsync(context, "accountant", "Invoices.Delete", TenantA);
         await SeedAsync(context, "accountant", "Invoices.Read", TenantA);
         await SeedAsync(context, "reader", "Invoices.Read", TenantA);
         EfCorePermissionGrantStore<TestDbContext> store = new(context, new SimpleGuidGenerator());
 
-        // Act
         IReadOnlyList<string> permissions =
-            await store.GetGrantedPermissionsAsync("accountant", TenantA, TestContext.Current.CancellationToken);
+            await store.GetGrantedPermissionsAsync(R, "accountant", TenantA, TestContext.Current.CancellationToken);
 
-        // Assert
         permissions.ShouldBe(["Invoices.Delete", "Invoices.Read"]);
     }
 
-    // --- GetGrantedRolesAsync ---
+    // --- GetGranteesAsync ---
 
     [Fact]
-    public async Task GetGrantedRolesAsync_ReturnsRolesForPermission()
+    public async Task GetGranteesAsync_ReturnsGranteesForPermission()
     {
-        // Arrange
         await using TestDbContext context = CreateContext();
         await SeedAsync(context, "accountant", "Invoices.Delete", TenantA);
         await SeedAsync(context, "manager", "Invoices.Delete", TenantA);
         await SeedAsync(context, "reader", "Invoices.Read", TenantA);
         EfCorePermissionGrantStore<TestDbContext> store = new(context, new SimpleGuidGenerator());
 
-        // Act
-        IReadOnlyList<string> roles =
-            await store.GetGrantedRolesAsync("Invoices.Delete", TenantA, TestContext.Current.CancellationToken);
+        IReadOnlyList<string> grantees =
+            await store.GetGranteesAsync(R, "Invoices.Delete", TenantA, TestContext.Current.CancellationToken);
 
-        // Assert
-        roles.ShouldBe(["accountant", "manager"]);
+        grantees.ShouldBe(["accountant", "manager"]);
     }
 
     // --- GrantAsync ---
@@ -157,17 +154,17 @@ public sealed class EfCorePermissionGrantStoreTests
     [Fact]
     public async Task GrantAsync_NewGrant_ReturnsTrueAndPersists()
     {
-        // Arrange
         await using TestDbContext context = CreateContext();
         EfCorePermissionGrantStore<TestDbContext> store = new(context, new SimpleGuidGenerator());
 
-        // Act
-        bool result = await store.GrantAsync("Invoices.Delete", "accountant", TenantA, TestContext.Current.CancellationToken);
+        bool result = await store.GrantAsync(R, "accountant", "Invoices.Delete", TenantA, TestContext.Current.CancellationToken);
 
-        // Assert
         result.ShouldBeTrue();
         bool exists = await context.PermissionGrants.AnyAsync(
-            g => g.Name == "Invoices.Delete" && g.RoleName == "accountant" && g.TenantId == TenantA,
+            g => g.Name == "Invoices.Delete"
+                && g.ProviderName == R
+                && g.ProviderKey == "accountant"
+                && g.TenantId == TenantA,
             TestContext.Current.CancellationToken);
         exists.ShouldBeTrue();
     }
@@ -175,15 +172,12 @@ public sealed class EfCorePermissionGrantStoreTests
     [Fact]
     public async Task GrantAsync_AlreadyExists_ReturnsFalse()
     {
-        // Arrange
         await using TestDbContext context = CreateContext();
         await SeedAsync(context, "accountant", "Invoices.Delete", TenantA);
         EfCorePermissionGrantStore<TestDbContext> store = new(context, new SimpleGuidGenerator());
 
-        // Act
-        bool result = await store.GrantAsync("Invoices.Delete", "accountant", TenantA, TestContext.Current.CancellationToken);
+        bool result = await store.GrantAsync(R, "accountant", "Invoices.Delete", TenantA, TestContext.Current.CancellationToken);
 
-        // Assert
         result.ShouldBeFalse();
     }
 
@@ -192,18 +186,18 @@ public sealed class EfCorePermissionGrantStoreTests
     [Fact]
     public async Task RevokeAsync_ExistingGrant_ReturnsTrueAndRemoves()
     {
-        // Arrange
         await using TestDbContext context = CreateContext();
         await SeedAsync(context, "accountant", "Invoices.Delete", TenantA);
         EfCorePermissionGrantStore<TestDbContext> store = new(context, new SimpleGuidGenerator());
 
-        // Act
-        bool result = await store.RevokeAsync("Invoices.Delete", "accountant", TenantA, TestContext.Current.CancellationToken);
+        bool result = await store.RevokeAsync(R, "accountant", "Invoices.Delete", TenantA, TestContext.Current.CancellationToken);
 
-        // Assert
         result.ShouldBeTrue();
         bool exists = await context.PermissionGrants.AnyAsync(
-            g => g.Name == "Invoices.Delete" && g.RoleName == "accountant" && g.TenantId == TenantA,
+            g => g.Name == "Invoices.Delete"
+                && g.ProviderName == R
+                && g.ProviderKey == "accountant"
+                && g.TenantId == TenantA,
             TestContext.Current.CancellationToken);
         exists.ShouldBeFalse();
     }
@@ -211,14 +205,11 @@ public sealed class EfCorePermissionGrantStoreTests
     [Fact]
     public async Task RevokeAsync_NotExists_ReturnsFalse()
     {
-        // Arrange
         await using TestDbContext context = CreateContext();
         EfCorePermissionGrantStore<TestDbContext> store = new(context, new SimpleGuidGenerator());
 
-        // Act
-        bool result = await store.RevokeAsync("Invoices.Delete", "accountant", TenantA, TestContext.Current.CancellationToken);
+        bool result = await store.RevokeAsync(R, "accountant", "Invoices.Delete", TenantA, TestContext.Current.CancellationToken);
 
-        // Assert
         result.ShouldBeFalse();
     }
 
@@ -239,10 +230,10 @@ public sealed class EfCorePermissionGrantStoreTests
         {
             Id = Guid.NewGuid(),
             Name = permissionName,
-            RoleName = roleName,
+            ProviderName = R,
+            ProviderKey = roleName,
             TenantId = tenantId
         });
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
     }
-
 }

--- a/tests/Granit.Authorization.EntityFrameworkCore.Tests/PermissionGrantEntityTests.cs
+++ b/tests/Granit.Authorization.EntityFrameworkCore.Tests/PermissionGrantEntityTests.cs
@@ -1,3 +1,4 @@
+using Granit.Authorization;
 using Granit.Authorization.Domain;
 using Granit.Domain;
 using Shouldly;
@@ -32,11 +33,19 @@ public sealed class PermissionGrantEntityTests
     }
 
     [Fact]
-    public void RoleName_Default_IsEmptyString()
+    public void ProviderName_Default_IsEmptyString()
     {
         PermissionGrant grant = new();
 
-        grant.RoleName.ShouldBe(string.Empty);
+        grant.ProviderName.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void ProviderKey_Default_IsEmptyString()
+    {
+        PermissionGrant grant = new();
+
+        grant.ProviderKey.ShouldBe(string.Empty);
     }
 
     [Fact]
@@ -57,13 +66,15 @@ public sealed class PermissionGrantEntityTests
         {
             Id = id,
             Name = "Invoices.Delete",
-            RoleName = "accountant",
+            ProviderName = PermissionGrantProviderNames.Role,
+            ProviderKey = "accountant",
             TenantId = tenantId
         };
 
         grant.Id.ShouldBe(id);
         grant.Name.ShouldBe("Invoices.Delete");
-        grant.RoleName.ShouldBe("accountant");
+        grant.ProviderName.ShouldBe("R");
+        grant.ProviderKey.ShouldBe("accountant");
         grant.TenantId.ShouldBe(tenantId);
     }
 }

--- a/tests/Granit.Authorization.Tests/NullPermissionGrantStoreTests.cs
+++ b/tests/Granit.Authorization.Tests/NullPermissionGrantStoreTests.cs
@@ -14,20 +14,20 @@ namespace Granit.Authorization.Tests;
 
 public sealed class NullPermissionGrantStoreTests
 {
+    private const string R = PermissionGrantProviderNames.Role;
+
     [Fact]
     public async Task IsGrantedAsync_AlwaysReturnsFalse()
     {
-        // Arrange
         NullPermissionGrantStore store = new(NullLogger<NullPermissionGrantStore>.Instance);
 
-        // Act
         bool result = await store.IsGrantedAsync(
+            R,
             "admin",
             "Invoices.Delete",
             tenantId: null,
             TestContext.Current.CancellationToken);
 
-        // Assert
         result.ShouldBeFalse("NullPermissionGrantStore denies every permission by design");
     }
 
@@ -36,78 +36,64 @@ public sealed class NullPermissionGrantStoreTests
     [InlineData("editor", "Products.Create", "00000000-0000-0000-0000-000000000001")]
     [InlineData("viewer", "Reports.Export", "00000000-0000-0000-0000-000000000002")]
     public async Task IsGrantedAsync_AnyArguments_AlwaysReturnsFalse(
-        string roleName,
+        string providerKey,
         string permissionName,
         string? tenantIdString)
     {
-        // Arrange
         NullPermissionGrantStore store = new(NullLogger<NullPermissionGrantStore>.Instance);
         Guid? tenantId = tenantIdString is null ? null : Guid.Parse(tenantIdString);
 
-        // Act
         bool result = await store.IsGrantedAsync(
-            roleName,
+            R,
+            providerKey,
             permissionName,
             tenantId,
             TestContext.Current.CancellationToken);
 
-        // Assert
         result.ShouldBeFalse();
     }
 
     [Fact]
     public async Task GetGrantedPermissionsAsync_ReturnsEmpty()
     {
-        // Arrange
         NullPermissionGrantStore store = new(NullLogger<NullPermissionGrantStore>.Instance);
 
-        // Act
         IReadOnlyList<string> result = await store.GetGrantedPermissionsAsync(
-            "admin", tenantId: null, TestContext.Current.CancellationToken);
+            R, "admin", tenantId: null, TestContext.Current.CancellationToken);
 
-        // Assert
         result.ShouldBeEmpty();
     }
 
     [Fact]
-    public async Task GetGrantedRolesAsync_ReturnsEmpty()
+    public async Task GetGranteesAsync_ReturnsEmpty()
     {
-        // Arrange
         NullPermissionGrantStore store = new(NullLogger<NullPermissionGrantStore>.Instance);
 
-        // Act
-        IReadOnlyList<string> result = await store.GetGrantedRolesAsync(
-            "Invoices.Delete", tenantId: null, TestContext.Current.CancellationToken);
+        IReadOnlyList<string> result = await store.GetGranteesAsync(
+            R, "Invoices.Delete", tenantId: null, TestContext.Current.CancellationToken);
 
-        // Assert
         result.ShouldBeEmpty();
     }
 
     [Fact]
     public async Task GrantAsync_ReturnsFalse()
     {
-        // Arrange
         NullPermissionGrantStore store = new(NullLogger<NullPermissionGrantStore>.Instance);
 
-        // Act
         bool result = await store.GrantAsync(
-            "Invoices.Delete", "admin", tenantId: null, TestContext.Current.CancellationToken);
+            R, "admin", "Invoices.Delete", tenantId: null, TestContext.Current.CancellationToken);
 
-        // Assert
         result.ShouldBeFalse();
     }
 
     [Fact]
     public async Task RevokeAsync_ReturnsFalse()
     {
-        // Arrange
         NullPermissionGrantStore store = new(NullLogger<NullPermissionGrantStore>.Instance);
 
-        // Act
         bool result = await store.RevokeAsync(
-            "Invoices.Delete", "admin", tenantId: null, TestContext.Current.CancellationToken);
+            R, "admin", "Invoices.Delete", tenantId: null, TestContext.Current.CancellationToken);
 
-        // Assert
         result.ShouldBeFalse();
     }
 }

--- a/tests/Granit.Authorization.Tests/PermissionCacheInvalidationHandlerTests.cs
+++ b/tests/Granit.Authorization.Tests/PermissionCacheInvalidationHandlerTests.cs
@@ -10,37 +10,32 @@ namespace Granit.Authorization.Tests;
 
 public sealed class PermissionCacheInvalidationHandlerTests
 {
+    private const string R = PermissionGrantProviderNames.Role;
     private static readonly Guid TenantId = Guid.NewGuid();
 
     [Fact]
     public async Task HandleAsync_ExpiresCacheEntryWithCorrectKey()
     {
-        // Arrange
         IFusionCache cache = Substitute.For<IFusionCache>();
 
-        var @event = new PermissionGrantChangedEvent("Invoices.Delete", "accountant", TenantId, IsGranted: true);
+        var @event = new PermissionGrantChangedEvent("Invoices.Delete", R, "accountant", TenantId, IsGranted: true);
 
-        // Act
         await PermissionCacheInvalidationHandler.HandleAsync(@event, cache, TestContext.Current.CancellationToken);
 
-        // Assert
-        string expectedKey = PermissionChecker.BuildCacheKey(TenantId, "accountant", "Invoices.Delete");
+        string expectedKey = PermissionChecker.BuildCacheKey(TenantId, R, "accountant", "Invoices.Delete");
         await cache.Received(1).ExpireAsync(expectedKey, Arg.Any<FusionCacheEntryOptions?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task HandleAsync_GlobalScope_UsesGlobalCacheKey()
     {
-        // Arrange
         IFusionCache cache = Substitute.For<IFusionCache>();
 
-        var @event = new PermissionGrantChangedEvent("Invoices.Delete", "accountant", TenantId: null, IsGranted: false);
+        var @event = new PermissionGrantChangedEvent("Invoices.Delete", R, "accountant", TenantId: null, IsGranted: false);
 
-        // Act
         await PermissionCacheInvalidationHandler.HandleAsync(@event, cache, TestContext.Current.CancellationToken);
 
-        // Assert
-        string expectedKey = PermissionChecker.BuildCacheKey(null, "accountant", "Invoices.Delete");
+        string expectedKey = PermissionChecker.BuildCacheKey(null, R, "accountant", "Invoices.Delete");
         expectedKey.ShouldStartWith("perm:global:");
         await cache.Received(1).RemoveAsync(expectedKey, Arg.Any<FusionCacheEntryOptions?>(), Arg.Any<CancellationToken>());
     }
@@ -52,15 +47,13 @@ public sealed class PermissionCacheInvalidationHandlerTests
     [Fact]
     public async Task HandleAsync_GrantCreated_CallsExpireAsync()
     {
-        // Arrange — VULN-204: grants use soft-expire (stale "denied" is safe)
+        // VULN-204: grants use soft-expire (stale "denied" is safe)
         IFusionCache cache = Substitute.For<IFusionCache>();
-        var @event = new PermissionGrantChangedEvent("Orders.Create", "editor", TenantId, IsGranted: true);
+        var @event = new PermissionGrantChangedEvent("Orders.Create", R, "editor", TenantId, IsGranted: true);
 
-        // Act
         await PermissionCacheInvalidationHandler.HandleAsync(@event, cache, TestContext.Current.CancellationToken);
 
-        // Assert — ExpireAsync called, NOT RemoveAsync
-        string expectedKey = PermissionChecker.BuildCacheKey(TenantId, "editor", "Orders.Create");
+        string expectedKey = PermissionChecker.BuildCacheKey(TenantId, R, "editor", "Orders.Create");
         await cache.Received(1).ExpireAsync(expectedKey, Arg.Any<FusionCacheEntryOptions?>(), Arg.Any<CancellationToken>());
         await cache.DidNotReceive().RemoveAsync(expectedKey, Arg.Any<FusionCacheEntryOptions?>(), Arg.Any<CancellationToken>());
     }
@@ -68,15 +61,13 @@ public sealed class PermissionCacheInvalidationHandlerTests
     [Fact]
     public async Task HandleAsync_GrantRevoked_CallsRemoveAsync()
     {
-        // Arrange — VULN-204: revocations use hard-remove to prevent stale-while-revalidate
+        // VULN-204: revocations use hard-remove to prevent stale-while-revalidate
         IFusionCache cache = Substitute.For<IFusionCache>();
-        var @event = new PermissionGrantChangedEvent("Orders.Create", "editor", TenantId, IsGranted: false);
+        var @event = new PermissionGrantChangedEvent("Orders.Create", R, "editor", TenantId, IsGranted: false);
 
-        // Act
         await PermissionCacheInvalidationHandler.HandleAsync(@event, cache, TestContext.Current.CancellationToken);
 
-        // Assert — RemoveAsync called, NOT ExpireAsync
-        string expectedKey = PermissionChecker.BuildCacheKey(TenantId, "editor", "Orders.Create");
+        string expectedKey = PermissionChecker.BuildCacheKey(TenantId, R, "editor", "Orders.Create");
         await cache.Received(1).RemoveAsync(expectedKey, Arg.Any<FusionCacheEntryOptions?>(), Arg.Any<CancellationToken>());
         await cache.DidNotReceive().ExpireAsync(expectedKey, Arg.Any<FusionCacheEntryOptions?>(), Arg.Any<CancellationToken>());
     }
@@ -88,18 +79,15 @@ public sealed class PermissionCacheInvalidationHandlerTests
     [Fact]
     public async Task HandleAsync_DifferentPermissions_UseDifferentCacheKeys()
     {
-        // Arrange
         IFusionCache cache = Substitute.For<IFusionCache>();
-        var event1 = new PermissionGrantChangedEvent("Invoices.Read", "editor", TenantId, IsGranted: true);
-        var event2 = new PermissionGrantChangedEvent("Invoices.Delete", "editor", TenantId, IsGranted: true);
+        var event1 = new PermissionGrantChangedEvent("Invoices.Read", R, "editor", TenantId, IsGranted: true);
+        var event2 = new PermissionGrantChangedEvent("Invoices.Delete", R, "editor", TenantId, IsGranted: true);
 
-        // Act
         await PermissionCacheInvalidationHandler.HandleAsync(event1, cache, TestContext.Current.CancellationToken);
         await PermissionCacheInvalidationHandler.HandleAsync(event2, cache, TestContext.Current.CancellationToken);
 
-        // Assert
-        string key1 = PermissionChecker.BuildCacheKey(TenantId, "editor", "Invoices.Read");
-        string key2 = PermissionChecker.BuildCacheKey(TenantId, "editor", "Invoices.Delete");
+        string key1 = PermissionChecker.BuildCacheKey(TenantId, R, "editor", "Invoices.Read");
+        string key2 = PermissionChecker.BuildCacheKey(TenantId, R, "editor", "Invoices.Delete");
         key1.ShouldNotBe(key2);
 
         await cache.Received(1).ExpireAsync(key1, Arg.Any<FusionCacheEntryOptions?>(), Arg.Any<CancellationToken>());
@@ -107,23 +95,40 @@ public sealed class PermissionCacheInvalidationHandlerTests
     }
 
     [Fact]
-    public async Task HandleAsync_DifferentRoles_UseDifferentCacheKeys()
+    public async Task HandleAsync_DifferentGrantees_UseDifferentCacheKeys()
     {
-        // Arrange
         IFusionCache cache = Substitute.For<IFusionCache>();
-        var event1 = new PermissionGrantChangedEvent("Invoices.Delete", "accountant", TenantId, IsGranted: false);
-        var event2 = new PermissionGrantChangedEvent("Invoices.Delete", "editor", TenantId, IsGranted: false);
+        var event1 = new PermissionGrantChangedEvent("Invoices.Delete", R, "accountant", TenantId, IsGranted: false);
+        var event2 = new PermissionGrantChangedEvent("Invoices.Delete", R, "editor", TenantId, IsGranted: false);
 
-        // Act
         await PermissionCacheInvalidationHandler.HandleAsync(event1, cache, TestContext.Current.CancellationToken);
         await PermissionCacheInvalidationHandler.HandleAsync(event2, cache, TestContext.Current.CancellationToken);
 
-        // Assert
-        string key1 = PermissionChecker.BuildCacheKey(TenantId, "accountant", "Invoices.Delete");
-        string key2 = PermissionChecker.BuildCacheKey(TenantId, "editor", "Invoices.Delete");
+        string key1 = PermissionChecker.BuildCacheKey(TenantId, R, "accountant", "Invoices.Delete");
+        string key2 = PermissionChecker.BuildCacheKey(TenantId, R, "editor", "Invoices.Delete");
         key1.ShouldNotBe(key2);
 
         await cache.Received(1).RemoveAsync(key1, Arg.Any<FusionCacheEntryOptions?>(), Arg.Any<CancellationToken>());
         await cache.Received(1).RemoveAsync(key2, Arg.Any<FusionCacheEntryOptions?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_DifferentProviders_UseDifferentCacheKeys()
+    {
+        IFusionCache cache = Substitute.For<IFusionCache>();
+        var roleEvent = new PermissionGrantChangedEvent(
+            "Invoices.Delete", PermissionGrantProviderNames.Role, "alice", TenantId, IsGranted: true);
+        var userEvent = new PermissionGrantChangedEvent(
+            "Invoices.Delete", PermissionGrantProviderNames.User, "alice", TenantId, IsGranted: true);
+
+        await PermissionCacheInvalidationHandler.HandleAsync(roleEvent, cache, TestContext.Current.CancellationToken);
+        await PermissionCacheInvalidationHandler.HandleAsync(userEvent, cache, TestContext.Current.CancellationToken);
+
+        string roleKey = PermissionChecker.BuildCacheKey(TenantId, PermissionGrantProviderNames.Role, "alice", "Invoices.Delete");
+        string userKey = PermissionChecker.BuildCacheKey(TenantId, PermissionGrantProviderNames.User, "alice", "Invoices.Delete");
+        roleKey.ShouldNotBe(userKey);
+
+        await cache.Received(1).ExpireAsync(roleKey, Arg.Any<FusionCacheEntryOptions?>(), Arg.Any<CancellationToken>());
+        await cache.Received(1).ExpireAsync(userKey, Arg.Any<FusionCacheEntryOptions?>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Granit.Authorization.Tests/PermissionCheckerProviderOrchestrationTests.cs
+++ b/tests/Granit.Authorization.Tests/PermissionCheckerProviderOrchestrationTests.cs
@@ -1,0 +1,183 @@
+// =============================================================================
+// Tests — PermissionChecker multi-provider orchestration
+// =============================================================================
+// These tests exercise the U → R → C provider chain:
+//   - A user-level grant short-circuits role and client lookups
+//   - A role-level grant short-circuits the client lookup
+//   - A client-level grant is consulted last
+//   - Side enforcement runs before any provider lookup
+// =============================================================================
+
+using System.Diagnostics.Metrics;
+using Granit.Authorization.Cache;
+using Granit.Authorization.Diagnostics;
+using Granit.Authorization.Options;
+using Granit.Authorization.Services;
+using Granit.MultiTenancy;
+using Granit.Users;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Granit.Authorization.Tests;
+
+public sealed class PermissionCheckerProviderOrchestrationTests
+{
+    private const string Permission = "Invoices.Delete";
+
+    [Fact]
+    public async Task UserGrant_ShortCircuitsRoleAndClient()
+    {
+        IPermissionGrantStore store = Substitute.For<IPermissionGrantStore>();
+        store.IsGrantedAsync("U", "alice", Permission, null, Arg.Any<CancellationToken>()).Returns(true);
+
+        PermissionChecker checker = BuildChecker(
+            userId: "alice", roles: ["editor"], clientId: "spa", store: store);
+
+        bool granted = await checker.IsGrantedAsync(Permission, TestContext.Current.CancellationToken);
+
+        granted.ShouldBeTrue();
+        await store.DidNotReceive().IsGrantedAsync(
+            "R", Arg.Any<string>(), Permission, Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await store.DidNotReceive().IsGrantedAsync(
+            "C", Arg.Any<string>(), Permission, Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task NoUserGrant_RoleGrant_StopsBeforeClient()
+    {
+        IPermissionGrantStore store = Substitute.For<IPermissionGrantStore>();
+        store.IsGrantedAsync("U", "alice", Permission, null, Arg.Any<CancellationToken>()).Returns(false);
+        store.IsGrantedAsync("R", "editor", Permission, null, Arg.Any<CancellationToken>()).Returns(true);
+
+        PermissionChecker checker = BuildChecker(
+            userId: "alice", roles: ["editor"], clientId: "spa", store: store);
+
+        bool granted = await checker.IsGrantedAsync(Permission, TestContext.Current.CancellationToken);
+
+        granted.ShouldBeTrue();
+        await store.DidNotReceive().IsGrantedAsync(
+            "C", Arg.Any<string>(), Permission, Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task NoUserNorRoleGrant_ClientGrant_Resolves()
+    {
+        IPermissionGrantStore store = Substitute.For<IPermissionGrantStore>();
+        store.IsGrantedAsync(Arg.Any<string>(), Arg.Any<string>(), Permission, null, Arg.Any<CancellationToken>())
+            .Returns(false);
+        store.IsGrantedAsync("C", "m2m-worker", Permission, null, Arg.Any<CancellationToken>()).Returns(true);
+
+        PermissionChecker checker = BuildChecker(
+            userId: "alice", roles: ["editor"], clientId: "m2m-worker", store: store);
+
+        bool granted = await checker.IsGrantedAsync(Permission, TestContext.Current.CancellationToken);
+
+        granted.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task NoProviderGrants_ReturnsFalse()
+    {
+        IPermissionGrantStore store = Substitute.For<IPermissionGrantStore>();
+        store.IsGrantedAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        PermissionChecker checker = BuildChecker(
+            userId: "alice", roles: ["editor"], clientId: "spa", store: store);
+
+        bool granted = await checker.IsGrantedAsync(Permission, TestContext.Current.CancellationToken);
+
+        granted.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task AnonymousClient_OnlyClientKeyIsConsulted()
+    {
+        // Machine-to-machine: no user, no roles, only client_id. Only the client provider yields keys.
+        IPermissionGrantStore store = Substitute.For<IPermissionGrantStore>();
+        store.IsGrantedAsync("C", "m2m-worker", Permission, null, Arg.Any<CancellationToken>()).Returns(true);
+
+        PermissionChecker checker = BuildChecker(
+            userId: null, roles: [], clientId: "m2m-worker", store: store);
+
+        bool granted = await checker.IsGrantedAsync(Permission, TestContext.Current.CancellationToken);
+
+        granted.ShouldBeTrue();
+        await store.DidNotReceive().IsGrantedAsync(
+            "U", Arg.Any<string>(), Permission, Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await store.DidNotReceive().IsGrantedAsync(
+            "R", Arg.Any<string>(), Permission, Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SideMismatch_NoProviderConsulted()
+    {
+        // Host-only permission checked under an active tenant: should deny without hitting the store.
+        IPermissionGrantStore store = Substitute.For<IPermissionGrantStore>();
+        PermissionDefinition definition = new(Permission, null, "TestGroup", MultiTenancySide.Host);
+
+        PermissionChecker checker = BuildChecker(
+            userId: "alice", roles: ["editor"], clientId: "spa",
+            store: store,
+            tenantId: Guid.NewGuid(),
+            definition: definition);
+
+        bool granted = await checker.IsGrantedAsync(Permission, TestContext.Current.CancellationToken);
+
+        granted.ShouldBeFalse();
+        await store.DidNotReceive().IsGrantedAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+    }
+
+    // --- Helpers ---
+
+    private static PermissionChecker BuildChecker(
+        string? userId,
+        IReadOnlyList<string> roles,
+        string? clientId,
+        IPermissionGrantStore store,
+        Guid? tenantId = null,
+        PermissionDefinition? definition = null)
+    {
+        ICurrentUserService user = Substitute.For<ICurrentUserService>();
+        user.IsAuthenticated.Returns(true);
+        user.UserId.Returns(userId);
+        user.GetRoles().Returns(roles);
+        user.ClientId.Returns(clientId);
+
+        ICurrentTenant tenant = Substitute.For<ICurrentTenant>();
+        tenant.IsAvailable.Returns(tenantId.HasValue);
+        tenant.Id.Returns(tenantId);
+
+        IPermissionDefinitionManager manager = Substitute.For<IPermissionDefinitionManager>();
+        manager.Exists(Permission).Returns(true);
+        manager.Find(Permission).Returns(definition
+            ?? new PermissionDefinition(Permission, null, "TestGroup", MultiTenancySide.Both));
+
+        IFusionCache cache = new FusionCache(new FusionCacheOptions());
+
+        GranitAuthorizationOptions opts = new()
+        {
+            AdminRoles = ["admin"],
+            CacheDuration = TimeSpan.FromMinutes(5),
+        };
+
+        IMeterFactory meterFactory = Substitute.For<IMeterFactory>();
+        meterFactory.Create(Arg.Any<MeterOptions>()).Returns(new Meter("test"));
+        AuthorizationMetrics metrics = new(meterFactory);
+
+        IEnumerable<IPermissionGrantProvider> providers =
+        [
+            new UserPermissionGrantProvider(),
+            new RolePermissionGrantProvider(),
+            new ClientPermissionGrantProvider(),
+        ];
+
+        return new PermissionChecker(
+            user, tenant, manager, store, providers, cache, metrics,
+            Microsoft.Extensions.Options.Options.Create(opts));
+    }
+}

--- a/tests/Granit.Authorization.Tests/PermissionCheckerTests.cs
+++ b/tests/Granit.Authorization.Tests/PermissionCheckerTests.cs
@@ -356,7 +356,7 @@ public sealed class PermissionCheckerTests
         meterFactory.Create(Arg.Any<MeterOptions>()).Returns(new Meter("test"));
         AuthorizationMetrics metrics = new(meterFactory);
 
-        PermissionChecker checker = new(user, tenant, manager, store, cache, metrics,
+        PermissionChecker checker = new(user, tenant, manager, store, BuildDefaultProviders(), cache, metrics,
             Microsoft.Extensions.Options.Options.Create(opts));
 
         // Act
@@ -450,8 +450,19 @@ public sealed class PermissionCheckerTests
         meterFactory.Create(Arg.Any<MeterOptions>()).Returns(new Meter("test"));
         AuthorizationMetrics metrics = new(meterFactory);
 
-        return new PermissionChecker(user, tenant, manager, grantStore, cacheService, metrics, Microsoft.Extensions.Options.Options.Create(opts));
+        return new PermissionChecker(user, tenant, manager, grantStore, BuildDefaultProviders(), cacheService, metrics, Microsoft.Extensions.Options.Options.Create(opts));
     }
+
+    /// <summary>
+    /// Default U → R → C provider chain matching the registration order in
+    /// <c>AuthorizationServiceCollectionExtensions.AddGranitAuthorization</c>.
+    /// </summary>
+    private static IEnumerable<IPermissionGrantProvider> BuildDefaultProviders() =>
+    [
+        new UserPermissionGrantProvider(),
+        new RolePermissionGrantProvider(),
+        new ClientPermissionGrantProvider(),
+    ];
 
     /// <summary>
     /// Cache substitute that always calls the factory (simulates a cache miss on every call).

--- a/tests/Granit.Authorization.Tests/PermissionCheckerTests.cs
+++ b/tests/Granit.Authorization.Tests/PermissionCheckerTests.cs
@@ -340,6 +340,8 @@ public sealed class PermissionCheckerTests
 
         IPermissionDefinitionManager manager = Substitute.For<IPermissionDefinitionManager>();
         manager.Exists(DefinedPermission).Returns(true);
+        manager.Find(DefinedPermission)
+            .Returns(new PermissionDefinition(DefinedPermission, null, "TestGroup", MultiTenancySide.Both));
 
         IPermissionGrantStore store = Substitute.For<IPermissionGrantStore>();
         IFusionCache cache = Substitute.For<IFusionCache>();
@@ -430,6 +432,9 @@ public sealed class PermissionCheckerTests
         IPermissionDefinitionManager manager = Substitute.For<IPermissionDefinitionManager>();
         manager.Exists(DefinedPermission).Returns(true);
         manager.Exists(UndefinedPermission).Returns(false);
+        manager.Find(DefinedPermission)
+            .Returns(new PermissionDefinition(DefinedPermission, null, "TestGroup", MultiTenancySide.Both));
+        manager.Find(UndefinedPermission).Returns((PermissionDefinition?)null);
 
         IPermissionGrantStore grantStore = store ?? Substitute.For<IPermissionGrantStore>();
         IFusionCache cacheService = cache ?? BuildPassThroughCache();

--- a/tests/Granit.Authorization.Tests/PermissionCheckerTests.cs
+++ b/tests/Granit.Authorization.Tests/PermissionCheckerTests.cs
@@ -54,7 +54,7 @@ public sealed class PermissionCheckerTests
         // Assert
         result.ShouldBeTrue();
         await store.DidNotReceive().IsGrantedAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
     }
 
     // --- Not authenticated ---
@@ -92,7 +92,7 @@ public sealed class PermissionCheckerTests
         // Assert
         result.ShouldBeTrue();
         await store.DidNotReceive().IsGrantedAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
     }
 
     // --- Undefined permission ---
@@ -117,7 +117,7 @@ public sealed class PermissionCheckerTests
     {
         // Arrange
         IPermissionGrantStore store = Substitute.For<IPermissionGrantStore>();
-        store.IsGrantedAsync("editor", DefinedPermission, TenantId, Arg.Any<CancellationToken>())
+        store.IsGrantedAsync("R", "editor", DefinedPermission, TenantId, Arg.Any<CancellationToken>())
             .Returns(true);
 
         IFusionCache cache = BuildPassThroughCache();
@@ -135,7 +135,7 @@ public sealed class PermissionCheckerTests
         // Assert
         result.ShouldBeTrue();
         await store.Received(1).IsGrantedAsync(
-            "editor", DefinedPermission, TenantId, Arg.Any<CancellationToken>());
+            "R", "editor", DefinedPermission, TenantId, Arg.Any<CancellationToken>());
     }
 
     // --- Cache hit → store NOT called ---
@@ -166,7 +166,7 @@ public sealed class PermissionCheckerTests
         // Assert
         result.ShouldBeTrue();
         await store.DidNotReceive().IsGrantedAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
     }
 
     // --- Multi-role OR logic ---
@@ -176,9 +176,9 @@ public sealed class PermissionCheckerTests
     {
         // Arrange
         IPermissionGrantStore store = Substitute.For<IPermissionGrantStore>();
-        store.IsGrantedAsync("reader", DefinedPermission, null, Arg.Any<CancellationToken>())
+        store.IsGrantedAsync("R", "reader", DefinedPermission, null, Arg.Any<CancellationToken>())
             .Returns(false);
-        store.IsGrantedAsync("editor", DefinedPermission, null, Arg.Any<CancellationToken>())
+        store.IsGrantedAsync("R", "editor", DefinedPermission, null, Arg.Any<CancellationToken>())
             .Returns(true);
 
         PermissionChecker checker = BuildChecker(
@@ -199,7 +199,7 @@ public sealed class PermissionCheckerTests
     {
         // Arrange
         IPermissionGrantStore store = Substitute.For<IPermissionGrantStore>();
-        store.IsGrantedAsync(Arg.Any<string>(), DefinedPermission, null, Arg.Any<CancellationToken>())
+        store.IsGrantedAsync("R", Arg.Any<string>(), DefinedPermission, null, Arg.Any<CancellationToken>())
             .Returns(false);
 
         PermissionChecker checker = BuildChecker(
@@ -221,15 +221,15 @@ public sealed class PermissionCheckerTests
     public void BuildCacheKey_WithTenantId_FormatsCorrectly()
     {
         var tenant = Guid.Parse("12345678-1234-1234-1234-123456789abc");
-        string key = PermissionChecker.BuildCacheKey(tenant, "editor", "Invoices.Delete");
-        key.ShouldBe($"perm:{tenant}:editor:Invoices.Delete");
+        string key = PermissionChecker.BuildCacheKey(tenant, "R", "editor", "Invoices.Delete");
+        key.ShouldBe($"perm:{tenant}:R:editor:Invoices.Delete");
     }
 
     [Fact]
     public void BuildCacheKey_WithoutTenantId_UsesGlobalSegment()
     {
-        string key = PermissionChecker.BuildCacheKey(null, "editor", "Invoices.Delete");
-        key.ShouldBe("perm:global:editor:Invoices.Delete");
+        string key = PermissionChecker.BuildCacheKey(null, "R", "editor", "Invoices.Delete");
+        key.ShouldBe("perm:global:R:editor:Invoices.Delete");
     }
 
     // --- AdminRole bypass (case-insensitive) ---
@@ -255,7 +255,7 @@ public sealed class PermissionCheckerTests
         // Assert
         result.ShouldBeTrue();
         await store.DidNotReceive().IsGrantedAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
     }
 
     // --- AlwaysAllow requires authentication ---
@@ -282,7 +282,7 @@ public sealed class PermissionCheckerTests
     {
         // Arrange
         IPermissionGrantStore store = Substitute.For<IPermissionGrantStore>();
-        store.IsGrantedAsync("editor", DefinedPermission, TenantId, Arg.Any<CancellationToken>())
+        store.IsGrantedAsync("R", "editor", DefinedPermission, TenantId, Arg.Any<CancellationToken>())
             .Returns(true);
 
         PermissionChecker checker = BuildChecker(
@@ -298,7 +298,7 @@ public sealed class PermissionCheckerTests
         // Assert
         result.ShouldBeTrue();
         await store.Received(1).IsGrantedAsync(
-            "editor", DefinedPermission, TenantId, Arg.Any<CancellationToken>());
+            "R", "editor", DefinedPermission, TenantId, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -306,7 +306,7 @@ public sealed class PermissionCheckerTests
     {
         // Arrange
         IPermissionGrantStore store = Substitute.For<IPermissionGrantStore>();
-        store.IsGrantedAsync("editor", DefinedPermission, null, Arg.Any<CancellationToken>())
+        store.IsGrantedAsync("R", "editor", DefinedPermission, null, Arg.Any<CancellationToken>())
             .Returns(true);
 
         PermissionChecker checker = BuildChecker(
@@ -322,7 +322,7 @@ public sealed class PermissionCheckerTests
         // Assert
         result.ShouldBeTrue();
         await store.Received(1).IsGrantedAsync(
-            "editor", DefinedPermission, null, Arg.Any<CancellationToken>());
+            "R", "editor", DefinedPermission, null, Arg.Any<CancellationToken>());
     }
 
     // --- AdminRole with multiple admin roles configured ---
@@ -365,7 +365,7 @@ public sealed class PermissionCheckerTests
         // Assert
         result.ShouldBeTrue();
         await store.DidNotReceive().IsGrantedAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
     }
 
     // --- Empty roles list ---
@@ -393,17 +393,17 @@ public sealed class PermissionCheckerTests
     [Fact]
     public void BuildCacheKey_EmptyRoleName_IncludesEmptySegment()
     {
-        string key = PermissionChecker.BuildCacheKey(null, "", "Invoices.Delete");
+        string key = PermissionChecker.BuildCacheKey(null, "R", "", "Invoices.Delete");
 
-        key.ShouldBe("perm:global::Invoices.Delete");
+        key.ShouldBe("perm:global:R::Invoices.Delete");
     }
 
     [Fact]
     public void BuildCacheKey_EmptyPermissionName_IncludesEmptySegment()
     {
-        string key = PermissionChecker.BuildCacheKey(null, "editor", "");
+        string key = PermissionChecker.BuildCacheKey(null, "R", "editor", "");
 
-        key.ShouldBe("perm:global:editor:");
+        key.ShouldBe("perm:global:R:editor:");
     }
 
     // --- Helpers ---

--- a/tests/Granit.Authorization.Tests/PermissionGrantChangedEventTests.cs
+++ b/tests/Granit.Authorization.Tests/PermissionGrantChangedEventTests.cs
@@ -1,3 +1,4 @@
+using Granit.Authorization;
 using Granit.Authorization.Events;
 using Shouldly;
 using Xunit;
@@ -6,15 +7,18 @@ namespace Granit.Authorization.Tests;
 
 public sealed class PermissionGrantChangedEventTests
 {
+    private const string R = PermissionGrantProviderNames.Role;
+
     [Fact]
     public void Constructor_SetsAllProperties()
     {
         var tenantId = Guid.NewGuid();
 
-        PermissionGrantChangedEvent @event = new("Invoices.Delete", "accountant", tenantId, true);
+        PermissionGrantChangedEvent @event = new("Invoices.Delete", R, "accountant", tenantId, true);
 
         @event.PermissionName.ShouldBe("Invoices.Delete");
-        @event.RoleName.ShouldBe("accountant");
+        @event.ProviderName.ShouldBe(R);
+        @event.ProviderKey.ShouldBe("accountant");
         @event.TenantId.ShouldBe(tenantId);
         @event.IsGranted.ShouldBeTrue();
     }
@@ -22,7 +26,7 @@ public sealed class PermissionGrantChangedEventTests
     [Fact]
     public void Constructor_WithNullTenantId_SetsNull()
     {
-        PermissionGrantChangedEvent @event = new("Invoices.Read", "editor", null, false);
+        PermissionGrantChangedEvent @event = new("Invoices.Read", R, "editor", null, false);
 
         @event.TenantId.ShouldBeNull();
         @event.IsGranted.ShouldBeFalse();
@@ -32,8 +36,8 @@ public sealed class PermissionGrantChangedEventTests
     public void Equality_SameValues_AreEqual()
     {
         var tenantId = Guid.NewGuid();
-        PermissionGrantChangedEvent first = new("Invoices.Read", "editor", tenantId, true);
-        PermissionGrantChangedEvent second = new("Invoices.Read", "editor", tenantId, true);
+        PermissionGrantChangedEvent first = new("Invoices.Read", R, "editor", tenantId, true);
+        PermissionGrantChangedEvent second = new("Invoices.Read", R, "editor", tenantId, true);
 
         first.ShouldBe(second);
     }
@@ -42,8 +46,8 @@ public sealed class PermissionGrantChangedEventTests
     public void Equality_DifferentPermission_AreNotEqual()
     {
         var tenantId = Guid.NewGuid();
-        PermissionGrantChangedEvent first = new("Invoices.Read", "editor", tenantId, true);
-        PermissionGrantChangedEvent second = new("Invoices.Write", "editor", tenantId, true);
+        PermissionGrantChangedEvent first = new("Invoices.Read", R, "editor", tenantId, true);
+        PermissionGrantChangedEvent second = new("Invoices.Write", R, "editor", tenantId, true);
 
         first.ShouldNotBe(second);
     }
@@ -53,11 +57,21 @@ public sealed class PermissionGrantChangedEventTests
     // =========================================================================
 
     [Fact]
-    public void Equality_DifferentRoleName_AreNotEqual()
+    public void Equality_DifferentProviderKey_AreNotEqual()
     {
         var tenantId = Guid.NewGuid();
-        PermissionGrantChangedEvent first = new("Invoices.Read", "editor", tenantId, true);
-        PermissionGrantChangedEvent second = new("Invoices.Read", "viewer", tenantId, true);
+        PermissionGrantChangedEvent first = new("Invoices.Read", R, "editor", tenantId, true);
+        PermissionGrantChangedEvent second = new("Invoices.Read", R, "viewer", tenantId, true);
+
+        first.ShouldNotBe(second);
+    }
+
+    [Fact]
+    public void Equality_DifferentProviderName_AreNotEqual()
+    {
+        var tenantId = Guid.NewGuid();
+        PermissionGrantChangedEvent first = new("Invoices.Read", PermissionGrantProviderNames.Role, "alice", tenantId, true);
+        PermissionGrantChangedEvent second = new("Invoices.Read", PermissionGrantProviderNames.User, "alice", tenantId, true);
 
         first.ShouldNotBe(second);
     }
@@ -65,8 +79,8 @@ public sealed class PermissionGrantChangedEventTests
     [Fact]
     public void Equality_DifferentTenantId_AreNotEqual()
     {
-        PermissionGrantChangedEvent first = new("Invoices.Read", "editor", Guid.NewGuid(), true);
-        PermissionGrantChangedEvent second = new("Invoices.Read", "editor", Guid.NewGuid(), true);
+        PermissionGrantChangedEvent first = new("Invoices.Read", R, "editor", Guid.NewGuid(), true);
+        PermissionGrantChangedEvent second = new("Invoices.Read", R, "editor", Guid.NewGuid(), true);
 
         first.ShouldNotBe(second);
     }
@@ -75,8 +89,8 @@ public sealed class PermissionGrantChangedEventTests
     public void Equality_DifferentIsGranted_AreNotEqual()
     {
         var tenantId = Guid.NewGuid();
-        PermissionGrantChangedEvent first = new("Invoices.Read", "editor", tenantId, true);
-        PermissionGrantChangedEvent second = new("Invoices.Read", "editor", tenantId, false);
+        PermissionGrantChangedEvent first = new("Invoices.Read", R, "editor", tenantId, true);
+        PermissionGrantChangedEvent second = new("Invoices.Read", R, "editor", tenantId, false);
 
         first.ShouldNotBe(second);
     }
@@ -89,13 +103,13 @@ public sealed class PermissionGrantChangedEventTests
     public void WithExpression_CreatesModifiedCopy()
     {
         var tenantId = Guid.NewGuid();
-        PermissionGrantChangedEvent original = new("Invoices.Read", "editor", tenantId, true);
+        PermissionGrantChangedEvent original = new("Invoices.Read", R, "editor", tenantId, true);
 
         PermissionGrantChangedEvent modified = original with { IsGranted = false };
 
         modified.IsGranted.ShouldBeFalse();
         modified.PermissionName.ShouldBe("Invoices.Read");
-        modified.RoleName.ShouldBe("editor");
+        modified.ProviderKey.ShouldBe("editor");
         modified.TenantId.ShouldBe(tenantId);
     }
 }

--- a/tests/Granit.Authorization.Tests/PermissionGrantProviderTests.cs
+++ b/tests/Granit.Authorization.Tests/PermissionGrantProviderTests.cs
@@ -1,0 +1,83 @@
+using Granit.Authorization.Services;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authorization.Tests;
+
+/// <summary>
+/// Covers the key-extraction behavior of the three built-in grant providers.
+/// </summary>
+public sealed class PermissionGrantProviderTests
+{
+    [Fact]
+    public void User_NameIsU()
+        => new UserPermissionGrantProvider().Name.ShouldBe("U");
+
+    [Fact]
+    public void Role_NameIsR()
+        => new RolePermissionGrantProvider().Name.ShouldBe("R");
+
+    [Fact]
+    public void Client_NameIsC()
+        => new ClientPermissionGrantProvider().Name.ShouldBe("C");
+
+    // --- User provider ---
+
+    [Fact]
+    public void User_NoUserId_ReturnsEmpty()
+    {
+        IReadOnlyList<string> keys = new UserPermissionGrantProvider()
+            .GetProviderKeys(new PermissionGrantLookupContext(UserId: null, Roles: [], ClientId: null));
+
+        keys.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void User_HasUserId_ReturnsSingleton()
+    {
+        IReadOnlyList<string> keys = new UserPermissionGrantProvider()
+            .GetProviderKeys(new PermissionGrantLookupContext("alice", Roles: ["editor"], ClientId: "spa"));
+
+        keys.ShouldBe(["alice"]);
+    }
+
+    // --- Role provider ---
+
+    [Fact]
+    public void Role_NoRoles_ReturnsEmpty()
+    {
+        IReadOnlyList<string> keys = new RolePermissionGrantProvider()
+            .GetProviderKeys(new PermissionGrantLookupContext("alice", Roles: [], ClientId: null));
+
+        keys.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Role_MultipleRoles_ReturnsAll()
+    {
+        IReadOnlyList<string> keys = new RolePermissionGrantProvider()
+            .GetProviderKeys(new PermissionGrantLookupContext("alice", Roles: ["editor", "reader"], ClientId: null));
+
+        keys.ShouldBe(["editor", "reader"]);
+    }
+
+    // --- Client provider ---
+
+    [Fact]
+    public void Client_NoClientId_ReturnsEmpty()
+    {
+        IReadOnlyList<string> keys = new ClientPermissionGrantProvider()
+            .GetProviderKeys(new PermissionGrantLookupContext("alice", Roles: [], ClientId: null));
+
+        keys.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Client_HasClientId_ReturnsSingleton()
+    {
+        IReadOnlyList<string> keys = new ClientPermissionGrantProvider()
+            .GetProviderKeys(new PermissionGrantLookupContext(null, Roles: [], ClientId: "m2m-worker"));
+
+        keys.ShouldBe(["m2m-worker"]);
+    }
+}

--- a/tests/Granit.Authorization.Tests/PermissionManagerTests.cs
+++ b/tests/Granit.Authorization.Tests/PermissionManagerTests.cs
@@ -3,7 +3,8 @@
 // =============================================================================
 // Verifies that the manager:
 //   - Validates permission definition before store access
-//   - Delegates grant/revoke to IPermissionGrantStore
+//   - Delegates grant/revoke to IPermissionGrantStore using the
+//     (providerName, providerKey) tuple
 //   - Publishes PermissionGrantChangedEvent + emits [AUDIT] log on state change
 //   - Is no-op when store reports no change (idempotent)
 //   - Throws InvalidOperationException for undefined permissions
@@ -25,6 +26,7 @@ public sealed class PermissionManagerTests
 {
     private const string DefinedPermission = "Invoices.Delete";
     private const string UndefinedPermission = "Unknown.Permission";
+    private const string R = PermissionGrantProviderNames.Role;
     private static readonly Guid TenantId = Guid.NewGuid();
 
     // --- SetAsync: grant ---
@@ -32,29 +34,25 @@ public sealed class PermissionManagerTests
     [Fact]
     public async Task SetAsync_GrantNew_DelegatesToStorePublishesEventAndLogsAudit()
     {
-        // Arrange
         (PermissionManager manager, IPermissionGrantStore store,
             ILocalEventBus eventBus, ILogger<PermissionManager> logger) = BuildManager();
 
-        store.GrantAsync(DefinedPermission, "accountant", TenantId, Arg.Any<CancellationToken>())
+        store.GrantAsync(R, "accountant", DefinedPermission, TenantId, Arg.Any<CancellationToken>())
             .Returns(true);
 
-        // Act
-        await manager.SetAsync(DefinedPermission, "accountant", TenantId, isGranted: true, TestContext.Current.CancellationToken);
+        await manager.SetAsync(DefinedPermission, R, "accountant", TenantId, isGranted: true, TestContext.Current.CancellationToken);
 
-        // Assert — store called
-        await store.Received(1).GrantAsync(DefinedPermission, "accountant", TenantId, Arg.Any<CancellationToken>());
+        await store.Received(1).GrantAsync(R, "accountant", DefinedPermission, TenantId, Arg.Any<CancellationToken>());
 
-        // Assert — event published for cache invalidation
         await eventBus.Received(1).PublishAsync(
             Arg.Is<PermissionGrantChangedEvent>(e =>
                 e.PermissionName == DefinedPermission &&
-                e.RoleName == "accountant" &&
+                e.ProviderName == R &&
+                e.ProviderKey == "accountant" &&
                 e.TenantId == TenantId &&
                 e.IsGranted),
             Arg.Any<CancellationToken>());
 
-        // Assert — ISO 27001 audit log emitted
         logger.Received(1).Log(
             LogLevel.Information,
             Arg.Any<EventId>(),
@@ -68,29 +66,25 @@ public sealed class PermissionManagerTests
     [Fact]
     public async Task SetAsync_RevokeExisting_DelegatesToStorePublishesEventAndLogsAudit()
     {
-        // Arrange
         (PermissionManager manager, IPermissionGrantStore store,
             ILocalEventBus eventBus, ILogger<PermissionManager> logger) = BuildManager();
 
-        store.RevokeAsync(DefinedPermission, "accountant", TenantId, Arg.Any<CancellationToken>())
+        store.RevokeAsync(R, "accountant", DefinedPermission, TenantId, Arg.Any<CancellationToken>())
             .Returns(true);
 
-        // Act
-        await manager.SetAsync(DefinedPermission, "accountant", TenantId, isGranted: false, TestContext.Current.CancellationToken);
+        await manager.SetAsync(DefinedPermission, R, "accountant", TenantId, isGranted: false, TestContext.Current.CancellationToken);
 
-        // Assert — store called
-        await store.Received(1).RevokeAsync(DefinedPermission, "accountant", TenantId, Arg.Any<CancellationToken>());
+        await store.Received(1).RevokeAsync(R, "accountant", DefinedPermission, TenantId, Arg.Any<CancellationToken>());
 
-        // Assert — event published for cache invalidation
         await eventBus.Received(1).PublishAsync(
             Arg.Is<PermissionGrantChangedEvent>(e =>
                 e.PermissionName == DefinedPermission &&
-                e.RoleName == "accountant" &&
+                e.ProviderName == R &&
+                e.ProviderKey == "accountant" &&
                 e.TenantId == TenantId &&
                 !e.IsGranted),
             Arg.Any<CancellationToken>());
 
-        // Assert — audit log emitted
         logger.Received(1).Log(
             LogLevel.Information,
             Arg.Any<EventId>(),
@@ -104,21 +98,17 @@ public sealed class PermissionManagerTests
     [Fact]
     public async Task SetAsync_GrantAlreadyExists_NoOpNoEventNoLog()
     {
-        // Arrange
         (PermissionManager manager, IPermissionGrantStore store,
             ILocalEventBus eventBus, ILogger<PermissionManager> logger) = BuildManager();
 
-        store.GrantAsync(DefinedPermission, "accountant", TenantId, Arg.Any<CancellationToken>())
+        store.GrantAsync(R, "accountant", DefinedPermission, TenantId, Arg.Any<CancellationToken>())
             .Returns(false); // store reports no change (already existed)
 
-        // Act
-        await manager.SetAsync(DefinedPermission, "accountant", TenantId, isGranted: true, TestContext.Current.CancellationToken);
+        await manager.SetAsync(DefinedPermission, R, "accountant", TenantId, isGranted: true, TestContext.Current.CancellationToken);
 
-        // Assert — no event published (no-op)
         await eventBus.DidNotReceive().PublishAsync(
             Arg.Any<PermissionGrantChangedEvent>(), Arg.Any<CancellationToken>());
 
-        // Assert — no audit log (no-op)
         logger.DidNotReceive().Log(
             Arg.Any<LogLevel>(),
             Arg.Any<EventId>(),
@@ -132,17 +122,50 @@ public sealed class PermissionManagerTests
     [Fact]
     public async Task SetAsync_UndefinedPermission_ThrowsWithoutStoreAccess()
     {
-        // Arrange
         (PermissionManager manager, IPermissionGrantStore store, _, _) = BuildManager();
 
-        // Act
-        Func<Task> act = () => manager.SetAsync(UndefinedPermission, "accountant", TenantId, isGranted: true);
+        Func<Task> act = () => manager.SetAsync(UndefinedPermission, R, "accountant", TenantId, isGranted: true);
 
-        // Assert
         (await Should.ThrowAsync<InvalidOperationException>(act)).Message.ShouldContain($"'{UndefinedPermission}'");
 
         await store.DidNotReceive().GrantAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+    }
+
+    // --- SetAsync: validator rejects ---
+
+    [Fact]
+    public async Task SetAsync_GrantRejectedByValidator_ThrowsWithoutStoreAccess()
+    {
+        (PermissionManager manager, IPermissionGrantStore store, _, _) = BuildManager(
+            validators:
+            [
+                new StubValidator(PermissionGrantValidationResult.Reject("test_reject", "nope"))
+            ]);
+
+        Func<Task> act = () => manager.SetAsync(DefinedPermission, R, "accountant", TenantId, isGranted: true);
+
+        (await Should.ThrowAsync<InvalidOperationException>(act)).Message.ShouldContain("test_reject");
+
+        await store.DidNotReceive().GrantAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SetAsync_RevokeBypassesValidators()
+    {
+        // Validators only gate additions; revocations must always proceed so that a grant made
+        // under relaxed rules can still be removed after the policy tightens.
+        StubValidator hostile = new(PermissionGrantValidationResult.Reject("would_block", "should not fire"));
+        (PermissionManager manager, IPermissionGrantStore store, _, _) = BuildManager(validators: [hostile]);
+
+        store.RevokeAsync(R, "accountant", DefinedPermission, TenantId, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        await manager.SetAsync(DefinedPermission, R, "accountant", TenantId, isGranted: false, TestContext.Current.CancellationToken);
+
+        hostile.CallCount.ShouldBe(0);
+        await store.Received(1).RevokeAsync(R, "accountant", DefinedPermission, TenantId, Arg.Any<CancellationToken>());
     }
 
     // --- IsGrantedAsync ---
@@ -150,15 +173,12 @@ public sealed class PermissionManagerTests
     [Fact]
     public async Task IsGrantedAsync_DelegatesToStore()
     {
-        // Arrange
         (PermissionManager manager, IPermissionGrantStore store, _, _) = BuildManager();
-        store.IsGrantedAsync("accountant", DefinedPermission, TenantId, Arg.Any<CancellationToken>())
+        store.IsGrantedAsync(R, "accountant", DefinedPermission, TenantId, Arg.Any<CancellationToken>())
             .Returns(true);
 
-        // Act
-        bool result = await manager.IsGrantedAsync(DefinedPermission, "accountant", TenantId, TestContext.Current.CancellationToken);
+        bool result = await manager.IsGrantedAsync(DefinedPermission, R, "accountant", TenantId, TestContext.Current.CancellationToken);
 
-        // Assert
         result.ShouldBeTrue();
     }
 
@@ -167,43 +187,38 @@ public sealed class PermissionManagerTests
     [Fact]
     public async Task GetGrantedPermissionsAsync_DelegatesToStore()
     {
-        // Arrange
         (PermissionManager manager, IPermissionGrantStore store, _, _) = BuildManager();
         IReadOnlyList<string> expected = ["Invoices.Delete", "Invoices.Read"];
-        store.GetGrantedPermissionsAsync("accountant", TenantId, Arg.Any<CancellationToken>())
+        store.GetGrantedPermissionsAsync(R, "accountant", TenantId, Arg.Any<CancellationToken>())
             .Returns(expected);
 
-        // Act
         IReadOnlyList<string> permissions =
-            await manager.GetGrantedPermissionsAsync("accountant", TenantId, TestContext.Current.CancellationToken);
+            await manager.GetGrantedPermissionsAsync(R, "accountant", TenantId, TestContext.Current.CancellationToken);
 
-        // Assert
         permissions.ShouldBe(expected);
     }
 
-    // --- GetGrantedRolesAsync ---
+    // --- GetGranteesAsync ---
 
     [Fact]
-    public async Task GetGrantedRolesAsync_DelegatesToStore()
+    public async Task GetGranteesAsync_DelegatesToStore()
     {
-        // Arrange
         (PermissionManager manager, IPermissionGrantStore store, _, _) = BuildManager();
         IReadOnlyList<string> expected = ["accountant", "manager"];
-        store.GetGrantedRolesAsync(DefinedPermission, TenantId, Arg.Any<CancellationToken>())
+        store.GetGranteesAsync(R, DefinedPermission, TenantId, Arg.Any<CancellationToken>())
             .Returns(expected);
 
-        // Act
-        IReadOnlyList<string> roles =
-            await manager.GetGrantedRolesAsync(DefinedPermission, TenantId, TestContext.Current.CancellationToken);
+        IReadOnlyList<string> grantees =
+            await manager.GetGranteesAsync(R, DefinedPermission, TenantId, TestContext.Current.CancellationToken);
 
-        // Assert
-        roles.ShouldBe(expected);
+        grantees.ShouldBe(expected);
     }
 
     // --- Helpers ---
 
     private static (PermissionManager, IPermissionGrantStore,
-        ILocalEventBus, ILogger<PermissionManager>) BuildManager()
+        ILocalEventBus, ILogger<PermissionManager>) BuildManager(
+            IEnumerable<IPermissionGrantValidator>? validators = null)
     {
         IPermissionGrantStore store = Substitute.For<IPermissionGrantStore>();
 
@@ -222,10 +237,23 @@ public sealed class PermissionManagerTests
         PermissionManager manager = new(
             store,
             definitionManager,
-            grantValidators: [],
+            grantValidators: validators ?? [],
             eventBus,
             logger);
 
         return (manager, store, eventBus, logger);
+    }
+
+    private sealed class StubValidator(PermissionGrantValidationResult result) : IPermissionGrantValidator
+    {
+        public int CallCount { get; private set; }
+
+        public ValueTask<PermissionGrantValidationResult> ValidateAsync(
+            PermissionGrantValidationContext context,
+            CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return ValueTask.FromResult(result);
+        }
     }
 }

--- a/tests/Granit.Authorization.Tests/PermissionManagerTests.cs
+++ b/tests/Granit.Authorization.Tests/PermissionManagerTests.cs
@@ -210,6 +210,9 @@ public sealed class PermissionManagerTests
         IPermissionDefinitionManager definitionManager = Substitute.For<IPermissionDefinitionManager>();
         definitionManager.Exists(DefinedPermission).Returns(true);
         definitionManager.Exists(UndefinedPermission).Returns(false);
+        definitionManager.Find(DefinedPermission)
+            .Returns(new PermissionDefinition(DefinedPermission, null, "TestGroup", MultiTenancySide.Both));
+        definitionManager.Find(UndefinedPermission).Returns((PermissionDefinition?)null);
 
         ILocalEventBus eventBus = Substitute.For<ILocalEventBus>();
 
@@ -219,6 +222,7 @@ public sealed class PermissionManagerTests
         PermissionManager manager = new(
             store,
             definitionManager,
+            grantValidators: [],
             eventBus,
             logger);
 

--- a/tests/Granit.Workflow.Notifications.Tests/IdentityApproverResolverTests.cs
+++ b/tests/Granit.Workflow.Notifications.Tests/IdentityApproverResolverTests.cs
@@ -31,7 +31,7 @@ public sealed class IdentityApproverResolverTests
     [Fact]
     public async Task ResolveApproversAsync_WithRolesAndUsers_ReturnsUserIds()
     {
-        _permissionManagerReader.GetGrantedRolesAsync("workflow.publish", null, Arg.Any<CancellationToken>())
+        _permissionManagerReader.GetGranteesAsync("R", "workflow.publish", null, Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<string>)["editor"]);
 
         _identityProvider.GetRoleMembersAsync("editor", Arg.Any<CancellationToken>())
@@ -52,7 +52,7 @@ public sealed class IdentityApproverResolverTests
     [Fact]
     public async Task ResolveApproversAsync_NoRolesGranted_ReturnsEmptyList()
     {
-        _permissionManagerReader.GetGrantedRolesAsync("workflow.publish", null, Arg.Any<CancellationToken>())
+        _permissionManagerReader.GetGranteesAsync("R", "workflow.publish", null, Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<string>)[]);
 
         IReadOnlyList<string> result = await _resolver.ResolveApproversAsync(
@@ -64,7 +64,7 @@ public sealed class IdentityApproverResolverTests
     [Fact]
     public async Task ResolveApproversAsync_RoleWithNoUsers_ReturnsEmptyList()
     {
-        _permissionManagerReader.GetGrantedRolesAsync("workflow.publish", null, Arg.Any<CancellationToken>())
+        _permissionManagerReader.GetGranteesAsync("R", "workflow.publish", null, Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<string>)["editor"]);
 
         _identityProvider.GetRoleMembersAsync("editor", Arg.Any<CancellationToken>())
@@ -79,7 +79,7 @@ public sealed class IdentityApproverResolverTests
     [Fact]
     public async Task ResolveApproversAsync_DuplicateUsersAcrossRoles_ReturnsDeduplicatedList()
     {
-        _permissionManagerReader.GetGrantedRolesAsync("workflow.publish", null, Arg.Any<CancellationToken>())
+        _permissionManagerReader.GetGranteesAsync("R", "workflow.publish", null, Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<string>)["editor", "admin"]);
 
         _identityProvider.GetRoleMembersAsync("editor", Arg.Any<CancellationToken>())
@@ -112,7 +112,7 @@ public sealed class IdentityApproverResolverTests
         _currentTenant.IsAvailable.Returns(true);
         _currentTenant.Id.Returns(tenantId);
 
-        _permissionManagerReader.GetGrantedRolesAsync("workflow.publish", tenantId, Arg.Any<CancellationToken>())
+        _permissionManagerReader.GetGranteesAsync("R", "workflow.publish", tenantId, Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<string>)["editor"]);
 
         _identityProvider.GetRoleMembersAsync("editor", Arg.Any<CancellationToken>())
@@ -125,7 +125,7 @@ public sealed class IdentityApproverResolverTests
             "workflow.publish", TestContext.Current.CancellationToken);
 
         result.Count.ShouldBe(1);
-        await _permissionManagerReader.Received(1).GetGrantedRolesAsync(
-            "workflow.publish", tenantId, Arg.Any<CancellationToken>());
+        await _permissionManagerReader.Received(1).GetGranteesAsync(
+            "R", "workflow.publish", tenantId, Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Summary

Introduces a first-class host/tenant scope on permissions and redesigns the grant
model around the ABP-aligned `(ProviderName, ProviderKey, Name, TenantId)` tuple,
stored at the Host schema.

- **`MultiTenancySide`** enum on every `PermissionDefinition` (`Host | Tenant | Both`), enforced at check time in `PermissionChecker` and at grant time via a new `IPermissionGrantValidator` chain. Soft-dependency on `Granit.MultiTenancy` — `NullTenantContext` keeps the behavior coherent for single-tenant consumers.
- **ABP-style grant providers** — `IPermissionGrantProvider` (U/R/C) registered via `TryAddEnumerable`, iterated by `PermissionChecker` in a deterministic **User → Role → Client** order (specific → generic). The store/manager/event surface carries `(ProviderName, ProviderKey)` everywhere; cache keys are provider-scoped to avoid collisions (`perm:{tenantId|"global"}:{providerName}:{providerKey}:{permissionName}`).
- **Host-schema storage** — `GranitAuthorizationDbProperties.DbSchema` falls back to `HostDbSchema` so grants sit next to Identity and OpenIddict. Consumers call `modelBuilder.ConfigureAuthorizationModule()` from their host `DbContext`. Dev-state rebuild (no data migration).
- **Framework permissions tagged** — Host-only: MultiTenancy.Tenants.*, Diagnostics.Monitoring.Read, Settings.Global.*, Features.Flags.Manage, Auditing.AuditEntries.Manage, OpenIddict.Scopes.*, IdentityLocal.Users.Impersonate, BackgroundJobs.Jobs.*, Subscriptions.Plans.*, Subscriptions.Prices.*. Tenant-only: Settings.Tenant.*. Everything else explicit `Both`.
- **Missing `AllowHostAccess()` wired** on SaaS-billing endpoints (Invoicing, Payments, CustomerBalance, Tax, Subscriptions/Seats) so the host can bill tenants end-to-end. A follow-up PR replaces the dual declaration by deriving host access from the permission's `MultiTenancySide`.
- **Docs** — new page `authorization-multitenancy-side.mdx` covering both concepts.

Breaking changes (dev-only, no stable release yet): `PermissionGrant.RoleName` is removed in favor of `ProviderName`/`ProviderKey`; `IPermissionGrantStore`, `IPermissionManagerReader/Writer`, `PermissionGrantChangedEvent`, and `PermissionChecker.BuildCacheKey` all gain a provider dimension. Consumer apps must drop + recreate the authorization schema at the Host level.

## Test plan

- [ ] `dotnet build Granit.slnx` — 0 warnings / 0 errors
- [ ] `dotnet test tests/Granit.Authorization.Tests` — 202 tests passing, incl. U→R→C orchestration and side-enforcement edge cases
- [ ] `dotnet test tests/Granit.Authorization.EntityFrameworkCore.Tests` — store CRUD against the new (ProviderName, ProviderKey) tuple
- [ ] `dotnet test tests/Granit.Authorization.Endpoints.Tests` — role-scoped admin endpoints
- [ ] `dotnet test tests/Granit.Workflow.Notifications.Tests` — IdentityApproverResolver migrated to GetGranteesAsync
- [ ] `dotnet format Granit.slnx --verify-no-changes`
- [ ] `npx astro build` in `docs-site/` — 0 errors
- [ ] Consumer side: drop dev DBs, re-run EF migrations; check host + tenant permission flows