### PR TITLE
test(authorization): PostgreSQL integration tests for role metadata + grants

### DIFF
--- a/.github/shard-filters/security.slnf
+++ b/.github/shard-filters/security.slnf
@@ -107,6 +107,7 @@
       "tests/Granit.Authentication.JwtBearer.Tests/Granit.Authentication.JwtBearer.Tests.csproj",
       "tests/Granit.Authentication.OpenIddict.Tests/Granit.Authentication.OpenIddict.Tests.csproj",
       "tests/Granit.Authorization.Endpoints.Tests/Granit.Authorization.Endpoints.Tests.csproj",
+      "tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration/Granit.Authorization.EntityFrameworkCore.Tests.Integration.csproj",
       "tests/Granit.Authorization.EntityFrameworkCore.Tests/Granit.Authorization.EntityFrameworkCore.Tests.csproj",
       "tests/Granit.Authorization.Tests/Granit.Authorization.Tests.csproj",
       "tests/Granit.Bff.BackgroundJobs.Tests/Granit.Bff.BackgroundJobs.Tests.csproj",

--- a/.github/test-shards.json
+++ b/.github/test-shards.json
@@ -221,6 +221,7 @@
         "tests/Granit.Oidc.TokenManagement.Tests",
         "tests/Granit.Authorization.Endpoints.Tests",
         "tests/Granit.Authorization.EntityFrameworkCore.Tests",
+        "tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration",
         "tests/Granit.Authorization.Tests",
         "tests/Granit.Bff.BackgroundJobs.Tests",
         "tests/Granit.Bff.EntityFrameworkCore.Tests",

--- a/.slnf/framework-only.slnf
+++ b/.slnf/framework-only.slnf
@@ -204,6 +204,7 @@
       "tests/Granit.Authentication.OpenIddict.Tests/Granit.Authentication.OpenIddict.Tests.csproj",
       "tests/Granit.Authorization.AI.Tests/Granit.Authorization.AI.Tests.csproj",
       "tests/Granit.Authorization.Endpoints.Tests/Granit.Authorization.Endpoints.Tests.csproj",
+      "tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration/Granit.Authorization.EntityFrameworkCore.Tests.Integration.csproj",
       "tests/Granit.Authorization.EntityFrameworkCore.Tests/Granit.Authorization.EntityFrameworkCore.Tests.csproj",
       "tests/Granit.Authorization.Tests/Granit.Authorization.Tests.csproj",
       "tests/Granit.Bundle.Tests/Granit.Bundle.Tests.csproj",

--- a/.slnf/security.slnf
+++ b/.slnf/security.slnf
@@ -94,6 +94,7 @@
       "tests/Granit.Authentication.OpenIddict.Tests/Granit.Authentication.OpenIddict.Tests.csproj",
       "tests/Granit.Authorization.AI.Tests/Granit.Authorization.AI.Tests.csproj",
       "tests/Granit.Authorization.Endpoints.Tests/Granit.Authorization.Endpoints.Tests.csproj",
+      "tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration/Granit.Authorization.EntityFrameworkCore.Tests.Integration.csproj",
       "tests/Granit.Authorization.EntityFrameworkCore.Tests/Granit.Authorization.EntityFrameworkCore.Tests.csproj",
       "tests/Granit.Authorization.Tests/Granit.Authorization.Tests.csproj",
       "tests/Granit.Bff.BackgroundJobs.Tests/Granit.Bff.BackgroundJobs.Tests.csproj",

--- a/Granit.slnx
+++ b/Granit.slnx
@@ -350,6 +350,7 @@
     <Project Path="tests/Granit.Authorization.AI.Tests/Granit.Authorization.AI.Tests.csproj" />
     <Project Path="tests/Granit.Authorization.Endpoints.Tests/Granit.Authorization.Endpoints.Tests.csproj" />
     <Project Path="tests/Granit.Authorization.EntityFrameworkCore.Tests/Granit.Authorization.EntityFrameworkCore.Tests.csproj" />
