### PR TITLE
test(identity-local-aspnetidentity): HTTP integration tests for /admin/roles

### DIFF
--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/Granit.Identity.Local.AspNetIdentity.Tests.Integration.csproj
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/Granit.Identity.Local.AspNetIdentity.Tests.Integration.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Testcontainers.PostgreSql" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Shouldly" />
@@ -29,6 +30,7 @@
     <ProjectReference Include="..\..\src\Granit.Guids\Granit.Guids.csproj" />
     <ProjectReference Include="..\..\src\Granit.Identity.Local\Granit.Identity.Local.csproj" />
     <ProjectReference Include="..\..\src\Granit.Identity.Local.AspNetIdentity\Granit.Identity.Local.AspNetIdentity.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Identity.Local.Endpoints\Granit.Identity.Local.Endpoints.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/GranitRoleEndpointsTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/GranitRoleEndpointsTests.cs
@@ -1,0 +1,245 @@
+using System.Net;
+using System.Net.Http.Json;
+using Granit.Authorization;
+using Granit.Authorization.Domain;
+using Granit.MultiTenancy;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// HTTP-level integration tests for the <c>/admin/roles</c> CRUD endpoints.
+/// Covers the visibility matrix applied by <c>ICurrentTenant</c>, the
+/// <c>AllowTenantRoles</c> Phase-1 refusal, and the system-role protection
+/// rules. Permission-grant enforcement is deliberately bypassed at the
+/// authorization-policy layer — see <see cref="PermissiveAuthorizationPolicyProvider"/>
+/// for the rationale.
+/// </summary>
+public sealed class GranitRoleEndpointsTests
+    : IClassFixture<RoleEndpointsTestApplication>, IAsyncLifetime
+{
+    private readonly RoleEndpointsTestApplication _app;
+    private readonly Guid _tenantA = Guid.NewGuid();
+    private readonly Guid _tenantB = Guid.NewGuid();
+
+    public GranitRoleEndpointsTests(RoleEndpointsTestApplication app) => _app = app;
+
+    public ValueTask InitializeAsync() => new(_app.ResetDatabaseAsync());
+
+    public ValueTask DisposeAsync() => default;
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Listing — visibility matrix
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_AsHostAdmin_SeesAllRoles()
+    {
+        await SeedMetadataAsync("SuperAdmin", MultiTenancySide.Host, tenantId: null);
+        await SeedMetadataAsync("User", MultiTenancySide.Both, tenantId: null);
+        await SeedMetadataAsync("Manager", MultiTenancySide.Tenant, tenantId: _tenantA);
+        await SeedMetadataAsync("Manager", MultiTenancySide.Tenant, tenantId: _tenantB);
+
+        HttpResponseMessage response = await _app.HttpClient
+            .GetAsync("/admin/roles", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        RoleResponseLite[]? roles = await response.Content
+            .ReadFromJsonAsync<RoleResponseLite[]>(TestContext.Current.CancellationToken);
+
+        roles.ShouldNotBeNull();
+        roles.Length.ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task List_AsTenantAdmin_SeesBothAndOwnTenantOnly()
+    {
+        await SeedMetadataAsync("SuperAdmin", MultiTenancySide.Host, tenantId: null);
+        await SeedMetadataAsync("User", MultiTenancySide.Both, tenantId: null);
+        await SeedMetadataAsync("Manager", MultiTenancySide.Tenant, tenantId: _tenantA);
+        await SeedMetadataAsync("Manager", MultiTenancySide.Tenant, tenantId: _tenantB);
+
+        using IDisposable _ = _app.CurrentTenant.Change(_tenantA);
+
+        HttpResponseMessage response = await _app.HttpClient
+            .GetAsync("/admin/roles", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        RoleResponseLite[]? roles = await response.Content
+            .ReadFromJsonAsync<RoleResponseLite[]>(TestContext.Current.CancellationToken);
+
+        roles.ShouldNotBeNull();
+        roles.Select(r => r.Name).OrderBy(n => n, StringComparer.Ordinal)
+            .ShouldBe(["Manager", "User"]);
+        roles.ShouldNotContain(r => r.MultiTenancySide == MultiTenancySide.Host);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // GetById — invisible roles surface as 404 (never 403, to prevent leak)
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetById_AsTenantAdmin_HostRole_Returns404()
+    {
+        RoleMetadata hostRole = await SeedMetadataAsync(
+            "SuperAdmin", MultiTenancySide.Host, tenantId: null);
+
+        using IDisposable _ = _app.CurrentTenant.Change(_tenantA);
+
+        HttpResponseMessage response = await _app.HttpClient.GetAsync(
+            $"/admin/roles/{hostRole.Id:D}", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetById_AsTenantAdmin_OtherTenantRole_Returns404()
+    {
+        RoleMetadata otherTenantRole = await SeedMetadataAsync(
+            "Manager", MultiTenancySide.Tenant, tenantId: _tenantB);
+
+        using IDisposable _ = _app.CurrentTenant.Change(_tenantA);
+
+        HttpResponseMessage response = await _app.HttpClient.GetAsync(
+            $"/admin/roles/{otherTenantRole.Id:D}", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // POST — AllowTenantRoles flag (Phase 1 refusal)
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Create_SideTenant_AllowTenantRolesFalse_Returns403()
+    {
+        using IDisposable _ = _app.CurrentTenant.Change(_tenantA);
+
+        HttpResponseMessage response = await _app.HttpClient.PostAsJsonAsync(
+            "/admin/roles",
+            new
+            {
+                name = "Manager",
+                multiTenancySide = (int)MultiTenancySide.Tenant,
+                tenantId = _tenantA,
+            },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // System role protection
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Delete_SystemRole_Returns403()
+    {
+        RoleMetadata system = await SeedMetadataAsync(
+            "SuperAdmin", MultiTenancySide.Host, tenantId: null, isSystem: true);
+
+        HttpResponseMessage response = await _app.HttpClient.DeleteAsync(
+            $"/admin/roles/{system.Id:D}", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Rename_SystemRole_Returns403()
+    {
+        RoleMetadata system = await SeedMetadataAsync(
+            "User", MultiTenancySide.Both, tenantId: null, isSystem: true);
+
+        HttpResponseMessage response = await _app.HttpClient.PutAsJsonAsync(
+            $"/admin/roles/{system.Id:D}",
+            new { name = "RenamedUser" },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Cross-tenant mutation — invisibility wins over 403 (no existence leak)
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Rename_AsTenantAdmin_OtherTenantRole_Returns404()
+    {
+        RoleMetadata otherTenantRole = await SeedMetadataAsync(
+            "Manager", MultiTenancySide.Tenant, tenantId: _tenantB);
+
+        using IDisposable _ = _app.CurrentTenant.Change(_tenantA);
+
+        HttpResponseMessage response = await _app.HttpClient.PutAsJsonAsync(
+            $"/admin/roles/{otherTenantRole.Id:D}",
+            new { name = "Hijacked" },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Happy path — proves the orchestrator is wired end-to-end through HTTP
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Create_AsHostAdmin_SideHost_Returns201()
+    {
+        HttpResponseMessage response = await _app.HttpClient.PostAsJsonAsync(
+            "/admin/roles",
+            new
+            {
+                name = "Auditor",
+                multiTenancySide = (int)MultiTenancySide.Host,
+                tenantId = (Guid?)null,
+                description = "Read-only platform auditor.",
+            },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+
+        RoleResponseLite? created = await response.Content
+            .ReadFromJsonAsync<RoleResponseLite>(TestContext.Current.CancellationToken);
+
+        created.ShouldNotBeNull();
+        created.Name.ShouldBe("Auditor");
+        created.MultiTenancySide.ShouldBe(MultiTenancySide.Host);
+        created.IsSystem.ShouldBeFalse();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // helpers
+    // ─────────────────────────────────────────────────────────────────────
+
+    private async Task<RoleMetadata> SeedMetadataAsync(
+        string name, MultiTenancySide side, Guid? tenantId, bool isSystem = false)
+    {
+        await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
+        IRoleMetadataStore store = scope.ServiceProvider.GetRequiredService<IRoleMetadataStore>();
+
+        var metadata = RoleMetadata.Create(
+            id: Guid.NewGuid(),
+            name: name,
+            multiTenancySide: side,
+            tenantId: tenantId,
+            clientId: null,
+            description: null,
+            isSystem: isSystem);
+
+        await store.AddAsync(metadata, TestContext.Current.CancellationToken);
+        return metadata;
+    }
+
+    private sealed record RoleResponseLite(
+        Guid Id,
+        string Name,
+        MultiTenancySide MultiTenancySide,
+        Guid? TenantId,
+        string? ClientId,
+        string? Description,
+        bool IsSystem);
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/MutableCurrentTenant.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/MutableCurrentTenant.cs
@@ -1,0 +1,35 @@
+using Granit.MultiTenancy;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// Test-only <see cref="ICurrentTenant"/> whose state can be flipped between tests
+/// to drive the host/tenant visibility scenarios. Registered as a singleton so
+/// each test can mutate the active tenant without rebuilding the service provider.
+/// </summary>
+public sealed class MutableCurrentTenant : ICurrentTenant
+{
+    public bool IsAvailable => Id is not null;
+
+    public Guid? Id { get; private set; }
+
+    public string? Name { get; private set; }
+
+    public IDisposable Change(Guid? id, string? name = null)
+    {
+        Guid? previousId = Id;
+        string? previousName = Name;
+        Id = id;
+        Name = name;
+        return new Scope(this, previousId, previousName);
+    }
+
+    private sealed class Scope(MutableCurrentTenant owner, Guid? previousId, string? previousName) : IDisposable
+    {
+        public void Dispose()
+        {
+            owner.Id = previousId;
+            owner.Name = previousName;
+        }
+    }
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/PermissiveAuthorizationPolicyProvider.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/PermissiveAuthorizationPolicyProvider.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// Policy provider that resolves every named policy — including the dynamic
+/// <c>IdentityLocal.Roles.*</c> permission names declared by the role endpoints —
+/// to a single "requires an authenticated user" policy. This short-circuits the
+/// real <c>DynamicPermissionPolicyProvider</c> / <c>PermissionChecker</c> path
+/// so the endpoint tests aren't pulled into seeding permission grants, which is
+/// orthogonal to the visibility-matrix behaviour they're meant to verify.
+/// </summary>
+internal sealed class PermissiveAuthorizationPolicyProvider : IAuthorizationPolicyProvider
+{
+    private static readonly AuthorizationPolicy AuthenticatedPolicy =
+        new AuthorizationPolicyBuilder(TestAuthHandler.SchemeName)
+            .RequireAuthenticatedUser()
+            .Build();
+
+    public Task<AuthorizationPolicy> GetDefaultPolicyAsync() =>
+        Task.FromResult(AuthenticatedPolicy);
+
+    public Task<AuthorizationPolicy?> GetFallbackPolicyAsync() =>
+        Task.FromResult<AuthorizationPolicy?>(AuthenticatedPolicy);
+
+    public Task<AuthorizationPolicy?> GetPolicyAsync(string policyName) =>
+        Task.FromResult<AuthorizationPolicy?>(AuthenticatedPolicy);
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleEndpointsTestApplication.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleEndpointsTestApplication.cs
@@ -1,0 +1,138 @@
+using Granit.Authorization.EntityFrameworkCore.Extensions;
+using Granit.Guids.Extensions;
+using Granit.Identity.Local.AspNetIdentity.Internal;
+using Granit.Identity.Local.Domain;
+using Granit.Identity.Local.Endpoints.Extensions;
+using Granit.Identity.Local.Services;
+using Granit.MultiTenancy;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// Collection fixture that boots a real <see cref="WebApplication"/> with the
+/// <c>/admin/roles</c> endpoints mapped against a PostgreSQL 17 container.
+/// Exposes a mutable <see cref="ICurrentTenant"/> so tests can flip between host
+/// admin and tenant admin contexts without rebuilding the server.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Authentication is handled by <see cref="TestAuthHandler"/> which unconditionally
+/// authenticates every request; authorization is deliberately widened via
+/// <see cref="PermissiveAuthorizationPolicyProvider"/> so the permission-grant
+/// evaluation pipeline (<c>DynamicPermissionPolicyProvider</c> /
+/// <c>IPermissionChecker</c>) doesn't gate these tests. That surface is covered
+/// by unit tests around <c>PermissionChecker</c>; here we focus on the visibility
+/// matrix, the <c>AllowTenantRoles</c> flag, and the system-role protection rules
+/// applied inside the endpoint handlers.
+/// </para>
+/// </remarks>
+public sealed class RoleEndpointsTestApplication : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres = new();
+    private WebApplication? _app;
+    private MutableCurrentTenant? _currentTenant;
+
+    public HttpClient HttpClient =>
+        _app?.GetTestClient() ?? throw new InvalidOperationException("Fixture not initialized.");
+
+    public MutableCurrentTenant CurrentTenant =>
+        _currentTenant ?? throw new InvalidOperationException("Fixture not initialized.");
+
+    public IServiceProvider Services =>
+        _app?.Services ?? throw new InvalidOperationException("Fixture not initialized.");
+
+    public async ValueTask InitializeAsync()
+    {
+        await _postgres.InitializeAsync();
+
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+
+        builder.Services.AddDbContext<TestIdentityDbContext>(opts =>
+            opts.UseNpgsql(_postgres.ConnectionString));
+        builder.Services.AddDbContext<TestHostDbContext>(opts =>
+            opts.UseNpgsql(_postgres.ConnectionString));
+
+        builder.Services.AddIdentityCore<GranitUser>()
+            .AddRoles<GranitRole>()
+            .AddEntityFrameworkStores<TestIdentityDbContext>();
+
+        builder.Services.AddGranitAuthorizationEntityFrameworkCore<TestHostDbContext>();
+        builder.Services.AddGranitGuids();
+        builder.Services.AddScoped<IGranitRoleOrchestrator, GranitRoleOrchestrator>();
+
+        _currentTenant = new MutableCurrentTenant();
+        builder.Services.AddSingleton<ICurrentTenant>(_currentTenant);
+
+        builder.Services
+            .AddAuthentication(TestAuthHandler.SchemeName)
+            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                TestAuthHandler.SchemeName, _ => { });
+
+        // Replace the default policy provider so dynamic permission policy names
+        // (e.g. "IdentityLocal.Roles.Read") resolve to a permissive policy.
+        builder.Services.AddAuthorization();
+        builder.Services.Replace(ServiceDescriptor.Singleton<
+            IAuthorizationPolicyProvider, PermissiveAuthorizationPolicyProvider>());
+
+        _app = builder.Build();
+
+        _app.UseAuthentication();
+        _app.UseAuthorization();
+        _app.MapGranitRoles();
+
+        await using (AsyncServiceScope scope = _app.Services.CreateAsyncScope())
+        {
+            TestIdentityDbContext idCtx = scope.ServiceProvider.GetRequiredService<TestIdentityDbContext>();
+            TestHostDbContext hostCtx = scope.ServiceProvider.GetRequiredService<TestHostDbContext>();
+            await idCtx.Database.EnsureCreatedAsync();
+            await hostCtx.GetService<IRelationalDatabaseCreator>().CreateTablesAsync();
+        }
+
+        await _app.StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_app is not null)
+        {
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+
+        await _postgres.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Truncates all Identity and authorization rows so each test starts from an
+    /// empty schema. The container itself stays warm across tests.
+    /// </summary>
+    public async Task ResetDatabaseAsync()
+    {
+        CurrentTenant.Change(id: null);
+
+        await using AsyncServiceScope scope = Services.CreateAsyncScope();
+        TestIdentityDbContext idCtx = scope.ServiceProvider.GetRequiredService<TestIdentityDbContext>();
+        TestHostDbContext hostCtx = scope.ServiceProvider.GetRequiredService<TestHostDbContext>();
+
+        await hostCtx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE authorization_role_metadata, authorization_permission_grants RESTART IDENTITY CASCADE;");
+        await idCtx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE \"AspNetUserRoles\", \"AspNetRoleClaims\", \"AspNetUserClaims\", \"AspNetUserLogins\", \"AspNetUserTokens\", \"AspNetUsers\", \"AspNetRoles\" RESTART IDENTITY CASCADE;");
+    }
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/TestAuthHandler.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/TestAuthHandler.cs
@@ -1,0 +1,36 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// Unconditionally authenticates every request as a synthetic "admin" principal.
+/// Combined with <see cref="PermissiveAuthorizationPolicyProvider"/>, this lets the
+/// endpoint tests focus on the visibility-matrix / validation logic rather than the
+/// permission-grant evaluation pipeline — permission enforcement is covered by
+/// unit tests around <c>IPermissionChecker</c>.
+/// </summary>
+internal sealed class TestAuthHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    public const string SchemeName = "Test";
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        Claim[] claims =
+        [
+            new(ClaimTypes.NameIdentifier, "test-admin"),
+            new(ClaimTypes.Name, "test-admin"),
+        ];
+        var identity = new ClaimsIdentity(claims, SchemeName);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, SchemeName);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/packages.lock.json
@@ -23,6 +23,16 @@
           "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
         }
       },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "lWyzApi1g8/r0eXqZBbl5bA8zewS8koxOir83/+OvJcyn2HazdUzPFd4MWc9uMdVzCRX6Z5aY4tNK+N0pWXMLg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7"
+        }
+      },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",
         "requested": "[3.*, )",
@@ -32,11 +42,11 @@
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
-        "resolved": "18.4.0",
-        "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
+        "resolved": "18.5.0",
+        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.4.0",
-          "Microsoft.TestPlatform.TestHost": "18.4.0"
+          "Microsoft.CodeCoverage": "18.5.0",
+          "Microsoft.TestPlatform.TestHost": "18.5.0"
         }
       },
       "Npgsql.EntityFrameworkCore.PostgreSQL": {
@@ -93,6 +103,19 @@
           "xunit.v3.mtp-v1": "[3.2.2]"
         }
       },
+      "Asp.Versioning.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "cMRE5nvNMfBgfkb0XFWst/7UtyXCjoAXnV0L4Scx4P9fcf0idgrj1Z0c+3ylsy01K4cOib7dKhCBfpg5z3r0Kg=="
+      },
+      "Asp.Versioning.Http": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "xmNm9FM2d20NKy7i1osEQysf7pJ4iJjWnM6e8CoeIhUREqG8nugsfC82pGpmzlatjAJL5T52ieSpyW+GFdSsSQ==",
+        "dependencies": {
+          "Asp.Versioning.Abstractions": "10.0.0"
+        }
+      },
       "BouncyCastle.Cryptography": {
         "type": "Transitive",
         "resolved": "2.6.2",
@@ -135,6 +158,11 @@
         "resolved": "2.23.0",
         "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
       },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "2UM9EtTmX6yF6Efa6WOO7wmHz2kPksmnzPmMwveuOGJQwbtNg5wKGj7usGLr8Ve3AMhIAc2yqyRXt1xNsed3hg=="
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -142,8 +170,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "9O0BtCfzCWrkAmK187ugKdq72HHOXoOUjuWFDVc2LsZZ0pOnA9bTt+Sg9q4cF+MoAaUU+MuWtvBuFsnduviJow=="
+        "resolved": "18.5.0",
+        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Transitive",
@@ -154,6 +182,16 @@
         "type": "Transitive",
         "resolved": "10.0.7",
         "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "gCglFg/9Chu3lyJNytRuQAYM3mXQKNs1i01Cz2bc545QaHQ+LbBb4O5UCfu968Gro3ZVSOZ/ktilmPcaUSGSZA=="
+      },
+      "Microsoft.OpenApi": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -187,15 +225,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "4L6m2kS2pY5uJ9cpeRxzW22opr6ttScIRqsOpMDQpgENp/ZwxkkQCcmc6LRSURo2dFaaSW5KVflQZvroiJ7Wzg=="
+        "resolved": "18.5.0",
+        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "gZsCHI+zOmZCcKZieIL4Jg14qKD2OGZOmX5DehuIk1EA9BN6Crm0+taXQNEuajOH1G9CCyBxw8VWR4t5tumcng==",
+        "resolved": "18.5.0",
+        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -318,6 +356,11 @@
           "xunit.v3.runner.common": "[3.2.2]"
         }
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
       },
@@ -374,6 +417,25 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
+      "granit.http.abstractions": {
+        "type": "Project"
+      },
+      "granit.http.apidocumentation": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Http.ApiVersioning": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )",
+          "Scalar.AspNetCore": "[2.*, )"
+        }
+      },
+      "granit.http.apiversioning": {
+        "type": "Project",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "[10.0.0-preview.*, )",
+          "Asp.Versioning.Mvc.ApiExplorer": "[10.0.0-preview.*, )",
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.http.exceptionhandling": {
         "type": "Project",
         "dependencies": {
@@ -408,6 +470,28 @@
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
+      "granit.identity.local.endpoints": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Http.Abstractions": "[0.1.0-dev, )",
+          "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.Identity.Local": "[0.1.0-dev, )",
+          "Granit.Settings": "[0.1.0-dev, )",
+          "Granit.Validation": "[0.1.0-dev, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "SmartFormat": "[3.*, )"
         }
       },
       "granit.persistence": {
@@ -451,6 +535,58 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.validation": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.*, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.*, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.*, )"
+        }
+      },
+      "Asp.Versioning.Mvc": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0-preview.*, )",
+        "resolved": "10.0.0",
+        "contentHash": "W0wZ+0uZ0UK4KstjvEkNBZ0xxhBmxunwNg8582SVyyW7txQmSXibtm8fC4o82LaemPquYskms67bIbJOSrnlug==",
+        "dependencies": {
+          "Asp.Versioning.Http": "10.0.0"
+        }
+      },
+      "Asp.Versioning.Mvc.ApiExplorer": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0-preview.*, )",
+        "resolved": "10.0.0",
+        "contentHash": "H54UOpRoc4RmhQ4RA2lzDz43a/hAu/JN19Yyy/DNmH4XlRxhemfhifJyh9BaXNJOtGa2Dnu2xEeP4VSiTdUdAg==",
+        "dependencies": {
+          "Asp.Versioning.Mvc": "10.0.0"
+        }
+      },
+      "FluentValidation": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1"
+        }
+      },
+      "Microsoft.AspNetCore.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "vKiAcGXG0BwNVw3bOjjWRLnp9tR18dR7MiwpvC94h0yFS+zfnzGHzS/JmmgwUdRixrGxrlIMRAWrVc+2DfAGlg==",
+        "dependencies": {
+          "Microsoft.OpenApi": "2.0.0"
+        }
+      },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -484,6 +620,21 @@
         "requested": "[1.15.*, )",
         "resolved": "1.14.0",
         "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "Scalar.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.14.3",
