### PR TITLE
test(identity-local-aspnetidentity): PostgreSQL orchestrator integration tests

### DIFF
--- a/.github/shard-filters/security.slnf
+++ b/.github/shard-filters/security.slnf
@@ -123,6 +123,7 @@
       "tests/Granit.Identity.Federated.Keycloak.Tests/Granit.Identity.Federated.Keycloak.Tests.csproj",
       "tests/Granit.Identity.Federated.Privacy.Tests/Granit.Identity.Federated.Privacy.Tests.csproj",
       "tests/Granit.Identity.Federated.Tests/Granit.Identity.Federated.Tests.csproj",
+      "tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/Granit.Identity.Local.AspNetIdentity.Tests.Integration.csproj",
       "tests/Granit.Identity.Local.AspNetIdentity.Tests/Granit.Identity.Local.AspNetIdentity.Tests.csproj",
       "tests/Granit.Identity.Local.Endpoints.Tests/Granit.Identity.Local.Endpoints.Tests.csproj",
       "tests/Granit.Identity.Local.Notifications.Tests/Granit.Identity.Local.Notifications.Tests.csproj",

--- a/.github/test-shards.json
+++ b/.github/test-shards.json
@@ -237,6 +237,7 @@
         "tests/Granit.Identity.Federated.GoogleCloud.Tests",
         "tests/Granit.Identity.Federated.Keycloak.Tests",
         "tests/Granit.Identity.Local.AspNetIdentity.Tests",
+        "tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration",
         "tests/Granit.Identity.Local.Endpoints.Tests",
         "tests/Granit.Identity.Local.Notifications.Tests",
         "tests/Granit.Identity.Local.Tests",

--- a/.slnf/security.slnf
+++ b/.slnf/security.slnf
@@ -113,6 +113,7 @@
       "tests/Granit.Identity.Federated.Keycloak.Tests/Granit.Identity.Federated.Keycloak.Tests.csproj",
       "tests/Granit.Identity.Federated.Privacy.Tests/Granit.Identity.Federated.Privacy.Tests.csproj",
       "tests/Granit.Identity.Federated.Tests/Granit.Identity.Federated.Tests.csproj",
+      "tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/Granit.Identity.Local.AspNetIdentity.Tests.Integration.csproj",
       "tests/Granit.Identity.Local.AspNetIdentity.Tests/Granit.Identity.Local.AspNetIdentity.Tests.csproj",
       "tests/Granit.Identity.Local.Endpoints.Tests/Granit.Identity.Local.Endpoints.Tests.csproj",
       "tests/Granit.Identity.Local.Notifications.Tests/Granit.Identity.Local.Notifications.Tests.csproj",

--- a/Granit.slnx
+++ b/Granit.slnx
@@ -575,6 +575,7 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Granit.DataExchange.BlobStorage.Tests/Granit.DataExchange.BlobStorage.Tests.csproj" />
+    <Project Path="tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/Granit.Identity.Local.AspNetIdentity.Tests.Integration.csproj" />
     <Project Path="tests/Granit.MultiTenancy.Provisioning.Tests/Granit.MultiTenancy.Provisioning.Tests.csproj" />
   </Folder>
   <Folder Name="/tests/AI/">

