### PR TITLE
chore: remove references to external framework inspiration

### DIFF
--- a/.claude/prompts/documentation-refactoring-plan.md
+++ b/.claude/prompts/documentation-refactoring-plan.md
@@ -20,7 +20,7 @@ into a world-class English documentation site suitable for open-source publicati
 **Granit** is a modular .NET 10 framework (93 NuGet packages) for building
 production-ready ASP.NET Core APIs. Key characteristics:
 
-- **Module system**: ABP-inspired `[DependsOn]` with topological loading, `IsEnabled()`,
+- **Module system**: `[DependsOn]` with topological loading, `IsEnabled()`,
   auto-discovery of validators/providers, fluent `GranitBuilder` API
 - **5 bundles**: Essentials, Api, Documents, Notifications, SaaS — meta-packages for
   quick onboarding
@@ -379,12 +379,10 @@ Study these for inspiration — not to copy, but to match their quality level:
    section, stability levels, governance
 4. **Stripe** (docs.stripe.com) — rigor: compilable snippets, intent-based API docs
 5. **React** (react.dev) — concept-first: every hook introduced by its problem
-6. **ABP Framework** (abp.io/docs) — direct competitor: module system, .NET, DI
-   conventions, multi-tenancy
-7. **Laravel** (laravel.com/docs) — elegant structure, progressive disclosure
-8. **Next.js** (nextjs.org/docs) — App Router docs restructure, learn-by-doing
-9. **Rust** (doc.rust-lang.org/book) — "The Book": progressive tutorial + reference
-10. **Tailwind CSS** (tailwindcss.com/docs) — reference-heavy, excellent search
+6. **Laravel** (laravel.com/docs) — elegant structure, progressive disclosure
+7. **Next.js** (nextjs.org/docs) — App Router docs restructure, learn-by-doing
+8. **Rust** (doc.rust-lang.org/book) — "The Book": progressive tutorial + reference
+9. **Tailwind CSS** (tailwindcss.com/docs) — reference-heavy, excellent search
 
 The target quality is a deliberate mix of:
 Django (structure) + Kubernetes (governance) + Stripe (rigor) + Spring (conventions).

--- a/docs-site/src/content/docs/blog/introducing-granit.mdx
+++ b/docs-site/src/content/docs/blog/introducing-granit.mdx
@@ -27,7 +27,7 @@ The .NET ecosystem has mature building blocks — Entity Framework Core, ASP.NET
 
 Granit answers these questions with **conventions over configuration**. You declare your module, list its dependencies, and the framework handles the cross-cutting concerns: audit interceptors, soft-delete query filters, tenant isolation, encryption at rest, structured logging. Your team writes domain logic instead of infrastructure glue.
 
-This is not a full-stack application template. It is not a code generator. It is a **framework of composable, independently versioned packages** that you pull in through NuGet and configure through a module system inspired by ABP's architecture — but built from scratch for .NET 10, C# 14, and modern deployment targets.
+This is not a full-stack application template. It is not a code generator. It is a **framework of composable, independently versioned packages** that you pull in through NuGet and configure through a dependency-declared module system — built from scratch for .NET 10, C# 14, and modern deployment targets.
 
 ## Core principles
 

--- a/docs-site/src/content/docs/dotnet/architecture/patterns/extra-properties.md
+++ b/docs-site/src/content/docs/dotnet/architecture/patterns/extra-properties.md
@@ -13,8 +13,8 @@ entity, enabling applications to store custom key-value pairs without modifying
 the framework's database schema. Properties that need SQL indexing or query
 filtering can be **promoted** to real SQL columns at startup.
 
-Also known as: **Property Bag**, **Object Extension** (ABP), **EAV** (legacy),
-**user_metadata** (Auth0), **Custom Attributes** (Keycloak).
+Also known as: **Property Bag**, **EAV** (legacy), **user_metadata** (Auth0),
+**Custom Attributes** (Keycloak).
 
 ## Diagram
 
@@ -142,7 +142,6 @@ JSON for the rest).
 | Framework | Mechanism | SQL promotion | Schema-free |
 |-----------|-----------|:---:|:---:|
 | **Granit** | `IHasExtraProperties` + `MapProperty<T>` | Yes | Yes |
-| **ABP** | `ExtraProperties` + `ObjectExtensionManager` | Yes | Yes |
 | **Auth0** | `user_metadata` / `app_metadata` | No | Yes |
 | **Keycloak** | `attributes` dictionary | No | Yes |
 | **Entra ID** | `extensionAttribute1-15` | Yes (fixed) | No (15 max) |