+        "contentHash": "RUy9LiqIl8AY6j2veG2h5gLv31L/REoMMIYm2/7V73nEI/N0EnMpUjuz6FDNDrwhFi2hjqZGXYXA6Li8bZcilA=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
       },
       "ZiggyCreatures.FusionCache": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Summary

Closes the second leg of #1087 by adding WebApplication/TestServer-based integration tests for the `/admin/roles` CRUD endpoints. Runs against the same PostgreSQL 17 container used by the orchestrator tests landed in #1089.

## Scenarios covered

| Scenario | Expected |
| -------- | -------- |
| Host admin `GET /admin/roles` | Sees Host + Both + per-tenant roles |
| Tenant admin `GET /admin/roles` | Sees only Both + own-tenant; Host and other-tenant filtered out |
| Tenant admin `GET /admin/roles/{host-role-id}` | 404 (never 403 — no existence leak) |
| Tenant admin `GET /admin/roles/{other-tenant-role-id}` | 404 |
| `POST /admin/roles` with `Side=Tenant` when `AllowTenantRoles=false` | 403 |
| `DELETE` / `PUT` on a system role | 403 |
| Tenant admin `PUT /admin/roles/{other-tenant-role-id}` | 404 (invisibility beats 403) |
| Host admin `POST /admin/roles` with `Side=Host` | 201, orchestrator wired end-to-end |

