### PR TITLE
refactor(endpoints)!: unify OpenAPI tags with Module - SubGroup convention

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -9080,6 +9080,12 @@
           "kind": "property",
           "signature": "long MaxUploadBytes",
           "returnType": "long"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
         }
       ]
     },
@@ -9775,12 +9781,12 @@
       "kind": "class",
       "project": "Granit.CustomerBalance.Endpoints",
       "file": "src/Granit.CustomerBalance.Endpoints/Extensions/CustomerBalanceEndpointRouteBuilderExtensions.cs",
-      "line": 13,
+      "line": 14,
       "members": [
         {
           "name": "MapGranitCustomerBalance",
           "kind": "method",
-          "signature": "MapGranitCustomerBalance(this IEndpointRouteBuilder endpoints)",
+          "signature": "MapGranitCustomerBalance(this IEndpointRouteBuilder endpoints, Action<CustomerBalanceEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -9793,6 +9799,28 @@
       "file": "src/Granit.CustomerBalance.Endpoints/GranitCustomerBalanceEndpointsModule.cs",
       "line": 14,
       "members": []
+    },
+    {
+      "name": "CustomerBalanceEndpointsOptions",
+      "fqn": "Granit.CustomerBalance.Endpoints.Options.CustomerBalanceEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.CustomerBalance.Endpoints",
+      "file": "src/Granit.CustomerBalance.Endpoints/Options/CustomerBalanceEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
     },
     {
       "name": "Accounts",
@@ -16761,6 +16789,12 @@
           "kind": "property",
           "signature": "string TagName",
           "returnType": "string"
+        },
+        {
+          "name": "WebhookTagName",
+          "kind": "property",
+          "signature": "string WebhookTagName",
+          "returnType": "string"
         }
       ]
     },
@@ -20600,12 +20634,12 @@
       "kind": "class",
       "project": "Granit.Invoicing.Endpoints",
       "file": "src/Granit.Invoicing.Endpoints/Extensions/InvoicingEndpointRouteBuilderExtensions.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "MapGranitInvoicing",
           "kind": "method",
-          "signature": "MapGranitInvoicing(this IEndpointRouteBuilder endpoints)",
+          "signature": "MapGranitInvoicing(this IEndpointRouteBuilder endpoints, Action<InvoicingEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -20618,6 +20652,28 @@
       "file": "src/Granit.Invoicing.Endpoints/GranitInvoicingEndpointsModule.cs",
       "line": 14,
       "members": []
+    },
+    {
+      "name": "InvoicingEndpointsOptions",
+      "fqn": "Granit.Invoicing.Endpoints.Options.InvoicingEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Invoicing.Endpoints",
+      "file": "src/Granit.Invoicing.Endpoints/Options/InvoicingEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
     },
     {
       "name": "CreditNotes",
@@ -22753,12 +22809,12 @@
       "kind": "class",
       "project": "Granit.Metering.Endpoints",
       "file": "src/Granit.Metering.Endpoints/Extensions/MeteringEndpointRouteBuilderExtensions.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "MapGranitMetering",
           "kind": "method",
-          "signature": "MapGranitMetering(this IEndpointRouteBuilder endpoints)",
+          "signature": "MapGranitMetering(this IEndpointRouteBuilder endpoints, Action<MeteringEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -22771,6 +22827,28 @@
       "file": "src/Granit.Metering.Endpoints/GranitMeteringEndpointsModule.cs",
       "line": 16,
       "members": []
+    },
+    {
+      "name": "MeteringEndpointsOptions",
+      "fqn": "Granit.Metering.Endpoints.Options.MeteringEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Metering.Endpoints",
+      "file": "src/Granit.Metering.Endpoints/Options/MeteringEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
     },
     {
       "name": "MeteringPermissions",
@@ -25218,12 +25296,12 @@
       "kind": "class",
       "project": "Granit.Notifications.Endpoints",
       "file": "src/Granit.Notifications.Endpoints/Endpoints/MobilePushTokenEndpoints.cs",
-      "line": 19,
+      "line": 20,
       "members": [
         {
           "name": "MapGranitMobilePushTokens",
           "kind": "method",
-          "signature": "MapGranitMobilePushTokens(this IEndpointRouteBuilder endpoints, string prefix = \"api/notifications/mobile-push/tokens\")",
+          "signature": "MapGranitMobilePushTokens(this IEndpointRouteBuilder endpoints, string prefix = \"api/notifications/mobile-push/tokens\", Action<NotificationEndpointsOptions>? configure = null)",
           "returnType": "IEndpointRouteBuilder"
         }
       ]
@@ -25271,6 +25349,12 @@
           "name": "TagName",
           "kind": "property",
           "signature": "string TagName",
+          "returnType": "string"
+        },
+        {
+          "name": "MobilePushTagName",
+          "kind": "property",
+          "signature": "string MobilePushTagName",
           "returnType": "string"
         }
       ]
@@ -29347,12 +29431,12 @@
       "kind": "class",
       "project": "Granit.Payments.Endpoints",
       "file": "src/Granit.Payments.Endpoints/Extensions/PaymentsEndpointRouteBuilderExtensions.cs",
-      "line": 10,
+      "line": 11,
       "members": [
         {
           "name": "MapGranitPayments",
           "kind": "method",
-          "signature": "MapGranitPayments(this IEndpointRouteBuilder endpoints)",
+          "signature": "MapGranitPayments(this IEndpointRouteBuilder endpoints, Action<PaymentsEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -29365,6 +29449,46 @@
       "file": "src/Granit.Payments.Endpoints/GranitPaymentsEndpointsModule.cs",
       "line": 14,
       "members": []
+    },
+    {
+      "name": "PaymentsEndpointsOptions",
+      "fqn": "Granit.Payments.Endpoints.Options.PaymentsEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Payments.Endpoints",
+      "file": "src/Granit.Payments.Endpoints/Options/PaymentsEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TransactionsTagName",
+          "kind": "property",
+          "signature": "string TransactionsTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "MethodsTagName",
+          "kind": "property",
+          "signature": "string MethodsTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "ConfigurationTagName",
+          "kind": "property",
+          "signature": "string ConfigurationTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "WebhooksTagName",
+          "kind": "property",
+          "signature": "string WebhooksTagName",
+          "returnType": "string"
+        }
+      ]
     },
     {
       "name": "Charges",
@@ -32527,7 +32651,7 @@
         {
           "name": "MapGranitPrivacyExportDownload",
           "kind": "method",
-          "signature": "MapGranitPrivacyExportDownload(this IEndpointRouteBuilder endpoints, string routePrefix = \"privacy\")",
+          "signature": "MapGranitPrivacyExportDownload(this IEndpointRouteBuilder endpoints, string routePrefix = \"privacy\", string tagName = \"Privacy\")",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -37103,9 +37227,21 @@
           "returnType": "string"
         },
         {
-          "name": "TagName",
+          "name": "GlobalTagName",
           "kind": "property",
-          "signature": "string TagName",
+          "signature": "string GlobalTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "TenantTagName",
+          "kind": "property",
+          "signature": "string TenantTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "UserTagName",
+          "kind": "property",
+          "signature": "string UserTagName",
           "returnType": "string"
         }
       ]