+    <Project Path="tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration/Granit.Authorization.EntityFrameworkCore.Tests.Integration.csproj" />
     <Project Path="tests/Granit.Authorization.Tests/Granit.Authorization.Tests.csproj" />
     <Project Path="tests/Granit.Bff.BackgroundJobs.Tests/Granit.Bff.BackgroundJobs.Tests.csproj" />
     <Project Path="tests/Granit.Bff.Endpoints.Tests/Granit.Bff.Endpoints.Tests.csproj" />

--- a/src/Granit.Authorization.EntityFrameworkCore/DbContext/PermissionGrantModelBuilderExtensions.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/DbContext/PermissionGrantModelBuilderExtensions.cs
@@ -19,7 +19,7 @@ public static class PermissionGrantModelBuilderExtensions
     /// </para>
     /// <para>
     /// The unique index uses PostgreSQL <c>NULLS NOT DISTINCT</c> semantics (via the
-    /// <c>Npgsql:IndexNullsDistinct</c> annotation) so host-level grants with
+    /// <c>Npgsql:NullsDistinct</c> annotation) so host-level grants with
     /// <c>TenantId = null</c> cannot duplicate each other on the same
     /// <c>(ProviderName, ProviderKey, Name)</c> tuple.
     /// </para>
@@ -37,7 +37,7 @@ public static class PermissionGrantModelBuilderExtensions
             entity.Property(e => e.ProviderKey).HasMaxLength(256).IsRequired();
             entity.HasIndex(e => new { e.TenantId, e.ProviderName, e.ProviderKey, e.Name })
                   .IsUnique()
-                  .HasAnnotation("Npgsql:IndexNullsDistinct", false)
+                  .HasAnnotation("Npgsql:NullsDistinct", false)
                   .HasDatabaseName($"uq_{GranitAuthorizationDbProperties.DbTablePrefix}permission_grants_tenant_provider_key_name");
         });
 

--- a/src/Granit.Authorization.EntityFrameworkCore/DbContext/RoleMetadataModelBuilderExtensions.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/DbContext/RoleMetadataModelBuilderExtensions.cs
@@ -40,7 +40,7 @@ public static class RoleMetadataModelBuilderExtensions
 
             entity.HasIndex(e => new { e.Name, e.TenantId, e.ClientId })
                   .IsUnique()
-                  .HasAnnotation("Npgsql:IndexNullsDistinct", false)
+                  .HasAnnotation("Npgsql:NullsDistinct", false)
                   .HasDatabaseName($"uq_{GranitAuthorizationDbProperties.DbTablePrefix}role_metadata_name_tenant_client");
         });
 

--- a/src/Granit.Authorization.EntityFrameworkCore/Granit.Authorization.EntityFrameworkCore.csproj
+++ b/src/Granit.Authorization.EntityFrameworkCore/Granit.Authorization.EntityFrameworkCore.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.Authorization.EntityFrameworkCore.Tests" />
+    <InternalsVisibleTo Include="Granit.Authorization.EntityFrameworkCore.Tests.Integration" />
     <!-- Required by Castle.DynamicProxy (NSubstitute) to proxy internal types in tests -->
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
   </ItemGroup>

