### PR TITLE
fix(bff): dedupe OIDC scopes in the authorize URL

### DIFF
--- a/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
+++ b/src/Granit.Bff.Endpoints/Endpoints/BffLoginEndpoints.cs
@@ -115,9 +115,14 @@ internal static partial class BffLoginEndpoints
             new FusionCacheEntryOptions { Duration = TimeSpan.FromMinutes(10) },
             token: cancellationToken).ConfigureAwait(false);
 
-        // Build authorization URL
+        // Build authorization URL.
+        // Deduplicate defensively: IConfiguration binding onto a pre-initialised
+        // string[] can produce duplicates when the default values and an
+        // appsettings section declare overlapping scopes. Duplicates in the
+        // `scope` parameter are tolerated by most OIDC servers but bloat the
+        // /connect/authorize URL and were observed in production on 2026-04-22.
 #pragma warning disable GRSEC003 // Building OIDC authorize URL with client credentials
-        string scopes = string.Join(" ", frontend.Scopes);
+        string scopes = string.Join(" ", frontend.Scopes.Distinct(StringComparer.Ordinal));
         string pathPrefix = string.IsNullOrEmpty(frontend.PathPrefix) ? "" : frontend.PathPrefix;
         string callbackUrl = $"{httpContext.Request.Scheme}://{httpContext.Request.Host}{pathPrefix}/bff/callback";
         string authorityBase = bffOptions.Authority.ToString().TrimEnd('/');

--- a/tests/Granit.Bff.Endpoints.Tests/Integration/BffEndpointsIntegrationTests.cs
+++ b/tests/Granit.Bff.Endpoints.Tests/Integration/BffEndpointsIntegrationTests.cs
@@ -652,6 +652,32 @@ public sealed class BffEndpointsIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task GetLogin_DuplicateScopes_DedupedInAuthorizeUrl()
+    {
+        // Simulate the IConfiguration-binding concatenation quirk observed in
+        // production: the default Scopes array was appended to — not replaced —
+        // by an appsettings section with overlapping values, which surfaced on
+        // /connect/authorize as a doubled scope list. The dedup in
+        // BffLoginEndpoints is the guardrail.
+        await _server.DisposeAsync();
+        _server = await BffEndpointsTestServer.CreateAsync(
+            scopes: ["openid", "profile", "email", "openid", "profile", "email"]);
+
+        HttpResponseMessage response = await _server.SendWithoutRedirectAsync(
+            new HttpRequestMessage(HttpMethod.Get, "/app/bff/login"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+
+        string redirectUrl = response.Headers.Location!.ToString();
+        string scopeParam = HttpUtility.ParseQueryString(
+            new Uri(redirectUrl).Query)["scope"]!;
+
+        string[] emitted = scopeParam.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        emitted.ShouldBe(["openid", "profile", "email"], ignoreOrder: false);
+    }
+
+    [Fact]
     public async Task GetLogin_StoresPkceStateInCache()
     {
         HttpResponseMessage response = await _server.SendWithoutRedirectAsync(

--- a/tests/Granit.Bff.Endpoints.Tests/Integration/BffEndpointsTestServer.cs
+++ b/tests/Granit.Bff.Endpoints.Tests/Integration/BffEndpointsTestServer.cs
@@ -93,7 +93,7 @@ internal sealed class BffEndpointsTestServer : IAsyncDisposable
         TokenEndpointHandler = tokenEndpointHandler;
     }
 
-    public static async Task<BffEndpointsTestServer> CreateAsync()
+    public static async Task<BffEndpointsTestServer> CreateAsync(string[]? scopes = null)
     {
         // Reset the static singleton guard so each test can register endpoints
         ResetEndpointsMappedFlag();
@@ -138,7 +138,7 @@ internal sealed class BffEndpointsTestServer : IAsyncDisposable
             ClientId = "test-client-id",
             ClientSecret = "test-client-secret",
             PathPrefix = TestPathPrefix,
-            Scopes = ["openid", "profile"],
+            Scopes = scopes ?? ["openid", "profile"],
         };
 
         GranitBffOptions bffOptions = new()


### PR DESCRIPTION
## Summary

`BffLoginEndpoints` used to project `frontend.Scopes` verbatim into the `scope` query parameter on `/connect/authorize`. When the same scope list is declared both as the default in `BffFrontendOptions` and in `appsettings.json`, `IConfiguration` binding onto the pre-initialised `string[]` can produce duplicates — observed in production on 2026-04-22 as a doubled scope list in the authorize URL.

Fix: deduplicate defensively at the join site with `Distinct(StringComparer.Ordinal)`. First occurrence wins so ordering is preserved. No behaviour change for correctly-configured frontends.

## Why dedup rather than changing the default

Two options were considered:

1. **Breaking change**: default `Scopes = []` in `BffFrontendOptions` and make apps declare them explicitly in config. Fixes the root cause but breaks consumers that relied on the framework-provided defaults.
2. **Dedup at the join site** (this PR): one-line guardrail, non-breaking, transparent — if a consumer reads `frontend.Scopes` elsewhere they still see the raw configured values and can decide locally.

The join in `BffLoginEndpoints` is the only site where `frontend.Scopes` is projected into an OIDC URL, so the dedup covers both the non-PAR redirect and the PAR push path (the joined string flows through both branches).

## Test plan

- [x] `dotnet build src/Granit.Bff.Endpoints` → 0 warnings / 0 errors
- [x] `dotnet test tests/Granit.Bff.Endpoints.Tests` → 89/89 passing (1 new)
- [x] `dotnet format --verify-no-changes` → clean on both projects
- [x] New test `GetLogin_DuplicateScopes_DedupedInAuthorizeUrl` asserts the emitted `scope` parameter contains each scope exactly once when the frontend is configured with duplicates