### PR TITLE
chore(openapi): endpoint metadata cleanup + schema example providers

### DIFF
--- a/.claude/skills/audit/checklist.md
+++ b/.claude/skills/audit/checklist.md
@@ -297,9 +297,17 @@ Ref: `docs-site/…/api/exception-handling.mdx`
 
 ---
 
-## 5. OpenAPI endpoint metadata (`--scope openapi`)
+## 5. OpenAPI endpoint metadata and compatibility (`--scope openapi`)
 
-Every endpoint MUST declare all 5 elements:
+This scope verifies that every endpoint is correctly declared AND that its runtime
+contract (handler signature, return types, parameter binding, authorization)
+is consistent with the OpenAPI metadata exposed to clients. Inconsistencies
+between the handler and the metadata produce broken SDKs, wrong typings in the
+frontend generator, and misleading Scalar documentation.
+
+### 5a. Mandatory metadata elements
+
+Every endpoint MUST declare all 5 elements — chained in this canonical order:
 
 - [ ] `.WithName("VerbNoun")` — PascalCase operation ID
 - [ ] `.WithSummary("Imperative sentence.")` — ~100 chars, ends with period
@@ -307,37 +315,266 @@ Every endpoint MUST declare all 5 elements:
 - [ ] `.Produces<T>()` — success response type (mapped from handler return type)
 - [ ] `.ProducesProblem(StatusCodes.StatusXxx)` — one per error path in handler
 
+### 5b. Handler ↔ metadata return-type consistency (CRITICAL)
+
+The handler's declared return type MUST match the `.Produces*()` declarations
+exactly — every branch covered, no extra declarations.
+
+- [ ] Handler returns a concrete `Results<...>` discriminated union when it can
+  produce multiple status codes — never loose `IResult` or `Task<IResult>`
+- [ ] Single-status handlers use the concrete type (`Ok<T>`, `Created<T>`,
+  `NoContent`, `Accepted<T>`, `FileStreamHttpResult`, `ProblemHttpResult`)
+- [ ] **Every** branch of the `Results<...>` union has a matching
+  `.Produces*()` or `.ProducesProblem()` declaration
+- [ ] **No** `.Produces*()` declaration without a corresponding handler branch
+  (false documentation)
+- [ ] No `Task<IActionResult>` or `ActionResult<T>` (MVC pattern — wrong in
+  Minimal API)
+- [ ] No `async void`; async handlers return `Task<Results<...>>`
+
 ### Return type mapping
 
-| Handler return | Produces | ProducesProblem |
-|----------------|----------|-----------------|
+| Handler return | Produces declaration | ProducesProblem declaration |
+| -------------- | ------------------- | --------------------------- |
 | `Ok<T>` | `.Produces<T>()` | — |
 | `Created<T>` | `.Produces<T>(Status201Created)` | — |
 | `Created` (no body) | `.Produces(Status201Created)` | — |
 | `NoContent` | `.Produces(Status204NoContent)` | — |
-| `Accepted` | `.Produces(Status202Accepted)` | — |
-| `NotFound` in `Results` | — | `.ProducesProblem(Status404NotFound)` |
-| `ProblemHttpResult` in `Results` | — | `.ProducesProblem(StatusXxx)` |
-| `ValidationProblem` in `Results` | — | `.ProducesValidationProblem()` |
-| `FileStreamHttpResult` | `.Produces(Status200OK, contentType: "...")` | — |
+| `Accepted<T>` | `.Produces<T>(Status202Accepted)` | — |
+| `Accepted` (no body) | `.Produces(Status202Accepted)` | — |
+| `NotFound` | — | `.ProducesProblem(Status404NotFound)` |
+| `Conflict<T>` or `Conflict` | — | `.ProducesProblem(Status409Conflict)` |
+| `ProblemHttpResult` | — | `.ProducesProblem(StatusXxx)` (one per path) |
+| `ValidationProblem` | — | `.ProducesValidationProblem()` |
+| `FileStreamHttpResult` | `.Produces(Status200OK, contentType: "…")` | — |
+| `PhysicalFileHttpResult` | `.Produces(Status200OK, contentType: "…")` | — |
+| `RedirectHttpResult` | `.Produces(Status302Found)` | — |
+| `UnauthorizedHttpResult` | — | `.ProducesProblem(Status401Unauthorized)` |
 
-### Route groups
+### 5c. Error response coverage
 
-- [ ] `endpoints.MapGranitGroup(prefix)` — not `MapGroup()` (auto-validation)
+The framework's `ProblemDetailsResponseOperationTransformer`
+(`Granit.Http.ApiDocumentation`) **auto-injects** these responses — do NOT
+declare them manually (redundant, and the transformer wires the shared
+`ProblemDetails` schema under `application/problem+json`):
+
+| Status | Auto-injected when | Manual declaration |
+| ------ | ------------------ | ------------------ |
+| `401 Unauthorized` | `[Authorize]` present and no `[AllowAnonymous]` | Redundant — do not add |
+| `403 Forbidden` | same as 401 | Redundant — do not add |
+| `422 Unprocessable Entity` | endpoint has a request body AND no existing 400 | Redundant — do not add |
+| `500 Internal Server Error` | always (every operation) | Redundant — do not add |
+
+What the endpoint MUST still declare:
+
+- [ ] Every business error path declared explicitly:
+  - `404 Not Found` whenever the handler does a lookup by id and can return
+    `TypedResults.NotFound()` — the transformer only **enriches** an existing
+    404 with the ProblemDetails schema, it does not create it
+  - `409 Conflict` for concurrency conflicts or duplicates
+  - `410 Gone`, `412 Precondition Failed`, `423 Locked`, `429 Too Many Requests`
+    when the handler returns these explicitly
+  - Custom statuses from `TypedResults.Problem(..., statusCode: X)`
+- [ ] No `BadRequest<string>()` — always `TypedResults.Problem()` (RFC 7807,
+  GRAPI002)
+- [ ] Never `Results.*()` — always `TypedResults.*()` (GRAPI001)
+- [ ] Do NOT manually declare `.ProducesProblem(401/403/422/500)` — flag
+  redundant declarations as `CLEANUP` (noise, drifts from framework defaults)
+- [ ] If the endpoint has **no route parameter** and shows 404 in the generated
+  OpenAPI document, it's a Wolverine phantom — the transformer strips it
+  automatically (no action needed)
+
+### 5d. Route groups and URL structure
+
+- [ ] `endpoints.MapGranitGroup(prefix)` — not `MapGroup()` (enables auto-
+  validation and standard filters)
 - [ ] Route prefix is kebab-case and plural
+- [ ] Route parameters use `camelCase` with explicit constraints where relevant
+  (`{id:guid}`, `{tenantId:guid}`, `{version:int}`)
+- [ ] Route constraint type matches the parameter type in the handler signature
+  (e.g. `{id:guid}` → `Guid id`, `{page:int}` → `int page`)
 
-### Schema examples
+### 5e. Parameter binding
 
-- [ ] `ISchemaExampleProvider` implemented for request DTOs with realistic values
-- [ ] Internal-only endpoints marked with `[InternalApiAttribute]`
+- [ ] Explicit binding attributes when the source is ambiguous:
+  `[FromRoute]`, `[FromQuery]`, `[FromHeader]`, `[FromBody]`, `[FromForm]`,
+  `[FromServices]`
+- [ ] Complex types bound from query string use `[AsParameters]` with a record
+  — not individual `[FromQuery]` parameters (improves OpenAPI schema)
+- [ ] `[FromBody]` used at most once per endpoint
+- [ ] Cancellation token (`CancellationToken`) is the **last** parameter and is
+  not decorated with any binding attribute
+- [ ] `HttpContext` parameter is not decorated with a binding attribute
+- [ ] Optional parameters have a default value or are nullable — the OpenAPI
+  `required` flag must reflect reality
 
-### API documentation
+### 5f. Content types — requests
 
-- [ ] Never Swashbuckle / NSwag — native `Microsoft.AspNetCore.OpenApi` only
-- [ ] Scalar UI for documentation
-- [ ] One OpenAPI document per API major version
+- [ ] JSON endpoints: no explicit `.Accepts<T>()` needed (inferred from
+  `[FromBody]`)
+- [ ] File upload endpoints (`IFormFile` / `IFormFileCollection`):
+  - Handler parameters decorated with `[FromForm]`
+  - `.DisableAntiforgery()` applied (Minimal API requires explicit opt-out for
+    multipart)
+  - `.Accepts<TRequest>("multipart/form-data")` declared so Scalar shows the
+    file picker
+- [ ] Raw binary body (`Stream`, `PipeReader`): `.Accepts<Stream>("application/
+  octet-stream")` or the correct MIME
 
