### PR TITLE
feat(authorization, identity-local): Phase 1 — RoleMetadata + role CRUD

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19577,7 +19577,7 @@
       "kind": "record",
       "project": "Granit.Identity.Local",
       "file": "src/Granit.Identity.Local/Services/IGranitRoleOrchestrator.cs",
-      "line": 59,
+      "line": 60,
       "members": []
     },
     {
@@ -19720,7 +19720,7 @@
       "kind": "interface",
       "project": "Granit.Identity.Local",
       "file": "src/Granit.Identity.Local/Services/IGranitRoleOrchestrator.cs",
-      "line": 27,
+      "line": 28,
       "members": [
         {
           "name": "CreateAsync",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18126,22 +18126,6 @@
       ]
     },
     {
-      "name": "TenantAwareRoleLookupNormalizer",
-      "fqn": "Granit.Identity.Local.AspNetIdentity.Internal.TenantAwareRoleLookupNormalizer",
-      "kind": "class",
-      "project": "Granit.Identity.Local.AspNetIdentity",
-      "file": "src/Granit.Identity.Local.AspNetIdentity/Internal/TenantAwareRoleLookupNormalizer.cs",
-      "line": 31,
-      "members": [
-        {
-          "name": "NormalizeName",
-          "kind": "method",
-          "signature": "NormalizeName(string? name)",
-          "returnType": "string?"
-        }
-      ]
-    },
-    {
       "name": "IdentityLocalMetrics",
       "fqn": "Granit.Identity.Local.Diagnostics.IdentityLocalMetrics",
       "kind": "class",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -6242,6 +6242,34 @@
       ]
     },
     {
+      "name": "RoleMetadata",
+      "fqn": "Granit.Authorization.Domain.RoleMetadata",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Domain/RoleMetadata.cs",
+      "line": 35,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        },
+        {
+          "name": "TenantId",
+          "kind": "property",
+          "signature": "Guid? TenantId",
+          "returnType": "Guid?"
+        },
+        {
+          "name": "RoleMetadata",
+          "kind": "method",
+          "signature": "RoleMetadata()",
+          "returnType": "string? Description { get; private set; } public bool IsSystem { get; private set; } private"
+        }
+      ]
+    },
+    {
       "name": "MyPermissionsResponse",
       "fqn": "Granit.Authorization.Endpoints.Dtos.MyPermissionsResponse",
       "kind": "record",
@@ -6358,7 +6386,14 @@
       "project": "Granit.Authorization.EntityFrameworkCore",
       "file": "src/Granit.Authorization.EntityFrameworkCore/DbContext/IPermissionGrantDbContext.cs",
       "line": 11,
-      "members": []
+      "members": [
+        {
+          "name": "PermissionGrants",
+          "kind": "property",
+          "signature": "DbSet<PermissionGrant> PermissionGrants",
+          "returnType": "DbSet<PermissionGrant>"
+        }
+      ]
     },
     {
       "name": "PermissionGrantModelBuilderExtensions",
@@ -6372,6 +6407,22 @@
           "name": "ConfigureAuthorizationModule",
           "kind": "method",
           "signature": "ConfigureAuthorizationModule(this ModelBuilder builder)",
+          "returnType": "ModelBuilder"
+        }
+      ]
+    },
+    {
+      "name": "RoleMetadataModelBuilderExtensions",
+      "fqn": "Granit.Authorization.EntityFrameworkCore.DbContext.RoleMetadataModelBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Authorization.EntityFrameworkCore",
+      "file": "src/Granit.Authorization.EntityFrameworkCore/DbContext/RoleMetadataModelBuilderExtensions.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "ConfigureRoleMetadata",
+          "kind": "method",
+          "signature": "ConfigureRoleMetadata(this ModelBuilder builder)",
           "returnType": "ModelBuilder"
         }
       ]
@@ -6420,11 +6471,54 @@
       "members": []
     },
     {
+      "name": "RoleCreatedEvent",
+      "fqn": "Granit.Authorization.Events.RoleCreatedEvent",
+      "kind": "record",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Events/RoleCreatedEvent.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "RoleDeletedEvent",
+      "fqn": "Granit.Authorization.Events.RoleDeletedEvent",
+      "kind": "record",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Events/RoleDeletedEvent.cs",
+      "line": 18,
+      "members": []
+    },
+    {
+      "name": "RoleUpdatedEvent",
+      "fqn": "Granit.Authorization.Events.RoleUpdatedEvent",
+      "kind": "record",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Events/RoleUpdatedEvent.cs",
+      "line": 15,
+      "members": []
+    },
+    {
       "name": "PermissionGrantExportDefinition",
       "fqn": "Granit.Authorization.Exports.PermissionGrantExportDefinition",
       "kind": "class",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/Exports/PermissionGrantExportDefinition.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "RoleMetadataExportDefinition",
+      "fqn": "Granit.Authorization.Exports.RoleMetadataExportDefinition",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Exports/RoleMetadataExportDefinition.cs",
       "line": 6,
       "members": [
         {
@@ -6700,6 +6794,52 @@
       ]
     },
     {
+      "name": "IRoleMetadataStore",
+      "fqn": "Granit.Authorization.IRoleMetadataStore",
+      "kind": "interface",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/IRoleMetadataStore.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "FindByIdAsync",
+          "kind": "method",
+          "signature": "FindByIdAsync(Guid id, CancellationToken cancellationToken = default)",
+          "returnType": "Task<RoleMetadata?>"
+        },
+        {
+          "name": "FindByNameAsync",
+          "kind": "method",
+          "signature": "FindByNameAsync(string name, Guid? tenantId, string? clientId, CancellationToken cancellationToken = default)",
+          "returnType": "Task<RoleMetadata?>"
+        },
+        {
+          "name": "ListAllAsync",
+          "kind": "method",
+          "signature": "ListAllAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<IReadOnlyList<RoleMetadata>>"
+        },
+        {
+          "name": "AddAsync",
+          "kind": "method",
+          "signature": "AddAsync(RoleMetadata role, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "UpdateAsync",
+          "kind": "method",
+          "signature": "UpdateAsync(RoleMetadata role, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RemoveAsync",
+          "kind": "method",
+          "signature": "RemoveAsync(RoleMetadata role, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "GranitAuthorizationOptions",
       "fqn": "Granit.Authorization.Options.GranitAuthorizationOptions",
       "kind": "class",
@@ -6797,6 +6937,22 @@
       "kind": "class",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/Queries/PermissionGrantQueryDefinition.cs",
+      "line": 10,
+      "members": [
+        {
+          "name": "Name",
+          "kind": "property",
+          "signature": "string Name",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "RoleMetadataQueryDefinition",
+      "fqn": "Granit.Authorization.Queries.RoleMetadataQueryDefinition",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Queries/RoleMetadataQueryDefinition.cs",
       "line": 10,
       "members": [
         {

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18502,6 +18502,33 @@
       "members": []
     },
     {
+      "name": "RoleCreateRequest",
+      "fqn": "Granit.Identity.Local.Endpoints.Dtos.RoleCreateRequest",
+      "kind": "record",
+      "project": "Granit.Identity.Local.Endpoints",
+      "file": "src/Granit.Identity.Local.Endpoints/Dtos/RoleCreateRequest.cs",
+      "line": 17,
+      "members": []
+    },
+    {
+      "name": "RoleResponse",
+      "fqn": "Granit.Identity.Local.Endpoints.Dtos.RoleResponse",
+      "kind": "record",
+      "project": "Granit.Identity.Local.Endpoints",
+      "file": "src/Granit.Identity.Local.Endpoints/Dtos/RoleResponse.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "RoleUpdateRequest",
+      "fqn": "Granit.Identity.Local.Endpoints.Dtos.RoleUpdateRequest",
+      "kind": "record",
+      "project": "Granit.Identity.Local.Endpoints",
+      "file": "src/Granit.Identity.Local.Endpoints/Dtos/RoleUpdateRequest.cs",
+      "line": 6,
+      "members": []
+    },
+    {
       "name": "AccountEndpointRouteBuilderExtensions",
       "fqn": "Granit.Identity.Local.Endpoints.Extensions.AccountEndpointRouteBuilderExtensions",
       "kind": "class",
@@ -18513,6 +18540,22 @@
           "name": "MapGranitAccount",
           "kind": "method",
           "signature": "MapGranitAccount(this IEndpointRouteBuilder endpoints, Action<AccountEndpointsOptions>? configure = null)",
+          "returnType": "RouteGroupBuilder"
+        }
+      ]
+    },
+    {
+      "name": "RoleEndpointRouteBuilderExtensions",
+      "fqn": "Granit.Identity.Local.Endpoints.Extensions.RoleEndpointRouteBuilderExtensions",
+      "kind": "class",
+      "project": "Granit.Identity.Local.Endpoints",
+      "file": "src/Granit.Identity.Local.Endpoints/Extensions/RoleEndpointRouteBuilderExtensions.cs",
+      "line": 13,
+      "members": [
+        {
+          "name": "MapGranitRoles",
+          "kind": "method",
+          "signature": "MapGranitRoles(this IEndpointRouteBuilder endpoints, Action<RoleEndpointsOptions>? configure = null)",
           "returnType": "RouteGroupBuilder"
         }
       ]
@@ -18628,12 +18671,43 @@
       ]
     },
     {
+      "name": "RoleEndpointsOptions",
+      "fqn": "Granit.Identity.Local.Endpoints.Options.RoleEndpointsOptions",
+      "kind": "class",
+      "project": "Granit.Identity.Local.Endpoints",
+      "file": "src/Granit.Identity.Local.Endpoints/Options/RoleEndpointsOptions.cs",
+      "line": 6,
+      "members": [
+        {
+          "name": "RolesRoutePrefix",
+          "kind": "property",
+          "signature": "string RolesRoutePrefix",
+          "returnType": "string"
+        },
+        {
+          "name": "TagName",
+          "kind": "property",
+          "signature": "string TagName",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
       "name": "IdentityLocalPermissions",
       "fqn": "Granit.Identity.Local.Endpoints.Permissions.IdentityLocalPermissions",
       "kind": "class",
       "project": "Granit.Identity.Local.Endpoints",
       "file": "src/Granit.Identity.Local.Endpoints/Permissions/IdentityLocalPermissions.cs",
       "line": 11,
+      "members": []
+    },
+    {
+      "name": "Roles",
+      "fqn": "Granit.Identity.Local.Endpoints.Permissions.Roles",
+      "kind": "class",
+      "project": "Granit.Identity.Local.Endpoints",
+      "file": "src/Granit.Identity.Local.Endpoints/Permissions/IdentityLocalPermissions.cs",
+      "line": 24,
       "members": []
     },
     {

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18124,6 +18124,22 @@
       ]
     },
     {
+      "name": "TenantAwareRoleLookupNormalizer",
+      "fqn": "Granit.Identity.Local.AspNetIdentity.Internal.TenantAwareRoleLookupNormalizer",
+      "kind": "class",
+      "project": "Granit.Identity.Local.AspNetIdentity",
+      "file": "src/Granit.Identity.Local.AspNetIdentity/Internal/TenantAwareRoleLookupNormalizer.cs",
+      "line": 31,
+      "members": [
+        {
+          "name": "NormalizeName",
+          "kind": "method",
+          "signature": "NormalizeName(string? name)",
+          "returnType": "string?"
+        }
+      ]
+    },
+    {
       "name": "IdentityLocalMetrics",
       "fqn": "Granit.Identity.Local.Diagnostics.IdentityLocalMetrics",
       "kind": "class",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -854,6 +854,7 @@
       "name": "Granit.Identity.Local",
       "deps": [
         "Granit",
+        "Granit.Authorization",
         "Granit.DataExchange.Abstractions",
         "Granit.Events",
         "Granit.Guids",
@@ -868,7 +869,8 @@
       "name": "Granit.Identity.Local.AspNetIdentity",
       "deps": [
         "Granit.Identity",
-        "Granit.Identity.Local"
+        "Granit.Identity.Local",
+        "Granit.Persistence.EntityFrameworkCore"
       ],
       "framework": "net10.0"
     },
@@ -18097,7 +18099,7 @@
       "kind": "class",
       "project": "Granit.Identity.Local.AspNetIdentity",
       "file": "src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs",
-      "line": 30,
+      "line": 31,
       "members": [
         {
           "name": "ConfigureServices",
@@ -19512,6 +19514,15 @@
       "members": []
     },
     {
+      "name": "CreateRoleCommand",
+      "fqn": "Granit.Identity.Local.Services.CreateRoleCommand",
+      "kind": "record",
+      "project": "Granit.Identity.Local",
+      "file": "src/Granit.Identity.Local/Services/IGranitRoleOrchestrator.cs",
+      "line": 59,
+      "members": []
+    },
+    {
       "name": "ExternalLoginInfo",
       "fqn": "Granit.Identity.Local.Services.ExternalLoginInfo",
       "kind": "record",
@@ -19642,6 +19653,34 @@
           "kind": "method",
           "signature": "IsProviderConfigured(string providerName)",
           "returnType": "bool"
+        }
+      ]
+    },
+    {
+      "name": "IGranitRoleOrchestrator",
+      "fqn": "Granit.Identity.Local.Services.IGranitRoleOrchestrator",
+      "kind": "interface",
+      "project": "Granit.Identity.Local",
+      "file": "src/Granit.Identity.Local/Services/IGranitRoleOrchestrator.cs",
+      "line": 27,
+      "members": [
+        {
+          "name": "CreateAsync",
+          "kind": "method",
+          "signature": "CreateAsync(CreateRoleCommand command, CancellationToken cancellationToken = default)",
+          "returnType": "Task<RoleMetadata>"
+        },
+        {
+          "name": "RenameAsync",
+          "kind": "method",
+          "signature": "RenameAsync(Guid roleId, string newName, string? newDescription, CancellationToken cancellationToken = default)",
+          "returnType": "Task<RoleMetadata>"
+        },
+        {
+          "name": "DeleteAsync",
+          "kind": "method",
+          "signature": "DeleteAsync(Guid roleId, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
         }
       ]
     },

--- a/src/Granit.Authorization.EntityFrameworkCore/DbContext/IPermissionGrantDbContext.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/DbContext/IPermissionGrantDbContext.cs
@@ -10,6 +10,18 @@ namespace Granit.Authorization.EntityFrameworkCore.DbContext;
 /// </summary>
 public interface IPermissionGrantDbContext
 {
-    /// <summary>Permission grants table. Configured with a unique index on (TenantId, Name, RoleName).</summary>
+    /// <summary>Permission grants table. Configured with a unique index on (TenantId, ProviderName, ProviderKey, Name).</summary>
     DbSet<PermissionGrant> PermissionGrants { get; }
+
+    /// <summary>
+    /// Role metadata table — declarative scope (<see cref="Granit.MultiTenancy.MultiTenancySide"/>,
+    /// optional tenant / OIDC client) for roles managed via <see cref="IRoleMetadataStore"/>.
+    /// </summary>
+    /// <remarks>
+    /// Default interface implementation resolves the set via the containing
+    /// <see cref="Microsoft.EntityFrameworkCore.DbContext"/>, so existing host contexts that
+    /// only declared <see cref="PermissionGrants"/> continue to compile. Override only if
+    /// the set is exposed under a different property or a non-standard configuration.
+    /// </remarks>
+    DbSet<RoleMetadata> RoleMetadata => ((Microsoft.EntityFrameworkCore.DbContext)this).Set<RoleMetadata>();
 }

--- a/src/Granit.Authorization.EntityFrameworkCore/DbContext/PermissionGrantModelBuilderExtensions.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/DbContext/PermissionGrantModelBuilderExtensions.cs
@@ -10,10 +10,19 @@ public static class PermissionGrantModelBuilderExtensions
     /// Applies all entity configurations for the Granit Authorization module.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Configures the <see cref="PermissionGrant"/> entity: host-level table name, column
     /// constraints, and unique composite index on
-    /// <c>(TenantId, ProviderName, ProviderKey, Name)</c>. Call this from
-    /// <c>OnModelCreating</c> in the host application's DbContext.
+    /// <c>(TenantId, ProviderName, ProviderKey, Name)</c>. Also wires the
+    /// <see cref="RoleMetadata"/> configuration via <see cref="RoleMetadataModelBuilderExtensions.ConfigureRoleMetadata"/>.
+    /// Call this from <c>OnModelCreating</c> in the host application's DbContext.
+    /// </para>
+    /// <para>
+    /// The unique index uses PostgreSQL <c>NULLS NOT DISTINCT</c> semantics (via the
+    /// <c>Npgsql:IndexNullsDistinct</c> annotation) so host-level grants with
+    /// <c>TenantId = null</c> cannot duplicate each other on the same
+    /// <c>(ProviderName, ProviderKey, Name)</c> tuple.
+    /// </para>
     /// </remarks>
     public static ModelBuilder ConfigureAuthorizationModule(this ModelBuilder builder)
     {
@@ -28,8 +37,11 @@ public static class PermissionGrantModelBuilderExtensions
             entity.Property(e => e.ProviderKey).HasMaxLength(256).IsRequired();
             entity.HasIndex(e => new { e.TenantId, e.ProviderName, e.ProviderKey, e.Name })
                   .IsUnique()
+                  .HasAnnotation("Npgsql:IndexNullsDistinct", false)
                   .HasDatabaseName($"uq_{GranitAuthorizationDbProperties.DbTablePrefix}permission_grants_tenant_provider_key_name");
         });
+
+        builder.ConfigureRoleMetadata();
 
         return builder;
     }

--- a/src/Granit.Authorization.EntityFrameworkCore/DbContext/RoleMetadataModelBuilderExtensions.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/DbContext/RoleMetadataModelBuilderExtensions.cs
@@ -1,0 +1,49 @@
+using Granit.Authorization.Domain;
+using Granit.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Authorization.EntityFrameworkCore.DbContext;
+
+/// <summary>EF Core model builder extensions for <see cref="RoleMetadata"/>.</summary>
+public static class RoleMetadataModelBuilderExtensions
+{
+    /// <summary>
+    /// Applies the entity configuration for <see cref="RoleMetadata"/>: host-level table
+    /// name, column constraints, unique composite index on <c>(Name, TenantId, ClientId)</c>
+    /// with PostgreSQL <c>NULLS NOT DISTINCT</c> semantics, and a CHECK constraint enforcing
+    /// the <c>MultiTenancySide</c> ↔ <c>TenantId</c> invariant at the database level.
+    /// </summary>
+    /// <remarks>
+    /// Call from <c>OnModelCreating</c> in the host application's DbContext alongside
+    /// <see cref="PermissionGrantModelBuilderExtensions.ConfigureAuthorizationModule"/>.
+    /// </remarks>
+    public static ModelBuilder ConfigureRoleMetadata(this ModelBuilder builder)
+    {
+        builder.Entity<RoleMetadata>(entity =>
+        {
+            entity.ToTable(
+                GranitAuthorizationDbProperties.DbTablePrefix + "role_metadata",
+                GranitAuthorizationDbProperties.DbSchema,
+                table => table.HasCheckConstraint(
+                    $"ck_{GranitAuthorizationDbProperties.DbTablePrefix}role_metadata_side_tenant_consistency",
+                    // Side values: Host = 1, Tenant = 2, Both = 3 (Host | Tenant)
+                    $"(\"{nameof(RoleMetadata.MultiTenancySide)}\" = {(int)MultiTenancySide.Host} AND \"{nameof(RoleMetadata.TenantId)}\" IS NULL)" +
+                    $" OR (\"{nameof(RoleMetadata.MultiTenancySide)}\" = {(int)MultiTenancySide.Both} AND \"{nameof(RoleMetadata.TenantId)}\" IS NULL)" +
+                    $" OR (\"{nameof(RoleMetadata.MultiTenancySide)}\" = {(int)MultiTenancySide.Tenant} AND \"{nameof(RoleMetadata.TenantId)}\" IS NOT NULL)"));
+
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Name).HasMaxLength(256).IsRequired();
+            entity.Property(e => e.ClientId).HasMaxLength(256);
+            entity.Property(e => e.Description).HasMaxLength(2048);
+            entity.Property(e => e.MultiTenancySide).IsRequired();
+            entity.Property(e => e.IsSystem).IsRequired();
+
+            entity.HasIndex(e => new { e.Name, e.TenantId, e.ClientId })
+                  .IsUnique()
+                  .HasAnnotation("Npgsql:IndexNullsDistinct", false)
+                  .HasDatabaseName($"uq_{GranitAuthorizationDbProperties.DbTablePrefix}role_metadata_name_tenant_client");
+        });
+
+        return builder;
+    }
+}

--- a/src/Granit.Authorization.EntityFrameworkCore/Extensions/AuthorizationEfCoreServiceCollectionExtensions.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/Extensions/AuthorizationEfCoreServiceCollectionExtensions.cs
@@ -12,11 +12,12 @@ namespace Granit.Authorization.EntityFrameworkCore.Extensions;
 public static class AuthorizationEfCoreServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers EF Core persistence for permission grants.
-    /// Replaces the default <see cref="NullPermissionGrantStore"/> registered by
-    /// <c>Granit.Authorization</c> with <see cref="EfCorePermissionGrantStore{TContext}"/>.
-    /// <c>IPermissionManagerReader</c> and <c>IPermissionManagerWriter</c> are already registered
-    /// by <c>Granit.Authorization</c> and delegate to the store.
+    /// Registers EF Core persistence for permission grants and role metadata.
+    /// Replaces the default <see cref="NullPermissionGrantStore"/> and
+    /// <see cref="Services.NullRoleMetadataStore"/> registered by <c>Granit.Authorization</c>
+    /// with EF-backed implementations. <c>IPermissionManagerReader</c> and
+    /// <c>IPermissionManagerWriter</c> are already registered by <c>Granit.Authorization</c>
+    /// and delegate to the store.
     /// </summary>
     /// <typeparam name="TContext">
     /// The application DbContext, which must implement <see cref="IPermissionGrantDbContext"/>.
@@ -28,6 +29,10 @@ public static class AuthorizationEfCoreServiceCollectionExtensions
         // Replace the NullPermissionGrantStore registered by Granit.Authorization
         services.Replace(ServiceDescriptor.Scoped<IPermissionGrantStore,
             EfCorePermissionGrantStore<TContext>>());
+
+        // Replace the NullRoleMetadataStore registered by Granit.Authorization
+        services.Replace(ServiceDescriptor.Scoped<IRoleMetadataStore,
+            EfCoreRoleMetadataStore<TContext>>());
 
         return services;
     }

