### PR TITLE
test(identity-local-aspnetidentity): permission-grant enforcement on /admin/roles (#1102)

### DIFF
--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/Granit.Identity.Local.AspNetIdentity.Tests.Integration.csproj
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/Granit.Identity.Local.AspNetIdentity.Tests.Integration.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="ZiggyCreatures.FusionCache" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Shouldly" />

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/GranitRoleEndpointsPermissionTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/GranitRoleEndpointsPermissionTests.cs
@@ -1,0 +1,229 @@
+using System.Net;
+using System.Net.Http.Json;
+using Granit.Authorization.Domain;
+using Granit.Identity.Local.Endpoints.Permissions;
+using Granit.MultiTenancy;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// End-to-end tests that exercise the **real** Granit.Authorization pipeline against
+/// <c>/admin/roles</c>: <c>DynamicPermissionPolicyProvider</c> resolves the permission
+/// name to a policy, <c>PermissionAuthorizationHandler</c> invokes
+/// <c>PermissionChecker</c>, which walks the grant providers and ends up in
+/// <c>EfCorePermissionGrantStore</c> against real PostgreSQL.
+/// </summary>
+/// <remarks>
+/// Permission grants are seeded as user-scope rows
+/// (<c>ProviderName = "U"</c>, <c>ProviderKey = user-sub</c>). Role-scope and
+/// client-scope grant coverage is left for the follow-ups that introduce realm/client
+/// role plumbing (#1098 – #1100).
+/// </remarks>
+public sealed class GranitRoleEndpointsPermissionTests
+    : IClassFixture<RoleEndpointsPermissionTestApplication>, IAsyncLifetime
+{
+    private readonly RoleEndpointsPermissionTestApplication _app;
+
+    public GranitRoleEndpointsPermissionTests(RoleEndpointsPermissionTestApplication app) =>
+        _app = app;
+
+    public ValueTask InitializeAsync() => new(_app.ResetAsync());
+
+    public ValueTask DisposeAsync() => default;
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Authentication
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Get_Unauthenticated_Returns401()
+    {
+        using HttpClient client = _app.CreateAnonymousClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            "/admin/roles", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Get_Authenticated_NoGrant_Returns403()
+    {
+        using HttpClient client = _app.CreateAuthenticatedClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            "/admin/roles", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Roles.Read grant — GET allowed, POST denied
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Get_WithReadGrant_Returns200()
+    {
+        await _app.GrantToUserAsync(
+            RoleEndpointsPermissionTestApplication.TestUserId,
+            IdentityLocalPermissions.Roles.Read,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        using HttpClient client = _app.CreateAuthenticatedClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            "/admin/roles", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Post_WithReadGrantOnly_Returns403()
+    {
+        await _app.GrantToUserAsync(
+            RoleEndpointsPermissionTestApplication.TestUserId,
+            IdentityLocalPermissions.Roles.Read,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        using HttpClient client = _app.CreateAuthenticatedClient();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/admin/roles",
+            new { name = "Auditor", multiTenancySide = (int)MultiTenancySide.Host, tenantId = (Guid?)null },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Roles.Manage grant — POST / PUT allowed, DELETE denied
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Post_WithManageGrant_Returns201()
+    {
+        await _app.GrantToUserAsync(
+            RoleEndpointsPermissionTestApplication.TestUserId,
+            IdentityLocalPermissions.Roles.Manage,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        using HttpClient client = _app.CreateAuthenticatedClient();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/admin/roles",
+            new { name = "Auditor", multiTenancySide = (int)MultiTenancySide.Host, tenantId = (Guid?)null },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+    }
+
+    [Fact]
+    public async Task Delete_WithManageGrantOnly_Returns403()
+    {
+        await _app.GrantToUserAsync(
+            RoleEndpointsPermissionTestApplication.TestUserId,
+            IdentityLocalPermissions.Roles.Manage,
+            cancellationToken: TestContext.Current.CancellationToken);
+        RoleMetadata target = await _app.SeedRoleMetadataAsync(
+            "Disposable", MultiTenancySide.Both, tenantId: null,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        using HttpClient client = _app.CreateAuthenticatedClient();
+
+        HttpResponseMessage response = await client.DeleteAsync(
+            $"/admin/roles/{target.Id:D}", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Roles.Delete grant — DELETE allowed
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Delete_WithDeleteGrant_Returns204()
+    {
+        await _app.GrantToUserAsync(
+            RoleEndpointsPermissionTestApplication.TestUserId,
+            IdentityLocalPermissions.Roles.Delete,
+            cancellationToken: TestContext.Current.CancellationToken);
+        await _app.GrantToUserAsync(
+            RoleEndpointsPermissionTestApplication.TestUserId,
+            IdentityLocalPermissions.Roles.Read,
+            cancellationToken: TestContext.Current.CancellationToken);
+        RoleMetadata target = await _app.SeedRoleMetadataAsync(
+            "Disposable", MultiTenancySide.Both, tenantId: null,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        using HttpClient client = _app.CreateAuthenticatedClient();
+
+        HttpResponseMessage response = await client.DeleteAsync(
+            $"/admin/roles/{target.Id:D}", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Tenant-scope grants
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Get_TenantScopeGrant_InMatchingTenantContext_Returns200()
+    {
+        var tenantA = Guid.NewGuid();
+        await _app.GrantToUserAsync(
+            RoleEndpointsPermissionTestApplication.TestUserId,
+            IdentityLocalPermissions.Roles.Read,
+            tenantId: tenantA,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        using IDisposable _ = _app.CurrentTenant.Change(tenantA);
+        using HttpClient client = _app.CreateAuthenticatedClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            "/admin/roles", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Get_TenantScopeGrant_FromOtherTenantContext_Returns403()
+    {
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        await _app.GrantToUserAsync(
+            RoleEndpointsPermissionTestApplication.TestUserId,
+            IdentityLocalPermissions.Roles.Read,
+            tenantId: tenantA,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        using IDisposable _ = _app.CurrentTenant.Change(tenantB);
+        using HttpClient client = _app.CreateAuthenticatedClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            "/admin/roles", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Get_TenantScopeGrant_FromHostContext_Returns403()
+    {
+        var tenantA = Guid.NewGuid();
+        await _app.GrantToUserAsync(
+            RoleEndpointsPermissionTestApplication.TestUserId,
+            IdentityLocalPermissions.Roles.Read,
+            tenantId: tenantA,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // No CurrentTenant.Change — stays at host.
+        using HttpClient client = _app.CreateAuthenticatedClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            "/admin/roles", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/HttpContextCurrentUserService.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/HttpContextCurrentUserService.cs
@@ -1,0 +1,35 @@
+using System.Security.Claims;
+using Granit.Users;
+using Microsoft.AspNetCore.Http;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// Minimal HttpContext-backed <see cref="ICurrentUserService"/> for the permission
+/// enforcement tests — reads <c>sub</c> / <c>NameIdentifier</c> and role claims from
+/// the authenticated principal attached by <see cref="TestAuthHandler"/>.
+/// </summary>
+internal sealed class HttpContextCurrentUserService(IHttpContextAccessor accessor) : ICurrentUserService
+{
+    private ClaimsPrincipal? User => accessor.HttpContext?.User;
+
+    public string? UserId =>
+        User?.FindFirstValue(ClaimTypes.NameIdentifier) ?? User?.FindFirstValue("sub");
+
+    public string? UserName => User?.Identity?.Name;
+
+    public string? Email => User?.FindFirstValue(ClaimTypes.Email);
+
+    public string? FirstName => User?.FindFirstValue(ClaimTypes.GivenName);
+
+    public string? LastName => User?.FindFirstValue(ClaimTypes.Surname);
+
+    public string? ClientId => User?.FindFirstValue("client_id");
+
+    public bool IsAuthenticated => User?.Identity?.IsAuthenticated ?? false;
+
+    public IReadOnlyList<string> GetRoles() =>
+        User is null ? [] : [.. User.FindAll(ClaimTypes.Role).Select(c => c.Value)];
+
+    public bool IsInRole(string role) => User?.IsInRole(role) ?? false;
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleEndpointsPermissionTestApplication.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleEndpointsPermissionTestApplication.cs
@@ -1,0 +1,229 @@
+using System.Diagnostics.Metrics;
+using Granit.Authorization;
+using Granit.Authorization.Domain;
+using Granit.Authorization.EntityFrameworkCore.Extensions;
+using Granit.Authorization.Extensions;
+using Granit.Guids.Extensions;
+using Granit.Identity.Local.AspNetIdentity.Internal;
+using Granit.Identity.Local.Domain;
+using Granit.Identity.Local.Endpoints.Extensions;
+using Granit.Identity.Local.Services;
+using Granit.MultiTenancy;
+using Granit.Users;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// Collection fixture for permission-grant enforcement tests on <c>/admin/roles</c>.
+/// Unlike <see cref="RoleEndpointsTestApplication"/> — which short-circuits the
+/// authorization pipeline via <see cref="PermissiveAuthorizationPolicyProvider"/> to
+/// focus on the visibility matrix — this fixture wires the **real** Granit.Authorization
+/// stack (<c>DynamicPermissionPolicyProvider</c> + <c>PermissionAuthorizationHandler</c>
+/// + <c>PermissionChecker</c>) so tests can exercise the user/role/client grant
+/// resolution path end-to-end against real PostgreSQL.
+/// </summary>
+public sealed class RoleEndpointsPermissionTestApplication : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres = new();
+    private WebApplication? _app;
+    private MutableCurrentTenant? _currentTenant;
+
+    internal const string TestUserId = "user-test-42";
+
+    public MutableCurrentTenant CurrentTenant =>
+        _currentTenant ?? throw new InvalidOperationException("Fixture not initialized.");
+
+    public async ValueTask InitializeAsync()
+    {
+        await _postgres.InitializeAsync();
+
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+
+        builder.Services.AddDbContext<TestIdentityDbContext>(opts =>
+            opts.UseNpgsql(_postgres.ConnectionString));
+        builder.Services.AddDbContext<TestHostDbContext>(opts =>
+            opts.UseNpgsql(_postgres.ConnectionString));
+
+        builder.Services.AddIdentityCore<GranitUser>()
+            .AddRoles<GranitRole>()
+            .AddEntityFrameworkStores<TestIdentityDbContext>();
+
+        builder.Services.Replace(ServiceDescriptor.Scoped<
+            ILookupNormalizer, TenantAwareRoleLookupNormalizer>());
+
+        // Full Granit.Authorization wiring — policy provider + permission checker +
+        // grant providers (user / role / client) + EF-backed stores. AddAuthorization
+        // itself must be called (registers the middleware's plumbing); AddGranitAuthorization
+        // only adds the policy provider + handlers.
+        builder.Services.AddAuthorization();
+        builder.Services.AddGranitAuthorization();
+        builder.Services.AddGranitAuthorizationEntityFrameworkCore<TestHostDbContext>();
+        builder.Services.AddSingleton<IPermissionDefinitionProvider, TestPermissionDefinitionProvider>();
+
+        builder.Services.AddGranitGuids();
+        builder.Services.AddScoped<IGranitRoleOrchestrator, GranitRoleOrchestrator>();
+
+        _currentTenant = new MutableCurrentTenant();
+        builder.Services.AddSingleton<ICurrentTenant>(_currentTenant);
+
+        builder.Services.AddHttpContextAccessor();
+        builder.Services.AddScoped<ICurrentUserService, HttpContextCurrentUserService>();
+
+        // FusionCache backs the PermissionChecker. In-memory default with a short
+        // duration to avoid cross-test bleed; ResetAsync also purges it explicitly.
+        builder.Services.AddFusionCache();
+
+        builder.Services.TryAddSingleton<IMeterFactory>(_ => new NoopMeterFactory());
+
+        builder.Services
+            .AddAuthentication(TestAuthHandler.SchemeName)
+            .AddScheme<AuthenticationSchemeOptions, SubjectTestAuthHandler>(
+                TestAuthHandler.SchemeName, _ => { });
+
+        // Do NOT replace IAuthorizationPolicyProvider — we want the real
+        // DynamicPermissionPolicyProvider registered by AddGranitAuthorization().
+
+        _app = builder.Build();
+
+        _app.UseAuthentication();
+        _app.UseAuthorization();
+        _app.MapGranitRoles();
+
+        await using (AsyncServiceScope scope = _app.Services.CreateAsyncScope())
+        {
+            TestIdentityDbContext idCtx = scope.ServiceProvider.GetRequiredService<TestIdentityDbContext>();
+            TestHostDbContext hostCtx = scope.ServiceProvider.GetRequiredService<TestHostDbContext>();
+            await idCtx.Database.EnsureCreatedAsync();
+            await hostCtx.GetService<IRelationalDatabaseCreator>().CreateTablesAsync();
+        }
+
+        await _app.StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_app is not null)
+        {
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+
+        await _postgres.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Builds an <see cref="HttpClient"/> that authenticates every request as
+    /// <paramref name="userId"/> via the <see cref="SubjectTestAuthHandler"/>.
+    /// </summary>
+    public HttpClient CreateAuthenticatedClient(string userId = TestUserId)
+    {
+        HttpClient client = _app?.GetTestClient()
+            ?? throw new InvalidOperationException("Fixture not initialized.");
+        client.DefaultRequestHeaders.Add(SubjectTestAuthHandler.SubjectHeader, userId);
+        return client;
+    }
+
+    /// <summary>Builds an <see cref="HttpClient"/> with no auth header (anonymous).</summary>
+    public HttpClient CreateAnonymousClient() =>
+        _app?.GetTestClient() ?? throw new InvalidOperationException("Fixture not initialized.");
+
+    /// <summary>Seeds a user-scope permission grant row directly via the host DbContext.</summary>
+    public async Task GrantToUserAsync(
+        string userId, string permissionName, Guid? tenantId = null,
+        CancellationToken cancellationToken = default)
+    {
+        await using AsyncServiceScope scope = _app!.Services.CreateAsyncScope();
+        TestHostDbContext hostCtx = scope.ServiceProvider.GetRequiredService<TestHostDbContext>();
+
+        var grant = PermissionGrant.Create(
+            id: Guid.NewGuid(),
+            permissionName: permissionName,
+            providerName: PermissionGrantProviderNames.User,
+            providerKey: userId,
+            tenantId: tenantId);
+
+        hostCtx.PermissionGrants.Add(grant);
+        await hostCtx.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <summary>Seeds a <see cref="RoleMetadata"/> row directly (no Identity counterpart).</summary>
+    public async Task<RoleMetadata> SeedRoleMetadataAsync(
+        string name, MultiTenancySide side, Guid? tenantId, bool isSystem = false,
+        CancellationToken cancellationToken = default)
+    {
+        await using AsyncServiceScope scope = _app!.Services.CreateAsyncScope();
+        IRoleMetadataStore store = scope.ServiceProvider.GetRequiredService<IRoleMetadataStore>();
+
+        var metadata = RoleMetadata.Create(
+            id: Guid.NewGuid(),
+            name: name,
+            multiTenancySide: side,
+            tenantId: tenantId,
+            clientId: null,
+            description: null,
+            isSystem: isSystem);
+
+        await store.AddAsync(metadata, cancellationToken);
+        return metadata;
+    }
+
+    /// <summary>
+    /// Truncates all grants / metadata / identity rows AND flushes the permission
+    /// checker cache so each test starts from a clean slate.
+    /// </summary>
+    public async Task ResetAsync()
+    {
+        CurrentTenant.Change(id: null);
+
+        await using AsyncServiceScope scope = _app!.Services.CreateAsyncScope();
+        TestIdentityDbContext idCtx = scope.ServiceProvider.GetRequiredService<TestIdentityDbContext>();
+        TestHostDbContext hostCtx = scope.ServiceProvider.GetRequiredService<TestHostDbContext>();
+
+        await hostCtx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE authorization_role_metadata, authorization_permission_grants RESTART IDENTITY CASCADE;");
+        await idCtx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE \"AspNetUserRoles\", \"AspNetRoleClaims\", \"AspNetUserClaims\", \"AspNetUserLogins\", \"AspNetUserTokens\", \"AspNetUsers\", \"AspNetRoles\" RESTART IDENTITY CASCADE;");
+
+        IFusionCache cache = scope.ServiceProvider.GetRequiredService<IFusionCache>();
+        await cache.ClearAsync();
+    }
+
+    /// <summary>Minimal no-op meter factory — only required because PermissionChecker resolves AuthorizationMetrics.</summary>
+    private sealed class NoopMeterFactory : IMeterFactory
+    {
+        private readonly List<Meter> _meters = [];
+
+        public Meter Create(MeterOptions options)
+        {
+            Meter meter = new(options);
+            _meters.Add(meter);
+            return meter;
+        }
+
+        public void Dispose()
+        {
+            foreach (Meter meter in _meters)
+            {
+                meter.Dispose();
+            }
+            _meters.Clear();
+        }
+    }
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/SubjectTestAuthHandler.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/SubjectTestAuthHandler.cs
@@ -1,0 +1,42 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// Authenticates the request only when the <see cref="SubjectHeader"/> is present on
+/// the incoming request, setting the header value as the <c>NameIdentifier</c> claim
+/// (which <see cref="HttpContextCurrentUserService"/> reads as <c>sub</c>).
+/// Absence of the header surfaces as a 401 through the auth pipeline.
+/// </summary>
+internal sealed class SubjectTestAuthHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    public const string SubjectHeader = "X-Test-Sub";
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue(SubjectHeader, out Microsoft.Extensions.Primitives.StringValues values)
+            || string.IsNullOrWhiteSpace(values.ToString()))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        string subject = values.ToString();
+        Claim[] claims =
+        [
+            new Claim(ClaimTypes.NameIdentifier, subject),
+            new Claim("sub", subject),
+        ];
+        var identity = new ClaimsIdentity(claims, TestAuthHandler.SchemeName);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, TestAuthHandler.SchemeName);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/TestPermissionDefinitionProvider.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/TestPermissionDefinitionProvider.cs
@@ -1,0 +1,35 @@
+using Granit.Authorization;
+using Granit.Identity.Local.Endpoints.Permissions;
+using Granit.Localization;
+using Granit.MultiTenancy;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// Minimal provider that declares the three <c>IdentityLocal.Roles.*</c> permissions
+/// under test. Matches the production <c>IdentityLocalPermissionDefinitionProvider</c>
+/// (internal) in name and <see cref="MultiTenancySide"/> without pulling
+/// <c>InternalsVisibleTo</c> just for the tests.
+/// </summary>
+internal sealed class TestPermissionDefinitionProvider : IPermissionDefinitionProvider
+{
+    public void DefinePermissions(IPermissionDefinitionContext context)
+    {
+        PermissionGroup group = context.AddGroup(
+            IdentityLocalPermissions.GroupName,
+            LocalizableString.Fixed($"PermissionGroup:{IdentityLocalPermissions.GroupName}"));
+
+        group.AddPermission(
+            IdentityLocalPermissions.Roles.Read,
+            LocalizableString.Fixed("Permission:IdentityLocal.Roles.Read"),
+            MultiTenancySide.Both);
+        group.AddPermission(
+            IdentityLocalPermissions.Roles.Manage,
+            LocalizableString.Fixed("Permission:IdentityLocal.Roles.Manage"),
+            MultiTenancySide.Both);
+        group.AddPermission(
+            IdentityLocalPermissions.Roles.Delete,
+            LocalizableString.Fixed("Permission:IdentityLocal.Roles.Delete"),
+            MultiTenancySide.Both);
+    }
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/packages.lock.json
@@ -103,6 +103,12 @@
           "xunit.v3.mtp-v1": "[3.2.2]"
         }
       },
+      "ZiggyCreatures.FusionCache": {
+        "type": "Direct",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog=="
+      },
       "Asp.Versioning.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.0",
@@ -635,12 +641,6 @@
         "dependencies": {
           "ZString": "2.6.0"
         }
-      },
-      "ZiggyCreatures.FusionCache": {
-        "type": "CentralTransitive",
-        "requested": "[2.*, )",
-        "resolved": "2.6.0",
-        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog=="
       },
       "ZiggyCreatures.FusionCache.OpenTelemetry": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Summary

Stacked on #1105 (which is stacked on #1104). Adds a dedicated integration fixture that wires the **real** Granit.Authorization pipeline against `/admin/roles` so the permission-grant evaluation path is exercised end-to-end against real PostgreSQL — the complement of the visibility-matrix tests in #1091 which deliberately short-circuit authorization via `PermissiveAuthorizationPolicyProvider`.

Closes #1102.

## Scenarios (10 tests)

| Grant | Request | Expected |
| ----- | ------- | -------- |
| (none, unauthenticated) | any | 401 |
| (none, authenticated) | any | 403 |
| `Roles.Read` | `GET /admin/roles` | 200 |
| `Roles.Read` | `POST /admin/roles` | 403 |
| `Roles.Manage` | `POST /admin/roles` | 201 |
| `Roles.Manage` | `DELETE /admin/roles/{id}` | 403 |
| `Roles.Delete` (+ Read) | `DELETE /admin/roles/{id}` | 204 |
| Tenant-scoped `Roles.Read` (TenantId = A) | `GET` in tenant A context | 200 |
| Tenant-scoped `Roles.Read` (TenantId = A) | `GET` in tenant B context | 403 |
| Tenant-scoped `Roles.Read` (TenantId = A) | `GET` in host context | 403 |

## Design

- **`SubjectTestAuthHandler`** authenticates only when `X-Test-Sub` is present; absence → 401. Writes the header value as `sub` / `NameIdentifier` claims.
- **`HttpContextCurrentUserService`** reads claims for the `ICurrentUserService` contract.
- **`TestPermissionDefinitionProvider`** declares the three `IdentityLocal.Roles.*` permissions with `Side=Both` — mirrors the production internal provider without forcing an `InternalsVisibleTo`.
- **`ResetAsync`** truncates grants / metadata / identity rows **and** flushes FusionCache so per-test isolation holds even through the permission checker cache.

Role-scope and client-scope grant coverage (complementing the user-scope rows tested here) is parked for the realm/client-role stories (#1098 – #1100) that populate `ClientId` on `RoleMetadata`.

## Test plan

- [x] Integration suite 29/29 passing on local PG 17 (7 orchestrator, 12 endpoint visibility, 10 new permission enforcement).
- [x] `dotnet format --verify-no-changes` → clean.
- [ ] CI green on the `security` shard (awaits remote run).

## Merge order

Stacked on `feat/allow-tenant-roles-default` (#1105), itself stacked on `feat/tenant-aware-role-lookup` (#1104). Retarget to `develop` once #1104 + #1105 land.