-Ref: `CLAUDE.md §OpenAPI metadata`, `docs-site/…/api/api-documentation.mdx`
+### 5g. Content types — responses
+
+- [ ] `FileStreamHttpResult` / `PhysicalFileHttpResult` declare the correct
+  MIME type via `.Produces(Status200OK, contentType: "application/pdf")` (or
+  specific type)
+- [ ] Streaming download endpoints default to `application/octet-stream` when
+  the content type is unknown at compile time — but set it at runtime on the
+  result
+- [ ] JSON responses do not redundantly declare `contentType` (inferred)
+
+### 5h. Authorization and anonymous access
+
+- [ ] Every endpoint exposes its security stance explicitly:
+  `.RequireAuthorization("Group.Resource.Action")` **or** `.AllowAnonymous()`
+  — no implicit default
+- [ ] Permission string passed to `RequireAuthorization` exists as a constant
+  in the module's `{Module}Permissions` nested static class (grep to verify)
+- [ ] Anonymous endpoints are rare and justified (health checks, public docs,
+  auth callbacks) — flag unexpected `AllowAnonymous` usage
+- [ ] When `.RequireAuthorization(...)` is present, `.ProducesProblem(401)` and
+  `.ProducesProblem(403)` are declared (see §5c)
+
+### 5i. Tags and grouping (Scalar UI)
+
+- [ ] `.WithTags("{Module}")` applied at the group level (or per endpoint)
+  so Scalar groups operations by module
+- [ ] Tag name matches the canonical module name (PascalCase, e.g.
+  `"BlobStorage"`, `"QueryEngine"`) — not a legacy name
+- [ ] Endpoints within the same module share the same tag
+
+### 5j. OperationId uniqueness
+
+- [ ] `.WithName(...)` values are unique across the **entire solution** (Scalar
+  uses them as anchors; SDK generators use them as method names)
+- [ ] No duplicates across modules (common collision: `Create`, `Delete`,
+  `GetById` without a noun prefix)
+- [ ] Use specific verbs: `CreateBlobDescriptor`, not `Create`
+
+### 5k. Schema examples and DTOs
+
+- [ ] `ISchemaExampleProvider<TRequest>` implemented for each non-trivial
+  `*Request` DTO with realistic values (no `"string"`, `0`, `00000000-0000-...`)
+- [ ] Enum JSON serialization uses `JsonStringEnumConverter` (PascalCase)
+- [ ] Date/time properties are `DateTime` / `DateTimeOffset` → ISO 8601 with
+  timezone in OpenAPI
+- [ ] Identifiers are `Guid` → `string` with `format: uuid` in OpenAPI
+- [ ] Value objects (`SingleValueObject<T>`) expose the underlying primitive in
+  OpenAPI via the framework's `SingleValueObjectSchemaTransformer`
+- [ ] Request DTOs declared in `.Endpoints/Dtos/` — entities are never returned
+
+### 5l. Deprecation and versioning
+
+- [ ] Deprecated endpoints use
+  `.WithMetadata(new DeprecatedAttribute { SunsetDate = "YYYY-MM-DD", Link = "…" })`
+  from `Granit.Http.ApiVersioning.Deprecation` — emits RFC 8594 `Deprecation`,
+  `Sunset`, and `Link` response headers (preferred over raw
+  `op.Deprecated = true`)
+- [ ] Add `[Obsolete]` on the handler method so callers see a compiler warning
+- [ ] No hand-rolled API versioning in URLs (`/v1/…`) — versioning is driven by
+  `ApiDocumentation:MajorVersions` in configuration (generates
+  `/openapi/v1.json`, `/openapi/v2.json`)
+- [ ] One OpenAPI document per declared major version — registered by
+  `Granit.Http.ApiDocumentation` (never call `AddOpenApi()` manually in app code
+  when the module is used)
+
+### 5m. Internal / hidden endpoints
+
+- [ ] Internal-only endpoints (inter-service webhooks, sync jobs, raw admin)
+  marked with `[InternalApi]` from `Granit.Http.ApiDocumentation.Attributes`
+  — silently excluded from all generated OpenAPI documents by
+  `InternalApiDocumentTransformer`
+- [ ] Do NOT use `[ExcludeFromDescription]` — the framework's `[InternalApi]`
+  is the idiomatic marker and integrates with the document transformer
+  pipeline
+
+### 5n. Granit framework alignment (`Granit.Http.ApiDocumentation`)
+
+- [ ] Native `Microsoft.AspNetCore.OpenApi` via `GranitHttpApiDocumentationModule`
+  only — NEVER Swashbuckle or NSwag (flag any `Swashbuckle.*` or `NSwag.*`
+  `<PackageReference>`)
+- [ ] Host calls `app.UseGranitApiDocumentation()` in `Program.cs` (not manual
+  `MapOpenApi()` + custom UI wiring)
+- [ ] `ApiDocumentationOptions` bound from `ApiDocumentation` section in
+  `appsettings.json` (`MajorVersions`, `Title`, `Description`, `ContactEmail`,
+  `LogoUrl`, `FaviconUrl`, `EnableInProduction`, `EnableTenantHeader`,
+  `AuthorizationPolicy`, `OAuth2`)
+- [ ] `EnableInProduction = false` unless explicitly required (ISO 27001 —
+  OpenAPI surface is a reconnaissance vector)
+- [ ] Tenant-aware apps: `EnableTenantHeader = true` documents the
+  `X-Tenant-Id` header on every endpoint; anonymous-tenant endpoints opt out
+  with `[AllowAnonymousTenant]`
+- [ ] OAuth2 flows use `OAuth2Options` binding — do not hand-wire
+  `OpenApiSecurityScheme` (the `OAuth2SecuritySchemeTransformer` handles it)
+- [ ] Request DTO examples supplied via `ISchemaExampleProvider` implemented
+  in each `.Endpoints` package — NEVER inline JSON in the endpoint chain,
+  NEVER `[OpenApiExample]`-style hacks. The
+  `SchemaExampleSchemaTransformer` deep-clones examples from the provider.
+- [ ] Well-known parameter names (`userId`, `roleName`, `permissionName`,
+  `entityType`, `entryId`, `jobId`, etc.) inherit descriptions from
+  `ParameterDescriptionOperationTransformer` — do NOT re-describe them
+  manually unless overriding
+
+### 5o. Auto-injected responses — do NOT duplicate
+
+`ProblemDetailsResponseOperationTransformer` injects responses based on
+endpoint metadata. Manual declarations for these statuses are redundant
+noise and should be flagged as `CLEANUP`:
+
+- [ ] No manual `.ProducesProblem(StatusCodes.Status401Unauthorized)` on
+  `[Authorize]` endpoints — auto-injected
+- [ ] No manual `.ProducesProblem(StatusCodes.Status403Forbidden)` on
+  `[Authorize]` endpoints — auto-injected
+- [ ] No manual `.ProducesProblem(StatusCodes.Status422UnprocessableEntity)`
+  on endpoints with a request body — auto-injected when no 400 exists
+- [ ] No manual `.ProducesProblem(StatusCodes.Status500InternalServerError)`
+  — auto-injected on every operation
+- [ ] 404 response from `TypedResults.NotFound()` is automatically enriched
+  with the shared `ProblemDetails` schema — the endpoint only needs to
+  declare `.ProducesProblem(404)` if the handler branches to it
+
+### 5p. Detection strategy
+
+When auditing a module's endpoints:
+
+1. Enumerate endpoint files: `Glob src/Granit.{Module}.Endpoints/**/*Endpoints.cs`
+2. For each file, use MCP `get_file_overview` to list `Map*` methods
+3. For each `Map*` method, use MCP `get_symbol_detail` to read the chain
+4. Cross-reference the handler signature (return type, parameters) with the
+   `.With*`/`.Produces*` chain — mismatches are `BREAKING` (wrong SDK output)
+5. Grep for violations:
+   - `Results\.(Ok|BadRequest|NotFound|Problem)` → use `TypedResults` (GRAPI001)
+   - `BadRequest<string>` → use `Problem()` (GRAPI002)
+   - `Swashbuckle|NSwag` in `.csproj` → remove
+   - `MapGroup\(` (without `Granit`) in `.Endpoints/` → use `MapGranitGroup`
+   - `.RequireAuthorization\(\)` with no argument → specify a permission string
+   - `Task<IActionResult>` or `ActionResult<` → wrong pattern in Minimal API
+
+### Severity guidance
+
+| Finding | Severity |
+| ------- | -------- |
+| Handler branch not declared in `.Produces*()` | BREAKING (SDK mismatch) |
+| `.Produces*()` without matching handler branch | CONVENTION |
+| Missing one of the 5 mandatory metadata elements | CONVENTION |
+| Duplicate `OperationId` across solution | BREAKING (SDK codegen fails) |
+| Missing `.RequireAuthorization` / `.AllowAnonymous` | ARCHITECTURE (security) |
+| `MapGroup` instead of `MapGranitGroup` | CONVENTION (loses auto-validation) |
+| Entity returned from endpoint | ARCHITECTURE (leaks persistence) |
+| Swashbuckle / NSwag reference | ARCHITECTURE |
+| Wrong route constraint type | BREAKING (binding fails at runtime) |
+| Missing `.DisableAntiforgery()` on multipart | BREAKING (endpoint rejects requests) |
+
+Ref: `CLAUDE.md §OpenAPI metadata`, `docs-site/…/api/api-documentation.mdx`,
+`docs-site/…/architecture/http-conventions.md`
 
 ---
 

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1506,6 +1506,7 @@
         "Granit.Authorization",
         "Granit.Guids",
         "Granit.Http.Abstractions",
