### PR TITLE
fix(privacy): [SagaIdentity] on Privacy saga-starting messages

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -32681,7 +32681,7 @@
       "kind": "record",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataDeletion/Events/DeletionDeferredEto.cs",
-      "line": 10,
+      "line": 11,
       "members": []
     },
     {
@@ -32858,7 +32858,7 @@
       "kind": "record",
       "project": "Granit.Privacy",
       "file": "src/Granit.Privacy/DataExport/Events/PersonalDataRequestedEto.cs",
-      "line": 9,
+      "line": 10,
       "members": []
     },
     {

--- a/src/Granit.Privacy/DataDeletion/Events/DeletionDeferredEto.cs
+++ b/src/Granit.Privacy/DataDeletion/Events/DeletionDeferredEto.cs
@@ -1,5 +1,6 @@
 using Granit.DataProtection;
 using Granit.Events;
+using Wolverine.Persistence.Sagas;
 
 namespace Granit.Privacy.DataDeletion.Events;
 
@@ -8,7 +9,7 @@ namespace Granit.Privacy.DataDeletion.Events;
 /// Starts the <see cref="PersonalDataDeletionSaga"/> which schedules the actual deletion.
 /// </summary>
 public sealed record DeletionDeferredEto(
-    Guid RequestId,
+    [property: SagaIdentity] Guid RequestId,
     Guid UserId,
     [property: SensitiveData(Level = Sensitivity.Confidential)]
     string RequestedBy,

--- a/src/Granit.Privacy/DataExport/Events/PersonalDataRequestedEto.cs
+++ b/src/Granit.Privacy/DataExport/Events/PersonalDataRequestedEto.cs
@@ -1,4 +1,5 @@
 using Granit.Events;
+using Wolverine.Persistence.Sagas;
 
 namespace Granit.Privacy.DataExport.Events;
 
@@ -7,7 +8,7 @@ namespace Granit.Privacy.DataExport.Events;
 /// Each registered data provider handles this event and prepares its fragment.
 /// </summary>
 public sealed record PersonalDataRequestedEto(
-    Guid RequestId,
+    [property: SagaIdentity] Guid RequestId,
     Guid UserId,
     DateTimeOffset RequestedAt,
     string Regulation,

--- a/tests/Granit.ArchitectureTests/SagaConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/SagaConventionTests.cs
@@ -1,0 +1,154 @@
+using System.Reflection;
+using Shouldly;
+using Wolverine;
+using Wolverine.Persistence.Sagas;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Validates Wolverine saga conventions.
+/// </summary>
+public sealed class SagaConventionTests
+{
+    private static readonly string[] StartMethodNames =
+    [
+        "Start",
+        "StartAsync",
+        "Starts",
+        "StartsAsync",
+        "StartOrHandle",
+        "StartOrHandleAsync",
+        "StartsOrHandle",
+        "StartsOrHandleAsync",
+    ];
+
+    /// <summary>
+    /// Wolverine resolves the saga id from the initiating message via (in order):
+    /// <c>[SagaIdentity]</c>, <c>[SagaIdentityFrom]</c> on the parameter,
+    /// <c>{SagaType}Id</c>, <c>{SagaTypeWithoutSagaSuffix}Id</c>, <c>SagaId</c>, <c>Id</c>.
+    /// If none match, the saga is persisted with <see cref="Guid.Empty"/> and the
+    /// lightweight storage throws <c>ArgumentOutOfRangeException</c> at insert time.
+    /// This test ensures every Start message carries a resolvable saga id member.
+    /// </summary>
+    [Fact]
+    public void Saga_start_messages_must_expose_a_resolvable_saga_identity()
+    {
+        string outputDir = Path.GetDirectoryName(typeof(SagaConventionTests).Assembly.Location)!;
+
+        Assembly[] granitAssemblies = Directory.GetFiles(outputDir, "Granit.*.dll")
+            .Where(path => !Path.GetFileNameWithoutExtension(path).Contains("Tests"))
+            .Select(TryLoadAssembly)
+            .Where(a => a is not null)
+            .ToArray()!;
+
+        List<string> violations = [];
+
+        foreach (Assembly assembly in granitAssemblies)
+        {
+            Type[] sagaTypes;
+            try
+            {
+                sagaTypes = assembly.GetTypes()
+                    .Where(t => !t.IsAbstract && typeof(Saga).IsAssignableFrom(t))
+                    .ToArray();
+            }
+            catch (ReflectionTypeLoadException)
+            {
+                continue;
+            }
+
+            foreach (Type sagaType in sagaTypes)
+            {
+                foreach (MethodInfo method in GetStartMethods(sagaType))
+                {
+                    ParameterInfo[] parameters = method.GetParameters();
+                    if (parameters.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    ParameterInfo messageParameter = parameters[0];
+                    Type messageType = messageParameter.ParameterType;
+
+                    if (HasResolvableSagaIdentity(sagaType, messageParameter, messageType))
+                    {
+                        continue;
+                    }
+
+                    violations.Add(
+                        $"{sagaType.FullName}.{method.Name}({messageType.Name}): message '{messageType.Name}' has no member " +
+                        $"resolvable as the saga identity. Add [SagaIdentity] on a property, or rename it to " +
+                        $"'{sagaType.Name}Id' / 'SagaId' / 'Id'.");
+                }
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Every message that starts a Wolverine saga must expose a resolvable saga identity. " +
+            "Without it, Wolverine persists the saga with Guid.Empty and the PostgreSQL " +
+            "lightweight saga storage throws ArgumentOutOfRangeException at runtime.");
+    }
+
+    private static IEnumerable<MethodInfo> GetStartMethods(Type sagaType) =>
+        sagaType.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => StartMethodNames.Contains(m.Name, StringComparer.Ordinal));
+
+    private static bool HasResolvableSagaIdentity(Type sagaType, ParameterInfo parameter, Type messageType)
+    {
+        if (parameter.GetCustomAttribute<SagaIdentityFromAttribute>() is { } fromAttr
+            && HasMember(messageType, fromAttr.PropertyName))
+        {
+            return true;
+        }
+
+        if (GetMessageMembers(messageType).Any(m => m.GetCustomAttribute<SagaIdentityAttribute>() is not null))
+        {
+            return true;
+        }
+
+        string sagaName = sagaType.Name;
+        string sagaNameWithoutSuffix = sagaName.EndsWith("Saga", StringComparison.Ordinal)
+            ? sagaName[..^"Saga".Length]
+            : sagaName;
+
+        string[] conventionalNames =
+        [
+            $"{sagaName}Id",
+            $"{sagaNameWithoutSuffix}Id",
+            "SagaId",
+            "Id",
+        ];
+
+        return conventionalNames.Any(name => HasMember(messageType, name));
+    }
+
+    private static bool HasMember(Type type, string memberName) =>
+        type.GetProperty(memberName, BindingFlags.Public | BindingFlags.Instance) is not null
+        || type.GetField(memberName, BindingFlags.Public | BindingFlags.Instance) is not null;
+
+    private static IEnumerable<MemberInfo> GetMessageMembers(Type messageType)
+    {
+        foreach (PropertyInfo property in messageType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            yield return property;
+        }
+
+        foreach (FieldInfo field in messageType.GetFields(BindingFlags.Public | BindingFlags.Instance))
+        {
+            yield return field;
+        }
+    }
+
+    private static Assembly? TryLoadAssembly(string path)
+    {
+        try
+        {
+            return Assembly.LoadFrom(path);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or FileLoadException)
+        {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `PersonalDataRequestedEto.RequestId` and `DeletionDeferredEto.RequestId` now carry `[SagaIdentity]`, aligning them with the already-annotated follow-up messages.
- Without this, Wolverine could not resolve the saga correlation id from the initiating message and `PostgresqlSagaStorage` failed at insert with `ArgumentOutOfRangeException: You must define the saga id when using the lightweight saga storage`.
- Adds `SagaConventionTests.Saga_start_messages_must_expose_a_resolvable_saga_identity` so this can't regress — the test scans every `Saga` subclass, walks its `Start*` methods, and verifies the first parameter exposes a resolvable identity (`[SagaIdentity]`, `[SagaIdentityFrom]`, `{Saga}Id`, `SagaId`, or `Id`).

Unblocks Privacy export in downstream consumers (showcase, etc.) — the new dev package will resolve the saga id correctly.

## Test plan

- [x] `dotnet test tests/Granit.Privacy.Tests` — 139 passed
- [x] `dotnet test tests/Granit.ArchitectureTests` — 115 passed (includes the new test)
- [ ] Showcase: trigger a `POST /privacy/export` request against develop build and verify the saga persists + `ExportCompletedEto` is eventually published