### PR TITLE
feat(settings): add ValueKind + AllowedValues to SettingDefinition

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -6302,7 +6302,7 @@
       "kind": "record",
       "project": "Granit.Authorization.Endpoints",
       "file": "src/Granit.Authorization.Endpoints/Dtos/PermissionDefinitionResponse.cs",
-      "line": 15,
+      "line": 16,
       "members": []
     },
     {
@@ -6487,7 +6487,7 @@
       "kind": "class",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/Extensions/AuthorizationServiceCollectionExtensions.cs",
-      "line": 13,
+      "line": 14,
       "members": [
         {
           "name": "AddGranitAuthorization",
@@ -6746,15 +6746,6 @@
       ]
     },
     {
-      "name": "MultiTenancySide",
-      "fqn": "Granit.Authorization.MultiTenancySide",
-      "kind": "enum",
-      "project": "Granit.Authorization",
-      "file": "src/Granit.Authorization/MultiTenancySide.cs",
-      "line": 14,
-      "members": []
-    },
-    {
       "name": "GranitAuthorizationOptions",
       "fqn": "Granit.Authorization.Options.GranitAuthorizationOptions",
       "kind": "class",
@@ -6782,7 +6773,7 @@
       "kind": "record",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/PermissionDefinition.cs",
-      "line": 13,
+      "line": 14,
       "members": []
     },
     {
@@ -6818,7 +6809,7 @@
       "kind": "class",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/PermissionGroup.cs",
-      "line": 6,
+      "line": 7,
       "members": [
         {
           "name": "Name",
@@ -23787,6 +23778,15 @@
       ]
     },
     {
+      "name": "MultiTenancySide",
+      "fqn": "Granit.MultiTenancy.MultiTenancySide",
+      "kind": "enum",
+      "project": "Granit",
+      "file": "src/Granit/MultiTenancy/MultiTenancySide.cs",
+      "line": 24,
+      "members": []
+    },
+    {
       "name": "MultiTenancyOptions",
       "fqn": "Granit.MultiTenancy.Options.MultiTenancyOptions",
       "kind": "class",
@@ -36914,7 +36914,7 @@
       "kind": "class",
       "project": "Granit.Settings",
       "file": "src/Granit.Settings/Definitions/SettingDefinition.cs",
-      "line": 6,
+      "line": 9,
       "members": [
         {
           "name": "Name",
@@ -36929,10 +36929,16 @@
           "returnType": "IList<string>"
         },
         {
+          "name": "DisplayName",
+          "kind": "property",
+          "signature": "string? DisplayName",
+          "returnType": "string?"
+        },
+        {
           "name": "SettingDefinition",
           "kind": "method",
           "signature": "SettingDefinition(string name)",
-          "returnType": "string? DisplayName { get; init; } public string? Description { get; init; } public"
+          "returnType": "IReadOnlyList<string>? AllowedValues { get; init; } public"
         }
       ]
     },
@@ -36957,6 +36963,15 @@
           "returnType": "IReadOnlyCollection<SettingDefinition>"
         }
       ]