--- a/docs-site/src/content/docs/dotnet/architecture/patterns/module-system.md
+++ b/docs-site/src/content/docs/dotnet/architecture/patterns/module-system.md
@@ -1,6 +1,6 @@
 ---
 title: "Module System Pattern — DependsOn Graph"
-description: "ABP-inspired module system with topological sorting for deterministic startup ordering"
+description: "DependsOn-based module system with topological sorting for deterministic startup ordering"
 sidebar:
   label: Module System
   order: 1
@@ -13,8 +13,7 @@ each owning its own service registration and initialization lifecycle. A central
 loader resolves startup order through topological sorting of declared dependencies,
 guaranteeing that a module never starts before its prerequisites.
 
-Granit implements a variant inspired by the ABP framework (ASP.NET Boilerplate),
-adapted for an ecosystem of independent NuGet packages.
+Granit implements this pattern adapted for an ecosystem of independent NuGet packages.
 
 ## Diagram
 

--- a/docs-site/src/content/docs/dotnet/concepts/framework-vs-modules.mdx
+++ b/docs-site/src/content/docs/dotnet/concepts/framework-vs-modules.mdx
@@ -21,7 +21,7 @@ features. Without a formal boundary:
 - New contributors cannot tell which packages they *must* understand versus which
   they can skip.
 
-Frameworks like ABP solve this with separate repositories (`framework/` vs `modules/`).
+Some frameworks solve this by splitting into separate repositories (`framework/` vs `modules/`).
 Granit solves it with a **classification rule**, an **architecture test**, and
 **solution filters** -- no physical split required.
 

--- a/docs-site/src/content/docs/dotnet/concepts/module-system.mdx
+++ b/docs-site/src/content/docs/dotnet/concepts/module-system.mdx
@@ -17,7 +17,7 @@ ASP.NET Core gives you dependency injection but no concept of a **module**. When
 - **Conditional loading** -- Vault is useless in local development, Redis is optional if no connection string is configured.
 - **Discovery** -- you need a single entry point that pulls in the entire dependency tree without listing every package by hand.
 
-Granit solves this with a lightweight module system inspired by ABP Framework, built on four primitives: `GranitModule`, `[DependsOn]`, topological sort, and a two-phase lifecycle.
+Granit solves this with a lightweight module system built on four primitives: `GranitModule`, `[DependsOn]`, topological sort, and a two-phase lifecycle.
 
 ## Core concepts
 

