### PR TITLE
feat(authorization)!: invalidate role caches on RoleUpdated / RoleDeleted (#1101)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -6188,6 +6188,22 @@
       "members": []
     },
     {
+      "name": "RoleCacheInvalidationHandler",
+      "fqn": "Granit.Authorization.Cache.RoleCacheInvalidationHandler",
+      "kind": "class",
+      "project": "Granit.Authorization",
+      "file": "src/Granit.Authorization/Cache/RoleCacheInvalidationHandler.cs",
+      "line": 26,
+      "members": [
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(RoleUpdatedEvent @event, IFusionCache cache, CancellationToken cancellationToken)",
+          "returnType": "Task"
+        }
+      ]
+    },
+    {
       "name": "AuthorizationMetrics",
       "fqn": "Granit.Authorization.Diagnostics.AuthorizationMetrics",
       "kind": "class",
@@ -6496,7 +6512,7 @@
       "kind": "record",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/Events/RoleUpdatedEvent.cs",
-      "line": 15,
+      "line": 20,
       "members": []
     },
     {

--- a/src/Granit.Authorization/Cache/RoleCacheInvalidationHandler.cs
+++ b/src/Granit.Authorization/Cache/RoleCacheInvalidationHandler.cs
@@ -1,0 +1,60 @@
+using Granit.Authorization.Events;
+using Granit.Authorization.Services;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Granit.Authorization.Cache;
+
+/// <summary>
+/// Wolverine message handlers — flush stale permission-check cache entries when a
+/// role is renamed or deleted.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="PermissionChecker"/> tags every role-scope grant cache entry with
+/// <c>role:{roleName}</c>. A rename or delete therefore only needs to call
+/// <see cref="IFusionCache.RemoveByTagAsync(string,FusionCacheEntryOptions?,CancellationToken)"/>
+/// on the stale name; every tenant that had cached a check for that role is
+/// flushed in a single call.
+/// </para>
+/// <para>
+/// Discovered by Wolverine's handler scanning convention: class name ends in
+/// <c>"Handler"</c>, method named <c>HandleAsync</c> with the message as first
+/// parameter. Additional parameters are resolved from the application's DI
+/// container. No WolverineFx package reference is required in this project.
+/// </para>
+/// </remarks>
+public class RoleCacheInvalidationHandler
+{
+    /// <summary>
+    /// Invalidates role-scope permission cache entries for the renamed role. When
+    /// <see cref="RoleUpdatedEvent.PreviousName"/> is <see langword="null"/> (description-only
+    /// update) the cache is left untouched because the role-name-based tag is stable.
+    /// </summary>
+    public static async Task HandleAsync(
+        RoleUpdatedEvent @event,
+        IFusionCache cache,
+        CancellationToken cancellationToken)
+    {
+        if (@event.PreviousName is null)
+        {
+            return;
+        }
+
+        await cache.RemoveByTagAsync(
+            PermissionChecker.RoleTag(@event.PreviousName),
+            token: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Invalidates every role-scope permission cache entry for the deleted role
+    /// across every tenant. Subsequent permission checks for that name re-query the
+    /// grant store, which has no rows for the role, and return <c>denied</c>.
+    /// </summary>
+    public static Task HandleAsync(
+        RoleDeletedEvent @event,
+        IFusionCache cache,
+        CancellationToken cancellationToken) =>
+        cache.RemoveByTagAsync(
+            PermissionChecker.RoleTag(@event.Name),
+            token: cancellationToken).AsTask();
+}

--- a/src/Granit.Authorization/Domain/RoleMetadata.cs
+++ b/src/Granit.Authorization/Domain/RoleMetadata.cs
@@ -135,10 +135,13 @@ public sealed class RoleMetadata : AuditedAggregateRoot, IMultiTenant
             return;
         }
 
+        string? previousName = nameChanged ? Name : null;
+
         Name = newName;
         Description = newDescription;
 
-        AddDomainEvent(new RoleUpdatedEvent(Id, Name, MultiTenancySide, TenantId, ClientId));
+        AddDomainEvent(new RoleUpdatedEvent(
+            Id, Name, previousName, MultiTenancySide, TenantId, ClientId));
     }
 
     /// <summary>

--- a/src/Granit.Authorization/Events/RoleUpdatedEvent.cs
+++ b/src/Granit.Authorization/Events/RoleUpdatedEvent.cs
@@ -9,12 +9,18 @@ namespace Granit.Authorization.Events;
 /// </summary>
 /// <param name="RoleId">Aggregate identifier.</param>
 /// <param name="Name">New role name.</param>
+/// <param name="PreviousName">
+/// Name the role had before the update, when it was renamed. <see langword="null"/>
+/// when only the description changed (name was not renamed). Cache invalidation
+/// handlers use this to flush entries keyed on the stale name.
+/// </param>
 /// <param name="MultiTenancySide">Side applicability (unchanged since creation).</param>
 /// <param name="TenantId">Tenant scope (unchanged since creation).</param>
 /// <param name="ClientId">OIDC client scope (unchanged since creation).</param>
 public sealed record RoleUpdatedEvent(
     Guid RoleId,
     string Name,
+    string? PreviousName,
     MultiTenancySide MultiTenancySide,
     Guid? TenantId,
     string? ClientId) : IDomainEvent;

--- a/src/Granit.Authorization/Services/PermissionChecker.cs
+++ b/src/Granit.Authorization/Services/PermissionChecker.cs
@@ -91,7 +91,8 @@ internal sealed class PermissionChecker(
                                 provider.Name, providerKey, permissionName, tenantId, ct)
                             .ConfigureAwait(false));
                     },