--- a/src/Granit.Authorization.EntityFrameworkCore/Stores/EfCoreRoleMetadataStore.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/Stores/EfCoreRoleMetadataStore.cs
@@ -1,0 +1,67 @@
+using Granit.Authorization;
+using Granit.Authorization.Domain;
+using Granit.Authorization.EntityFrameworkCore.DbContext;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Authorization.EntityFrameworkCore.Stores;
+
+/// <summary>
+/// EF Core implementation of <see cref="IRoleMetadataStore"/>.
+/// </summary>
+/// <remarks>
+/// Read queries use <c>AsNoTracking</c> by default; writes expect the caller to have
+/// already loaded or constructed the aggregate (see <c>IGranitRoleOrchestrator</c>).
+/// </remarks>
+internal sealed class EfCoreRoleMetadataStore<TContext>(TContext context)
+    : IRoleMetadataStore
+    where TContext : Microsoft.EntityFrameworkCore.DbContext, IPermissionGrantDbContext
+{
+    /// <inheritdoc />
+    public Task<RoleMetadata?> FindByIdAsync(Guid id, CancellationToken cancellationToken = default) =>
+        context.RoleMetadata
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.Id == id, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<RoleMetadata?> FindByNameAsync(
+        string name,
+        Guid? tenantId,
+        string? clientId,
+        CancellationToken cancellationToken = default) =>
+        context.RoleMetadata
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                r => r.Name == name && r.TenantId == tenantId && r.ClientId == clientId,
+                cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<RoleMetadata>> ListAllAsync(CancellationToken cancellationToken = default) =>
+        await context.RoleMetadata
+            .AsNoTracking()
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+    /// <inheritdoc />
+    public async Task AddAsync(RoleMetadata role, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(role);
+        context.RoleMetadata.Add(role);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task UpdateAsync(RoleMetadata role, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(role);
+        context.RoleMetadata.Update(role);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task RemoveAsync(RoleMetadata role, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(role);
+        role.MarkAsDeleted();
+        context.RoleMetadata.Remove(role);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Granit.Authorization/Domain/RoleMetadata.cs
+++ b/src/Granit.Authorization/Domain/RoleMetadata.cs
@@ -1,0 +1,194 @@
+using Granit.Authorization.Events;
+using Granit.Domain;
+using Granit.MultiTenancy;
+
+namespace Granit.Authorization.Domain;
+
+/// <summary>
+/// Declarative metadata for a role: its name, tenant scope, owning OIDC client (if any),
+/// and <see cref="Granit.MultiTenancy.MultiTenancySide"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Symmetric to <see cref="PermissionDefinition"/>. While the underlying role lives in the
+/// identity provider (local <c>GranitRole</c>, Keycloak realm role, Entra app role, etc.),
+/// <see cref="RoleMetadata"/> holds the Granit-layer scoping attributes that the identity
+/// provider does not model natively — primarily which side (Host / Tenant / Both) the role
+/// applies to and which <see cref="Granit.MultiTenancy.ICurrentTenant"/> it belongs to when
+/// scoped.
+/// </para>
+/// <para>
+/// Invariants enforced by the <see cref="Create"/> factory and a matching database
+/// <c>CHECK</c> constraint:
+/// </para>
+/// <list type="bullet">
+///   <item><see cref="MultiTenancySide.Host"/> ⇒ <see cref="TenantId"/> must be <see langword="null"/>.</item>
+///   <item><see cref="MultiTenancySide.Both"/> ⇒ <see cref="TenantId"/> must be <see langword="null"/> (role is defined globally but assignable in any tenant context).</item>
+///   <item><see cref="MultiTenancySide.Tenant"/> ⇒ <see cref="TenantId"/> must be non-null.</item>
+/// </list>
+/// <para>
+/// Uniqueness is enforced on the composite <c>(Name, TenantId, ClientId)</c> with
+/// <c>NULLS NOT DISTINCT</c> semantics (PostgreSQL 15+) so host-scope rows with
+/// <c>TenantId = null</c> and <c>ClientId = null</c> cannot duplicate each other.
+/// </para>
+/// </remarks>
+public sealed class RoleMetadata : AuditedAggregateRoot, IMultiTenant
+{
+    /// <summary>Human-readable role name, e.g. <c>"TenantAdministrator"</c>. Max 256 characters.</summary>
+    public string Name { get; private set; } = string.Empty;
+
+    /// <summary>Tenant scope. Non-null only when <see cref="MultiTenancySide"/> is <see cref="MultiTenancySide.Tenant"/>.</summary>
+    public Guid? TenantId { get; private set; }
+
+    /// <summary>
+    /// OIDC client identifier the role is scoped to (<c>null</c> for realm / global roles).
+    /// Max 256 characters. Populated for provider-native client roles in Phase 2; always
+    /// <see langword="null"/> for locally created roles in Phase 1.
+    /// </summary>
+    public string? ClientId { get; private set; }
+
+    /// <summary>Host / tenant applicability side. Default on new declarations is <see cref="MultiTenancySide.Both"/>.</summary>
+    public MultiTenancySide MultiTenancySide { get; private set; } = MultiTenancySide.Both;
+
+    /// <summary>Optional description displayed in admin UIs. Max 2048 characters.</summary>
+    public string? Description { get; private set; }
+
+    /// <summary>
+    /// <see langword="true"/> for roles provisioned by the platform seeder (e.g. <c>SuperAdmin</c>,
+    /// <c>TenantAdministrator</c>, <c>User</c>). System roles cannot be renamed or deleted
+    /// through the CRUD endpoints.
+    /// </summary>
+    public bool IsSystem { get; private set; }
+
+    /// <summary>Required by EF Core materialization — never call from application code.</summary>
+    private RoleMetadata() { }
+
+    Guid? IMultiTenant.TenantId
+    {
+        get => TenantId;
+        set => TenantId = value;
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="RoleMetadata"/> and raises a <see cref="RoleCreatedEvent"/>
+    /// to be dispatched after the transaction commits.
+    /// </summary>
+    /// <param name="id">Aggregate identifier (typically supplied by <c>IGuidGenerator</c>).</param>
+    /// <param name="name">Role name. Max 256 chars, non-empty.</param>
+    /// <param name="multiTenancySide">Side applicability.</param>
+    /// <param name="tenantId">Tenant scope. Must be non-null iff side is <see cref="MultiTenancySide.Tenant"/>.</param>
+    /// <param name="clientId">Optional OIDC client scope. Max 256 chars.</param>
+    /// <param name="description">Optional description. Max 2048 chars.</param>
+    /// <param name="isSystem">Mark as seeded by the platform.</param>
+    public static RoleMetadata Create(
+        Guid id,
+        string name,
+        MultiTenancySide multiTenancySide,
+        Guid? tenantId,
+        string? clientId = null,
+        string? description = null,
+        bool isSystem = false)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ValidateLengths(name, clientId, description);
+        ValidateSideTenantConsistency(multiTenancySide, tenantId);
+
+        RoleMetadata role = new()
+        {
+            Id = id,
+            Name = name,
+            MultiTenancySide = multiTenancySide,
+            TenantId = tenantId,
+            ClientId = clientId,
+            Description = description,
+            IsSystem = isSystem,
+        };
+
+        role.AddDomainEvent(new RoleCreatedEvent(
+            id, name, multiTenancySide, tenantId, clientId));
+
+        return role;
+    }
+
+    /// <summary>
+    /// Renames the role and / or updates its description. Raises <see cref="RoleUpdatedEvent"/>
+    /// on any actual change. No-op if no property changes.
+    /// </summary>
+    /// <remarks>
+    /// Side and tenant scope are immutable after creation to preserve the domain invariants
+    /// and the uniqueness index. Change the scope by deleting and re-creating the role.
+    /// </remarks>
+    public void Rename(string newName, string? newDescription)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(newName);
+        ValidateLengths(newName, ClientId, newDescription);
+
+        bool nameChanged = !string.Equals(newName, Name, StringComparison.Ordinal);
+        bool descriptionChanged = !string.Equals(newDescription, Description, StringComparison.Ordinal);
+
+        if (!nameChanged && !descriptionChanged)
+        {
+            return;
+        }
+
+        Name = newName;
+        Description = newDescription;
+
+        AddDomainEvent(new RoleUpdatedEvent(Id, Name, MultiTenancySide, TenantId, ClientId));
+    }
+
+    /// <summary>
+    /// Raises <see cref="RoleDeletedEvent"/> dispatched after commit. Call before removing
+    /// the entity from the <c>DbContext</c> so the interceptor can collect the event from
+    /// the still-tracked <c>Deleted</c> entry.
+    /// </summary>
+    public void MarkAsDeleted()
+    {
+        AddDomainEvent(new RoleDeletedEvent(Id, Name, MultiTenancySide, TenantId, ClientId));
+    }
+
+    private static void ValidateLengths(string name, string? clientId, string? description)
+    {
+        if (name.Length > 256)
+        {
+            throw new ArgumentException("Role name exceeds 256 characters.", nameof(name));
+        }
+
+        if (clientId is { Length: > 256 })
+        {
+            throw new ArgumentException("Client id exceeds 256 characters.", nameof(clientId));
+        }
+
+        if (description is { Length: > 2048 })
+        {
+            throw new ArgumentException("Description exceeds 2048 characters.", nameof(description));
+        }
+    }
+
+    private static void ValidateSideTenantConsistency(MultiTenancySide side, Guid? tenantId)
+    {
+        switch (side)
+        {
+            case MultiTenancySide.Host:
+            case MultiTenancySide.Both:
+                if (tenantId is not null)
+                {
+                    throw new ArgumentException(
+                        $"Role with MultiTenancySide '{side}' must have a null TenantId.",
+                        nameof(tenantId));
+                }
+                break;
+            case MultiTenancySide.Tenant:
+                if (tenantId is null)
+                {
+                    throw new ArgumentException(
+                        "Tenant-scoped role requires a non-null TenantId.",
+                        nameof(tenantId));
+                }
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(side), side, "Unknown MultiTenancySide value.");
+        }
+    }
+}

--- a/src/Granit.Authorization/Domain/RoleMetadata.cs
+++ b/src/Granit.Authorization/Domain/RoleMetadata.cs
@@ -42,9 +42,13 @@ public sealed class RoleMetadata : AuditedAggregateRoot, IMultiTenant
 
     /// <summary>
     /// OIDC client identifier the role is scoped to (<c>null</c> for realm / global roles).
-    /// Max 256 characters. Populated for provider-native client roles in Phase 2; always
-    /// <see langword="null"/> for locally created roles in Phase 1.
+    /// Max 256 characters.
     /// </summary>
+    /// <remarks>
+    /// Reserved for a future realm vs client role distinction on federated providers
+    /// (Keycloak client roles, Entra app roles, etc.). Locally created roles leave this
+    /// <see langword="null"/>.
+    /// </remarks>
     public string? ClientId { get; private set; }
 
     /// <summary>Host / tenant applicability side. Default on new declarations is <see cref="MultiTenancySide.Both"/>.</summary>

--- a/src/Granit.Authorization/Domain/RoleMetadata.cs
+++ b/src/Granit.Authorization/Domain/RoleMetadata.cs
@@ -146,10 +146,8 @@ public sealed class RoleMetadata : AuditedAggregateRoot, IMultiTenant
     /// the entity from the <c>DbContext</c> so the interceptor can collect the event from
     /// the still-tracked <c>Deleted</c> entry.
     /// </summary>
-    public void MarkAsDeleted()
-    {
+    public void MarkAsDeleted() =>
         AddDomainEvent(new RoleDeletedEvent(Id, Name, MultiTenancySide, TenantId, ClientId));
-    }
 
     private static void ValidateLengths(string name, string? clientId, string? description)
     {

--- a/src/Granit.Authorization/Events/RoleCreatedEvent.cs
+++ b/src/Granit.Authorization/Events/RoleCreatedEvent.cs
@@ -1,0 +1,23 @@
+using Granit.Events;
+using Granit.MultiTenancy;
+
+namespace Granit.Authorization.Events;
+
+/// <summary>
+/// Raised when a new <see cref="Domain.RoleMetadata"/> aggregate is created.
+/// </summary>
+/// <remarks>
+/// Domain event — dispatched after <c>SaveChanges</c> commits by
+/// <c>DomainEventDispatcherInterceptor</c>.
+/// </remarks>
+/// <param name="RoleId">Aggregate identifier.</param>
+/// <param name="Name">Role name.</param>
+/// <param name="MultiTenancySide">Side applicability declared at creation.</param>
+/// <param name="TenantId">Tenant scope (<see langword="null"/> for <see cref="MultiTenancySide.Host"/> / <see cref="MultiTenancySide.Both"/>).</param>
+/// <param name="ClientId">OIDC client scope (<see langword="null"/> for realm / global roles).</param>
+public sealed record RoleCreatedEvent(
+    Guid RoleId,
+    string Name,
+    MultiTenancySide MultiTenancySide,
+    Guid? TenantId,
+    string? ClientId) : IDomainEvent;

--- a/src/Granit.Authorization/Events/RoleDeletedEvent.cs
+++ b/src/Granit.Authorization/Events/RoleDeletedEvent.cs
@@ -1,0 +1,23 @@
+using Granit.Events;
+using Granit.MultiTenancy;
+
+namespace Granit.Authorization.Events;
+
+/// <summary>
+/// Raised when a <see cref="Domain.RoleMetadata"/> is hard-deleted.
+/// </summary>
+/// <remarks>
+/// Consumers should cascade invalidation of any permission grants or user assignments
+/// keyed on <paramref name="RoleId"/> / <paramref name="Name"/>.
+/// </remarks>
+/// <param name="RoleId">Aggregate identifier.</param>
+/// <param name="Name">Name at deletion time.</param>
+/// <param name="MultiTenancySide">Side applicability.</param>
+/// <param name="TenantId">Tenant scope.</param>
+/// <param name="ClientId">OIDC client scope.</param>
+public sealed record RoleDeletedEvent(
+    Guid RoleId,
+    string Name,
+    MultiTenancySide MultiTenancySide,
+    Guid? TenantId,
+    string? ClientId) : IDomainEvent;

--- a/src/Granit.Authorization/Events/RoleUpdatedEvent.cs
+++ b/src/Granit.Authorization/Events/RoleUpdatedEvent.cs
@@ -1,0 +1,20 @@
+using Granit.Events;
+using Granit.MultiTenancy;
+
+namespace Granit.Authorization.Events;
+
+/// <summary>
+/// Raised when an existing <see cref="Domain.RoleMetadata"/> is renamed or its description
+/// changes. Side and tenant scope are immutable after creation.
+/// </summary>
+/// <param name="RoleId">Aggregate identifier.</param>
+/// <param name="Name">New role name.</param>
+/// <param name="MultiTenancySide">Side applicability (unchanged since creation).</param>
+/// <param name="TenantId">Tenant scope (unchanged since creation).</param>
+/// <param name="ClientId">OIDC client scope (unchanged since creation).</param>
+public sealed record RoleUpdatedEvent(
+    Guid RoleId,
+    string Name,
+    MultiTenancySide MultiTenancySide,
+    Guid? TenantId,
+    string? ClientId) : IDomainEvent;

--- a/src/Granit.Authorization/Exports/RoleMetadataExportDefinition.cs
+++ b/src/Granit.Authorization/Exports/RoleMetadataExportDefinition.cs
@@ -1,0 +1,25 @@
+using Granit.Authorization.Domain;
+using Granit.DataExchange.Export;
+
+namespace Granit.Authorization.Exports;
+
+public sealed class RoleMetadataExportDefinition : ExportDefinition<RoleMetadata>
+{
+    public override string Name => "Granit.Authorization.RoleMetadataExport";
+
+    protected override void Configure(ExportDefinitionBuilder<RoleMetadata> builder)
+    {
+        builder
+            .IncludeId()
+            .Field(r => r.Name)
+            .Field(r => r.MultiTenancySide)
+            .Field(r => r.TenantId)
+            .Field(r => r.ClientId)
+            .Field(r => r.Description)
+            .Field(r => r.IsSystem)
+            .Field(r => r.CreatedAt, f => f.Format("O"))
+            .Field(r => r.CreatedBy)
+            .Field(r => r.ModifiedAt, f => f.Format("O"))
+            .Field(r => r.ModifiedBy);
+    }
+}

--- a/src/Granit.Authorization/Extensions/AuthorizationServiceCollectionExtensions.cs
+++ b/src/Granit.Authorization/Extensions/AuthorizationServiceCollectionExtensions.cs
@@ -32,6 +32,7 @@ public static class AuthorizationServiceCollectionExtensions
         services.AddSingleton<IPermissionDefinitionManager, PermissionDefinitionManager>();
 
         services.TryAddSingleton<IPermissionGrantStore, NullPermissionGrantStore>();
+        services.TryAddSingleton<IRoleMetadataStore, NullRoleMetadataStore>();
         services.TryAddSingleton<AuthorizationMetrics>();
 
         services.AddScoped<IPermissionChecker, PermissionChecker>();

--- a/src/Granit.Authorization/Extensions/AuthorizationServiceCollectionExtensions.cs
+++ b/src/Granit.Authorization/Extensions/AuthorizationServiceCollectionExtensions.cs
@@ -40,7 +40,8 @@ public static class AuthorizationServiceCollectionExtensions
         services.AddScoped<IPermissionManagerReader, PermissionManager>();
         services.AddScoped<IPermissionManagerWriter, PermissionManager>();
 
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<
+        // Scoped because it depends on IRoleMetadataStore (also Scoped when backed by EF Core).
+        services.TryAddEnumerable(ServiceDescriptor.Scoped<
             IPermissionGrantValidator, MultiTenancySidePermissionGrantValidator>());
 
         // Grant providers evaluated in the order below: specific → generic.

--- a/src/Granit.Authorization/GranitAuthorizationModule.cs
+++ b/src/Granit.Authorization/GranitAuthorizationModule.cs
@@ -31,6 +31,9 @@ public sealed class GranitAuthorizationModule : GranitModule
         context.Services.AddQueryDefinition<PermissionGrant, PermissionGrantQueryDefinition>();
         context.Services.AddExportDefinition<PermissionGrant, PermissionGrantExportDefinition>();
 
+        context.Services.AddQueryDefinition<RoleMetadata, RoleMetadataQueryDefinition>();
+        context.Services.AddExportDefinition<RoleMetadata, RoleMetadataExportDefinition>();
+
         foreach (Assembly assembly in context.ModuleAssemblies)
         {
             IEnumerable<Type> providerTypes = assembly.GetTypes()

--- a/src/Granit.Authorization/IRoleMetadataStore.cs
+++ b/src/Granit.Authorization/IRoleMetadataStore.cs
@@ -1,0 +1,42 @@
+using Granit.Authorization.Domain;
+
+namespace Granit.Authorization;
+
+/// <summary>
+/// Persistence abstraction for <see cref="RoleMetadata"/>.
+/// </summary>
+/// <remarks>
+/// Consumers (the grant validator, CRUD endpoints, orchestrator) depend on this
+/// contract so roles defined by the local identity store and by future federated
+/// providers share the same metadata surface.
+/// </remarks>
+public interface IRoleMetadataStore
+{
+    /// <summary>Returns the role with the given identifier, or <see langword="null"/> if absent.</summary>
+    Task<RoleMetadata?> FindByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the role matching the given <paramref name="name"/>, <paramref name="tenantId"/>
+    /// and <paramref name="clientId"/> triplet, or <see langword="null"/> if absent.
+    /// </summary>
+    Task<RoleMetadata?> FindByNameAsync(
+        string name,
+        Guid? tenantId,
+        string? clientId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns every role stored in the backing provider. Caller is expected to filter
+    /// for visibility — this method performs no tenant scoping.
+    /// </summary>
+    Task<IReadOnlyList<RoleMetadata>> ListAllAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Adds a new role metadata row.</summary>
+    Task AddAsync(RoleMetadata role, CancellationToken cancellationToken = default);
+
+    /// <summary>Persists modifications applied to a tracked <see cref="RoleMetadata"/>.</summary>
+    Task UpdateAsync(RoleMetadata role, CancellationToken cancellationToken = default);
+
+    /// <summary>Removes a role metadata row.</summary>
+    Task RemoveAsync(RoleMetadata role, CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Authorization/Queries/RoleMetadataQueryDefinition.cs
+++ b/src/Granit.Authorization/Queries/RoleMetadataQueryDefinition.cs
@@ -1,0 +1,32 @@
+using Granit.Authorization.Domain;
+using Granit.QueryEngine;
+
+namespace Granit.Authorization.Queries;
+
+/// <summary>
+/// Query definition for <see cref="RoleMetadata"/> — declares columns, filters, sorting,
+/// and search for the query engine.
+/// </summary>
+public sealed class RoleMetadataQueryDefinition : QueryDefinition<RoleMetadata>
+{
+    /// <inheritdoc/>
+    public override string Name => "Granit.Authorization.RoleMetadataQuery";
+
+    /// <inheritdoc/>
+    protected override void Configure(QueryDefinitionBuilder<RoleMetadata> builder)
+    {
+        builder
+            .Column(r => r.Name, c => c.Label("Name").LabelKey("Authorization.Columns.RoleName").Filterable().Sortable())
+            .Column(r => r.TenantId, c => c.Label("Tenant").LabelKey("Authorization.Columns.Tenant").Filterable().Sortable())
+            .Column(r => r.ClientId, c => c.Label("Client").LabelKey("Authorization.Columns.ClientId").Filterable().Sortable())
+            .Column(r => r.MultiTenancySide, c => c.Label("Side").LabelKey("Authorization.Columns.MultiTenancySide").Filterable().Sortable())
+            .Column(r => r.Description, c => c.Label("Description").LabelKey("Authorization.Columns.Description").Filterable())
+            .Column(r => r.IsSystem, c => c.Label("System").LabelKey("Authorization.Columns.IsSystem").Filterable().Sortable())
+            .Column(r => r.CreatedAt, c => c.Label("Created At").LabelKey("Authorization.Columns.CreatedAt").Sortable())
+            .Column(r => r.ModifiedAt, c => c.Label("Modified At").LabelKey("Authorization.Columns.ModifiedAt").Sortable())
+            .GlobalSearch(r => r.Name, r => r.Description!)
+            .DateFilter(r => r.CreatedAt)
+            .DefaultSort("name")
+            .DefaultPageSize(25);
+    }
+}

--- a/src/Granit.Authorization/Services/MultiTenancySidePermissionGrantValidator.cs
+++ b/src/Granit.Authorization/Services/MultiTenancySidePermissionGrantValidator.cs
@@ -1,40 +1,112 @@
+using Granit.Authorization.Domain;
 using Granit.MultiTenancy;
 
 namespace Granit.Authorization.Services;
 
 /// <summary>
-/// Rejects permission grants whose target scope contradicts the permission's declared
-/// <see cref="MultiTenancySide"/>:
-/// <list type="bullet">
-/// <item><see cref="MultiTenancySide.Host"/> permissions must be granted with <c>TenantId == null</c>.</item>
-/// <item><see cref="MultiTenancySide.Tenant"/> permissions must be granted with a non-null <c>TenantId</c>.</item>
-/// <item><see cref="MultiTenancySide.Both"/> permissions are accepted regardless.</item>
-/// </list>
-/// Registered by default via <c>GranitAuthorizationModule</c>.
+/// Rejects permission grants whose target scope contradicts either the permission's
+/// declared <see cref="MultiTenancySide"/> or — for role grants — the role's declared
+/// scope (<see cref="RoleMetadata.MultiTenancySide"/> / <see cref="RoleMetadata.TenantId"/>).
 /// </summary>
-internal sealed class MultiTenancySidePermissionGrantValidator : IPermissionGrantValidator
+/// <remarks>
+/// <para>
+/// Permission checks (always applied):
+/// <list type="bullet">
+///   <item><see cref="MultiTenancySide.Host"/> permissions must be granted with <c>TenantId == null</c>.</item>
+///   <item><see cref="MultiTenancySide.Tenant"/> permissions must be granted with a non-null <c>TenantId</c>.</item>
+///   <item><see cref="MultiTenancySide.Both"/> permissions are accepted regardless.</item>
+/// </list>
+/// </para>
+/// <para>
+/// Role-side checks (only when <see cref="PermissionGrantValidationContext.ProviderName"/>
+/// is <see cref="PermissionGrantProviderNames.Role"/>):
+/// <list type="bullet">
+///   <item>A <see cref="MultiTenancySide.Host"/> role cannot receive tenant-scoped grants.</item>
+///   <item>A <see cref="MultiTenancySide.Tenant"/> role cannot receive host-level grants, and its <see cref="RoleMetadata.TenantId"/> must match the grant's tenant scope.</item>
+///   <item>A <see cref="MultiTenancySide.Both"/> role is accepted in either context.</item>
+/// </list>
+/// The role is located via <see cref="IRoleMetadataStore"/>, trying the grant's tenant
+/// scope first and falling back to the global namespace. When no matching role metadata
+/// exists the validator returns success — absence of metadata is not treated as a grant
+/// violation (it may simply mean the role was registered before the metadata surface
+/// existed, or the <c>NullRoleMetadataStore</c> fallback is active).
+/// </para>
+/// <para>Registered by default via <c>GranitAuthorizationModule</c>.</para>
+/// </remarks>
+internal sealed class MultiTenancySidePermissionGrantValidator(
+    IRoleMetadataStore roleMetadataStore) : IPermissionGrantValidator
 {
     /// <inheritdoc />
-    public ValueTask<PermissionGrantValidationResult> ValidateAsync(
+    public async ValueTask<PermissionGrantValidationResult> ValidateAsync(
         PermissionGrantValidationContext context,
         CancellationToken cancellationToken = default)
     {
-        MultiTenancySide side = context.Definition.MultiTenancySide;
+        MultiTenancySide permissionSide = context.Definition.MultiTenancySide;
 
-        if (!side.HasFlag(MultiTenancySide.Host) && context.TenantId is null)
+        if (!permissionSide.HasFlag(MultiTenancySide.Host) && context.TenantId is null)
         {
-            return ValueTask.FromResult(PermissionGrantValidationResult.Reject(
+            return PermissionGrantValidationResult.Reject(
                 "side_host_forbidden",
-                $"Permission '{context.PermissionName}' is Tenant-only; host-level grant (TenantId == null) refused."));
+                $"Permission '{context.PermissionName}' is Tenant-only; host-level grant (TenantId == null) refused.");
         }
 
-        if (!side.HasFlag(MultiTenancySide.Tenant) && context.TenantId is not null)
+        if (!permissionSide.HasFlag(MultiTenancySide.Tenant) && context.TenantId is not null)
         {
-            return ValueTask.FromResult(PermissionGrantValidationResult.Reject(
+            return PermissionGrantValidationResult.Reject(
                 "side_tenant_forbidden",
-                $"Permission '{context.PermissionName}' is Host-only; tenant-scoped grant refused."));
+                $"Permission '{context.PermissionName}' is Host-only; tenant-scoped grant refused.");
         }
 
-        return ValueTask.FromResult(PermissionGrantValidationResult.Success);
+        if (context.ProviderName != PermissionGrantProviderNames.Role)
+        {
+            return PermissionGrantValidationResult.Success;
+        }
+
+        RoleMetadata? role = null;
+        if (context.TenantId is Guid grantTenantId)
+        {
+            role = await roleMetadataStore.FindByNameAsync(
+                context.ProviderKey, grantTenantId, clientId: null, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        role ??= await roleMetadataStore.FindByNameAsync(
+            context.ProviderKey, tenantId: null, clientId: null, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (role is null)
+        {
+            // No metadata registered for this role — defer to the permission-side checks above.
+            // This preserves backward compatibility with deployments that grant to roles created
+            // outside the Granit RoleMetadata surface (legacy rows, provider-native roles, tests).
+            return PermissionGrantValidationResult.Success;
+        }
+
+        if (role.MultiTenancySide == MultiTenancySide.Host && context.TenantId is not null)
+        {
+            return PermissionGrantValidationResult.Reject(
+                "role_side_forbidden",
+                $"Role '{context.ProviderKey}' is Host-only; tenant-scoped grant refused.");
+        }
+
+        if (role.MultiTenancySide == MultiTenancySide.Tenant)
+        {
+            if (context.TenantId is null)
+            {
+                return PermissionGrantValidationResult.Reject(
+                    "role_side_forbidden",
+                    $"Role '{context.ProviderKey}' is Tenant-only; host-level grant refused.");
+            }
+
+            if (role.TenantId != context.TenantId)
+            {
+                return PermissionGrantValidationResult.Reject(
+                    "role_tenant_mismatch",
+                    $"Role '{context.ProviderKey}' belongs to tenant {role.TenantId:D}; " +
+                    $"grant targeting tenant {context.TenantId:D} refused.");
+            }
+        }
+
+        return PermissionGrantValidationResult.Success;
     }
 }

--- a/src/Granit.Authorization/Services/NullRoleMetadataStore.cs
+++ b/src/Granit.Authorization/Services/NullRoleMetadataStore.cs
@@ -1,0 +1,43 @@
+using Granit.Authorization.Domain;
+
+namespace Granit.Authorization.Services;
+
+/// <summary>
+/// No-op <see cref="IRoleMetadataStore"/> registered when no EF Core implementation
+/// is wired. Every read returns no role and every write throws.
+/// </summary>
+/// <remarks>
+/// Useful for consumers that reference <c>Granit.Authorization</c> but never persist
+/// role metadata (tests, read-only projections, providers that rely solely on grants).
+/// </remarks>
+internal sealed class NullRoleMetadataStore : IRoleMetadataStore
+{
+    /// <inheritdoc />
+    public Task<RoleMetadata?> FindByIdAsync(Guid id, CancellationToken cancellationToken = default) =>
+        Task.FromResult<RoleMetadata?>(null);
+
+    /// <inheritdoc />
+    public Task<RoleMetadata?> FindByNameAsync(
+        string name, Guid? tenantId, string? clientId, CancellationToken cancellationToken = default) =>
+        Task.FromResult<RoleMetadata?>(null);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<RoleMetadata>> ListAllAsync(CancellationToken cancellationToken = default) =>
+        Task.FromResult<IReadOnlyList<RoleMetadata>>([]);
+
+    /// <inheritdoc />
+    public Task AddAsync(RoleMetadata role, CancellationToken cancellationToken = default) =>
+        throw new InvalidOperationException(
+            "No IRoleMetadataStore implementation is registered. " +
+            "Add Granit.Authorization.EntityFrameworkCore (or an equivalent provider) and wire the store.");
+
+    /// <inheritdoc />
+    public Task UpdateAsync(RoleMetadata role, CancellationToken cancellationToken = default) =>
+        throw new InvalidOperationException(
+            "No IRoleMetadataStore implementation is registered.");
+
+    /// <inheritdoc />
+    public Task RemoveAsync(RoleMetadata role, CancellationToken cancellationToken = default) =>
+        throw new InvalidOperationException(
+            "No IRoleMetadataStore implementation is registered.");
+}

--- a/src/Granit.Identity.Local.AspNetIdentity/Granit.Identity.Local.AspNetIdentity.csproj
+++ b/src/Granit.Identity.Local.AspNetIdentity/Granit.Identity.Local.AspNetIdentity.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Granit.Identity\Granit.Identity.csproj" />
     <ProjectReference Include="..\Granit.Identity.Local\Granit.Identity.Local.csproj" />
+    <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs
@@ -42,14 +42,13 @@ public sealed partial class GranitIdentityLocalAspNetIdentityModule : GranitModu
         // Replace default UserManager with GranitUserManager (exponential backoff lockout)
         context.Services.Replace(ServiceDescriptor.Scoped<UserManager<GranitUser>, GranitUserManager>());
 
-        // TenantAwareRoleLookupNormalizer is intentionally NOT registered in Phase 1.
-        // It will prefix NormalizedName with T_{tenantId}_ when a tenant context is active,
-        // enabling two tenants to share the same role display name without colliding on the
-        // ASP.NET Core Identity global unique index on AspNetRoles.NormalizedName. Phase 1
-        // blocks Side=Tenant role creation via a feature flag on the endpoints, so no
-        // prefix is needed yet. Register via:
-        //   context.Services.Replace(ServiceDescriptor.Scoped<ILookupNormalizer, TenantAwareRoleLookupNormalizer>());
-        // once the flag is flipped in Phase 2. See RoleMetadata docs.
+        // TenantAwareRoleLookupNormalizer is intentionally NOT registered by default.
+        // It prefixes NormalizedName with T_{tenantId}_ when a tenant context is active,
+        // enabling two tenants to share the same role display name without colliding on
+        // the ASP.NET Core Identity global unique index on AspNetRoles.NormalizedName.
+        // Applications that enable RoleEndpointsOptions.AllowTenantRoles must register it:
+        //   context.Services.Replace(
+        //       ServiceDescriptor.Scoped<ILookupNormalizer, TenantAwareRoleLookupNormalizer>());
 
         // Replace default claims principal factory to inject tenant_id into the Identity cookie.
         // This ensures multi-tenancy middleware can resolve the tenant from the authenticated

--- a/src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs
@@ -5,6 +5,7 @@ using Granit.Identity.Local.AspNetIdentity.Internal;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Services;
 using Granit.Modularity;
+using Granit.Persistence.EntityFrameworkCore.DataSeeding;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -55,6 +56,13 @@ public sealed partial class GranitIdentityLocalAspNetIdentityModule : GranitModu
         // cookie on subsequent requests (authorize, refresh, 2FA second step).
         context.Services.Replace(ServiceDescriptor.Scoped<
             IUserClaimsPrincipalFactory<GranitUser>, GranitUserClaimsPrincipalFactory>());
+
+        // Role orchestration — dual-writes GranitRole (Identity DbContext) + RoleMetadata
+        // (host DbContext) with compensating delete on metadata failure.
+        context.Services.TryAddScoped<IGranitRoleOrchestrator, GranitRoleOrchestrator>();
+
+        // Seed SuperAdmin / TenantAdministrator / User on host data seed.
+        context.Services.AddTransient<IHostDataSeedContributor, IdentityLocalRoleSeedContributor>();
 
         // ASP.NET Core Identity service implementations (depend on UserManager<GranitUser>)
         context.Services.TryAddScoped<ITotpService, TotpService>();

--- a/src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs
@@ -41,6 +41,15 @@ public sealed partial class GranitIdentityLocalAspNetIdentityModule : GranitModu
         // Replace default UserManager with GranitUserManager (exponential backoff lockout)
         context.Services.Replace(ServiceDescriptor.Scoped<UserManager<GranitUser>, GranitUserManager>());
 
+        // TenantAwareRoleLookupNormalizer is intentionally NOT registered in Phase 1.
+        // It will prefix NormalizedName with T_{tenantId}_ when a tenant context is active,
+        // enabling two tenants to share the same role display name without colliding on the
+        // ASP.NET Core Identity global unique index on AspNetRoles.NormalizedName. Phase 1
+        // blocks Side=Tenant role creation via a feature flag on the endpoints, so no
+        // prefix is needed yet. Register via:
+        //   context.Services.Replace(ServiceDescriptor.Scoped<ILookupNormalizer, TenantAwareRoleLookupNormalizer>());
+        // once the flag is flipped in Phase 2. See RoleMetadata docs.
+
         // Replace default claims principal factory to inject tenant_id into the Identity cookie.
         // This ensures multi-tenancy middleware can resolve the tenant from the authenticated
         // cookie on subsequent requests (authorize, refresh, 2FA second step).

--- a/src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs
@@ -42,13 +42,9 @@ public sealed partial class GranitIdentityLocalAspNetIdentityModule : GranitModu
         // Replace default UserManager with GranitUserManager (exponential backoff lockout)
         context.Services.Replace(ServiceDescriptor.Scoped<UserManager<GranitUser>, GranitUserManager>());
 
-        // TenantAwareRoleLookupNormalizer is intentionally NOT registered by default.
-        // It prefixes NormalizedName with T_{tenantId}_ when a tenant context is active,
-        // enabling two tenants to share the same role display name without colliding on
-        // the ASP.NET Core Identity global unique index on AspNetRoles.NormalizedName.
-        // Applications that enable RoleEndpointsOptions.AllowTenantRoles must register it:
-        //   context.Services.Replace(
-        //       ServiceDescriptor.Scoped<ILookupNormalizer, TenantAwareRoleLookupNormalizer>());
+        // TenantAwareRoleLookupNormalizer is intentionally not wired here. When
+        // RoleEndpointsOptions.AllowTenantRoles is enabled, applications must replace the
+        // framework default ILookupNormalizer with that type — see the class remarks.
 
         // Replace default claims principal factory to inject tenant_id into the Identity cookie.
         // This ensures multi-tenancy middleware can resolve the tenant from the authenticated

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/GranitRoleOrchestrator.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/GranitRoleOrchestrator.cs
@@ -1,0 +1,205 @@
+using Granit.Authorization;
+using Granit.Authorization.Domain;
+using Granit.Guids;
+using Granit.Identity.Local.Domain;
+using Granit.Identity.Local.Services;
+using Granit.MultiTenancy;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Identity.Local.AspNetIdentity.Internal;
+
+/// <summary>
+/// Coordinates the dual write between <see cref="GranitRole"/> (Identity DbContext) and
+/// <see cref="RoleMetadata"/> (host DbContext that implements <c>IPermissionGrantDbContext</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Phase 1 uses a compensating-write strategy rather than a cross-DbContext transaction:
+/// the role is created in the Identity DbContext first, then the metadata is persisted
+/// via <see cref="IRoleMetadataStore"/>. If the metadata write fails the GranitRole is
+/// deleted so the invariant "every Granit-managed role has matching metadata" converges.
+/// </para>
+/// <para>
+/// This avoids the MSDTC escalation hazard of <c>TransactionScope</c> on Linux with
+/// Npgsql. A future refinement can swap this implementation for a shared-connection
+/// EF Core transaction (<c>Database.OpenConnectionAsync</c> / <c>SetDbConnection</c> /
+/// <c>BeginTransactionAsync</c> / <c>UseTransactionAsync</c>) when both DbContexts are
+/// known to target the same physical database.
+/// </para>
+/// </remarks>
+internal sealed partial class GranitRoleOrchestrator(
+    RoleManager<GranitRole> roleManager,
+    IRoleMetadataStore roleMetadataStore,
+    IGuidGenerator guidGenerator,
+    ILogger<GranitRoleOrchestrator> logger) : IGranitRoleOrchestrator
+{
+    /// <inheritdoc />
+    public async Task<RoleMetadata> CreateAsync(
+        CreateRoleCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        Guid roleId = guidGenerator.Create();
+        GranitRole granitRole = new()
+        {
+            Id = roleId,
+            Name = command.Name,
+            Description = command.Description,
+        };
+
+        IdentityResult createResult = await roleManager.CreateAsync(granitRole).ConfigureAwait(false);
+        if (!createResult.Succeeded)
+        {
+            throw new InvalidOperationException(
+                $"Failed to create GranitRole '{command.Name}': " +
+                string.Join("; ", createResult.Errors.Select(e => $"{e.Code}: {e.Description}")));
+        }
+
+        try
+        {
+            var metadata = RoleMetadata.Create(
+                roleId,
+                command.Name,
+                command.MultiTenancySide,
+                command.TenantId,
+                command.ClientId,
+                command.Description,
+                command.IsSystem);
+
+            await roleMetadataStore.AddAsync(metadata, cancellationToken).ConfigureAwait(false);
+            return metadata;
+        }
+        catch (Exception ex)
+        {
+            LogMetadataFailedCompensating(logger, ex, roleId, command.Name);
+            await CompensateDeleteAsync(granitRole).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<RoleMetadata> RenameAsync(
+        Guid roleId,
+        string newName,
+        string? newDescription,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(newName);
+
+        RoleMetadata? existingMetadata = await roleMetadataStore.FindByIdAsync(roleId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new InvalidOperationException($"No RoleMetadata found for id {roleId:D}.");
+
+        if (existingMetadata.IsSystem)
+        {
+            throw new InvalidOperationException(
+                $"Role '{existingMetadata.Name}' is a system role and cannot be renamed.");
+        }
+
+        GranitRole? granitRole = await roleManager.FindByIdAsync(roleId.ToString("D"))
+            .ConfigureAwait(false)
+            ?? throw new InvalidOperationException($"No GranitRole found for id {roleId:D}.");
+
+        string previousName = granitRole.Name!;
+        string? previousDescription = granitRole.Description;
+
+        granitRole.Name = newName;
+        granitRole.Description = newDescription;
+        IdentityResult updateResult = await roleManager.UpdateAsync(granitRole).ConfigureAwait(false);
+        if (!updateResult.Succeeded)
+        {
+            throw new InvalidOperationException(
+                $"Failed to update GranitRole '{previousName}': " +
+                string.Join("; ", updateResult.Errors.Select(e => $"{e.Code}: {e.Description}")));
+        }
+
+        try
+        {
+            existingMetadata.Rename(newName, newDescription);
+            await roleMetadataStore.UpdateAsync(existingMetadata, cancellationToken).ConfigureAwait(false);
+            return existingMetadata;
+        }
+        catch (Exception ex)
+        {
+            LogRenameFailedCompensating(logger, ex, roleId, newName);
+            granitRole.Name = previousName;
+            granitRole.Description = previousDescription;
+            try
+            {
+                await roleManager.UpdateAsync(granitRole).ConfigureAwait(false);
+            }
+            catch (Exception compEx)
+            {
+                LogCompensationFailed(logger, compEx, roleId);
+            }
+
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteAsync(Guid roleId, CancellationToken cancellationToken = default)
+    {
+        RoleMetadata? metadata = await roleMetadataStore.FindByIdAsync(roleId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new InvalidOperationException($"No RoleMetadata found for id {roleId:D}.");
+
+        if (metadata.IsSystem)
+        {
+            throw new InvalidOperationException(
+                $"Role '{metadata.Name}' is a system role and cannot be deleted.");
+        }
+
+        GranitRole? granitRole = await roleManager.FindByIdAsync(roleId.ToString("D")).ConfigureAwait(false);
+
+        await roleMetadataStore.RemoveAsync(metadata, cancellationToken).ConfigureAwait(false);
+
+        if (granitRole is not null)
+        {
+            IdentityResult deleteResult = await roleManager.DeleteAsync(granitRole).ConfigureAwait(false);
+            if (!deleteResult.Succeeded)
+            {
+                // Metadata is already gone — surface the error so the operator knows
+                // a GranitRole orphan is now in the Identity store. The FK-free nature
+                // of the dual model means no referential integrity breakage, but the
+                // role should be cleaned up.
+                throw new InvalidOperationException(
+                    $"RoleMetadata for '{metadata.Name}' deleted but GranitRole cleanup failed: " +
+                    string.Join("; ", deleteResult.Errors.Select(e => $"{e.Code}: {e.Description}")));
+            }
+        }
+    }
+
+    private async Task CompensateDeleteAsync(GranitRole granitRole)
+    {
+        try
+        {
+            IdentityResult deleteResult = await roleManager.DeleteAsync(granitRole).ConfigureAwait(false);
+            if (!deleteResult.Succeeded)
+            {
+                LogCompensationFailed(logger, exception: null, granitRole.Id);
+            }
+        }
+        catch (Exception ex)
+        {
+            LogCompensationFailed(logger, ex, granitRole.Id);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Error,
+        Message = "RoleMetadata creation failed for role {RoleId} ('{RoleName}') — compensating by deleting GranitRole.")]
+    private static partial void LogMetadataFailedCompensating(
+        ILogger logger, Exception exception, Guid roleId, string roleName);
+
+    [LoggerMessage(Level = LogLevel.Error,
+        Message = "RoleMetadata rename failed for role {RoleId} → '{NewName}' — compensating by reverting GranitRole.")]
+    private static partial void LogRenameFailedCompensating(
+        ILogger logger, Exception exception, Guid roleId, string newName);
+
+    [LoggerMessage(Level = LogLevel.Critical,
+        Message = "Compensation action failed for role {RoleId} — manual cleanup required (orphan GranitRole or RoleMetadata row).")]
+    private static partial void LogCompensationFailed(
+        ILogger logger, Exception? exception, Guid roleId);
+}

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/GranitRoleOrchestrator.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/GranitRoleOrchestrator.cs
@@ -15,17 +15,18 @@ namespace Granit.Identity.Local.AspNetIdentity.Internal;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Phase 1 uses a compensating-write strategy rather than a cross-DbContext transaction:
-/// the role is created in the Identity DbContext first, then the metadata is persisted
-/// via <see cref="IRoleMetadataStore"/>. If the metadata write fails the GranitRole is
+/// Uses a compensating-write strategy rather than a cross-DbContext transaction: the role
+/// is created in the Identity DbContext first, then the metadata is persisted via
+/// <see cref="IRoleMetadataStore"/>. If the metadata write fails the GranitRole is
 /// deleted so the invariant "every Granit-managed role has matching metadata" converges.
 /// </para>
 /// <para>
 /// This avoids the MSDTC escalation hazard of <c>TransactionScope</c> on Linux with
-/// Npgsql. A future refinement can swap this implementation for a shared-connection
-/// EF Core transaction (<c>Database.OpenConnectionAsync</c> / <c>SetDbConnection</c> /
-/// <c>BeginTransactionAsync</c> / <c>UseTransactionAsync</c>) when both DbContexts are
-/// known to target the same physical database.
+/// Npgsql and works regardless of whether both DbContexts share a physical database.
+/// Deployments that guarantee both contexts target the same database and can expose their
+/// connection across assemblies may replace this with a shared-connection EF Core
+/// transaction (<c>Database.OpenConnectionAsync</c> / <c>SetDbConnection</c> /
+/// <c>BeginTransactionAsync</c> / <c>UseTransactionAsync</c>).
 /// </para>
 /// </remarks>
 internal sealed partial class GranitRoleOrchestrator(

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/GranitRoleOrchestrator.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/GranitRoleOrchestrator.cs
@@ -72,7 +72,7 @@ internal sealed partial class GranitRoleOrchestrator(
             await roleMetadataStore.AddAsync(metadata, cancellationToken).ConfigureAwait(false);
             return metadata;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogMetadataFailedCompensating(logger, ex, roleId, command.Name);
             await CompensateDeleteAsync(granitRole).ConfigureAwait(false);
@@ -122,7 +122,7 @@ internal sealed partial class GranitRoleOrchestrator(
             await roleMetadataStore.UpdateAsync(existingMetadata, cancellationToken).ConfigureAwait(false);
             return existingMetadata;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogRenameFailedCompensating(logger, ex, roleId, newName);
             granitRole.Name = previousName;
@@ -131,7 +131,7 @@ internal sealed partial class GranitRoleOrchestrator(
             {
                 await roleManager.UpdateAsync(granitRole).ConfigureAwait(false);
             }
-            catch (Exception compEx)
+            catch (Exception compEx) when (compEx is not OperationCanceledException)
             {
                 LogCompensationFailed(logger, compEx, roleId);
             }
@@ -183,7 +183,7 @@ internal sealed partial class GranitRoleOrchestrator(
                 LogCompensationFailed(logger, exception: null, granitRole.Id);
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogCompensationFailed(logger, ex, granitRole.Id);
         }

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/IdentityLocalRoleSeedContributor.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/IdentityLocalRoleSeedContributor.cs
@@ -1,0 +1,100 @@
+using Granit.Authorization;
+using Granit.Authorization.Domain;
+using Granit.Identity.Local.Domain;
+using Granit.Identity.Local.Services;
+using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore.DataSeeding;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Identity.Local.AspNetIdentity.Internal;
+
+/// <summary>
+/// Seeds the three platform-provided system roles and their <see cref="RoleMetadata"/> rows:
+/// <list type="bullet">
+///   <item><c>SuperAdmin</c> — <see cref="MultiTenancySide.Host"/>, platform administrator.</item>
+///   <item><c>TenantAdministrator</c> — <see cref="MultiTenancySide.Both"/>, defined globally, assignable per tenant.</item>
+///   <item><c>User</c> — <see cref="MultiTenancySide.Both"/>, default role for new users.</item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// Idempotent: each role is created only if no matching <see cref="RoleMetadata"/> row
+/// already exists for the <c>(Name, TenantId, ClientId)</c> triplet. System roles flagged
+/// <see cref="RoleMetadata.IsSystem"/> are protected from CRUD-endpoint deletion / rename.
+/// </remarks>
+internal sealed partial class IdentityLocalRoleSeedContributor(
+    IGranitRoleOrchestrator orchestrator,
+    IRoleMetadataStore roleMetadataStore,
+    RoleManager<GranitRole> roleManager,
+    ILogger<IdentityLocalRoleSeedContributor> logger) : IHostDataSeedContributor
+{
+    private static readonly SystemRoleDescriptor[] SystemRoles =
+    [
+        new("SuperAdmin", MultiTenancySide.Host, "Platform administrator with cross-tenant access."),
+        new("TenantAdministrator", MultiTenancySide.Both, "Administrator within a tenant — can manage tenant users, roles, and settings."),
+        new("User", MultiTenancySide.Both, "Default role assigned to every authenticated user."),
+    ];
+
+    /// <inheritdoc />
+    public async Task SeedAsync(DataSeedContext context, CancellationToken cancellationToken = default)
+    {
+        foreach (SystemRoleDescriptor descriptor in SystemRoles)
+        {
+            await SeedSystemRoleAsync(descriptor, cancellationToken).ConfigureAwait(false);
+        }
+
+        LogSeedingCompleted(logger, SystemRoles.Length);
+    }
+
+    private async Task SeedSystemRoleAsync(SystemRoleDescriptor descriptor, CancellationToken cancellationToken)
+    {
+        RoleMetadata? existingMetadata = await roleMetadataStore
+            .FindByNameAsync(descriptor.Name, tenantId: null, clientId: null, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (existingMetadata is not null)
+        {
+            LogRoleUnchanged(logger, descriptor.Name);
+            return;
+        }
+
+        // Repair path: a GranitRole may exist without RoleMetadata (partial failure of a
+        // previous seed). Reuse it so we don't hit the unique-name index.
+        GranitRole? existingRole = await roleManager.FindByNameAsync(descriptor.Name).ConfigureAwait(false);
+        if (existingRole is not null)
+        {
+            await roleManager.DeleteAsync(existingRole).ConfigureAwait(false);
+            LogOrphanGranitRoleRemoved(logger, descriptor.Name);
+        }
+
+        await orchestrator.CreateAsync(
+            new CreateRoleCommand(
+                Name: descriptor.Name,
+                MultiTenancySide: descriptor.Side,
+                TenantId: null,
+                ClientId: null,
+                Description: descriptor.Description,
+                IsSystem: true),
+            cancellationToken).ConfigureAwait(false);
+
+        LogRoleCreated(logger, descriptor.Name, descriptor.Side);
+    }
+
+    private sealed record SystemRoleDescriptor(string Name, MultiTenancySide Side, string Description);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Identity.Local system role seeding completed — {RoleCount} role(s) verified.")]
+    private static partial void LogSeedingCompleted(ILogger logger, int roleCount);
+
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "System role '{RoleName}' already exists — skipping.")]
+    private static partial void LogRoleUnchanged(ILogger logger, string roleName);
+
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "Created system role '{RoleName}' with side {Side}.")]
+    private static partial void LogRoleCreated(ILogger logger, string roleName, MultiTenancySide side);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Orphan GranitRole '{RoleName}' without RoleMetadata removed before re-seed.")]
+    private static partial void LogOrphanGranitRoleRemoved(ILogger logger, string roleName);
+}

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/TenantAwareRoleLookupNormalizer.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/TenantAwareRoleLookupNormalizer.cs
@@ -28,7 +28,7 @@ namespace Granit.Identity.Local.AspNetIdentity.Internal;
 /// table needs the prefix strategy.
 /// </para>
 /// </remarks>
-public sealed class TenantAwareRoleLookupNormalizer(ICurrentTenant currentTenant) : ILookupNormalizer
+internal sealed class TenantAwareRoleLookupNormalizer(ICurrentTenant currentTenant) : ILookupNormalizer
 {
     private const string TenantPrefixMarker = "T_";
 

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/TenantAwareRoleLookupNormalizer.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/TenantAwareRoleLookupNormalizer.cs
@@ -1,0 +1,53 @@
+using Granit.MultiTenancy;
+using Microsoft.AspNetCore.Identity;
+
+namespace Granit.Identity.Local.AspNetIdentity.Internal;
+
+/// <summary>
+/// <see cref="ILookupNormalizer"/> that prefixes role names with the current tenant id when a
+/// tenant context is active, so the same display name (e.g. <c>"Manager"</c>) can coexist across
+/// tenants on a single globally-unique <c>GranitRole.NormalizedName</c> column.
+/// </summary>
+/// <remarks>
+/// <para>
+/// ASP.NET Core Identity enforces a process-wide unique index on
+/// <c>AspNetRoles.NormalizedName</c>. A naive lookup normalizer (<see cref="UpperInvariantLookupNormalizer"/>)
+/// collides the first time two tenants create a role with the same display name. Prefixing the
+/// normalized form with <c>T_{tenantId}_</c> when <see cref="ICurrentTenant.IsAvailable"/> is
+/// <see langword="true"/> restores tenant-isolated role namespaces while keeping
+/// <see cref="Microsoft.AspNetCore.Identity.IdentityRole{TKey}.Name"/> as the clean display value.
+/// </para>
+/// <para>
+/// Host-scope roles (<see cref="Granit.Authorization.Domain.RoleMetadata"/> with
+/// <see cref="MultiTenancySide.Host"/> or <see cref="MultiTenancySide.Both"/>) are seeded and
+/// resolved outside a tenant context, so their normalized names stay un-prefixed.
+/// </para>
+/// <para>
+/// User name normalization falls through to the standard upper-invariant behavior because
+/// <c>GranitUser</c> already scopes users per tenant via <c>TenantId</c> — only the role
+/// table needs the prefix strategy.
+/// </para>
+/// </remarks>
+public sealed class TenantAwareRoleLookupNormalizer(ICurrentTenant currentTenant) : ILookupNormalizer
+{
+    private const string TenantPrefixMarker = "T_";
+
+    /// <inheritdoc />
+    public string? NormalizeName(string? name)
+    {
+        if (name is null)
+        {
+            return null;
+        }
+
+        string upper = name.ToUpperInvariant();
+
+        return currentTenant.IsAvailable
+            ? $"{TenantPrefixMarker}{currentTenant.Id:N}_{upper}"
+            : upper;
+    }
+
+    /// <inheritdoc />
+    public string? NormalizeEmail(string? email) =>
+        email?.ToUpperInvariant();
+}

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/TenantAwareRoleLookupNormalizer.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/TenantAwareRoleLookupNormalizer.cs
@@ -27,6 +27,14 @@ namespace Granit.Identity.Local.AspNetIdentity.Internal;
 /// <c>GranitUser</c> already scopes users per tenant via <c>TenantId</c> — only the role
 /// table needs the prefix strategy.
 /// </para>
+/// <para>
+/// This implementation is intentionally not registered by
+/// <c>GranitIdentityLocalAspNetIdentityModule</c>. Applications that enable
+/// <c>RoleEndpointsOptions.AllowTenantRoles</c> must replace the framework default
+/// <see cref="ILookupNormalizer"/> with this type (scoped lifetime required because
+/// <see cref="ICurrentTenant"/> is scoped). See the Granit docs for the full wiring
+/// example.
+/// </para>
 /// </remarks>
 internal sealed class TenantAwareRoleLookupNormalizer(ICurrentTenant currentTenant) : ILookupNormalizer
 {

--- a/src/Granit.Identity.Local.AspNetIdentity/packages.lock.json
+++ b/src/Granit.Identity.Local.AspNetIdentity/packages.lock.json
@@ -11,25 +11,33 @@
       "Microsoft.EntityFrameworkCore": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "eDy7bu3G+51FRC0cPtXTqUI9iAdDYl/XBQ5UguN8NFOA7QNmFvUEf36wA7PZ4ctsnxRN4t3dIvs2VKVE5H+EQQ==",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.6",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "4F+e6uxhVmyduu+Ve1INxek94adt4RAddWqykXNDnOOWQrJJ20izw/9qRpZdkLnIW9oj/3qnLWUtsv37U0xJCw=="
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "PIcmALdKzeSJNWmxsLDsS8XKFqiH5+9GzIM+qd3w1efYIwmO0w5304i37/SkfynctHZwkiiQjb2mkoIXU1CGZg=="
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
       },
       "granit": {
         "type": "Project"
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
       },
       "granit.caching": {
         "type": "Project",
@@ -65,6 +73,12 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {
@@ -76,6 +90,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
@@ -83,6 +98,25 @@
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -105,6 +139,24 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
         }
       },
       "OpenTelemetry.Api": {

--- a/src/Granit.Identity.Local.Endpoints/Dtos/RoleCreateRequest.cs
+++ b/src/Granit.Identity.Local.Endpoints/Dtos/RoleCreateRequest.cs
@@ -5,8 +5,8 @@ namespace Granit.Identity.Local.Endpoints.Dtos;
 /// <summary>Request to create a new local role.</summary>
 /// <param name="Name">Display name of the role (max 256 chars).</param>
 /// <param name="MultiTenancySide">
-/// Host / Tenant / Both applicability. <see cref="MultiTenancySide.Tenant"/> is refused in
-/// Phase 1 unless the <c>AllowTenantRoles</c> option is flipped.
+/// Host / Tenant / Both applicability. <see cref="MultiTenancySide.Tenant"/> is refused
+/// unless <c>RoleEndpointsOptions.AllowTenantRoles</c> is enabled.
 /// </param>
 /// <param name="TenantId">
 /// Tenant identifier — required iff <paramref name="MultiTenancySide"/> is

--- a/src/Granit.Identity.Local.Endpoints/Dtos/RoleCreateRequest.cs
+++ b/src/Granit.Identity.Local.Endpoints/Dtos/RoleCreateRequest.cs
@@ -1,0 +1,21 @@
+using Granit.MultiTenancy;
+
+namespace Granit.Identity.Local.Endpoints.Dtos;
+
+/// <summary>Request to create a new local role.</summary>
+/// <param name="Name">Display name of the role (max 256 chars).</param>
+/// <param name="MultiTenancySide">
+/// Host / Tenant / Both applicability. <see cref="MultiTenancySide.Tenant"/> is refused in
+/// Phase 1 unless the <c>AllowTenantRoles</c> option is flipped.
+/// </param>
+/// <param name="TenantId">
+/// Tenant identifier — required iff <paramref name="MultiTenancySide"/> is
+/// <see cref="MultiTenancySide.Tenant"/>. Must match the caller's tenant context when
+/// invoked from a tenant admin.
+/// </param>
+/// <param name="Description">Optional description (max 2048 chars).</param>
+public sealed record RoleCreateRequest(
+    string Name,
+    MultiTenancySide MultiTenancySide,
+    Guid? TenantId,
+    string? Description);

--- a/src/Granit.Identity.Local.Endpoints/Dtos/RoleResponse.cs
+++ b/src/Granit.Identity.Local.Endpoints/Dtos/RoleResponse.cs
@@ -7,7 +7,7 @@ namespace Granit.Identity.Local.Endpoints.Dtos;
 /// <param name="Name">Role display name.</param>
 /// <param name="MultiTenancySide">Host / Tenant / Both applicability.</param>
 /// <param name="TenantId">Tenant scope (null for Host / Both).</param>
-/// <param name="ClientId">OIDC client scope (always null in Phase 1).</param>
+/// <param name="ClientId">OIDC client scope — reserved for future realm / client role distinction; currently always null.</param>
 /// <param name="Description">Optional description.</param>
 /// <param name="IsSystem"><c>true</c> for platform-seeded roles (cannot be renamed or deleted).</param>
 /// <param name="CreatedAt">Creation timestamp.</param>

--- a/src/Granit.Identity.Local.Endpoints/Dtos/RoleResponse.cs
+++ b/src/Granit.Identity.Local.Endpoints/Dtos/RoleResponse.cs
@@ -1,0 +1,24 @@
+using Granit.MultiTenancy;
+
+namespace Granit.Identity.Local.Endpoints.Dtos;
+
+/// <summary>Role detail payload returned by the CRUD endpoints.</summary>
+/// <param name="Id">Aggregate identifier.</param>
+/// <param name="Name">Role display name.</param>
+/// <param name="MultiTenancySide">Host / Tenant / Both applicability.</param>
+/// <param name="TenantId">Tenant scope (null for Host / Both).</param>
+/// <param name="ClientId">OIDC client scope (always null in Phase 1).</param>
+/// <param name="Description">Optional description.</param>
+/// <param name="IsSystem"><c>true</c> for platform-seeded roles (cannot be renamed or deleted).</param>
+/// <param name="CreatedAt">Creation timestamp.</param>
+/// <param name="ModifiedAt">Last modification timestamp.</param>
+public sealed record RoleResponse(
+    Guid Id,
+    string Name,
+    MultiTenancySide MultiTenancySide,
+    Guid? TenantId,
+    string? ClientId,
+    string? Description,
+    bool IsSystem,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset? ModifiedAt);

--- a/src/Granit.Identity.Local.Endpoints/Dtos/RoleUpdateRequest.cs
+++ b/src/Granit.Identity.Local.Endpoints/Dtos/RoleUpdateRequest.cs
@@ -1,0 +1,6 @@
+namespace Granit.Identity.Local.Endpoints.Dtos;
+
+/// <summary>Request to rename / update a local role's description. Side and tenant scope are immutable.</summary>
+/// <param name="Name">New display name (max 256 chars).</param>
+/// <param name="Description">New description (max 2048 chars, nullable to clear).</param>
+public sealed record RoleUpdateRequest(string Name, string? Description);

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
@@ -1,5 +1,6 @@
 using Granit.Authorization;
 using Granit.Authorization.Domain;
+using Granit.Http.Idempotency.Attributes;
 using Granit.Identity.Local.Endpoints.Dtos;
 using Granit.Identity.Local.Endpoints.Options;
 using Granit.Identity.Local.Endpoints.Permissions;
@@ -53,6 +54,7 @@ internal static class GranitRoleEndpoints
             .WithDescription(
                 "Invariants: Host / Both ⇒ TenantId must be null; Tenant ⇒ TenantId required. "
                 + "Phase 1 refuses Side=Tenant unless the AllowTenantRoles option is enabled.")
+            .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces<RoleResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status403Forbidden)
@@ -62,6 +64,7 @@ internal static class GranitRoleEndpoints
             .WithName("RenameRole")
             .WithSummary("Renames a role and updates its description.")
             .WithDescription("Side and tenant scope are immutable. System roles and non-visible roles cannot be renamed.")
+            .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces<RoleResponse>()
             .ProducesValidationProblem()
             .ProducesProblem(StatusCodes.Status404NotFound)
@@ -72,6 +75,7 @@ internal static class GranitRoleEndpoints
             .WithName("DeleteRole")
             .WithSummary("Hard-deletes a non-system role.")
             .WithDescription("System roles (SuperAdmin, TenantAdministrator, User) and non-visible roles cannot be deleted.")
+            .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status403Forbidden)

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
@@ -53,7 +53,7 @@ internal static class GranitRoleEndpoints
             .WithSummary("Creates a new local role and its RoleMetadata row.")
             .WithDescription(
                 "Invariants: Host / Both ⇒ TenantId must be null; Tenant ⇒ TenantId required. "
-                + "Phase 1 refuses Side=Tenant unless the AllowTenantRoles option is enabled.")
+                + "Side=Tenant requests are refused unless RoleEndpointsOptions.AllowTenantRoles is enabled.")
             .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces<RoleResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem()
@@ -122,7 +122,7 @@ internal static class GranitRoleEndpoints
         {
             return TypedResults.Problem(
                 statusCode: StatusCodes.Status403Forbidden,
-                detail: "Tenant-scoped role creation is disabled in this deployment (Phase 1). " +
+                detail: "Tenant-scoped role creation is disabled. " +
                         "Set RoleEndpointsOptions.AllowTenantRoles = true to enable it.");
         }
 

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
@@ -1,0 +1,284 @@
+using Granit.Authorization;
+using Granit.Authorization.Domain;
+using Granit.Identity.Local.Endpoints.Dtos;
+using Granit.Identity.Local.Endpoints.Options;
+using Granit.Identity.Local.Endpoints.Permissions;
+using Granit.Identity.Local.Services;
+using Granit.MultiTenancy;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Identity.Local.Endpoints.Endpoints;
+
+/// <summary>
+/// Host / tenant admin CRUD endpoints for local roles (<see cref="RoleMetadata"/>).
+/// </summary>
+/// <remarks>
+/// Visibility matrix applied server-side via <see cref="ICurrentTenant"/>:
+/// <list type="bullet">
+///   <item><b>Host admin</b>: full CRUD on Host + Both roles ; read-only view on Tenant roles.</item>
+///   <item><b>Tenant admin</b>: read-only + assignable on Both roles ; full CRUD on own-tenant roles ; Host and other-tenant roles invisible.</item>
+/// </list>
+/// Non-visible roles surface as 404 on direct lookups — the endpoints never disclose
+/// their existence by returning 403.
+/// </remarks>
+internal static class GranitRoleEndpoints
+{
+    internal static RouteGroupBuilder MapGranitRoleEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/", ListAsync)
+            .WithName("ListRoles")
+            .WithSummary("Lists roles visible in the caller's context.")
+            .WithDescription(
+                "Host admins see every role (CRUD on Host / Both, read-only on tenant roles). "
+                + "Tenant admins see Both roles (read-only) plus their own tenant roles (CRUD).")
+            .Produces<IReadOnlyList<RoleResponse>>()
+            .RequireAuthorization(IdentityLocalPermissions.Roles.Read);
+
+        group.MapGet("/{id:guid}", GetByIdAsync)
+            .WithName("GetRole")
+            .WithSummary("Returns a single role by identifier.")
+            .WithDescription("Returns 404 when the role is not visible in the caller's context (no 403 to prevent leak).")
+            .Produces<RoleResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .RequireAuthorization(IdentityLocalPermissions.Roles.Read);
+
+        group.MapPost("/", CreateAsync)
+            .WithName("CreateRole")
+            .WithSummary("Creates a new local role and its RoleMetadata row.")
+            .WithDescription(
+                "Invariants: Host / Both ⇒ TenantId must be null; Tenant ⇒ TenantId required. "
+                + "Phase 1 refuses Side=Tenant unless the AllowTenantRoles option is enabled.")
+            .Produces<RoleResponse>(StatusCodes.Status201Created)
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .RequireAuthorization(IdentityLocalPermissions.Roles.Manage);
+
+        group.MapPut("/{id:guid}", RenameAsync)
+            .WithName("RenameRole")
+            .WithSummary("Renames a role and updates its description.")
+            .WithDescription("Side and tenant scope are immutable. System roles and non-visible roles cannot be renamed.")
+            .Produces<RoleResponse>()
+            .ProducesValidationProblem()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .RequireAuthorization(IdentityLocalPermissions.Roles.Manage);
+
+        group.MapDelete("/{id:guid}", DeleteAsync)
+            .WithName("DeleteRole")
+            .WithSummary("Hard-deletes a non-system role.")
+            .WithDescription("System roles (SuperAdmin, TenantAdministrator, User) and non-visible roles cannot be deleted.")
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .RequireAuthorization(IdentityLocalPermissions.Roles.Delete);
+
+        return group;
+    }
+
+    private static async Task<Ok<IReadOnlyList<RoleResponse>>> ListAsync(
+        [FromServices] IRoleMetadataStore store,
+        [FromServices] ICurrentTenant currentTenant,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<RoleMetadata> all = await store.ListAllAsync(cancellationToken).ConfigureAwait(false);
+        IReadOnlyList<RoleResponse> visible = [.. all.Where(r => IsVisible(r, currentTenant)).Select(Map)];
+        return TypedResults.Ok(visible);
+    }
+
+    private static async Task<Results<Ok<RoleResponse>, ProblemHttpResult>> GetByIdAsync(
+        Guid id,
+        [FromServices] IRoleMetadataStore store,
+        [FromServices] ICurrentTenant currentTenant,
+        CancellationToken cancellationToken)
+    {
+        RoleMetadata? role = await store.FindByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        if (role is null || !IsVisible(role, currentTenant))
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound, detail: $"Role {id:D} not found.");
+        }
+
+        return TypedResults.Ok(Map(role));
+    }
+
+    private static async Task<Results<Created<RoleResponse>, ProblemHttpResult>> CreateAsync(
+        [FromBody] RoleCreateRequest request,
+        [FromServices] IGranitRoleOrchestrator orchestrator,
+        [FromServices] ICurrentTenant currentTenant,
+        [FromServices] IOptions<RoleEndpointsOptions> options,
+        CancellationToken cancellationToken)
+    {
+        RoleEndpointsOptions opts = options.Value;
+
+        if (request.MultiTenancySide == MultiTenancySide.Tenant && !opts.AllowTenantRoles)
+        {
+            return TypedResults.Problem(
+                statusCode: StatusCodes.Status403Forbidden,
+                detail: "Tenant-scoped role creation is disabled in this deployment (Phase 1). " +
+                        "Set RoleEndpointsOptions.AllowTenantRoles = true to enable it.");
+        }
+
+        // Tenant admins may only create roles in their own tenant.
+        if (currentTenant.IsAvailable && request.MultiTenancySide == MultiTenancySide.Tenant
+            && request.TenantId != currentTenant.Id)
+        {
+            return TypedResults.Problem(
+                statusCode: StatusCodes.Status403Forbidden,
+                detail: "Tenant admins can only create roles within their own tenant.");
+        }
+
+        // Tenant admins cannot create Host or Both roles (platform-level scope).
+        if (currentTenant.IsAvailable && request.MultiTenancySide != MultiTenancySide.Tenant)
+        {
+            return TypedResults.Problem(
+                statusCode: StatusCodes.Status403Forbidden,
+                detail: "Host and Both roles are managed from the host admin context.");
+        }
+
+        RoleMetadata created;
+        try
+        {
+            created = await orchestrator.CreateAsync(
+                new CreateRoleCommand(
+                    Name: request.Name,
+                    MultiTenancySide: request.MultiTenancySide,
+                    TenantId: request.TenantId,
+                    ClientId: null,
+                    Description: request.Description,
+                    IsSystem: false),
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (ArgumentException ex)
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status400BadRequest, detail: ex.Message);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status409Conflict, detail: ex.Message);
+        }
+
+        return TypedResults.Created($"/admin/roles/{created.Id:D}", Map(created));
+    }
+
+    private static async Task<Results<Ok<RoleResponse>, ProblemHttpResult>> RenameAsync(
+        Guid id,
+        [FromBody] RoleUpdateRequest request,
+        [FromServices] IGranitRoleOrchestrator orchestrator,
+        [FromServices] IRoleMetadataStore store,
+        [FromServices] ICurrentTenant currentTenant,
+        CancellationToken cancellationToken)
+    {
+        RoleMetadata? role = await store.FindByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        if (role is null || !IsVisible(role, currentTenant))
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound, detail: $"Role {id:D} not found.");
+        }
+
+        if (!CanMutate(role, currentTenant))
+        {
+            return TypedResults.Problem(
+                statusCode: StatusCodes.Status403Forbidden,
+                detail: "You do not have permission to modify this role.");
+        }
+
+        try
+        {
+            RoleMetadata updated = await orchestrator
+                .RenameAsync(id, request.Name, request.Description, cancellationToken)
+                .ConfigureAwait(false);
+            return TypedResults.Ok(Map(updated));
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("system role", StringComparison.OrdinalIgnoreCase))
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status403Forbidden, detail: ex.Message);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status409Conflict, detail: ex.Message);
+        }
+    }
+
+    private static async Task<Results<NoContent, ProblemHttpResult>> DeleteAsync(
+        Guid id,
+        [FromServices] IGranitRoleOrchestrator orchestrator,
+        [FromServices] IRoleMetadataStore store,
+        [FromServices] ICurrentTenant currentTenant,
+        CancellationToken cancellationToken)
+    {
+        RoleMetadata? role = await store.FindByIdAsync(id, cancellationToken).ConfigureAwait(false);
+        if (role is null || !IsVisible(role, currentTenant))
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound, detail: $"Role {id:D} not found.");
+        }
+
+        if (!CanMutate(role, currentTenant))
+        {
+            return TypedResults.Problem(
+                statusCode: StatusCodes.Status403Forbidden,
+                detail: "You do not have permission to delete this role.");
+        }
+
+        try
+        {
+            await orchestrator.DeleteAsync(id, cancellationToken).ConfigureAwait(false);
+            return TypedResults.NoContent();
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("system role", StringComparison.OrdinalIgnoreCase))
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status403Forbidden, detail: ex.Message);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status409Conflict, detail: ex.Message);
+        }
+    }
+
+    /// <summary>Applies the visibility matrix: Host invisible to tenant admins; other-tenant roles invisible.</summary>
+    private static bool IsVisible(RoleMetadata role, ICurrentTenant currentTenant)
+    {
+        if (!currentTenant.IsAvailable)
+        {
+            // Host admin sees everything.
+            return true;
+        }
+
+        // Tenant admin context.
+        return role.MultiTenancySide switch
+        {
+            MultiTenancySide.Host => false,
+            MultiTenancySide.Both => true,
+            MultiTenancySide.Tenant => role.TenantId == currentTenant.Id,
+            _ => false,
+        };
+    }
+
+    /// <summary>
+    /// Tenant admins cannot mutate Host or Both roles (read-only view). Host admins can mutate
+    /// anything — Tenant-own editing cross-tenant is also permitted for platform support.
+    /// </summary>
+    private static bool CanMutate(RoleMetadata role, ICurrentTenant currentTenant)
+    {
+        if (!currentTenant.IsAvailable)
+        {
+            return true;
+        }
+
+        return role.MultiTenancySide == MultiTenancySide.Tenant
+            && role.TenantId == currentTenant.Id;
+    }
+
+    private static RoleResponse Map(RoleMetadata role) =>
+        new(role.Id,
+            role.Name,
+            role.MultiTenancySide,
+            role.TenantId,
+            role.ClientId,
+            role.Description,
+            role.IsSystem,
+            role.CreatedAt,
+            role.ModifiedAt);
+}

--- a/src/Granit.Identity.Local.Endpoints/Extensions/RoleEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Identity.Local.Endpoints/Extensions/RoleEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,36 @@
+using Granit.Identity.Local.Endpoints.Endpoints;
+using Granit.Identity.Local.Endpoints.Options;
+using Granit.Validation.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Identity.Local.Endpoints.Extensions;
+
+/// <summary>
+/// Extension methods for registering the local role CRUD endpoints.
+/// </summary>
+public static class RoleEndpointRouteBuilderExtensions
+{
+    /// <summary>
+    /// Maps <c>/admin/roles</c> CRUD endpoints (list / get / create / rename / delete).
+    /// </summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="configure">Optional delegate to customize <see cref="RoleEndpointsOptions"/>.</param>
+    /// <returns>The role <see cref="RouteGroupBuilder"/> for further chaining.</returns>
+    public static RouteGroupBuilder MapGranitRoles(
+        this IEndpointRouteBuilder endpoints,
+        Action<RoleEndpointsOptions>? configure = null)
+    {
+        RoleEndpointsOptions options = new();
+        configure?.Invoke(options);
+
+        RouteGroupBuilder group = endpoints
+            .MapGranitGroup(options.RolesRoutePrefix)
+            .WithTags(options.TagName)
+            .RequireAuthorization();
+
+        group.MapGranitRoleEndpoints();
+        return group;
+    }
+}

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/cs.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/cs.json
@@ -2,6 +2,16 @@
   "culture": "cs",
   "texts": {
     "PermissionGroup:IdentityLocal": "Místní identita",
-    "Permission:IdentityLocal.Users.Impersonate": "Vydávat se za uživatele"
+    "Permission:IdentityLocal.Users.Impersonate": "Vydávat se za uživatele",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
+    "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/de.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/de.json
@@ -2,6 +2,16 @@
   "culture": "de",
   "texts": {
     "PermissionGroup:IdentityLocal": "Lokale Identität",
-    "Permission:IdentityLocal.Users.Impersonate": "Benutzer imitieren"
+    "Permission:IdentityLocal.Users.Impersonate": "Benutzer imitieren",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
+    "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/en.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/en.json
@@ -2,6 +2,16 @@
   "culture": "en",
   "texts": {
     "PermissionGroup:IdentityLocal": "Local Identity",
-    "Permission:IdentityLocal.Users.Impersonate": "Impersonate users"
+    "Permission:IdentityLocal.Users.Impersonate": "Impersonate users",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
+    "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/es.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/es.json
@@ -2,6 +2,16 @@
   "culture": "es",
   "texts": {
     "PermissionGroup:IdentityLocal": "Identidad local",
-    "Permission:IdentityLocal.Users.Impersonate": "Suplantar usuarios"
+    "Permission:IdentityLocal.Users.Impersonate": "Suplantar usuarios",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
+    "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/fr.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/fr.json
@@ -1,7 +1,17 @@
 {
   "culture": "fr",
   "texts": {
-    "PermissionGroup:IdentityLocal": "Identit\u00e9 locale",
-    "Permission:IdentityLocal.Users.Impersonate": "Se faire passer pour un utilisateur"
+    "PermissionGroup:IdentityLocal": "Identité locale",
+    "Permission:IdentityLocal.Users.Impersonate": "Se faire passer pour un utilisateur",
+    "Permission:IdentityLocal.Roles.Read": "Lire les rôles",
+    "Permission:IdentityLocal.Roles.Manage": "Créer et renommer les rôles",
+    "Permission:IdentityLocal.Roles.Delete": "Supprimer les rôles",
+    "Granit:Identity:Role:TenantIdRequired": "Les rôles de tenant requièrent un TenantId non nul.",
+    "Granit:Identity:Role:TenantIdForbidden": "Les rôles Host et Both doivent avoir un TenantId nul.",
+    "Granit:Identity:Role:CannotDeleteSystem": "Les rôles système ne peuvent pas être supprimés.",
+    "Granit:Identity:Role:CannotRenameSystem": "Les rôles système ne peuvent pas être renommés.",
+    "Granit:Identity:Role:NameAlreadyExists": "Un rôle portant ce nom existe déjà dans cette portée.",
+    "Granit:Identity:Role:TenantRolesDisabled": "La création de rôles de tenant est désactivée dans ce déploiement.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Les administrateurs de tenant ne peuvent gérer que les rôles de leur propre tenant."
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/hi.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/hi.json
@@ -2,6 +2,16 @@
   "culture": "hi",
   "texts": {
     "PermissionGroup:IdentityLocal": "स्थानीय पहचान",
-    "Permission:IdentityLocal.Users.Impersonate": "उपयोगकर्ताओं का प्रतिरूपण करें"
+    "Permission:IdentityLocal.Users.Impersonate": "उपयोगकर्ताओं का प्रतिरूपण करें",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
+    "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/it.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/it.json
@@ -2,6 +2,16 @@
   "culture": "it",
   "texts": {
     "PermissionGroup:IdentityLocal": "Identità locale",
-    "Permission:IdentityLocal.Users.Impersonate": "Impersonare utenti"
+    "Permission:IdentityLocal.Users.Impersonate": "Impersonare utenti",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
+    "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/ja.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/ja.json
@@ -2,6 +2,16 @@
   "culture": "ja",
   "texts": {
     "PermissionGroup:IdentityLocal": "ローカル ID",
-    "Permission:IdentityLocal.Users.Impersonate": "ユーザーになりすます"
+    "Permission:IdentityLocal.Users.Impersonate": "ユーザーになりすます",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
+    "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/ko.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/ko.json
@@ -2,6 +2,16 @@
   "culture": "ko",
   "texts": {
     "PermissionGroup:IdentityLocal": "로컬 ID",
-    "Permission:IdentityLocal.Users.Impersonate": "사용자 가장"
+    "Permission:IdentityLocal.Users.Impersonate": "사용자 가장",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
+    "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/nl.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/nl.json
@@ -2,6 +2,16 @@
   "culture": "nl",
   "texts": {
     "PermissionGroup:IdentityLocal": "Lokale identiteit",
-    "Permission:IdentityLocal.Users.Impersonate": "Gebruikers nabootsen"
+    "Permission:IdentityLocal.Users.Impersonate": "Gebruikers nabootsen",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
+    "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/pl.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/pl.json
@@ -2,6 +2,16 @@
   "culture": "pl",
   "texts": {
     "PermissionGroup:IdentityLocal": "Tożsamość lokalna",
-    "Permission:IdentityLocal.Users.Impersonate": "Podszywanie się pod użytkowników"
+    "Permission:IdentityLocal.Users.Impersonate": "Podszywanie się pod użytkowników",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
+    "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/pt.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/pt.json
@@ -2,6 +2,16 @@
   "culture": "pt",
   "texts": {
     "PermissionGroup:IdentityLocal": "Identidade local",
-    "Permission:IdentityLocal.Users.Impersonate": "Personificar utilizadores"
+    "Permission:IdentityLocal.Users.Impersonate": "Personificar utilizadores",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
+    "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/sv.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/sv.json
@@ -2,6 +2,16 @@
   "culture": "sv",
   "texts": {
     "PermissionGroup:IdentityLocal": "Lokal identitet",
-    "Permission:IdentityLocal.Users.Impersonate": "Imitera användare"
+    "Permission:IdentityLocal.Users.Impersonate": "Imitera användare",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
+    "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/tr.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/tr.json
@@ -2,6 +2,16 @@
   "culture": "tr",
   "texts": {
     "PermissionGroup:IdentityLocal": "Yerel kimlik",
-    "Permission:IdentityLocal.Users.Impersonate": "Kullanıcıların kimliğine bürünme"
+    "Permission:IdentityLocal.Users.Impersonate": "Kullanıcıların kimliğine bürünme",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
+    "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/zh.json
+++ b/src/Granit.Identity.Local.Endpoints/Localization/IdentityLocalEndpoints/zh.json
@@ -2,6 +2,16 @@
   "culture": "zh",
   "texts": {
     "PermissionGroup:IdentityLocal": "本地身份",
-    "Permission:IdentityLocal.Users.Impersonate": "模拟用户"
+    "Permission:IdentityLocal.Users.Impersonate": "模拟用户",
+    "Permission:IdentityLocal.Roles.Read": "Read roles",
+    "Permission:IdentityLocal.Roles.Manage": "Create and rename roles",
+    "Permission:IdentityLocal.Roles.Delete": "Delete roles",
+    "Granit:Identity:Role:TenantIdRequired": "Tenant-scoped roles require a non-null TenantId.",
+    "Granit:Identity:Role:TenantIdForbidden": "Host and Both roles must have a null TenantId.",
+    "Granit:Identity:Role:CannotDeleteSystem": "System roles cannot be deleted.",
+    "Granit:Identity:Role:CannotRenameSystem": "System roles cannot be renamed.",
+    "Granit:Identity:Role:NameAlreadyExists": "A role with this name already exists in the target scope.",
+    "Granit:Identity:Role:TenantRolesDisabled": "Tenant-scoped role creation is disabled in this deployment.",
+    "Granit:Identity:Role:CrossTenantForbidden": "Tenant administrators can only manage roles within their own tenant."
   }
 }

--- a/src/Granit.Identity.Local.Endpoints/Options/RoleEndpointsOptions.cs
+++ b/src/Granit.Identity.Local.Endpoints/Options/RoleEndpointsOptions.cs
@@ -12,12 +12,14 @@ public sealed class RoleEndpointsOptions
     public string TagName { get; set; } = "Identity - Roles";
 
     /// <summary>
-    /// When <see langword="false"/> (Phase 1 default), create / rename / delete endpoints
-    /// refuse <see cref="Granit.MultiTenancy.MultiTenancySide.Tenant"/> role requests — only
-    /// host-level and Both roles are creatable. Flip to <see langword="true"/> once
-    /// <c>TenantAwareRoleLookupNormalizer</c> is wired (Phase 2) so tenant-scoped roles
-    /// can coexist without colliding on the ASP.NET Core Identity
-    /// <c>AspNetRoles.NormalizedName</c> unique index.
+    /// When <see langword="false"/> (default), create / rename / delete endpoints refuse
+    /// <see cref="Granit.MultiTenancy.MultiTenancySide.Tenant"/> role requests — only
+    /// host-level and Both roles are creatable.
     /// </summary>
+    /// <remarks>
+    /// Opt-in requires <c>TenantAwareRoleLookupNormalizer</c> to be registered as the
+    /// <c>ILookupNormalizer</c>; otherwise two tenants with the same role display name
+    /// collide on the ASP.NET Core Identity <c>AspNetRoles.NormalizedName</c> unique index.
+    /// </remarks>
     public bool AllowTenantRoles { get; set; }
 }

--- a/src/Granit.Identity.Local.Endpoints/Options/RoleEndpointsOptions.cs
+++ b/src/Granit.Identity.Local.Endpoints/Options/RoleEndpointsOptions.cs
@@ -1,0 +1,23 @@
+namespace Granit.Identity.Local.Endpoints.Options;
+
+/// <summary>
+/// Options for the local role CRUD endpoints.
+/// </summary>
+public sealed class RoleEndpointsOptions
+{
+    /// <summary>Route prefix for the role CRUD endpoints. Default: <c>"admin/roles"</c>.</summary>
+    public string RolesRoutePrefix { get; set; } = "admin/roles";
+
+    /// <summary>OpenAPI tag for the role CRUD endpoints. Default: <c>"Identity - Roles"</c>.</summary>
+    public string TagName { get; set; } = "Identity - Roles";
+
+    /// <summary>
+    /// When <see langword="false"/> (Phase 1 default), create / rename / delete endpoints
+    /// refuse <see cref="Granit.MultiTenancy.MultiTenancySide.Tenant"/> role requests — only
+    /// host-level and Both roles are creatable. Flip to <see langword="true"/> once
+    /// <c>TenantAwareRoleLookupNormalizer</c> is wired (Phase 2) so tenant-scoped roles
+    /// can coexist without colliding on the ASP.NET Core Identity
+    /// <c>AspNetRoles.NormalizedName</c> unique index.
+    /// </summary>
+    public bool AllowTenantRoles { get; set; }
+}

--- a/src/Granit.Identity.Local.Endpoints/Permissions/IdentityLocalPermissionDefinitionProvider.cs
+++ b/src/Granit.Identity.Local.Endpoints/Permissions/IdentityLocalPermissionDefinitionProvider.cs
@@ -26,5 +26,27 @@ internal sealed class IdentityLocalPermissionDefinitionProvider : IPermissionDef
             LocalizableString.Create<IdentityLocalEndpointsLocalizationResource>(
                 "Permission:IdentityLocal.Users.Impersonate"),
             MultiTenancySide.Host);
+
+        // Role CRUD — assignable in both host and tenant admin contexts. Visibility matrix
+        // + the AllowTenantRoles feature flag on endpoint options gate who can create
+        // tenant-scoped roles; the permission itself stays Side=Both so either admin can
+        // hold it.
+        group.AddPermission(
+            IdentityLocalPermissions.Roles.Read,
+            LocalizableString.Create<IdentityLocalEndpointsLocalizationResource>(
+                "Permission:IdentityLocal.Roles.Read"),
+            MultiTenancySide.Both);
+
+        group.AddPermission(
+            IdentityLocalPermissions.Roles.Manage,
+            LocalizableString.Create<IdentityLocalEndpointsLocalizationResource>(
+                "Permission:IdentityLocal.Roles.Manage"),
+            MultiTenancySide.Both);
+
+        group.AddPermission(
+            IdentityLocalPermissions.Roles.Delete,
+            LocalizableString.Create<IdentityLocalEndpointsLocalizationResource>(
+                "Permission:IdentityLocal.Roles.Delete"),
+            MultiTenancySide.Both);
     }
 }

--- a/src/Granit.Identity.Local.Endpoints/Permissions/IdentityLocalPermissions.cs
+++ b/src/Granit.Identity.Local.Endpoints/Permissions/IdentityLocalPermissions.cs
@@ -19,4 +19,17 @@ public static class IdentityLocalPermissions
         /// <summary>Permission to impersonate a user by issuing a short-lived token.</summary>
         public const string Impersonate = "IdentityLocal.Users.Impersonate";
     }
+
+    /// <summary>Permissions for the local role CRUD endpoints.</summary>
+    public static class Roles
+    {
+        /// <summary>Read / list local roles visible in the caller's context.</summary>
+        public const string Read = "IdentityLocal.Roles.Read";
+
+        /// <summary>Create or rename local roles.</summary>
+        public const string Manage = "IdentityLocal.Roles.Manage";
+
+        /// <summary>Hard-delete non-system roles.</summary>
+        public const string Delete = "IdentityLocal.Roles.Delete";
+    }
 }

--- a/src/Granit.Identity.Local.Endpoints/Validators/RoleCreateRequestValidator.cs
+++ b/src/Granit.Identity.Local.Endpoints/Validators/RoleCreateRequestValidator.cs
@@ -1,0 +1,33 @@
+using FluentValidation;
+using Granit.Identity.Local.Endpoints.Dtos;
+using Granit.MultiTenancy;
+using Granit.Validation;
+using Granit.Validation.Extensions;
+
+namespace Granit.Identity.Local.Endpoints.Validators;
+
+/// <summary>Validates <see cref="RoleCreateRequest"/>.</summary>
+internal sealed class RoleCreateRequestValidator : GranitValidator<RoleCreateRequest>
+{
+    public RoleCreateRequestValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(256);
+
+        RuleFor(x => x.Description)
+            .MaximumLength(2048);
+
+        RuleFor(x => x.MultiTenancySide)
+            .IsInEnum();
+
+        // Side ↔ TenantId consistency (mirrors RoleMetadata.Create domain invariant).
+        RuleFor(x => x)
+            .Must(x => x.MultiTenancySide != MultiTenancySide.Tenant || x.TenantId is not null)
+            .WithErrorCodeAndMessage("Granit:Identity:Role:TenantIdRequired");
+
+        RuleFor(x => x)
+            .Must(x => x.MultiTenancySide == MultiTenancySide.Tenant || x.TenantId is null)
+            .WithErrorCodeAndMessage("Granit:Identity:Role:TenantIdForbidden");
+    }
+}

--- a/src/Granit.Identity.Local.Endpoints/Validators/RoleUpdateRequestValidator.cs
+++ b/src/Granit.Identity.Local.Endpoints/Validators/RoleUpdateRequestValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+using Granit.Identity.Local.Endpoints.Dtos;
+using Granit.Validation;
+
+namespace Granit.Identity.Local.Endpoints.Validators;
+
+/// <summary>Validates <see cref="RoleUpdateRequest"/>.</summary>
+internal sealed class RoleUpdateRequestValidator : GranitValidator<RoleUpdateRequest>
+{
+    public RoleUpdateRequestValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(256);
+
+        RuleFor(x => x.Description)
+            .MaximumLength(2048);
+    }
+}

--- a/src/Granit.Identity.Local.Endpoints/packages.lock.json
+++ b/src/Granit.Identity.Local.Endpoints/packages.lock.json
@@ -10,15 +10,15 @@
       },
       "Asp.Versioning.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "I4CuGwl0nO98j6Ft6XlGBgzj1+goE/TSVlnHKgtRkuMZ0K4gy9I+Wyrtto8dyt0hWcFMDFAZ4lYNr58DSemH1g=="
+        "resolved": "10.0.0",
+        "contentHash": "cMRE5nvNMfBgfkb0XFWst/7UtyXCjoAXnV0L4Scx4P9fcf0idgrj1Z0c+3ylsy01K4cOib7dKhCBfpg5z3r0Kg=="
       },
       "Asp.Versioning.Http": {
         "type": "Transitive",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "4/QzujOrkGn9sMch3eHhR5LpVJ4Xo5T2BNg7U1/r4YwEa8JywzkoGQHjW7Nk0W8ljETnpoJaO5mrTsfEOnJK3A==",
+        "resolved": "10.0.0",
+        "contentHash": "xmNm9FM2d20NKy7i1osEQysf7pJ4iJjWnM6e8CoeIhUREqG8nugsfC82pGpmzlatjAJL5T52ieSpyW+GFdSsSQ==",
         "dependencies": {
-          "Asp.Versioning.Abstractions": "10.0.0-preview.2"
+          "Asp.Versioning.Abstractions": "10.0.0"
         }
       },
       "Microsoft.OpenApi": {
@@ -112,6 +112,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
@@ -166,19 +167,19 @@
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "AyrcDwLzJp8yRJaFjZMJXkR1Rx2UaJkwGrGlX8sxIt2F5ZGiZwn/puXkB/oEaq55TxLkpiXWAOHHFsiVptp0fA==",
+        "resolved": "10.0.0",
+        "contentHash": "W0wZ+0uZ0UK4KstjvEkNBZ0xxhBmxunwNg8582SVyyW7txQmSXibtm8fC4o82LaemPquYskms67bIbJOSrnlug==",
         "dependencies": {
-          "Asp.Versioning.Http": "10.0.0-preview.2"
+          "Asp.Versioning.Http": "10.0.0"
         }
       },
       "Asp.Versioning.Mvc.ApiExplorer": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "G/LhAaLQj+gsB8UXRNm65fxjsI7fe87itZExb+MvJOQdrXYalZKbwuzMntO95xM5cKDrDgLnCH64fl6w173aGg==",
+        "resolved": "10.0.0",
+        "contentHash": "H54UOpRoc4RmhQ4RA2lzDz43a/hAu/JN19Yyy/DNmH4XlRxhemfhifJyh9BaXNJOtGa2Dnu2xEeP4VSiTdUdAg==",
         "dependencies": {
-          "Asp.Versioning.Mvc": "10.0.0-preview.2"
+          "Asp.Versioning.Mvc": "10.0.0"
         }
       },
       "FluentValidation": {
@@ -199,8 +200,8 @@
       "Microsoft.AspNetCore.OpenApi": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "WTAQe7MAbbKztRyeCRGZOqqlIqpMHDBz+jKo7LLY6hp4qRqn7iucR24u32KJVxV7mF3tSEfwXH96NgGSiDBw7A==",
+        "resolved": "10.0.7",
+        "contentHash": "vKiAcGXG0BwNVw3bOjjWRLnp9tR18dR7MiwpvC94h0yFS+zfnzGHzS/JmmgwUdRixrGxrlIMRAWrVc+2DfAGlg==",
         "dependencies": {
           "Microsoft.OpenApi": "2.0.0"
         }

--- a/src/Granit.Identity.Local.Notifications/packages.lock.json
+++ b/src/Granit.Identity.Local.Notifications/packages.lock.json
@@ -10,28 +10,36 @@
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "lYQ9S1FGXIWIU7243RimdAXQYsFDeLhSSZvbSDwbeI/kCzZ4MIYXpp3kMQ+bDJXwl9pzMRIYkd4f9zGqcYxfAQ==",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "a7bA7IT3ngIgcOMb/2MVH5CcfSxUCeQ6QXWS1Vt6oFpzLTH3U1+J2Xtc64Uw3whX9akYG8eR/UQeEzxo64zZLg==",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L8P21mqaG+CXvPheLndean/cHCOcItJqH8nx+0YQnK7wAiOR0G1IOC418ZSzTMD2D6Gmo0f2M5WR70XtpX2B8g=="
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
       "granit": {
         "type": "Project"
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
       },
       "granit.caching": {
         "type": "Project",
@@ -91,6 +99,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
@@ -150,71 +159,71 @@
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "Ilr690V+E1H116ncF00KIlvRloKXBdCExaNqcT9BvCcS5nFGR1pcTamSA2EI8pOXbNp0DHZm8K8h6Wl1hMSbIQ==",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "5godKXBBsObgl/dBQKgrFeHFd6vVVOMGK3TuKLPNlwJgabFKl5vISSHLw5hWUtd+zKcl/Llmw25dsGlySxXJJg==",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "h22Fm4VxRmr4ty9rxJaW0i51xD56Bl5QhQ2hsGY2vl+6FioWmBhkpg3B78XQaK25N+hE41gZLZuYKGQS+OGbdw==",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.6",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "w+dX4SIr1X9yegX2yX2dU1XtP4JAUVNdvOG/Evn+H+ndn96YzfIPX52FALXChrRNWFR9l77FQyg1mB7WQo6iOA=="
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "1YgBO3wAy0dlpQyVTKWBSPND/t0yZHsvd3shGpbeEwH8JSb2hnFI2pNFrOOUi/stsp+T/dqwqmRIGh47ibo9bw==",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "v5RTWm+3Gdub21ADJeRG5bunOOxutFNBZk6qGH6Az4L5nyRZoLe3Kse7jfAyUcdEoiKp72XpNw/wGR+9wP+MtQ==",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "O7xt1vYMxku2+/WpFkh6X8RzUtYbKR+XCt0KOO0W9TbRbFeQdfb9Nry/CdVq57kOyOKS3Z4qD1xqV/8LpJQ0Xw==",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "OpenTelemetry.Api": {

--- a/src/Granit.Identity.Local.Privacy/packages.lock.json
+++ b/src/Granit.Identity.Local.Privacy/packages.lock.json
@@ -25,8 +25,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.24.1",
-        "contentHash": "aZlQx92iNtt4XT5u7j1Qwsx4fjabneWGco2TP4Ms7ivNwLNN6jFxwX084i/HyRAW1NIbro7T0VeFpstlDNEEdw==",
+        "resolved": "1.26.0",
+        "contentHash": "StYdHzKheT//Lt7z4XRCz6dpUgUrhoN/MA96FuJfydQkwOmU/wqOYaaNJmeKDAM1HjYx2BfeKruy8Fk2iEYw5g==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -36,15 +36,15 @@
           "Microsoft.Extensions.Hosting": "10.0.0",
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Polly.Core": "8.6.5",
-          "Spectre.Console": "0.53.0"
+          "Spectre.Console": "0.55.0"
         }
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.27.0",
-        "contentHash": "OAnWVIbLp7qZxLGLixvzeRnwm+cEl7qEL/GVWAK8ndsAqXBKsGU26RGf2rNJE2qxiWHTs+f4nh1bkAbtk+Ps9Q==",
+        "resolved": "1.29.0",
+        "contentHash": "WFsuQXsnh77U40PwBAtMxwls3AdBZRVlkWaNbwNrMbBbu4UrFTwlMjbu2+I9xDWrdrlnbEa0Bt5kQCeHHX2QVQ==",
         "dependencies": {
-          "JasperFx": "1.24.0"
+          "JasperFx": "1.26.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -159,19 +159,19 @@
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "lYQ9S1FGXIWIU7243RimdAXQYsFDeLhSSZvbSDwbeI/kCzZ4MIYXpp3kMQ+bDJXwl9pzMRIYkd4f9zGqcYxfAQ==",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "a7bA7IT3ngIgcOMb/2MVH5CcfSxUCeQ6QXWS1Vt6oFpzLTH3U1+J2Xtc64Uw3whX9akYG8eR/UQeEzxo64zZLg==",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.CommandLine": {
@@ -246,11 +246,11 @@
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L98Xe5C+xyKytLNLiEyQ0rcY8GNXAeAn1xKsE0YDxPx/mXBYYtRoj8pC2cnbSFQUlOzBkyO90ivMSV22SRETFg==",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
@@ -260,10 +260,10 @@
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "iU/lPyrjHVA4jJ7Bl/VpXvgsAD4qJWc4oPSVJjMBeZjmv7IIo8wBKxnOUoXdZcSCUJ6MeBMs3WpXNfncO7OzRg==",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.FileProviders.Physical": {
@@ -388,8 +388,8 @@
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L8P21mqaG+CXvPheLndean/cHCOcItJqH8nx+0YQnK7wAiOR0G1IOC418ZSzTMD2D6Gmo0f2M5WR70XtpX2B8g=="
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
       "NewId": {
         "type": "Transitive",
@@ -408,8 +408,16 @@
       },
       "Spectre.Console": {
         "type": "Transitive",
-        "resolved": "0.53.0",
-        "contentHash": "m2iv8Egfywp7FaNLKCmCFHbSf36D4ctzZKvlAK9NXMyGLh6L+CnrZWK8o+LOYsoAS1jtoHn0W1BT0W8vuq/FUw=="
+        "resolved": "0.55.0",
+        "contentHash": "2TVhUHFsDux0Z+y2Hv4bFsOMuON4SuotEEKkMparFkp5Rm259naaaEQrN4Sv6C1cbsiGKPjfkJDGgUp+hZPjTw==",
+        "dependencies": {
+          "Spectre.Console.Ansi": "0.55.0"
+        }
+      },
+      "Spectre.Console.Ansi": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "GIfgOvuF8MpU52bprhwtDEtx0gmVIGOepM8bw0lH/TSMD0rg1Xp+5Y53kPG8rFVdcpbNANlhDQ5mEVVPO3/2Tg=="
       },
       "System.Composition": {
         "type": "Transitive",
@@ -461,6 +469,14 @@
       },
       "granit": {
         "type": "Project"
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
       },
       "granit.blobstorage": {
         "type": "Project",
@@ -532,6 +548,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
@@ -622,84 +639,84 @@
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "Ilr690V+E1H116ncF00KIlvRloKXBdCExaNqcT9BvCcS5nFGR1pcTamSA2EI8pOXbNp0DHZm8K8h6Wl1hMSbIQ==",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "5godKXBBsObgl/dBQKgrFeHFd6vVVOMGK3TuKLPNlwJgabFKl5vISSHLw5hWUtd+zKcl/Llmw25dsGlySxXJJg==",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "h22Fm4VxRmr4ty9rxJaW0i51xD56Bl5QhQ2hsGY2vl+6FioWmBhkpg3B78XQaK25N+hE41gZLZuYKGQS+OGbdw==",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.6",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "w+dX4SIr1X9yegX2yX2dU1XtP4JAUVNdvOG/Evn+H+ndn96YzfIPX52FALXChrRNWFR9l77FQyg1mB7WQo6iOA=="
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "x3C8tgsX+xWvV5u76LFm24/U7sSnCRjuudBkbFsMV/DIqCA85te7YGg6dpa7lBToDhi4Lry9E7Arpy0laUw5AQ==",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.6",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "1YgBO3wAy0dlpQyVTKWBSPND/t0yZHsvd3shGpbeEwH8JSb2hnFI2pNFrOOUi/stsp+T/dqwqmRIGh47ibo9bw==",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "v5RTWm+3Gdub21ADJeRG5bunOOxutFNBZk6qGH6Az4L5nyRZoLe3Kse7jfAyUcdEoiKp72XpNw/wGR+9wP+MtQ==",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "O7xt1vYMxku2+/WpFkh6X8RzUtYbKR+XCt0KOO0W9TbRbFeQdfb9Nry/CdVq57kOyOKS3Z4qD1xqV/8LpJQ0Xw==",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "OpenTelemetry.Api": {
@@ -717,11 +734,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.31.1",
-        "contentHash": "SsVN2EYsO3gmnmaRBiBVgqoFD1STX4BIQdVE+oqNd5L1qmgcBSwiml7LG+ZTekRRA0rTZ5UsVIDFzGgXNmLhtQ==",
+        "resolved": "5.32.0",
+        "contentHash": "/fxTzZoQVIirESc6o41jALj4wZ+sSHVgaN//h26aM2o++QDOEtu5/JbB2RIcckCRxbSVX8B3jS/Fphh4KSpypQ==",
         "dependencies": {
-          "JasperFx": "1.24.1",
-          "JasperFx.Events": "1.27.0",
+          "JasperFx": "1.26.0",
+          "JasperFx.Events": "1.29.0",
           "JasperFx.RuntimeCompiler": "4.4.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",

--- a/src/Granit.Identity.Local/Granit.Identity.Local.csproj
+++ b/src/Granit.Identity.Local/Granit.Identity.Local.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Events\Granit.Events.csproj" />
     <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />

--- a/src/Granit.Identity.Local/Services/IGranitRoleOrchestrator.cs
+++ b/src/Granit.Identity.Local/Services/IGranitRoleOrchestrator.cs
@@ -1,0 +1,65 @@
+using Granit.Authorization.Domain;
+using Granit.MultiTenancy;
+
+namespace Granit.Identity.Local.Services;
+
+/// <summary>
+/// Coordinates the dual write between <c>GranitRole</c> (local identity) and
+/// <see cref="RoleMetadata"/> (authorization scope metadata) for CRUD operations
+/// exposed by the admin endpoints.
+/// </summary>
+/// <remarks>
+/// <para>
+/// GranitRole rows live in the Identity DbContext (e.g. <c>OpenIddictDbContext</c>) while
+/// <see cref="RoleMetadata"/> rows live in the host DbContext that implements
+/// <c>IPermissionGrantDbContext</c>. The orchestrator serialises the two writes and
+/// performs a compensating delete of the GranitRole if the <see cref="RoleMetadata"/>
+/// write fails, so the invariant "every Granit-managed role has matching metadata"
+/// converges even without a cross-DbContext transaction.
+/// </para>
+/// <para>
+/// Phase 1 uses this compensating-write approach. A future refinement can swap the
+/// implementation for a shared-connection EF Core transaction when both DbContexts
+/// target the same physical database, as documented in
+/// <c>docs/dotnet/security/authorization-multitenancy-side.mdx</c>.
+/// </para>
+/// </remarks>
+public interface IGranitRoleOrchestrator
+{
+    /// <summary>
+    /// Creates a local <c>GranitRole</c> and its <see cref="RoleMetadata"/> row, raising
+    /// a <c>RoleCreatedEvent</c> domain event on the aggregate.
+    /// </summary>
+    Task<RoleMetadata> CreateAsync(CreateRoleCommand command, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Renames the role (both local and metadata side) and optionally updates its
+    /// description. Side and tenant scope are immutable after creation.
+    /// </summary>
+    Task<RoleMetadata> RenameAsync(
+        Guid roleId,
+        string newName,
+        string? newDescription,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Hard-deletes the role. System roles (<see cref="RoleMetadata.IsSystem"/>) cannot
+    /// be deleted through this path.
+    /// </summary>
+    Task DeleteAsync(Guid roleId, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Input for <see cref="IGranitRoleOrchestrator.CreateAsync"/>.</summary>
+/// <param name="Name">Role display name, e.g. <c>"Manager"</c>.</param>
+/// <param name="MultiTenancySide">Declarative scope of the role.</param>
+/// <param name="TenantId">Tenant identifier — must be set iff <paramref name="MultiTenancySide"/> is <see cref="Granit.MultiTenancy.MultiTenancySide.Tenant"/>.</param>
+/// <param name="ClientId">Optional OIDC client scope (always <c>null</c> in Phase 1).</param>
+/// <param name="Description">Optional description.</param>
+/// <param name="IsSystem">Mark the role as platform-provisioned (prevents CRUD via endpoints).</param>
+public sealed record CreateRoleCommand(
+    string Name,
+    MultiTenancySide MultiTenancySide,
+    Guid? TenantId,
+    string? ClientId = null,
+    string? Description = null,
+    bool IsSystem = false);

--- a/src/Granit.Identity.Local/Services/IGranitRoleOrchestrator.cs
+++ b/src/Granit.Identity.Local/Services/IGranitRoleOrchestrator.cs
@@ -12,16 +12,17 @@ namespace Granit.Identity.Local.Services;
 /// <para>
 /// GranitRole rows live in the Identity DbContext (e.g. <c>OpenIddictDbContext</c>) while
 /// <see cref="RoleMetadata"/> rows live in the host DbContext that implements
-/// <c>IPermissionGrantDbContext</c>. The orchestrator serialises the two writes and
-/// performs a compensating delete of the GranitRole if the <see cref="RoleMetadata"/>
+/// <c>IPermissionGrantDbContext</c>. The default implementation serialises the two writes
+/// and performs a compensating delete of the GranitRole if the <see cref="RoleMetadata"/>
 /// write fails, so the invariant "every Granit-managed role has matching metadata"
 /// converges even without a cross-DbContext transaction.
 /// </para>
 /// <para>
-/// Phase 1 uses this compensating-write approach. A future refinement can swap the
-/// implementation for a shared-connection EF Core transaction when both DbContexts
-/// target the same physical database, as documented in
-/// <c>docs/dotnet/security/authorization-multitenancy-side.mdx</c>.
+/// A shared-connection EF Core transaction is preferable when both DbContexts target the
+/// same physical database, but requires the Identity DbContext to expose its
+/// <c>DbConnection</c> across assemblies — the current <c>OpenIddictDbContext</c> is
+/// <c>internal sealed</c>. Implementers that control both contexts can register an
+/// alternative implementation of this interface that opens a shared transaction instead.
 /// </para>
 /// </remarks>
 public interface IGranitRoleOrchestrator
@@ -53,7 +54,7 @@ public interface IGranitRoleOrchestrator
 /// <param name="Name">Role display name, e.g. <c>"Manager"</c>.</param>
 /// <param name="MultiTenancySide">Declarative scope of the role.</param>
 /// <param name="TenantId">Tenant identifier — must be set iff <paramref name="MultiTenancySide"/> is <see cref="Granit.MultiTenancy.MultiTenancySide.Tenant"/>.</param>
-/// <param name="ClientId">Optional OIDC client scope (always <c>null</c> in Phase 1).</param>
+/// <param name="ClientId">Optional OIDC client scope — reserved for future realm / client role distinction.</param>
 /// <param name="Description">Optional description.</param>
 /// <param name="IsSystem">Mark the role as platform-provisioned (prevents CRUD via endpoints).</param>
 public sealed record CreateRoleCommand(

--- a/src/Granit.Identity.Local/packages.lock.json
+++ b/src/Granit.Identity.Local/packages.lock.json
@@ -11,6 +11,14 @@
       "granit": {
         "type": "Project"
       },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.OpenIddict.BackgroundJobs/packages.lock.json
+++ b/src/Granit.OpenIddict.BackgroundJobs/packages.lock.json
@@ -57,19 +57,19 @@
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "lYQ9S1FGXIWIU7243RimdAXQYsFDeLhSSZvbSDwbeI/kCzZ4MIYXpp3kMQ+bDJXwl9pzMRIYkd4f9zGqcYxfAQ==",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "a7bA7IT3ngIgcOMb/2MVH5CcfSxUCeQ6QXWS1Vt6oFpzLTH3U1+J2Xtc64Uw3whX9akYG8eR/UQeEzxo64zZLg==",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -100,11 +100,11 @@
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L98Xe5C+xyKytLNLiEyQ0rcY8GNXAeAn1xKsE0YDxPx/mXBYYtRoj8pC2cnbSFQUlOzBkyO90ivMSV22SRETFg==",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
@@ -117,10 +117,10 @@
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "iU/lPyrjHVA4jJ7Bl/VpXvgsAD4qJWc4oPSVJjMBeZjmv7IIo8wBKxnOUoXdZcSCUJ6MeBMs3WpXNfncO7OzRg==",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http.Diagnostics": {
@@ -174,8 +174,8 @@
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L8P21mqaG+CXvPheLndean/cHCOcItJqH8nx+0YQnK7wAiOR0G1IOC418ZSzTMD2D6Gmo0f2M5WR70XtpX2B8g=="
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
       "Microsoft.Extensions.Resilience": {
         "type": "Transitive",
@@ -400,6 +400,14 @@
       "granit": {
         "type": "Project"
       },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.backgroundjobs": {
         "type": "Project",
         "dependencies": {
@@ -478,6 +486,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
@@ -556,52 +565,52 @@
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "Ilr690V+E1H116ncF00KIlvRloKXBdCExaNqcT9BvCcS5nFGR1pcTamSA2EI8pOXbNp0DHZm8K8h6Wl1hMSbIQ==",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "5godKXBBsObgl/dBQKgrFeHFd6vVVOMGK3TuKLPNlwJgabFKl5vISSHLw5hWUtd+zKcl/Llmw25dsGlySxXJJg==",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "h22Fm4VxRmr4ty9rxJaW0i51xD56Bl5QhQ2hsGY2vl+6FioWmBhkpg3B78XQaK25N+hE41gZLZuYKGQS+OGbdw==",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.6",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "w+dX4SIr1X9yegX2yX2dU1XtP4JAUVNdvOG/Evn+H+ndn96YzfIPX52FALXChrRNWFR9l77FQyg1mB7WQo6iOA=="
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "x3C8tgsX+xWvV5u76LFm24/U7sSnCRjuudBkbFsMV/DIqCA85te7YGg6dpa7lBToDhi4Lry9E7Arpy0laUw5AQ==",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.6",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http": {
@@ -632,33 +641,33 @@
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "1YgBO3wAy0dlpQyVTKWBSPND/t0yZHsvd3shGpbeEwH8JSb2hnFI2pNFrOOUi/stsp+T/dqwqmRIGh47ibo9bw==",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "v5RTWm+3Gdub21ADJeRG5bunOOxutFNBZk6qGH6Az4L5nyRZoLe3Kse7jfAyUcdEoiKp72XpNw/wGR+9wP+MtQ==",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "O7xt1vYMxku2+/WpFkh6X8RzUtYbKR+XCt0KOO0W9TbRbFeQdfb9Nry/CdVq57kOyOKS3Z4qD1xqV/8LpJQ0Xw==",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "OpenIddict.EntityFrameworkCore": {

--- a/src/Granit.OpenIddict.Endpoints/packages.lock.json
+++ b/src/Granit.OpenIddict.Endpoints/packages.lock.json
@@ -10,15 +10,15 @@
       },
       "Asp.Versioning.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "I4CuGwl0nO98j6Ft6XlGBgzj1+goE/TSVlnHKgtRkuMZ0K4gy9I+Wyrtto8dyt0hWcFMDFAZ4lYNr58DSemH1g=="
+        "resolved": "10.0.0",
+        "contentHash": "cMRE5nvNMfBgfkb0XFWst/7UtyXCjoAXnV0L4Scx4P9fcf0idgrj1Z0c+3ylsy01K4cOib7dKhCBfpg5z3r0Kg=="
       },
       "Asp.Versioning.Http": {
         "type": "Transitive",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "4/QzujOrkGn9sMch3eHhR5LpVJ4Xo5T2BNg7U1/r4YwEa8JywzkoGQHjW7Nk0W8ljETnpoJaO5mrTsfEOnJK3A==",
+        "resolved": "10.0.0",
+        "contentHash": "xmNm9FM2d20NKy7i1osEQysf7pJ4iJjWnM6e8CoeIhUREqG8nugsfC82pGpmzlatjAJL5T52ieSpyW+GFdSsSQ==",
         "dependencies": {
-          "Asp.Versioning.Abstractions": "10.0.0-preview.2"
+          "Asp.Versioning.Abstractions": "10.0.0"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
@@ -351,6 +351,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
@@ -426,19 +427,19 @@
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "AyrcDwLzJp8yRJaFjZMJXkR1Rx2UaJkwGrGlX8sxIt2F5ZGiZwn/puXkB/oEaq55TxLkpiXWAOHHFsiVptp0fA==",
+        "resolved": "10.0.0",
+        "contentHash": "W0wZ+0uZ0UK4KstjvEkNBZ0xxhBmxunwNg8582SVyyW7txQmSXibtm8fC4o82LaemPquYskms67bIbJOSrnlug==",
         "dependencies": {
-          "Asp.Versioning.Http": "10.0.0-preview.2"
+          "Asp.Versioning.Http": "10.0.0"
         }
       },
       "Asp.Versioning.Mvc.ApiExplorer": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "G/LhAaLQj+gsB8UXRNm65fxjsI7fe87itZExb+MvJOQdrXYalZKbwuzMntO95xM5cKDrDgLnCH64fl6w173aGg==",
+        "resolved": "10.0.0",
+        "contentHash": "H54UOpRoc4RmhQ4RA2lzDz43a/hAu/JN19Yyy/DNmH4XlRxhemfhifJyh9BaXNJOtGa2Dnu2xEeP4VSiTdUdAg==",
         "dependencies": {
-          "Asp.Versioning.Mvc": "10.0.0-preview.2"
+          "Asp.Versioning.Mvc": "10.0.0"
         }
       },
       "FluentValidation": {
@@ -459,8 +460,8 @@
       "Microsoft.AspNetCore.OpenApi": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "WTAQe7MAbbKztRyeCRGZOqqlIqpMHDBz+jKo7LLY6hp4qRqn7iucR24u32KJVxV7mF3tSEfwXH96NgGSiDBw7A==",
+        "resolved": "10.0.7",
+        "contentHash": "vKiAcGXG0BwNVw3bOjjWRLnp9tR18dR7MiwpvC94h0yFS+zfnzGHzS/JmmgwUdRixrGxrlIMRAWrVc+2DfAGlg==",
         "dependencies": {
           "Microsoft.OpenApi": "2.0.0"
         }

--- a/src/Granit.OpenIddict.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/packages.lock.json
@@ -5,10 +5,10 @@
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "zLlJ5K1vxA3c5/YVLFH4RxnqG+fXnYqkzutOJZ8TeGyrm/hzDq6W01AunvhYOAp3m5kLeeoxMDVapXSgTtd6Yg==",
+        "resolved": "10.0.7",
+        "contentHash": "WAMNMV7m019wBaem9YAyK+nsR6r5ixBL/kOPybO9QhEkwG4dOeVG3vvTTkI5I6q6fp5+MN6IuYxxV/2HYiI9vw==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -20,20 +20,20 @@
       "Microsoft.EntityFrameworkCore": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "eDy7bu3G+51FRC0cPtXTqUI9iAdDYl/XBQ5UguN8NFOA7QNmFvUEf36wA7PZ4ctsnxRN4t3dIvs2VKVE5H+EQQ==",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.6",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7"
         }
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "t+pXPUjiAemBTstY57yUAoywOO6znVD3lwy7UERJpji0wmS70XHg0h8EcpX6+7KT6ZVCIndr1pW0GdOobZ4yCg==",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.6"
+          "Microsoft.EntityFrameworkCore": "10.0.7"
         }
       },
       "OpenIddict": {
@@ -67,13 +67,13 @@
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "4F+e6uxhVmyduu+Ve1INxek94adt4RAddWqykXNDnOOWQrJJ20izw/9qRpZdkLnIW9oj/3qnLWUtsv37U0xJCw=="
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "PIcmALdKzeSJNWmxsLDsS8XKFqiH5+9GzIM+qd3w1efYIwmO0w5304i37/SkfynctHZwkiiQjb2mkoIXU1CGZg=="
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
@@ -301,6 +301,14 @@
       "granit": {
         "type": "Project"
       },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -358,6 +366,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
@@ -440,10 +449,10 @@
       "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "PkQ8fY/N811NelZ/Hhi9Y+1TDPiE9XGTzNcyMkaXl8ygYhiQ9ykVSvnzsF2YEtrNVRSs1S123b/dF91EHBJ7BQ==",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http.Resilience": {

--- a/src/Granit.OpenIddict.Server/packages.lock.json
+++ b/src/Granit.OpenIddict.Server/packages.lock.json
@@ -280,6 +280,14 @@
       "granit": {
         "type": "Project"
       },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -331,6 +339,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",

--- a/src/Granit.OpenIddict/packages.lock.json
+++ b/src/Granit.OpenIddict/packages.lock.json
@@ -273,6 +273,14 @@
       "granit": {
         "type": "Project"
       },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -324,6 +332,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",

--- a/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
+++ b/src/bundles/Granit.Bundle.OpenIddict/packages.lock.json
@@ -10,42 +10,42 @@
       },
       "Asp.Versioning.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "I4CuGwl0nO98j6Ft6XlGBgzj1+goE/TSVlnHKgtRkuMZ0K4gy9I+Wyrtto8dyt0hWcFMDFAZ4lYNr58DSemH1g==",
+        "resolved": "10.0.0",
+        "contentHash": "cMRE5nvNMfBgfkb0XFWst/7UtyXCjoAXnV0L4Scx4P9fcf0idgrj1Z0c+3ylsy01K4cOib7dKhCBfpg5z3r0Kg==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "10.0.0"
         }
       },
       "Asp.Versioning.Http": {
         "type": "Transitive",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "4/QzujOrkGn9sMch3eHhR5LpVJ4Xo5T2BNg7U1/r4YwEa8JywzkoGQHjW7Nk0W8ljETnpoJaO5mrTsfEOnJK3A==",
+        "resolved": "10.0.0",
+        "contentHash": "xmNm9FM2d20NKy7i1osEQysf7pJ4iJjWnM6e8CoeIhUREqG8nugsfC82pGpmzlatjAJL5T52ieSpyW+GFdSsSQ==",
         "dependencies": {
-          "Asp.Versioning.Abstractions": "10.0.0-preview.2"
+          "Asp.Versioning.Abstractions": "10.0.0"
         }
       },
       "Microsoft.AspNetCore.Cryptography.Internal": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "uilNcQcBAXgf/hJl5cVwXkYd2frzHatkcnXXNZ26d9geELozdQnbY6XkP2QAiJV2RL2B5wU7NWdnXkpb+mLLhg=="
+        "resolved": "10.0.7",
+        "contentHash": "unTeI3bPmzsl5Xo2Irg7jW8osCjo/H2rBT5sTqopUUI0gbLyTYuTjDyxoKjykjS/nS2jUdAKVFWFoGF1s1g4HQ=="
       },
       "Microsoft.AspNetCore.Cryptography.KeyDerivation": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "uIxxPb3NQ2SiPfA6x7ze7TbqlqwC30IJHythvX2USvv81Akp0wfWvVHis8VxHaurDJIhWOt94n+taJuEzrtNnA==",
+        "resolved": "10.0.7",
+        "contentHash": "qwLYWCaxt23MF7ea/rIDvaRg3oyi6O51nU1YivAuBojrAvUjROHeIpIBxHaWvpH3WoWFf9lX5V40ufo/KKp5ZQ==",
         "dependencies": {
-          "Microsoft.AspNetCore.Cryptography.Internal": "10.0.6"
+          "Microsoft.AspNetCore.Cryptography.Internal": "10.0.7"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "4F+e6uxhVmyduu+Ve1INxek94adt4RAddWqykXNDnOOWQrJJ20izw/9qRpZdkLnIW9oj/3qnLWUtsv37U0xJCw=="
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "PIcmALdKzeSJNWmxsLDsS8XKFqiH5+9GzIM+qd3w1efYIwmO0w5304i37/SkfynctHZwkiiQjb2mkoIXU1CGZg=="
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
@@ -68,27 +68,27 @@
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "lYQ9S1FGXIWIU7243RimdAXQYsFDeLhSSZvbSDwbeI/kCzZ4MIYXpp3kMQ+bDJXwl9pzMRIYkd4f9zGqcYxfAQ==",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "a7bA7IT3ngIgcOMb/2MVH5CcfSxUCeQ6QXWS1Vt6oFpzLTH3U1+J2Xtc64Uw3whX9akYG8eR/UQeEzxo64zZLg==",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "poUvwtf92bEs8uBH3aRRs/ZgiAw+Z485EU7TtVPBt//MmD0uMPERe7+v3Ur7lpD8XgIEDL9sDoTBcW1LMG97CQ==",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection.AutoActivation": {
@@ -101,21 +101,21 @@
       },
       "Microsoft.Extensions.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "vbigpAOKX+Bbm2uJQ/AqXqONEPPB3ZYkynRT24vo5ZWF1rzKPtVjpkQkJx5qTGp2dqNV5In9QqboayqmKdvGUA==",
+        "resolved": "10.0.7",
+        "contentHash": "l+smp1qPlU0OUXD0OGfdp7OUFrbdq7ZaP5T7m2WpfZ4RFKD7iG73BAT7tjSMxNmbSXkhAn1jYHOAqzYG1r9sNg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.6",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.6"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L98Xe5C+xyKytLNLiEyQ0rcY8GNXAeAn1xKsE0YDxPx/mXBYYtRoj8pC2cnbSFQUlOzBkyO90ivMSV22SRETFg==",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
@@ -128,15 +128,15 @@
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "ChhUF6HVSz9DwBgTyHtWbGzH8kWMbEFS7gqrqBnZQhHJFFK7L1k5BX7UCiIHiCap5HEDS6bZYks79JK4c+H0GQ=="
+        "resolved": "10.0.7",
+        "contentHash": "8Oq/03og7ihwbfx+EjfWhYCdMldClxqnqB9w5ZI4KxuhoiUVDxZYVl06K7fhROOoelhKOtnCUtATCqTCrqSGmA=="
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "iU/lPyrjHVA4jJ7Bl/VpXvgsAD4qJWc4oPSVJjMBeZjmv7IIo8wBKxnOUoXdZcSCUJ6MeBMs3WpXNfncO7OzRg==",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http.Diagnostics": {
@@ -160,33 +160,33 @@
       },
       "Microsoft.Extensions.Identity.Core": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "yDTzOrAccPWGjHVsfCVrlmPFYzCvYuMQup+UhlVy+Z74eeUawdgHHR2a2NbjUQCek/Bkb1iCYt8WyRxKI7Nj6w==",
+        "resolved": "10.0.7",
+        "contentHash": "br70n9iuhhn4HU6DrNH96/Rdh6dnW72VoLioQ9UF+XYSjAEREe1TqgyuvUJBVJzayRyuy+rWQrx3eOF38udeSQ==",
         "dependencies": {
-          "Microsoft.AspNetCore.Cryptography.KeyDerivation": "10.0.6",
-          "Microsoft.Extensions.Diagnostics": "10.0.6",
-          "Microsoft.Extensions.Logging": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.AspNetCore.Cryptography.KeyDerivation": "10.0.7",
+          "Microsoft.Extensions.Diagnostics": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Identity.Stores": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "ujKclUOCemLz1r/jdIVcI6anzssaPbqDQq0IZqVclwErhfsH+QgG+dh8PLdtavUCtJ2SXVx/+JRxEYI/WrueMQ==",
+        "resolved": "10.0.7",
+        "contentHash": "zDsolTKiYBP29zxszqNMpecPDkuJtq0JCh4rqXZryGQV+azGDBpCZ7DyUpKk2Pp8Ea3pKaXttZZJRy7c3ay+UA==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Identity.Core": "10.0.6",
-          "Microsoft.Extensions.Logging": "10.0.6"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Identity.Core": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "ZjpnbMD88IcZQE2pE9lcGv3mkH2mlApPWNh88ya1wJpcxZLp7p4aN7twI2FpawGPAsXNpmMgtKaz3o796YWKWQ==",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging.Configuration": {
@@ -211,8 +211,8 @@
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L8P21mqaG+CXvPheLndean/cHCOcItJqH8nx+0YQnK7wAiOR0G1IOC418ZSzTMD2D6Gmo0f2M5WR70XtpX2B8g=="
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
       "Microsoft.Extensions.Resilience": {
         "type": "Transitive",
@@ -566,6 +566,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
@@ -580,6 +581,7 @@
         "dependencies": {
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )"
         }
       },
@@ -732,19 +734,19 @@
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "AyrcDwLzJp8yRJaFjZMJXkR1Rx2UaJkwGrGlX8sxIt2F5ZGiZwn/puXkB/oEaq55TxLkpiXWAOHHFsiVptp0fA==",
+        "resolved": "10.0.0",
+        "contentHash": "W0wZ+0uZ0UK4KstjvEkNBZ0xxhBmxunwNg8582SVyyW7txQmSXibtm8fC4o82LaemPquYskms67bIbJOSrnlug==",
         "dependencies": {
-          "Asp.Versioning.Http": "10.0.0-preview.2"
+          "Asp.Versioning.Http": "10.0.0"
         }
       },
       "Asp.Versioning.Mvc.ApiExplorer": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "G/LhAaLQj+gsB8UXRNm65fxjsI7fe87itZExb+MvJOQdrXYalZKbwuzMntO95xM5cKDrDgLnCH64fl6w173aGg==",
+        "resolved": "10.0.0",
+        "contentHash": "H54UOpRoc4RmhQ4RA2lzDz43a/hAu/JN19Yyy/DNmH4XlRxhemfhifJyh9BaXNJOtGa2Dnu2xEeP4VSiTdUdAg==",
         "dependencies": {
-          "Asp.Versioning.Mvc": "10.0.0-preview.2"
+          "Asp.Versioning.Mvc": "10.0.0"
         }
       },
       "Cronos": {
@@ -772,18 +774,18 @@
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "zLlJ5K1vxA3c5/YVLFH4RxnqG+fXnYqkzutOJZ8TeGyrm/hzDq6W01AunvhYOAp3m5kLeeoxMDVapXSgTtd6Yg==",
+        "resolved": "10.0.7",
+        "contentHash": "WAMNMV7m019wBaem9YAyK+nsR6r5ixBL/kOPybO9QhEkwG4dOeVG3vvTTkI5I6q6fp5+MN6IuYxxV/2HYiI9vw==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.6",
-          "Microsoft.Extensions.Identity.Stores": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Identity.Stores": "10.0.7"
         }
       },
       "Microsoft.AspNetCore.OpenApi": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "WTAQe7MAbbKztRyeCRGZOqqlIqpMHDBz+jKo7LLY6hp4qRqn7iucR24u32KJVxV7mF3tSEfwXH96NgGSiDBw7A==",
+        "resolved": "10.0.7",
+        "contentHash": "vKiAcGXG0BwNVw3bOjjWRLnp9tR18dR7MiwpvC94h0yFS+zfnzGHzS/JmmgwUdRixrGxrlIMRAWrVc+2DfAGlg==",
         "dependencies": {
           "Microsoft.OpenApi": "2.0.0"
         }
@@ -791,99 +793,99 @@
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "eDy7bu3G+51FRC0cPtXTqUI9iAdDYl/XBQ5UguN8NFOA7QNmFvUEf36wA7PZ4ctsnxRN4t3dIvs2VKVE5H+EQQ==",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.6",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.6",
-          "Microsoft.Extensions.Caching.Memory": "10.0.6",
-          "Microsoft.Extensions.Logging": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
         }
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "t+pXPUjiAemBTstY57yUAoywOO6znVD3lwy7UERJpji0wmS70XHg0h8EcpX6+7KT6ZVCIndr1pW0GdOobZ4yCg==",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.6",
-          "Microsoft.Extensions.Caching.Memory": "10.0.6",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging": "10.0.6"
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "Ilr690V+E1H116ncF00KIlvRloKXBdCExaNqcT9BvCcS5nFGR1pcTamSA2EI8pOXbNp0DHZm8K8h6Wl1hMSbIQ==",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "5godKXBBsObgl/dBQKgrFeHFd6vVVOMGK3TuKLPNlwJgabFKl5vISSHLw5hWUtd+zKcl/Llmw25dsGlySxXJJg==",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "h22Fm4VxRmr4ty9rxJaW0i51xD56Bl5QhQ2hsGY2vl+6FioWmBhkpg3B78XQaK25N+hE41gZLZuYKGQS+OGbdw==",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.6",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "w+dX4SIr1X9yegX2yX2dU1XtP4JAUVNdvOG/Evn+H+ndn96YzfIPX52FALXChrRNWFR9l77FQyg1mB7WQo6iOA=="
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "G6AVN2vs66Gu8IkB2FwsVJRpIkkTmPJ+NmAUH7+N+VGGI6qK38OXMZLipjCaOYdj2DW6ge2IIXdwZjhNJefD0w==",
+        "resolved": "10.0.7",
+        "contentHash": "hs9YULcNhj1UiPjhNoJIDBWS92GvAVzT6DyuvbkoxvDcASZUQFVwQ9EAKtgrOfTaI0Vy6U6RwycXko1SIESM8w==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "PkQ8fY/N811NelZ/Hhi9Y+1TDPiE9XGTzNcyMkaXl8ygYhiQ9ykVSvnzsF2YEtrNVRSs1S123b/dF91EHBJ7BQ==",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.6",
-          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.6",
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "x3C8tgsX+xWvV5u76LFm24/U7sSnCRjuudBkbFsMV/DIqCA85te7YGg6dpa7lBToDhi4Lry9E7Arpy0laUw5AQ==",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.6",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http": {
@@ -914,51 +916,51 @@
       "Microsoft.Extensions.Localization": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "iiM6XtI22oEav13ecJwCgMYaTsxPKAYBVlOv0i6HJ7zlkgPc5Wb++7Ucox8AJjzY3pkCwZLatITHkY23g9QHGA==",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Localization.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Localization.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "eXchxdBgomnydhkgk1jCoCgiYL5dYp0TKVPhLSClGirmkEMAW5j8yJQjIoIwoRN5nmER/OYglYxc+wO15zuRkQ=="
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "1YgBO3wAy0dlpQyVTKWBSPND/t0yZHsvd3shGpbeEwH8JSb2hnFI2pNFrOOUi/stsp+T/dqwqmRIGh47ibo9bw==",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "v5RTWm+3Gdub21ADJeRG5bunOOxutFNBZk6qGH6Az4L5nyRZoLe3Kse7jfAyUcdEoiKp72XpNw/wGR+9wP+MtQ==",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "O7xt1vYMxku2+/WpFkh6X8RzUtYbKR+XCt0KOO0W9TbRbFeQdfb9Nry/CdVq57kOyOKS3Z4qD1xqV/8LpJQ0Xw==",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "OpenIddict": {

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -80,15 +80,15 @@
       },
       "Asp.Versioning.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "I4CuGwl0nO98j6Ft6XlGBgzj1+goE/TSVlnHKgtRkuMZ0K4gy9I+Wyrtto8dyt0hWcFMDFAZ4lYNr58DSemH1g=="
+        "resolved": "10.0.0",
+        "contentHash": "cMRE5nvNMfBgfkb0XFWst/7UtyXCjoAXnV0L4Scx4P9fcf0idgrj1Z0c+3ylsy01K4cOib7dKhCBfpg5z3r0Kg=="
       },
       "Asp.Versioning.Http": {
         "type": "Transitive",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "4/QzujOrkGn9sMch3eHhR5LpVJ4Xo5T2BNg7U1/r4YwEa8JywzkoGQHjW7Nk0W8ljETnpoJaO5mrTsfEOnJK3A==",
+        "resolved": "10.0.0",
+        "contentHash": "xmNm9FM2d20NKy7i1osEQysf7pJ4iJjWnM6e8CoeIhUREqG8nugsfC82pGpmzlatjAJL5T52ieSpyW+GFdSsSQ==",
         "dependencies": {
-          "Asp.Versioning.Abstractions": "10.0.0-preview.2"
+          "Asp.Versioning.Abstractions": "10.0.0"
         }
       },
       "AWSSDK.Core": {
@@ -341,22 +341,22 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.24.1",
-        "contentHash": "aZlQx92iNtt4XT5u7j1Qwsx4fjabneWGco2TP4Ms7ivNwLNN6jFxwX084i/HyRAW1NIbro7T0VeFpstlDNEEdw==",
+        "resolved": "1.26.0",
+        "contentHash": "StYdHzKheT//Lt7z4XRCz6dpUgUrhoN/MA96FuJfydQkwOmU/wqOYaaNJmeKDAM1HjYx2BfeKruy8Fk2iEYw5g==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
           "Microsoft.Bcl.TimeProvider": "10.0.0",
           "Polly.Core": "8.6.5",
-          "Spectre.Console": "0.53.0"
+          "Spectre.Console": "0.55.0"
         }
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.27.0",
-        "contentHash": "OAnWVIbLp7qZxLGLixvzeRnwm+cEl7qEL/GVWAK8ndsAqXBKsGU26RGf2rNJE2qxiWHTs+f4nh1bkAbtk+Ps9Q==",
+        "resolved": "1.29.0",
+        "contentHash": "WFsuQXsnh77U40PwBAtMxwls3AdBZRVlkWaNbwNrMbBbu4UrFTwlMjbu2+I9xDWrdrlnbEa0Bt5kQCeHHX2QVQ==",
         "dependencies": {
-          "JasperFx": "1.24.0"
+          "JasperFx": "1.26.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -411,8 +411,8 @@
       },
       "Microsoft.AspNetCore.TestHost": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "2A6dxcSGlisnVLDp6mTyHiFJgAj/Ahm/t/tfWiowUhqea3SFmpGrQhiQEaCAgj7TwfVQp7IX1XN7MkFRx/u3UQ=="
+        "resolved": "10.0.7",
+        "contentHash": "2UM9EtTmX6yF6Efa6WOO7wmHz2kPksmnzPmMwveuOGJQwbtNg5wKGj7usGLr8Ve3AMhIAc2yqyRXt1xNsed3hg=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -559,21 +559,21 @@
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "OqZDg2/SROHR33XJLaf3kIU2zEbxcZ2ef+O/HIyZWfiKenp/B2qgy/jv6wJmmsBgh4ETaRKdlcLyJ9es2woKCg==",
+        "resolved": "10.0.7",
+        "contentHash": "xVrtBg3M1wJlBDkoT0dXEYB/wSc8bIHJPYtw/bu1AqpWgF79uPSs87DAhERR/Ilumre6TKZa1cjMg3VUUObVLA==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "4F+e6uxhVmyduu+Ve1INxek94adt4RAddWqykXNDnOOWQrJJ20izw/9qRpZdkLnIW9oj/3qnLWUtsv37U0xJCw=="
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "PIcmALdKzeSJNWmxsLDsS8XKFqiH5+9GzIM+qd3w1efYIwmO0w5304i37/SkfynctHZwkiiQjb2mkoIXU1CGZg=="
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "Transitive",
@@ -593,12 +593,12 @@
       },
       "Microsoft.EntityFrameworkCore.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "dxlPx5pTERV+MhoG35tDyZ5sj50uoOs3FjLaHjpG62dpGXKsDk85VN0H0iDbJYBU+7w7F0wNr4HPxgl62utWqw==",
+        "resolved": "10.0.7",
+        "contentHash": "XVjGSW98Z/f3nFZsZILL/tntgM8i2hxUDUB4Nzt7ZvJ63MczC/VG4zjQh+m+q88SU+IJBUDipJJpkYBU57YWXg==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "10.0.6",
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.6",
-          "Microsoft.Extensions.DependencyModel": "10.0.6",
+          "Microsoft.Data.Sqlite.Core": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7",
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
@@ -619,8 +619,8 @@
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "xHMiq0J/wbyKDQ/tHB1FxylNWZLLlSf61Fw8XRneG6KTovjabNJiWtQoJ1MKCk71Bjr1TG1wAPVe8QZYphihLQ=="
+        "resolved": "10.0.7",
+        "contentHash": "gCglFg/9Chu3lyJNytRuQAYM3mXQKNs1i01Cz2bc545QaHQ+LbBb4O5UCfu968Gro3ZVSOZ/ktilmPcaUSGSZA=="
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",
@@ -973,10 +973,10 @@
       },
       "OpenTelemetry.Api.ProviderBuilderExtensions": {
         "type": "Transitive",
-        "resolved": "1.15.2",
-        "contentHash": "+UIz3GpBUrapW5IRnvPGdvVhhvW686lbIcNo/7ENOjB++djsdEsFxILTFYJ673cU0l8Da/OtV+IcE49OKJUM5w==",
+        "resolved": "1.15.3",
+        "contentHash": "SYn0lqYDwLMWhv/zlNGsQcl2yX++yTumanX46bmOZE/ZDOd1WjPBO2kZaZgKLEZTZk48pavIFGJ6vOvxXgWVFQ==",
         "dependencies": {
-          "OpenTelemetry.Api": "1.15.2"
+          "OpenTelemetry.Api": "1.15.3"
         }
       },
       "Pipelines.Sockets.Unofficial": {
@@ -1093,8 +1093,16 @@
       },
       "Spectre.Console": {
         "type": "Transitive",
-        "resolved": "0.53.0",
-        "contentHash": "m2iv8Egfywp7FaNLKCmCFHbSf36D4ctzZKvlAK9NXMyGLh6L+CnrZWK8o+LOYsoAS1jtoHn0W1BT0W8vuq/FUw=="
+        "resolved": "0.55.0",
+        "contentHash": "2TVhUHFsDux0Z+y2Hv4bFsOMuON4SuotEEKkMparFkp5Rm259naaaEQrN4Sv6C1cbsiGKPjfkJDGgUp+hZPjTw==",
+        "dependencies": {
+          "Spectre.Console.Ansi": "0.55.0"
+        }
+      },
+      "Spectre.Console.Ansi": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "GIfgOvuF8MpU52bprhwtDEtx0gmVIGOepM8bw0lH/TSMD0rg1Xp+5Y53kPG8rFVdcpbNANlhDQ5mEVVPO3/2Tg=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -1236,39 +1244,39 @@
       },
       "Weasel.Core": {
         "type": "Transitive",
-        "resolved": "8.13.0",
-        "contentHash": "zfNfdPSPk4pzYPjyEiHlnx7E8qliXdIYEIigo72Kemnl6mCYF2SEZ5VY4p8ppEP0T3J3uePlo74IV1cH+SnBgA==",
+        "resolved": "8.14.1",
+        "contentHash": "k9uZuArMJpOSIQ7If0bD3KNPrzIvEmE0nrqjLmQCm4KJPY7F0Qyz0hxIpdmD1LZu7qKiDCC2eiKNvYTVj0qTng==",
         "dependencies": {
-          "JasperFx": "1.24.0"
+          "JasperFx": "1.26.0"
         }
       },
       "Weasel.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "8.13.0",
-        "contentHash": "oFBFaA0r+rAmD2l8XzAWqHsD6FIcdlIUkr2D+V+iK8UPQh7h4KR2vhNQHxp8izCCQswS542Ty59eoMzNRNBmsA==",
+        "resolved": "8.14.1",
+        "contentHash": "tF0xX8zUDX+QTeSrtwCJHAjiXlX2ekHZvyi1I7bMZ6vzmZzs8rR5f6UFjwXs+cCzvKiNvmTPDpYfhOdzD1hmvQ==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore.Relational": "10.0.0",
-          "Weasel.Core": "8.13.0"
+          "Weasel.Core": "8.14.1"
         }
       },
       "Weasel.Postgresql": {
         "type": "Transitive",
-        "resolved": "8.13.0",
-        "contentHash": "OhXormfdPOsHRYCzOdshWQmVIw/LbZGGYOczLabkBKpAe4caYeOiPRtQCDEgmjVlkX6qBirs5HkVJq4Rm6lubg==",
+        "resolved": "8.14.1",
+        "contentHash": "bi2XmS2t8/6y95SXG15pF7bkX7na+bbUHj1Nr2rLTlrOUP1IZJJCnllRHYnFHuiYOthx50LhqZ1QZT+XhhnHTg==",
         "dependencies": {
           "DistributedLock.Postgres": "1.3.0",
           "Npgsql": "9.0.4",
           "Npgsql.NetTopologySuite": "9.0.4",
-          "Weasel.Core": "8.13.0"
+          "Weasel.Core": "8.14.1"
         }
       },
       "Weasel.SqlServer": {
         "type": "Transitive",
-        "resolved": "8.13.0",
-        "contentHash": "YsrAP2kL5N1sjq+Yq12pIbvtoJZux0vxyAgwfJBh5/8a8d+ewbVxdpx16TaQGq1iEiKGnAyrZVQGQv7o4Ou/HA==",
+        "resolved": "8.14.1",
+        "contentHash": "04wtlTJ8M/lBe30TtAOpHALJVrlZtPU4PyPPSm5Fa3nd96lkkeNiPa9l+XcI52hYtBCD0z50Lbd93fMz/1NB4g==",
         "dependencies": {
           "Microsoft.Data.SqlClient": "6.1.3",
-          "Weasel.Core": "8.13.0"
+          "Weasel.Core": "8.14.1"
         }
       },
       "WebDriverBiDi": {
@@ -1278,11 +1286,11 @@
       },
       "WolverineFx.RDBMS": {
         "type": "Transitive",
-        "resolved": "5.31.1",
-        "contentHash": "NxIBUAaFuDXRxx/G56cYyUdr4DICXHRLMHWOZdJtORZtc/A6fVFcfgVeoYZA178HTfWB3raOTAbIIzlZuCIxCw==",
+        "resolved": "5.32.0",
+        "contentHash": "uS/sNsetxg5saHrkr80Z9HrCCx7KgVkrwaOe6NyQck2Dz59j/kLQEwvUvECrTJDK06zIDiUilXkisDDH4niTtQ==",
         "dependencies": {
-          "Weasel.Core": "8.13.0",
-          "WolverineFx": "5.31.1"
+          "Weasel.Core": "8.14.1",
+          "WolverineFx": "5.32.0"
         }
       },
       "xunit.analyzers": {
@@ -2171,6 +2179,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
@@ -2185,6 +2194,7 @@
         "dependencies": {
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )"
         }
       },
@@ -3555,19 +3565,19 @@
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "AyrcDwLzJp8yRJaFjZMJXkR1Rx2UaJkwGrGlX8sxIt2F5ZGiZwn/puXkB/oEaq55TxLkpiXWAOHHFsiVptp0fA==",
+        "resolved": "10.0.0",
+        "contentHash": "W0wZ+0uZ0UK4KstjvEkNBZ0xxhBmxunwNg8582SVyyW7txQmSXibtm8fC4o82LaemPquYskms67bIbJOSrnlug==",
         "dependencies": {
-          "Asp.Versioning.Http": "10.0.0-preview.2"
+          "Asp.Versioning.Http": "10.0.0"
         }
       },
       "Asp.Versioning.Mvc.ApiExplorer": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "G/LhAaLQj+gsB8UXRNm65fxjsI7fe87itZExb+MvJOQdrXYalZKbwuzMntO95xM5cKDrDgLnCH64fl6w173aGg==",
+        "resolved": "10.0.0",
+        "contentHash": "H54UOpRoc4RmhQ4RA2lzDz43a/hAu/JN19Yyy/DNmH4XlRxhemfhifJyh9BaXNJOtGa2Dnu2xEeP4VSiTdUdAg==",
         "dependencies": {
-          "Asp.Versioning.Mvc": "10.0.0-preview.2"
+          "Asp.Versioning.Mvc": "10.0.0"
         }
       },
       "AWSSDK.CognitoIdentityProvider": {
@@ -3812,8 +3822,8 @@
       "Microsoft.AspNetCore.Authentication.JwtBearer": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "JVPyTTr5J/Z5PikptDP2g8qwNJBJ09GZ7yHpaPDAMZ0qKeA2ZKqpZhUNJk1clBqZJeMj2T7gZ5o6oOrmLxuBdw==",
+        "resolved": "10.0.7",
+        "contentHash": "g8klpd7OFJfJOq1EJKcBO8C8I8Dp0QUWoKDPUvvJYe+xunVyBHq6YxfF2CAc6+rkniV25iaWl+6RK87c25n4lA==",
         "dependencies": {
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.0.1"
         }
@@ -3821,27 +3831,27 @@
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "zLlJ5K1vxA3c5/YVLFH4RxnqG+fXnYqkzutOJZ8TeGyrm/hzDq6W01AunvhYOAp3m5kLeeoxMDVapXSgTtd6Yg==",
+        "resolved": "10.0.7",
+        "contentHash": "WAMNMV7m019wBaem9YAyK+nsR6r5ixBL/kOPybO9QhEkwG4dOeVG3vvTTkI5I6q6fp5+MN6IuYxxV/2HYiI9vw==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
         }
       },
       "Microsoft.AspNetCore.Mvc.Testing": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "OjebKy5JV75OIN0zXNAMzC5YtJTf/dd5UfIl8E/vUMakwYjEhod5gjQo3EUC0HpUgwsrNpCBs3uS+Qxw2Y+axA==",