--- a/docs-site/src/content/docs/dotnet/infrastructure/event-bus.mdx
+++ b/docs-site/src/content/docs/dotnet/infrastructure/event-bus.mdx
@@ -14,8 +14,7 @@ Looking for the complete list of events? Check the [Event Catalog](/dotnet/infra
 
 Think of events in two ways: a **phone call** (local — instant, same room, you hear
 the answer immediately) and **registered mail** (distributed — crosses boundaries,
-guaranteed delivery, but you don't know when). Granit's dual event bus, inspired by
-[ABP Framework](https://abp.io/docs/latest/framework/infrastructure/event-bus),
+guaranteed delivery, but you don't know when). Granit's dual event bus
 gives you both — and lets you swap the transport without touching business code.
 
 ## Package structure

--- a/docs-site/src/content/docs/dotnet/infrastructure/multi-tenancy/host-tenant.mdx
+++ b/docs-site/src/content/docs/dotnet/infrastructure/multi-tenancy/host-tenant.mdx
@@ -78,7 +78,7 @@ is a data filter, not a schema router.
 | Module | IMultiTenant | Justification |
 |--------|-------------|---------------|
 | MultiTenancy (Tenant) | No | Tenant registry = host by definition |
-| OpenIddict (Users) | Yes (nullable) | Identity centralized (like ABP) |
+| OpenIddict (Users) | Yes (nullable) | Identity centralized at host level |
 | OpenIddict (Roles) | No | Global RBAC shared cross-tenant |
 | OpenIddict (Applications) | Yes (nullable) | OIDC apps: global or per-tenant |
 | OpenIddict (SigningKeys) | No | Cryptographic infrastructure |
@@ -118,11 +118,10 @@ Some host modules contain data for both host and tenants, differentiated by `Ten
 - **Auditing** — `TenantId = null` = host audit entries, `TenantId = {guid}` = tenant audit.
   Centralized in the host schema for ISO 27001 unified cross-tenant audit trail.
 
-## Host-level identity (like ABP)
+## Host-level identity
 
 Identity tables (users, roles, applications, tokens) stay in the **host schema only** —
-never duplicated in tenant schemas or databases. This is the same pattern ABP Framework
-uses:
+never duplicated in tenant schemas or databases:
 
 - `OpenIddictDbContext` uses `AddGranitDbContext` (standard, never isolated)
 - Authentication always goes through the host (BFF → OpenIddict → host DB)

--- a/docs-site/src/content/docs/dotnet/security/authorization-multitenancy-side.mdx
+++ b/docs-site/src/content/docs/dotnet/security/authorization-multitenancy-side.mdx
@@ -75,7 +75,7 @@ Host-sided permissions (platform admin, tenant provisioning) closes the most com
 privilege-escalation holes without boiling the ocean.
 </Aside>
 
-## Grant providers (ABP-style)
+## Grant providers
 
 Grants are no longer role-only. A `PermissionGrant` row now carries:
 

--- a/src/Granit.Authorization.Endpoints/Endpoints/PermissionGrantEndpoints.cs
+++ b/src/Granit.Authorization.Endpoints/Endpoints/PermissionGrantEndpoints.cs
@@ -16,8 +16,8 @@ namespace Granit.Authorization.Endpoints.Endpoints;
 /// Admin endpoints for viewing and managing role → permission grants.
 /// </summary>
 /// <remarks>
-/// These endpoints operate on the role provider (<c>"R"</c>) of the underlying ABP-style
-/// grant model. Endpoints targeting user-level (<c>"U"</c>) or OIDC-client-level (<c>"C"</c>)
+/// These endpoints operate on the role provider (<c>"R"</c>) of the underlying
+/// multi-provider grant model. Endpoints targeting user-level (<c>"U"</c>) or OIDC-client-level (<c>"C"</c>)
 /// grants can be added in sibling modules without changing this route surface.
 /// </remarks>
 internal static partial class PermissionGrantEndpoints

--- a/src/Granit.Authorization.EntityFrameworkCore/GranitAuthorizationDbProperties.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/GranitAuthorizationDbProperties.cs
@@ -9,7 +9,7 @@ namespace Granit.Authorization.EntityFrameworkCore;
 /// <para>
 /// Authorization grants are host-level: they may target host users (<c>TenantId == null</c>)
 /// or tenant-scoped users (<c>TenantId</c> set), but the storage itself always lives in the
-/// host schema alongside Identity and OpenIddict — per the ABP-aligned topology.
+/// host schema alongside Identity and OpenIddict.
 /// </para>
 /// <para>
 /// <b>Important:</b> Set these properties at application startup, before

--- a/src/Granit.Authorization/Domain/PermissionGrant.cs
+++ b/src/Granit.Authorization/Domain/PermissionGrant.cs
@@ -8,7 +8,7 @@ namespace Granit.Authorization.Domain;
 /// </summary>
 /// <remarks>
 /// <para>
-/// ABP-style multi-provider model: <see cref="ProviderName"/> identifies the grantee kind
+/// Multi-provider model: <see cref="ProviderName"/> identifies the grantee kind
 /// (<c>"R"</c> for role, <c>"U"</c> for user, <c>"C"</c> for OIDC client) and
 /// <see cref="ProviderKey"/> holds the provider-specific identifier (role name, user id,
 /// client id). Extension points may introduce additional providers (organization, group,

--- a/src/Granit.Authorization/IPermissionGrantStore.cs
+++ b/src/Granit.Authorization/IPermissionGrantStore.cs
@@ -1,7 +1,7 @@
 namespace Granit.Authorization;
 
 /// <summary>
-/// Data access layer for permission grants. Operates on the ABP-style
+/// Data access layer for permission grants. Operates on the
 /// <c>(providerName, providerKey, permissionName, tenantId)</c> tuple.
 /// Called by <see cref="IPermissionChecker"/> (read) and <c>PermissionManager</c> (read/write).
 /// Default implementation is <c>NullPermissionGrantStore</c> (always false, writes are no-ops).

--- a/src/Granit.Authorization/IPermissionManagerReader.cs
+++ b/src/Granit.Authorization/IPermissionManagerReader.cs
@@ -1,7 +1,7 @@
 namespace Granit.Authorization;
 
 /// <summary>
-/// Read-only service for querying grant state via the ABP-style
+/// Read-only service for querying grant state via the
 /// <c>(providerName, providerKey)</c> tuple.
 /// Available only when <c>Granit.Authorization.EntityFrameworkCore</c> is registered.
 /// </summary>

--- a/src/Granit.Authorization/IPermissionManagerWriter.cs
+++ b/src/Granit.Authorization/IPermissionManagerWriter.cs
@@ -1,7 +1,7 @@
 namespace Granit.Authorization;
 
 /// <summary>
-/// Administrative service for mutating grants in the ABP-style
+/// Administrative service for mutating grants in the
 /// <c>(providerName, providerKey)</c> model.
 /// Each call to <see cref="SetAsync"/> runs the <see cref="IPermissionGrantValidator"/> chain
 /// (for additions), emits an ISO 27001 audit log entry, and invalidates the cache.

--- a/src/Granit.Authorization/PermissionGrantProviderNames.cs
+++ b/src/Granit.Authorization/PermissionGrantProviderNames.cs
@@ -2,7 +2,7 @@ namespace Granit.Authorization;
 
 /// <summary>
 /// Canonical provider names identifying the grantee of a <see cref="Domain.PermissionGrant"/>.
-/// Kept short for compact storage — single-char letters match ABP's convention.
+/// Kept short for compact storage — single-char letters keep indexes compact.
 /// </summary>
 /// <remarks>
 /// Extend this type with additional providers (e.g. <c>"O"</c> for organization, <c>"G"</c> for

--- a/src/Granit/Exceptions/IUserFriendlyException.cs
+++ b/src/Granit/Exceptions/IUserFriendlyException.cs
@@ -1,7 +1,7 @@
 // CA1711: the "Exception" suffix on an interface is intentional.
 // This convention makes it immediately clear that the interface marks exceptions
 // whose messages are safe to expose to end users. Renaming to "IUserFriendlyError" would
-// break the semantic clarity of the pattern (inspired by ABP's naming convention).
+// break the semantic clarity of the pattern.
 #pragma warning disable CA1711
 
 namespace Granit.Exceptions;

--- a/tests/Granit.Authorization.EntityFrameworkCore.Tests/EfCorePermissionGrantStoreTests.cs
+++ b/tests/Granit.Authorization.EntityFrameworkCore.Tests/EfCorePermissionGrantStoreTests.cs
@@ -6,7 +6,7 @@
 //   - Retourne false si le grantee (ProviderName/ProviderKey), la permission ou le tenant
 //     ne correspondent pas
 //   - Gère correctement les grants à portée globale (TenantId null)
-// Les grants sont scopés via le tuple ABP-style (ProviderName, ProviderKey) où
+// Les grants sont scopés via le tuple (ProviderName, ProviderKey) où
 // ProviderName="R" identifie un grantee de type rôle.
 // =============================================================================
 

--- a/tests/Granit.MultiTenancy.Tests/GranitMultiTenancyModuleTests.cs
+++ b/tests/Granit.MultiTenancy.Tests/GranitMultiTenancyModuleTests.cs
@@ -1,8 +1,7 @@
 // =============================================================================
 // GranitMultiTenancyModuleTests - DI integration tests for the module
 // =============================================================================
-// Verifies the complete service wiring via AddGranit<T>(),
-// in the style of AbpIntegratedTest<T> in ABP Framework.
+// Verifies the complete service wiring via AddGranit<T>().
 //
 // Each test bootstraps the MultiTenancy module (standalone, no Security dependency)
 // and resolves services from the real DI container.
@@ -109,7 +108,7 @@ public sealed class GranitMultiTenancyModuleTests
             "MultiTenancy module is standalone with no Security dependency");
     }
 
-    // --- Functional test (AbpIntegratedTest style) ---
+    // --- Functional test ---
 
     [Fact]
     public void ICurrentTenant_Resolved_From_DI_Change_Works()

--- a/tests/Granit.Settings.Tests/GranitSettingsModuleTests.cs
+++ b/tests/Granit.Settings.Tests/GranitSettingsModuleTests.cs
@@ -1,8 +1,7 @@
 // =============================================================================
 // GranitSettingsModuleTests - Tests d'intégration DI du module Settings
 // =============================================================================
-// Vérifie le câblage complet des services via AddGranit<GranitSettingsModule>(),
-// à la manière d'AbpIntegratedTest<T> dans ABP Framework.
+// Vérifie le câblage complet des services via AddGranit<GranitSettingsModule>().
 // =============================================================================
 
 using Granit.Extensions;
@@ -152,7 +151,7 @@ public sealed class GranitSettingsModuleTests
         granitApp.GetModuleTypes().ShouldContain(typeof(GranitSettingsModule));
     }
 
-    // --- Test fonctionnel (style AbpIntegratedTest) ---
+    // --- Test fonctionnel ---
 
     [Fact]
     public async Task SetGlobal_Then_GetOrNull_Returns_StoredValue()


### PR DESCRIPTION
## Summary

- Strips every mention of the former external-framework name from comments, XML docs, and the documentation site.
- No functional changes — pure comment/doc edits across 20 files (8 source, 3 tests, 8 docs, 1 internal prompt).
- The codebase now stands on its own terminology (multi-provider grant model, host-level identity, module system with `[DependsOn]`).

## Test plan

- [ ] CI green on the branch (build, format, tests, architecture tests)
- [ ] `grep -ri "abp" src tests docs-site/src .claude` returns no functional matches