@@ -38269,12 +38405,12 @@
       "kind": "class",
       "project": "Granit.Subscriptions.Endpoints",
       "file": "src/Granit.Subscriptions.Endpoints/Extensions/SubscriptionsEndpointRouteBuilderExtensions.cs",
-      "line": 14,
+      "line": 15,
       "members": [
         {
           "name": "MapGranitSubscriptions",
           "kind": "method",
-          "signature": "MapGranitSubscriptions(this IEndpointRouteBuilder endpoints)",
+          "signature": "MapGranitSubscriptions(this IEndpointRouteBuilder endpoints, Action<SubscriptionsEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -38287,6 +38423,46 @@
       "file": "src/Granit.Subscriptions.Endpoints/GranitSubscriptionsEndpointsModule.cs",
       "line": 16,
       "members": []
+    },
+    {
+      "name": "SubscriptionsEndpointsOptions",
+      "fqn": "Granit.Subscriptions.Endpoints.Options.SubscriptionsEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Subscriptions.Endpoints",
+      "file": "src/Granit.Subscriptions.Endpoints/Options/SubscriptionsEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "PlansTagName",
+          "kind": "property",
+          "signature": "string PlansTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "PricesTagName",
+          "kind": "property",
+          "signature": "string PricesTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "SubscriptionsTagName",
+          "kind": "property",
+          "signature": "string SubscriptionsTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "SeatsTagName",
+          "kind": "property",
+          "signature": "string SeatsTagName",
+          "returnType": "string"
+        }
+      ]
     },
     {
       "name": "Plans",
@@ -39526,12 +39702,12 @@
       "kind": "class",
       "project": "Granit.Tax.Endpoints",
       "file": "src/Granit.Tax.Endpoints/Extensions/TaxEndpointRouteBuilderExtensions.cs",
-      "line": 13,
+      "line": 14,
       "members": [
         {
           "name": "MapGranitTax",
           "kind": "method",
-          "signature": "MapGranitTax(this IEndpointRouteBuilder endpoints)",
+          "signature": "MapGranitTax(this IEndpointRouteBuilder endpoints, Action<TaxEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -39544,6 +39720,34 @@
       "file": "src/Granit.Tax.Endpoints/GranitTaxEndpointsModule.cs",
       "line": 12,
       "members": []
+    },
+    {
+      "name": "TaxEndpointsOptions",
+      "fqn": "Granit.Tax.Endpoints.Options.TaxEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Tax.Endpoints",
+      "file": "src/Granit.Tax.Endpoints/Options/TaxEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RoutePrefix",
+          "kind": "property",
+          "signature": "string RoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "ValidationTagName",
+          "kind": "property",
+          "signature": "string ValidationTagName",
+          "returnType": "string"
+        },
+        {
+          "name": "RatesTagName",
+          "kind": "property",
+          "signature": "string RatesTagName",
+          "returnType": "string"
+        }
+      ]
     },
     {
       "name": "Rates",
@@ -44309,7 +44513,7 @@
         {
           "name": "MapGranitWebhooksRedelivery",
           "kind": "method",
-          "signature": "MapGranitWebhooksRedelivery(this IEndpointRouteBuilder endpoints, string routePrefix = \"webhooks\")",
+          "signature": "MapGranitWebhooksRedelivery(this IEndpointRouteBuilder endpoints, string routePrefix = \"webhooks\", string tagName = \"Webhooks\")",
           "returnType": "IEndpointRouteBuilder"
         }
       ]

--- a/src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Bff.Endpoints/Extensions/BffEndpointRouteBuilderExtensions.cs
@@ -77,7 +77,7 @@ public static class BffEndpointRouteBuilderExtensions
 
         RouteGroupBuilder group = endpoints
             .MapGranitGroup(groupPrefix)
-            .WithTags($"BFF ({frontend.Name})");
+            .WithTags($"BFF - {frontend.Name}");
 
         group.MapLoginEndpoints(frontend);
         group.MapLogoutEndpoints(frontend);

--- a/src/Granit.BlobStorage.Proxy/Extensions/BlobStorageProxyEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.BlobStorage.Proxy/Extensions/BlobStorageProxyEndpointRouteBuilderExtensions.cs
@@ -38,7 +38,7 @@ public static class BlobStorageProxyEndpointRouteBuilderExtensions
 
         RouteGroupBuilder group = endpoints
             .MapGranitGroup(options.RoutePrefix)
-            .WithTags("Blob Proxy");
+            .WithTags(options.TagName);
 
         group.MapPut("/upload/{token}", ProxyEndpoints.HandleUploadAsync)
             .WithName("BlobProxyUpload")

--- a/src/Granit.BlobStorage.Proxy/Options/ProxyBlobOptions.cs
+++ b/src/Granit.BlobStorage.Proxy/Options/ProxyBlobOptions.cs
@@ -28,4 +28,10 @@ public sealed class ProxyBlobOptions
     /// Maximum upload size in bytes accepted by the proxy. Defaults to 100 MB.
     /// </summary>
     public long MaxUploadBytes { get; set; } = 104_857_600;
+
+    /// <summary>
+    /// OpenAPI tag name for proxy endpoints.
+    /// Default: <c>"Blob Proxy"</c>.
+    /// </summary>
+    public string TagName { get; set; } = "Blob Proxy";
 }