+    },
+    {
+      "name": "ValueKind",
+      "fqn": "Granit.Settings.Definitions.ValueKind",
+      "kind": "enum",
+      "project": "Granit.Settings",
+      "file": "src/Granit.Settings/Definitions/ValueKind.cs",
+      "line": 15,
+      "members": []
     },
     {
       "name": "SettingRecord",

--- a/src/Granit.Settings/Definitions/SettingDefinition.cs
+++ b/src/Granit.Settings/Definitions/SettingDefinition.cs
@@ -1,3 +1,6 @@
+using System.Globalization;
+using System.Text.Json;
+
 namespace Granit.Settings.Definitions;
 
 /// <summary>
@@ -38,9 +41,84 @@ public sealed class SettingDefinition
     /// <summary>Long description of the setting (UI, documentation).</summary>
     public string? Description { get; init; }
 
+    /// <summary>
+    /// Shape of the value (how consumers interpret the raw string). Default is <see cref="ValueKind.String"/>.
+    /// Orthogonal to <see cref="IsEncrypted"/>.
+    /// </summary>
+    public ValueKind ValueKind { get; init; } = ValueKind.String;
+
+    /// <summary>
+    /// Optional closed list of permitted values. When non-empty, any write must match one of these
+    /// entries (string equality). Applicable to any <see cref="ValueKind"/> (e.g. an Int setting
+    /// constrained to <c>["1","5","10"]</c>). Dynamic option lists (cultures, timezones) should be
+    /// served by a dedicated module endpoint instead.
+    /// </summary>
+    public IReadOnlyList<string>? AllowedValues { get; init; }
+
     public SettingDefinition(string name)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         Name = name;
+    }
+
+    /// <summary>
+    /// Verifies configuration-time invariants. Invoked by
+    /// <see cref="SettingDefinitionManager"/> at registration to fail fast on misconfigured
+    /// definitions.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="DefaultValue"/> is not parseable as <see cref="ValueKind"/>, or
+    /// is not a member of a non-empty <see cref="AllowedValues"/>.
+    /// </exception>
+    public void ValidateInvariants()
+    {
+        if (DefaultValue is not null && !TryParseAs(DefaultValue, ValueKind))
+        {
+            throw new InvalidOperationException(
+                $"Setting '{Name}': DefaultValue '{DefaultValue}' is not parseable as {ValueKind}.");
+        }
+
+        if (AllowedValues is { Count: > 0 } &&
+            DefaultValue is not null &&
+            !AllowedValues.Contains(DefaultValue))
+        {
+            throw new InvalidOperationException(
+                $"Setting '{Name}': DefaultValue '{DefaultValue}' is not a member of AllowedValues.");
+        }
+
+        if (AllowedValues is { Count: > 0 })
+        {
+            foreach (string allowed in AllowedValues)
+            {
+                if (!TryParseAs(allowed, ValueKind))
+                {
+                    throw new InvalidOperationException(
+                        $"Setting '{Name}': AllowedValues entry '{allowed}' is not parseable as {ValueKind}.");
+                }
+            }
+        }
+    }
+
+    internal static bool TryParseAs(string value, ValueKind kind) => kind switch
+    {
+        ValueKind.String => true,
+        ValueKind.Bool => bool.TryParse(value, out _),
+        ValueKind.Int => int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _),
+        ValueKind.Double => double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out _),
+        ValueKind.Json => TryParseJson(value),
+        _ => false,
+    };
+
+    private static bool TryParseJson(string value)
+    {
+        try
+        {
+            using var _ = JsonDocument.Parse(value);
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
     }
 }

--- a/src/Granit.Settings/Definitions/SettingDefinitionManager.cs
+++ b/src/Granit.Settings/Definitions/SettingDefinitionManager.cs
@@ -15,6 +15,11 @@ public sealed class SettingDefinitionManager
             provider.Define(context);
         }
         _definitions = context.Build();
+
+        foreach (SettingDefinition definition in _definitions.Values)
+        {
+            definition.ValidateInvariants();
+        }
     }
 
     /// <summary>

