### PR TITLE
refactor(identity-local)!: split Account tag + unify impersonation tag

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18340,15 +18340,75 @@
           "returnType": "string"
         },
         {
-          "name": "AccountTagName",
+          "name": "LoginTagName",
           "kind": "property",
-          "signature": "string AccountTagName",
+          "signature": "string LoginTagName",
           "returnType": "string"
         },
         {
-          "name": "AdminTagName",
+          "name": "RegistrationTagName",
           "kind": "property",
-          "signature": "string AdminTagName",
+          "signature": "string RegistrationTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "ProfileTagName",
+          "kind": "property",
+          "signature": "string ProfileTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "EmailChangeTagName",
+          "kind": "property",
+          "signature": "string EmailChangeTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "PasswordTagName",
+          "kind": "property",
+          "signature": "string PasswordTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "TwoFactorTagName",
+          "kind": "property",
+          "signature": "string TwoFactorTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "ExternalLoginsTagName",
+          "kind": "property",
+          "signature": "string ExternalLoginsTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "PasskeysTagName",
+          "kind": "property",
+          "signature": "string PasskeysTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "DeletionTagName",
+          "kind": "property",
+          "signature": "string DeletionTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "SessionTagName",
+          "kind": "property",
+          "signature": "string SessionTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "ConfigTagName",
+          "kind": "property",
+          "signature": "string ConfigTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "ImpersonationTagName",
+          "kind": "property",
+          "signature": "string ImpersonationTagName",
           "returnType": "string"
         }
       ]

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountConfigEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountConfigEndpoints.cs
@@ -15,13 +15,15 @@ internal static class AccountConfigEndpoints
     /// </summary>
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="routePrefix">Route prefix. Default: <c>"api/account"</c>.</param>
+    /// <param name="tag">OpenAPI tag. Default: <c>"Account - Config"</c>.</param>
     /// <returns>The endpoint route builder for chaining.</returns>
     internal static IEndpointRouteBuilder MapGranitAccountConfig(
         this IEndpointRouteBuilder endpoints,
-        string routePrefix = "api/account") =>
+        string routePrefix = "api/account",
+        string tag = "Account - Config") =>
         endpoints.MapGranitModuleConfigAsync<IdentityLocalConfigProvider, IdentityLocalConfigResponse>(
             routePrefix,
             "GetAccountConfig",
-            "Account",
+            tag,
             builder => builder.AllowAnonymous());
 }

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountSessionEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountSessionEndpoints.cs
@@ -13,7 +13,7 @@ namespace Granit.Identity.Local.Endpoints.Endpoints;
 
 internal static class AccountSessionEndpoints
 {
-    internal static RouteGroupBuilder MapAccountSessionEndpoints(this RouteGroupBuilder group)
+    internal static RouteGroupBuilder MapAccountSessionHeartbeatEndpoint(this RouteGroupBuilder group)
     {
         group.MapPost("/session/heartbeat", (Delegate)HeartbeatAsync)
             .WithName("SessionHeartbeat")
@@ -24,6 +24,11 @@ internal static class AccountSessionEndpoints
             .Produces(StatusCodes.Status204NoContent)
             .RequireAuthorization();
 
+        return group;
+    }
+
+    internal static RouteGroupBuilder MapAccountBackToImpersonatorEndpoint(this RouteGroupBuilder group)
+    {
         group.MapPost("/session/back-to-impersonator", (Delegate)BackToImpersonatorAsync)
             .WithName("BackToImpersonator")
             .WithSummary("Ends an impersonation session and returns to the admin account.")

--- a/src/Granit.Identity.Local.Endpoints/Extensions/AccountEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Identity.Local.Endpoints/Extensions/AccountEndpointRouteBuilderExtensions.cs
@@ -15,6 +15,14 @@ public static class AccountEndpointRouteBuilderExtensions
     /// <summary>
     /// Maps the account self-service and admin impersonation endpoints.
     /// </summary>
+    /// <remarks>
+    /// Endpoints are split into functional tag groups (Login, Registration, Profile,
+    /// Email Change, Password, Two-Factor, External Logins, Passkeys, Deletion,
+    /// Session, Config) so the Scalar UI exposes each self-service feature as its
+    /// own collapsible section. The admin-start and user-end impersonation endpoints
+    /// share a single <c>"Impersonation"</c> tag even though they live on different
+    /// URL roots, so the feature's full surface is visible at a glance.
+    /// </remarks>
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize endpoint options.</param>
     /// <returns>The account <see cref="RouteGroupBuilder"/> for further chaining.</returns>
@@ -25,29 +33,33 @@ public static class AccountEndpointRouteBuilderExtensions
         AccountEndpointsOptions options = new();
         configure?.Invoke(options);
 
-        // ──── Account self-service (/api/account) ────
-        RouteGroupBuilder accountGroup = endpoints
-            .MapGranitGroup(options.AccountRoutePrefix)
-            .WithTags(options.AccountTagName);
+        // ──── Account self-service (/api/account) — split into feature sub-tags ────
+        RouteGroupBuilder accountGroup = endpoints.MapGranitGroup(options.AccountRoutePrefix);
 
-        accountGroup.MapAccountLoginEndpoints();
-        accountGroup.MapAccountRegistrationEndpoints();
-        accountGroup.MapAccountProfileEndpoints();
-        accountGroup.MapAccountEmailChangeEndpoints();
-        accountGroup.MapAccountPasswordEndpoints();
-        accountGroup.MapAccountTwoFactorEndpoints();
-        accountGroup.MapAccountExternalLoginEndpoints();
-        accountGroup.MapAccountPasskeyEndpoints();
-        accountGroup.MapAccountDeletionEndpoints();
-        accountGroup.MapAccountSessionEndpoints();
+        accountGroup.MapGroup(string.Empty).WithTags(options.LoginTagName).MapAccountLoginEndpoints();
+        accountGroup.MapGroup(string.Empty).WithTags(options.RegistrationTagName).MapAccountRegistrationEndpoints();
+        accountGroup.MapGroup(string.Empty).WithTags(options.ProfileTagName).MapAccountProfileEndpoints();
+        accountGroup.MapGroup(string.Empty).WithTags(options.EmailChangeTagName).MapAccountEmailChangeEndpoints();
+        accountGroup.MapGroup(string.Empty).WithTags(options.PasswordTagName).MapAccountPasswordEndpoints();
+        accountGroup.MapGroup(string.Empty).WithTags(options.TwoFactorTagName).MapAccountTwoFactorEndpoints();
+        accountGroup.MapGroup(string.Empty).WithTags(options.ExternalLoginsTagName).MapAccountExternalLoginEndpoints();
+        accountGroup.MapGroup(string.Empty).WithTags(options.PasskeysTagName).MapAccountPasskeyEndpoints();
+        accountGroup.MapGroup(string.Empty).WithTags(options.DeletionTagName).MapAccountDeletionEndpoints();
+        accountGroup.MapGroup(string.Empty).WithTags(options.SessionTagName).MapAccountSessionHeartbeatEndpoint();
+
+        // ──── Impersonation — shared tag across admin-start (/admin/users/{id}/impersonate)
+        //      and user-end (/account/session/back-to-impersonator) ────
+        accountGroup.MapGroup(string.Empty)
+            .WithTags(options.ImpersonationTagName)
+            .MapAccountBackToImpersonatorEndpoint();
 
         // ──── Public config (/api/account/config) ────
-        endpoints.MapGranitAccountConfig(options.AccountRoutePrefix);
+        endpoints.MapGranitAccountConfig(options.AccountRoutePrefix, options.ConfigTagName);
 
         // ──── Admin management (/api/admin) ────
         RouteGroupBuilder adminGroup = endpoints
             .MapGranitGroup(options.AdminRoutePrefix)
-            .WithTags(options.AdminTagName)
+            .WithTags(options.ImpersonationTagName)
             .RequireAuthorization();
 
         adminGroup.MapAdminImpersonationEndpoints();

--- a/src/Granit.Identity.Local.Endpoints/Options/AccountEndpointsOptions.cs
+++ b/src/Granit.Identity.Local.Endpoints/Options/AccountEndpointsOptions.cs
@@ -11,9 +11,46 @@ public sealed class AccountEndpointsOptions
     /// <summary>Route prefix for admin management endpoints. Default: <c>"admin"</c>.</summary>
     public string AdminRoutePrefix { get; set; } = "admin";
 
-    /// <summary>OpenAPI tag name for account self-service endpoints. Default: <c>"Account"</c>.</summary>
-    public string AccountTagName { get; set; } = "Account";
+    /// <summary>OpenAPI tag for authentication endpoints (login, 2FA completion). Default: <c>"Account - Login"</c>.</summary>
+    public string LoginTagName { get; set; } = "Account - Login";
 
-    /// <summary>OpenAPI tag name for admin impersonation endpoints. Default: <c>"Admin Impersonation"</c>.</summary>
-    public string AdminTagName { get; set; } = "Admin Impersonation";
+    /// <summary>OpenAPI tag for registration endpoints (register, confirm email, resend confirmation). Default: <c>"Account - Registration"</c>.</summary>
+    public string RegistrationTagName { get; set; } = "Account - Registration";
+
+    /// <summary>OpenAPI tag for profile endpoints (get profile, update profile). Default: <c>"Account - Profile"</c>.</summary>
+    public string ProfileTagName { get; set; } = "Account - Profile";
+
+    /// <summary>OpenAPI tag for email-change endpoints (change email, confirm email change). Default: <c>"Account - Email Change"</c>.</summary>
+    public string EmailChangeTagName { get; set; } = "Account - Email Change";
+
+    /// <summary>OpenAPI tag for password endpoints (change, forgot, reset). Default: <c>"Account - Password"</c>.</summary>
+#pragma warning disable GRSEC003 // OpenAPI tag label, not a secret
+    public string PasswordTagName { get; set; } = "Account - Password";
+#pragma warning restore GRSEC003
+
+    /// <summary>OpenAPI tag for two-factor endpoints (enable, disable, recovery codes). Default: <c>"Account - Two-Factor"</c>.</summary>
+    public string TwoFactorTagName { get; set; } = "Account - Two-Factor";
+
+    /// <summary>OpenAPI tag for external-login endpoints (challenge, callback, list, unlink). Default: <c>"Account - External Logins"</c>.</summary>
+    public string ExternalLoginsTagName { get; set; } = "Account - External Logins";
+
+    /// <summary>OpenAPI tag for passkey endpoints (register, assertion, list, delete). Default: <c>"Account - Passkeys"</c>.</summary>
+    public string PasskeysTagName { get; set; } = "Account - Passkeys";
+
+    /// <summary>OpenAPI tag for account deletion endpoint. Default: <c>"Account - Deletion"</c>.</summary>
+    public string DeletionTagName { get; set; } = "Account - Deletion";
+
+    /// <summary>OpenAPI tag for session endpoints (heartbeat). Default: <c>"Account - Session"</c>.</summary>
+    public string SessionTagName { get; set; } = "Account - Session";
+
+    /// <summary>OpenAPI tag for the public config endpoint. Default: <c>"Account - Config"</c>.</summary>
+    public string ConfigTagName { get; set; } = "Account - Config";
+
+    /// <summary>
+    /// OpenAPI tag shared by both impersonation endpoints:
+    /// <c>POST /admin/users/{userId}/impersonate</c> (start) and
+    /// <c>POST /account/session/back-to-impersonator</c> (end).
+    /// Default: <c>"Impersonation"</c>.
+    /// </summary>
+    public string ImpersonationTagName { get; set; } = "Impersonation";
 }


### PR DESCRIPTION
## Summary

Two OpenAPI tag fixes on `Granit.Identity.Local.Endpoints` flagged during review of the Scalar UI:

### 1. Account tag was too broad
The single `Account` tag grouped ~30 endpoints (login, registration, profile, email change, password, 2FA, external logins, passkeys, deletion, session, config). Scalar rendered one unreadable section. Split into 11 functional sub-tags following the `<Module> - <SubGroup>` convention:

- `Account - Login` — `/login`, `/login/two-factor`
- `Account - Registration` — `/register`, `/confirm-email`, `/resend-confirmation-email`
- `Account - Profile` — `GET/PUT /profile`
- `Account - Email Change` — `/change-email`, `/confirm-email-change`
- `Account - Password` — `/change-password`, `/forgot-password`, `/reset-password`
- `Account - Two-Factor` — `/two-factor/*`
- `Account - External Logins` — `/external-logins/*`
- `Account - Passkeys` — `/passkeys/*`
- `Account - Deletion` — `/delete`
- `Account - Session` — `/session/heartbeat`
- `Account - Config` — `/config`

### 2. Impersonation was fragmented across two tags
`POST /admin/users/{id}/impersonate` (start) lived under `Admin Impersonation`; `POST /account/session/back-to-impersonator` (end) lived under `Account`. Two halves of the same feature. Both now share a single `Impersonation` tag.

## Breaking changes

- `AccountEndpointsOptions.AccountTagName` and `.AdminTagName` removed. Replaced by 12 per-feature tag properties (`LoginTagName`, `RegistrationTagName`, …) and `ImpersonationTagName`. Consumers overriding these options must migrate.
- `AccountSessionEndpoints.MapAccountSessionEndpoints` split into `MapAccountSessionHeartbeatEndpoint` + `MapAccountBackToImpersonatorEndpoint` (both `internal` — no external consumers affected).
- `MapGranitAccountConfig` (`internal`) gains a `tag` parameter.

Any generated SDK/client pinning operations by tag will need regeneration.

## Test plan

- [x] `dotnet build src/Granit.Identity.Local.Endpoints`
- [x] `dotnet test tests/Granit.Identity.Local.Endpoints.Tests` (142/142 passing)
- [ ] Manual Scalar verification on a host app — confirm 11 `Account - *` sections + unified `Impersonation` tag