--- a/src/Granit.CustomerBalance.Endpoints/Extensions/CustomerBalanceEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Extensions/CustomerBalanceEndpointRouteBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Granit.Authorization.Extensions;
 using Granit.CustomerBalance.Endpoints.Dtos;
 using Granit.CustomerBalance.Endpoints.Internal;
+using Granit.CustomerBalance.Endpoints.Options;
 using Granit.CustomerBalance.Endpoints.Permissions;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
@@ -13,12 +14,19 @@ namespace Granit.CustomerBalance.Endpoints.Extensions;
 public static class CustomerBalanceEndpointRouteBuilderExtensions
 {
     /// <summary>Maps the customer balance endpoints.</summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="configure">Optional delegate to customize <see cref="CustomerBalanceEndpointsOptions"/>.</param>
+    /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
     public static RouteGroupBuilder MapGranitCustomerBalance(
-        this IEndpointRouteBuilder endpoints)
+        this IEndpointRouteBuilder endpoints,
+        Action<CustomerBalanceEndpointsOptions>? configure = null)
     {
+        CustomerBalanceEndpointsOptions options = new();
+        configure?.Invoke(options);
+
         RouteGroupBuilder group = endpoints
-            .MapGranitGroup("customer-balance")
-            .WithTags("Customer Balance");
+            .MapGranitGroup(options.RoutePrefix)
+            .WithTags(options.TagName);
 
         group.MapGet("/balance", GetBalanceEndpoint.HandleAsync)
             .WithName("GetCustomerBalance")

--- a/src/Granit.CustomerBalance.Endpoints/Options/CustomerBalanceEndpointsOptions.cs
+++ b/src/Granit.CustomerBalance.Endpoints/Options/CustomerBalanceEndpointsOptions.cs
@@ -1,0 +1,22 @@
+namespace Granit.CustomerBalance.Endpoints.Options;
+
+/// <summary>
+/// Configuration options for the customer balance endpoints.
+/// </summary>
+public sealed class CustomerBalanceEndpointsOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "CustomerBalanceEndpoints";
+
+    /// <summary>
+    /// Route prefix for all customer balance endpoints.
+    /// Default: <c>"customer-balance"</c>.
+    /// </summary>
+    public string RoutePrefix { get; set; } = "customer-balance";
+
+    /// <summary>
+    /// OpenAPI tag name for customer balance endpoints.
+    /// Default: <c>"Customer Balance"</c>.
+    /// </summary>
+    public string TagName { get; set; } = "Customer Balance";
+}

--- a/src/Granit.Identity.Endpoints/Endpoints/IdentityWebhookEndpoints.cs
+++ b/src/Granit.Identity.Endpoints/Endpoints/IdentityWebhookEndpoints.cs
@@ -26,7 +26,8 @@ internal static class IdentityWebhookEndpoints
 
     internal static IEndpointRouteBuilder MapWebhookEndpoint(
         this IEndpointRouteBuilder endpoints,
-        string prefix)
+        string prefix,
+        string tagName)
     {
         string webhookRoute = string.IsNullOrEmpty(prefix)
             ? "identity/webhook"
@@ -36,7 +37,7 @@ internal static class IdentityWebhookEndpoints
             .WithName("IdentityWebhook")
             .WithSummary("Receives identity provider webhook events (user created/updated/deleted).")
             .WithDescription("Webhook receiver for identity provider event notifications. Validates the HMAC signature (if configured) and processes user_created, user_updated, and user_deleted events by refreshing or removing the corresponding cache entries. No authentication required — security relies on the HMAC signature validation.")
-            .WithTags("Identity - Webhook")
+            .WithTags(tagName)
             .Produces(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status400BadRequest)

--- a/src/Granit.Identity.Endpoints/Extensions/IdentityEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Identity.Endpoints/Extensions/IdentityEndpointRouteBuilderExtensions.cs
@@ -66,7 +66,7 @@ public static class IdentityEndpointRouteBuilderExtensions
             .MapRgpdEndpoints();
 
         // Webhook endpoint (outside the authorized group — uses signature validation)
-        endpoints.MapWebhookEndpoint("");
+        endpoints.MapWebhookEndpoint("", options.WebhookTagName);
 
         return group;
     }

--- a/src/Granit.Identity.Endpoints/Options/IdentityEndpointsOptions.cs
+++ b/src/Granit.Identity.Endpoints/Options/IdentityEndpointsOptions.cs
@@ -19,4 +19,10 @@ public sealed class IdentityEndpointsOptions
     /// Default: <c>"Identity - User Cache"</c>.
     /// </summary>
     public string TagName { get; set; } = "Identity - User Cache";
+
+    /// <summary>
+    /// OpenAPI tag name for the identity-provider webhook receiver endpoint.
+    /// Default: <c>"Identity - Webhook"</c>.
+    /// </summary>
+    public string WebhookTagName { get; set; } = "Identity - Webhook";
 }

--- a/src/Granit.Invoicing.Endpoints/Extensions/InvoicingEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Invoicing.Endpoints/Extensions/InvoicingEndpointRouteBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Granit.Invoicing.Domain;
 using Granit.Invoicing.Endpoints.Endpoints;
+using Granit.Invoicing.Endpoints.Options;
 using Granit.QueryEngine.AspNetCore.Extensions;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