--- a/tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration/Granit.Authorization.EntityFrameworkCore.Tests.Integration.csproj
+++ b/tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration/Granit.Authorization.EntityFrameworkCore.Tests.Integration.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <!-- Exclude from dotnet test in CI unit-test job (requires PostgreSQL Testcontainer). -->
+    <IsTestProject Condition="'$(SkipIntegrationTests)' == 'true'">false</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Testcontainers.PostgreSql" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Authorization\Granit.Authorization.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Authorization.EntityFrameworkCore\Granit.Authorization.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration/PermissionGrantPostgresTests.cs
+++ b/tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration/PermissionGrantPostgresTests.cs
@@ -1,0 +1,76 @@
+using Granit.Authorization;
+using Granit.Authorization.Domain;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authorization.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// Regression coverage for the <c>NULLS NOT DISTINCT</c> annotation applied to the
+/// <c>authorization_permission_grants</c> unique index. Before the fix, two host-level
+/// grants (<c>TenantId = null</c>) on the same <c>(ProviderName, ProviderKey, Name)</c>
+/// tuple could silently duplicate — the index treated nulls as distinct per ANSI default.
+/// </summary>
+public sealed class PermissionGrantPostgresTests : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private TestAuthorizationDbContext _context = null!;
+
+    public PermissionGrantPostgresTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async ValueTask InitializeAsync()
+    {
+        DbContextOptions<TestAuthorizationDbContext> options =
+            new DbContextOptionsBuilder<TestAuthorizationDbContext>()
+                .UseNpgsql(_postgres.ConnectionString)
+                .Options;
+
+        _context = new TestAuthorizationDbContext(options);
+        await _context.Database.EnsureCreatedAsync();
+        await _context.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE authorization_role_metadata, authorization_permission_grants RESTART IDENTITY CASCADE;");
+    }
+
+    public ValueTask DisposeAsync() => _context.DisposeAsync();
+
+    [Fact]
+    public async Task HostGrant_DuplicateTuple_RejectedByUniqueIndex()
+    {
+        _context.Set<PermissionGrant>().Add(PermissionGrant.Create(
+            Guid.NewGuid(), "Invoices.Delete",
+            PermissionGrantProviderNames.Role, "accountant", tenantId: null));
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        _context.Set<PermissionGrant>().Add(PermissionGrant.Create(
+            Guid.NewGuid(), "Invoices.Delete",
+            PermissionGrantProviderNames.Role, "accountant", tenantId: null));
+
+        DbUpdateException ex = await Should.ThrowAsync<DbUpdateException>(async () =>
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken));
+
+        ex.InnerException.ShouldBeOfType<PostgresException>()
+            .SqlState.ShouldBe(PostgresErrorCodes.UniqueViolation);
+    }
+
+    [Fact]
+    public async Task SameTuple_DifferentTenants_BothPersisted()
+    {
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+
+        _context.Set<PermissionGrant>().Add(PermissionGrant.Create(
+            Guid.NewGuid(), "Invoices.Delete",
+            PermissionGrantProviderNames.Role, "accountant", tenantA));
+        _context.Set<PermissionGrant>().Add(PermissionGrant.Create(
+            Guid.NewGuid(), "Invoices.Delete",
+            PermissionGrantProviderNames.Role, "accountant", tenantB));
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        int count = await _context.Set<PermissionGrant>().AsNoTracking()
+            .CountAsync(g => g.Name == "Invoices.Delete" && g.ProviderKey == "accountant",
+                TestContext.Current.CancellationToken);
+        count.ShouldBe(2);
+    }
+}

--- a/tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration/PostgresFixture.cs
+++ b/tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration/PostgresFixture.cs
@@ -1,0 +1,19 @@
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Granit.Authorization.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// Starts a PostgreSQL 17 container once per test collection and exposes the connection string.
+/// </summary>
+public sealed class PostgresFixture : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("postgres:17-alpine")
+        .Build();
+
+    public string ConnectionString => _container.GetConnectionString();
+
+    public ValueTask InitializeAsync() => new(_container.StartAsync());
+
+    public ValueTask DisposeAsync() => _container.DisposeAsync();
+}