--- a/src/Granit.Identity.Local.AspNetIdentity/Granit.Identity.Local.AspNetIdentity.csproj
+++ b/src/Granit.Identity.Local.AspNetIdentity/Granit.Identity.Local.AspNetIdentity.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.Identity.Local.AspNetIdentity.Tests" />
+    <InternalsVisibleTo Include="Granit.Identity.Local.AspNetIdentity.Tests.Integration" />
     <InternalsVisibleTo Include="Granit.OpenIddict.Tests.Integration" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/Granit.Identity.Local.AspNetIdentity.Tests.Integration.csproj
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/Granit.Identity.Local.AspNetIdentity.Tests.Integration.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <!-- Exclude from dotnet test in CI unit-test job (requires PostgreSQL Testcontainer). -->
+    <IsTestProject Condition="'$(SkipIntegrationTests)' == 'true'">false</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Testcontainers.PostgreSql" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Authorization\Granit.Authorization.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Authorization.EntityFrameworkCore\Granit.Authorization.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Guids\Granit.Guids.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Identity.Local\Granit.Identity.Local.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Identity.Local.AspNetIdentity\Granit.Identity.Local.AspNetIdentity.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/PostgresFixture.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/PostgresFixture.cs
@@ -1,0 +1,19 @@
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// Starts a PostgreSQL 17 container once per collection and exposes the connection string.
+/// </summary>
+public sealed class PostgresFixture : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder("postgres:17-alpine")
+        .Build();
+
+    public string ConnectionString => _container.GetConnectionString();
+
+    public ValueTask InitializeAsync() => new(_container.StartAsync());
+
+    public ValueTask DisposeAsync() => _container.DisposeAsync();
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorTestApplication.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorTestApplication.cs
@@ -1,0 +1,106 @@
+using Granit.Authorization.EntityFrameworkCore.Extensions;
+using Granit.Guids.Extensions;
+using Granit.Identity.Local.AspNetIdentity.Internal;
+using Granit.Identity.Local.Domain;
+using Granit.Identity.Local.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// Collection fixture that starts a PostgreSQL 17 container and builds a minimal service
+/// provider wiring everything the <see cref="GranitRoleOrchestrator"/> needs:
+/// ASP.NET Core Identity (with <c>GranitUser</c> / <c>GranitRole</c>), the
+/// authorization <see cref="TestHostDbContext"/> backing <c>IRoleMetadataStore</c>, and
+/// the orchestrator itself.
+/// </summary>
+/// <remarks>
+/// Uses two separate DbContexts — <see cref="TestIdentityDbContext"/> for Identity rows
+/// and <see cref="TestHostDbContext"/> for authorization rows — mirroring the production
+/// dual-DbContext shape the compensating-write strategy was designed for. Both point at
+/// the same physical database (same connection string) since the orchestrator makes no
+/// assumption about database locality.
+/// </remarks>
+public sealed class RoleOrchestratorTestApplication : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres = new();
+    private ServiceProvider? _services;
+
+    public IServiceProvider Services =>
+        _services ?? throw new InvalidOperationException("Fixture not initialized.");
+
+    public async ValueTask InitializeAsync()
+    {
+        await _postgres.InitializeAsync();
+
+        ServiceCollection services = [];
+
+        services.AddLogging(builder => builder.AddDebug());
+
+        services.AddDbContext<TestIdentityDbContext>(opts =>
+            opts.UseNpgsql(_postgres.ConnectionString));
+        services.AddDbContext<TestHostDbContext>(opts =>
+            opts.UseNpgsql(_postgres.ConnectionString));
+
+        // ASP.NET Core Identity — lightweight IdentityCore pipeline is enough for the
+        // orchestrator; no cookies / token providers / email services required.
+        services.AddIdentityCore<GranitUser>()
+            .AddRoles<GranitRole>()
+            .AddEntityFrameworkStores<TestIdentityDbContext>();
+
+        // IRoleMetadataStore → EfCoreRoleMetadataStore<TestHostDbContext>
+        services.AddGranitAuthorizationEntityFrameworkCore<TestHostDbContext>();
+
+        // IGuidGenerator (UuidV7 default) — required by the orchestrator.
+        services.AddGranitGuids();
+
+        // The orchestrator itself (internal; visible via InternalsVisibleTo).
+        services.AddScoped<IGranitRoleOrchestrator, GranitRoleOrchestrator>();
+
+        _services = services.BuildServiceProvider();
+
+        // Create the schema for both contexts against the same physical database.
+        // EnsureCreated on the first context creates its tables; for the second we
+        // must call CreateTablesAsync directly — EnsureCreated's HasTables() guard
+        // would short-circuit once any EF-managed table exists. This mirrors the
+        // standard "multiple DbContexts, one database" workaround.
+        await using AsyncServiceScope scope = _services.CreateAsyncScope();
+        TestIdentityDbContext idCtx = scope.ServiceProvider.GetRequiredService<TestIdentityDbContext>();
+        TestHostDbContext hostCtx = scope.ServiceProvider.GetRequiredService<TestHostDbContext>();
+        await idCtx.Database.EnsureCreatedAsync();
+        await hostCtx.GetService<IRelationalDatabaseCreator>().CreateTablesAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_services is not null)
+        {
+            await _services.DisposeAsync();
+        }
+
+        await _postgres.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Truncates all Identity and authorization rows — call at the start of each test
+    /// to guarantee isolation regardless of order. Uses <c>TRUNCATE … CASCADE</c>
+    /// rather than <c>EnsureDeleted</c>/<c>EnsureCreated</c> to keep the container warm.
+    /// </summary>
+    public async Task ResetDatabaseAsync()
+    {
+        await using AsyncServiceScope scope = Services.CreateAsyncScope();
+        TestIdentityDbContext idCtx = scope.ServiceProvider.GetRequiredService<TestIdentityDbContext>();
+        TestHostDbContext hostCtx = scope.ServiceProvider.GetRequiredService<TestHostDbContext>();
+
+        await hostCtx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE authorization_role_metadata, authorization_permission_grants RESTART IDENTITY CASCADE;");
+        await idCtx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE \"AspNetUserRoles\", \"AspNetRoleClaims\", \"AspNetUserClaims\", \"AspNetUserLogins\", \"AspNetUserTokens\", \"AspNetUsers\", \"AspNetRoles\" RESTART IDENTITY CASCADE;");
+    }
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorTests.cs
@@ -1,0 +1,252 @@
+using Granit.Authorization;
+using Granit.Authorization.Domain;
+using Granit.Identity.Local.Domain;
+using Granit.Identity.Local.Services;
+using Granit.MultiTenancy;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// End-to-end tests for <see cref="IGranitRoleOrchestrator"/> against real PostgreSQL:
+/// proves the compensating-write strategy converges the "every GranitRole has matching
+/// RoleMetadata" invariant even when the metadata write fails (and vice-versa for
+/// rename). Also pins down the system-role protection rules.
+/// </summary>
+public sealed class RoleOrchestratorTests : IClassFixture<RoleOrchestratorTestApplication>, IAsyncLifetime
+{
+    private readonly RoleOrchestratorTestApplication _app;
+
+    public RoleOrchestratorTests(RoleOrchestratorTestApplication app) => _app = app;
+
+    public ValueTask InitializeAsync() => new(_app.ResetDatabaseAsync());
+
+    public ValueTask DisposeAsync() => default;
+
+    // ─────────────────────────────────────────────────────────────────────
+    // CreateAsync
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateAsync_HappyPath_PersistsRoleAndMetadata()
+    {
+        await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
+        IGranitRoleOrchestrator orchestrator = scope.ServiceProvider
+            .GetRequiredService<IGranitRoleOrchestrator>();
+        RoleManager<GranitRole> roleManager = scope.ServiceProvider
+            .GetRequiredService<RoleManager<GranitRole>>();
+        IRoleMetadataStore store = scope.ServiceProvider.GetRequiredService<IRoleMetadataStore>();
+
+        RoleMetadata created = await orchestrator.CreateAsync(
+            new CreateRoleCommand(
+                Name: "Manager",
+                MultiTenancySide: MultiTenancySide.Both,
+                TenantId: null,
+                Description: "Business manager."),
+            TestContext.Current.CancellationToken);
+
+        created.Name.ShouldBe("Manager");
+
+        GranitRole? identityRole = await roleManager.FindByIdAsync(created.Id.ToString("D"));
+        identityRole.ShouldNotBeNull();
+        identityRole.Name.ShouldBe("Manager");
+        identityRole.Description.ShouldBe("Business manager.");
+
+        RoleMetadata? metadata = await store.FindByIdAsync(created.Id, TestContext.Current.CancellationToken);
+        metadata.ShouldNotBeNull();
+        metadata.MultiTenancySide.ShouldBe(MultiTenancySide.Both);
+        metadata.TenantId.ShouldBeNull();
+        metadata.IsSystem.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task CreateAsync_DuplicateMetadataName_CompensatesByDeletingGranitRole()
+    {
+        // Seed a metadata-only row that will collide with the orchestrator's insert.
+        // No matching GranitRole exists, so the Identity CreateAsync step succeeds;
+        // the metadata AddAsync then violates the (Name, TenantId, ClientId) unique
+        // index and must trigger the compensating delete.
+        await SeedMetadataOnlyAsync("Manager", MultiTenancySide.Both, tenantId: null);
+
+        await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
+        IGranitRoleOrchestrator orchestrator = scope.ServiceProvider
+            .GetRequiredService<IGranitRoleOrchestrator>();
+        RoleManager<GranitRole> roleManager = scope.ServiceProvider
+            .GetRequiredService<RoleManager<GranitRole>>();
+
+        await Should.ThrowAsync<DbUpdateException>(async () =>
+            await orchestrator.CreateAsync(
+                new CreateRoleCommand("Manager", MultiTenancySide.Both, TenantId: null),
+                TestContext.Current.CancellationToken));
+
+        // Invariant: no orphan GranitRole remains with display name "Manager".
+        GranitRole? orphan = await roleManager.FindByNameAsync("Manager");
+        orphan.ShouldBeNull();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // RenameAsync
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RenameAsync_HappyPath_UpdatesBothRoleAndMetadata()
+    {
+        RoleMetadata created = await CreateRoleViaOrchestratorAsync(
+            "Alpha", MultiTenancySide.Both, tenantId: null);
+
+        await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
+        IGranitRoleOrchestrator orchestrator = scope.ServiceProvider
+            .GetRequiredService<IGranitRoleOrchestrator>();
+        RoleManager<GranitRole> roleManager = scope.ServiceProvider
+            .GetRequiredService<RoleManager<GranitRole>>();
+        IRoleMetadataStore store = scope.ServiceProvider.GetRequiredService<IRoleMetadataStore>();
+
+        await orchestrator.RenameAsync(
+            created.Id,
+            newName: "AlphaPrime",
+            newDescription: "Renamed.",
+            TestContext.Current.CancellationToken);
+
+        GranitRole? identityRole = await roleManager.FindByIdAsync(created.Id.ToString("D"));
+        identityRole.ShouldNotBeNull();
+        identityRole.Name.ShouldBe("AlphaPrime");
+        identityRole.Description.ShouldBe("Renamed.");
+
+        RoleMetadata? metadata = await store.FindByIdAsync(created.Id, TestContext.Current.CancellationToken);
+        metadata.ShouldNotBeNull();
+        metadata.Name.ShouldBe("AlphaPrime");
+        metadata.Description.ShouldBe("Renamed.");
+    }
+
+    [Fact]
+    public async Task RenameAsync_MetadataNameCollision_RevertsIdentityRole()
+    {
+        // Alpha has a matched GranitRole + RoleMetadata (via orchestrator).
+        RoleMetadata alpha = await CreateRoleViaOrchestratorAsync(
+            "Alpha", MultiTenancySide.Both, tenantId: null);
+
+        // Beta exists only in RoleMetadata. When we rename Alpha → "Beta", the
+        // Identity update on Alpha succeeds (no "Beta" GranitRole yet) but the
+        // metadata update hits the unique index → orchestrator compensates.
+        await SeedMetadataOnlyAsync("Beta", MultiTenancySide.Both, tenantId: null);
+
+        await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
+        IGranitRoleOrchestrator orchestrator = scope.ServiceProvider
+            .GetRequiredService<IGranitRoleOrchestrator>();
+        RoleManager<GranitRole> roleManager = scope.ServiceProvider
+            .GetRequiredService<RoleManager<GranitRole>>();
+
+        await Should.ThrowAsync<DbUpdateException>(async () =>
+            await orchestrator.RenameAsync(
+                alpha.Id,
+                newName: "Beta",
+                newDescription: null,
+                TestContext.Current.CancellationToken));
+
+        // Invariant: the Identity-side GranitRole kept its original name.
+        GranitRole? identityRole = await roleManager.FindByIdAsync(alpha.Id.ToString("D"));
+        identityRole.ShouldNotBeNull();
+        identityRole.Name.ShouldBe("Alpha");
+    }
+
+    [Fact]
+    public async Task RenameAsync_SystemRole_Refused()
+    {
+        // IsSystem=true is only settable via the factory — use the store directly so
+        // we don't need an orchestrator code path for seeding system roles.
+        RoleMetadata system = await SeedMetadataOnlyAsync(
+            "SuperAdmin", MultiTenancySide.Host, tenantId: null, isSystem: true);
+
+        await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
+        IGranitRoleOrchestrator orchestrator = scope.ServiceProvider
+            .GetRequiredService<IGranitRoleOrchestrator>();
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await orchestrator.RenameAsync(
+                system.Id, newName: "NotSuperAdmin", newDescription: null,
+                TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("system role");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // DeleteAsync
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteAsync_HappyPath_RemovesBothRoleAndMetadata()
+    {
+        RoleMetadata created = await CreateRoleViaOrchestratorAsync(
+            "Disposable", MultiTenancySide.Both, tenantId: null);
+
+        await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
+        IGranitRoleOrchestrator orchestrator = scope.ServiceProvider
+            .GetRequiredService<IGranitRoleOrchestrator>();
+        RoleManager<GranitRole> roleManager = scope.ServiceProvider
+            .GetRequiredService<RoleManager<GranitRole>>();
+        IRoleMetadataStore store = scope.ServiceProvider.GetRequiredService<IRoleMetadataStore>();
+
+        await orchestrator.DeleteAsync(created.Id, TestContext.Current.CancellationToken);
+
+        GranitRole? identityRole = await roleManager.FindByIdAsync(created.Id.ToString("D"));
+        identityRole.ShouldBeNull();
+
+        RoleMetadata? metadata = await store.FindByIdAsync(created.Id, TestContext.Current.CancellationToken);
+        metadata.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_SystemRole_Refused()
+    {
+        RoleMetadata system = await SeedMetadataOnlyAsync(
+            "TenantAdministrator", MultiTenancySide.Both, tenantId: null, isSystem: true);
+
+        await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
+        IGranitRoleOrchestrator orchestrator = scope.ServiceProvider
+            .GetRequiredService<IGranitRoleOrchestrator>();
+
+        InvalidOperationException ex = await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await orchestrator.DeleteAsync(system.Id, TestContext.Current.CancellationToken));
+
+        ex.Message.ShouldContain("system role");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // helpers
+    // ─────────────────────────────────────────────────────────────────────
+
+    private async Task<RoleMetadata> CreateRoleViaOrchestratorAsync(
+        string name, MultiTenancySide side, Guid? tenantId)
+    {
+        await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
+        IGranitRoleOrchestrator orchestrator = scope.ServiceProvider
+            .GetRequiredService<IGranitRoleOrchestrator>();
+        return await orchestrator.CreateAsync(
+            new CreateRoleCommand(name, side, tenantId),
+            TestContext.Current.CancellationToken);
+    }
+
+    private async Task<RoleMetadata> SeedMetadataOnlyAsync(
+        string name, MultiTenancySide side, Guid? tenantId, bool isSystem = false)
+    {
+        await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
+        TestHostDbContext hostCtx = scope.ServiceProvider.GetRequiredService<TestHostDbContext>();
+
+        var metadata = RoleMetadata.Create(
+            id: Guid.NewGuid(),
+            name: name,
+            multiTenancySide: side,
+            tenantId: tenantId,
+            clientId: null,
+            description: null,
+            isSystem: isSystem);
+
+        hostCtx.Set<RoleMetadata>().Add(metadata);
+        await hostCtx.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return metadata;
+    }
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/TestHostDbContext.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/TestHostDbContext.cs
@@ -1,0 +1,23 @@
+using Granit.Authorization.Domain;
+using Granit.Authorization.EntityFrameworkCore.DbContext;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// Minimal host DbContext used by the orchestrator integration tests — exposes the
+/// authorization entities (<see cref="PermissionGrant"/> and <see cref="RoleMetadata"/>)
+/// via <see cref="IPermissionGrantDbContext"/> so the
+/// <c>EfCoreRoleMetadataStore&lt;TContext&gt;</c> can be wired against it.
+/// </summary>
+internal sealed class TestHostDbContext(DbContextOptions<TestHostDbContext> options)
+    : Microsoft.EntityFrameworkCore.DbContext(options), IPermissionGrantDbContext
+{
+    public DbSet<PermissionGrant> PermissionGrants => Set<PermissionGrant>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.ConfigureAuthorizationModule();
+    }
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/TestIdentityDbContext.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/TestIdentityDbContext.cs
@@ -1,0 +1,14 @@
+using Granit.Identity.Local.Domain;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// Minimal ASP.NET Core Identity DbContext used by the orchestrator integration tests.
+/// Stores <c>GranitUser</c> / <c>GranitRole</c> via the stock Identity schema.
+/// Mirrors production deployments that keep Identity tables in a dedicated DbContext
+/// (in Granit's OIDC flow that role is played by the internal <c>OpenIddictDbContext</c>).
+/// </summary>
+internal sealed class TestIdentityDbContext(DbContextOptions<TestIdentityDbContext> options)
+    : IdentityDbContext<GranitUser, GranitRole, Guid>(options);

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/packages.lock.json
@@ -1,0 +1,515 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[8.*, )",
+        "resolved": "8.0.1",
+        "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
+      },
+      "JunitXml.TestLogger": {
+        "type": "Direct",
+        "requested": "[7.*, )",
+        "resolved": "7.1.0",
+        "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
+      },
+      "Microsoft.AspNetCore.Identity.EntityFrameworkCore": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "WAMNMV7m019wBaem9YAyK+nsR6r5ixBL/kOPybO9QhEkwG4dOeVG3vvTTkI5I6q6fp5+MN6IuYxxV/2HYiI9vw==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
+        }
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.*, )",
+        "resolved": "18.4.0",
+        "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.4.0",
+          "Microsoft.TestPlatform.TestHost": "18.4.0"
+        }
+      },
+      "Npgsql.EntityFrameworkCore.PostgreSQL": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.1",
+        "contentHash": "P6EwH0Q4xkaA264iNZDqCPhWt8pscfUGxXazDQg4noBfqjoOlk4hKWfvBjF9ZX3R/9JybRmmJfmxr2iBMj0EpA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
+          "Npgsql": "10.0.2"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.*, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "Shouldly": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.3.0",
+        "contentHash": "sDetrWXrl6YXZ4HeLsdBoNk3uIa7K+V4uvIJ+cqdRa5DrFxeTED7VkjoxCuU1kJWpUuBDZz2QXFzSxBtVXLwRQ==",
+        "dependencies": {
+          "DiffEngine": "11.3.0",
+          "EmptyFiles": "4.4.0"
+        }
+      },
+      "Testcontainers.PostgreSql": {
+        "type": "Direct",
+        "requested": "[4.*, )",
+        "resolved": "4.11.0",
+        "contentHash": "OWGi0Og+qFpr2OPDignA74aJSfUd0nvZOaXNGWXwMJR1BvpdzhCNHQB2h7yLSTb0a8JVmmQQ4mUpHAC9q27NLw==",
+        "dependencies": {
+          "Testcontainers": "4.11.0"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.*, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.*, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g=="
+      },
+      "DiffEngine": {
+        "type": "Transitive",
+        "resolved": "11.3.0",
+        "contentHash": "k0ZgZqd09jLZQjR8FyQbSQE86Q7QZnjEzq1LPHtj1R2AoWO8sjV5x+jlSisL7NZAbUOI4y+7Bog8gkr9WIRBGw==",
+        "dependencies": {
+          "EmptyFiles": "4.4.0",
+          "System.Management": "6.0.1"
+        }
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "hGLHCNUsQbT2Ab/HUznRnNqYZQs40zInXa3eLwYjeNyfUYbw1pqqDGqcOLl5uGepS8IuigEYakEdAcVT/2ezYg=="
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "8FU7zmttFQzp0xb0EPupxQ0nGtC2cTpukgh3jMxMT8luj5TSDyzIKTnroDpXCjpg9P2fV+6JIvC+IetsMEfyBA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1"
+        }
+      },
+      "EmptyFiles": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "gwJEfIGS7FhykvtZoscwXj/XwW+mJY6UbAZk+qtLKFUGWC95kfKXnj8VkxsZQnWBxJemM/q664rGLN5nf+OHZw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.4.0",
+        "contentHash": "9O0BtCfzCWrkAmK187ugKdq72HHOXoOUjuWFDVc2LsZZ0pOnA9bTt+Sg9q4cF+MoAaUU+MuWtvBuFsnduviJow=="
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.4.0",
+        "contentHash": "4L6m2kS2pY5uJ9cpeRxzW22opr6ttScIRqsOpMDQpgENp/ZwxkkQCcmc6LRSURo2dFaaSW5KVflQZvroiJ7Wzg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.4.0",
+        "contentHash": "gZsCHI+zOmZCcKZieIL4Jg14qKD2OGZOmX5DehuIk1EA9BN6Crm0+taXQNEuajOH1G9CCyBxw8VWR4t5tumcng==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Npgsql": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg=="
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2025.1.0",
+        "contentHash": "jrnbtf0ItVaXAe6jE8X/kSLa6uC+0C+7W1vepcnRQB/rD88qy4IxG7Lf1FIbWmkoc4iVXv0pKrz+Wc6J4ngmHw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.6.2"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Management": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "10J1D0h/lioojphfJ4Fuh5ZUThT/xOVHdV9roGBittKKNP2PMjrvibEdbVTGZcPra1399Ja3tqIJLyQrc5Wmhg==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "Testcontainers": {
+        "type": "Transitive",
+        "resolved": "4.11.0",
+        "contentHash": "9pBNaK9Ra3GVnr5h6gaDJOBH0txA5G3Juho5WANPuyu38l5xyr2lCvf11oA5/uSd+Lh4Wtng34nKp3nMiea02g==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1",
+          "Docker.DotNet.Enhanced.X509": "3.131.1",
+          "SSH.NET": "2025.1.0",
+          "SharpZipLib": "1.4.2"
+        }
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "granit": {
+        "type": "Project"
+      },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.authorization.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.*, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
+      "granit.dataexchange.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.events": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.identity": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.identity.local": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Events": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Identity": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.identity.local.aspnetidentity": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Identity": "[0.1.0-dev, )",
+          "Granit.Identity.Local": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.settings": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Events": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.14.0",
+        "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog=="
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds real-PostgreSQL integration coverage for `IGranitRoleOrchestrator`, completing the orchestrator leg of #1087. The new `Granit.Identity.Local.AspNetIdentity.Tests.Integration` project wires two DbContexts (Identity + host authorization) against a PG 17 Testcontainer and exercises the compensating-write paths the in-memory EF provider cannot validate.

Scenarios covered:

- `CreateAsync` happy path — GranitRole + RoleMetadata persisted together.
- `CreateAsync` metadata unique-index collision — compensation deletes the freshly created GranitRole so no orphan remains.
- `RenameAsync` happy path — both sides updated.
- `RenameAsync` metadata collision — Identity name reverted after the host-side unique-index violation.
- `RenameAsync` / `DeleteAsync` on a system role — refused with a clear message.
- `DeleteAsync` happy path — both rows removed.

Relates to #1087. The `/admin/roles` HTTP-level visibility-matrix tests (second leg of the issue) are intentionally left for a follow-up PR to keep this one focused — they require a distinct fixture (`WebApplicationFactory` + test auth handler + permission-grant seeding).

## Test plan

- [x] `dotnet build tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration` → 0 warnings / 0 errors
- [x] `dotnet test tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration` → 7/7 passing on local PG 17 container
- [x] `dotnet format --verify-no-changes` → clean
- [x] Project added to `.github/test-shards.json` (`security` shard) + solution filter regenerated
- [ ] CI green on the `security` shard (awaits remote run)