@@ -12,11 +13,19 @@ namespace Granit.Invoicing.Endpoints.Extensions;
 public static class InvoicingEndpointRouteBuilderExtensions
 {
     /// <summary>Maps the invoicing administration endpoints.</summary>
-    public static RouteGroupBuilder MapGranitInvoicing(this IEndpointRouteBuilder endpoints)
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="configure">Optional delegate to customize <see cref="InvoicingEndpointsOptions"/>.</param>
+    /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
+    public static RouteGroupBuilder MapGranitInvoicing(
+        this IEndpointRouteBuilder endpoints,
+        Action<InvoicingEndpointsOptions>? configure = null)
     {
+        InvoicingEndpointsOptions options = new();
+        configure?.Invoke(options);
+
         RouteGroupBuilder group = endpoints
-            .MapGranitGroup("invoicing")
-            .WithTags("Invoicing");
+            .MapGranitGroup(options.RoutePrefix)
+            .WithTags(options.TagName);
 
         group.MapInvoiceEndpoints();
 

--- a/src/Granit.Invoicing.Endpoints/Options/InvoicingEndpointsOptions.cs
+++ b/src/Granit.Invoicing.Endpoints/Options/InvoicingEndpointsOptions.cs
@@ -1,0 +1,22 @@
+namespace Granit.Invoicing.Endpoints.Options;
+
+/// <summary>
+/// Configuration options for the invoicing endpoints.
+/// </summary>
+public sealed class InvoicingEndpointsOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "InvoicingEndpoints";
+
+    /// <summary>
+    /// Route prefix for all invoicing endpoints.
+    /// Default: <c>"invoicing"</c>.
+    /// </summary>
+    public string RoutePrefix { get; set; } = "invoicing";
+
+    /// <summary>
+    /// OpenAPI tag name for invoicing endpoints.
+    /// Default: <c>"Invoicing"</c>.
+    /// </summary>
+    public string TagName { get; set; } = "Invoicing";
+}

--- a/src/Granit.Metering.Endpoints/Extensions/MeteringEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Metering.Endpoints/Extensions/MeteringEndpointRouteBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Metering.Endpoints.Endpoints;
+using Granit.Metering.Endpoints.Options;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -12,12 +13,19 @@ namespace Granit.Metering.Endpoints.Extensions;
 public static class MeteringEndpointRouteBuilderExtensions
 {
     /// <summary>Maps the metering endpoints.</summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="configure">Optional delegate to customize <see cref="MeteringEndpointsOptions"/>.</param>
+    /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
     public static RouteGroupBuilder MapGranitMetering(
-        this IEndpointRouteBuilder endpoints)
+        this IEndpointRouteBuilder endpoints,
+        Action<MeteringEndpointsOptions>? configure = null)
     {
+        MeteringEndpointsOptions options = new();
+        configure?.Invoke(options);
+
         RouteGroupBuilder group = endpoints
-            .MapGranitGroup("metering")
-            .WithTags("Metering");
+            .MapGranitGroup(options.RoutePrefix)
+            .WithTags(options.TagName);
 
         group.MapMeterDefinitionEndpoints();
         group.MapUsageEndpoints();

--- a/src/Granit.Metering.Endpoints/Options/MeteringEndpointsOptions.cs
+++ b/src/Granit.Metering.Endpoints/Options/MeteringEndpointsOptions.cs
@@ -1,0 +1,22 @@
+namespace Granit.Metering.Endpoints.Options;
+
+/// <summary>
+/// Configuration options for the metering endpoints.
+/// </summary>
+public sealed class MeteringEndpointsOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "MeteringEndpoints";
+
+    /// <summary>
+    /// Route prefix for all metering endpoints.
+    /// Default: <c>"metering"</c>.
+    /// </summary>
+    public string RoutePrefix { get; set; } = "metering";
+
+    /// <summary>
+    /// OpenAPI tag name for metering endpoints.
+    /// Default: <c>"Metering"</c>.
+    /// </summary>
+    public string TagName { get; set; } = "Metering";
+}

--- a/src/Granit.MultiTenancy.Endpoints/Extensions/MultiTenancyEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.MultiTenancy.Endpoints/Extensions/MultiTenancyEndpointRouteBuilderExtensions.cs
@@ -17,7 +17,8 @@ namespace Granit.MultiTenancy.Endpoints.Extensions;
 public static class MultiTenancyEndpointRouteBuilderExtensions
 {
     /// <summary>
-    /// Maps multi-tenancy management endpoints under <c>/{prefix}/admin/tenants</c>.
+    /// Maps multi-tenancy management endpoints under <c>/{prefix}/tenants</c>
+    /// (default prefix: <c>multi-tenancy</c>, so the full path is <c>/multi-tenancy/tenants</c>).
     /// </summary>
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="configure">Optional delegate to customize <see cref="MultiTenancyEndpointsOptions"/>.</param>
@@ -37,10 +38,10 @@ public static class MultiTenancyEndpointRouteBuilderExtensions
         RouteGroupBuilder tenantsGroup = group.MapGranitGroup("tenants");
 
         // Note: Tenant listing is handled by Granit.QueryEngine. Consumers should register
-        // a query endpoint at the same prefix, e.g.:
+        // a query endpoint at the same prefix as the CRUD endpoints above, e.g.:
         //   api.MapGranitQuery<Tenant>(
         //       sp => sp.GetRequiredService<IQueryableSource<Tenant>>().GetQueryable(),
-        //       "admin/tenants",
+        //       "multi-tenancy/tenants",
         //       opts => opts.AuthorizationPolicy = MultiTenancyPermissions.Tenants.Read);
         //
         // This keeps Granit.MultiTenancy.Endpoints decoupled from EF Core and the query engine,

--- a/src/Granit.MultiTenancy.Endpoints/GranitMultiTenancyEndpointsModule.cs
+++ b/src/Granit.MultiTenancy.Endpoints/GranitMultiTenancyEndpointsModule.cs
@@ -10,7 +10,7 @@ namespace Granit.MultiTenancy.Endpoints;
 /// </summary>
 /// <remarks>
 /// Exposes tenant CRUD and activation/deactivation endpoints under
-/// <c>/{prefix}/admin/tenants</c> (<see cref="Extensions.MultiTenancyEndpointRouteBuilderExtensions.MapGranitMultiTenancy"/>).
+/// <c>/{prefix}/multi-tenancy/tenants</c> (<see cref="Extensions.MultiTenancyEndpointRouteBuilderExtensions.MapGranitMultiTenancy"/>).
 /// Permission definition providers are auto-discovered by the authorization module.
 /// </remarks>
 [DependsOn(

--- a/src/Granit.Notifications.Endpoints/Endpoints/MobilePushTokenEndpoints.cs
+++ b/src/Granit.Notifications.Endpoints/Endpoints/MobilePushTokenEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using Granit.MultiTenancy;
 using Granit.Notifications.Endpoints.Dtos;
+using Granit.Notifications.Endpoints.Options;
 using Granit.Notifications.Endpoints.Permissions;
 using Granit.Notifications.MobilePush;
 using Granit.Timing;
@@ -19,13 +20,20 @@ namespace Granit.Notifications.Endpoints.Endpoints;
 public static class MobilePushTokenEndpoints
 {
     /// <summary>Maps mobile push token management endpoints.</summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="prefix">Route prefix. Default <c>"api/notifications/mobile-push/tokens"</c>.</param>
+    /// <param name="configure">Optional delegate to customize <see cref="NotificationEndpointsOptions"/> (tag only).</param>
     public static IEndpointRouteBuilder MapGranitMobilePushTokens(
         this IEndpointRouteBuilder endpoints,
-        string prefix = "api/notifications/mobile-push/tokens")
+        string prefix = "api/notifications/mobile-push/tokens",
+        Action<NotificationEndpointsOptions>? configure = null)
     {
+        NotificationEndpointsOptions options = new();
+        configure?.Invoke(options);
+
         RouteGroupBuilder group = endpoints.MapGranitGroup(prefix)
             .RequireAuthorization()
-            .WithTags("Notifications - Mobile Push");
+            .WithTags(options.MobilePushTagName);
 
         group.MapPost("/", RegisterTokenAsync)
             .RequireAuthorization(NotificationPermissions.UserNotifications.Manage)

--- a/src/Granit.Notifications.Endpoints/Options/NotificationEndpointsOptions.cs
+++ b/src/Granit.Notifications.Endpoints/Options/NotificationEndpointsOptions.cs
@@ -16,4 +16,10 @@ public sealed class NotificationEndpointsOptions
     /// Default: <c>"Notifications"</c>.
     /// </summary>
     public string TagName { get; set; } = "Notifications";
+
+    /// <summary>
+    /// OpenAPI tag name for mobile push device token endpoints.
+    /// Default: <c>"Notifications - Mobile Push"</c>.
+    /// </summary>
+    public string MobilePushTagName { get; set; } = "Notifications - Mobile Push";
 }

--- a/src/Granit.Payments.Endpoints/Extensions/PaymentsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Payments.Endpoints/Extensions/PaymentsEndpointRouteBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Granit.Payments.Endpoints.Endpoints;
+using Granit.Payments.Endpoints.Options;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -17,17 +18,32 @@ public static class PaymentsEndpointRouteBuilderExtensions
     /// </code>
     /// </remarks>
     /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="configure">Optional delegate to customize <see cref="PaymentsEndpointsOptions"/>.</param>
     /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
-    public static RouteGroupBuilder MapGranitPayments(this IEndpointRouteBuilder endpoints)
+    public static RouteGroupBuilder MapGranitPayments(
+        this IEndpointRouteBuilder endpoints,
+        Action<PaymentsEndpointsOptions>? configure = null)
     {
-        RouteGroupBuilder group = endpoints
-            .MapGranitGroup("payments")
-            .WithTags("Payments");
+        PaymentsEndpointsOptions options = new();
+        configure?.Invoke(options);
 
-        group.MapTransactionEndpoints();
-        group.MapPaymentMethodEndpoints();
-        group.MapPaymentMethodConfigurationEndpoints();
-        group.MapWebhookEndpoints();
+        RouteGroupBuilder group = endpoints.MapGranitGroup(options.RoutePrefix);
+
+        RouteGroupBuilder transactionsGroup = group.MapGranitGroup(string.Empty)
+            .WithTags(options.TransactionsTagName);
+        transactionsGroup.MapTransactionEndpoints();
+
+        RouteGroupBuilder methodsGroup = group.MapGranitGroup(string.Empty)
+            .WithTags(options.MethodsTagName);
+        methodsGroup.MapPaymentMethodEndpoints();
+
+        RouteGroupBuilder configurationGroup = group.MapGranitGroup(string.Empty)
+            .WithTags(options.ConfigurationTagName);
+        configurationGroup.MapPaymentMethodConfigurationEndpoints();
+
+        RouteGroupBuilder webhooksGroup = group.MapGranitGroup(string.Empty)
+            .WithTags(options.WebhooksTagName);
+        webhooksGroup.MapWebhookEndpoints();
 
         return group;
     }

--- a/src/Granit.Payments.Endpoints/Options/PaymentsEndpointsOptions.cs
+++ b/src/Granit.Payments.Endpoints/Options/PaymentsEndpointsOptions.cs
@@ -1,0 +1,40 @@
+namespace Granit.Payments.Endpoints.Options;
+
+/// <summary>
+/// Configuration options for the payments endpoints.
+/// </summary>
+public sealed class PaymentsEndpointsOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "PaymentsEndpoints";
+
+    /// <summary>
+    /// Route prefix for all payment endpoints.
+    /// Default: <c>"payments"</c>.
+    /// </summary>
+    public string RoutePrefix { get; set; } = "payments";
+
+    /// <summary>
+    /// OpenAPI tag name for transaction endpoints.
+    /// Default: <c>"Payments - Transactions"</c>.
+    /// </summary>
+    public string TransactionsTagName { get; set; } = "Payments - Transactions";
+
+    /// <summary>
+    /// OpenAPI tag name for saved payment method endpoints.
+    /// Default: <c>"Payments - Methods"</c>.
+    /// </summary>
+    public string MethodsTagName { get; set; } = "Payments - Methods";
+
+    /// <summary>
+    /// OpenAPI tag name for payment method configuration (activation) endpoints.
+    /// Default: <c>"Payments - Configuration"</c>.
+    /// </summary>
+    public string ConfigurationTagName { get; set; } = "Payments - Configuration";
+
+    /// <summary>
+    /// OpenAPI tag name for inbound provider webhook endpoints.
+    /// Default: <c>"Payments - Webhooks"</c>.
+    /// </summary>
+    public string WebhooksTagName { get; set; } = "Payments - Webhooks";
+}

--- a/src/Granit.Privacy.BlobStorage/DataExport/ExportArchiveAssemblyHandler.cs
+++ b/src/Granit.Privacy.BlobStorage/DataExport/ExportArchiveAssemblyHandler.cs
@@ -186,7 +186,7 @@ public sealed partial class ExportArchiveAssemblyHandler(
         response.EnsureSuccessStatusCode();
 
         ZipArchiveEntry entry = zip.CreateEntry(entryName, CompressionLevel.Optimal);
-        await using Stream entryStream = entry.Open();
+        await using Stream entryStream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using Stream contentStream = await response.Content
             .ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         await contentStream.CopyToAsync(entryStream, cancellationToken).ConfigureAwait(false);
@@ -211,7 +211,7 @@ public sealed partial class ExportArchiveAssemblyHandler(
             fragments);
 
         ZipArchiveEntry entry = zip.CreateEntry("manifest.json", CompressionLevel.Optimal);
-        await using Stream entryStream = entry.Open();
+        await using Stream entryStream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await JsonSerializer.SerializeAsync(entryStream, manifest, ManifestJsonOptions, cancellationToken)
             .ConfigureAwait(false);
     }

--- a/src/Granit.Privacy.BlobStorage/Extensions/PrivacyBlobStorageEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Privacy.BlobStorage/Extensions/PrivacyBlobStorageEndpointRouteBuilderExtensions.cs
@@ -22,17 +22,23 @@ public static class PrivacyBlobStorageEndpointRouteBuilderExtensions
     /// </summary>
     /// <param name="endpoints">The endpoint route builder.</param>
     /// <param name="routePrefix">Route prefix — typically mirrors <c>MapGranitPrivacy</c>. Default <c>"privacy"</c>.</param>
+    /// <param name="tagName">
+    /// OpenAPI tag. Default <c>"Privacy"</c> — matches <c>PrivacyEndpointsOptions.TagName</c>.
+    /// Override when the host customizes the Privacy tag.
+    /// </param>
     public static RouteGroupBuilder MapGranitPrivacyExportDownload(
         this IEndpointRouteBuilder endpoints,
-        string routePrefix = "privacy")
+        string routePrefix = "privacy",
+        string tagName = "Privacy")
     {
         ArgumentNullException.ThrowIfNull(endpoints);
         ArgumentException.ThrowIfNullOrWhiteSpace(routePrefix);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tagName);
 
         RouteGroupBuilder group = endpoints
             .MapGroup(routePrefix)
             .RequireAuthorization()
-            .WithTags("Privacy");
+            .WithTags(tagName);
 
         group.MapGet("/exports/{requestId:guid}/download", HandleDownloadAsync)
              .WithName("DownloadPrivacyExportArchive")

--- a/src/Granit.Settings.Endpoints/Extensions/AdminSettingsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Settings.Endpoints/Extensions/AdminSettingsEndpointRouteBuilderExtensions.cs
@@ -34,7 +34,7 @@ public static class AdminSettingsEndpointRouteBuilderExtensions
 
         RouteGroupBuilder group = endpoints
             .MapGranitGroup(options.GlobalRoutePrefix)
-            .WithTags(options.TagName);
+            .WithTags(options.GlobalTagName);
 
         group.MapGet("", HandleGetAllGlobalSettingsAsync)
              .RequireAuthorization(SettingsPermissions.Global.Read)
@@ -85,7 +85,7 @@ public static class AdminSettingsEndpointRouteBuilderExtensions
 
         RouteGroupBuilder group = endpoints
             .MapGranitGroup(options.TenantRoutePrefix)
-            .WithTags(options.TagName);
+            .WithTags(options.TenantTagName);
 
         group.MapGet("", HandleGetAllTenantSettingsAsync)
              .RequireAuthorization(SettingsPermissions.Tenant.Read)

--- a/src/Granit.Settings.Endpoints/Extensions/UserSettingsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Settings.Endpoints/Extensions/UserSettingsEndpointRouteBuilderExtensions.cs
@@ -35,7 +35,7 @@ public static class UserSettingsEndpointRouteBuilderExtensions
         RouteGroupBuilder group = endpoints
             .MapGranitGroup(options.UserRoutePrefix)
             .RequireAuthorization()
-            .WithTags(options.TagName);
+            .WithTags(options.UserTagName);
 
         group.MapGet("", HandleGetAllUserSettingsAsync)
              .WithName("GetAllUserSettings")

--- a/src/Granit.Settings.Endpoints/Options/SettingsEndpointsOptions.cs
+++ b/src/Granit.Settings.Endpoints/Options/SettingsEndpointsOptions.cs
@@ -24,8 +24,20 @@ public sealed class SettingsEndpointsOptions
     public string TenantRoutePrefix { get; set; } = "settings/tenant";
 
     /// <summary>
-    /// OpenAPI tag name for all settings endpoints.
-    /// Default: <c>"Settings"</c>.
+    /// OpenAPI tag name for global setting administration endpoints.
+    /// Default: <c>"Settings - Global"</c>.
     /// </summary>
-    public string TagName { get; set; } = "Settings";
+    public string GlobalTagName { get; set; } = "Settings - Global";
+
+    /// <summary>
+    /// OpenAPI tag name for tenant-scoped setting administration endpoints.
+    /// Default: <c>"Settings - Tenant"</c>.
+    /// </summary>
+    public string TenantTagName { get; set; } = "Settings - Tenant";
+
+    /// <summary>
+    /// OpenAPI tag name for user-scoped setting endpoints.
+    /// Default: <c>"Settings - User"</c>.
+    /// </summary>
+    public string UserTagName { get; set; } = "Settings - User";
 }

--- a/src/Granit.Subscriptions.Endpoints/Extensions/SubscriptionsEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Subscriptions.Endpoints/Extensions/SubscriptionsEndpointRouteBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Granit.QueryEngine.AspNetCore.Extensions;
 using Granit.Subscriptions.Domain;
 using Granit.Subscriptions.Endpoints.Endpoints;
+using Granit.Subscriptions.Endpoints.Options;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -14,23 +15,39 @@ namespace Granit.Subscriptions.Endpoints.Extensions;
 public static class SubscriptionsEndpointRouteBuilderExtensions
 {
     /// <summary>Maps the subscription administration endpoints.</summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="configure">Optional delegate to customize <see cref="SubscriptionsEndpointsOptions"/>.</param>
+    /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
     public static RouteGroupBuilder MapGranitSubscriptions(
-        this IEndpointRouteBuilder endpoints)
+        this IEndpointRouteBuilder endpoints,
+        Action<SubscriptionsEndpointsOptions>? configure = null)
     {
-        RouteGroupBuilder group = endpoints
-            .MapGranitGroup("subscriptions")
-            .WithTags("Subscriptions");
+        SubscriptionsEndpointsOptions options = new();
+        configure?.Invoke(options);
 
-        group.MapPlanReadEndpoints();
-        group.MapPlanWriteEndpoints();
-        group.MapPriceVersioningEndpoints();
-        group.MapSubscriptionEndpoints();
-        group.MapSeatEndpoints();
+        RouteGroupBuilder group = endpoints.MapGranitGroup(options.RoutePrefix);
+
+        RouteGroupBuilder plansGroup = group.MapGranitGroup(string.Empty)
+            .WithTags(options.PlansTagName);
+        plansGroup.MapPlanReadEndpoints();
+        plansGroup.MapPlanWriteEndpoints();
+
+        RouteGroupBuilder pricesGroup = group.MapGranitGroup(string.Empty)
+            .WithTags(options.PricesTagName);
+        pricesGroup.MapPriceVersioningEndpoints();
+
+        RouteGroupBuilder subscriptionsGroup = group.MapGranitGroup(string.Empty)
+            .WithTags(options.SubscriptionsTagName);
+        subscriptionsGroup.MapSubscriptionEndpoints();
 
         // Query engine endpoint — paginated, filterable list.
         // When no tenant context is active, the IQueryableSource disables the
         // multi-tenant filter so host admin sees all subscriptions cross-tenant.
-        group.MapGranitGroup("subscriptions").MapGranitQuery<Subscription>();
+        subscriptionsGroup.MapGranitGroup("subscriptions").MapGranitQuery<Subscription>();
+
+        RouteGroupBuilder seatsGroup = group.MapGranitGroup(string.Empty)
+            .WithTags(options.SeatsTagName);
+        seatsGroup.MapSeatEndpoints();
 
         return group;
     }

--- a/src/Granit.Subscriptions.Endpoints/Options/SubscriptionsEndpointsOptions.cs
+++ b/src/Granit.Subscriptions.Endpoints/Options/SubscriptionsEndpointsOptions.cs
@@ -1,0 +1,40 @@
+namespace Granit.Subscriptions.Endpoints.Options;
+
+/// <summary>
+/// Configuration options for the subscriptions endpoints.
+/// </summary>
+public sealed class SubscriptionsEndpointsOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "SubscriptionsEndpoints";
+
+    /// <summary>
+    /// Route prefix for all subscription endpoints.
+    /// Default: <c>"subscriptions"</c>.
+    /// </summary>
+    public string RoutePrefix { get; set; } = "subscriptions";
+
+    /// <summary>
+    /// OpenAPI tag name for plan catalog endpoints.
+    /// Default: <c>"Subscriptions - Plans"</c>.
+    /// </summary>
+    public string PlansTagName { get; set; } = "Subscriptions - Plans";
+
+    /// <summary>
+    /// OpenAPI tag name for price version endpoints.
+    /// Default: <c>"Subscriptions - Prices"</c>.
+    /// </summary>
+    public string PricesTagName { get; set; } = "Subscriptions - Prices";
+
+    /// <summary>
+    /// OpenAPI tag name for subscription lifecycle endpoints.
+    /// Default: <c>"Subscriptions - Subscriptions"</c>.
+    /// </summary>
+    public string SubscriptionsTagName { get; set; } = "Subscriptions - Subscriptions";
+
+    /// <summary>
+    /// OpenAPI tag name for seat assignment endpoints.
+    /// Default: <c>"Subscriptions - Seats"</c>.
+    /// </summary>
+    public string SeatsTagName { get; set; } = "Subscriptions - Seats";
+}

