### PR TITLE
feat(query-engine): expose enum values in FilterableField metadata

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -35483,7 +35483,7 @@
       "kind": "record",
       "project": "Granit.QueryEngine.Abstractions",
       "file": "src/Granit.QueryEngine.Abstractions/Meta/FilterableField.cs",
-      "line": 11,
+      "line": 16,
       "members": []
     },
     {

--- a/src/Granit.QueryEngine.Abstractions/Meta/FilterableField.cs
+++ b/src/Granit.QueryEngine.Abstractions/Meta/FilterableField.cs
@@ -8,7 +8,13 @@ namespace Granit.QueryEngine.Meta;
 /// <param name="Name">Property name.</param>
 /// <param name="Type">CLR type name.</param>
 /// <param name="Operators">Available filter operators for this field.</param>
+/// <param name="EnumValues">
+/// For enum-typed fields, the set of valid value names (e.g. <c>["Active", "Inactive"]</c>).
+/// <see langword="null"/> for non-enum fields. Lets the frontend render a dropdown of
+/// suggestions instead of a free-text input when entering the filter value.
+/// </param>
 public sealed record FilterableField(
     string Name,
     string Type,
-    IReadOnlyList<FilterOperator> Operators);
+    IReadOnlyList<FilterOperator> Operators,
+    IReadOnlyList<string>? EnumValues = null);

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs
@@ -269,7 +269,8 @@ internal sealed class QueryEngine<TEntity>(
                 .Select(c => new FilterableField(
                     c.PropertyName,
                     c.ClrType.Name,
-                    FilterOperatorInference.GetOperators(c.ClrType)))
+                    FilterOperatorInference.GetOperators(c.ClrType),
+                    GetEnumValues(c.ClrType)))
                 .ToList(),
             SortableFields = _builder.Columns
                 .Where(c => c.IsSortable)
@@ -300,6 +301,12 @@ internal sealed class QueryEngine<TEntity>(
                 _builder.CursorPropertyName is not null),
             DefaultSort = _builder.DefaultSortValue,
         };
+    }
+
+    private static string[]? GetEnumValues(Type clrType)
+    {
+        Type underlying = Nullable.GetUnderlyingType(clrType) ?? clrType;
+        return underlying.IsEnum ? Enum.GetNames(underlying) : null;
     }
 
     private static string ResolveLabel(ColumnDescriptor column, IStringLocalizer? localizer)

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryEngineTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryEngineTests.cs
@@ -272,6 +272,28 @@ public sealed class QueryEngineTests : IAsyncLifetime
         priceField.Operators.ShouldContain(FilterOperator.Between);
     }
 
+    [Fact]
+    public void GetMetadata_populates_enum_values_for_enum_fields()
+    {
+        ProductQueryDefinition definition = new();
+        QueryEngine<TestProduct> engine = new(definition, NullLogger<QueryEngine<TestProduct>>.Instance, Microsoft.Extensions.Options.Options.Create(new Granit.QueryEngine.Options.QueryEngineOptions()));
+
+        QueryMetadata metadata = engine.GetMetadata();
+
+        FilterableField categoryField = metadata.FilterableFields
+            .First(f => f.Name == "Category");
+        categoryField.EnumValues.ShouldNotBeNull();
+        categoryField.EnumValues.ShouldBe(["Electronics", "Books", "Clothing"], ignoreOrder: true);
+
+        FilterableField nameField = metadata.FilterableFields
+            .First(f => f.Name == "Name");
+        nameField.EnumValues.ShouldBeNull();
+
+        FilterableField priceField = metadata.FilterableFields
+            .First(f => f.Name == "Price");
+        priceField.EnumValues.ShouldBeNull();
+    }
+
     private sealed class QuickFilterDefinition : QueryDefinition<TestProduct>
     {
         public override string Name => "Test.Products.QuickFilter";


### PR DESCRIPTION
## Summary

When a query definition marks an enum-typed column as `Filterable()`, the
`/meta` endpoint currently reports `type: "AggregationPeriod"` (or
whatever the enum name is) with operators `[Eq, In]` — but **does not**
surface the set of valid values. Frontends fall back to a free-text
input, forcing users to type exact enum names by hand.

This PR adds an optional `EnumValues` property to `FilterableField` and
auto-populates it in the EF Core query engine implementation whenever
the column's CLR type is an enum (nullable-unwrapped).

## Why

The frontend `@granit/query-engine` SDK already expects this field
(`FilterableField.enumValues?: readonly string[]`) and `useSmartFilter`
already renders values as selectable suggestions in the `enterValue`
phase — see `buildEnumSuggestions`. The backend was simply not emitting
them, so the dropdown never appeared.

This is the minimum backend-side change needed to unlock enum dropdowns
in every `SmartFilterBar` across the admin app: `period`, `aggregationType`,
`activated`, `category`, `status`, `changeType`, etc.

## Design

- Optional property on the record, defaults to `null` — backward
  compatible for any serialized snapshot test or consumer that ignores
  it.
- Auto-detected from `Type.IsEnum` on the nullable-unwrapped CLR type,
  matching the pattern used by `FilterOperatorInference.GetOperators`.
- No per-column configuration needed — the builder already has the
  type info.

## Scope

- `FilterableField` record gains `IReadOnlyList<string>? EnumValues`.
- `QueryEngine<TEntity>.GetMetadata()` in the EF Core implementation
  populates it.
- `Granit.Metering.Endpoints` builds cleanly against the new contract
  without any change (additive property).
- No database migration.

## Test plan

- [x] `dotnet build src/Granit.QueryEngine.EntityFrameworkCore` — clean
- [x] `Granit.QueryEngine.EntityFrameworkCore.Tests` — 13 passed (incl.
      new `GetMetadata_populates_enum_values_for_enum_fields`)
- [x] `Granit.QueryEngine.Tests` — 285 passed
- [x] `Granit.QueryEngine.AspNetCore.Tests` — 74 passed
- [x] `Granit.QueryEngine.AspNetCore.Tests.Integration` — 14 passed
- [x] `Granit.Metering.Endpoints` builds — confirms no downstream break
- [ ] Smoke test in showcase-admin-react `/metering/usage`: verify the
      `period` column now offers `Hourly / Daily / BillingPeriod` as
      suggestions in the SmartFilterBar

## Related

- Front SDK already handles `enumValues` since the `useSmartFilter`
  hook was shipped — this closes the backend gap.
- Follow-up work tracked separately: DateTime picker (step 2),
  reference-data lookups (step 3).