--- a/tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration/RoleMetadataPostgresTests.cs
+++ b/tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration/RoleMetadataPostgresTests.cs
@@ -1,0 +1,205 @@
+using Granit.Authorization.Domain;
+using Granit.Authorization.EntityFrameworkCore.Stores;
+using Granit.MultiTenancy;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authorization.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// Integration tests for <see cref="RoleMetadata"/> persistence against a real PostgreSQL 17
+/// instance — validates behavior that the in-memory EF provider cannot exercise:
+/// <list type="bullet">
+///   <item>The composite unique index with <c>NULLS NOT DISTINCT</c> semantics.</item>
+///   <item>The <c>CHECK</c> constraint enforcing the <c>Side</c> ↔ <c>TenantId</c> invariant.</item>
+///   <item>The <see cref="EfCoreRoleMetadataStore{TContext}"/> roundtrip (add, find, list, remove).</item>
+/// </list>
+/// </summary>
+public sealed class RoleMetadataPostgresTests : IClassFixture<PostgresFixture>, IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres;
+    private TestAuthorizationDbContext _context = null!;
+
+    public RoleMetadataPostgresTests(PostgresFixture postgres) => _postgres = postgres;
+
+    public async ValueTask InitializeAsync()
+    {
+        DbContextOptions<TestAuthorizationDbContext> options =
+            new DbContextOptionsBuilder<TestAuthorizationDbContext>()
+                .UseNpgsql(_postgres.ConnectionString)
+                .Options;
+
+        _context = new TestAuthorizationDbContext(options);
+        await _context.Database.EnsureCreatedAsync();
+        await _context.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE authorization_role_metadata, authorization_permission_grants RESTART IDENTITY CASCADE;");
+    }
+
+    public ValueTask DisposeAsync() => _context.DisposeAsync();
+
+    // ─────────────────────────────────────────────────────────────────────
+    // NULLS NOT DISTINCT on (Name, TenantId, ClientId)
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HostRole_DuplicateName_RejectedByUniqueIndex()
+    {
+        var first = RoleMetadata.Create(
+            Guid.NewGuid(), "SuperAdmin", MultiTenancySide.Host, tenantId: null);
+        _context.Set<RoleMetadata>().Add(first);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var duplicate = RoleMetadata.Create(
+            Guid.NewGuid(), "SuperAdmin", MultiTenancySide.Host, tenantId: null);
+        _context.Set<RoleMetadata>().Add(duplicate);
+
+        DbUpdateException ex = await Should.ThrowAsync<DbUpdateException>(async () =>
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken));
+
+        ex.InnerException.ShouldBeOfType<PostgresException>()
+            .SqlState.ShouldBe(PostgresErrorCodes.UniqueViolation);
+    }
+
+    [Fact]
+    public async Task BothRole_DuplicateName_RejectedByUniqueIndex()
+    {
+        // Both rows have (Name, TenantId, ClientId) = (X, null, null) — must collide under NULLS NOT DISTINCT.
+        var first = RoleMetadata.Create(
+            Guid.NewGuid(), "User", MultiTenancySide.Both, tenantId: null);
+        _context.Set<RoleMetadata>().Add(first);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var duplicate = RoleMetadata.Create(
+            Guid.NewGuid(), "User", MultiTenancySide.Both, tenantId: null);
+        _context.Set<RoleMetadata>().Add(duplicate);
+
+        DbUpdateException ex = await Should.ThrowAsync<DbUpdateException>(async () =>
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken));
+
+        ex.InnerException.ShouldBeOfType<PostgresException>()
+            .SqlState.ShouldBe(PostgresErrorCodes.UniqueViolation);
+    }
+
+    [Fact]
+    public async Task TenantRoles_SameNameInDifferentTenants_BothPersisted()
+    {
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+
+        _context.Set<RoleMetadata>().Add(
+            RoleMetadata.Create(Guid.NewGuid(), "Manager", MultiTenancySide.Tenant, tenantA));
+        _context.Set<RoleMetadata>().Add(
+            RoleMetadata.Create(Guid.NewGuid(), "Manager", MultiTenancySide.Tenant, tenantB));
+
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        int count = await _context.Set<RoleMetadata>().AsNoTracking()
+            .CountAsync(r => r.Name == "Manager", TestContext.Current.CancellationToken);
+        count.ShouldBe(2);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // CHECK constraint ck_authorization_role_metadata_side_tenant_consistency
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CheckConstraint_RejectsHostRoleWithNonNullTenantId()
+    {
+        RoleMetadata invalid = BuildInvalidRoleMetadata(
+            name: "GhostHost", side: MultiTenancySide.Host, tenantId: Guid.NewGuid());
+        _context.Set<RoleMetadata>().Add(invalid);
+
+        DbUpdateException ex = await Should.ThrowAsync<DbUpdateException>(async () =>
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken));
+
+        PostgresException pg = ex.InnerException.ShouldBeOfType<PostgresException>();
+        pg.SqlState.ShouldBe(PostgresErrorCodes.CheckViolation);
+        pg.ConstraintName!.ShouldContain("side_tenant_consistency");
+    }
+
+    [Fact]
+    public async Task CheckConstraint_RejectsTenantRoleWithNullTenantId()
+    {
+        RoleMetadata invalid = BuildInvalidRoleMetadata(
+            name: "GhostTenant", side: MultiTenancySide.Tenant, tenantId: null);
+        _context.Set<RoleMetadata>().Add(invalid);
+
+        DbUpdateException ex = await Should.ThrowAsync<DbUpdateException>(async () =>
+            await _context.SaveChangesAsync(TestContext.Current.CancellationToken));
+
+        ex.InnerException.ShouldBeOfType<PostgresException>()
+            .SqlState.ShouldBe(PostgresErrorCodes.CheckViolation);
+    }
+
+    /// <summary>
+    /// Builds a <see cref="RoleMetadata"/> that violates the <c>Side</c> ↔ <c>TenantId</c>
+    /// invariant, bypassing the <see cref="RoleMetadata.Create"/> factory via reflection on
+    /// the private parameterless constructor + private setters. The point of these tests is
+    /// to prove the database CHECK constraint is a valid guardrail on top of the domain
+    /// invariant, not to exercise the factory itself.
+    /// </summary>
+    private static RoleMetadata BuildInvalidRoleMetadata(
+        string name, MultiTenancySide side, Guid? tenantId)
+    {
+        var instance = (RoleMetadata)Activator.CreateInstance(
+            typeof(RoleMetadata), nonPublic: true)!;
+        SetProperty(instance, nameof(RoleMetadata.Id), Guid.NewGuid());
+        SetProperty(instance, nameof(RoleMetadata.Name), name);
+        SetProperty(instance, nameof(RoleMetadata.MultiTenancySide), side);
+        SetProperty(instance, nameof(RoleMetadata.TenantId), tenantId);
+        SetProperty(instance, nameof(RoleMetadata.IsSystem), false);
+        return instance;
+    }
+
+    private static void SetProperty<T>(RoleMetadata target, string propertyName, T value)
+    {
+        System.Reflection.PropertyInfo property = typeof(RoleMetadata)
+            .GetProperty(propertyName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"Property {propertyName} not found.");
+        property.SetValue(target, value);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // EfCoreRoleMetadataStore roundtrip
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Store_Add_Then_FindByName_ReturnsSeededRow()
+    {
+        EfCoreRoleMetadataStore<TestAuthorizationDbContext> store = new(_context);
+        var role = RoleMetadata.Create(
+            Guid.NewGuid(), "TenantAdministrator", MultiTenancySide.Both, tenantId: null,
+            description: "Administrator within a tenant.");
+
+        await store.AddAsync(role, TestContext.Current.CancellationToken);
+
+        RoleMetadata? found = await store.FindByNameAsync(
+            "TenantAdministrator", tenantId: null, clientId: null,
+            TestContext.Current.CancellationToken);
+
+        found.ShouldNotBeNull();
+        found.Id.ShouldBe(role.Id);
+        found.MultiTenancySide.ShouldBe(MultiTenancySide.Both);
+        found.Description.ShouldBe("Administrator within a tenant.");
+    }
+
+    [Fact]
+    public async Task Store_Remove_RaisesRoleDeletedEventViaMarkAsDeleted()
+    {
+        EfCoreRoleMetadataStore<TestAuthorizationDbContext> store = new(_context);
+        var role = RoleMetadata.Create(
+            Guid.NewGuid(), "DisposableRole", MultiTenancySide.Both, tenantId: null);
+        await store.AddAsync(role, TestContext.Current.CancellationToken);
+
+        RoleMetadata? tracked = await _context.Set<RoleMetadata>()
+            .FirstAsync(r => r.Id == role.Id, TestContext.Current.CancellationToken);
+
+        await store.RemoveAsync(tracked, TestContext.Current.CancellationToken);
+
+        RoleMetadata? afterDelete = await _context.Set<RoleMetadata>().AsNoTracking()
+            .FirstOrDefaultAsync(r => r.Id == role.Id, TestContext.Current.CancellationToken);
+        afterDelete.ShouldBeNull();
+    }
+}

