### PR TITLE
refactor(authorization): promote PermissionGrant to AuditedAggregateRoot

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -6213,7 +6213,7 @@
       "kind": "class",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/Domain/PermissionGrant.cs",
-      "line": 22,
+      "line": 30,
       "members": [
         {
           "name": "Name",
@@ -6232,6 +6232,12 @@
           "kind": "property",
           "signature": "string ProviderKey",
           "returnType": "string"
+        },
+        {
+          "name": "PermissionGrant",
+          "kind": "method",
+          "signature": "PermissionGrant()",
+          "returnType": "Guid? TenantId { get; private set; } private"
         }
       ]
     },
@@ -6410,7 +6416,7 @@
       "kind": "record",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/Events/PermissionGrantChangedEvent.cs",
-      "line": 17,
+      "line": 20,
       "members": []
     },
     {

--- a/src/Granit.Authorization.EntityFrameworkCore/Stores/EfCorePermissionGrantStore.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/Stores/EfCorePermissionGrantStore.cs
@@ -98,14 +98,12 @@ internal sealed class EfCorePermissionGrantStore<TContext>(
             return false;
         }
 
-        context.PermissionGrants.Add(new PermissionGrant
-        {
-            Id = guidGenerator.Create(),
-            Name = permissionName,
-            ProviderName = providerName,
-            ProviderKey = providerKey,
-            TenantId = tenantId
-        });
+        context.PermissionGrants.Add(PermissionGrant.Create(
+            guidGenerator.Create(),
+            permissionName,
+            providerName,
+            providerKey,
+            tenantId));
 
         try
         {
@@ -142,6 +140,7 @@ internal sealed class EfCorePermissionGrantStore<TContext>(
             return false;
         }
 
+        existing.MarkAsRevoked();
         context.PermissionGrants.Remove(existing);
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Granit.Authorization/Domain/PermissionGrant.cs
+++ b/src/Granit.Authorization/Domain/PermissionGrant.cs
@@ -1,3 +1,4 @@
+using Granit.Authorization.Events;
 using Granit.Domain;
 
 namespace Granit.Authorization.Domain;
@@ -15,28 +16,105 @@ namespace Granit.Authorization.Domain;
 /// geography) without schema changes.
 /// </para>
 /// <para>
-/// Audited via <see cref="AuditedEntity"/> interceptor (CreatedAt, CreatedBy, ModifiedAt,
+/// Aggregate root — invariants are enforced by the static <see cref="Create"/> factory
+/// (required fields, max lengths). External code must NOT mutate properties after creation;
+/// use <see cref="MarkAsRevoked"/> before removing the entity from the <c>DbContext</c> so
+/// the revocation <see cref="PermissionGrantChangedEvent"/> is collected by the
+/// <c>DomainEventDispatcherInterceptor</c>.
+/// </para>
+/// <para>
+/// Audited via <see cref="AuditedAggregateRoot"/> (CreatedAt, CreatedBy, ModifiedAt,
 /// ModifiedBy). Unique index covers <c>(TenantId, ProviderName, ProviderKey, Name)</c>.
 /// </para>
 /// </remarks>
-public sealed class PermissionGrant : AuditedEntity, IMultiTenant
+public sealed class PermissionGrant : AuditedAggregateRoot, IMultiTenant
 {
     /// <summary>Permission name, e.g. <c>"Invoices.Delete"</c>. Max 256 characters.</summary>
-    public string Name { get; init; } = string.Empty;
+    public string Name { get; private set; } = string.Empty;
 
     /// <summary>
     /// Provider identifier for the grantee. Use <see cref="PermissionGrantProviderNames"/>
     /// constants: <c>"R"</c> (role), <c>"U"</c> (user), <c>"C"</c> (OIDC client). Max 8 characters.
     /// </summary>
-    public string ProviderName { get; init; } = string.Empty;
+    public string ProviderName { get; private set; } = string.Empty;
 
     /// <summary>
     /// Provider-specific grantee key: role name for <c>"R"</c>, user id for <c>"U"</c>,
     /// OIDC <c>client_id</c> for <c>"C"</c>. Max 256 characters.
     /// </summary>
-    public string ProviderKey { get; init; } = string.Empty;
+    public string ProviderKey { get; private set; } = string.Empty;
 
     /// <summary>Tenant scope. Null means the grant applies at the host (cross-tenant) level.</summary>
-    /// <remarks>Keeps <c>set</c> to satisfy <see cref="IMultiTenant"/> interceptor injection.</remarks>
-    public Guid? TenantId { get; set; }
+    public Guid? TenantId { get; private set; }
+
+    /// <summary>Required by EF Core materialization — never call from application code.</summary>
+    private PermissionGrant() { }
+
+    Guid? IMultiTenant.TenantId
+    {
+        get => TenantId;
+        set => TenantId = value;
+    }
+
+    /// <summary>
+    /// Creates a new permission grant and raises a <see cref="PermissionGrantChangedEvent"/>
+    /// (<c>IsGranted = true</c>) dispatched after the transaction commits.
+    /// </summary>
+    /// <param name="id">Aggregate identifier (typically supplied by <c>IGuidGenerator</c>).</param>
+    /// <param name="permissionName">Permission name, e.g. <c>"Invoices.Delete"</c>. Max 256 chars.</param>
+    /// <param name="providerName">Provider kind: <c>"R"</c>, <c>"U"</c>, or <c>"C"</c>. Max 8 chars.</param>
+    /// <param name="providerKey">Provider-specific key. Max 256 chars.</param>
+    /// <param name="tenantId">Tenant scope, or <see langword="null"/> for host-level grants.</param>
+    public static PermissionGrant Create(
+        Guid id,
+        string permissionName,
+        string providerName,
+        string providerKey,
+        Guid? tenantId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(permissionName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerKey);
+
+        if (permissionName.Length > 256)
+        {
+            throw new ArgumentException("Permission name exceeds 256 characters.", nameof(permissionName));
+        }
+
+        if (providerName.Length > 8)
+        {
+            throw new ArgumentException("Provider name exceeds 8 characters.", nameof(providerName));
+        }
+
+        if (providerKey.Length > 256)
+        {
+            throw new ArgumentException("Provider key exceeds 256 characters.", nameof(providerKey));
+        }
+
+        PermissionGrant grant = new()
+        {
+            Id = id,
+            Name = permissionName,
+            ProviderName = providerName,
+            ProviderKey = providerKey,
+            TenantId = tenantId,
+        };
+
+        grant.AddDomainEvent(new PermissionGrantChangedEvent(
+            permissionName, providerName, providerKey, tenantId, IsGranted: true));
+
+        return grant;
+    }
+
+    /// <summary>
+    /// Raises a revocation <see cref="PermissionGrantChangedEvent"/> (<c>IsGranted = false</c>)
+    /// dispatched after the transaction commits. Call before removing the entity from the
+    /// <c>DbContext</c> so the interceptor can collect the event from the still-tracked
+    /// <c>Deleted</c> entry.
+    /// </summary>
+    public void MarkAsRevoked()
+    {
+        AddDomainEvent(new PermissionGrantChangedEvent(
+            Name, ProviderName, ProviderKey, TenantId, IsGranted: false));
+    }
 }

--- a/src/Granit.Authorization/Events/PermissionGrantChangedEvent.cs
+++ b/src/Granit.Authorization/Events/PermissionGrantChangedEvent.cs
@@ -1,3 +1,5 @@
+using Granit.Events;
+
 namespace Granit.Authorization.Events;
 
 /// <summary>
@@ -5,9 +7,10 @@ namespace Granit.Authorization.Events;
 /// OIDC client).
 /// </summary>
 /// <remarks>
-/// Consumed by <see cref="Cache.PermissionCacheInvalidationHandler"/> to remove the stale
-/// entry from <see cref="Caching.ICacheService{PermissionGrantCacheItem}"/>.
-/// Publish this event after any <see cref="IPermissionManagerWriter"/> mutation.
+/// Domain event collected from <see cref="Domain.PermissionGrant"/> via
+/// <c>AddDomainEvent</c> (create/revoke paths) and dispatched by the
+/// <c>DomainEventDispatcherInterceptor</c> after <c>SaveChanges</c> commits. Consumed by
+/// <see cref="Cache.PermissionCacheInvalidationHandler"/> to invalidate the stale entry.
 /// </remarks>
 /// <param name="PermissionName">The permission that was granted or revoked.</param>
 /// <param name="ProviderName">Provider identifier for the grantee (<c>"R"</c>, <c>"U"</c>, <c>"C"</c>).</param>
@@ -19,4 +22,4 @@ public sealed record PermissionGrantChangedEvent(
     string ProviderName,
     string ProviderKey,
     Guid? TenantId,
-    bool IsGranted);
+    bool IsGranted) : IDomainEvent;

--- a/src/Granit.Authorization/Services/PermissionManager.cs
+++ b/src/Granit.Authorization/Services/PermissionManager.cs
@@ -1,5 +1,3 @@
-using Granit.Authorization.Events;
-using Granit.Events;
 using Microsoft.Extensions.Logging;
 
 namespace Granit.Authorization.Services;
@@ -7,14 +5,14 @@ namespace Granit.Authorization.Services;
 /// <summary>
 /// Domain service implementing <see cref="IPermissionManagerReader"/> and <see cref="IPermissionManagerWriter"/>.
 /// Delegates data access to <see cref="IPermissionGrantStore"/> and provides business logic:
-/// permission definition validation, grant validation chain, event-driven cache invalidation,
-/// and ISO 27001 audit logging.
+/// permission definition validation, grant validation chain, and ISO 27001 audit logging.
+/// Cache invalidation flows through <c>PermissionGrantChangedEvent</c> domain events raised
+/// by the <c>PermissionGrant</c> aggregate and dispatched by the EF Core interceptor.
 /// </summary>
 internal sealed partial class PermissionManager(
     IPermissionGrantStore grantStore,
     IPermissionDefinitionManager definitionManager,
     IEnumerable<IPermissionGrantValidator> grantValidators,
-    ILocalEventBus eventBus,
     ILogger<PermissionManager> logger)
     : IPermissionManagerReader, IPermissionManagerWriter
 {
@@ -69,11 +67,9 @@ internal sealed partial class PermissionManager(
             return; // no-op: state already matches requested value (or idempotent race)
         }
 
-        // Event-driven cache invalidation — consumed by PermissionCacheInvalidationHandler.
-        // Decoupled from the store so other modules can react to permission changes.
-        await eventBus.PublishAsync(
-            new PermissionGrantChangedEvent(permissionName, providerName, providerKey, tenantId, isGranted),
-            cancellationToken).ConfigureAwait(false);
+        // Cache invalidation flows via PermissionGrantChangedEvent domain events raised by
+        // the PermissionGrant aggregate (Create / MarkAsRevoked) and dispatched by
+        // DomainEventDispatcherInterceptor after SaveChanges commits. No manual publish here.
 
         // ISO 27001 audit trail: emitted as structured log → Serilog → OTLP → Loki (3-year retention)
         // RGPD: no personal data — only provider key, permission name, tenant scope

--- a/tests/Granit.Authorization.EntityFrameworkCore.Tests/EfCorePermissionGrantStoreTests.cs
+++ b/tests/Granit.Authorization.EntityFrameworkCore.Tests/EfCorePermissionGrantStoreTests.cs
@@ -226,14 +226,12 @@ public sealed class EfCorePermissionGrantStoreTests
         string permissionName,
         Guid? tenantId)
     {
-        context.PermissionGrants.Add(new PermissionGrant
-        {
-            Id = Guid.NewGuid(),
-            Name = permissionName,
-            ProviderName = R,
-            ProviderKey = roleName,
-            TenantId = tenantId
-        });
+        context.PermissionGrants.Add(PermissionGrant.Create(
+            Guid.NewGuid(),
+            permissionName,
+            R,
+            roleName,
+            tenantId));
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/tests/Granit.Authorization.EntityFrameworkCore.Tests/PermissionGrantEntityTests.cs
+++ b/tests/Granit.Authorization.EntityFrameworkCore.Tests/PermissionGrantEntityTests.cs
@@ -1,5 +1,6 @@
 using Granit.Authorization;
 using Granit.Authorization.Domain;
+using Granit.Authorization.Events;
 using Granit.Domain;
 using Shouldly;
 using Xunit;
@@ -9,67 +10,33 @@ namespace Granit.Authorization.EntityFrameworkCore.Tests;
 public sealed class PermissionGrantEntityTests
 {
     [Fact]
-    public void InheritsFromAuditedEntity()
+    public void InheritsFromAuditedAggregateRoot()
     {
-        PermissionGrant grant = new();
+        PermissionGrant grant = NewGrant();
 
-        grant.ShouldBeAssignableTo<AuditedEntity>();
+        grant.ShouldBeAssignableTo<AuditedAggregateRoot>();
     }
 
     [Fact]
     public void ImplementsIMultiTenant()
     {
-        PermissionGrant grant = new();
+        PermissionGrant grant = NewGrant();
 
         grant.ShouldBeAssignableTo<IMultiTenant>();
     }
 
     [Fact]
-    public void Name_Default_IsEmptyString()
+    public void Create_PopulatesAllProperties()
     {
-        PermissionGrant grant = new();
-
-        grant.Name.ShouldBe(string.Empty);
-    }
-
-    [Fact]
-    public void ProviderName_Default_IsEmptyString()
-    {
-        PermissionGrant grant = new();
-
-        grant.ProviderName.ShouldBe(string.Empty);
-    }
-
-    [Fact]
-    public void ProviderKey_Default_IsEmptyString()
-    {
-        PermissionGrant grant = new();
-
-        grant.ProviderKey.ShouldBe(string.Empty);
-    }
-
-    [Fact]
-    public void TenantId_Default_IsNull()
-    {
-        PermissionGrant grant = new();
-
-        grant.TenantId.ShouldBeNull();
-    }
-
-    [Fact]
-    public void Properties_CanBeSet()
-    {
-        var tenantId = Guid.NewGuid();
         var id = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
 
-        PermissionGrant grant = new()
-        {
-            Id = id,
-            Name = "Invoices.Delete",
-            ProviderName = PermissionGrantProviderNames.Role,
-            ProviderKey = "accountant",
-            TenantId = tenantId
-        };
+        var grant = PermissionGrant.Create(
+            id,
+            "Invoices.Delete",
+            PermissionGrantProviderNames.Role,
+            "accountant",
+            tenantId);
 
         grant.Id.ShouldBe(id);
         grant.Name.ShouldBe("Invoices.Delete");
@@ -77,4 +44,103 @@ public sealed class PermissionGrantEntityTests
         grant.ProviderKey.ShouldBe("accountant");
         grant.TenantId.ShouldBe(tenantId);
     }
+
+    [Fact]
+    public void Create_HostScoped_LeavesTenantIdNull()
+    {
+        var grant = PermissionGrant.Create(
+            Guid.NewGuid(), "Invoices.Delete", "R", "accountant", tenantId: null);
+
+        grant.TenantId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Create_RaisesGrantChangedEvent_IsGrantedTrue()
+    {
+        var tenantId = Guid.NewGuid();
+
+        var grant = PermissionGrant.Create(
+            Guid.NewGuid(), "Invoices.Delete", "R", "accountant", tenantId);
+
+        grant.DomainEvents.Count.ShouldBe(1);
+        PermissionGrantChangedEvent evt = grant.DomainEvents.Single().ShouldBeOfType<PermissionGrantChangedEvent>();
+        evt.PermissionName.ShouldBe("Invoices.Delete");
+        evt.ProviderName.ShouldBe("R");
+        evt.ProviderKey.ShouldBe("accountant");
+        evt.TenantId.ShouldBe(tenantId);
+        evt.IsGranted.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void MarkAsRevoked_RaisesGrantChangedEvent_IsGrantedFalse()
+    {
+        var grant = PermissionGrant.Create(
+            Guid.NewGuid(), "Invoices.Delete", "R", "accountant", tenantId: null);
+        grant.ClearDomainEvents();
+
+        grant.MarkAsRevoked();
+
+        grant.DomainEvents.Count.ShouldBe(1);
+        PermissionGrantChangedEvent evt = grant.DomainEvents.Single().ShouldBeOfType<PermissionGrantChangedEvent>();
+        evt.PermissionName.ShouldBe("Invoices.Delete");
+        evt.IsGranted.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Create_RejectsNullOrWhitespacePermissionName(string? permissionName)
+    {
+        Should.Throw<ArgumentException>(() =>
+            PermissionGrant.Create(Guid.NewGuid(), permissionName!, "R", "accountant", null));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Create_RejectsNullOrWhitespaceProviderName(string? providerName)
+    {
+        Should.Throw<ArgumentException>(() =>
+            PermissionGrant.Create(Guid.NewGuid(), "Invoices.Delete", providerName!, "accountant", null));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Create_RejectsNullOrWhitespaceProviderKey(string? providerKey)
+    {
+        Should.Throw<ArgumentException>(() =>
+            PermissionGrant.Create(Guid.NewGuid(), "Invoices.Delete", "R", providerKey!, null));
+    }
+
+    [Fact]
+    public void Create_RejectsPermissionNameOver256Chars()
+    {
+        string longName = new('x', 257);
+
+        Should.Throw<ArgumentException>(() =>
+            PermissionGrant.Create(Guid.NewGuid(), longName, "R", "accountant", null));
+    }
+
+    [Fact]
+    public void Create_RejectsProviderNameOver8Chars()
+    {
+        Should.Throw<ArgumentException>(() =>
+            PermissionGrant.Create(Guid.NewGuid(), "Invoices.Delete", "ProviderTooLong", "accountant", null));
+    }
+
+    [Fact]
+    public void Create_RejectsProviderKeyOver256Chars()
+    {
+        string longKey = new('x', 257);
+
+        Should.Throw<ArgumentException>(() =>
+            PermissionGrant.Create(Guid.NewGuid(), "Invoices.Delete", "R", longKey, null));
+    }
+
+    private static PermissionGrant NewGrant() =>
+        PermissionGrant.Create(Guid.NewGuid(), "Sample.Perm", "R", "role-a", null);
 }

--- a/tests/Granit.Authorization.Tests/PermissionManagerTests.cs
+++ b/tests/Granit.Authorization.Tests/PermissionManagerTests.cs
@@ -5,16 +5,18 @@
 //   - Validates permission definition before store access
 //   - Delegates grant/revoke to IPermissionGrantStore using the
 //     (providerName, providerKey) tuple
-//   - Publishes PermissionGrantChangedEvent + emits [AUDIT] log on state change
-//   - Is no-op when store reports no change (idempotent)
+//   - Emits the [AUDIT] log on state change
+//   - Is no-op (no audit log) when store reports no change (idempotent)
 //   - Throws InvalidOperationException for undefined permissions
 //   - Delegates read operations to IPermissionGrantStore
+//
+// Cache invalidation via PermissionGrantChangedEvent is now raised by the
+// PermissionGrant aggregate (Create / MarkAsRevoked) and dispatched by the
+// DomainEventDispatcherInterceptor — covered in PermissionGrantEntityTests.
 // =============================================================================
 
 using Granit.Authorization;
-using Granit.Authorization.Events;
 using Granit.Authorization.Services;
-using Granit.Events;
 using Granit.MultiTenancy;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -33,10 +35,9 @@ public sealed class PermissionManagerTests
     // --- SetAsync: grant ---
 
     [Fact]
-    public async Task SetAsync_GrantNew_DelegatesToStorePublishesEventAndLogsAudit()
+    public async Task SetAsync_GrantNew_DelegatesToStoreAndLogsAudit()
     {
-        (PermissionManager manager, IPermissionGrantStore store,
-            ILocalEventBus eventBus, ILogger<PermissionManager> logger) = BuildManager();
+        (PermissionManager manager, IPermissionGrantStore store, ILogger<PermissionManager> logger) = BuildManager();
 
         store.GrantAsync(R, "accountant", DefinedPermission, TenantId, Arg.Any<CancellationToken>())
             .Returns(true);
@@ -44,15 +45,6 @@ public sealed class PermissionManagerTests
         await manager.SetAsync(DefinedPermission, R, "accountant", TenantId, isGranted: true, TestContext.Current.CancellationToken);
 
         await store.Received(1).GrantAsync(R, "accountant", DefinedPermission, TenantId, Arg.Any<CancellationToken>());
-
-        await eventBus.Received(1).PublishAsync(
-            Arg.Is<PermissionGrantChangedEvent>(e =>
-                e.PermissionName == DefinedPermission &&
-                e.ProviderName == R &&
-                e.ProviderKey == "accountant" &&
-                e.TenantId == TenantId &&
-                e.IsGranted),
-            Arg.Any<CancellationToken>());
 
         logger.Received(1).Log(
             LogLevel.Information,
@@ -65,10 +57,9 @@ public sealed class PermissionManagerTests
     // --- SetAsync: revoke ---
 
     [Fact]
-    public async Task SetAsync_RevokeExisting_DelegatesToStorePublishesEventAndLogsAudit()
+    public async Task SetAsync_RevokeExisting_DelegatesToStoreAndLogsAudit()
     {
-        (PermissionManager manager, IPermissionGrantStore store,
-            ILocalEventBus eventBus, ILogger<PermissionManager> logger) = BuildManager();
+        (PermissionManager manager, IPermissionGrantStore store, ILogger<PermissionManager> logger) = BuildManager();
 
         store.RevokeAsync(R, "accountant", DefinedPermission, TenantId, Arg.Any<CancellationToken>())
             .Returns(true);
@@ -76,15 +67,6 @@ public sealed class PermissionManagerTests
         await manager.SetAsync(DefinedPermission, R, "accountant", TenantId, isGranted: false, TestContext.Current.CancellationToken);
 
         await store.Received(1).RevokeAsync(R, "accountant", DefinedPermission, TenantId, Arg.Any<CancellationToken>());
-
-        await eventBus.Received(1).PublishAsync(
-            Arg.Is<PermissionGrantChangedEvent>(e =>
-                e.PermissionName == DefinedPermission &&
-                e.ProviderName == R &&
-                e.ProviderKey == "accountant" &&
-                e.TenantId == TenantId &&
-                !e.IsGranted),
-            Arg.Any<CancellationToken>());
 
         logger.Received(1).Log(
             LogLevel.Information,
@@ -97,18 +79,14 @@ public sealed class PermissionManagerTests
     // --- SetAsync: no-op ---
 
     [Fact]
-    public async Task SetAsync_GrantAlreadyExists_NoOpNoEventNoLog()
+    public async Task SetAsync_GrantAlreadyExists_NoOpNoLog()
     {
-        (PermissionManager manager, IPermissionGrantStore store,
-            ILocalEventBus eventBus, ILogger<PermissionManager> logger) = BuildManager();
+        (PermissionManager manager, IPermissionGrantStore store, ILogger<PermissionManager> logger) = BuildManager();
 
         store.GrantAsync(R, "accountant", DefinedPermission, TenantId, Arg.Any<CancellationToken>())
             .Returns(false); // store reports no change (already existed)
 
         await manager.SetAsync(DefinedPermission, R, "accountant", TenantId, isGranted: true, TestContext.Current.CancellationToken);
-
-        await eventBus.DidNotReceive().PublishAsync(
-            Arg.Any<PermissionGrantChangedEvent>(), Arg.Any<CancellationToken>());
 
         logger.DidNotReceive().Log(
             Arg.Any<LogLevel>(),
@@ -123,7 +101,7 @@ public sealed class PermissionManagerTests
     [Fact]
     public async Task SetAsync_UndefinedPermission_ThrowsWithoutStoreAccess()
     {
-        (PermissionManager manager, IPermissionGrantStore store, _, _) = BuildManager();
+        (PermissionManager manager, IPermissionGrantStore store, _) = BuildManager();
 
         Func<Task> act = () => manager.SetAsync(UndefinedPermission, R, "accountant", TenantId, isGranted: true);
 
@@ -138,7 +116,7 @@ public sealed class PermissionManagerTests
     [Fact]
     public async Task SetAsync_GrantRejectedByValidator_ThrowsWithoutStoreAccess()
     {
-        (PermissionManager manager, IPermissionGrantStore store, _, _) = BuildManager(
+        (PermissionManager manager, IPermissionGrantStore store, _) = BuildManager(
             validators:
             [
                 new StubValidator(PermissionGrantValidationResult.Reject("test_reject", "nope"))
@@ -158,7 +136,7 @@ public sealed class PermissionManagerTests
         // Validators only gate additions; revocations must always proceed so that a grant made
         // under relaxed rules can still be removed after the policy tightens.
         StubValidator hostile = new(PermissionGrantValidationResult.Reject("would_block", "should not fire"));
-        (PermissionManager manager, IPermissionGrantStore store, _, _) = BuildManager(validators: [hostile]);
+        (PermissionManager manager, IPermissionGrantStore store, _) = BuildManager(validators: [hostile]);
 
         store.RevokeAsync(R, "accountant", DefinedPermission, TenantId, Arg.Any<CancellationToken>())
             .Returns(true);
@@ -174,7 +152,7 @@ public sealed class PermissionManagerTests
     [Fact]
     public async Task IsGrantedAsync_DelegatesToStore()
     {
-        (PermissionManager manager, IPermissionGrantStore store, _, _) = BuildManager();
+        (PermissionManager manager, IPermissionGrantStore store, _) = BuildManager();
         store.IsGrantedAsync(R, "accountant", DefinedPermission, TenantId, Arg.Any<CancellationToken>())
             .Returns(true);
 
@@ -188,7 +166,7 @@ public sealed class PermissionManagerTests
     [Fact]
     public async Task GetGrantedPermissionsAsync_DelegatesToStore()
     {
-        (PermissionManager manager, IPermissionGrantStore store, _, _) = BuildManager();
+        (PermissionManager manager, IPermissionGrantStore store, _) = BuildManager();
         IReadOnlyList<string> expected = ["Invoices.Delete", "Invoices.Read"];
         store.GetGrantedPermissionsAsync(R, "accountant", TenantId, Arg.Any<CancellationToken>())
             .Returns(expected);
@@ -204,7 +182,7 @@ public sealed class PermissionManagerTests
     [Fact]
     public async Task GetGranteesAsync_DelegatesToStore()
     {
-        (PermissionManager manager, IPermissionGrantStore store, _, _) = BuildManager();
+        (PermissionManager manager, IPermissionGrantStore store, _) = BuildManager();
         IReadOnlyList<string> expected = ["accountant", "manager"];
         store.GetGranteesAsync(R, DefinedPermission, TenantId, Arg.Any<CancellationToken>())
             .Returns(expected);
@@ -217,9 +195,8 @@ public sealed class PermissionManagerTests
 
     // --- Helpers ---
 
-    private static (PermissionManager, IPermissionGrantStore,
-        ILocalEventBus, ILogger<PermissionManager>) BuildManager(
-            IEnumerable<IPermissionGrantValidator>? validators = null)
+    private static (PermissionManager, IPermissionGrantStore, ILogger<PermissionManager>) BuildManager(
+        IEnumerable<IPermissionGrantValidator>? validators = null)
     {
         IPermissionGrantStore store = Substitute.For<IPermissionGrantStore>();
 
@@ -230,8 +207,6 @@ public sealed class PermissionManagerTests
             .Returns(new PermissionDefinition(DefinedPermission, null, "TestGroup", MultiTenancySide.Both));
         definitionManager.Find(UndefinedPermission).Returns((PermissionDefinition?)null);
 
-        ILocalEventBus eventBus = Substitute.For<ILocalEventBus>();
-
         ILogger<PermissionManager> logger = Substitute.For<ILogger<PermissionManager>>();
         logger.IsEnabled(LogLevel.Information).Returns(true);
 
@@ -239,10 +214,9 @@ public sealed class PermissionManagerTests
             store,
             definitionManager,
             grantValidators: validators ?? [],
-            eventBus,
             logger);
 
-        return (manager, store, eventBus, logger);
+        return (manager, store, logger);
     }
 
     private sealed class StubValidator(PermissionGrantValidationResult result) : IPermissionGrantValidator


### PR DESCRIPTION
## Summary

Align `PermissionGrant` on the aggregate root pattern used throughout the framework
(private setters, static `Create` factory, domain events via `AddDomainEvent`) so that
the upcoming `RoleMetadata` aggregate lands in a coherent module. No behavioral change.

- `PermissionGrant` now extends `AuditedAggregateRoot`, exposes only private setters, and has an explicit `IMultiTenant.TenantId` interface implementation.
- Invariants enforced in `PermissionGrant.Create(id, permissionName, providerName, providerKey, tenantId)`: non-null / non-whitespace fields, max lengths (256 / 8 / 256).
- `PermissionGrantChangedEvent` is now a proper `IDomainEvent`. It is raised by `Create` (`IsGranted: true`) and by a new `MarkAsRevoked()` method (`IsGranted: false`) instead of being published manually from `PermissionManager`.
- `EfCorePermissionGrantStore.GrantAsync` uses the factory; `RevokeAsync` calls `MarkAsRevoked()` before `Remove` so `DomainEventDispatcherInterceptor` can collect the event from the still-tracked `Deleted` entry.
- `PermissionManager` no longer depends on `ILocalEventBus` — cache invalidation flows via the aggregate → interceptor → `IDomainEventDispatcher` → Wolverine. `PermissionCacheInvalidationHandler` routing is preserved.

## Why

Upcoming `RoleMetadata` + role CRUD work needs the same DDD treatment (aggregate root
with invariants on `MultiTenancySide` and `TenantId`). Shipping both in a single PR
would mix refactor and feature concerns; this prep-PR lands the pattern alignment
first with zero functional change.

## Test plan

- [x] `dotnet test tests/Granit.Authorization.Tests` — 202 / 202 passed
- [x] `dotnet test tests/Granit.Authorization.EntityFrameworkCore.Tests` — 40 / 40 passed (includes rewritten `PermissionGrantEntityTests` covering factory invariants, domain events from `Create` and `MarkAsRevoked`, `AuditedAggregateRoot` inheritance)
- [x] `dotnet test tests/Granit.ArchitectureTests --filter DomainConventionTests` — 7 / 7 passed (private setters, factory method, private ctor rules now cover `PermissionGrant`)
- [ ] Verify cache invalidation still fires end-to-end through the domain event dispatcher on an integration environment