--- a/src/Granit.Tax.Endpoints/Extensions/TaxEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Tax.Endpoints/Extensions/TaxEndpointRouteBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Granit.Authorization.Extensions;
 using Granit.QueryEngine.AspNetCore.Extensions;
 using Granit.Tax.Endpoints.Endpoints;
+using Granit.Tax.Endpoints.Options;
 using Granit.Tax.Endpoints.Permissions;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
@@ -13,19 +14,27 @@ namespace Granit.Tax.Endpoints.Extensions;
 public static class TaxEndpointRouteBuilderExtensions
 {
     /// <summary>Maps the tax administration endpoints.</summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="configure">Optional delegate to customize <see cref="TaxEndpointsOptions"/>.</param>
+    /// <returns>The <see cref="RouteGroupBuilder"/> for further chaining.</returns>
     public static RouteGroupBuilder MapGranitTax(
-        this IEndpointRouteBuilder endpoints)
+        this IEndpointRouteBuilder endpoints,
+        Action<TaxEndpointsOptions>? configure = null)
     {
-        RouteGroupBuilder group = endpoints
-            .MapGranitGroup("tax")
-            .WithTags("Tax");
+        TaxEndpointsOptions options = new();
+        configure?.Invoke(options);
 
-        group.MapGranitGroup("ids").MapValidationEndpoints();
+        RouteGroupBuilder group = endpoints.MapGranitGroup(options.RoutePrefix);
+
+        group.MapGranitGroup("ids")
+            .WithTags(options.ValidationTagName)
+            .MapValidationEndpoints();
 
         // Rate endpoints — query engine for list/meta/saved-views, custom lookup for /{countryCode}.
         // Both behind Tax.Rates.Read.
         RouteGroupBuilder ratesGroup = group
             .MapGranitGroup("rates")
+            .WithTags(options.RatesTagName)
             .RequireAuthorization(TaxPermissions.Rates.Read)
             .AllowHostAccess();
         ratesGroup.MapGranitQuery<TaxRateEntry>();

--- a/src/Granit.Tax.Endpoints/Options/TaxEndpointsOptions.cs
+++ b/src/Granit.Tax.Endpoints/Options/TaxEndpointsOptions.cs
@@ -1,0 +1,28 @@
+namespace Granit.Tax.Endpoints.Options;
+
+/// <summary>
+/// Configuration options for the tax endpoints.
+/// </summary>
+public sealed class TaxEndpointsOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "TaxEndpoints";
+
+    /// <summary>
+    /// Route prefix for all tax endpoints.
+    /// Default: <c>"tax"</c>.
+    /// </summary>
+    public string RoutePrefix { get; set; } = "tax";
+
+    /// <summary>
+    /// OpenAPI tag name for tax-ID validation endpoints.
+    /// Default: <c>"Tax - Validation"</c>.
+    /// </summary>
+    public string ValidationTagName { get; set; } = "Tax - Validation";
+
+    /// <summary>
+    /// OpenAPI tag name for tax rate lookup endpoints.
+    /// Default: <c>"Tax - Rates"</c>.
+    /// </summary>
+    public string RatesTagName { get; set; } = "Tax - Rates";
+}