-                    new FusionCacheEntryOptions { Duration = opts.CacheDuration },
+                    options: new FusionCacheEntryOptions { Duration = opts.CacheDuration },
+                    tags: BuildCacheTags(provider.Name, providerKey),
                     token: cancellationToken).ConfigureAwait(false);
 
                 if (result.IsGranted)
@@ -237,13 +238,15 @@ internal sealed class PermissionChecker(
                     granted.Add(perm);
                 }
 
+                IEnumerable<string>? tags = BuildCacheTags(provider.Name, providerKey);
                 foreach (string perm in uncached)
                 {
                     bool isGranted = granteeGrants.Contains(perm);
                     await cache.SetAsync(
                         BuildCacheKey(tenantId, provider.Name, providerKey, perm),
                         new PermissionGrantCacheItem(isGranted),
-                        entryOptions,
+                        options: entryOptions,
+                        tags: tags,
                         token: cancellationToken).ConfigureAwait(false);
                 }
             }
@@ -257,6 +260,23 @@ internal sealed class PermissionChecker(
     /// </summary>
     internal static string BuildCacheKey(Guid? tenantId, string providerName, string providerKey, string permissionName) =>
         $"perm:{tenantId?.ToString() ?? "global"}:{providerName}:{providerKey}:{permissionName}";
+
+    /// <summary>
+    /// Builds the FusionCache tag set for a permission grant cache entry. Role-scope
+    /// grants are tagged with <c>role:{roleName}</c> so <c>RoleUpdatedEvent</c> /
+    /// <c>RoleDeletedEvent</c> handlers can flush every stale entry for a given role
+    /// via <c>RemoveByTagAsync</c> in one shot — across every tenant that had cached
+    /// it. User and client grants currently have no tag (cache invalidation for those
+    /// flows goes through <see cref="Cache.PermissionCacheInvalidationHandler"/>
+    /// listening on <c>PermissionGrantChangedEvent</c>).
+    /// </summary>
+    internal static IEnumerable<string>? BuildCacheTags(string providerName, string providerKey) =>
+        providerName == PermissionGrantProviderNames.Role
+            ? [RoleTag(providerKey)]
+            : null;
+
+    /// <summary>Tag applied to every role-scope grant cache entry for <paramref name="roleName"/>.</summary>
+    internal static string RoleTag(string roleName) => $"role:{roleName}";
 
     // Side enforcement: a Host-sided permission is only grantable when no tenant is active;
     // a Tenant-sided one only when a tenant is active. Both-sided permissions pass in any context.

--- a/tests/Granit.Authorization.EntityFrameworkCore.Tests/RoleMetadataEntityTests.cs
+++ b/tests/Granit.Authorization.EntityFrameworkCore.Tests/RoleMetadataEntityTests.cs
@@ -142,9 +142,10 @@ public sealed class RoleMetadataEntityTests
     }
 
     [Fact]