+        "Granit.Http.ApiDocumentation",
         "Granit.Payments",
         "Granit.RateLimiting",
         "Granit.Validation"

--- a/src/Granit.AI.Endpoints/Endpoints/AIChatEndpoints.cs
+++ b/src/Granit.AI.Endpoints/Endpoints/AIChatEndpoints.cs
@@ -26,7 +26,6 @@ internal static class AIChatEndpoints
                 + "Returns 404 if the workspace does not exist, or 502 if the provider is unavailable.")
             .Produces<AIChatResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .ProducesProblem(StatusCodes.Status502BadGateway);
 
         group.MapPost("/chat/{workspaceName}/stream", StreamAsync)
@@ -40,7 +39,6 @@ internal static class AIChatEndpoints
                 + "or 502/503 if the provider is unavailable.")
             .Produces<string>(StatusCodes.Status200OK, "text/event-stream")
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .ProducesProblem(StatusCodes.Status502BadGateway)
             .ProducesProblem(StatusCodes.Status503ServiceUnavailable);
 

--- a/src/Granit.AI.Endpoints/Endpoints/AIWorkspaceEndpoints.cs
+++ b/src/Granit.AI.Endpoints/Endpoints/AIWorkspaceEndpoints.cs
@@ -50,8 +50,7 @@ internal static class AIWorkspaceEndpoints
                 + "System workspaces cannot be modified and return 422. "
                 + "Returns 404 if the workspace does not exist.")
             .Produces<AIWorkspaceResponse>()
-            .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
+            .ProducesProblem(StatusCodes.Status404NotFound);
 
         group.MapDelete("/workspaces/{name}", DeleteAsync)
             .WithName("DeleteAIWorkspace")

--- a/src/Granit.AI.Endpoints/Internal/AISchemaExampleProvider.cs
+++ b/src/Granit.AI.Endpoints/Internal/AISchemaExampleProvider.cs
@@ -1,0 +1,69 @@
+using System.Text.Json.Nodes;
+using Granit.AI.Endpoints.Dtos;
+using Granit.Http.ApiDocumentation;
+
+namespace Granit.AI.Endpoints.Internal;
+
+/// <summary>
+/// Provides OpenAPI schema examples for AI Request and Response DTOs (chat, embeddings, workspaces).
+/// </summary>
+internal sealed class AISchemaExampleProvider : ISchemaExampleProvider
+{
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<Type, JsonNode> GetExamples() =>
+        new Dictionary<Type, JsonNode>
+        {
+            // ──── Chat ────
+            [typeof(AIChatRequest)] = new JsonObject
+            {
+                ["messages"] = new JsonArray
+                {
+                    new JsonObject
+                    {
+                        ["role"] = "system",
+                        ["content"] = "You are a concise assistant that answers in one sentence.",
+                    },
+                    new JsonObject
+                    {
+                        ["role"] = "user",
+                        ["content"] = "Summarize RFC 7807 in one sentence.",
+                    },
+                },
+            },
+            [typeof(AIChatMessageRequest)] = new JsonObject
+            {
+                ["role"] = "user",
+                ["content"] = "What is the capital of Belgium?",
+            },
+
+            // ──── Embeddings ────
+            [typeof(AIEmbeddingRequest)] = new JsonObject
+            {
+                ["inputs"] = new JsonArray
+                {
+                    "The quick brown fox jumps over the lazy dog.",
+                    "Granit is a modular .NET 10 framework.",
+                },
+            },
+
+            // ──── Workspaces ────
+            [typeof(AIWorkspaceCreateRequest)] = new JsonObject
+            {
+                ["name"] = "support-triage",
+                ["provider"] = "OpenAI",
+                ["model"] = "gpt-4o",
+                ["systemPrompt"] = "You classify incoming support tickets into one of: billing, bug, feature-request, other.",
+                ["temperature"] = 0.2f,
+                ["maxOutputTokens"] = 512,
+            },
+            [typeof(AIWorkspaceUpdateRequest)] = new JsonObject
+            {
+                ["provider"] = "OpenAI",
+                ["model"] = "gpt-4o-mini",
+                ["systemPrompt"] = "You classify incoming support tickets into one of: billing, bug, feature-request, other.",
+                ["temperature"] = 0.2f,
+                ["maxOutputTokens"] = 512,
+                ["activated"] = true,
+            },
+        };
+}

--- a/src/Granit.Authentication.ApiKeys.Endpoints/Endpoints/ApiKeyCreateEndpoints.cs
+++ b/src/Granit.Authentication.ApiKeys.Endpoints/Endpoints/ApiKeyCreateEndpoints.cs
@@ -23,8 +23,7 @@ internal static class ApiKeyCreateEndpoints
             .WithSummary("Creates a new API key. The raw secret is returned once.")
             .WithDescription("Generates a new API key with the specified type, environment, permissions, and optional CIDR restrictions. The caller must possess every permission being assigned (privilege escalation prevention). The response includes the full raw secret — this is the only time the secret is available. Store it securely; it cannot be retrieved later. The key is immediately active.")
             .WithMetadata(new IdempotentAttribute { Required = false })
-            .Produces<ApiKeyCreateResponse>(StatusCodes.Status201Created)
-            .ProducesProblem(StatusCodes.Status403Forbidden);
+            .Produces<ApiKeyCreateResponse>(StatusCodes.Status201Created);
 
         return group;
     }

--- a/src/Granit.Authentication.ApiKeys.Endpoints/Endpoints/ApiKeyScopesEndpoints.cs
+++ b/src/Granit.Authentication.ApiKeys.Endpoints/Endpoints/ApiKeyScopesEndpoints.cs
@@ -22,7 +22,6 @@ internal static class ApiKeyScopesEndpoints
             .WithDescription("Replaces the full list of permissions and allowed CIDR ranges for the specified key. The caller must possess every permission being assigned (privilege escalation prevention). Both fields are replaced entirely (not merged). Returns 404 if the key does not exist.")
             .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces(StatusCodes.Status204NoContent)
-            .ProducesProblem(StatusCodes.Status403Forbidden)
             .ProducesProblem(StatusCodes.Status404NotFound);
 
         return group;

--- a/src/Granit.Authorization.Endpoints/Endpoints/PermissionGrantEndpoints.cs
+++ b/src/Granit.Authorization.Endpoints/Endpoints/PermissionGrantEndpoints.cs
@@ -42,16 +42,14 @@ internal static partial class PermissionGrantEndpoints
             .WithSummary("Grants a permission to a role. No-op if already granted.")
             .WithDescription("Grants the specified permission to the role for the current tenant. The permission name must match a registered permission definition (returns 422 otherwise). The calling user must hold the permission being granted (privilege escalation prevention). Idempotent — granting an already-granted permission is a no-op.")
             .Produces(StatusCodes.Status204NoContent)