--- a/src/Granit.Webhooks/Endpoints/WebhookRedeliveryEndpoint.cs
+++ b/src/Granit.Webhooks/Endpoints/WebhookRedeliveryEndpoint.cs
@@ -15,14 +15,21 @@ public static class WebhookRedeliveryEndpoint
     /// <summary>
     /// Maps <c>POST /webhooks/deliveries/{deliveryId}/retry</c> (or custom prefix).
     /// </summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="routePrefix">Route prefix. Default <c>"webhooks"</c>.</param>
+    /// <param name="tagName">
+    /// OpenAPI tag. Default <c>"Webhooks"</c> — matches <c>WebhooksEndpointsOptions.TagName</c>.
+    /// Override when the host customizes the Webhooks tag.
+    /// </param>
     public static IEndpointRouteBuilder MapGranitWebhooksRedelivery(
         this IEndpointRouteBuilder endpoints,
-        string routePrefix = "webhooks")
+        string routePrefix = "webhooks",
+        string tagName = "Webhooks")
     {
         endpoints
             .MapPost($"{routePrefix}/deliveries/{{deliveryId:guid}}/retry", HandleRetryAsync)
             .WithName("RetryWebhookDelivery")
-            .WithTags("Webhooks")
+            .WithTags(tagName)
             .WithSummary("Retries a previously failed webhook delivery attempt.")
             .WithDescription("Enqueues a manual redelivery for a previously failed webhook delivery attempt. Returns 404 if the delivery does not exist, 409 if the delivery is not in a retryable state (e.g., already succeeded or retry in progress), and 400 for other validation errors.")
             .RequireAuthorization()

--- a/tests/Granit.Settings.Endpoints.Tests/SettingsEndpointsOptionsTests.cs
+++ b/tests/Granit.Settings.Endpoints.Tests/SettingsEndpointsOptionsTests.cs
@@ -31,11 +31,27 @@ public sealed class SettingsEndpointsOptionsTests
     }
 
     [Fact]