-    public void Rename_ChangesNameAndDescription_RaisesEvent()
+    public void Rename_ChangesNameAndDescription_RaisesEventWithPreviousName()
     {
         RoleMetadata role = NewHostRole();
+        string originalName = role.Name;
         role.ClearDomainEvents();
 
         role.Rename("PlatformAdmin", "Updated description");
@@ -152,7 +153,22 @@ public sealed class RoleMetadataEntityTests
         role.Name.ShouldBe("PlatformAdmin");
         role.Description.ShouldBe("Updated description");
         role.DomainEvents.Count.ShouldBe(1);
-        role.DomainEvents.Single().ShouldBeOfType<RoleUpdatedEvent>();
+        RoleUpdatedEvent evt = role.DomainEvents.Single().ShouldBeOfType<RoleUpdatedEvent>();
+        evt.Name.ShouldBe("PlatformAdmin");
+        evt.PreviousName.ShouldBe(originalName);
+    }
+
+    [Fact]
+    public void Rename_DescriptionOnly_RaisesEventWithNullPreviousName()
+    {
+        RoleMetadata role = NewHostRole();
+        role.ClearDomainEvents();
+
+        role.Rename(role.Name, "New description only");
+
+        role.DomainEvents.Count.ShouldBe(1);
+        RoleUpdatedEvent evt = role.DomainEvents.Single().ShouldBeOfType<RoleUpdatedEvent>();
+        evt.PreviousName.ShouldBeNull();
     }
 
     [Fact]

