### PR TITLE
fix(openapi): MapGranitQuery inherits parent group tag

### DIFF
--- a/src/Granit.QueryEngine.AspNetCore/Extensions/QueryEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.QueryEngine.AspNetCore/Extensions/QueryEndpointRouteBuilderExtensions.cs
@@ -77,10 +77,18 @@ public static class QueryEndpointRouteBuilderExtensions
         QueryEndpointOptions options = new();
         configure?.Invoke(options);
 
-        string tag = options.TagName ?? typeof(TEntity).Name;
         string entityName = typeof(TEntity).Name;
 
-        RouteGroupBuilder group = endpoints.MapGranitGroup(prefix).WithTags(tag);
+        RouteGroupBuilder group = endpoints.MapGranitGroup(prefix);
+
+        // Only apply an explicit tag override. When TagName is null, inherit the
+        // parent group's tag — previously we forced typeof(TEntity).Name, which
+        // replaced module tags like "Auditing" with entity class names like
+        // "AuditEntry" and leaked internal type names into the OpenAPI UI.
+        if (!string.IsNullOrEmpty(options.TagName))
+        {
+            group.WithTags(options.TagName);
+        }
 
         if (options.AuthorizationPolicy is not null)
         {


### PR DESCRIPTION
## Summary
- `MapGranitQuery<T>()` forced `WithTags(options.TagName ?? typeof(TEntity).Name)` on its internal sub-group, which overrode the module tag set by every caller.
- As a result, admin grids in Scalar surfaced entity class names (`AIUsageRecord`, `AuditEntry`, `AuditEntityChange`, `BlobDescriptor`, `Invoice`, `ScheduledAction`, `Subscription`, `TaxRateEntry`, `WebhookSubscription`, `WebhookDeliveryAttempt`) instead of the parent tag (`AI - Usage`, `Audit Log`, `Blob Storage`, `Webhooks`, …).
- Fix: only apply `WithTags` when the caller explicitly sets `TagName`; otherwise inherit from the parent. No call-site changes needed since every consumer already tags its parent group.

Follow-up to the OpenAPI tag convention introduced in #1071.

## Test plan
- [x] `dotnet build src/Granit.QueryEngine.AspNetCore`
- [x] `dotnet test tests/Granit.QueryEngine.AspNetCore.Tests` (74/74 passing)
- [ ] Regenerate OpenAPI on a host app (showcase/guava) and verify Scalar shows the parent tag for every `MapGranitQuery<T>` grid