+        "resolved": "10.0.7",
+        "contentHash": "lWyzApi1g8/r0eXqZBbl5bA8zewS8koxOir83/+OvJcyn2HazdUzPFd4MWc9uMdVzCRX6Z5aY4tNK+N0pWXMLg==",
         "dependencies": {
-          "Microsoft.AspNetCore.TestHost": "10.0.6",
-          "Microsoft.Extensions.DependencyModel": "10.0.6"
+          "Microsoft.AspNetCore.TestHost": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7"
         }
       },
       "Microsoft.AspNetCore.OpenApi": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "WTAQe7MAbbKztRyeCRGZOqqlIqpMHDBz+jKo7LLY6hp4qRqn7iucR24u32KJVxV7mF3tSEfwXH96NgGSiDBw7A==",
+        "resolved": "10.0.7",
+        "contentHash": "vKiAcGXG0BwNVw3bOjjWRLnp9tR18dR7MiwpvC94h0yFS+zfnzGHzS/JmmgwUdRixrGxrlIMRAWrVc+2DfAGlg==",
         "dependencies": {
           "Microsoft.OpenApi": "2.0.0"
         }
@@ -3849,8 +3859,8 @@
       "Microsoft.AspNetCore.OutputCaching.StackExchangeRedis": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "92Y6+hxR8nTOQ7Gqic4I3U+6PTSRW2/e4YvsN3g62P43jLp4jD2d9yfJ1648WeasYr4Q996ZtIheOVVTJMMUTg==",