-            .ProducesValidationProblem()
-            .ProducesProblem(StatusCodes.Status403Forbidden);
+            .ProducesValidationProblem();
 
         adminGroup.MapDelete("/{roleName}/{permissionName}", RevokePermissionAsync)
             .WithName("RevokePermission")
             .WithSummary("Revokes a permission from a role. No-op if not granted.")
             .WithDescription("Revokes the specified permission from the role for the current tenant. The permission name must match a registered permission definition (returns 422 otherwise). The calling user must hold the permission being revoked (privilege escalation prevention). Idempotent — revoking a non-granted permission is a no-op.")
             .Produces(StatusCodes.Status204NoContent)
-            .ProducesValidationProblem()
-            .ProducesProblem(StatusCodes.Status403Forbidden);
+            .ProducesValidationProblem();
 
         return group;
     }

--- a/src/Granit.BlobStorage.Endpoints/Internal/BlobStorageSchemaExampleProvider.cs
+++ b/src/Granit.BlobStorage.Endpoints/Internal/BlobStorageSchemaExampleProvider.cs
@@ -1,0 +1,66 @@
+using System.Text.Json.Nodes;
+using Granit.BlobStorage.Endpoints.Dtos;
+using Granit.Http.ApiDocumentation;
+
+namespace Granit.BlobStorage.Endpoints.Internal;
+
+/// <summary>
+/// Provides OpenAPI schema examples for BlobStorage Request and Response DTOs.
+/// </summary>
+internal sealed class BlobStorageSchemaExampleProvider : ISchemaExampleProvider
+{
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<Type, JsonNode> GetExamples() =>
+        new Dictionary<Type, JsonNode>
+        {
+            [typeof(BlobUploadInitiateRequest)] = new JsonObject
+            {
+                ["containerName"] = "medical-images",
+                ["fileName"] = "xray-2026-04-20.png",
+                ["contentType"] = "image/png",
+                ["sizeBytes"] = 2_458_112L,
+            },
+            [typeof(BlobUploadInitiateResponse)] = new JsonObject
+            {
+                ["blobId"] = "01960f3a-5c9e-7c3b-b4a2-abc123def456",
+                ["uploadUrl"] = "https://storage.acme.example/medical-images/01960f3a...?sig=...",
+                ["httpMethod"] = "PUT",
+                ["expiresAt"] = "2026-04-20T15:30:00+00:00",
+                ["requiredHeaders"] = new JsonObject
+                {
+                    ["x-ms-blob-type"] = "BlockBlob",
+                    ["content-type"] = "image/png",
+                },
+            },
+            [typeof(BlobConfirmUploadRequest)] = new JsonObject
+            {
+                ["containerName"] = "medical-images",
+            },
+            [typeof(BlobDeleteRequest)] = new JsonObject
+            {
+                ["containerName"] = "medical-images",
+                ["deletionReason"] = "RGPD Art. 17 erasure request",
+            },
+            [typeof(BlobDownloadUrlRequest)] = new JsonObject
+            {
+                ["containerName"] = "medical-images",
+                ["fileName"] = "xray-2026-04-20.png",
+            },
+            [typeof(BlobDescriptorResponse)] = new JsonObject
+            {
+                ["id"] = "01960f3a-5c9e-7c3b-b4a2-abc123def456",
+                ["containerName"] = "medical-images",
+                ["originalFileName"] = "xray-2026-04-20.png",
+                ["declaredContentType"] = "image/png",
+                ["verifiedContentType"] = "image/png",
+                ["declaredSizeBytes"] = 2_458_112L,
+                ["actualSizeBytes"] = 2_458_112L,
+                ["status"] = "Validated",
+                ["rejectionReason"] = null,
+                ["deletionReason"] = null,
+                ["createdAt"] = "2026-04-20T14:22:30+00:00",
+                ["validatedAt"] = "2026-04-20T14:22:45+00:00",
+                ["deletedAt"] = null,
+            },
+        };
+}

--- a/src/Granit.DataExchange.Csv/packages.lock.json
+++ b/src/Granit.DataExchange.Csv/packages.lock.json
@@ -11,8 +11,8 @@
       "Sep": {
         "type": "Direct",
         "requested": "[0.*, )",
-        "resolved": "0.12.4",
-        "contentHash": "9d8BQepYsyjnwxqRv2V+KQ0IfST3jWK+ufhcafNbrZ2duZxBR4/g33t0rFBtc9dL8/gtMvWsd+U/b6RRHp/8Pw==",
+        "resolved": "0.12.5",
+        "contentHash": "yS1EgVf7a3QZ3hKN/B+Yh8kHbAvdtkDLdWf74sk3fFweLc4k9SSvMGig8k8lBK3iDXeVx9r7W44g/nBxYFIuLw==",
         "dependencies": {
           "csFastFloat": "4.1.5"
         }

--- a/src/Granit.Features.Endpoints/Extensions/FeaturesEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Features.Endpoints/Extensions/FeaturesEndpointRouteBuilderExtensions.cs
@@ -90,8 +90,7 @@ public static class FeaturesEndpointRouteBuilderExtensions
              .WithSummary("Sets a tenant-level feature override.")
              .WithDescription("Creates or updates a tenant-level override for the specified feature. The value is validated against the feature's value type (Toggle: true/false, Numeric: min/max bounds, Selection: allowed values). Returns 404 if the feature is not declared. Requires the Features.Manage permission.")
              .Produces(StatusCodes.Status204NoContent)
-             .ProducesProblem(StatusCodes.Status404NotFound)
-             .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
+             .ProducesProblem(StatusCodes.Status404NotFound);
 
         group.MapDelete("/overrides/{name}", HandleDeleteOverrideAsync)
              .RequireAuthorization(FeaturesPermissions.Flags.Manage)

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AdminImpersonationEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AdminImpersonationEndpoints.cs
@@ -23,7 +23,6 @@ internal static class AdminImpersonationEndpoints
                 + "Writes audit log and sends transparency notification.")
             .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces<ImpersonationResponse>()
-            .ProducesProblem(StatusCodes.Status403Forbidden)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(IdentityLocalPermissions.Users.Impersonate);
 

