### PR TITLE
fix(migrations): create DI scope in MigrationStartupService to resolve ICommandSender

### DIFF
--- a/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationStartupService.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore.Migrations/Internal/MigrationStartupService.cs
@@ -2,6 +2,7 @@ using Granit.Commands;
 using Granit.Persistence.EntityFrameworkCore.Migrations.Messages;
 using Granit.Persistence.EntityFrameworkCore.Migrations.Options;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -16,7 +17,9 @@ namespace Granit.Persistence.EntityFrameworkCore.Migrations.Internal;
 /// On startup, queries all <see cref="MigrationProgress"/> rows with status
 /// <see cref="MigrationStatus.Pending"/> or <see cref="MigrationStatus.InProgress"/>
 /// and dispatches one <see cref="RunMigrationBatchCommand"/> per cycle per tenant via
-/// <see cref="ICommandSender"/>.
+/// <see cref="ICommandSender"/>, resolved in a short-lived scope (<see cref="ICommandSender"/>
+/// is Scoped so its <c>ICurrentTenant</c> / <c>ICurrentUserService</c> dependencies resolve
+/// cleanly even though this service runs as a Singleton <see cref="IHostedService"/>).
 /// </para>
 /// <para>
 /// If <see cref="ITenantEnumerator"/> yields tenant identifiers (Tenant-per-Schema or