+        "resolved": "10.0.7",
+        "contentHash": "+Cf0YGN/0NW5T5sciooAsXN/13wmakw26Y1CWC7Kv9Ls8qMhywpqMf178PqQFOZW+jc/doT5QPoAO3eqfNkV2w==",
         "dependencies": {
           "StackExchange.Redis": "2.7.27"
         }
@@ -3858,8 +3868,8 @@
       "Microsoft.AspNetCore.SignalR.StackExchangeRedis": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "ZFVMwxhszVfkdT3uPM8x0eFL4AbO3hZTjpxrbcvbzOhyUV1sa/quys2fnXZDFUl99nFuTwjUE5N5GJXEgS9qxQ==",
+        "resolved": "10.0.7",
+        "contentHash": "b+Gazwfx+rQKRwUnPBAsuXnsg8T6hMSriIATAQ3AqR6HJP0UJZw0+Lcr2dFTDul0SSNnskK+UEkqZO78EMHSHw==",
         "dependencies": {
           "MessagePack": "2.5.187",
           "StackExchange.Redis": "2.7.27"
@@ -3907,39 +3917,39 @@
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "eDy7bu3G+51FRC0cPtXTqUI9iAdDYl/XBQ5UguN8NFOA7QNmFvUEf36wA7PZ4ctsnxRN4t3dIvs2VKVE5H+EQQ==",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.6",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7"
         }
       },
       "Microsoft.EntityFrameworkCore.InMemory": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "yQQLR6s0NOBJvg/du/w/mJn9ESlQ0XkAQ0zJEPhtlS/Vsnay6LRSdh39Sxy9/SkpYLoNoI9c6FUyP+UIE+BWdg==",
