### PR TITLE
feat(identity-local): tenant-aware role lookup (#1094)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19715,6 +19715,22 @@
       ]
     },
     {
+      "name": "IGranitRoleLookup",
+      "fqn": "Granit.Identity.Local.Services.IGranitRoleLookup",
+      "kind": "interface",
+      "project": "Granit.Identity.Local",
+      "file": "src/Granit.Identity.Local/Services/IGranitRoleLookup.cs",
+      "line": 28,
+      "members": [
+        {
+          "name": "FindByNameAsync",
+          "kind": "method",
+          "signature": "FindByNameAsync(string name, string? clientId = null, CancellationToken cancellationToken = default)",
+          "returnType": "Task<RoleMetadata?>"
+        }
+      ]
+    },
+    {
       "name": "IGranitRoleOrchestrator",
       "fqn": "Granit.Identity.Local.Services.IGranitRoleOrchestrator",
       "kind": "interface",

--- a/docs-site/src/content/docs/dotnet/architecture/adr/023-tenant-aware-role-lookup.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/023-tenant-aware-role-lookup.md
@@ -1,0 +1,119 @@
+---
+title: "ADR-023: Tenant-aware role lookup"
+description: "Universal ILookupNormalizer registration and IGranitRoleLookup abstraction for multi-tenant role resolution"
+sidebar:
+  order: 23
+  label: "023 - Tenant-aware role lookup"
+---
+
+> **Date:** 2026-04-22
+> **Authors:** Jean-Francois Meyers
+> **Scope:** `Granit.Identity.Local.AspNetIdentity`, `Granit.Identity.Local`
+
+## Context
+
+`RoleMetadata` (introduced in Phase 1 — ADR-020 references it) carries a
+declarative `MultiTenancySide` scope so a single display name like `Manager` can
+exist both as a host role and, independently, as a tenant role inside each
+tenant. ASP.NET Core Identity's `AspNetRoles.NormalizedName` column, however, is
+indexed with a **process-wide** unique constraint — two tenants cannot both have
+a `Manager` entry under the default `UpperInvariantLookupNormalizer`.
+
+Phase 1 shipped `TenantAwareRoleLookupNormalizer` but deliberately left it
+unregistered because two design questions were unresolved:
+
+1. `ILookupNormalizer.NormalizeName` is invoked for both `NormalizedUserName`
+   and `NormalizedName` — should we prefix user names too, or find a way to
+   apply the prefix only to roles?
+2. `Both`-scope roles (`TenantAdministrator`, `User`) are stored with
+   `TenantId = null` and therefore with an un-prefixed `NormalizedName`. Queried
+   from a tenant context, the prefixed lookup misses them. How do callers
+   discover these globally-defined roles from inside a tenant?
+
+This ADR pins down the answers.
+
+## Decision
+
+### 1. Register `TenantAwareRoleLookupNormalizer` universally
+
+`GranitIdentityLocalAspNetIdentityModule` replaces the default
+`ILookupNormalizer` with `TenantAwareRoleLookupNormalizer` unconditionally
+(scoped lifetime). The prefix therefore also applies to
+`GranitUser.NormalizedUserName`, with the following semantics:
+
+| Context of creation | Context of lookup | Found? |
+| ------------------- | ----------------- | ------ |
+| Host | Host `FindByNameAsync` | ✅ |
+| Tenant A | Tenant A `FindByNameAsync` | ✅ |
+| Tenant A | Tenant B `FindByNameAsync` | ❌ (invisible) |
+| Tenant A | Host `FindByNameAsync` | ❌ (invisible) |
+| Host | Tenant A `FindByNameAsync` | ❌ (invisible) |
+
+This matches Granit's tenant-isolation intent: host and tenant administrative
+contexts never share a user-by-name lookup in practice. Email-based lookups
+(`NormalizeEmail`) stay upper-invariant so cross-context login by email still
+works for the rare case of a platform-level service hitting a tenant user via
+email.
+
+**Rejected alternative**: flag the behavior behind
+`RoleEndpointsOptions.AllowTenantRoles`. That ties a platform-wide
+infrastructure concern (ASP.NET Identity indexing) to an endpoints-specific
+flag, and produces silent semantic changes the day the flag flips. The
+universal registration is simpler and the user-name side effect is benign in
+practice (see table above).
+
+### 2. Introduce `IGranitRoleLookup`
+
+A new abstraction (`Granit.Identity.Local.Services.IGranitRoleLookup`) is the
+canonical lookup path for business code. It routes through `IRoleMetadataStore`
+(the authoritative catalog) rather than `RoleManager.FindByNameAsync`, and
+implements the tenant-aware fallback:
+
+1. If a tenant context is active, try the tenant-scope row
+   (`TenantId = currentTenant.Id`).
+2. Otherwise — or on a miss — try the host-scope row (`TenantId = null`),
+   which covers both `Host` and `Both` roles.
+
+Other-tenant rows are never returned. `ClientId` is propagated through both
+probes to leave room for the Phase 2 realm/client role distinction
+(#1098 – #1100).
+
+`RoleManager<GranitRole>.FindByNameAsync` is reserved for the one legitimate
+Identity-table use case: the orphan-repair path in
+`IdentityLocalRoleSeedContributor` that detects a `GranitRole` left over from a
+partial seed without matching `RoleMetadata`.
+
+## Consequences
+
+### Positive
+
+- Same display name usable across tenants without leaking through the global
+  unique index.
+- Business flows consistently see roles through one lens (`IGranitRoleLookup`),
+  independent of the normalizer strategy.
+- `Both`-scope roles (seeded platform-wide) stay discoverable from every tenant
+  via the host-scope fallback.
+
+### Negative
+
+- Users created in a tenant context are not findable by `UserManager.FindByNameAsync`
+  from the host context (and vice-versa). Applications that need cross-context
+  lookup must use `FindByEmailAsync` or query `GranitUser` directly through the
+  DbContext with an explicit `TenantId` filter.
+- The `TenantAwareRoleLookupNormalizer` is scoped, which costs a per-request
+  allocation compared to the singleton `UpperInvariantLookupNormalizer`. The
+  overhead is dominated by the scoped `ICurrentTenant` resolution that already
+  exists on every request path, so net impact is negligible.
+
+## Migration
+
+Phase 1 callers of `RoleManager.FindByNameAsync` for business lookups: none
+found in the framework source at the time of this ADR. New callers must use
+`IGranitRoleLookup`; reviewers should flag direct `RoleManager.FindByNameAsync`
+usage outside of the orphan-repair path.
+
+## References
+
+- #1087 — RoleMetadata Phase 1 integration tests (orchestrator + endpoints).
+- #1094 — Phase 2 story landing this ADR.
+- ADR-020 — Declarative Query/Export definitions placement.

--- a/docs-site/src/data/constants.ts
+++ b/docs-site/src/data/constants.ts
@@ -5,4 +5,4 @@ export const CULTURE_COUNT = 18;
 export const BASE_LANGUAGE_COUNT = 15;
 export const REGIONAL_VARIANT_COUNT = 3;
 export const PATTERN_COUNT = 57;
-export const ADR_COUNT = 21;
+export const ADR_COUNT = 23;

--- a/src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs
@@ -42,9 +42,18 @@ public sealed partial class GranitIdentityLocalAspNetIdentityModule : GranitModu
         // Replace default UserManager with GranitUserManager (exponential backoff lockout)
         context.Services.Replace(ServiceDescriptor.Scoped<UserManager<GranitUser>, GranitUserManager>());
 
-        // TenantAwareRoleLookupNormalizer is intentionally not wired here. When
-        // RoleEndpointsOptions.AllowTenantRoles is enabled, applications must replace the
-        // framework default ILookupNormalizer with that type — see the class remarks.
+        // Tenant-aware role lookup: the normalizer prefixes every NormalizeName call
+        // with the current tenant id when one is active, letting the same display name
+        // coexist across tenants on ASP.NET Identity's global NormalizedName index.
+        // Scoped because it depends on the scoped ICurrentTenant. See ADR-023 for the
+        // rationale behind the universal (vs flag-gated) registration.
+        context.Services.Replace(ServiceDescriptor.Scoped<
+            ILookupNormalizer, TenantAwareRoleLookupNormalizer>());
+
+        // Canonical lookup abstraction for Granit-internal role queries. Prefers the
+        // tenant-scoped row when a tenant context is active and falls back to the
+        // host-scope row for Both-side roles that are assignable but stored globally.
+        context.Services.TryAddScoped<IGranitRoleLookup, GranitRoleLookup>();
 
         // Replace default claims principal factory to inject tenant_id into the Identity cookie.
         // This ensures multi-tenancy middleware can resolve the tenant from the authenticated

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/GranitRoleLookup.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/GranitRoleLookup.cs
@@ -1,0 +1,37 @@
+using Granit.Authorization;
+using Granit.Authorization.Domain;
+using Granit.Identity.Local.Services;
+using Granit.MultiTenancy;
+
+namespace Granit.Identity.Local.AspNetIdentity.Internal;
+
+/// <inheritdoc cref="IGranitRoleLookup" />
+internal sealed class GranitRoleLookup(
+    IRoleMetadataStore roleMetadataStore,
+    ICurrentTenant currentTenant) : IGranitRoleLookup
+{
+    /// <inheritdoc />
+    public async Task<RoleMetadata?> FindByNameAsync(
+        string name,
+        string? clientId = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        if (currentTenant.IsAvailable)
+        {
+            RoleMetadata? tenantScopedRole = await roleMetadataStore
+                .FindByNameAsync(name, currentTenant.Id, clientId, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (tenantScopedRole is not null)
+            {
+                return tenantScopedRole;
+            }
+        }
+
+        return await roleMetadataStore
+            .FindByNameAsync(name, tenantId: null, clientId, cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/TenantAwareRoleLookupNormalizer.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/TenantAwareRoleLookupNormalizer.cs
@@ -23,17 +23,27 @@ namespace Granit.Identity.Local.AspNetIdentity.Internal;
 /// resolved outside a tenant context, so their normalized names stay un-prefixed.
 /// </para>
 /// <para>
-/// User name normalization falls through to the standard upper-invariant behavior because
-/// <c>GranitUser</c> already scopes users per tenant via <c>TenantId</c> — only the role
-/// table needs the prefix strategy.
+/// <see cref="ILookupNormalizer.NormalizeName"/> is invoked by ASP.NET Identity for both
+/// <c>NormalizedUserName</c> and <c>NormalizedName</c> lookups — the contract has no way
+/// to distinguish users from roles from inside the normalizer. The universal prefix
+/// therefore also scopes <c>GranitUser.NormalizedUserName</c> per tenant: users created
+/// inside a tenant context are invisible to host-side <c>FindByNameAsync</c> lookups and
+/// vice-versa. This matches Granit's tenant-isolation intent — host and tenant admin
+/// contexts never share a user-by-name lookup in practice. Email-based lookups
+/// (<see cref="NormalizeEmail"/>) stay upper-invariant so cross-context login by email
+/// still works.
 /// </para>
 /// <para>
-/// This implementation is intentionally not registered by
-/// <c>GranitIdentityLocalAspNetIdentityModule</c>. Applications that enable
-/// <c>RoleEndpointsOptions.AllowTenantRoles</c> must replace the framework default
-/// <see cref="ILookupNormalizer"/> with this type (scoped lifetime required because
-/// <see cref="ICurrentTenant"/> is scoped). See the Granit docs for the full wiring
-/// example.
+/// Business callers should query roles through <c>IGranitRoleLookup</c>, not through
+/// <c>RoleManager&lt;GranitRole&gt;.FindByNameAsync</c>: the lookup service routes via
+/// <c>IRoleMetadataStore</c> (the canonical source of truth) and handles the
+/// <c>Both</c>-scope fallback that <c>RoleManager</c> cannot express from inside a
+/// tenant context. See ADR-023.
+/// </para>
+/// <para>
+/// Registered as <see cref="Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped"/>
+/// by <c>GranitIdentityLocalAspNetIdentityModule</c> because <see cref="ICurrentTenant"/>
+/// is scoped.
 /// </para>
 /// </remarks>
 internal sealed class TenantAwareRoleLookupNormalizer(ICurrentTenant currentTenant) : ILookupNormalizer

--- a/src/Granit.Identity.Local/Services/IGranitRoleLookup.cs
+++ b/src/Granit.Identity.Local/Services/IGranitRoleLookup.cs
@@ -1,0 +1,42 @@
+using Granit.Authorization.Domain;
+
+namespace Granit.Identity.Local.Services;
+
+/// <summary>
+/// Canonical role lookup for Granit-internal flows. Encapsulates the precedence
+/// between tenant-scoped and Both-scope <see cref="RoleMetadata"/> rows so callers
+/// do not have to replicate the fallback logic at every site.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Prefer this abstraction over <c>RoleManager&lt;GranitRole&gt;.FindByNameAsync</c>
+/// for business lookups. The <see cref="Microsoft.AspNetCore.Identity.RoleManager{T}"/>
+/// is tied to ASP.NET Identity's <c>NormalizedName</c> indexing strategy and therefore
+/// sensitive to the registered <see cref="Microsoft.AspNetCore.Identity.ILookupNormalizer"/>;
+/// <see cref="IGranitRoleLookup"/> routes through <see cref="Granit.Authorization.IRoleMetadataStore"/>
+/// which is the source of truth for the role catalog.
+/// </para>
+/// <para>
+/// Resolution order when a tenant context is active:
+/// <list type="number">
+///   <item>A tenant-scope row matching the current tenant (<c>Side = Tenant</c>, <c>TenantId = currentTenant.Id</c>).</item>
+///   <item>A host / Both scope row (<c>TenantId = null</c>) — covers the <c>Both</c> roles assignable inside tenants.</item>
+/// </list>
+/// Host context skips step 1. Other-tenant rows are never returned.
+/// </para>
+/// </remarks>
+public interface IGranitRoleLookup
+{
+    /// <summary>
+    /// Finds a role by display name, applying the tenant-aware precedence.
+    /// Returns <see langword="null"/> if no matching <see cref="RoleMetadata"/>
+    /// row exists in the caller's scope.
+    /// </summary>
+    /// <param name="name">Display name (e.g. <c>"Manager"</c>).</param>
+    /// <param name="clientId">Optional OIDC client scope (reserved for Phase 2 realm/client-role distinction).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<RoleMetadata?> FindByNameAsync(
+        string name,
+        string? clientId = null,
+        CancellationToken cancellationToken = default);
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests/Internal/GranitRoleLookupTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests/Internal/GranitRoleLookupTests.cs
@@ -1,0 +1,151 @@
+using Granit.Authorization;
+using Granit.Authorization.Domain;
+using Granit.Identity.Local.AspNetIdentity.Internal;
+using Granit.MultiTenancy;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Internal;
+
+public sealed class GranitRoleLookupTests
+{
+    private readonly IRoleMetadataStore _store = Substitute.For<IRoleMetadataStore>();
+    private readonly ICurrentTenant _currentTenant = Substitute.For<ICurrentTenant>();
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Host context — never consults the tenant-scoped row
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FindByNameAsync_HostContext_QueriesHostScopeOnly()
+    {
+        _currentTenant.IsAvailable.Returns(false);
+        var hostRole = RoleMetadata.Create(
+            Guid.NewGuid(), "SuperAdmin", MultiTenancySide.Host, tenantId: null);
+        _store.FindByNameAsync("SuperAdmin", null, null, Arg.Any<CancellationToken>())
+            .Returns(hostRole);
+
+        GranitRoleLookup lookup = new(_store, _currentTenant);
+
+        RoleMetadata? result = await lookup.FindByNameAsync(
+            "SuperAdmin", cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldBe(hostRole);
+
+        // Never asks the store with a specific tenantId when outside a tenant context.
+        await _store.DidNotReceive().FindByNameAsync(
+            Arg.Any<string>(), Arg.Is<Guid?>(id => id != null),
+            Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Tenant context — tenant-scope row wins, Both-scope row is the fallback
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FindByNameAsync_TenantContext_TenantScopeRole_TakesPrecedence()
+    {
+        var tenantId = Guid.NewGuid();
+        _currentTenant.IsAvailable.Returns(true);
+        _currentTenant.Id.Returns(tenantId);
+
+        var tenantRole = RoleMetadata.Create(
+            Guid.NewGuid(), "Manager", MultiTenancySide.Tenant, tenantId);
+        _store.FindByNameAsync("Manager", tenantId, null, Arg.Any<CancellationToken>())
+            .Returns(tenantRole);
+
+        GranitRoleLookup lookup = new(_store, _currentTenant);
+
+        RoleMetadata? result = await lookup.FindByNameAsync(
+            "Manager", cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldBe(tenantRole);
+
+        // The fallback to host-scope row is not needed.
+        await _store.DidNotReceive().FindByNameAsync(
+            "Manager", (Guid?)null, null, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task FindByNameAsync_TenantContext_NoTenantScopeRow_FallsBackToBothScope()
+    {
+        var tenantId = Guid.NewGuid();
+        _currentTenant.IsAvailable.Returns(true);
+        _currentTenant.Id.Returns(tenantId);
+
+        var bothRole = RoleMetadata.Create(
+            Guid.NewGuid(), "User", MultiTenancySide.Both, tenantId: null);
+        _store.FindByNameAsync("User", tenantId, null, Arg.Any<CancellationToken>())
+            .Returns((RoleMetadata?)null);
+        _store.FindByNameAsync("User", (Guid?)null, null, Arg.Any<CancellationToken>())
+            .Returns(bothRole);
+
+        GranitRoleLookup lookup = new(_store, _currentTenant);
+
+        RoleMetadata? result = await lookup.FindByNameAsync(
+            "User", cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldBe(bothRole);
+    }
+
+    [Fact]
+    public async Task FindByNameAsync_TenantContext_NoMatch_ReturnsNull()
+    {
+        var tenantId = Guid.NewGuid();
+        _currentTenant.IsAvailable.Returns(true);
+        _currentTenant.Id.Returns(tenantId);
+
+        _store.FindByNameAsync("Ghost", Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns((RoleMetadata?)null);
+
+        GranitRoleLookup lookup = new(_store, _currentTenant);
+
+        RoleMetadata? result = await lookup.FindByNameAsync(
+            "Ghost", cancellationToken: TestContext.Current.CancellationToken);
+
+        result.ShouldBeNull();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // ClientId propagates through both probes (reserved for realm/client distinction)
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FindByNameAsync_WithClientId_PropagatesToStoreOnBothProbes()
+    {
+        var tenantId = Guid.NewGuid();
+        _currentTenant.IsAvailable.Returns(true);
+        _currentTenant.Id.Returns(tenantId);
+
+        _store.FindByNameAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns((RoleMetadata?)null);
+
+        GranitRoleLookup lookup = new(_store, _currentTenant);
+
+        await lookup.FindByNameAsync(
+            "ClientRole", clientId: "showcase-admin",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        await _store.Received(1).FindByNameAsync(
+            "ClientRole", tenantId, "showcase-admin", Arg.Any<CancellationToken>());
+        await _store.Received(1).FindByNameAsync(
+            "ClientRole", (Guid?)null, "showcase-admin", Arg.Any<CancellationToken>());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Guards
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task FindByNameAsync_NullOrWhitespace_Throws(string? name)
+    {
+        GranitRoleLookup lookup = new(_store, _currentTenant);
+
+        await Should.ThrowAsync<ArgumentException>(async () =>
+            await lookup.FindByNameAsync(name!, cancellationToken: TestContext.Current.CancellationToken));
+    }
+}


### PR DESCRIPTION
## Summary

First story of the Phase 2 epic (#1093). Wires `TenantAwareRoleLookupNormalizer` unconditionally in `GranitIdentityLocalAspNetIdentityModule` and introduces `IGranitRoleLookup` as the canonical abstraction for Granit-internal role queries.

Closes #1094.

## What changes

- **Normalizer registered** — `ILookupNormalizer` is replaced (scoped) with `TenantAwareRoleLookupNormalizer`. When a tenant context is active, `NormalizeName` returns `T_{tenantId:N}_{UPPER}`; otherwise plain upper-invariant. `NormalizeEmail` stays upper-invariant so cross-context email lookups keep working.
- **`IGranitRoleLookup`** (new) in `Granit.Identity.Local.Services` — routes queries through `IRoleMetadataStore` (canonical catalog) and implements the Both-scope fallback: tenant-scope row first (when tenant active), then `TenantId = null` row covering Host + Both.
- **ADR-023** captures the design trade-offs and the side effect on user-name lookup (users created in tenant A are invisible to `UserManager.FindByNameAsync` in host context — intentional, matches the isolation model).
- **Constants** — `ADR_COUNT` corrected from 21 → 23 (was already out-of-sync before this PR; folder has ADR-001 … ADR-023).

## Why universal registration rather than flag-gated

Tying a platform-wide infrastructure concern (ASP.NET Identity `NormalizedName` indexing) to the endpoints-scoped `RoleEndpointsOptions.AllowTenantRoles` would produce a silent semantic change on the day the flag flips (#1095). The universal registration is simpler and the side effect on user-name lookup is benign in every realistic Granit scenario — email-based login remains the primary authentication path. Full rationale in ADR-023.

## Test plan

- [x] `dotnet build` on all touched projects → 0 warnings / 0 errors
- [x] `dotnet test Granit.Identity.Local.AspNetIdentity.Tests` → 181/181 passing (8 new `IGranitRoleLookup` tests, 5 pre-existing normalizer tests)
- [x] `dotnet test Granit.ArchitectureTests` → 117/117 passing
- [x] `dotnet format --verify-no-changes` → clean on all 3 touched projects
- [x] `npx markdownlint-cli2 docs-site/.../023-tenant-aware-role-lookup.md` → 0 errors
- [ ] CI green across all shards (awaits remote run)

## Follow-ups

This story unblocks #1095 (lift `AllowTenantRoles` to `true` by default) and prepares the `clientId` plumbing for #1098 – #1100 (realm vs client-role distinction per provider).