--- a/tests/Granit.Authorization.Tests/PermissionCheckerCacheTagTests.cs
+++ b/tests/Granit.Authorization.Tests/PermissionCheckerCacheTagTests.cs
@@ -1,0 +1,48 @@
+using Granit.Authorization.Services;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Authorization.Tests;
+
+/// <summary>
+/// Pins the tag contract consumed by <see cref="Cache.RoleCacheInvalidationHandler"/>:
+/// every role-scope grant cache entry MUST carry the <c>role:{name}</c> tag so
+/// role-event handlers can invalidate stale entries with a single
+/// <c>RemoveByTagAsync</c> call.
+/// </summary>
+public sealed class PermissionCheckerCacheTagTests
+{
+    [Fact]
+    public void BuildCacheTags_RoleProvider_ReturnsRoleTag()
+    {
+        IEnumerable<string>? tags = PermissionChecker.BuildCacheTags(
+            PermissionGrantProviderNames.Role, providerKey: "Manager");
+
+        tags.ShouldNotBeNull();
+        tags.ShouldBe(["role:Manager"]);
+    }
+
+    [Fact]
+    public void BuildCacheTags_UserProvider_ReturnsNull()
+    {
+        IEnumerable<string>? tags = PermissionChecker.BuildCacheTags(
+            PermissionGrantProviderNames.User, providerKey: "user-42");
+
+        tags.ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildCacheTags_ClientProvider_ReturnsNull()
+    {
+        IEnumerable<string>? tags = PermissionChecker.BuildCacheTags(
+            PermissionGrantProviderNames.Client, providerKey: "admin-spa");
+
+        tags.ShouldBeNull();
+    }
+
+    [Fact]
+    public void RoleTag_FormatStable()
+    {
+        PermissionChecker.RoleTag("X").ShouldBe("role:X");
+    }
+}

--- a/tests/Granit.Authorization.Tests/RoleCacheInvalidationHandlerTests.cs
+++ b/tests/Granit.Authorization.Tests/RoleCacheInvalidationHandlerTests.cs
@@ -1,0 +1,81 @@
+using Granit.Authorization.Cache;
+using Granit.Authorization.Events;
+using Granit.Authorization.Services;
+using Granit.MultiTenancy;
+using NSubstitute;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Granit.Authorization.Tests;
+
+/// <summary>
+/// Verifies that <see cref="RoleCacheInvalidationHandler"/> flushes stale
+/// permission-check cache entries when a role is renamed or deleted. The
+/// handler relies on <see cref="PermissionChecker.RoleTag"/> being applied to
+/// role-scope cache entries at set time (covered separately in
+/// <see cref="PermissionCheckerCacheTagTests"/>).
+/// </summary>
+public sealed class RoleCacheInvalidationHandlerTests
+{
+    [Fact]
+    public async Task RoleUpdated_Renamed_RemovesByPreviousNameTag()
+    {
+        IFusionCache cache = Substitute.For<IFusionCache>();
+        var @event = new RoleUpdatedEvent(
+            RoleId: Guid.NewGuid(),
+            Name: "TeamLead",
+            PreviousName: "Manager",
+            MultiTenancySide: MultiTenancySide.Tenant,
+            TenantId: Guid.NewGuid(),
+            ClientId: null);
+
+        await RoleCacheInvalidationHandler.HandleAsync(
+            @event, cache, TestContext.Current.CancellationToken);
+
+        await cache.Received(1).RemoveByTagAsync(
+            PermissionChecker.RoleTag("Manager"),
+            Arg.Any<FusionCacheEntryOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RoleUpdated_DescriptionOnly_NoCacheCall()
+    {
+        IFusionCache cache = Substitute.For<IFusionCache>();
+        var @event = new RoleUpdatedEvent(
+            RoleId: Guid.NewGuid(),
+            Name: "Manager",
+            PreviousName: null,
+            MultiTenancySide: MultiTenancySide.Tenant,
+            TenantId: Guid.NewGuid(),
+            ClientId: null);
+
+        await RoleCacheInvalidationHandler.HandleAsync(
+            @event, cache, TestContext.Current.CancellationToken);
+
+        await cache.DidNotReceive().RemoveByTagAsync(
+            Arg.Any<string>(),
+            Arg.Any<FusionCacheEntryOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RoleDeleted_RemovesByRoleNameTag()
+    {
+        IFusionCache cache = Substitute.For<IFusionCache>();
+        var @event = new RoleDeletedEvent(
+            RoleId: Guid.NewGuid(),
+            Name: "Disposable",
+            MultiTenancySide: MultiTenancySide.Both,
+            TenantId: null,
+            ClientId: null);
+
+        await RoleCacheInvalidationHandler.HandleAsync(
+            @event, cache, TestContext.Current.CancellationToken);
+
+        await cache.Received(1).RemoveByTagAsync(
+            PermissionChecker.RoleTag("Disposable"),
+            Arg.Any<FusionCacheEntryOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary

Closes the stale-cache drift that persisted after a role rename / delete: the permission-check cache keyed every role-scope result on the role name (via `providerKey`), with no invalidation hook on role lifecycle events. After a rename, old name queries kept answering from cache; after a delete, the role's grants lingered until cache TTL.

Closes #1101.

## Design

- Every role-scope grant cache entry now carries a `role:{name}` FusionCache tag at set time (added in `PermissionChecker`). User- and client-scope entries keep no tag — their invalidation path is `PermissionGrantChangedEvent` handled by the existing `PermissionCacheInvalidationHandler`.
- `RoleCacheInvalidationHandler` (new) defines two Wolverine handlers:
  - `RoleUpdatedEvent` with non-null `PreviousName` → `RemoveByTagAsync` on the stale tag. Description-only updates are a no-op.
  - `RoleDeletedEvent` → `RemoveByTagAsync` on the role's deletion-time name.
- `RemoveByTagAsync` flushes entries across **every tenant** in a single call, so a Both-scope role rename / delete correctly evicts every tenant context that had cached the role. Slight over-invalidation when two scopes share a name (rare) — safe, preferred over under-invalidation.

## BREAKING

`RoleUpdatedEvent` gains a new positional field `string? PreviousName` between `Name` and `MultiTenancySide`. Consumers reconstructing the event (tests, bridges) must supply it; `null` means the name did not change.

## Test plan

- [x] `Granit.Authorization.Tests` — 223 passing (7 new: `RoleCacheInvalidationHandlerTests` + `PermissionCheckerCacheTagTests`).
- [x] `Granit.Authorization.EntityFrameworkCore.Tests` — 59 passing (strengthened `Rename_…` tests assert `PreviousName` plumbing).
- [x] `Granit.ArchitectureTests` — 117 passing.
- [x] `dotnet format --verify-no-changes` → clean on all three touched projects.
- [ ] CI green on the `security` shard (awaits remote run).

## Follow-up

Role-scope grant tagging is the first user of FusionCache tags in this codebase. Extending the same pattern to user- and client-scope entries (keyed by `user:{userId}` / `client:{clientId}`) would simplify the existing `PermissionCacheInvalidationHandler` to a single `RemoveByTagAsync` call — tracked separately if future events justify it.