+        "resolved": "10.0.7",
+        "contentHash": "RAns8RTPymM9GsIdY5Y8wWdpdMEXputTl24+95WhYzqF4HhT0i+jFmNgDxBTy386vU9ruoUC5gcPAiuJr8SZxg==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.6"
+          "Microsoft.EntityFrameworkCore": "10.0.7"
         }
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "t+pXPUjiAemBTstY57yUAoywOO6znVD3lwy7UERJpji0wmS70XHg0h8EcpX6+7KT6ZVCIndr1pW0GdOobZ4yCg==",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.6"
+          "Microsoft.EntityFrameworkCore": "10.0.7"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "EEkOdl08u45mfcQwTZfcwA0D6vjR4XqpJSIsLn9Wd++buEja3VK7oy0nVMF9b58P6ZKerUf2vGszc/6owUAANg==",
+        "resolved": "10.0.7",
+        "contentHash": "0cnk9Chkuz2Jc6pbXRqdjy2CMAi62q4dJhvJzG25iCIvbavUYLxk/5ukwM+mzOl7ADN88WPmY1Lx1cAH2g8QSA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.6",
-          "Microsoft.Extensions.DependencyModel": "10.0.6",
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
           "SQLitePCLRaw.core": "2.1.11"
         }
@@ -3947,11 +3957,11 @@
       "Microsoft.EntityFrameworkCore.SqlServer": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "07TkaZNqIsbzY4IhPO5Puag3wzVlhL4uJ+5x4wNLgp/Teen8fWh3sPdL2+OaboFBTeNOTo5vxpH2N6n52iX8ow==",