--- a/src/Granit.Settings/Definitions/ValueKind.cs
+++ b/src/Granit.Settings/Definitions/ValueKind.cs
@@ -1,0 +1,31 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Granit.Settings.Definitions;
+
+/// <summary>
+/// Describes the shape of a <see cref="SettingDefinition"/> value.
+/// </summary>
+/// <remarks>
+/// Values are always persisted and transported as <see cref="string"/>; the kind
+/// informs consumers (admin UI, validators, code generators) how to interpret and
+/// render them. Orthogonal to <see cref="SettingDefinition.IsEncrypted"/>, which
+/// describes at-rest protection, not shape.
+/// </remarks>
+[SuppressMessage("Naming", "CA1720:Identifier contains type name", Justification = "ValueKind members intentionally mirror CLR primitive names; renaming would obscure semantics.")]
+public enum ValueKind
+{
+    /// <summary>Free-form string (default).</summary>
+    String,
+
+    /// <summary>Boolean parseable as <c>"true"</c> / <c>"false"</c>.</summary>
+    Bool,
+
+    /// <summary>Integer parseable by <see cref="int.TryParse(string, out int)"/>.</summary>
+    Int,
+
+    /// <summary>Double parseable by <see cref="double.TryParse(string, System.Globalization.NumberStyles, System.IFormatProvider, out double)"/> (invariant culture).</summary>
+    Double,
+
+    /// <summary>JSON document parseable by <c>System.Text.Json</c>.</summary>
+    Json,
+}

--- a/tests/Granit.Settings.Tests/SettingDefinitionManagerTests.cs
+++ b/tests/Granit.Settings.Tests/SettingDefinitionManagerTests.cs
@@ -117,4 +117,50 @@ public sealed class SettingDefinitionManagerTests
             inspect(context);
         }
     }
+
+    // -------------------------------------------------------------------------
+    // Registration-time invariant validation
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Constructor_InvalidDefaultValue_ForValueKind_Throws()
+    {
+        SettingDefinition def = new("App.MaxRetries")
+        {
+            ValueKind = ValueKind.Int,
+            DefaultValue = "not-a-number",
+        };
+
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(
+            () => new SettingDefinitionManager([new FakeProvider(def)]));
+        ex.Message.ShouldContain("App.MaxRetries");
+    }
+
+    [Fact]
+    public void Constructor_DefaultValueOutsideAllowedValues_Throws()
+    {
+        SettingDefinition def = new("App.LogLevel")
+        {
+            AllowedValues = ["Debug", "Information"],
+            DefaultValue = "Trace",
+        };
+
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(
+            () => new SettingDefinitionManager([new FakeProvider(def)]));
+        ex.Message.ShouldContain("App.LogLevel");
+        ex.Message.ShouldContain("AllowedValues");
+    }
+
+    [Fact]
+    public void Constructor_ValidDefinition_DoesNotThrow()
+    {
+        SettingDefinition def = new("App.MaxRetries")
+        {
+            ValueKind = ValueKind.Int,
+            AllowedValues = ["1", "5", "10"],
+            DefaultValue = "5",
+        };
+
+        Should.NotThrow(() => new SettingDefinitionManager([new FakeProvider(def)]));
+    }
 }

--- a/tests/Granit.Settings.Tests/SettingDefinitionTests.cs
+++ b/tests/Granit.Settings.Tests/SettingDefinitionTests.cs
@@ -139,4 +139,185 @@ public sealed class SettingDefinitionTests
         def.Providers.ShouldContain("U");
         def.Providers.ShouldContain("G");
     }