--- a/tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration/TestAuthorizationDbContext.cs
+++ b/tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration/TestAuthorizationDbContext.cs
@@ -1,0 +1,24 @@
+using Granit.Authorization.Domain;
+using Granit.Authorization.EntityFrameworkCore.DbContext;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Authorization.EntityFrameworkCore.Tests.Integration;
+
+/// <summary>
+/// Minimal host DbContext used by the PG integration tests — exposes
+/// <see cref="PermissionGrant"/> and <see cref="RoleMetadata"/> through the
+/// framework's <see cref="IPermissionGrantDbContext"/> contract and wires both
+/// entity configurations via <see cref="PermissionGrantModelBuilderExtensions.ConfigureAuthorizationModule"/>.
+/// </summary>
+internal sealed class TestAuthorizationDbContext(
+    DbContextOptions<TestAuthorizationDbContext> options)
+    : Microsoft.EntityFrameworkCore.DbContext(options), IPermissionGrantDbContext
+{
+    public DbSet<PermissionGrant> PermissionGrants => Set<PermissionGrant>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.ConfigureAuthorizationModule();
+    }
+}

--- a/tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration/packages.lock.json
@@ -1,0 +1,626 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[8.*, )",
+        "resolved": "8.0.1",
+        "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.*, )",
+        "resolved": "18.4.0",
+        "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.4.0",
+          "Microsoft.TestPlatform.TestHost": "18.4.0"
+        }
+      },
+      "Npgsql.EntityFrameworkCore.PostgreSQL": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.1",
+        "contentHash": "P6EwH0Q4xkaA264iNZDqCPhWt8pscfUGxXazDQg4noBfqjoOlk4hKWfvBjF9ZX3R/9JybRmmJfmxr2iBMj0EpA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
+          "Npgsql": "10.0.2"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "Testcontainers.PostgreSql": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.11.0",
+        "contentHash": "OWGi0Og+qFpr2OPDignA74aJSfUd0nvZOaXNGWXwMJR1BvpdzhCNHQB2h7yLSTb0a8JVmmQQ4mUpHAC9q27NLw==",
+        "dependencies": {
+          "Testcontainers": "4.11.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "hGLHCNUsQbT2Ab/HUznRnNqYZQs40zInXa3eLwYjeNyfUYbw1pqqDGqcOLl5uGepS8IuigEYakEdAcVT/2ezYg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "8FU7zmttFQzp0xb0EPupxQ0nGtC2cTpukgh3jMxMT8luj5TSDyzIKTnroDpXCjpg9P2fV+6JIvC+IetsMEfyBA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.4.0",
+        "contentHash": "9O0BtCfzCWrkAmK187ugKdq72HHOXoOUjuWFDVc2LsZZ0pOnA9bTt+Sg9q4cF+MoAaUU+MuWtvBuFsnduviJow=="
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "8Oq/03og7ihwbfx+EjfWhYCdMldClxqnqB9w5ZI4KxuhoiUVDxZYVl06K7fhROOoelhKOtnCUtATCqTCrqSGmA=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.4.0",
+        "contentHash": "4L6m2kS2pY5uJ9cpeRxzW22opr6ttScIRqsOpMDQpgENp/ZwxkkQCcmc6LRSURo2dFaaSW5KVflQZvroiJ7Wzg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.4.0",
+        "contentHash": "gZsCHI+zOmZCcKZieIL4Jg14qKD2OGZOmX5DehuIk1EA9BN6Crm0+taXQNEuajOH1G9CCyBxw8VWR4t5tumcng==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Npgsql": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2025.1.0",
+        "contentHash": "jrnbtf0ItVaXAe6jE8X/kSLa6uC+0C+7W1vepcnRQB/rD88qy4IxG7Lf1FIbWmkoc4iVXv0pKrz+Wc6J4ngmHw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.6.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "Testcontainers": {
+        "type": "Transitive",
+        "resolved": "4.11.0",
+        "contentHash": "9pBNaK9Ra3GVnr5h6gaDJOBH0txA5G3Juho5WANPuyu38l5xyr2lCvf11oA5/uSd+Lh4Wtng34nKp3nMiea02g==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1",
+          "Docker.DotNet.Enhanced.X509": "3.131.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2025.1.0",
+          "SharpZipLib": "1.4.2"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.authorization.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "hs9YULcNhj1UiPjhNoJIDBWS92GvAVzT6DyuvbkoxvDcASZUQFVwQ9EAKtgrOfTaI0Vy6U6RwycXko1SIESM8w==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.14.0",
+        "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration` — a Testcontainers-backed test project that validates PG 17 behaviors the in-memory EF provider cannot exercise. Closes #1083 for the EF layer.

### `RoleMetadataPostgresTests`

- Composite unique index with `NULLS NOT DISTINCT` on `(Name, TenantId, ClientId)` rejects duplicate Host / Both rows sharing a name + null tenant + null client.
- Same-name tenant-scoped roles in different tenants both persist — `NULLS NOT DISTINCT` only affects nulls, not differing non-null values.
- `ck_authorization_role_metadata_side_tenant_consistency` CHECK constraint rejects rows whose Side contradicts the TenantId invariant. Uses reflection on the private ctor + setters to bypass the factory — the CHECK is a defense-in-depth guardrail on top of the domain invariant, and the test proves it.
- `EfCoreRoleMetadataStore<TContext>` roundtrip: `AddAsync` → `FindByNameAsync` retrieves the seeded row; `RemoveAsync` deletes it (also exercises `MarkAsDeleted` domain event collection on the deleted EF entry).

### `PermissionGrantPostgresTests`

- Regression coverage for the `NULLS NOT DISTINCT` fix on `(TenantId, ProviderName, ProviderKey, Name)` — duplicate host-level grants on the same tuple are rejected at the unique index.
- Same tuple across different tenants persists as two separate grants.

### Bug caught by the tests

The Npgsql annotation name was incorrect — I had `Npgsql:IndexNullsDistinct` (silent no-op) instead of the canonical `Npgsql:NullsDistinct` that `Npgsql.EntityFrameworkCore.PostgreSQL` recognises. Fixed in both `PermissionGrantModelBuilderExtensions` and `RoleMetadataModelBuilderExtensions`. Without these integration tests the regression would have shipped: the unique indexes were being created with default ANSI behavior (NULLs distinct), allowing silent duplicates.

## Scope covered / not covered

Covered:

- PG-specific uniqueness semantics (NULLS NOT DISTINCT).
- CHECK constraint enforcement.
- `EfCoreRoleMetadataStore` roundtrip on real PG.

Not covered (separate follow-up):

- `IGranitRoleOrchestrator` compensating-write under PG — requires wiring a dual-DbContext fixture (Identity + Host) inside Testcontainers, significant fixture scaffolding. Left for a future PR that extends `Granit.OpenIddict.Tests.Integration` (which already has the Identity half) with a host DbContext implementing `IPermissionGrantDbContext`.
- `GranitRoleEndpoints` HTTP-level visibility matrix — requires a full `WebApplicationFactory` setup with authentication.

## Infrastructure changes

- `.github/test-shards.json`: new project registered in the `security` shard.
- `.github/shard-filters/*.slnf`: regenerated by the pre-push hook.
- `Granit.slnx`: project registered in the solution.
- `Granit.Authorization.EntityFrameworkCore.csproj`: `InternalsVisibleTo` extended to the new integration test assembly (the store is `internal`).

## Test plan

- [x] `dotnet test tests/Granit.Authorization.EntityFrameworkCore.Tests.Integration` — 9 / 9 passed (PG 17 Testcontainer, ~1 s).
- [x] `dotnet test tests/Granit.Authorization.EntityFrameworkCore.Tests` — 58 / 58 passed (no regression on in-memory tests).
- [x] `dotnet test tests/Granit.Authorization.Tests` — 216 / 216 passed.