@@ -32,7 +35,7 @@ namespace Granit.Persistence.EntityFrameworkCore.Migrations.Internal;
 internal sealed partial class MigrationStartupService(
     IDbContextFactory<MigrationProgressDbContext> progressFactory,
     ITenantEnumerator tenantEnumerator,
-    ICommandSender commandSender,
+    IServiceScopeFactory scopeFactory,
     IOptions<MigrationStartupOptions> options,
     ILogger<MigrationStartupService> logger) : IHostedService
 {
@@ -76,6 +79,12 @@ internal sealed partial class MigrationStartupService(
 
         int batchSize = options.Value.DefaultBatchSize;
         List<RunMigrationBatchCommand> commands = BuildCommands(pending, tenantIds, batchSize);
+
+        // ICommandSender is Scoped; create a short-lived scope so it (and its scoped
+        // dependencies such as IMessageBus / OutgoingContextMiddleware) resolve correctly
+        // from this Singleton IHostedService.
+        await using AsyncServiceScope scope = scopeFactory.CreateAsyncScope();
+        ICommandSender commandSender = scope.ServiceProvider.GetRequiredService<ICommandSender>();
 
         foreach (RunMigrationBatchCommand command in commands)
         {

--- a/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine/Extensions/WolverineHostApplicationBuilderExtensions.cs
@@ -68,6 +68,10 @@ public static class WolverineHostApplicationBuilderExtensions
         // interfaces (IPaymentCommandDispatcher, IInvoiceCommandPublisher, etc.) with a single
         // provider-agnostic contract in the core Granit assembly. Named ICommandSender to
         // avoid collision with Wolverine.ICommandBus.
+        // Scoped so OutgoingContextMiddleware reads the caller's ICurrentTenant /
+        // ICurrentUserService and injects X-Tenant-Id / X-User-Id / traceparent into the
+        // outgoing envelope. Singleton consumers (IHostedService) must create a scope
+        // via IServiceScopeFactory before resolving ICommandSender.
         builder.Services.TryAddScoped<ICommandSender, WolverineCommandSender>();
 
         // Bind and validate options at startup via DI.

--- a/src/Granit.Wolverine/Internal/WolverineCommandSender.cs
+++ b/src/Granit.Wolverine/Internal/WolverineCommandSender.cs
@@ -8,9 +8,17 @@ namespace Granit.Wolverine.Internal;
 /// through <see cref="IMessageBus.SendAsync{T}(T, DeliveryOptions?)"/>.
 /// </summary>
 /// <remarks>
-/// Wolverine resolves the single registered handler by message type. The global policies
-/// registered in <c>AddGranitWolverine</c> — tenant / user / trace propagation,
-/// FluentValidation, retry, DLQ — apply to messages sent through this bus.
+/// <para>
+/// Registered as <b>Scoped</b> so the enclosing scope's <c>ICurrentTenant</c> /
+/// <c>ICurrentUserService</c> / W3C trace context flow into the
+/// <c>OutgoingContextMiddleware</c> and end up as <c>X-Tenant-Id</c> / <c>X-User-Id</c> /
+/// <c>traceparent</c> headers on the outgoing envelope.
+/// </para>
+/// <para>
+/// Singleton consumers (<c>IHostedService</c>) that need to dispatch commands must create
+/// a DI scope themselves via <c>IServiceScopeFactory.CreateAsyncScope()</c> and resolve
+/// <see cref="ICommandSender"/> inside it.
+/// </para>
 /// </remarks>
 internal sealed class WolverineCommandSender(IMessageBus bus) : ICommandSender
 {

--- a/tests/Granit.Persistence.EntityFrameworkCore.Migrations.Tests/MigrationStartupServiceTests.cs
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Migrations.Tests/MigrationStartupServiceTests.cs
@@ -82,10 +82,18 @@ public sealed class MigrationStartupServiceTests
         ICommandSender commandSender,
         int defaultBatchSize = 200)
     {
+        // MigrationStartupService is Singleton and creates a scope per dispatch to resolve
+        // the Scoped ICommandSender. Wrap the mocked sender in a real IServiceScopeFactory
+        // so GetRequiredService<ICommandSender>() inside the service returns the mock.
+        ServiceCollection services = new();
+        services.AddSingleton(commandSender);
+        IServiceScopeFactory scopeFactory = services.BuildServiceProvider()
+            .GetRequiredService<IServiceScopeFactory>();
+
         return new(
             factory,
             tenantEnumerator,
-            commandSender,
+            scopeFactory,
             Microsoft.Extensions.Options.Options.Create(new MigrationStartupOptions { DefaultBatchSize = defaultBatchSize }),
             NullLogger<MigrationStartupService>.Instance);
     }


### PR DESCRIPTION
## Symptom

After PR #1071 the Showcase host crashed at boot with:

```
System.InvalidOperationException: Cannot consume scoped service
'Granit.Commands.ICommandSender' from singleton
'Microsoft.Extensions.Hosting.IHostedService'.
```

`MigrationStartupService` is a Singleton `IHostedService` but it injected
`ICommandSender` directly. `ICommandSender` is registered as **Scoped**
(intentional — see below), so DI validation refused the construction.

## Why `ICommandSender` stays Scoped

`OutgoingContextMiddleware` reads `ICurrentTenant` and `ICurrentUserService`
(both Scoped) to inject `X-Tenant-Id` / `X-User-Id` / `traceparent` into every
outgoing envelope. If `ICommandSender` were Singleton and routed through a
`WolverineScopedSender` that creates its own scope, those two services would
resolve to their defaults inside that scope — **silently dropping tenant / user
propagation** on every dispatch from an endpoint or orchestrator.

`ICommandSender` must therefore stay Scoped so it inherits the caller's scope.
The correct fix is local to `MigrationStartupService` (the only Singleton
consumer): create a short-lived scope via `IServiceScopeFactory` and resolve
the sender inside it.

## Changes

- `MigrationStartupService`: inject `IServiceScopeFactory` instead of
  `ICommandSender`, wrap the dispatch loop in
  `await using AsyncServiceScope scope = scopeFactory.CreateAsyncScope();` +
  `scope.ServiceProvider.GetRequiredService<ICommandSender>()`.
- `WolverineCommandSender`: XML docs explicitly state the Scoped contract so
  future callers don't reintroduce the issue.
- `AddGranitWolverine`: comment on the `TryAddScoped<ICommandSender, ...>()`
  registration spells out the context-propagation rationale.
- `MigrationStartupServiceTests`: helper wraps the mocked `ICommandSender` in
  a real `IServiceScopeFactory` so the service resolves it from the scope.

## Test plan

- [x] `dotnet test tests/Granit.Persistence.EntityFrameworkCore.Migrations.Tests` — 69 / 69
- [x] `dotnet test tests/Granit.Wolverine.Tests` — 156 / 156
- [x] `dotnet test tests/Granit.ArchitectureTests` — 117 / 117
- [ ] Smoke-test: restart Showcase host — `showcase-migrator` should boot without the DI validation error