## Design choices

- **Auth is mocked** via a minimal `TestAuthHandler` that unconditionally authenticates every request. A `PermissiveAuthorizationPolicyProvider` resolves every policy name (including the dynamic `IdentityLocal.Roles.Read` / `Manage` / `Delete`) to a "requires an authenticated user" policy. This short-circuits `DynamicPermissionPolicyProvider` / `PermissionChecker` so the tests focus on the endpoint-level visibility matrix rather than the permission-grant evaluation pipeline — that surface is covered by unit tests around `IPermissionChecker` and would otherwise force the fixture to seed grants for every scenario.
- **Two DbContexts against the same physical DB** (`TestIdentityDbContext` + `TestHostDbContext`), using `CreateTablesAsync()` on the second to bypass `EnsureCreated`'s `HasTables()` guard — same pattern as PR #1089.
- **Mutable `ICurrentTenant`** registered as a singleton so tests flip host ↔ tenant A ↔ tenant B without rebuilding the server. Uses `using var _ = _app.CurrentTenant.Change(tenantA);` scoping.
- **Per-test TRUNCATE** keeps the container warm across the 9 tests.

## Test plan

- [x] `dotnet build` → 0 warnings / 0 errors
- [x] `dotnet test` → 16/16 (7 pre-existing orchestrator + 9 new endpoint tests) passing on local PG 17 container
- [x] `dotnet format --verify-no-changes` → clean
- [ ] CI green on the `security` shard (awaits remote run)

## Follow-ups (out of scope)

- Permission-grant enforcement tests — would need a fixture variant that seeds grants in `authorization_permission_grants` and asserts 401/403 based on the real `PermissionChecker` evaluation. Lower priority given the unit coverage already on `PermissionChecker`.
- A second app instance with `AllowTenantRoles = true` to verify the happy-path tenant creation flow once the flag is flipped in Phase 2.