--- a/src/Granit.Identity.Local.Endpoints/Internal/IdentityLocalSchemaExampleProvider.cs
+++ b/src/Granit.Identity.Local.Endpoints/Internal/IdentityLocalSchemaExampleProvider.cs
@@ -1,0 +1,112 @@
+using System.Text.Json.Nodes;
+using Granit.Http.ApiDocumentation;
+using Granit.Identity.Local.Endpoints.Dtos;
+
+namespace Granit.Identity.Local.Endpoints.Internal;
+
+/// <summary>
+/// Provides OpenAPI schema examples for Identity.Local Request DTOs (login, registration,
+/// 2FA, passkeys, password and profile management).
+/// </summary>
+internal sealed class IdentityLocalSchemaExampleProvider : ISchemaExampleProvider
+{
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<Type, JsonNode> GetExamples() =>
+        new Dictionary<Type, JsonNode>
+        {
+            // ──── Login / registration ────
+            // Placeholder credentials use angle-bracket syntax (<…>) so secret scanners
+            // and the GRSEC003 analyzer recognize them as example markers, not literals.
+            [typeof(AccountLoginRequest)] = new JsonObject
+            {
+                ["login"] = "alice@acme.example",
+                ["password"] = "<your-password>",
+                ["rememberMe"] = true,
+            },
+            [typeof(AccountLoginResponse)] = new JsonObject
+            {
+                ["succeeded"] = false,
+                ["requiresTwoFactor"] = true,
+                ["isLockedOut"] = false,
+                ["isNotAllowed"] = false,
+            },
+            [typeof(AccountRegisterRequest)] = new JsonObject
+            {
+                ["email"] = "alice@acme.example",
+                ["password"] = "<your-password>",
+                ["firstName"] = "Alice",
+                ["lastName"] = "Martin",
+            },
+
+            // ──── Two-factor authentication ────
+            [typeof(AccountTwoFactorLoginRequest)] = new JsonObject
+            {
+                ["code"] = "123456",
+                ["useRecoveryCode"] = false,
+                ["rememberMe"] = false,
+            },
+            [typeof(AccountTwoFactorEnableRequest)] = new JsonObject
+            {
+                ["code"] = "123456",
+            },
+            [typeof(AccountTwoFactorDisableRequest)] = new JsonObject
+            {
+                ["password"] = "<your-password>",
+            },
+
+            // ──── Password management ────
+            [typeof(AccountPasswordChangeRequest)] = new JsonObject
+            {
+                ["currentPassword"] = "<current-password>",
+                ["newPassword"] = "<new-password>",
+            },
+            [typeof(AccountForgotPasswordRequest)] = new JsonObject
+            {
+                ["email"] = "alice@acme.example",
+            },
+            [typeof(AccountPasswordResetRequest)] = new JsonObject
+            {
+                ["userId"] = "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                ["token"] = "<reset-token-from-email>",
+                ["newPassword"] = "<new-password>",
+            },
+
+            // ──── Email change ────
+            [typeof(AccountChangeEmailRequest)] = new JsonObject
+            {
+                ["newEmail"] = "alice.new@acme.example",
+            },
+            [typeof(AccountConfirmEmailChangeRequest)] = new JsonObject
+            {
+                ["userId"] = "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                ["newEmail"] = "alice.new@acme.example",
+                ["token"] = "<confirmation-token-from-email>",
+            },
+
+            // ──── Profile ────
+            [typeof(AccountProfileUpdateRequest)] = new JsonObject
+            {
+                ["firstName"] = "Alice",
+                ["lastName"] = "Martin",
+            },
+            [typeof(AccountDeleteRequest)] = new JsonObject
+            {
+                ["password"] = "<your-password>",
+            },
+
+            // ──── Passkeys (WebAuthn) ────
+            [typeof(AccountPasskeyLoginRequest)] = new JsonObject
+            {
+                ["credentialJson"] = "{\"id\":\"credential-id\",\"rawId\":\"...\",\"type\":\"public-key\",\"response\":{\"clientDataJSON\":\"...\",\"authenticatorData\":\"...\",\"signature\":\"...\",\"userHandle\":\"...\"}}",
+            },
+            [typeof(PasskeyRegistrationRequest)] = new JsonObject
+            {
+                ["credentialJson"] = "{\"id\":\"credential-id\",\"rawId\":\"...\",\"type\":\"public-key\",\"response\":{\"clientDataJSON\":\"...\",\"attestationObject\":\"...\"}}",
+                ["name"] = "iPhone 15",
+            },
+            [typeof(PasskeyRenameRequest)] = new JsonObject
+            {
+                ["name"] = "MacBook Pro (work)",
+            },
+        };
+}

--- a/src/Granit.Invoicing.Endpoints/Internal/InvoicingSchemaExampleProvider.cs
+++ b/src/Granit.Invoicing.Endpoints/Internal/InvoicingSchemaExampleProvider.cs
@@ -1,0 +1,68 @@
+using System.Text.Json.Nodes;
+using Granit.Http.ApiDocumentation;
+using Granit.Invoicing.Endpoints.Dtos;
+
+namespace Granit.Invoicing.Endpoints.Internal;
+
+/// <summary>
+/// Provides OpenAPI schema examples for Invoicing Request and Response DTOs.
+/// </summary>
+internal sealed class InvoicingSchemaExampleProvider : ISchemaExampleProvider
+{
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<Type, JsonNode> GetExamples() =>
+        new Dictionary<Type, JsonNode>
+        {
+            [typeof(InvoiceCreateRequest)] = new JsonObject
+            {
+                ["documentType"] = "Invoice",
+                ["currency"] = "EUR",
+                ["collectionMethod"] = "ChargeAutomatically",
+                ["billingReason"] = "Subscription",
+                ["parentInvoiceId"] = null,
+                ["creditNoteReason"] = null,
+                ["periodStart"] = "2026-04-01T00:00:00+00:00",
+                ["periodEnd"] = "2026-04-30T23:59:59+00:00",
+            },
+            [typeof(InvoiceResponse)] = new JsonObject
+            {
+                ["id"] = "01960f3a-5c9e-7c3b-b4a2-abc123def456",
+                ["documentType"] = "Invoice",
+                ["invoiceNumber"] = "INV-2026-00042",
+                ["status"] = "Open",
+                ["collectionMethod"] = "ChargeAutomatically",
+                ["billingReason"] = "Subscription",
+                ["currency"] = "EUR",
+                ["subtotal"] = 99.00m,
+                ["taxTotal"] = 20.79m,
+                ["total"] = 119.79m,
+                ["amountPaid"] = 0.00m,
+                ["amountCredited"] = 0.00m,
+                ["amountRemaining"] = 119.79m,
+                ["parentInvoiceId"] = null,
+                ["creditNoteReason"] = null,
+                ["issuedAt"] = "2026-04-20T10:00:00+00:00",
+                ["dueAt"] = "2026-05-20T10:00:00+00:00",
+                ["paidAt"] = null,
+                ["periodStart"] = "2026-04-01T00:00:00+00:00",
+                ["periodEnd"] = "2026-04-30T23:59:59+00:00",
+                ["lineItems"] = new JsonArray
+                {
+                    new JsonObject
+                    {
+                        ["id"] = "01960f3a-5c9e-7c3b-b4a2-000000000001",
+                        ["description"] = "Pro plan — April 2026",
+                        ["quantity"] = 1m,
+                        ["unitPrice"] = 99.00m,
+                        ["amount"] = 99.00m,
+                        ["taxRate"] = 0.21m,
+                        ["taxAmount"] = 20.79m,
+                        ["sourceType"] = "Subscription",
+                        ["sourceId"] = "01960f3a-5c9e-7c3b-b4a2-abc111222333",
+                        ["periodStart"] = "2026-04-01T00:00:00+00:00",
+                        ["periodEnd"] = "2026-04-30T23:59:59+00:00",
+                    },
+                },
+            },
+        };
+}

--- a/src/Granit.Localization.Endpoints/Extensions/LocalizationEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Localization.Endpoints/Extensions/LocalizationEndpointRouteBuilderExtensions.cs
@@ -118,16 +118,17 @@ public static partial class LocalizationEndpointRouteBuilderExtensions
             return Task.CompletedTask;
         }
 
-        foreach (IOpenApiParameter parameter in operation.Parameters)
+        IEnumerable<IOpenApiParameter> cultureNameQueryParams = operation.Parameters
+            .Where(p => p.Name == "cultureName"
+                && p.In == ParameterLocation.Query
+                && p.Schema is OpenApiSchema);
+
+        foreach (IOpenApiParameter parameter in cultureNameQueryParams)
         {
-            if (parameter.Name == "cultureName"
-                && parameter.In == ParameterLocation.Query
-                && parameter.Schema is OpenApiSchema schema)
-            {
-                parameter.Description ??= "Optional BCP 47 culture tag (e.g. 'fr', 'fr-BE', 'zh-Hant-TW'). When omitted, the Accept-Language header is used.";
-                schema.Pattern ??= "^[a-zA-Z]{2,8}(-[a-zA-Z0-9]{1,8})*$";
-                schema.Example ??= System.Text.Json.Nodes.JsonValue.Create("fr-BE");
-            }
+            var schema = (OpenApiSchema)parameter.Schema!;
+            parameter.Description ??= "Optional BCP 47 culture tag (e.g. 'fr', 'fr-BE', 'zh-Hant-TW'). When omitted, the Accept-Language header is used.";
+            schema.Pattern ??= "^[a-zA-Z]{2,8}(-[a-zA-Z0-9]{1,8})*$";
+            schema.Example ??= System.Text.Json.Nodes.JsonValue.Create("fr-BE");
         }
 
         return Task.CompletedTask;

--- a/src/Granit.Payments.Endpoints/Granit.Payments.Endpoints.csproj
+++ b/src/Granit.Payments.Endpoints/Granit.Payments.Endpoints.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
     <ProjectReference Include="..\Granit.Http.Abstractions\Granit.Http.Abstractions.csproj" />
+    <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
     <ProjectReference Include="..\Granit.Payments\Granit.Payments.csproj" />
     <ProjectReference Include="..\Granit.RateLimiting\Granit.RateLimiting.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />

--- a/src/Granit.Payments.Endpoints/Internal/PaymentsSchemaExampleProvider.cs
+++ b/src/Granit.Payments.Endpoints/Internal/PaymentsSchemaExampleProvider.cs
@@ -1,0 +1,62 @@
+using System.Text.Json.Nodes;
+using Granit.Http.ApiDocumentation;
+using Granit.Payments.Endpoints.Dtos;
+
+namespace Granit.Payments.Endpoints.Internal;
+
+/// <summary>
+/// Provides OpenAPI schema examples for Payments Response DTOs
+/// (payment methods, transactions, refunds, disputes, checkout sessions).
+/// </summary>
+internal sealed class PaymentsSchemaExampleProvider : ISchemaExampleProvider
+{
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<Type, JsonNode> GetExamples() =>
+        new Dictionary<Type, JsonNode>
+        {
+            [typeof(PaymentMethodResponse)] = new JsonObject
+            {
+                ["id"] = "01960f3a-5c9e-7c3b-b4a2-abc123def456",
+                ["type"] = "card",
+                ["providerName"] = "Stripe",
+                ["providerMethodId"] = "pm_1PabcDEF1234567890",
+                ["displayLabel"] = "Visa ending in 4242",
+                ["isDefault"] = true,
+                ["expiresAt"] = "2029-12-31T23:59:59+00:00",
+                ["tenantId"] = "01960f3a-5c9e-7c3b-b4a2-def456abc789",
+            },
+            [typeof(PaymentAvailableMethodResponse)] = new JsonObject
+            {
+                ["methodType"] = "card",
+                ["category"] = "Card",
+                ["providerName"] = "Stripe",
+                ["displayLabel"] = "Credit or debit card",
+                ["capability"] = null,
+            },
+            [typeof(PaymentTransactionResponse)] = new JsonObject
+            {
+                ["id"] = "01960f3a-5c9e-7c3b-b4a2-abc111222333",
+                ["invoiceId"] = "01960f3a-5c9e-7c3b-b4a2-def000000001",
+                ["amount"] = 119.79m,
+                ["currency"] = "EUR",
+                ["status"] = "Succeeded",
+                ["providerName"] = "Stripe",
+                ["providerTransactionId"] = "pi_3PabcDEF1234567890",
+                ["paymentMethodId"] = "01960f3a-5c9e-7c3b-b4a2-abc123def456",
+                ["actionUrl"] = null,
+                ["idempotencyKey"] = "invoice-INV-2026-00042-attempt-1",
+                ["failureCode"] = null,
+                ["succeededAt"] = "2026-04-20T10:05:12+00:00",
+                ["canceledAt"] = null,
+                ["refunds"] = new JsonArray(),
+                ["disputes"] = new JsonArray(),
+                ["tenantId"] = "01960f3a-5c9e-7c3b-b4a2-def456abc789",
+            },
+            [typeof(PaymentCheckoutSessionResponse)] = new JsonObject
+            {
+                ["url"] = "https://checkout.stripe.com/c/pay/cs_test_a1b2c3d4...",
+                ["sessionId"] = "cs_test_a1b2c3d4e5f67890",
+                ["expiresAt"] = "2026-04-20T11:05:12+00:00",
+            },
+        };
+}

--- a/src/Granit.Payments.Endpoints/packages.lock.json
+++ b/src/Granit.Payments.Endpoints/packages.lock.json
@@ -22,6 +22,19 @@
           "Newtonsoft.Json": "13.0.3"
         }
       },
+      "Asp.Versioning.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "I4CuGwl0nO98j6Ft6XlGBgzj1+goE/TSVlnHKgtRkuMZ0K4gy9I+Wyrtto8dyt0hWcFMDFAZ4lYNr58DSemH1g=="
+      },
+      "Asp.Versioning.Http": {
+        "type": "Transitive",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "4/QzujOrkGn9sMch3eHhR5LpVJ4Xo5T2BNg7U1/r4YwEa8JywzkoGQHjW7Nk0W8ljETnpoJaO5mrTsfEOnJK3A==",
+        "dependencies": {
+          "Asp.Versioning.Abstractions": "10.0.0-preview.2"
+        }
+      },
       "FastExpressionCompiler": {
         "type": "Transitive",
         "resolved": "5.3.0",
@@ -292,6 +305,22 @@
       "granit.http.abstractions": {
         "type": "Project"
       },
+      "granit.http.apidocumentation": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Http.ApiVersioning": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )",
+          "Scalar.AspNetCore": "[2.*, )"
+        }
+      },
+      "granit.http.apiversioning": {
+        "type": "Project",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "[10.0.0-preview.*, )",
+          "Asp.Versioning.Mvc.ApiExplorer": "[10.0.0-preview.*, )",
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.http.exceptionhandling": {
         "type": "Project",
         "dependencies": {
@@ -363,6 +392,24 @@
           "Microsoft.AspNetCore.OpenApi": "[10.*, )"
         }
       },
+      "Asp.Versioning.Mvc": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0-preview.*, )",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "AyrcDwLzJp8yRJaFjZMJXkR1Rx2UaJkwGrGlX8sxIt2F5ZGiZwn/puXkB/oEaq55TxLkpiXWAOHHFsiVptp0fA==",
+        "dependencies": {
+          "Asp.Versioning.Http": "10.0.0-preview.2"
+        }
+      },
+      "Asp.Versioning.Mvc.ApiExplorer": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0-preview.*, )",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "G/LhAaLQj+gsB8UXRNm65fxjsI7fe87itZExb+MvJOQdrXYalZKbwuzMntO95xM5cKDrDgLnCH64fl6w173aGg==",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "10.0.0-preview.2"
+        }
+      },
       "FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[12.*, )",
@@ -422,6 +469,12 @@
         "requested": "[1.15.*, )",
         "resolved": "1.14.0",
         "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "Scalar.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.14.1",
+        "contentHash": "neS3aI7YVPDY7+I9U8nYXvSnSy6lPvGyn5w52m0MCvC5COajK4HF4vsx70OO6Fw9bd7WXOUikSBdUaLfyTzw3g=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",

--- a/src/Granit.Privacy.Endpoints/Internal/PrivacySchemaExampleProvider.cs
+++ b/src/Granit.Privacy.Endpoints/Internal/PrivacySchemaExampleProvider.cs
@@ -1,0 +1,42 @@
+using System.Text.Json.Nodes;
+using Granit.Http.ApiDocumentation;
+using Granit.Privacy.Endpoints.Dtos;
+
+namespace Granit.Privacy.Endpoints.Internal;
+
+/// <summary>
+/// Provides OpenAPI schema examples for Privacy Request DTOs (GDPR consent, erasure,
+/// legal documents).
+/// </summary>
+internal sealed class PrivacySchemaExampleProvider : ISchemaExampleProvider
+{
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<Type, JsonNode> GetExamples() =>
+        new Dictionary<Type, JsonNode>
+        {
+            [typeof(PrivacyAcceptAgreementRequest)] = new JsonObject
+            {
+                ["documentId"] = "privacy-policy",
+                ["version"] = "2.1.0",
+            },
+            [typeof(PrivacyDeletionRequest)] = new JsonObject
+            {
+                ["reason"] = "Account closure — withdrawal of consent.",
+                ["defer"] = true,
+            },
+            [typeof(LegalDocumentCreateRequest)] = new JsonObject
+            {
+                ["documentId"] = "privacy-policy",
+                ["displayName"] = "Privacy Policy",
+                ["description"] = "Initial draft based on RGPD Art. 13 disclosure requirements.",
+                ["templateName"] = "PrivacyPolicy",
+            },
+            [typeof(LegalDocumentUpdateRequest)] = new JsonObject
+            {
+                ["displayName"] = "Privacy Policy",
+                ["description"] = "Added section on third-party analytics.",
+                ["templateName"] = "PrivacyPolicy",
+                ["documentBlobId"] = "01960f3a-5c9e-7c3b-b4a2-abc123def456",
+            },
+        };
+}

--- a/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataAdminEndpoints.cs
+++ b/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataAdminEndpoints.cs
@@ -36,7 +36,6 @@ internal static class ReferenceDataAdminEndpoints
             .WithSummary($"Creates a new {typeof(TEntity).Name} entry.")
             .WithDescription($"Creates a new {typeof(TEntity).Name} reference data entry with a unique code and localized labels for all supported languages. The entry is active by default. Optional validity date range can restrict when the entry is selectable.")
             .Produces(StatusCodes.Status201Created)