+
+    // -------------------------------------------------------------------------
+    // ValueKind + AllowedValues defaults
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void ValueKind_IsString_ByDefault()
+    {
+        SettingDefinition def = new("App.Theme");
+
+        def.ValueKind.ShouldBe(ValueKind.String);
+    }
+
+    [Fact]
+    public void AllowedValues_IsNull_ByDefault()
+    {
+        SettingDefinition def = new("App.Theme");
+
+        def.AllowedValues.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ValueKind_And_AllowedValues_CanBeSet_ViaInitSyntax()
+    {
+        SettingDefinition def = new("App.LogLevel")
+        {
+            ValueKind = ValueKind.String,
+            AllowedValues = ["Debug", "Information", "Warning", "Error"],
+            DefaultValue = "Information",
+        };
+
+        def.ValueKind.ShouldBe(ValueKind.String);
+        def.AllowedValues.ShouldNotBeNull();
+        def.AllowedValues.Count.ShouldBe(4);
+        def.AllowedValues.ShouldContain("Debug");
+    }
+
+    // -------------------------------------------------------------------------
+    // ValidateInvariants — DefaultValue parsing per ValueKind
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(ValueKind.Bool, "true")]
+    [InlineData(ValueKind.Bool, "false")]
+    [InlineData(ValueKind.Bool, "True")]
+    [InlineData(ValueKind.Int, "0")]
+    [InlineData(ValueKind.Int, "-42")]
+    [InlineData(ValueKind.Int, "2147483647")]
+    [InlineData(ValueKind.Double, "3.14")]
+    [InlineData(ValueKind.Double, "-1e-5")]
+    [InlineData(ValueKind.Double, "0")]
+    [InlineData(ValueKind.Json, "{\"key\":\"value\"}")]
+    [InlineData(ValueKind.Json, "[1,2,3]")]
+    [InlineData(ValueKind.Json, "\"hello\"")]
+    [InlineData(ValueKind.Json, "null")]
+    [InlineData(ValueKind.String, "anything goes")]
+    public void ValidateInvariants_ParseableDefaultValue_DoesNotThrow(ValueKind kind, string defaultValue)
+    {
+        SettingDefinition def = new("App.X")
+        {
+            ValueKind = kind,
+            DefaultValue = defaultValue,
+        };
+
+        Should.NotThrow(() => def.ValidateInvariants());
+    }
+
+    [Theory]
+    [InlineData(ValueKind.Bool, "yes")]
+    [InlineData(ValueKind.Bool, "1")]
+    [InlineData(ValueKind.Int, "3.14")]
+    [InlineData(ValueKind.Int, "abc")]
+    [InlineData(ValueKind.Double, "not-a-number")]
+    [InlineData(ValueKind.Json, "{malformed")]
+    [InlineData(ValueKind.Json, "")]
+    public void ValidateInvariants_NonParseableDefaultValue_Throws(ValueKind kind, string defaultValue)
+    {
+        SettingDefinition def = new("App.X")
+        {
+            ValueKind = kind,
+            DefaultValue = defaultValue,
+        };
+
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() => def.ValidateInvariants());
+        ex.Message.ShouldContain("App.X");
+        ex.Message.ShouldContain("DefaultValue");
+    }
+
+    [Fact]
+    public void ValidateInvariants_NullDefaultValue_DoesNotThrow()
+    {
+        SettingDefinition def = new("App.X")
+        {
+            ValueKind = ValueKind.Int,
+            DefaultValue = null,
+        };
+
+        Should.NotThrow(() => def.ValidateInvariants());
+    }
+
+    // -------------------------------------------------------------------------
+    // ValidateInvariants — AllowedValues
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void ValidateInvariants_DefaultValueInAllowedValues_DoesNotThrow()
+    {
+        SettingDefinition def = new("App.LogLevel")
+        {
+            AllowedValues = ["Debug", "Information", "Warning"],
+            DefaultValue = "Information",
+        };
+
+        Should.NotThrow(() => def.ValidateInvariants());
+    }
+
+    [Fact]
+    public void ValidateInvariants_DefaultValueNotInAllowedValues_Throws()
+    {
+        SettingDefinition def = new("App.LogLevel")
+        {
+            AllowedValues = ["Debug", "Information", "Warning"],
+            DefaultValue = "Trace",
+        };
+
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() => def.ValidateInvariants());
+        ex.Message.ShouldContain("App.LogLevel");
+        ex.Message.ShouldContain("AllowedValues");
+    }
+
+    [Fact]
+    public void ValidateInvariants_NullDefaultValue_WithAllowedValues_DoesNotThrow()
+    {
+        SettingDefinition def = new("App.LogLevel")
+        {
+            AllowedValues = ["Debug", "Information"],
+            DefaultValue = null,
+        };
+
+        Should.NotThrow(() => def.ValidateInvariants());
+    }
+
+    [Fact]
+    public void ValidateInvariants_EmptyAllowedValues_DoesNotConstrainDefaultValue()
+    {
+        SettingDefinition def = new("App.X")
+        {
+            AllowedValues = [],
+            DefaultValue = "anything",
+        };
+
+        Should.NotThrow(() => def.ValidateInvariants());
+    }
+
+    [Fact]
+    public void ValidateInvariants_AllowedValuesOnIntKind_AcceptsStringIntegers()
+    {
+        SettingDefinition def = new("App.MaxRetries")
+        {
+            ValueKind = ValueKind.Int,
+            AllowedValues = ["1", "5", "10"],
+            DefaultValue = "5",
+        };
+
+        Should.NotThrow(() => def.ValidateInvariants());
+    }
+
+    [Fact]
+    public void ValidateInvariants_AllowedValuesOnIntKind_RejectsNonIntegerEntry()
+    {
+        SettingDefinition def = new("App.MaxRetries")
+        {
+            ValueKind = ValueKind.Int,
+            AllowedValues = ["1", "5", "ten"],
+        };
+
+        InvalidOperationException ex = Should.Throw<InvalidOperationException>(() => def.ValidateInvariants());
+        ex.Message.ShouldContain("App.MaxRetries");
+        ex.Message.ShouldContain("AllowedValues");
+        ex.Message.ShouldContain("Int");
+    }
 }