-    public void TagName_Default_IsSettings()
+    public void GlobalTagName_Default_IsSettingsGlobal()
     {
         SettingsEndpointsOptions options = new();
 
-        options.TagName.ShouldBe("Settings");
+        options.GlobalTagName.ShouldBe("Settings - Global");
+    }
+
+    [Fact]
+    public void TenantTagName_Default_IsSettingsTenant()
+    {
+        SettingsEndpointsOptions options = new();
+
+        options.TenantTagName.ShouldBe("Settings - Tenant");
+    }
+
+    [Fact]
+    public void UserTagName_Default_IsSettingsUser()
+    {
+        SettingsEndpointsOptions options = new();
+
+        options.UserTagName.ShouldBe("Settings - User");
     }
 
     [Fact]
@@ -46,12 +62,16 @@ public sealed class SettingsEndpointsOptionsTests
             UserRoutePrefix = "custom/user",
             GlobalRoutePrefix = "custom/global",
             TenantRoutePrefix = "custom/tenant",
-            TagName = "CustomTag",
+            GlobalTagName = "CustomGlobal",
+            TenantTagName = "CustomTenant",
+            UserTagName = "CustomUser",
         };
 
         options.UserRoutePrefix.ShouldBe("custom/user");
         options.GlobalRoutePrefix.ShouldBe("custom/global");
         options.TenantRoutePrefix.ShouldBe("custom/tenant");