-            .ProducesProblem(StatusCodes.Status403Forbidden)
             .ProducesValidationProblem();
 
         group.MapPut("/{code}", UpdateAsync<TEntity>)
@@ -47,7 +46,6 @@ internal static class ReferenceDataAdminEndpoints
             .WithDescription($"Updates the labels, sort order, active status, and validity dates of an existing {typeof(TEntity).Name} entry. The code is immutable and cannot be changed. ExtraProperties use merge semantics: properties in the request are added or updated, properties not in the request are preserved. Returns 404 if no entry matches the code.")
             .Produces(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesProblem(StatusCodes.Status403Forbidden)
             .ProducesValidationProblem();
 
         group.MapDelete("/{code}", DeactivateAsync<TEntity>)
@@ -57,8 +55,7 @@ internal static class ReferenceDataAdminEndpoints
             .WithSummary($"Deactivates a {typeof(TEntity).Name} entry (soft delete).")
             .WithDescription($"Sets the entry's active flag to false. Deactivated entries are excluded from default queries but remain in the database for referential integrity. Returns 404 if no entry matches the code.")
             .Produces(StatusCodes.Status204NoContent)
-            .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesProblem(StatusCodes.Status403Forbidden);
+            .ProducesProblem(StatusCodes.Status404NotFound);
 
         return group;
     }

--- a/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataDynamicEndpoints.cs
+++ b/src/Granit.ReferenceData.Endpoints/Endpoints/ReferenceDataDynamicEndpoints.cs
@@ -73,7 +73,6 @@ internal static class ReferenceDataDynamicEndpoints
             .WithSummary($"Creates a new {typeName} entry.")
             .WithDescription($"Creates a new {typeName} reference data entry with a unique code and localized labels.")
             .Produces(StatusCodes.Status201Created)
-            .ProducesProblem(StatusCodes.Status403Forbidden)
             .ProducesValidationProblem()
             .WithMetadata(new ReferenceDataTypeNameMetadata(typeName));
 
@@ -85,7 +84,6 @@ internal static class ReferenceDataDynamicEndpoints
             .WithDescription($"Updates labels, sort order, active status, and validity dates. ExtraProperties use merge semantics: properties in the request are added or updated, properties not in the request are preserved. Returns 404 if not found.")
             .Produces(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesProblem(StatusCodes.Status403Forbidden)
             .ProducesValidationProblem()
             .WithMetadata(new ReferenceDataTypeNameMetadata(typeName));
 
@@ -97,7 +95,6 @@ internal static class ReferenceDataDynamicEndpoints
             .WithDescription($"Sets the entry's active flag to false. Returns 404 if not found.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesProblem(StatusCodes.Status403Forbidden)
             .WithMetadata(new ReferenceDataTypeNameMetadata(typeName));
 
         return group;

--- a/src/Granit.Subscriptions.Endpoints/Internal/SubscriptionsSchemaExampleProvider.cs
+++ b/src/Granit.Subscriptions.Endpoints/Internal/SubscriptionsSchemaExampleProvider.cs
@@ -1,0 +1,76 @@
+using System.Text.Json.Nodes;
+using Granit.Http.ApiDocumentation;
+using Granit.Subscriptions.Endpoints.Dtos;
+
+namespace Granit.Subscriptions.Endpoints.Internal;
+
+/// <summary>
+/// Provides OpenAPI schema examples for Subscriptions Request and Response DTOs.
+/// </summary>
+internal sealed class SubscriptionsSchemaExampleProvider : ISchemaExampleProvider
+{
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<Type, JsonNode> GetExamples() =>
+        new Dictionary<Type, JsonNode>
+        {
+            // ──── Plans ────
+            [typeof(PlanCreateRequest)] = new JsonObject
+            {
+                ["name"] = "Pro",
+                ["description"] = "For growing teams — unlimited projects and priority support.",
+                ["pricingModel"] = "Flat",
+                ["defaultInterval"] = "Monthly",
+                ["trialDays"] = 14,
+                ["seatLimit"] = 25,
+            },
+            [typeof(PlanUpdateRequest)] = new JsonObject
+            {
+                ["name"] = "Pro",
+                ["description"] = "For growing teams — unlimited projects, priority support, SSO.",
+                ["sortOrder"] = 20,
+            },
+            [typeof(PlanResponse)] = new JsonObject
+            {
+                ["id"] = "01960f3a-5c9e-7c3b-b4a2-abc123def456",
+                ["name"] = "Pro",
+                ["description"] = "For growing teams — unlimited projects and priority support.",
+                ["pricingModel"] = "Flat",
+                ["defaultInterval"] = "Monthly",
+                ["trialDays"] = 14,
+                ["seatLimit"] = 25,
+                ["sortOrder"] = 20,
+                ["lifecycleStatus"] = "Active",
+                ["prices"] = new JsonArray
+                {
+                    new JsonObject
+                    {
+                        ["id"] = "01960f3a-5c9e-7c3b-b4a2-abc111222333",
+                        ["amount"] = 99.00m,
+                        ["currency"] = "EUR",
+                        ["interval"] = "Monthly",
+                        ["effectiveFrom"] = "2026-01-01T00:00:00+00:00",
+                        ["isCurrent"] = true,
+                        ["replacedByPriceId"] = null,
+                        ["replacedAt"] = null,
+                    },
+                },
+            },
+
+            // ──── Subscriptions ────
+            [typeof(SubscriptionCreateRequest)] = new JsonObject
+            {
+                ["planId"] = "01960f3a-5c9e-7c3b-b4a2-abc123def456",
+                ["currency"] = "EUR",
+                ["trialEndsAt"] = "2026-05-04T00:00:00+00:00",
+            },
+            [typeof(SubscriptionCancelRequest)] = new JsonObject
+            {
+                ["reason"] = "Customer switching to annual billing.",
+                ["atPeriodEnd"] = true,
+            },
+            [typeof(SubscriptionChangePlanRequest)] = new JsonObject
+            {
+                ["newPlanId"] = "01960f3a-5c9e-7c3b-b4a2-def456abc789",
+            },
+        };
+}

--- a/src/Granit.Timeline.Endpoints/Endpoints/TimelineEntryEndpoints.cs
+++ b/src/Granit.Timeline.Endpoints/Endpoints/TimelineEntryEndpoints.cs
@@ -38,8 +38,7 @@ internal static class TimelineEntryEndpoints
             .WithSummary("Soft-deletes a comment or internal note (RGPD right to erasure).")
             .WithDescription("Performs a soft-delete on the timeline entry. Only the author or users with Timeline.Entries.Manage permission can delete. SystemLog entries are immutable (ISO 27001). Returns 404 if the entry does not exist.")
             .Produces(StatusCodes.Status204NoContent)
-            .ProducesProblem(StatusCodes.Status404NotFound)
-            .ProducesProblem(StatusCodes.Status403Forbidden);
+            .ProducesProblem(StatusCodes.Status404NotFound);
 
         return group;
     }

--- a/src/Granit.Timeline.Endpoints/Endpoints/TimelineFollowerEndpoints.cs
+++ b/src/Granit.Timeline.Endpoints/Endpoints/TimelineFollowerEndpoints.cs
@@ -21,16 +21,14 @@ internal static class TimelineFollowerEndpoints
             .WithName("FollowTimelineEntity")
             .WithSummary("Subscribes the current user as a follower of an entity.")
             .WithDescription("Adds the authenticated user to the follower list for the specified entity. Followers receive notifications when new timeline entries are posted. Idempotent.")
-            .Produces(StatusCodes.Status204NoContent)
-            .ProducesProblem(StatusCodes.Status401Unauthorized);
+            .Produces(StatusCodes.Status204NoContent);
 
         group.MapDelete("/{entityType}/{entityId}/follow", UnfollowAsync)
             .RequireAuthorization(TimelinePermissions.Followers.Manage)
             .WithName("UnfollowTimelineEntity")
             .WithSummary("Unsubscribes the current user from an entity.")
             .WithDescription("Removes the authenticated user from the follower list. Idempotent.")
-            .Produces(StatusCodes.Status204NoContent)
-            .ProducesProblem(StatusCodes.Status401Unauthorized);
+            .Produces(StatusCodes.Status204NoContent);
 
         group.MapGet("/{entityType}/{entityId}/followers", GetFollowersAsync)
             .WithName("GetTimelineFollowers")

--- a/src/Granit.Webhooks.Endpoints/Internal/WebhooksSchemaExampleProvider.cs
+++ b/src/Granit.Webhooks.Endpoints/Internal/WebhooksSchemaExampleProvider.cs
@@ -1,0 +1,41 @@
+using System.Text.Json.Nodes;
+using Granit.Http.ApiDocumentation;
+using Granit.Webhooks.Endpoints.Dtos;
+
+namespace Granit.Webhooks.Endpoints.Internal;
+
+/// <summary>
+/// Provides OpenAPI schema examples for Webhooks Request and Response DTOs.
+/// </summary>
+internal sealed class WebhooksSchemaExampleProvider : ISchemaExampleProvider
+{
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<Type, JsonNode> GetExamples() =>
+        new Dictionary<Type, JsonNode>
+        {
+            [typeof(WebhookSubscriptionCreateRequest)] = new JsonObject
+            {
+                ["targetUrl"] = "https://hooks.acme.example/granit/orders",
+                ["eventType"] = "order.fulfilled",
+            },
+            [typeof(WebhookSubscriptionUpdateRequest)] = new JsonObject
+            {
+                ["targetUrl"] = "https://hooks.acme.example/granit/orders-v2",
+            },
+            [typeof(WebhookSubscriptionDeactivateRequest)] = new JsonObject
+            {
+                ["reason"] = "Migrated to the new order pipeline.",
+            },
+            [typeof(WebhookSubscriptionResponse)] = new JsonObject
+            {
+                ["id"] = "01960f3a-5c9e-7c3b-b4a2-abc123def456",
+                ["targetUrl"] = "https://hooks.acme.example/granit/orders",
+                ["eventType"] = "order.fulfilled",
+                ["status"] = "Active",
+                ["consecutiveFailureCount"] = 0,
+                ["lastSuccessAt"] = "2026-04-20T13:45:12+00:00",
+                ["createdAt"] = "2026-03-15T09:00:00+00:00",
+                ["modifiedAt"] = null,
+            },
+        };
+}

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2800,6 +2800,7 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Payments": "[0.1.0-dev, )",
           "Granit.RateLimiting": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",

--- a/tests/Granit.DataExchange.Csv.Tests/packages.lock.json
+++ b/tests/Granit.DataExchange.Csv.Tests/packages.lock.json
@@ -508,8 +508,8 @@
       "Sep": {
         "type": "CentralTransitive",
         "requested": "[0.*, )",
-        "resolved": "0.12.4",
-        "contentHash": "9d8BQepYsyjnwxqRv2V+KQ0IfST3jWK+ufhcafNbrZ2duZxBR4/g33t0rFBtc9dL8/gtMvWsd+U/b6RRHp/8Pw==",
+        "resolved": "0.12.5",
+        "contentHash": "yS1EgVf7a3QZ3hKN/B+Yh8kHbAvdtkDLdWf74sk3fFweLc4k9SSvMGig8k8lBK3iDXeVx9r7W44g/nBxYFIuLw==",
         "dependencies": {
           "csFastFloat": "4.1.5"
         }

--- a/tests/Granit.Payments.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Payments.Endpoints.Tests/packages.lock.json
@@ -75,6 +75,22 @@
           "xunit.v3.mtp-v1": "[3.2.2]"
         }
       },
