### PR TITLE
feat(metering): expose QueryEngine endpoints for meters and usage aggregates

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -22809,7 +22809,7 @@
       "kind": "class",
       "project": "Granit.Metering.Endpoints",
       "file": "src/Granit.Metering.Endpoints/Extensions/MeteringEndpointRouteBuilderExtensions.cs",
-      "line": 13,
+      "line": 16,
       "members": [
         {
           "name": "MapGranitMetering",
@@ -22883,7 +22883,7 @@
       "kind": "class",
       "project": "Granit.Metering.EntityFrameworkCore",
       "file": "src/Granit.Metering.EntityFrameworkCore/Extensions/MeteringEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 13,
+      "line": 15,
       "members": [
         {
           "name": "AddGranitMeteringEntityFrameworkCore",

--- a/docs-site/src/content/docs/dotnet/saas/metering.mdx
+++ b/docs-site/src/content/docs/dotnet/saas/metering.mdx
@@ -265,9 +265,17 @@ Table prefix: `metering_` (configurable via `GranitMeteringDbProperties.DbTableP
 | GET | `/api/granit/metering/usage` | `Metering.Usage.Read` |
 | GET | `/api/granit/metering/quota/{meterId}` | `Metering.Usage.Read` |
 | POST | `/api/granit/metering/events` | `Metering.Usage.Record` |
+| GET | `/api/granit/metering/meter-definitions` | `Metering.Meters.Read` |
+| GET | `/api/granit/metering/usage-aggregates` | `Metering.Usage.Read` |
 
 All usage endpoints require tenant context. `POST /events` validates that each
 `MeterDefinitionId` in the batch belongs to the current tenant and is active.
+
+The `/meter-definitions` and `/usage-aggregates` routes expose the full Granit
+**QueryEngine** surface (`/`, `/meta`, `/saved-views/*`) — filter, sort, group,
+paginate, export to CSV/XLSX, and save per-user views. When called without a
+tenant context (host admin), the multi-tenant query filter is bypassed so the
+host can review usage cross-tenant.
 
 ## See also
 

--- a/src/Granit.Metering.Endpoints/Extensions/MeteringEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Metering.Endpoints/Extensions/MeteringEndpointRouteBuilderExtensions.cs
@@ -1,5 +1,8 @@
+using Granit.Metering.Domain;
 using Granit.Metering.Endpoints.Endpoints;
 using Granit.Metering.Endpoints.Options;
+using Granit.Metering.Endpoints.Permissions;
+using Granit.QueryEngine.AspNetCore.Extensions;
 using Granit.Validation.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -29,6 +32,17 @@ public static class MeteringEndpointRouteBuilderExtensions
 
         group.MapMeterDefinitionEndpoints();
         group.MapUsageEndpoints();
+
+        // Admin query endpoints — list / filter / sort / paginate / export via the QueryEngine.
+        // Mounted on dedicated sub-paths to avoid colliding with the business endpoints above
+        // (/meters returns only active meters; /usage returns a single aggregate by period).
+        group.MapGranitGroup("meter-definitions")
+            .MapGranitQuery<MeterDefinition>()
+            .RequireAuthorization(MeteringPermissions.Meters.Read);
+
+        group.MapGranitGroup("usage-aggregates")
+            .MapGranitQuery<UsageAggregate>()
+            .RequireAuthorization(MeteringPermissions.Usage.Read);
 
         return group;
     }

--- a/src/Granit.Metering.Endpoints/README.md
+++ b/src/Granit.Metering.Endpoints/README.md
@@ -11,3 +11,10 @@ Minimal API endpoints for Granit.Metering.
 | PUT | `/api/granit/metering/meters/{id}` | `Metering.Meters.Manage` |
 | GET | `/api/granit/metering/usage` | `Metering.Usage.Read` |
 | GET | `/api/granit/metering/quota/{meterId}` | `Metering.Usage.Read` |
+| GET | `/api/granit/metering/meter-definitions` (+ `/meta`, `/saved-views/*`) | `Metering.Meters.Read` |
+| GET | `/api/granit/metering/usage-aggregates` (+ `/meta`, `/saved-views/*`) | `Metering.Usage.Read` |
+
+The `/meter-definitions` and `/usage-aggregates` routes expose the Granit
+QueryEngine (filter, sort, group, paginate, CSV/XLSX export, saved views).
+When called without a tenant context (host admin), the multi-tenant query
+filter is bypassed for cross-tenant review.

--- a/src/Granit.Metering.EntityFrameworkCore/Extensions/MeteringEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Extensions/MeteringEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,5 +1,7 @@
+using Granit.Metering.Domain;
 using Granit.Metering.EntityFrameworkCore.Internal;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -30,6 +32,10 @@ public static class MeteringEntityFrameworkCoreHostApplicationBuilderExtensions
 
         builder.Services.TryAddScoped<IAggregationRunner, EfAggregationRunner>();
         builder.Services.TryAddScoped<IQuotaChecker, EfQuotaChecker>();
+
+        // Queryable sources for MapGranitQuery (host bypasses tenant filter for cross-tenant review).
+        builder.Services.AddScoped<IQueryableSource<MeterDefinition>, EfMeterDefinitionQueryableSource>();
+        builder.Services.AddScoped<IQueryableSource<UsageAggregate>, EfUsageAggregateQueryableSource>();
 
         return builder;
     }

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/EfMeterDefinitionQueryableSource.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/EfMeterDefinitionQueryableSource.cs
@@ -1,0 +1,28 @@
+using Granit.Metering.Domain;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Metering.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="MeterDefinition"/>.
+/// When no tenant context is active (host admin), the multi-tenant query filter is bypassed
+/// so all meter definitions are returned cross-tenant — required for platform-wide administration.
+/// </summary>
+internal sealed class EfMeterDefinitionQueryableSource(
+    IDbContextFactory<MeteringDbContext> contextFactory,
+    ICurrentTenant currentTenant) : IQueryableSource<MeterDefinition>
+{
+    private readonly MeteringDbContext _context = contextFactory.CreateDbContext();
+    private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+
+    public IQueryable<MeterDefinition> GetQueryable()
+    {
+        IQueryable<MeterDefinition> query = _context.MeterDefinitions.AsNoTracking();
+        return _bypassTenantFilter
+            ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            : query;
+    }
+}

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/EfUsageAggregateQueryableSource.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/EfUsageAggregateQueryableSource.cs
@@ -1,0 +1,28 @@
+using Granit.Metering.Domain;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore;
+using Granit.QueryEngine;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Metering.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IQueryableSource{TEntity}"/> for <see cref="UsageAggregate"/>.
+/// When no tenant context is active (host admin), the multi-tenant query filter is bypassed
+/// so usage rollups are returned cross-tenant — required for platform-wide usage review.
+/// </summary>
+internal sealed class EfUsageAggregateQueryableSource(
+    IDbContextFactory<MeteringDbContext> contextFactory,
+    ICurrentTenant currentTenant) : IQueryableSource<UsageAggregate>
+{
+    private readonly MeteringDbContext _context = contextFactory.CreateDbContext();
+    private readonly bool _bypassTenantFilter = !currentTenant.IsAvailable;
+
+    public IQueryable<UsageAggregate> GetQueryable()
+    {
+        IQueryable<UsageAggregate> query = _context.UsageAggregates.AsNoTracking();
+        return _bypassTenantFilter
+            ? query.IgnoreQueryFilters([GranitFilterNames.MultiTenant])
+            : query;
+    }
+}


### PR DESCRIPTION
## Summary

- Expose `MapGranitQuery<MeterDefinition>()` at `/api/granit/metering/meter-definitions` and `MapGranitQuery<UsageAggregate>()` at `/api/granit/metering/usage-aggregates`, so the Host admin can list, filter, sort, paginate and export (CSV/XLSX) meter definitions and usage rollups via the declarative `*QueryDefinition` / `*ExportDefinition` already owned by `Granit.Metering`.
- Add two `IQueryableSource<T>` EF implementations (`EfMeterDefinitionQueryableSource`, `EfUsageAggregateQueryableSource`) that follow the Auditing/Webhooks pattern: bypass the multi-tenant query filter when no tenant context is active, so the host can review usage cross-tenant.
- Keep the existing business endpoints untouched: `/meters` still returns only active meter definitions, `/usage` still returns a single aggregate for a given period. The query endpoints live on dedicated sub-paths to avoid collisions.
- Permissions reuse the existing policies (`Metering.Meters.Read`, `Metering.Usage.Read`) — no new permission constants.
- Docs + README updated with the two new routes and the cross-tenant behaviour note.

## Test plan

- [x] `dotnet build` on `Granit.Metering.EntityFrameworkCore` and `Granit.Metering.Endpoints` — clean
- [x] `dotnet format --verify-no-changes` on both projects — clean
- [x] `dotnet test tests/Granit.Metering.Endpoints.Tests` — 6/6 green
- [x] `dotnet test tests/Granit.Metering.EntityFrameworkCore.Tests` — 4/4 green
- [x] `dotnet test tests/Granit.ArchitectureTests` — 117/117 green
- [ ] Manually hit `GET /api/granit/metering/usage-aggregates/meta` in the Host to verify the Scalar UI and the `QueryMetadata` payload
- [ ] Manually hit `GET /api/granit/metering/usage-aggregates?filter[periodStart.gte]=2026-04-01` to verify filtering + pagination
- [ ] Export a CSV from `/usage-aggregates` and verify column headers use the `ExportHeader:*` localisation keys