-        options.TagName.ShouldBe("CustomTag");
+        options.GlobalTagName.ShouldBe("CustomGlobal");
+        options.TenantTagName.ShouldBe("CustomTenant");
+        options.UserTagName.ShouldBe("CustomUser");
     }
 }


### PR DESCRIPTION
## Summary

Applies the `Module - SubGroup` tag convention (already used by AI, Identity, Account) to the last few endpoint modules that were still bundling heterogeneous sub-domains under a single flat tag. Also removes every remaining hardcoded `.WithTags("...")` site and routes satellite endpoints through their owning module's options.

### Tag splits (breaking)

| Module | Before | After |
|---|---|---|
| Subscriptions | `Subscriptions` | `Subscriptions - Plans`, `Subscriptions - Prices`, `Subscriptions - Subscriptions`, `Subscriptions - Seats` |
| Settings | `Settings` | `Settings - Global`, `Settings - Tenant`, `Settings - User` |
| Payments | `Payments` | `Payments - Transactions`, `Payments - Methods`, `Payments - Configuration`, `Payments - Webhooks` |
| Tax | `Tax` | `Tax - Validation`, `Tax - Rates` |
| BFF | `BFF (name)` | `BFF - {name}` (parens → dash separator) |

### New `*EndpointsOptions` (with `RoutePrefix` + `TagName`)

Subscriptions, Payments, Tax, Invoicing, CustomerBalance, Metering — removing every remaining `WithTags("...")` hardcode and aligning with every other endpoint module.

### Satellite endpoint tag wiring

- `MobilePushTokenEndpoints` now reads `NotificationEndpointsOptions.MobilePushTagName`.
- `IdentityWebhookEndpoints` now reads `IdentityEndpointsOptions.WebhookTagName`.
- `MapGranitBlobProxy` reads `ProxyBlobOptions.TagName`.
- `MapGranitWebhooksRedelivery` and `MapGranitPrivacyExportDownload` (in packages that can't reference their owner's options) accept a `tagName` parameter with a default matching the owning module so hosts can stay consistent with any override.

## BREAKING CHANGE

Generated SDK grouping and Scalar UI tag labels change for Subscriptions, Settings, Payments, Tax, and BFF endpoints. Frontend codegen must be regenerated (showcase-admin-react and any downstream consumers).

## Test plan

- [x] `dotnet build Granit.slnx` — clean
- [x] `dotnet format --verify-no-changes` on touched files — clean
- [x] Endpoint test projects green: Bff, CustomerBalance, Identity, Invoicing, Metering, Notifications, Payments, Privacy, Subscriptions, Tax, Webhooks, Settings (542 tests)
- [x] `tests/Granit.ArchitectureTests` — 117/117 green
- [ ] Regenerate frontend SDK after merge, verify Scalar UI groups sub-tags correctly