+        "resolved": "10.0.7",
+        "contentHash": "jci/dpjLIZyrp0Kbt0kr1lh+7BXbJ3wNk+vTwS/Se65grEJSBC+eE2UAQsi/xSNB5lHP2dysyOMHugkpFwQwNA==",
         "dependencies": {
           "Microsoft.Data.SqlClient": "6.1.1",
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
         }
       },
       "Microsoft.Extensions.AI.Abstractions": {
@@ -3979,8 +3989,8 @@
       "Microsoft.Extensions.Caching.StackExchangeRedis": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "26xccg2/iKzDb3SYcI/bsQoujno5bb8pUp1WSRZ5BP43qk2L25XgY80cDO0dr2qeu152mcF2Qn2FjLeZn1yZZQ==",
+        "resolved": "10.0.7",
+        "contentHash": "TvD0totA8qeyrZ2YeY/qRNgYBy4BvO6dG59ziJDLVnLH4s2jeLUFEFcgA3xzqPhCMMbuz9bJTRwHxkZ/7c87jQ==",
         "dependencies": {
           "StackExchange.Redis": "2.7.27"
         }
@@ -3988,10 +3998,10 @@
       "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "PkQ8fY/N811NelZ/Hhi9Y+1TDPiE9XGTzNcyMkaXl8ygYhiQ9ykVSvnzsF2YEtrNVRSs1S123b/dF91EHBJ7BQ==",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http.Resilience": {
@@ -4146,43 +4156,43 @@
       "OpenTelemetry": {
         "type": "CentralTransitive",
         "requested": "[1.15.*, )",
-        "resolved": "1.15.2",
-        "contentHash": "XwXZR69HnMBwwzvVg6ONRoPl5jeSFJkqOftHLcbSvl9DG6vY1j0OJut3cHu9Vmc5r2zgEDIQclAqpDtbhPNQZA==",
+        "resolved": "1.15.3",
+        "contentHash": "N0i6WjPoHPbZyms1ugbDIFAJFuGlpeExJMU/+XSL0lQRUkg/D0utFkDoLXf8Z1km5B+xVZ2GyMXXiX8qdeNmPg==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.15.2"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.15.3"
         }
       },
       "OpenTelemetry.Api": {
         "type": "CentralTransitive",
         "requested": "[1.15.*, )",
-        "resolved": "1.15.2",
-        "contentHash": "7zeBVUVhVyVjzOUvEj8o+NkpEOKq77zjxH8akZBlN9LjuaSPUW/yV4EJrs393wxSLWC4eun1qwTN9NY21k5ixQ=="
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
       },
       "OpenTelemetry.Exporter.OpenTelemetryProtocol": {
         "type": "CentralTransitive",
         "requested": "[1.15.*, )",
-        "resolved": "1.15.2",
-        "contentHash": "qHAkKEGQ0REcwFP/gmldTbo3NxgG+0R6od5N7ndyXuJYqWRaWF38bko0KQkK57skSapMUXS8twQbHNMEEYCKLg==",
+        "resolved": "1.15.3",
+        "contentHash": "FEXJepcseTGbATiCkUfP7ipoFEYYfl/0UmmUwi0KxCPg9PaUA8ab2P1LGopK+/HExasJ1ZutFhZrN6WvUIR23g==",
         "dependencies": {
-          "OpenTelemetry": "1.15.2"
+          "OpenTelemetry": "1.15.3"
         }
       },
       "OpenTelemetry.Extensions.Hosting": {
         "type": "CentralTransitive",
         "requested": "[1.15.*, )",
-        "resolved": "1.15.2",
-        "contentHash": "T2nEP/lABOab8w8espx5biYGghw8errNlhhMLYmoXEhGT6EGB4CNhZInJPC+tOvlGUGFe54NM3TdSATxebwJ8g==",
+        "resolved": "1.15.3",
+        "contentHash": "u8n/W8yIlqv0BXZmvId1iVaeWXG42tGKdTkuLYg5g57Y/r9CeUNzqtrSHNdG5IoO8iPX79w3v+WsbAHgUQbfeg==",
         "dependencies": {
-          "OpenTelemetry": "1.15.2"
+          "OpenTelemetry": "1.15.3"
         }
       },
       "OpenTelemetry.Instrumentation.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[1.15.*, )",
-        "resolved": "1.15.1",
-        "contentHash": "wXaZTu6LHY8xcbRd6ClcrtjHqGVoGYCcArXEZA3iUjUcYSVYwDGyPU0PdkwTfylxv8JeCCVDQhVb0fT7xBJjGA==",
+        "resolved": "1.15.2",
+        "contentHash": "2nPd7r0ug/gd6/CNFL6Rlu+RSQ9WYGSGHAYQ1ssbSqyzKJpqTunfx2I/1O0WB5k+L0cyXbG4XVZpoSoUc3M7wg==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.0, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
         }
       },
       "OpenTelemetry.Instrumentation.EntityFrameworkCore": {
@@ -4197,10 +4207,10 @@
       "OpenTelemetry.Instrumentation.Http": {
         "type": "CentralTransitive",
         "requested": "[1.15.*, )",
-        "resolved": "1.15.0",
-        "contentHash": "uToc7bUp8IEdb0ny9mKsL6FrrYelINPzxxiSShJgOf4XmQc4Azww6S5RjRj24YhsOn2a1MABOrxfVTZXtDk4Eg==",
+        "resolved": "1.15.1",
+        "contentHash": "vFO4Fj/dXkoVNGo/nhoGpO2zYQmZwr4jTID7oRGo+XlQ8LqksyZjUXQ4p39RfUvTID7IzzL8Qe71tW7CcAFymA==",
         "dependencies": {
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.0, 2.0.0)"
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
         }
       },
       "PuppeteerSharp": {
@@ -4310,11 +4320,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.31.1",
-        "contentHash": "SsVN2EYsO3gmnmaRBiBVgqoFD1STX4BIQdVE+oqNd5L1qmgcBSwiml7LG+ZTekRRA0rTZ5UsVIDFzGgXNmLhtQ==",
+        "resolved": "5.32.0",
+        "contentHash": "/fxTzZoQVIirESc6o41jALj4wZ+sSHVgaN//h26aM2o++QDOEtu5/JbB2RIcckCRxbSVX8B3jS/Fphh4KSpypQ==",
         "dependencies": {
-          "JasperFx": "1.24.1",
-          "JasperFx.Events": "1.27.0",
+          "JasperFx": "1.26.0",
+          "JasperFx.Events": "1.29.0",
           "JasperFx.RuntimeCompiler": "4.4.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "NewId": "4.0.1",
@@ -4324,44 +4334,44 @@
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.31.1",
-        "contentHash": "AptlC0d0cimf/DqQeUGmAz0DveEb2M+z+tJPuB45V4ZyPzV8jzluojpq9EsdNeDW/siCd6pgaJltd9ODDnFkRw==",
+        "resolved": "5.32.0",
+        "contentHash": "YU1Jjg3K9s6fuBSNnQTMwTemXe2tXSTu63DUhZyIDzdBdCU5WT3O+lqmTLqSMUP29C81SHlsTP3AaHy5UBJAPw==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.2",
           "Microsoft.EntityFrameworkCore.Design": "10.0.2",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
-          "Weasel.EntityFrameworkCore": "8.13.0",
-          "WolverineFx.RDBMS": "5.31.1"
+          "Weasel.EntityFrameworkCore": "8.14.1",
+          "WolverineFx.RDBMS": "5.32.0"
         }
       },
       "WolverineFx.FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.31.1",
-        "contentHash": "XP2+w8oDzz4gtfIiOK6qG81Iya/6+8OOZcd7GtjO7pKDsqKJa0x3ig3sGzVL8Mk4iV/dEdcHtAnpU8xTVOsV2g==",
+        "resolved": "5.32.0",
+        "contentHash": "VY9++YIUlTV+YM6vU57yTupS3FDGg22k8zTe/UrN79X5eL6Pq4K8PEJqc/BtdXc8HY4YPewABx1XASZxQLr1Ng==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.31.1"
+          "WolverineFx": "5.32.0"
         }
       },
       "WolverineFx.Postgresql": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.31.1",
-        "contentHash": "66aSvtQmcPMVYe/MUFMtQLwve1Us6REE/ZgnADorhsPqgRND+WyzOgpu5ssMGTNY/eEAnXoh1ETHwt5pxi9Z0Q==",
+        "resolved": "5.32.0",
+        "contentHash": "P3Rk53xAkCl+sNImvEAVgvkMwufUwgOU2tWwD3TWt4hS//hkHW9fqzpHvZa3wVF2q+heTu3asUxKWlL5Yvzt0Q==",
         "dependencies": {
-          "Weasel.Postgresql": "8.13.0",
-          "WolverineFx.RDBMS": "5.31.1"
+          "Weasel.Postgresql": "8.14.1",
+          "WolverineFx.RDBMS": "5.32.0"
         }
       },
       "WolverineFx.SqlServer": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.31.1",