+      "Asp.Versioning.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "I4CuGwl0nO98j6Ft6XlGBgzj1+goE/TSVlnHKgtRkuMZ0K4gy9I+Wyrtto8dyt0hWcFMDFAZ4lYNr58DSemH1g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Asp.Versioning.Http": {
+        "type": "Transitive",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "4/QzujOrkGn9sMch3eHhR5LpVJ4Xo5T2BNg7U1/r4YwEa8JywzkoGQHjW7Nk0W8ljETnpoJaO5mrTsfEOnJK3A==",
+        "dependencies": {
+          "Asp.Versioning.Abstractions": "10.0.0-preview.2"
+        }
+      },
       "Castle.Core": {
         "type": "Transitive",
         "resolved": "5.1.1",
@@ -768,6 +784,22 @@
       "granit.http.abstractions": {
         "type": "Project"
       },
+      "granit.http.apidocumentation": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Http.ApiVersioning": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )",
+          "Scalar.AspNetCore": "[2.*, )"
+        }
+      },
+      "granit.http.apiversioning": {
+        "type": "Project",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "[10.0.0-preview.*, )",
+          "Asp.Versioning.Mvc.ApiExplorer": "[10.0.0-preview.*, )",
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.http.exceptionhandling": {
         "type": "Project",
         "dependencies": {
@@ -817,6 +849,7 @@
           "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
           "Granit.Payments": "[0.1.0-dev, )",
           "Granit.RateLimiting": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )",
@@ -854,6 +887,24 @@
           "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Microsoft.AspNetCore.OpenApi": "[10.*, )"
+        }
+      },
+      "Asp.Versioning.Mvc": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0-preview.*, )",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "AyrcDwLzJp8yRJaFjZMJXkR1Rx2UaJkwGrGlX8sxIt2F5ZGiZwn/puXkB/oEaq55TxLkpiXWAOHHFsiVptp0fA==",
+        "dependencies": {
+          "Asp.Versioning.Http": "10.0.0-preview.2"
+        }
+      },
+      "Asp.Versioning.Mvc.ApiExplorer": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0-preview.*, )",
+        "resolved": "10.0.0-preview.2",
+        "contentHash": "G/LhAaLQj+gsB8UXRNm65fxjsI7fe87itZExb+MvJOQdrXYalZKbwuzMntO95xM5cKDrDgLnCH64fl6w173aGg==",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "10.0.0-preview.2"
         }
       },
       "FluentValidation": {
@@ -1017,6 +1068,12 @@
         "requested": "[1.15.*, )",
         "resolved": "1.14.0",
         "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "Scalar.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.14.1",
+        "contentHash": "neS3aI7YVPDY7+I9U8nYXvSnSy6lPvGyn5w52m0MCvC5COajK4HF4vsx70OO6Fw9bd7WXOUikSBdUaLfyTzw3g=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Summary

- Align endpoint metadata with framework auto-injection behaviour — remove redundant `.ProducesProblem(401/403/422)` wherever the `ProblemDetailsResponseOperationTransformer` already wires them based on `[Authorize]` + request-body presence. Manual declarations on `[AllowAnonymous]` paths are intentionally kept.
- Type 4 `Granit.Localization.Endpoints` handlers as `Results<Ok<T>, ProblemHttpResult>` unions so OpenAPI metadata matches the actual branches instead of loose `IResult`.
- Add `ISchemaExampleProvider` implementations for 8 high-value modules covering ~50 DTOs (Identity.Local, BlobStorage, Webhooks, Invoicing, Subscriptions, AI, Privacy, Payments). Auto-discovered via reflection — no DI registration needed.
- Update the `/audit` skill (`checklist.md` §5) with 16 sub-sections covering handler↔metadata consistency, parameter binding, content types, authorization, tags, operation-id uniqueness, framework auto-injection, and a grep-based detection strategy.
- `Granit.Payments.Endpoints` gains a direct `<ProjectReference>` to `Granit.Http.ApiDocumentation` (other endpoint modules pull it transitively). `packages.lock.json` regenerated.

## Safety notes

Credential-like example values (passwords, tokens) use `<placeholder>` syntax — exempted by the GRSEC003 analyzer ([HardcodedSecretAnalyzer.cs:77](../blob/develop/src/Granit.Analyzers/HardcodedSecretAnalyzer.cs#L77)) and verified non-flagging against gitleaks locally.

## Test plan

- [x] `dotnet build` — full solution builds clean
- [x] `dotnet test tests/Granit.{Identity.Local,BlobStorage,Webhooks,Invoicing,Subscriptions,AI,Privacy,Payments}.Endpoints.Tests` — 422 pass / 0 fail
- [x] `dotnet test tests/Granit.{Authorization,Timeline,Features,ApiKeys,ReferenceData,Localization}.Endpoints.Tests` — 614 pass / 0 fail (from earlier cleanup pass)
- [x] `dotnet format --verify-no-changes` — clean across all 16 modified modules
- [x] `gitleaks detect` on all new providers — no leaks found
- [ ] CI: full solution build + tests
- [ ] CI: SonarCloud / gitleaks / CodeQL