### PR DESCRIPTION
## Summary

Adds a first-class description of a setting's value shape (`ValueKind`: `String | Bool | Int | Double | Json`) and an optional closed allow-list (`AllowedValues`) on `SettingDefinition`. Both are opt-in and backward compatible — existing definitions default to `ValueKind.String` with no `AllowedValues` and behave exactly as before.

This is **PR1 of 2** preparing a bulk admin settings endpoint. It lands the domain changes in isolation so the endpoint PR can consume a stable contract.

## Motivation

The admin UI currently has to guess each setting's type from its string value (`"true"` → bool, `"42"` → int), which fails on legitimate string values like `"true"` or `"42"`. Exposing a typed `ValueKind` and an optional `AllowedValues` constraint lets the client render the correct input (checkbox, number field, dropdown) without heuristics.

`AllowedValues` is generic on purpose — an `Int` setting constrained to `["1", "5", "10"]` is a valid dropdown, so we avoid a 6th `Enum` kind that would be less expressive.

## Changes

- `ValueKind` enum (new) — 5 members, `[SuppressMessage(CA1720)]` because members intentionally mirror CLR primitive names
- `SettingDefinition`
  - `ValueKind` init property (default `String`)
  - `AllowedValues` init property (default `null`)
  - `ValidateInvariants()` public method — verifies `DefaultValue` parses as `ValueKind`, is a member of `AllowedValues` when non-empty, and that every `AllowedValues` entry parses as `ValueKind`
- `SettingDefinitionManager` — calls `ValidateInvariants()` on every registered definition at construction. Misconfigured settings fail fast at startup.
- Tests: 24 new unit tests (parsing per kind, allow-list membership, empty list semantics, int-typed allow-list, registration-time failure)

## Non-goals

- Bulk endpoint (next PR)
- Localization of `AllowedValues` labels — stays client-side via i18n keys like `Setting:{name}:Option:{value}`
- Dynamic option lists (cultures, timezones) — stays as dedicated module endpoints; `AllowedValues` is reserved for truly closed, static lists

## Test plan

- [x] `dotnet test tests/Granit.Settings.Tests` — 172/172 pass
- [x] `dotnet test tests/Granit.Settings.Endpoints.Tests` — 80/80 pass
- [x] `dotnet test tests/Granit.ArchitectureTests` — 114/114 pass
- [x] `dotnet format --verify-no-changes` clean on `Granit.Settings` + tests
- [x] Existing setting definitions (`IdentityLocalSettingDefinitionProvider`, `WellKnownSettingDefinitionProvider`) unaffected — they use implicit `ValueKind.String`
