### PR TITLE
feat(identity-local)!: allow tenant-scoped role creation by default (#1095)

### DIFF
--- a/docs-site/src/content/docs/dotnet/security/authorization-roles.mdx
+++ b/docs-site/src/content/docs/dotnet/security/authorization-roles.mdx
@@ -97,7 +97,6 @@ The endpoints live in `Granit.Identity.Local.Endpoints` and map via:
 app.MapGranitRoles(opts =>
 {
     opts.RolesRoutePrefix = "admin/roles"; // default
-    opts.AllowTenantRoles = false;          // default — see below
 });
 ```
 
@@ -105,7 +104,7 @@ app.MapGranitRoles(opts =>
 | --- | --- | --- | --- |
 | `GET` | `/admin/roles` | `IdentityLocal.Roles.Read` | Scoped to visible roles (matrix below). |
 | `GET` | `/admin/roles/{id}` | `IdentityLocal.Roles.Read` | 404 when not visible. |
-| `POST` | `/admin/roles` | `IdentityLocal.Roles.Manage` | 403 if `AllowTenantRoles = false` and `Side = Tenant`. |
+| `POST` | `/admin/roles` | `IdentityLocal.Roles.Manage` | Tenant admins restricted to `Side = Tenant` within their own tenant. |
 | `PUT` | `/admin/roles/{id}` | `IdentityLocal.Roles.Manage` | Side and tenant scope are immutable. |
 | `DELETE` | `/admin/roles/{id}` | `IdentityLocal.Roles.Delete` | System roles refuse deletion with 403. |
 
@@ -120,33 +119,23 @@ Applied server-side via `ICurrentTenant` — the store never leaks a non-visible
 
 Non-visible roles **always** return 404, never 403 — existence is not disclosed.
 
-## Feature flag: `AllowTenantRoles`
+## Tenant-scoped roles and `NormalizedName`
 
-Tenant-scoped roles collide on ASP.NET Core Identity's process-wide unique index on
-`AspNetRoles.NormalizedName` when two tenants create a role with the same display name.
-The solution is `TenantAwareRoleLookupNormalizer`, which prefixes the normalized name
-with `T_{tenantId}_` whenever a tenant context is active — but it changes the
-normalization of **every** `UserManager` / `RoleManager` lookup, so it must be wired
-consciously.
+ASP.NET Core Identity enforces a process-wide unique index on
+`AspNetRoles.NormalizedName`, so two tenants creating a role named `Manager` would
+collide under the default upper-invariant normalizer.
+`GranitIdentityLocalAspNetIdentityModule` solves this by registering
+`TenantAwareRoleLookupNormalizer` unconditionally as the framework
+`ILookupNormalizer` (scoped lifetime): when a tenant context is active, the
+normalized form is prefixed with `T_{tenantId:N}_` so each tenant gets its own
+isolated namespace.
 
-The framework ships the normalizer ready to use but leaves it **unregistered** by
-default. Opt in by flipping the flag and registering the normalizer:
-
-```csharp title="Program.cs"
-app.MapGranitRoles(opts =>
-{
-    opts.AllowTenantRoles = true; // tenant admins can now CRUD tenant-scoped roles
-});
-
-// Wire the normalizer (scoped, depends on ICurrentTenant)
-builder.Services.Replace(ServiceDescriptor.Scoped<
-    ILookupNormalizer,
-    TenantAwareRoleLookupNormalizer>());
-```
-
-While `AllowTenantRoles` is `false` the CRUD endpoints refuse `Side = Tenant` create
-requests with a 403 `tenant-roles-disabled` problem detail — host and Both roles
-remain fully available.
+Callers that look up roles for business logic should route through
+`IGranitRoleLookup` rather than `RoleManager<GranitRole>.FindByNameAsync` — the
+lookup service queries `IRoleMetadataStore` (the canonical catalog) and applies
+the `Both`-scope fallback that a straight `RoleManager` call cannot express from
+inside a tenant context. The side effect on `UserManager.FindByNameAsync` is
+intentional and covered in ADR-023.
 
 ## Orchestration across two DbContexts
 

--- a/src/Granit.Identity.Local.Endpoints/Dtos/RoleCreateRequest.cs
+++ b/src/Granit.Identity.Local.Endpoints/Dtos/RoleCreateRequest.cs
@@ -5,8 +5,8 @@ namespace Granit.Identity.Local.Endpoints.Dtos;
 /// <summary>Request to create a new local role.</summary>
 /// <param name="Name">Display name of the role (max 256 chars).</param>
 /// <param name="MultiTenancySide">
-/// Host / Tenant / Both applicability. <see cref="MultiTenancySide.Tenant"/> is refused
-/// unless <c>RoleEndpointsOptions.AllowTenantRoles</c> is enabled.
+/// Host / Tenant / Both applicability. Tenant admins may only create roles with
+/// <see cref="MultiTenancySide.Tenant"/> and their own tenant id.
 /// </param>
 /// <param name="TenantId">
 /// Tenant identifier — required iff <paramref name="MultiTenancySide"/> is

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
@@ -2,7 +2,6 @@ using Granit.Authorization;
 using Granit.Authorization.Domain;
 using Granit.Http.Idempotency.Attributes;
 using Granit.Identity.Local.Endpoints.Dtos;
-using Granit.Identity.Local.Endpoints.Options;
 using Granit.Identity.Local.Endpoints.Permissions;
 using Granit.Identity.Local.Services;
 using Granit.MultiTenancy;
@@ -11,7 +10,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Options;
 
 namespace Granit.Identity.Local.Endpoints.Endpoints;
 
@@ -53,7 +51,8 @@ internal static class GranitRoleEndpoints
             .WithSummary("Creates a new local role and its RoleMetadata row.")
             .WithDescription(
                 "Invariants: Host / Both ⇒ TenantId must be null; Tenant ⇒ TenantId required. "
-                + "Side=Tenant requests are refused unless RoleEndpointsOptions.AllowTenantRoles is enabled.")
+                + "Tenant admins (ICurrentTenant active) can only create Tenant-side roles "
+                + "scoped to their own tenant.")
             .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces<RoleResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem()
@@ -113,19 +112,8 @@ internal static class GranitRoleEndpoints
         [FromBody] RoleCreateRequest request,
         [FromServices] IGranitRoleOrchestrator orchestrator,
         [FromServices] ICurrentTenant currentTenant,
-        [FromServices] IOptions<RoleEndpointsOptions> options,
         CancellationToken cancellationToken)
     {
-        RoleEndpointsOptions opts = options.Value;
-
-        if (request.MultiTenancySide == MultiTenancySide.Tenant && !opts.AllowTenantRoles)
-        {
-            return TypedResults.Problem(
-                statusCode: StatusCodes.Status403Forbidden,
-                detail: "Tenant-scoped role creation is disabled. " +
-                        "Set RoleEndpointsOptions.AllowTenantRoles = true to enable it.");
-        }
-
         // Tenant admins may only create roles in their own tenant.
         if (currentTenant.IsAvailable && request.MultiTenancySide == MultiTenancySide.Tenant
             && request.TenantId != currentTenant.Id)

--- a/src/Granit.Identity.Local.Endpoints/Options/RoleEndpointsOptions.cs
+++ b/src/Granit.Identity.Local.Endpoints/Options/RoleEndpointsOptions.cs
@@ -10,16 +10,4 @@ public sealed class RoleEndpointsOptions
 
     /// <summary>OpenAPI tag for the role CRUD endpoints. Default: <c>"Identity - Roles"</c>.</summary>
     public string TagName { get; set; } = "Identity - Roles";
-
-    /// <summary>
-    /// When <see langword="false"/> (default), create / rename / delete endpoints refuse
-    /// <see cref="Granit.MultiTenancy.MultiTenancySide.Tenant"/> role requests — only
-    /// host-level and Both roles are creatable.
-    /// </summary>
-    /// <remarks>
-    /// Opt-in requires <c>TenantAwareRoleLookupNormalizer</c> to be registered as the
-    /// <c>ILookupNormalizer</c>; otherwise two tenants with the same role display name
-    /// collide on the ASP.NET Core Identity <c>AspNetRoles.NormalizedName</c> unique index.
-    /// </remarks>
-    public bool AllowTenantRoles { get; set; }
 }

--- a/src/Granit.Identity.Local.Endpoints/Permissions/IdentityLocalPermissionDefinitionProvider.cs
+++ b/src/Granit.Identity.Local.Endpoints/Permissions/IdentityLocalPermissionDefinitionProvider.cs
@@ -27,10 +27,9 @@ internal sealed class IdentityLocalPermissionDefinitionProvider : IPermissionDef
                 "Permission:IdentityLocal.Users.Impersonate"),
             MultiTenancySide.Host);
 
-        // Role CRUD — assignable in both host and tenant admin contexts. Visibility matrix
-        // + the AllowTenantRoles feature flag on endpoint options gate who can create
-        // tenant-scoped roles; the permission itself stays Side=Both so either admin can
-        // hold it.
+        // Role CRUD — assignable in both host and tenant admin contexts. The visibility
+        // matrix inside the endpoint gates who can create tenant-scoped roles; the
+        // permission itself stays Side=Both so either admin can hold it.
         group.AddPermission(
             IdentityLocalPermissions.Roles.Read,
             LocalizableString.Create<IdentityLocalEndpointsLocalizationResource>(

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/GranitRoleEndpointsTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/GranitRoleEndpointsTests.cs
@@ -111,11 +111,11 @@ public sealed class GranitRoleEndpointsTests
     }
 
     // ─────────────────────────────────────────────────────────────────────
-    // POST — AllowTenantRoles flag (Phase 1 refusal)
+    // POST — tenant admin happy path + cross-tenant guard
     // ─────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task Create_SideTenant_AllowTenantRolesFalse_Returns403()
+    public async Task Create_AsTenantAdmin_SideTenantOwnTenant_Returns201()
     {
         using IDisposable _ = _app.CurrentTenant.Change(_tenantA);
 
@@ -126,7 +126,65 @@ public sealed class GranitRoleEndpointsTests
                 name = "Manager",
                 multiTenancySide = (int)MultiTenancySide.Tenant,
                 tenantId = _tenantA,
+                description = "Tenant-scoped operational manager.",
             },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+
+        RoleResponseLite? created = await response.Content
+            .ReadFromJsonAsync<RoleResponseLite>(TestContext.Current.CancellationToken);
+        created.ShouldNotBeNull();
+        created.MultiTenancySide.ShouldBe(MultiTenancySide.Tenant);
+        created.TenantId.ShouldBe(_tenantA);
+    }
+
+    [Fact]
+    public async Task Create_AsTenantAdmin_SameRoleNameInTwoTenants_BothPersist()
+    {
+        // Tenant A creates "Manager".
+        using (_app.CurrentTenant.Change(_tenantA))
+        {
+            HttpResponseMessage responseA = await _app.HttpClient.PostAsJsonAsync(
+                "/admin/roles",
+                new { name = "Manager", multiTenancySide = (int)MultiTenancySide.Tenant, tenantId = _tenantA },
+                TestContext.Current.CancellationToken);
+            responseA.StatusCode.ShouldBe(HttpStatusCode.Created);
+        }
+
+        // Tenant B creates another "Manager" — proves the tenant-prefixed normalizer
+        // keeps ASP.NET Identity's global NormalizedName index happy.
+        using (_app.CurrentTenant.Change(_tenantB))
+        {
+            HttpResponseMessage responseB = await _app.HttpClient.PostAsJsonAsync(
+                "/admin/roles",
+                new { name = "Manager", multiTenancySide = (int)MultiTenancySide.Tenant, tenantId = _tenantB },
+                TestContext.Current.CancellationToken);
+            responseB.StatusCode.ShouldBe(HttpStatusCode.Created);
+        }
+    }
+
+    [Fact]
+    public async Task Create_AsTenantAdmin_ForeignTenantId_Returns403()
+    {
+        using IDisposable _ = _app.CurrentTenant.Change(_tenantA);
+
+        HttpResponseMessage response = await _app.HttpClient.PostAsJsonAsync(
+            "/admin/roles",
+            new { name = "Hijack", multiTenancySide = (int)MultiTenancySide.Tenant, tenantId = _tenantB },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Create_AsTenantAdmin_SideHost_Returns403()
+    {
+        using IDisposable _ = _app.CurrentTenant.Change(_tenantA);
+
+        HttpResponseMessage response = await _app.HttpClient.PostAsJsonAsync(
+            "/admin/roles",
+            new { name = "SuperAdmin", multiTenancySide = (int)MultiTenancySide.Host, tenantId = (Guid?)null },
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleEndpointsTestApplication.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleEndpointsTestApplication.cs
@@ -72,6 +72,12 @@ public sealed class RoleEndpointsTestApplication : IAsyncLifetime
             .AddRoles<GranitRole>()
             .AddEntityFrameworkStores<TestIdentityDbContext>();
 
+        // Mirrors production wiring (GranitIdentityLocalAspNetIdentityModule): the
+        // tenant-aware normalizer lets two tenants hold a role with the same display
+        // name without tripping ASP.NET Identity's global NormalizedName unique index.
+        builder.Services.Replace(ServiceDescriptor.Scoped<
+            ILookupNormalizer, TenantAwareRoleLookupNormalizer>());
+
         builder.Services.AddGranitAuthorizationEntityFrameworkCore<TestHostDbContext>();
         builder.Services.AddGranitGuids();
         builder.Services.AddScoped<IGranitRoleOrchestrator, GranitRoleOrchestrator>();


### PR DESCRIPTION
## Summary

Stacked on #1104. Removes the Phase-1 `AllowTenantRoles` feature flag now that #1094 registers `TenantAwareRoleLookupNormalizer` unconditionally — tenant admins can create `Side=Tenant` roles out of the box.

Closes #1095.

## BREAKING

`RoleEndpointsOptions.AllowTenantRoles` no longer exists. Applications pinning it explicitly (true or false) must drop the assignment. Applications that want to lock tenant-scoped role creation can still revoke `IdentityLocal.Roles.Manage` from tenant admin roles — the authorization layer stays in charge.

## Changes

- `RoleEndpointsOptions.AllowTenantRoles` removed.
- `GranitRoleEndpoints.CreateAsync` no longer consults the flag. Existing tenant-guards (cross-tenant `TenantId`, host/Both side refused to tenant admins) stay in place.
- Integration fixture `RoleEndpointsTestApplication` registers `TenantAwareRoleLookupNormalizer` (scoped) to mirror production wiring from #1104.
- Four new tenant happy-path tests:
  - `Create_AsTenantAdmin_SideTenantOwnTenant_Returns201`
  - `Create_AsTenantAdmin_SameRoleNameInTwoTenants_BothPersist` — proves the normalizer prevents the global `NormalizedName` collision for two tenants holding the same display name.
  - `Create_AsTenantAdmin_ForeignTenantId_Returns403`
  - `Create_AsTenantAdmin_SideHost_Returns403`
- Obsolete test `Create_SideTenant_AllowTenantRolesFalse_Returns403` removed.
- Docs `authorization-roles.mdx` rewritten to drop the feature-flag section and point readers at `IGranitRoleLookup` + ADR-023.

## Test plan

- [x] Integration suite 19/19 passing on local PG 17 container (12 endpoint + 7 orchestrator, including the 4 new ones).
- [x] `dotnet format --verify-no-changes` → clean on all touched projects.
- [ ] CI green once #1104 is merged and this PR is retargeted to `develop`.

## Merge notes

Base is currently `feat/tenant-aware-role-lookup` (#1104). Retarget to `develop` after #1104 merges.