### PR TITLE
fix(bff): drop trailing slash from Effective*RedirectPath for OIDC exact match

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -7848,12 +7848,6 @@
           "kind": "property",
           "signature": "string EffectiveErrorRedirectPath",
           "returnType": "string"
-        },
-        {
-          "name": "UsePushedAuthorizationRequests",
-          "kind": "property",
-          "signature": "bool UsePushedAuthorizationRequests",
-          "returnType": "bool"
         }
       ]
     },

--- a/src/Granit.Bff/Options/GranitBffOptions.cs
+++ b/src/Granit.Bff/Options/GranitBffOptions.cs
@@ -181,7 +181,8 @@ public sealed class BffFrontendOptions
     /// <summary>
     /// Gets the effective post-login redirect path.
     /// When <see cref="ClientUrl"/> is set and no explicit path is configured,
-    /// returns <c>{ClientUrl}/</c>.
+    /// returns the canonical origin <c>{ClientUrl}</c> with no trailing slash
+    /// (matches how OIDC clients are typically registered).
     /// </summary>
     public string EffectivePostLoginRedirectPath =>
         PrefixWithClientUrl(PostLoginRedirectPath ?? (string.IsNullOrEmpty(PathPrefix) ? "/" : $"{PathPrefix}/"));
@@ -189,7 +190,8 @@ public sealed class BffFrontendOptions
     /// <summary>
     /// Gets the effective post-logout redirect path.
     /// When <see cref="ClientUrl"/> is set and no explicit path is configured,
-    /// returns <c>{ClientUrl}/</c>.
+    /// returns the canonical origin <c>{ClientUrl}</c> with no trailing slash
+    /// (required for OIDC exact-match on <c>post_logout_redirect_uri</c>).
     /// </summary>
     public string EffectivePostLogoutRedirectPath =>
         PrefixWithClientUrl(PostLogoutRedirectPath ?? (string.IsNullOrEmpty(PathPrefix) ? "/" : $"{PathPrefix}/"));
@@ -202,8 +204,19 @@ public sealed class BffFrontendOptions
     public string EffectiveErrorRedirectPath =>
         PrefixWithClientUrl(ErrorRedirectPath ?? (string.IsNullOrEmpty(PathPrefix) ? "/login" : $"{PathPrefix}/login"));
 
-    internal string PrefixWithClientUrl(string relativePath) =>
-        string.IsNullOrEmpty(ClientUrl) ? relativePath : $"{ClientUrl.TrimEnd('/')}{relativePath}";
+    internal string PrefixWithClientUrl(string relativePath)
+    {
+        if (string.IsNullOrEmpty(ClientUrl))
+        {
+            return relativePath;
+        }
+
+        // Canonicalize the origin: "http://host/" + "/" would yield "http://host/", but OIDC
+        // requires exact string match on post_logout_redirect_uri (RFC 6749 §3.1.2.3 / OIDC Core §3.1.2.1),
+        // and the natural registered form is just the origin "http://host" (no trailing slash).
+        string trimmedClientUrl = ClientUrl.TrimEnd('/');
+        return relativePath == "/" ? trimmedClientUrl : $"{trimmedClientUrl}{relativePath}";
+    }
 
     /// <summary>
     /// Gets or sets a value indicating whether the BFF should use Pushed Authorization

--- a/tests/Granit.Bff.Tests/Options/GranitBffOptionsTests.cs
+++ b/tests/Granit.Bff.Tests/Options/GranitBffOptionsTests.cs
@@ -299,7 +299,7 @@ public sealed class BffFrontendOptionsTests
             ClientUrl = "http://localhost:5173",
         };
 
-        frontend.EffectivePostLoginRedirectPath.ShouldBe("http://localhost:5173/");
+        frontend.EffectivePostLoginRedirectPath.ShouldBe("http://localhost:5173");
     }
 
     [Fact]
@@ -322,7 +322,7 @@ public sealed class BffFrontendOptionsTests
             ClientUrl = "http://localhost:5174",
         };
 
-        frontend.EffectivePostLogoutRedirectPath.ShouldBe("http://localhost:5174/");
+        frontend.EffectivePostLogoutRedirectPath.ShouldBe("http://localhost:5174");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes the canonical form of the effective redirect URIs produced by `BffFrontendOptions` when `ClientUrl` is set and no explicit redirect path is configured.

Previous behaviour (on `develop`):

```
ClientUrl = "http://localhost:5173"
EffectivePostLoginRedirectPath  = "http://localhost:5173/"
EffectivePostLogoutRedirectPath = "http://localhost:5173/"
```

After this PR:

```
EffectivePostLoginRedirectPath  = "http://localhost:5173"
EffectivePostLogoutRedirectPath = "http://localhost:5173"
```

## Why

OIDC mandates an **exact string match** on `post_logout_redirect_uri` (RFC 6749 §3.1.2.3, OIDC Core §3.1.2.1). In practice, clients are registered with the bare origin — `http://localhost:5173`, not `http://localhost:5173/` — so the trailing-slash form silently fails the provider's allow-list check and the logout flow hangs on the error page.

`post_login_redirect_uri` is more forgiving in most providers, but for consistency (and to avoid surprising the developer who sees login succeed but logout fail) we apply the same canonicalization to both.

`PrefixWithClientUrl` now treats `relativePath == "/"` as "no sub-path" and returns the trimmed origin. Every other path (`"/api/x"`, `"/login"`, …) keeps its leading slash. XML docs on both properties are updated to match.

## Test plan

- [x] `dotnet test tests/Granit.Bff.Tests` — 29 passed / 0 failed
- [x] `dotnet build src/Granit.Bff` — 0 warnings / 0 errors
- [x] `dotnet format src/Granit.Bff tests/Granit.Bff.Tests --verify-no-changes` — clean
- [ ] Manual: log in via BFF, log out, confirm the OIDC provider accepts the `post_logout_redirect_uri`