-        "contentHash": "/jfSMM0NdrXZk14XAMzsaJjdbMeuDZz8Flg8ZZuQVv+H2QjRh1udZotwfi2MFLXoncPi0upB9I1L2r5QArIWgQ==",
+        "resolved": "5.32.0",
+        "contentHash": "zri6eCZ2v5yEjbNkHNykKaH0K+BTdGUVMooWAxoEEV1fLu6kNeY6nFJKphJMQZYS+6mknhxwipfNUvCGicvvNw==",
         "dependencies": {
-          "Weasel.SqlServer": "8.13.0",
-          "WolverineFx.RDBMS": "5.31.1"
+          "Weasel.SqlServer": "8.14.1",
+          "WolverineFx.RDBMS": "5.32.0"
         }
       },
       "Yarp.ReverseProxy": {

--- a/tests/Granit.Authorization.EntityFrameworkCore.Tests/RoleMetadataEntityTests.cs
+++ b/tests/Granit.Authorization.EntityFrameworkCore.Tests/RoleMetadataEntityTests.cs
@@ -1,0 +1,192 @@
+using Granit.Authorization.Domain;
+using Granit.Authorization.Events;
+using Granit.Domain;
+using Granit.MultiTenancy;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authorization.EntityFrameworkCore.Tests;
+
+public sealed class RoleMetadataEntityTests
+{
+    [Fact]
+    public void InheritsFromAuditedAggregateRoot()
+    {
+        RoleMetadata role = NewHostRole();
+
+        role.ShouldBeAssignableTo<AuditedAggregateRoot>();
+    }
+
+    [Fact]
+    public void ImplementsIMultiTenant()
+    {
+        RoleMetadata role = NewHostRole();
+
+        role.ShouldBeAssignableTo<IMultiTenant>();
+    }
+
+    [Fact]
+    public void Create_Host_PopulatesAllProperties()
+    {
+        var id = Guid.NewGuid();
+
+        var role = RoleMetadata.Create(
+            id, "SuperAdmin", MultiTenancySide.Host, tenantId: null,
+            clientId: null, description: "Platform administrator", isSystem: true);
+
+        role.Id.ShouldBe(id);
+        role.Name.ShouldBe("SuperAdmin");
+        role.MultiTenancySide.ShouldBe(MultiTenancySide.Host);
+        role.TenantId.ShouldBeNull();
+        role.ClientId.ShouldBeNull();
+        role.Description.ShouldBe("Platform administrator");
+        role.IsSystem.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Create_Tenant_RequiresTenantId()
+    {
+        var tenantId = Guid.NewGuid();
+
+        var role = RoleMetadata.Create(
+            Guid.NewGuid(), "Manager", MultiTenancySide.Tenant, tenantId);
+
+        role.TenantId.ShouldBe(tenantId);
+        role.MultiTenancySide.ShouldBe(MultiTenancySide.Tenant);
+    }
+
+    [Fact]
+    public void Create_Both_LeavesTenantIdNull()
+    {
+        var role = RoleMetadata.Create(
+            Guid.NewGuid(), "User", MultiTenancySide.Both, tenantId: null);
+
+        role.TenantId.ShouldBeNull();
+        role.MultiTenancySide.ShouldBe(MultiTenancySide.Both);
+    }
+
+    [Fact]
+    public void Create_RaisesRoleCreatedEvent()
+    {
+        var id = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+
+        var role = RoleMetadata.Create(
+            id, "Manager", MultiTenancySide.Tenant, tenantId, clientId: "client-a");
+
+        role.DomainEvents.Count.ShouldBe(1);
+        RoleCreatedEvent evt = role.DomainEvents.Single().ShouldBeOfType<RoleCreatedEvent>();
+        evt.RoleId.ShouldBe(id);
+        evt.Name.ShouldBe("Manager");
+        evt.MultiTenancySide.ShouldBe(MultiTenancySide.Tenant);
+        evt.TenantId.ShouldBe(tenantId);
+        evt.ClientId.ShouldBe("client-a");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Create_RejectsNullOrWhitespaceName(string? name)
+    {
+        Should.Throw<ArgumentException>(() =>
+            RoleMetadata.Create(Guid.NewGuid(), name!, MultiTenancySide.Host, null));
+    }
+
+    [Fact]
+    public void Create_RejectsNameOver256Chars()
+    {
+        string longName = new('x', 257);
+
+        Should.Throw<ArgumentException>(() =>
+            RoleMetadata.Create(Guid.NewGuid(), longName, MultiTenancySide.Host, null));
+    }
+
+    [Fact]
+    public void Create_RejectsClientIdOver256Chars()
+    {
+        string longClient = new('c', 257);
+
+        Should.Throw<ArgumentException>(() =>
+            RoleMetadata.Create(Guid.NewGuid(), "Manager", MultiTenancySide.Host, null, clientId: longClient));
+    }
+
+    [Fact]
+    public void Create_RejectsDescriptionOver2048Chars()
+    {
+        string longDesc = new('d', 2049);
+
+        Should.Throw<ArgumentException>(() =>
+            RoleMetadata.Create(Guid.NewGuid(), "Manager", MultiTenancySide.Host, null, description: longDesc));
+    }
+
+    [Fact]
+    public void Create_Host_WithTenantId_Throws()
+    {
+        Should.Throw<ArgumentException>(() =>
+            RoleMetadata.Create(Guid.NewGuid(), "SuperAdmin", MultiTenancySide.Host, Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void Create_Both_WithTenantId_Throws()
+    {
+        Should.Throw<ArgumentException>(() =>
+            RoleMetadata.Create(Guid.NewGuid(), "User", MultiTenancySide.Both, Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void Create_Tenant_WithoutTenantId_Throws()
+    {
+        Should.Throw<ArgumentException>(() =>
+            RoleMetadata.Create(Guid.NewGuid(), "Manager", MultiTenancySide.Tenant, tenantId: null));
+    }
+
+    [Fact]
+    public void Rename_ChangesNameAndDescription_RaisesEvent()
+    {
+        RoleMetadata role = NewHostRole();
+        role.ClearDomainEvents();
+
+        role.Rename("PlatformAdmin", "Updated description");
+
+        role.Name.ShouldBe("PlatformAdmin");
+        role.Description.ShouldBe("Updated description");
+        role.DomainEvents.Count.ShouldBe(1);
+        role.DomainEvents.Single().ShouldBeOfType<RoleUpdatedEvent>();
+    }
+
+    [Fact]
+    public void Rename_NoChanges_IsNoOp()
+    {
+        RoleMetadata role = NewHostRole();
+        role.ClearDomainEvents();
+        string originalName = role.Name;
+        string? originalDesc = role.Description;
+
+        role.Rename(originalName, originalDesc);
+
+        role.DomainEvents.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void MarkAsDeleted_RaisesRoleDeletedEvent()
+    {
+        RoleMetadata role = NewHostRole();
+        role.ClearDomainEvents();
+
+        role.MarkAsDeleted();
+
+        role.DomainEvents.Count.ShouldBe(1);
+        RoleDeletedEvent evt = role.DomainEvents.Single().ShouldBeOfType<RoleDeletedEvent>();
+        evt.RoleId.ShouldBe(role.Id);
+        evt.Name.ShouldBe(role.Name);
+    }
+
+    private static RoleMetadata NewHostRole() =>
+        RoleMetadata.Create(
+            Guid.NewGuid(),
+            "SuperAdmin",
+            MultiTenancySide.Host,
+            tenantId: null,
+            description: "Initial description");
+}

--- a/tests/Granit.Authorization.Tests/MultiTenancySidePermissionGrantValidatorTests.cs
+++ b/tests/Granit.Authorization.Tests/MultiTenancySidePermissionGrantValidatorTests.cs
@@ -1,0 +1,235 @@
+using Granit.Authorization.Domain;
+using Granit.Authorization.Services;
+using Granit.MultiTenancy;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authorization.Tests;
+
+public sealed class MultiTenancySidePermissionGrantValidatorTests
+{
+    private const string R = PermissionGrantProviderNames.Role;
+    private static readonly Guid TenantA = Guid.NewGuid();
+    private static readonly Guid TenantB = Guid.NewGuid();
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Permission-side checks (existing behavior, unchanged)
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TenantOnlyPermission_HostLevelGrant_Rejected()
+    {
+        PermissionGrantValidationResult result = await Validate(
+            permissionSide: MultiTenancySide.Tenant,
+            providerName: R,
+            providerKey: "accountant",
+            grantTenantId: null);
+
+        result.IsValid.ShouldBeFalse();
+        result.ReasonCode.ShouldBe("side_host_forbidden");
+    }
+
+    [Fact]
+    public async Task HostOnlyPermission_TenantGrant_Rejected()
+    {
+        PermissionGrantValidationResult result = await Validate(
+            permissionSide: MultiTenancySide.Host,
+            providerName: R,
+            providerKey: "accountant",
+            grantTenantId: TenantA);
+
+        result.IsValid.ShouldBeFalse();
+        result.ReasonCode.ShouldBe("side_tenant_forbidden");
+    }
+
+    [Fact]
+    public async Task BothPermission_AnyScope_Accepted_WhenNoRoleMetadata()
+    {
+        (await Validate(MultiTenancySide.Both, R, "accountant", null)).IsValid.ShouldBeTrue();
+        (await Validate(MultiTenancySide.Both, R, "accountant", TenantA)).IsValid.ShouldBeTrue();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Non-role providers skip role lookups
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UserProvider_SkipsRoleMetadataLookup()
+    {
+        IRoleMetadataStore store = Substitute.For<IRoleMetadataStore>();
+
+        PermissionGrantValidationResult result = await Validate(
+            permissionSide: MultiTenancySide.Both,
+            providerName: PermissionGrantProviderNames.User,
+            providerKey: Guid.NewGuid().ToString(),
+            grantTenantId: TenantA,
+            store: store);
+
+        result.IsValid.ShouldBeTrue();
+        await store.DidNotReceive().FindByNameAsync(
+            Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ClientProvider_SkipsRoleMetadataLookup()
+    {
+        IRoleMetadataStore store = Substitute.For<IRoleMetadataStore>();
+
+        PermissionGrantValidationResult result = await Validate(
+            permissionSide: MultiTenancySide.Both,
+            providerName: PermissionGrantProviderNames.Client,
+            providerKey: "client-a",
+            grantTenantId: null,
+            store: store);
+
+        result.IsValid.ShouldBeTrue();
+        await store.DidNotReceive().FindByNameAsync(
+            Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Role-side matrix (plan §Validator matrix)
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HostRole_HostGrant_Accepted()
+    {
+        IRoleMetadataStore store = StoreWithRole(HostRole("SuperAdmin"));
+        PermissionGrantValidationResult result = await Validate(MultiTenancySide.Host, R, "SuperAdmin", null, store);
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task HostRole_TenantGrant_Rejected()
+    {
+        IRoleMetadataStore store = StoreWithRole(HostRole("SuperAdmin"));
+        PermissionGrantValidationResult result = await Validate(MultiTenancySide.Both, R, "SuperAdmin", TenantA, store);
+        result.IsValid.ShouldBeFalse();
+        result.ReasonCode.ShouldBe("role_side_forbidden");
+    }
+
+    [Fact]
+    public async Task TenantRole_HostGrant_Rejected()
+    {
+        IRoleMetadataStore store = StoreWithRole(TenantRole("Manager", TenantA));
+        PermissionGrantValidationResult result = await Validate(MultiTenancySide.Both, R, "Manager", null, store);
+        result.IsValid.ShouldBeFalse();
+        result.ReasonCode.ShouldBe("role_side_forbidden");
+    }
+
+    [Fact]
+    public async Task TenantRole_MatchingTenantGrant_Accepted()
+    {
+        IRoleMetadataStore store = StoreWithRole(TenantRole("Manager", TenantA));
+        PermissionGrantValidationResult result = await Validate(MultiTenancySide.Tenant, R, "Manager", TenantA, store);
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TenantRole_MismatchingTenantGrant_Rejected()
+    {
+        // Role belongs to TenantA; grant targets TenantB.
+        IRoleMetadataStore store = Substitute.For<IRoleMetadataStore>();
+        store.FindByNameAsync("Manager", TenantB, null, Arg.Any<CancellationToken>())
+             .Returns((RoleMetadata?)null);
+        store.FindByNameAsync("Manager", null, null, Arg.Any<CancellationToken>())
+             .Returns(TenantRole("Manager", TenantA));
+
+        PermissionGrantValidationResult result = await Validate(MultiTenancySide.Tenant, R, "Manager", TenantB, store);
+        result.IsValid.ShouldBeFalse();
+        result.ReasonCode.ShouldBe("role_tenant_mismatch");
+    }
+
+    [Fact]
+    public async Task BothRole_HostGrant_Accepted()
+    {
+        IRoleMetadataStore store = StoreWithRole(BothRole("User"));
+        PermissionGrantValidationResult result = await Validate(MultiTenancySide.Both, R, "User", null, store);
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task BothRole_TenantGrant_Accepted()
+    {
+        IRoleMetadataStore store = StoreWithRole(BothRole("User"));
+        PermissionGrantValidationResult result = await Validate(MultiTenancySide.Both, R, "User", TenantA, store);
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task NoRoleMetadata_FallsThroughToPermissionSideOnly()
+    {
+        IRoleMetadataStore store = Substitute.For<IRoleMetadataStore>();
+        store.FindByNameAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+             .Returns((RoleMetadata?)null);
+
+        PermissionGrantValidationResult result = await Validate(MultiTenancySide.Both, R, "legacy-role", TenantA, store);
+
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TenantScopedLookup_PreferredOverGlobal()
+    {
+        // Both a global "Manager" (Both side) and a tenant-scoped "Manager" exist.
+        // The validator should pick the tenant-scoped one when grant targets that tenant.
+        RoleMetadata tenantRole = TenantRole("Manager", TenantA);
+        RoleMetadata globalRole = BothRole("Manager");
+
+        IRoleMetadataStore store = Substitute.For<IRoleMetadataStore>();
+        store.FindByNameAsync("Manager", TenantA, null, Arg.Any<CancellationToken>())
+             .Returns(tenantRole);
+        store.FindByNameAsync("Manager", null, null, Arg.Any<CancellationToken>())
+             .Returns(globalRole);
+
+        PermissionGrantValidationResult result = await Validate(MultiTenancySide.Tenant, R, "Manager", TenantA, store);
+
+        result.IsValid.ShouldBeTrue();
+        // Assert: only the tenant-scoped lookup was needed (global fallback not called).
+        await store.Received(1).FindByNameAsync("Manager", TenantA, null, Arg.Any<CancellationToken>());
+        await store.DidNotReceive().FindByNameAsync("Manager", (Guid?)null, null, Arg.Any<CancellationToken>());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────
+
+    private static async Task<PermissionGrantValidationResult> Validate(
+        MultiTenancySide permissionSide,
+        string providerName,
+        string providerKey,
+        Guid? grantTenantId,
+        IRoleMetadataStore? store = null)
+    {
+        store ??= Substitute.For<IRoleMetadataStore>();
+        var validator = new MultiTenancySidePermissionGrantValidator(store);
+        var context = new PermissionGrantValidationContext(
+            PermissionName: "Sample.Perm",
+            ProviderName: providerName,
+            ProviderKey: providerKey,
+            TenantId: grantTenantId,
+            Definition: new PermissionDefinition("Sample.Perm", null, "Sample", permissionSide));
+
+        return await validator.ValidateAsync(context, TestContext.Current.CancellationToken);
+    }
+
+    private static IRoleMetadataStore StoreWithRole(RoleMetadata role)
+    {
+        // Simulate "the role exists in whatever scope the validator queries" — exercises
+        // the decision matrix without coupling the tests to the validator's lookup strategy.
+        IRoleMetadataStore store = Substitute.For<IRoleMetadataStore>();
+        store.FindByNameAsync(role.Name, Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+             .Returns(role);
+        return store;
+    }
+
+    private static RoleMetadata HostRole(string name) =>
+        RoleMetadata.Create(Guid.NewGuid(), name, MultiTenancySide.Host, tenantId: null);
+
+    private static RoleMetadata BothRole(string name) =>
+        RoleMetadata.Create(Guid.NewGuid(), name, MultiTenancySide.Both, tenantId: null);
+
+    private static RoleMetadata TenantRole(string name, Guid tenantId) =>
+        RoleMetadata.Create(Guid.NewGuid(), name, MultiTenancySide.Tenant, tenantId);
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/TenantAwareRoleLookupNormalizerTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/TenantAwareRoleLookupNormalizerTests.cs
@@ -1,0 +1,74 @@
+using Granit.Identity.Local.AspNetIdentity.Internal;
+using Granit.MultiTenancy;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests;
+
+public sealed class TenantAwareRoleLookupNormalizerTests
+{
+    [Fact]
+    public void NormalizeName_WithoutTenant_ReturnsUpperInvariant()
+    {
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.IsAvailable.Returns(false);
+
+        TenantAwareRoleLookupNormalizer normalizer = new(currentTenant);
+
+        normalizer.NormalizeName("Manager").ShouldBe("MANAGER");
+    }
+
+    [Fact]
+    public void NormalizeName_WithTenant_PrefixesWithTenantMarker()
+    {
+        var tenantId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.IsAvailable.Returns(true);
+        currentTenant.Id.Returns(tenantId);
+
+        TenantAwareRoleLookupNormalizer normalizer = new(currentTenant);
+
+        normalizer.NormalizeName("Manager").ShouldBe("T_11111111222233334444555555555555_MANAGER");
+    }
+
+    [Fact]
+    public void NormalizeName_DifferentTenants_ProduceDifferentKeys()
+    {
+        ICurrentTenant tenantA = Substitute.For<ICurrentTenant>();
+        tenantA.IsAvailable.Returns(true);
+        tenantA.Id.Returns(Guid.NewGuid());
+
+        ICurrentTenant tenantB = Substitute.For<ICurrentTenant>();
+        tenantB.IsAvailable.Returns(true);
+        tenantB.Id.Returns(Guid.NewGuid());
+
+        TenantAwareRoleLookupNormalizer normalizerA = new(tenantA);
+        TenantAwareRoleLookupNormalizer normalizerB = new(tenantB);
+
+        normalizerA.NormalizeName("Manager").ShouldNotBe(normalizerB.NormalizeName("Manager"));
+    }
+
+    [Fact]
+    public void NormalizeName_NullInput_ReturnsNull()
+    {
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.IsAvailable.Returns(false);
+
+        TenantAwareRoleLookupNormalizer normalizer = new(currentTenant);
+
+        normalizer.NormalizeName(null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void NormalizeEmail_ReturnsUpperInvariant()
+    {
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.IsAvailable.Returns(true);
+        currentTenant.Id.Returns(Guid.NewGuid());
+
+        TenantAwareRoleLookupNormalizer normalizer = new(currentTenant);
+
+        normalizer.NormalizeEmail("Alice@Example.com").ShouldBe("ALICE@EXAMPLE.COM");
+    }
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/packages.lock.json
@@ -100,13 +100,13 @@
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "4F+e6uxhVmyduu+Ve1INxek94adt4RAddWqykXNDnOOWQrJJ20izw/9qRpZdkLnIW9oj/3qnLWUtsv37U0xJCw=="
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "PIcmALdKzeSJNWmxsLDsS8XKFqiH5+9GzIM+qd3w1efYIwmO0w5304i37/SkfynctHZwkiiQjb2mkoIXU1CGZg=="
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -245,6 +245,14 @@
       "granit": {
         "type": "Project"
       },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -279,6 +287,12 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {
@@ -290,6 +304,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
@@ -304,7 +319,27 @@
         "dependencies": {
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -332,11 +367,29 @@
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "eDy7bu3G+51FRC0cPtXTqUI9iAdDYl/XBQ5UguN8NFOA7QNmFvUEf36wA7PZ4ctsnxRN4t3dIvs2VKVE5H+EQQ==",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.6",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
         }
       },
       "OpenTelemetry.Api": {

--- a/tests/Granit.Identity.Local.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/packages.lock.json
@@ -17,12 +17,12 @@
       "Microsoft.AspNetCore.Mvc.Testing": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "OjebKy5JV75OIN0zXNAMzC5YtJTf/dd5UfIl8E/vUMakwYjEhod5gjQo3EUC0HpUgwsrNpCBs3uS+Qxw2Y+axA==",
+        "resolved": "10.0.7",
+        "contentHash": "lWyzApi1g8/r0eXqZBbl5bA8zewS8koxOir83/+OvJcyn2HazdUzPFd4MWc9uMdVzCRX6Z5aY4tNK+N0pWXMLg==",
         "dependencies": {
-          "Microsoft.AspNetCore.TestHost": "10.0.6",
-          "Microsoft.Extensions.DependencyModel": "10.0.6",
-          "Microsoft.Extensions.Hosting": "10.0.6"
+          "Microsoft.AspNetCore.TestHost": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7",
+          "Microsoft.Extensions.Hosting": "10.0.7"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -77,18 +77,18 @@
       },
       "Asp.Versioning.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "I4CuGwl0nO98j6Ft6XlGBgzj1+goE/TSVlnHKgtRkuMZ0K4gy9I+Wyrtto8dyt0hWcFMDFAZ4lYNr58DSemH1g==",
+        "resolved": "10.0.0",
+        "contentHash": "cMRE5nvNMfBgfkb0XFWst/7UtyXCjoAXnV0L4Scx4P9fcf0idgrj1Z0c+3ylsy01K4cOib7dKhCBfpg5z3r0Kg==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "10.0.0"
         }
       },
       "Asp.Versioning.Http": {
         "type": "Transitive",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "4/QzujOrkGn9sMch3eHhR5LpVJ4Xo5T2BNg7U1/r4YwEa8JywzkoGQHjW7Nk0W8ljETnpoJaO5mrTsfEOnJK3A==",
+        "resolved": "10.0.0",
+        "contentHash": "xmNm9FM2d20NKy7i1osEQysf7pJ4iJjWnM6e8CoeIhUREqG8nugsfC82pGpmzlatjAJL5T52ieSpyW+GFdSsSQ==",
         "dependencies": {
-          "Asp.Versioning.Abstractions": "10.0.0-preview.2"
+          "Asp.Versioning.Abstractions": "10.0.0"
         }
       },
       "Castle.Core": {
@@ -120,8 +120,8 @@
       },
       "Microsoft.AspNetCore.TestHost": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "2A6dxcSGlisnVLDp6mTyHiFJgAj/Ahm/t/tfWiowUhqea3SFmpGrQhiQEaCAgj7TwfVQp7IX1XN7MkFRx/u3UQ=="
+        "resolved": "10.0.7",
+        "contentHash": "2UM9EtTmX6yF6Efa6WOO7wmHz2kPksmnzPmMwveuOGJQwbtNg5wKGj7usGLr8Ve3AMhIAc2yqyRXt1xNsed3hg=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -135,232 +135,232 @@
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "lYQ9S1FGXIWIU7243RimdAXQYsFDeLhSSZvbSDwbeI/kCzZ4MIYXpp3kMQ+bDJXwl9pzMRIYkd4f9zGqcYxfAQ==",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "a7bA7IT3ngIgcOMb/2MVH5CcfSxUCeQ6QXWS1Vt6oFpzLTH3U1+J2Xtc64Uw3whX9akYG8eR/UQeEzxo64zZLg==",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.CommandLine": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "QIhi6cJMfeGBGs36DGc+3k5yYFAc9TAk3TN3WaommALXVv+syLSIkFwDgXDtrXvAgvFwOrRjxWpzJ88TLD1uhA==",
+        "resolved": "10.0.7",
+        "contentHash": "3lNjglxfFxOzI9zG+3HSg/YSGqo//8Fqw6u6iuIamZb4JCorbA3JLaeWOpfKTAPi2UJwaispOXWx14dUqcGz4A==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.6",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.EnvironmentVariables": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "ZqkqIq6AXCBrLHqLGpjv0otGo0Dx1rF1UdDuVWDiog8jXuRwb3IH59fDONIxUschwDcYaD5xftrPCWdH1YD6lQ==",
+        "resolved": "10.0.7",
+        "contentHash": "TWto3imA+mJMLZI+5sbgLiFFoOFNFkizQYNaC5jTuiHKn3diwm1RN7mWDOEZN9kG2bixw7IvgpvtUG5/teSRzA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.6",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.FileExtensions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "hils30RkqBbtQVupvgUr7sgxJUYPc6YMEDge1QAXGTOhbRlqk2I0OH+BWMSsQjYnbGX2Ytl6EkrLgu9im6vE0w==",
+        "resolved": "10.0.7",
+        "contentHash": "qbZLvLsoTdArSloEnSxs21P781YUmwVmHc5NJPQD/ezAreQ7884z+6QfAZVKi86WAZtzx83jK2uC4itxOM44gQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.6",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.6",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Json": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "o/IG5ywTfT5U1ANCAC4w1vKtXapdL/OlunywrWboySYJB79eX0+mw7qxqNRkq1WMZOJoSyjPjbyZ17l3LS7A6Q==",
+        "resolved": "10.0.7",
+        "contentHash": "64dimvyyKk0dbUbrLg/YCv4ugJ4sVz2aXLwfvZwR1EC4tJqW9ru/oVRcXwoJRa2lQGXtYtlpk4maWOeIb48tQw==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.6",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.6",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.UserSecrets": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "DBuOHuzQitvowdS06xaHaOQl1Tcy8D+vU/FNAClkMPB23skPDbmN14t0ijJlQUGC9o10u+x+xVEsQk30ywYFtQ==",
+        "resolved": "10.0.7",
+        "contentHash": "YqVIICoIdl0016wkeO2WQS+uEbEXbUhMLKdC5rZNl1X3nu59F+nwaAHdHjq/4OK+Cx31DYmNUSFh+MUot8qSDw==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Configuration.Json": "10.0.6",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.6",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Json": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "poUvwtf92bEs8uBH3aRRs/ZgiAw+Z485EU7TtVPBt//MmD0uMPERe7+v3Ur7lpD8XgIEDL9sDoTBcW1LMG97CQ==",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "xHMiq0J/wbyKDQ/tHB1FxylNWZLLlSf61Fw8XRneG6KTovjabNJiWtQoJ1MKCk71Bjr1TG1wAPVe8QZYphihLQ=="
+        "resolved": "10.0.7",
+        "contentHash": "gCglFg/9Chu3lyJNytRuQAYM3mXQKNs1i01Cz2bc545QaHQ+LbBb4O5UCfu968Gro3ZVSOZ/ktilmPcaUSGSZA=="
       },
       "Microsoft.Extensions.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "vbigpAOKX+Bbm2uJQ/AqXqONEPPB3ZYkynRT24vo5ZWF1rzKPtVjpkQkJx5qTGp2dqNV5In9QqboayqmKdvGUA==",
+        "resolved": "10.0.7",
+        "contentHash": "l+smp1qPlU0OUXD0OGfdp7OUFrbdq7ZaP5T7m2WpfZ4RFKD7iG73BAT7tjSMxNmbSXkhAn1jYHOAqzYG1r9sNg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.6",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.6"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L98Xe5C+xyKytLNLiEyQ0rcY8GNXAeAn1xKsE0YDxPx/mXBYYtRoj8pC2cnbSFQUlOzBkyO90ivMSV22SRETFg==",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "iU/lPyrjHVA4jJ7Bl/VpXvgsAD4qJWc4oPSVJjMBeZjmv7IIo8wBKxnOUoXdZcSCUJ6MeBMs3WpXNfncO7OzRg==",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.FileProviders.Physical": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "t6T7umdzTKkSBOUMe5RYk826cTCsDU0hne9lPN5RGOSb3Kq0Xw8OEErM4zJ4dgZWV3G0ObK1Hf1IVU88uIKe6A==",
+        "resolved": "10.0.7",
+        "contentHash": "zhgWg/i0ECj5v0jLFBSZHplvc5ygCI91DR4nne+BP4XAKF5ycz0pEKnFiTw8C1jCABJEZsnBZh6pXAvn71kFmw==",
         "dependencies": {
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.6",
-          "Microsoft.Extensions.FileSystemGlobbing": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.FileSystemGlobbing": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "EG9GuYJlj1o1G8maSpKceZdj88OehKFRWaWp8BWUQWlvIJDWD8N0sIYDoRMGL/yX85H8KbVYPR9+dH/UjPEiKw=="
+        "resolved": "10.0.7",
+        "contentHash": "NTUspqB+vH9g4wAD6KPOBx01xqYuKXR/cHXm449zpbq1GqfjdAxBmg7eJXrNsPw7SKwIdT2cJ05GxYVvc+lvsA=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "ygrWasQx4OgbUfJpA2PQHon+c5yQWSoIpG2+f2uyEGs8ciTRoyn+Ne12e9zp6VZ2GNNb8CnUoxq1ika66tjVCA==",
+        "resolved": "10.0.7",
+        "contentHash": "M/vBpfWcschvS2EUeq7cHfscsxabiGTptXwV7GeSueovGiSoNjyo1j5PMcWuOAAQrRW3nRqxZk8NeumrmpzUBg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.6",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.6",
-          "Microsoft.Extensions.Configuration.CommandLine": "10.0.6",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.6",
-          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.6",
-          "Microsoft.Extensions.Configuration.Json": "10.0.6",
-          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Diagnostics": "10.0.6",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.6",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.6",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.6",
-          "Microsoft.Extensions.Logging.Console": "10.0.6",
-          "Microsoft.Extensions.Logging.Debug": "10.0.6",
-          "Microsoft.Extensions.Logging.EventLog": "10.0.6",
-          "Microsoft.Extensions.Logging.EventSource": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.7",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.7",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Json": "10.0.7",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.7",
+          "Microsoft.Extensions.Logging.Console": "10.0.7",
+          "Microsoft.Extensions.Logging.Debug": "10.0.7",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.7",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "ZjpnbMD88IcZQE2pE9lcGv3mkH2mlApPWNh88ya1wJpcxZLp7p4aN7twI2FpawGPAsXNpmMgtKaz3o796YWKWQ==",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "YXyeFL/MFNuy7k4zCIxldXdyyK7hpW3wPnqyS5HxOJ+BkMkaT7cYVmpWYNnRaiEM6a98vjVjvIRHiUUsTJfc6g==",
+        "resolved": "10.0.7",
+        "contentHash": "7BBnoGF37USiu7j434put9mDp7EjdlNDIZsR4vHfC1FbLZeLqiWjgJbeEtF0p59Ryqt8AtraHawf0ZKbe5jibg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.6",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.6"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging.Console": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "i6yclZFcPCX3MWphzPEbnBXpgT9vjZQppS4mFFvzSVols9JvvZPVeMe1ufv1bWC0/NwrBY5C+xKX4Joq+8HCkg==",
+        "resolved": "10.0.7",
+        "contentHash": "DA++Es6v6W0HfrOrw+K8WyN6jNnZHp640PDdEvl8yfeVmgflKdn6vSSFvufNUSOuY+M2ZaSUgfY+jUKtNpXcCw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging.Debug": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "CS6sPOCtu4NZo7fy4+475DPyqP0Yty2lj14yGZBC6JRdLQKuy+698gcZpKlCEzfr/0mqnbuBlrLRr/LgI7u/4g==",
+        "resolved": "10.0.7",
+        "contentHash": "Y6DSt/JZApunYWKqTtqbdsR6iqAvHx3D0tavbNJ1rnC24MUpF+3XO/VKgFi+9PFqMyvQ2GHBBGb8H3cLSw7rDg==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging.EventLog": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "E/EI8sRdfbdLfHsmtdVwvX2ygoyCvP0l8Bk95QS00nw7ZHuEIibalafSTNMGrIz34+Wriyivl6unQ56g634QPQ==",
+        "resolved": "10.0.7",
+        "contentHash": "1C8eTuxF6BLncNSJ1HCfmaBcjpUSqQDPlBVdYTlet9oldHTPpNh9iatxSJLs8TOqdp/FOpH+nSLdBve7fu9mTQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "System.Diagnostics.EventLog": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "System.Diagnostics.EventLog": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging.EventSource": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "On5ERRSmspe7/rCoiy+gaWmNI2hriIBTQS/2jtakeKE9MR7iDhOOjVjzjWapzZW3BlzAi4xCkocNqFl2AYQN3g==",
+        "resolved": "10.0.7",
+        "contentHash": "YWfndnDX1jVMGCN8d5T+rO+BO8sDw6BkYlUk0BYui+WP7+HhlWx8QLdA4yUDjrkGVb3AQxIWWEPVKw5Nnfj5GQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L8P21mqaG+CXvPheLndean/cHCOcItJqH8nx+0YQnK7wAiOR0G1IOC418ZSzTMD2D6Gmo0f2M5WR70XtpX2B8g=="
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
       "Microsoft.OpenApi": {
         "type": "Transitive",
@@ -428,8 +428,8 @@
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "RMe4gRBwSVd1O6HVRjNwLgcH2jjrT8sHyNRJegZLX68voA+HzMf1xZPvFxMMDpyW86B9U2pYslgl4DFCE61WyA=="
+        "resolved": "10.0.7",
+        "contentHash": "WbmDLeTPYhEzXhvYVioTVn/D1XX6bovyny9n5p8Zxtf03+eY385RB818teZm6n+fA63iZNvng0/Np4tLuhkMhQ=="
       },
       "System.Management": {
         "type": "Transitive",
@@ -605,6 +605,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
@@ -685,19 +686,19 @@
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "AyrcDwLzJp8yRJaFjZMJXkR1Rx2UaJkwGrGlX8sxIt2F5ZGiZwn/puXkB/oEaq55TxLkpiXWAOHHFsiVptp0fA==",
+        "resolved": "10.0.0",
+        "contentHash": "W0wZ+0uZ0UK4KstjvEkNBZ0xxhBmxunwNg8582SVyyW7txQmSXibtm8fC4o82LaemPquYskms67bIbJOSrnlug==",
         "dependencies": {
-          "Asp.Versioning.Http": "10.0.0-preview.2"
+          "Asp.Versioning.Http": "10.0.0"
         }
       },
       "Asp.Versioning.Mvc.ApiExplorer": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "G/LhAaLQj+gsB8UXRNm65fxjsI7fe87itZExb+MvJOQdrXYalZKbwuzMntO95xM5cKDrDgLnCH64fl6w173aGg==",
+        "resolved": "10.0.0",
+        "contentHash": "H54UOpRoc4RmhQ4RA2lzDz43a/hAu/JN19Yyy/DNmH4XlRxhemfhifJyh9BaXNJOtGa2Dnu2xEeP4VSiTdUdAg==",
         "dependencies": {
-          "Asp.Versioning.Mvc": "10.0.0-preview.2"
+          "Asp.Versioning.Mvc": "10.0.0"
         }
       },
       "Bogus": {
@@ -719,8 +720,8 @@
       "Microsoft.AspNetCore.OpenApi": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "WTAQe7MAbbKztRyeCRGZOqqlIqpMHDBz+jKo7LLY6hp4qRqn7iucR24u32KJVxV7mF3tSEfwXH96NgGSiDBw7A==",
+        "resolved": "10.0.7",
+        "contentHash": "vKiAcGXG0BwNVw3bOjjWRLnp9tR18dR7MiwpvC94h0yFS+zfnzGHzS/JmmgwUdRixrGxrlIMRAWrVc+2DfAGlg==",
         "dependencies": {
           "Microsoft.OpenApi": "2.0.0"
         }
@@ -728,102 +729,102 @@
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "Ilr690V+E1H116ncF00KIlvRloKXBdCExaNqcT9BvCcS5nFGR1pcTamSA2EI8pOXbNp0DHZm8K8h6Wl1hMSbIQ==",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "5godKXBBsObgl/dBQKgrFeHFd6vVVOMGK3TuKLPNlwJgabFKl5vISSHLw5hWUtd+zKcl/Llmw25dsGlySxXJJg==",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "h22Fm4VxRmr4ty9rxJaW0i51xD56Bl5QhQ2hsGY2vl+6FioWmBhkpg3B78XQaK25N+hE41gZLZuYKGQS+OGbdw==",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.6",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "w+dX4SIr1X9yegX2yX2dU1XtP4JAUVNdvOG/Evn+H+ndn96YzfIPX52FALXChrRNWFR9l77FQyg1mB7WQo6iOA=="
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "x3C8tgsX+xWvV5u76LFm24/U7sSnCRjuudBkbFsMV/DIqCA85te7YGg6dpa7lBToDhi4Lry9E7Arpy0laUw5AQ==",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.6",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Localization": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "iiM6XtI22oEav13ecJwCgMYaTsxPKAYBVlOv0i6HJ7zlkgPc5Wb++7Ucox8AJjzY3pkCwZLatITHkY23g9QHGA==",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Localization.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Localization.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "eXchxdBgomnydhkgk1jCoCgiYL5dYp0TKVPhLSClGirmkEMAW5j8yJQjIoIwoRN5nmER/OYglYxc+wO15zuRkQ=="
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "1YgBO3wAy0dlpQyVTKWBSPND/t0yZHsvd3shGpbeEwH8JSb2hnFI2pNFrOOUi/stsp+T/dqwqmRIGh47ibo9bw==",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "v5RTWm+3Gdub21ADJeRG5bunOOxutFNBZk6qGH6Az4L5nyRZoLe3Kse7jfAyUcdEoiKp72XpNw/wGR+9wP+MtQ==",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "O7xt1vYMxku2+/WpFkh6X8RzUtYbKR+XCt0KOO0W9TbRbFeQdfb9Nry/CdVq57kOyOKS3Z4qD1xqV/8LpJQ0Xw==",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "OpenTelemetry.Api": {

--- a/tests/Granit.Identity.Local.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Notifications.Tests/packages.lock.json
@@ -103,25 +103,25 @@
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "lYQ9S1FGXIWIU7243RimdAXQYsFDeLhSSZvbSDwbeI/kCzZ4MIYXpp3kMQ+bDJXwl9pzMRIYkd4f9zGqcYxfAQ==",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "a7bA7IT3ngIgcOMb/2MVH5CcfSxUCeQ6QXWS1Vt6oFpzLTH3U1+J2Xtc64Uw3whX9akYG8eR/UQeEzxo64zZLg==",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L8P21mqaG+CXvPheLndean/cHCOcItJqH8nx+0YQnK7wAiOR0G1IOC418ZSzTMD2D6Gmo0f2M5WR70XtpX2B8g=="
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -265,6 +265,14 @@
       "granit": {
         "type": "Project"
       },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -323,6 +331,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
@@ -390,71 +399,71 @@
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "Ilr690V+E1H116ncF00KIlvRloKXBdCExaNqcT9BvCcS5nFGR1pcTamSA2EI8pOXbNp0DHZm8K8h6Wl1hMSbIQ==",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "5godKXBBsObgl/dBQKgrFeHFd6vVVOMGK3TuKLPNlwJgabFKl5vISSHLw5hWUtd+zKcl/Llmw25dsGlySxXJJg==",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "h22Fm4VxRmr4ty9rxJaW0i51xD56Bl5QhQ2hsGY2vl+6FioWmBhkpg3B78XQaK25N+hE41gZLZuYKGQS+OGbdw==",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.6",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "w+dX4SIr1X9yegX2yX2dU1XtP4JAUVNdvOG/Evn+H+ndn96YzfIPX52FALXChrRNWFR9l77FQyg1mB7WQo6iOA=="
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "1YgBO3wAy0dlpQyVTKWBSPND/t0yZHsvd3shGpbeEwH8JSb2hnFI2pNFrOOUi/stsp+T/dqwqmRIGh47ibo9bw==",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "v5RTWm+3Gdub21ADJeRG5bunOOxutFNBZk6qGH6Az4L5nyRZoLe3Kse7jfAyUcdEoiKp72XpNw/wGR+9wP+MtQ==",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "O7xt1vYMxku2+/WpFkh6X8RzUtYbKR+XCt0KOO0W9TbRbFeQdfb9Nry/CdVq57kOyOKS3Z4qD1xqV/8LpJQ0Xw==",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "OpenTelemetry.Api": {

--- a/tests/Granit.Identity.Local.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Privacy.Tests/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "JasperFx": {
         "type": "Transitive",
-        "resolved": "1.24.1",
-        "contentHash": "aZlQx92iNtt4XT5u7j1Qwsx4fjabneWGco2TP4Ms7ivNwLNN6jFxwX084i/HyRAW1NIbro7T0VeFpstlDNEEdw==",
+        "resolved": "1.26.0",
+        "contentHash": "StYdHzKheT//Lt7z4XRCz6dpUgUrhoN/MA96FuJfydQkwOmU/wqOYaaNJmeKDAM1HjYx2BfeKruy8Fk2iEYw5g==",
         "dependencies": {
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
@@ -114,15 +114,15 @@
           "Microsoft.Extensions.Hosting": "10.0.0",
           "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Polly.Core": "8.6.5",
-          "Spectre.Console": "0.53.0"
+          "Spectre.Console": "0.55.0"
         }
       },
       "JasperFx.Events": {
         "type": "Transitive",
-        "resolved": "1.27.0",
-        "contentHash": "OAnWVIbLp7qZxLGLixvzeRnwm+cEl7qEL/GVWAK8ndsAqXBKsGU26RGf2rNJE2qxiWHTs+f4nh1bkAbtk+Ps9Q==",
+        "resolved": "1.29.0",
+        "contentHash": "WFsuQXsnh77U40PwBAtMxwls3AdBZRVlkWaNbwNrMbBbu4UrFTwlMjbu2+I9xDWrdrlnbEa0Bt5kQCeHHX2QVQ==",
         "dependencies": {
-          "JasperFx": "1.24.0"
+          "JasperFx": "1.26.0"
         }
       },
       "JasperFx.RuntimeCompiler": {
@@ -247,19 +247,19 @@
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "lYQ9S1FGXIWIU7243RimdAXQYsFDeLhSSZvbSDwbeI/kCzZ4MIYXpp3kMQ+bDJXwl9pzMRIYkd4f9zGqcYxfAQ==",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "a7bA7IT3ngIgcOMb/2MVH5CcfSxUCeQ6QXWS1Vt6oFpzLTH3U1+J2Xtc64Uw3whX9akYG8eR/UQeEzxo64zZLg==",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.CommandLine": {
@@ -334,11 +334,11 @@
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L98Xe5C+xyKytLNLiEyQ0rcY8GNXAeAn1xKsE0YDxPx/mXBYYtRoj8pC2cnbSFQUlOzBkyO90ivMSV22SRETFg==",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
@@ -348,10 +348,10 @@
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "iU/lPyrjHVA4jJ7Bl/VpXvgsAD4qJWc4oPSVJjMBeZjmv7IIo8wBKxnOUoXdZcSCUJ6MeBMs3WpXNfncO7OzRg==",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.FileProviders.Physical": {
@@ -476,8 +476,8 @@
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L8P21mqaG+CXvPheLndean/cHCOcItJqH8nx+0YQnK7wAiOR0G1IOC418ZSzTMD2D6Gmo0f2M5WR70XtpX2B8g=="
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -545,8 +545,16 @@
       },
       "Spectre.Console": {
         "type": "Transitive",
-        "resolved": "0.53.0",
-        "contentHash": "m2iv8Egfywp7FaNLKCmCFHbSf36D4ctzZKvlAK9NXMyGLh6L+CnrZWK8o+LOYsoAS1jtoHn0W1BT0W8vuq/FUw=="
+        "resolved": "0.55.0",
+        "contentHash": "2TVhUHFsDux0Z+y2Hv4bFsOMuON4SuotEEKkMparFkp5Rm259naaaEQrN4Sv6C1cbsiGKPjfkJDGgUp+hZPjTw==",
+        "dependencies": {
+          "Spectre.Console.Ansi": "0.55.0"
+        }
+      },
+      "Spectre.Console.Ansi": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "GIfgOvuF8MpU52bprhwtDEtx0gmVIGOepM8bw0lH/TSMD0rg1Xp+5Y53kPG8rFVdcpbNANlhDQ5mEVVPO3/2Tg=="
       },
       "System.CodeDom": {
         "type": "Transitive",
@@ -679,6 +687,14 @@
       "granit": {
         "type": "Project"
       },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.blobstorage": {
         "type": "Project",
         "dependencies": {
@@ -749,6 +765,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
@@ -846,84 +863,84 @@
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "Ilr690V+E1H116ncF00KIlvRloKXBdCExaNqcT9BvCcS5nFGR1pcTamSA2EI8pOXbNp0DHZm8K8h6Wl1hMSbIQ==",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "5godKXBBsObgl/dBQKgrFeHFd6vVVOMGK3TuKLPNlwJgabFKl5vISSHLw5hWUtd+zKcl/Llmw25dsGlySxXJJg==",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "h22Fm4VxRmr4ty9rxJaW0i51xD56Bl5QhQ2hsGY2vl+6FioWmBhkpg3B78XQaK25N+hE41gZLZuYKGQS+OGbdw==",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.6",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "w+dX4SIr1X9yegX2yX2dU1XtP4JAUVNdvOG/Evn+H+ndn96YzfIPX52FALXChrRNWFR9l77FQyg1mB7WQo6iOA=="
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "x3C8tgsX+xWvV5u76LFm24/U7sSnCRjuudBkbFsMV/DIqCA85te7YGg6dpa7lBToDhi4Lry9E7Arpy0laUw5AQ==",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.6",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "1YgBO3wAy0dlpQyVTKWBSPND/t0yZHsvd3shGpbeEwH8JSb2hnFI2pNFrOOUi/stsp+T/dqwqmRIGh47ibo9bw==",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "v5RTWm+3Gdub21ADJeRG5bunOOxutFNBZk6qGH6Az4L5nyRZoLe3Kse7jfAyUcdEoiKp72XpNw/wGR+9wP+MtQ==",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "O7xt1vYMxku2+/WpFkh6X8RzUtYbKR+XCt0KOO0W9TbRbFeQdfb9Nry/CdVq57kOyOKS3Z4qD1xqV/8LpJQ0Xw==",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "OpenTelemetry.Api": {
@@ -941,11 +958,11 @@
       "WolverineFx": {
         "type": "CentralTransitive",
         "requested": "[5.*, )",
-        "resolved": "5.31.1",
-        "contentHash": "SsVN2EYsO3gmnmaRBiBVgqoFD1STX4BIQdVE+oqNd5L1qmgcBSwiml7LG+ZTekRRA0rTZ5UsVIDFzGgXNmLhtQ==",
+        "resolved": "5.32.0",
+        "contentHash": "/fxTzZoQVIirESc6o41jALj4wZ+sSHVgaN//h26aM2o++QDOEtu5/JbB2RIcckCRxbSVX8B3jS/Fphh4KSpypQ==",
         "dependencies": {
-          "JasperFx": "1.24.1",
-          "JasperFx.Events": "1.27.0",
+          "JasperFx": "1.26.0",
+          "JasperFx.Events": "1.29.0",
           "JasperFx.RuntimeCompiler": "4.4.0",
           "JasperFx.SourceGeneration": "1.1.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.0",

--- a/tests/Granit.Identity.Local.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Tests/packages.lock.json
@@ -235,6 +235,14 @@
       "granit": {
         "type": "Project"
       },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -280,6 +288,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",

--- a/tests/Granit.OpenIddict.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.BackgroundJobs.Tests/packages.lock.json
@@ -132,19 +132,19 @@
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "lYQ9S1FGXIWIU7243RimdAXQYsFDeLhSSZvbSDwbeI/kCzZ4MIYXpp3kMQ+bDJXwl9pzMRIYkd4f9zGqcYxfAQ==",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "a7bA7IT3ngIgcOMb/2MVH5CcfSxUCeQ6QXWS1Vt6oFpzLTH3U1+J2Xtc64Uw3whX9akYG8eR/UQeEzxo64zZLg==",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -175,11 +175,11 @@
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L98Xe5C+xyKytLNLiEyQ0rcY8GNXAeAn1xKsE0YDxPx/mXBYYtRoj8pC2cnbSFQUlOzBkyO90ivMSV22SRETFg==",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
@@ -192,10 +192,10 @@
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "iU/lPyrjHVA4jJ7Bl/VpXvgsAD4qJWc4oPSVJjMBeZjmv7IIo8wBKxnOUoXdZcSCUJ6MeBMs3WpXNfncO7OzRg==",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http.Diagnostics": {
@@ -249,8 +249,8 @@
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L8P21mqaG+CXvPheLndean/cHCOcItJqH8nx+0YQnK7wAiOR0G1IOC418ZSzTMD2D6Gmo0f2M5WR70XtpX2B8g=="
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
       "Microsoft.Extensions.Resilience": {
         "type": "Transitive",
@@ -614,6 +614,14 @@
       "granit": {
         "type": "Project"
       },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.backgroundjobs": {
         "type": "Project",
         "dependencies": {
@@ -692,6 +700,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
@@ -780,52 +789,52 @@
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "Ilr690V+E1H116ncF00KIlvRloKXBdCExaNqcT9BvCcS5nFGR1pcTamSA2EI8pOXbNp0DHZm8K8h6Wl1hMSbIQ==",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "5godKXBBsObgl/dBQKgrFeHFd6vVVOMGK3TuKLPNlwJgabFKl5vISSHLw5hWUtd+zKcl/Llmw25dsGlySxXJJg==",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "h22Fm4VxRmr4ty9rxJaW0i51xD56Bl5QhQ2hsGY2vl+6FioWmBhkpg3B78XQaK25N+hE41gZLZuYKGQS+OGbdw==",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.6",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "w+dX4SIr1X9yegX2yX2dU1XtP4JAUVNdvOG/Evn+H+ndn96YzfIPX52FALXChrRNWFR9l77FQyg1mB7WQo6iOA=="
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "x3C8tgsX+xWvV5u76LFm24/U7sSnCRjuudBkbFsMV/DIqCA85te7YGg6dpa7lBToDhi4Lry9E7Arpy0laUw5AQ==",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.6",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http": {
@@ -856,33 +865,33 @@
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "1YgBO3wAy0dlpQyVTKWBSPND/t0yZHsvd3shGpbeEwH8JSb2hnFI2pNFrOOUi/stsp+T/dqwqmRIGh47ibo9bw==",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "v5RTWm+3Gdub21ADJeRG5bunOOxutFNBZk6qGH6Az4L5nyRZoLe3Kse7jfAyUcdEoiKp72XpNw/wGR+9wP+MtQ==",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "O7xt1vYMxku2+/WpFkh6X8RzUtYbKR+XCt0KOO0W9TbRbFeQdfb9Nry/CdVq57kOyOKS3Z4qD1xqV/8LpJQ0Xw==",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "OpenIddict": {

--- a/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Endpoints.Tests/packages.lock.json
@@ -26,11 +26,11 @@
       "Microsoft.AspNetCore.Mvc.Testing": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "OjebKy5JV75OIN0zXNAMzC5YtJTf/dd5UfIl8E/vUMakwYjEhod5gjQo3EUC0HpUgwsrNpCBs3uS+Qxw2Y+axA==",
+        "resolved": "10.0.7",
+        "contentHash": "lWyzApi1g8/r0eXqZBbl5bA8zewS8koxOir83/+OvJcyn2HazdUzPFd4MWc9uMdVzCRX6Z5aY4tNK+N0pWXMLg==",
         "dependencies": {
-          "Microsoft.AspNetCore.TestHost": "10.0.6",
-          "Microsoft.Extensions.DependencyModel": "10.0.6"
+          "Microsoft.AspNetCore.TestHost": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -103,15 +103,15 @@
       },
       "Asp.Versioning.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "I4CuGwl0nO98j6Ft6XlGBgzj1+goE/TSVlnHKgtRkuMZ0K4gy9I+Wyrtto8dyt0hWcFMDFAZ4lYNr58DSemH1g=="
+        "resolved": "10.0.0",
+        "contentHash": "cMRE5nvNMfBgfkb0XFWst/7UtyXCjoAXnV0L4Scx4P9fcf0idgrj1Z0c+3ylsy01K4cOib7dKhCBfpg5z3r0Kg=="
       },
       "Asp.Versioning.Http": {
         "type": "Transitive",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "4/QzujOrkGn9sMch3eHhR5LpVJ4Xo5T2BNg7U1/r4YwEa8JywzkoGQHjW7Nk0W8ljETnpoJaO5mrTsfEOnJK3A==",
+        "resolved": "10.0.0",
+        "contentHash": "xmNm9FM2d20NKy7i1osEQysf7pJ4iJjWnM6e8CoeIhUREqG8nugsfC82pGpmzlatjAJL5T52ieSpyW+GFdSsSQ==",
         "dependencies": {
-          "Asp.Versioning.Abstractions": "10.0.0-preview.2"
+          "Asp.Versioning.Abstractions": "10.0.0"
         }
       },
       "Castle.Core": {
@@ -140,8 +140,8 @@
       },
       "Microsoft.AspNetCore.TestHost": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "2A6dxcSGlisnVLDp6mTyHiFJgAj/Ahm/t/tfWiowUhqea3SFmpGrQhiQEaCAgj7TwfVQp7IX1XN7MkFRx/u3UQ=="
+        "resolved": "10.0.7",
+        "contentHash": "2UM9EtTmX6yF6Efa6WOO7wmHz2kPksmnzPmMwveuOGJQwbtNg5wKGj7usGLr8Ve3AMhIAc2yqyRXt1xNsed3hg=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -155,13 +155,13 @@
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "4F+e6uxhVmyduu+Ve1INxek94adt4RAddWqykXNDnOOWQrJJ20izw/9qRpZdkLnIW9oj/3qnLWUtsv37U0xJCw=="
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "PIcmALdKzeSJNWmxsLDsS8XKFqiH5+9GzIM+qd3w1efYIwmO0w5304i37/SkfynctHZwkiiQjb2mkoIXU1CGZg=="
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
@@ -180,8 +180,8 @@
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "xHMiq0J/wbyKDQ/tHB1FxylNWZLLlSf61Fw8XRneG6KTovjabNJiWtQoJ1MKCk71Bjr1TG1wAPVe8QZYphihLQ=="
+        "resolved": "10.0.7",
+        "contentHash": "gCglFg/9Chu3lyJNytRuQAYM3mXQKNs1i01Cz2bc545QaHQ+LbBb4O5UCfu968Gro3ZVSOZ/ktilmPcaUSGSZA=="
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",
@@ -622,6 +622,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
@@ -752,19 +753,19 @@
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "AyrcDwLzJp8yRJaFjZMJXkR1Rx2UaJkwGrGlX8sxIt2F5ZGiZwn/puXkB/oEaq55TxLkpiXWAOHHFsiVptp0fA==",
+        "resolved": "10.0.0",
+        "contentHash": "W0wZ+0uZ0UK4KstjvEkNBZ0xxhBmxunwNg8582SVyyW7txQmSXibtm8fC4o82LaemPquYskms67bIbJOSrnlug==",
         "dependencies": {
-          "Asp.Versioning.Http": "10.0.0-preview.2"
+          "Asp.Versioning.Http": "10.0.0"
         }
       },
       "Asp.Versioning.Mvc.ApiExplorer": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "G/LhAaLQj+gsB8UXRNm65fxjsI7fe87itZExb+MvJOQdrXYalZKbwuzMntO95xM5cKDrDgLnCH64fl6w173aGg==",
+        "resolved": "10.0.0",
+        "contentHash": "H54UOpRoc4RmhQ4RA2lzDz43a/hAu/JN19Yyy/DNmH4XlRxhemfhifJyh9BaXNJOtGa2Dnu2xEeP4VSiTdUdAg==",
         "dependencies": {
-          "Asp.Versioning.Mvc": "10.0.0-preview.2"
+          "Asp.Versioning.Mvc": "10.0.0"
         }
       },
       "FluentValidation": {
@@ -776,17 +777,17 @@
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "zLlJ5K1vxA3c5/YVLFH4RxnqG+fXnYqkzutOJZ8TeGyrm/hzDq6W01AunvhYOAp3m5kLeeoxMDVapXSgTtd6Yg==",
+        "resolved": "10.0.7",
+        "contentHash": "WAMNMV7m019wBaem9YAyK+nsR6r5ixBL/kOPybO9QhEkwG4dOeVG3vvTTkI5I6q6fp5+MN6IuYxxV/2HYiI9vw==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
         }
       },
       "Microsoft.AspNetCore.OpenApi": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "WTAQe7MAbbKztRyeCRGZOqqlIqpMHDBz+jKo7LLY6hp4qRqn7iucR24u32KJVxV7mF3tSEfwXH96NgGSiDBw7A==",
+        "resolved": "10.0.7",
+        "contentHash": "vKiAcGXG0BwNVw3bOjjWRLnp9tR18dR7MiwpvC94h0yFS+zfnzGHzS/JmmgwUdRixrGxrlIMRAWrVc+2DfAGlg==",
         "dependencies": {
           "Microsoft.OpenApi": "2.0.0"
         }
@@ -794,29 +795,29 @@
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "eDy7bu3G+51FRC0cPtXTqUI9iAdDYl/XBQ5UguN8NFOA7QNmFvUEf36wA7PZ4ctsnxRN4t3dIvs2VKVE5H+EQQ==",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.6",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7"
         }
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "t+pXPUjiAemBTstY57yUAoywOO6znVD3lwy7UERJpji0wmS70XHg0h8EcpX6+7KT6ZVCIndr1pW0GdOobZ4yCg==",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.6"
+          "Microsoft.EntityFrameworkCore": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "PkQ8fY/N811NelZ/Hhi9Y+1TDPiE9XGTzNcyMkaXl8ygYhiQ9ykVSvnzsF2YEtrNVRSs1S123b/dF91EHBJ7BQ==",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http.Resilience": {

--- a/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.EntityFrameworkCore.Tests/packages.lock.json
@@ -100,13 +100,13 @@
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "4F+e6uxhVmyduu+Ve1INxek94adt4RAddWqykXNDnOOWQrJJ20izw/9qRpZdkLnIW9oj/3qnLWUtsv37U0xJCw=="
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "PIcmALdKzeSJNWmxsLDsS8XKFqiH5+9GzIM+qd3w1efYIwmO0w5304i37/SkfynctHZwkiiQjb2mkoIXU1CGZg=="
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
@@ -468,6 +468,14 @@
       "granit": {
         "type": "Project"
       },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -525,6 +533,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
@@ -622,38 +631,38 @@
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "zLlJ5K1vxA3c5/YVLFH4RxnqG+fXnYqkzutOJZ8TeGyrm/hzDq6W01AunvhYOAp3m5kLeeoxMDVapXSgTtd6Yg==",
+        "resolved": "10.0.7",
+        "contentHash": "WAMNMV7m019wBaem9YAyK+nsR6r5ixBL/kOPybO9QhEkwG4dOeVG3vvTTkI5I6q6fp5+MN6IuYxxV/2HYiI9vw==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
         }
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "eDy7bu3G+51FRC0cPtXTqUI9iAdDYl/XBQ5UguN8NFOA7QNmFvUEf36wA7PZ4ctsnxRN4t3dIvs2VKVE5H+EQQ==",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.6",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7"
         }
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "t+pXPUjiAemBTstY57yUAoywOO6znVD3lwy7UERJpji0wmS70XHg0h8EcpX6+7KT6ZVCIndr1pW0GdOobZ4yCg==",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.6"
+          "Microsoft.EntityFrameworkCore": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "PkQ8fY/N811NelZ/Hhi9Y+1TDPiE9XGTzNcyMkaXl8ygYhiQ9ykVSvnzsF2YEtrNVRSs1S123b/dF91EHBJ7BQ==",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http.Resilience": {

--- a/tests/Granit.OpenIddict.Server.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Server.Tests/packages.lock.json
@@ -468,6 +468,14 @@
       "granit": {
         "type": "Project"
       },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -519,6 +527,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",

--- a/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests.Integration/packages.lock.json
@@ -17,11 +17,11 @@
       "Microsoft.AspNetCore.Mvc.Testing": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "OjebKy5JV75OIN0zXNAMzC5YtJTf/dd5UfIl8E/vUMakwYjEhod5gjQo3EUC0HpUgwsrNpCBs3uS+Qxw2Y+axA==",
+        "resolved": "10.0.7",
+        "contentHash": "lWyzApi1g8/r0eXqZBbl5bA8zewS8koxOir83/+OvJcyn2HazdUzPFd4MWc9uMdVzCRX6Z5aY4tNK+N0pWXMLg==",
         "dependencies": {
-          "Microsoft.AspNetCore.TestHost": "10.0.6",
-          "Microsoft.Extensions.DependencyModel": "10.0.6"
+          "Microsoft.AspNetCore.TestHost": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -96,15 +96,15 @@
       },
       "Asp.Versioning.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "I4CuGwl0nO98j6Ft6XlGBgzj1+goE/TSVlnHKgtRkuMZ0K4gy9I+Wyrtto8dyt0hWcFMDFAZ4lYNr58DSemH1g=="
+        "resolved": "10.0.0",
+        "contentHash": "cMRE5nvNMfBgfkb0XFWst/7UtyXCjoAXnV0L4Scx4P9fcf0idgrj1Z0c+3ylsy01K4cOib7dKhCBfpg5z3r0Kg=="
       },
       "Asp.Versioning.Http": {
         "type": "Transitive",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "4/QzujOrkGn9sMch3eHhR5LpVJ4Xo5T2BNg7U1/r4YwEa8JywzkoGQHjW7Nk0W8ljETnpoJaO5mrTsfEOnJK3A==",
+        "resolved": "10.0.0",
+        "contentHash": "xmNm9FM2d20NKy7i1osEQysf7pJ4iJjWnM6e8CoeIhUREqG8nugsfC82pGpmzlatjAJL5T52ieSpyW+GFdSsSQ==",
         "dependencies": {
-          "Asp.Versioning.Abstractions": "10.0.0-preview.2"
+          "Asp.Versioning.Abstractions": "10.0.0"
         }
       },
       "BouncyCastle.Cryptography": {
@@ -151,8 +151,8 @@
       },
       "Microsoft.AspNetCore.TestHost": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "2A6dxcSGlisnVLDp6mTyHiFJgAj/Ahm/t/tfWiowUhqea3SFmpGrQhiQEaCAgj7TwfVQp7IX1XN7MkFRx/u3UQ=="
+        "resolved": "10.0.7",
+        "contentHash": "2UM9EtTmX6yF6Efa6WOO7wmHz2kPksmnzPmMwveuOGJQwbtNg5wKGj7usGLr8Ve3AMhIAc2yqyRXt1xNsed3hg=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -166,13 +166,13 @@
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "4F+e6uxhVmyduu+Ve1INxek94adt4RAddWqykXNDnOOWQrJJ20izw/9qRpZdkLnIW9oj/3qnLWUtsv37U0xJCw=="
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "PIcmALdKzeSJNWmxsLDsS8XKFqiH5+9GzIM+qd3w1efYIwmO0w5304i37/SkfynctHZwkiiQjb2mkoIXU1CGZg=="
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
@@ -191,8 +191,8 @@
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "xHMiq0J/wbyKDQ/tHB1FxylNWZLLlSf61Fw8XRneG6KTovjabNJiWtQoJ1MKCk71Bjr1TG1wAPVe8QZYphihLQ=="
+        "resolved": "10.0.7",
+        "contentHash": "gCglFg/9Chu3lyJNytRuQAYM3mXQKNs1i01Cz2bc545QaHQ+LbBb4O5UCfu968Gro3ZVSOZ/ktilmPcaUSGSZA=="
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",
@@ -662,6 +662,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",
@@ -676,6 +677,7 @@
         "dependencies": {
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )"
         }
       },
@@ -812,19 +814,19 @@
       "Asp.Versioning.Mvc": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "AyrcDwLzJp8yRJaFjZMJXkR1Rx2UaJkwGrGlX8sxIt2F5ZGiZwn/puXkB/oEaq55TxLkpiXWAOHHFsiVptp0fA==",
+        "resolved": "10.0.0",
+        "contentHash": "W0wZ+0uZ0UK4KstjvEkNBZ0xxhBmxunwNg8582SVyyW7txQmSXibtm8fC4o82LaemPquYskms67bIbJOSrnlug==",
         "dependencies": {
-          "Asp.Versioning.Http": "10.0.0-preview.2"
+          "Asp.Versioning.Http": "10.0.0"
         }
       },
       "Asp.Versioning.Mvc.ApiExplorer": {
         "type": "CentralTransitive",
         "requested": "[10.0.0-preview.*, )",
-        "resolved": "10.0.0-preview.2",
-        "contentHash": "G/LhAaLQj+gsB8UXRNm65fxjsI7fe87itZExb+MvJOQdrXYalZKbwuzMntO95xM5cKDrDgLnCH64fl6w173aGg==",
+        "resolved": "10.0.0",
+        "contentHash": "H54UOpRoc4RmhQ4RA2lzDz43a/hAu/JN19Yyy/DNmH4XlRxhemfhifJyh9BaXNJOtGa2Dnu2xEeP4VSiTdUdAg==",
         "dependencies": {
-          "Asp.Versioning.Mvc": "10.0.0-preview.2"
+          "Asp.Versioning.Mvc": "10.0.0"
         }
       },
       "FluentValidation": {
@@ -845,17 +847,17 @@
       "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "zLlJ5K1vxA3c5/YVLFH4RxnqG+fXnYqkzutOJZ8TeGyrm/hzDq6W01AunvhYOAp3m5kLeeoxMDVapXSgTtd6Yg==",
+        "resolved": "10.0.7",
+        "contentHash": "WAMNMV7m019wBaem9YAyK+nsR6r5ixBL/kOPybO9QhEkwG4dOeVG3vvTTkI5I6q6fp5+MN6IuYxxV/2HYiI9vw==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
         }
       },
       "Microsoft.AspNetCore.OpenApi": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "WTAQe7MAbbKztRyeCRGZOqqlIqpMHDBz+jKo7LLY6hp4qRqn7iucR24u32KJVxV7mF3tSEfwXH96NgGSiDBw7A==",
+        "resolved": "10.0.7",
+        "contentHash": "vKiAcGXG0BwNVw3bOjjWRLnp9tR18dR7MiwpvC94h0yFS+zfnzGHzS/JmmgwUdRixrGxrlIMRAWrVc+2DfAGlg==",
         "dependencies": {
           "Microsoft.OpenApi": "2.0.0"
         }
@@ -863,29 +865,29 @@
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "eDy7bu3G+51FRC0cPtXTqUI9iAdDYl/XBQ5UguN8NFOA7QNmFvUEf36wA7PZ4ctsnxRN4t3dIvs2VKVE5H+EQQ==",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.6",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7"
         }
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "t+pXPUjiAemBTstY57yUAoywOO6znVD3lwy7UERJpji0wmS70XHg0h8EcpX6+7KT6ZVCIndr1pW0GdOobZ4yCg==",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.6"
+          "Microsoft.EntityFrameworkCore": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "PkQ8fY/N811NelZ/Hhi9Y+1TDPiE9XGTzNcyMkaXl8ygYhiQ9ykVSvnzsF2YEtrNVRSs1S123b/dF91EHBJ7BQ==",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.6"
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http.Resilience": {

--- a/tests/Granit.OpenIddict.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests/packages.lock.json
@@ -468,6 +468,14 @@
       "granit": {
         "type": "Project"
       },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
       "granit.caching": {
         "type": "Project",
         "dependencies": {
@@ -519,6 +527,7 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.Guids": "[0.1.0-dev, )",


### PR DESCRIPTION
## Summary

Phase 1 of the role scoping feature discussed in [plan](https://claude.ai/…) — adds the
`MultiTenancySide` concept at the role level, symmetric to what already exists on
`PermissionDefinition`, and exposes CRUD endpoints so Host and Tenant admins can
manage roles declaratively.

Builds on the DDD pattern established in #1081.

## What ships

- **`RoleMetadata` aggregate root** in `Granit.Authorization` — declarative scope (`Host` / `Tenant` / `Both`) + optional `TenantId` / `ClientId` + audit + invariants enforced by the static `Create` factory and a matching database `CHECK` constraint.
- **EF persistence** in `Granit.Authorization.EntityFrameworkCore` — new entity, unique index on `(Name, TenantId, ClientId)` with PostgreSQL `NULLS NOT DISTINCT` semantics, CHECK constraint `ck_authorization_role_metadata_side_tenant_consistency`. `DbSet<RoleMetadata>` exposed on `IPermissionGrantDbContext` via a default interface member (non-breaking).
- **Same PG `NULLS NOT DISTINCT` fix applied to `PermissionGrant`** — closes a latent silent-duplicate risk on host-scope grants.
- **Grant validator extension** — `MultiTenancySidePermissionGrantValidator` now looks up the target role via `IRoleMetadataStore` when `ProviderName == "R"` and enforces the full role-side × grant-tenant decision matrix (`role_side_forbidden`, `role_tenant_mismatch`). Roles without metadata fall through unchanged.
- **`TenantAwareRoleLookupNormalizer`** (ready but not yet registered — Phase 2) — prefixes `NormalizedName` with `T_{tenantId}_` in tenant contexts so two tenants can hold same-named roles without colliding on ASP.NET Identity's global unique index.
- **`IGranitRoleOrchestrator`** — serialises the dual write between `GranitRole` (Identity DbContext) and `RoleMetadata` (host DbContext) with a compensating delete on metadata failure. Avoids `TransactionScope` / MSDTC on Linux; shared-connection EF Core transaction left as a documented Phase 2 refinement.
- **`IdentityLocalRoleSeedContributor`** — idempotent seed of three system roles: `SuperAdmin` (Host), `TenantAdministrator` (Both), `User` (Both). Flagged `IsSystem=true` to prevent CRUD deletion / rename.
- **`/admin/roles` CRUD** — 5 endpoints with visibility matrix (Host admin sees everything, Tenant admin sees own-tenant + Both read-only, Host-only invisible). Non-visible roles return 404 (never 403) to avoid leaking existence. Feature flag `RoleEndpointsOptions.AllowTenantRoles` (default `false`) blocks Side=Tenant creation until Phase 2 wires the tenant-aware normalizer.
- **3 new permissions** in the `IdentityLocal` group: `Identity.Roles.Read / Manage / Delete` (all Side=Both).
- **FluentValidation validators** mirror the domain invariants at the DTO layer.
- **Query + Export definitions** registered for admin-grid consumption.
- **Localization** — 10 new keys translated in EN / FR, placeholders propagated to the 13 other base cultures (follow-up per-locale translation commits planned).

## Open follow-ups (hors Phase 1)

- Integration tests via Testcontainers (running in W4).
- Architecture test verifying `RoleMetadata` conforms to aggregate root conventions (currently implicit via the existing `DomainConventionTests` — to add an explicit test).
- Host app migration in `granit-showcase-dotnet` for the new `role_metadata` table + the `permission_grants` index fix.
- Docs extension on `authorization-multitenancy-side.mdx` + new page for role admin.
- Phase 2: realm vs client role distinction, `AllowTenantRoles` unlock + normalizer wiring, info-leak fix on existing `PermissionGrantEndpoints`.

## Test plan

- [x] `dotnet test tests/Granit.Authorization.Tests` — 216 / 216 passed (includes 14 validator matrix rows)
- [x] `dotnet test tests/Granit.Authorization.EntityFrameworkCore.Tests` — 58 / 58 passed (includes 18 RoleMetadata aggregate tests)
- [x] `dotnet test tests/Granit.Identity.Local.AspNetIdentity.Tests` — 173 / 173 passed (includes 5 normalizer tests)
- [x] `dotnet test tests/Granit.Identity.Local.Endpoints.Tests` — 142 / 142 passed
- [x] `dotnet test tests/Granit.ArchitectureTests --filter DomainConventionTests` — 7 / 7 passed
- [ ] Integration tests Testcontainers (CRUD end-to-end + visibility matrix)
- [ ] Host app migration applied on a fresh DB — schema + CHECK + indexes
- [ ] Smoke tests manuels via curl (6 scenarios listed in the plan)