### PR TITLE
feat(identity-local): atomic shared-connection transaction for role orchestration (#1097)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -6451,7 +6451,7 @@
       "kind": "class",
       "project": "Granit.Authorization.EntityFrameworkCore",
       "file": "src/Granit.Authorization.EntityFrameworkCore/Extensions/AuthorizationEfCoreServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 14,
       "members": []
     },
     {
@@ -6817,7 +6817,7 @@
       "kind": "interface",
       "project": "Granit.Authorization",
       "file": "src/Granit.Authorization/IRoleMetadataStore.cs",
-      "line": 13,
+      "line": 27,
       "members": [
         {
           "name": "FindByIdAsync",
@@ -28449,7 +28449,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.EntityFrameworkCore",
       "file": "src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 23,
+      "line": 24,
       "members": [
         {
           "name": "AddGranitOpenIddict",
@@ -32563,6 +32563,31 @@
           "returnType": "Task"
         }
       ]
+    },
+    {
+      "name": "IAuthorizationHostDbContextAccessor",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.SharedConnection.IAuthorizationHostDbContextAccessor",
+      "kind": "interface",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/SharedConnection/IAuthorizationHostDbContextAccessor.cs",
+      "line": 33,
+      "members": [
+        {
+          "name": "CreateFreshDbContextAsync",
+          "kind": "method",
+          "signature": "CreateFreshDbContextAsync(CancellationToken cancellationToken = default)",
+          "returnType": "Task<DbContext>"
+        }
+      ]
+    },
+    {
+      "name": "IIdentityDbContextAccessor",
+      "fqn": "Granit.Persistence.EntityFrameworkCore.SharedConnection.IIdentityDbContextAccessor",
+      "kind": "interface",
+      "project": "Granit.Persistence.EntityFrameworkCore",
+      "file": "src/Granit.Persistence.EntityFrameworkCore/SharedConnection/IIdentityDbContextAccessor.cs",
+      "line": 28,
+      "members": []
     },
     {
       "name": "SpecificationEvaluator",

--- a/docs-site/src/content/docs/dotnet/architecture/adr/024-role-orchestrator-shared-connection-transaction.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/024-role-orchestrator-shared-connection-transaction.md
@@ -1,0 +1,168 @@
+---
+title: "ADR-024: Shared-connection EF Core transaction for role orchestration"
+description: "Upgrade IGranitRoleOrchestrator from compensating-write to atomic shared-connection transaction when both DbContexts target the same database"
+sidebar:
+  order: 24
+  label: "024 - Role orchestrator atomic transaction"
+---
+
+> **Date:** 2026-04-22
+> **Authors:** Jean-Francois Meyers
+> **Scope:** `Granit.Identity.Local.AspNetIdentity`, `Granit.Authorization.EntityFrameworkCore`, `Granit.OpenIddict.EntityFrameworkCore`, `Granit.Persistence.EntityFrameworkCore`
+
+## Context
+
+`IGranitRoleOrchestrator` dual-writes every role lifecycle operation across two
+independent DbContexts: `GranitRole` lands in the Identity DbContext (typically
+`OpenIddictDbContext`) and `RoleMetadata` lands in the host application's DbContext
+(which implements `IPermissionGrantDbContext`). Phase 1 (PR #1082) used a
+**compensating-write** strategy — write Identity first, then metadata; on metadata
+failure delete the orphaned Identity role — because no portable atomic mechanism
+was available:
+
+- `TransactionScope` would escalate to MSDTC on Linux with Npgsql, which is not
+  supported.
+- EF Core's `Database.OpenConnectionAsync` / `SetDbConnection` / `BeginTransactionAsync` /
+  `UseTransactionAsync` pattern requires the Identity DbContext to expose its
+  `DbConnection` across assemblies — but `OpenIddictDbContext` is `internal sealed`.
+
+The compensating strategy leaves a non-atomic window: a process crash between the
+Identity INSERT and the metadata INSERT produces an orphan `GranitRole` that the
+seed contributor's repair path has to clean up on next startup. The risk is
+low-impact but real.
+
+This ADR records the Phase 2 upgrade (PR #1097): opt in to a **true atomic EF
+Core transaction** when the deployment satisfies the pre-conditions, while keeping
+the compensating path as the fallback for deployments that don't.
+
+## Decision
+
+### Accessor pattern (not `public sealed` OpenIddictDbContext)
+
+Two new interfaces in `Granit.Persistence.EntityFrameworkCore.SharedConnection`:
+
+- `IIdentityDbContextAccessor` — exposes the scoped Identity `DbContext` (same
+  instance ASP.NET Identity's `RoleStore` / `UserStore` use). Implemented by
+  `OpenIddictIdentityDbContextAccessor` in `Granit.OpenIddict.EntityFrameworkCore`.
+- `IAuthorizationHostDbContextAccessor` — factory-style; `CreateFreshDbContextAsync`
+  returns a freshly-built host `DbContext` via `IDbContextFactory<THost>`.
+  Implemented by `AuthorizationHostDbContextAccessor<TContext>` in
+  `Granit.Authorization.EntityFrameworkCore`.
+
+Both are registered automatically by the existing `AddGranitOpenIddict(...)` and
+`AddGranitAuthorizationEntityFrameworkCore<TContext>()` extensions — no host-app
+code change required.
+
+**Rationale for the accessor pattern instead of making `OpenIddictDbContext` public
+sealed:** `OpenIddictDbContext` extends `IdentityDbContext<GranitUser, GranitRole, Guid>`
+with a substantial public API surface (dozens of inherited members, multiple generic
+constraints). Exposing it publicly commits the framework to that shape. The
+accessor interface is 1 member, purpose-built, and easy to evolve.
+
+### Asymmetry: scoped Identity, factory host
+
+The Identity accessor returns the scoped instance because ASP.NET Identity's
+`RoleManager<GranitRole>` internally references a `RoleStore<GranitRole, OpenIddictDbContext, Guid>`
+whose `TContext` was resolved by DI at construction time. If the orchestrator
+handed the RoleManager a different DbContext, `RoleManager.CreateAsync` would
+write to the "wrong" context — not enrolled in the shared transaction. Staying
+scoped keeps RoleManager and the accessor pointing at the same instance.
+
+The host accessor, in contrast, returns a **fresh** context per call. The
+orchestrator swaps its underlying `DbConnection` (via `Database.SetDbConnection`)
+to share the Identity connection. Calling `SetDbConnection` on a DbContext that
+has already executed queries in the scope ("warm context") can throw
+`InvalidOperationException` on EF Core 8 / 9 / 10. A freshly-built context is
+guaranteed not to be warm, so the swap is always safe.
+
+Consequence: the orchestrator's atomic path **bypasses `IRoleMetadataStore`**
+inside the transaction block and writes directly via
+`freshHostCtx.Set<RoleMetadata>().Add(...)` + `SaveChangesAsync`. The store is
+tied to the *scoped* host context, which is not the one participating in the
+shared transaction. The duplicated logic is 2 lines (Add + SaveChanges); no
+meaningful redundancy.
+
+### Provider-agnostic connection-string comparison
+
+Connection-string equivalence is checked via
+`System.Data.Common.DbConnectionStringBuilder.EquivalentTo(DbConnectionStringBuilder)`
+— the ADO.NET base-class API that parses key/value pairs regardless of order and
+ignores whitespace. Works for every ADO.NET provider (Npgsql, SQL Server, SQLite,
+MySQL, etc.). Wrapped in `try/catch`: a malformed connection string throws, and
+the catch falls back to compensating-write.
+
+### Retry strategy compatibility
+
+Both supported providers unconditionally enable `EnableRetryOnFailure(3, 30s)`
+(see `NpgsqlDbContextOptionsExtensions` and `SqlServerDbContextOptionsExtensions`).
+Calling `Database.BeginTransactionAsync` while retry is active throws
+`InvalidOperationException` unless wrapped in
+`Database.CreateExecutionStrategy().ExecuteAsync(...)`. The atomic path does so;
+`ChangeTracker.Clear()` runs at the start of each attempt so a re-execution
+starts from clean tracker state.
+
+Transient errors (network blips, serialization failures) trigger a retry of the
+whole block — both contexts re-execute from scratch. Non-transient errors
+(unique-index violations, application exceptions) rethrow after `RollbackAsync`
+and the transaction dies cleanly.
+
+## Consequences
+
+### Positive
+
+- Atomic dual writes when both contexts target the same database. A crash
+  mid-operation leaves zero orphan rows.
+- No breaking change: applications not registering the accessors continue on the
+  compensating-write path, behavior unchanged from Phase 1.
+- Provider-agnostic (PostgreSQL tested end-to-end via Testcontainers; SQL Server
+  and other relational providers supported by the same API).
+- No `TransactionScope`, no MSDTC, no ambient transaction shenanigans.
+
+### Negative
+
+- Graceful-fallback complexity: the orchestrator now has two execution paths to
+  maintain. Mitigated by keeping them in clearly-separated private methods.
+- Requires the host DbContext to be registered via `AddDbContextFactory<T>`
+  (which `AddGranitDbContext` does). Apps using `AddDbContext<T>` alone don't
+  benefit from the atomic path — but they still work, via the compensating
+  fallback.
+- `ILogger` noise: per-call `Debug` messages document which path was selected.
+  Deployments that want to audit this can raise the log level or suppress the
+  category.
+
+## Pre-conditions for the atomic path
+
+At runtime, the orchestrator takes the atomic path iff **all** of:
+
+1. `IIdentityDbContextAccessor` is registered.
+2. `IAuthorizationHostDbContextAccessor` is registered AND
+   `IDbContextFactory<THost>` resolves successfully.
+3. Both resolved DbContexts report `Database.IsRelational() == true`.
+4. Their connection strings are equivalent (`DbConnectionStringBuilder.EquivalentTo`).
+
+Otherwise: compensating-write.
+
+## Providers covered
+
+| Provider | Retry enabled by Granit | Pattern validated | Integration test |
+| -------- | ----------------------- | ----------------- | ---------------- |
+| PostgreSQL (Npgsql) | `EnableRetryOnFailure(3, 30s)` | Yes | Testcontainers PG 17 |
+| SQL Server (`Microsoft.Data.SqlClient`) | `EnableRetryOnFailure(3, 30s)` | Same EF Core API | Follow-up (no Granit integration test exercises SQL Server on this path yet) |
+| Other relational providers (SQLite, MySQL via Pomelo, etc.) | Out of Granit's direct support | Covered by the `IExecutionStrategy` abstraction | Not covered |
+
+## Interceptor interaction
+
+Granit's EF interceptors (`AuditedEntityInterceptor`, `DomainEventDispatcherInterceptor`,
+`SoftDeleteInterceptor`, etc.) run through the standard `SaveChanges` pipeline,
+which operates on the context's current connection and transaction. They do not
+care that `SetDbConnection` swapped the underlying connection. `DomainEventDispatcherInterceptor`
+may publish integration events via `IDistributedEventBus` in `SavingChanges` —
+these writes happen on their own DbContext and are NOT enrolled in the shared
+transaction. This is consistent with the outbox pattern's existing behavior and
+is not a regression from Phase 1.
+
+## References
+
+- PR #1082 — Phase 1 `RoleMetadata` + compensating-write orchestrator.
+- PR #1097 — this ADR's implementing PR.
+- [Microsoft docs — Sharing connection and transaction](https://learn.microsoft.com/en-us/ef/core/saving/transactions#share-connection-and-transaction)

--- a/docs-site/src/data/constants.ts
+++ b/docs-site/src/data/constants.ts
@@ -5,4 +5,4 @@ export const CULTURE_COUNT = 18;
 export const BASE_LANGUAGE_COUNT = 15;
 export const REGIONAL_VARIANT_COUNT = 3;
 export const PATTERN_COUNT = 57;
-export const ADR_COUNT = 23;
+export const ADR_COUNT = 24;

--- a/src/Granit.Authorization.EntityFrameworkCore/Extensions/AuthorizationEfCoreServiceCollectionExtensions.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/Extensions/AuthorizationEfCoreServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using Granit.Authorization;
 using Granit.Authorization.EntityFrameworkCore.DbContext;
+using Granit.Authorization.EntityFrameworkCore.Internal;
 using Granit.Authorization.EntityFrameworkCore.Stores;
+using Granit.Persistence.EntityFrameworkCore.SharedConnection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -33,6 +35,12 @@ public static class AuthorizationEfCoreServiceCollectionExtensions
         // Replace the NullRoleMetadataStore registered by Granit.Authorization
         services.Replace(ServiceDescriptor.Scoped<IRoleMetadataStore,
             EfCoreRoleMetadataStore<TContext>>());
+
+        // Factory-style accessor consumed by IGranitRoleOrchestrator to open a
+        // fresh host DbContext for the shared-connection transaction path. Uses
+        // TryAdd so host apps can override with a custom accessor if needed.
+        services.TryAddScoped<IAuthorizationHostDbContextAccessor,
+            AuthorizationHostDbContextAccessor<TContext>>();
 
         return services;
     }

--- a/src/Granit.Authorization.EntityFrameworkCore/Internal/AuthorizationHostDbContextAccessor.cs
+++ b/src/Granit.Authorization.EntityFrameworkCore/Internal/AuthorizationHostDbContextAccessor.cs
@@ -1,0 +1,32 @@
+using Granit.Authorization.EntityFrameworkCore.DbContext;
+using Granit.Persistence.EntityFrameworkCore.SharedConnection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Granit.Authorization.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Factory-style accessor for the host application's authorization DbContext.
+/// Resolves <see cref="IDbContextFactory{TContext}"/> lazily via the service provider
+/// so consumers that only registered the DbContext via <c>AddDbContext&lt;T&gt;</c>
+/// (no factory) can still wire this accessor — the atomic path in
+/// <c>IGranitRoleOrchestrator</c> then naturally falls back to the compensating
+/// strategy because <see cref="CreateFreshDbContextAsync"/> throws.
+/// </summary>
+internal sealed class AuthorizationHostDbContextAccessor<TContext>(
+    IServiceProvider serviceProvider) : IAuthorizationHostDbContextAccessor
+    where TContext : Microsoft.EntityFrameworkCore.DbContext, IPermissionGrantDbContext
+{
+    public async Task<Microsoft.EntityFrameworkCore.DbContext> CreateFreshDbContextAsync(
+        CancellationToken cancellationToken = default)
+    {
+        IDbContextFactory<TContext>? factory =
+            serviceProvider.GetService<IDbContextFactory<TContext>>()
+            ?? throw new InvalidOperationException(
+                $"IDbContextFactory<{typeof(TContext).Name}> is not registered. " +
+                "The shared-connection atomic transaction path requires the host DbContext " +
+                "to be registered via AddDbContextFactory<T> (AddGranitDbContext does this by default).");
+
+        return await factory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Granit.Authorization/IRoleMetadataStore.cs
+++ b/src/Granit.Authorization/IRoleMetadataStore.cs
@@ -6,9 +6,23 @@ namespace Granit.Authorization;
 /// Persistence abstraction for <see cref="RoleMetadata"/>.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Consumers (the grant validator, CRUD endpoints, orchestrator) depend on this
 /// contract so roles defined by the local identity store and by future federated
 /// providers share the same metadata surface.
+/// </para>
+/// <para>
+/// <b>Orchestrator atomic path caveat.</b> When <c>IGranitRoleOrchestrator</c> takes
+/// its shared-connection atomic path (see ADR-024), the write methods on this
+/// interface (<see cref="AddAsync"/>, <see cref="UpdateAsync"/>, <see cref="RemoveAsync"/>)
+/// are <b>bypassed by design</b> — the orchestrator writes directly through a fresh
+/// <c>DbContext</c> attached to the shared transaction. Implementations that want to
+/// run additional business logic (in-memory event publication, extra validation,
+/// cross-cutting audit) around role persistence MUST NOT rely on being called
+/// through this contract; extract such logic into a domain service invoked by the
+/// orchestrator itself (or by the CRUD endpoint layer before orchestration) so it
+/// runs on both paths.
+/// </para>
 /// </remarks>
 public interface IRoleMetadataStore
 {

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/GranitRoleOrchestrator.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/GranitRoleOrchestrator.cs
@@ -1,10 +1,14 @@
+using System.Data.Common;
 using Granit.Authorization;
 using Granit.Authorization.Domain;
 using Granit.Guids;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Services;
 using Granit.MultiTenancy;
+using Granit.Persistence.EntityFrameworkCore.SharedConnection;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Logging;
 
 namespace Granit.Identity.Local.AspNetIdentity.Internal;
@@ -15,25 +19,34 @@ namespace Granit.Identity.Local.AspNetIdentity.Internal;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Uses a compensating-write strategy rather than a cross-DbContext transaction: the role
-/// is created in the Identity DbContext first, then the metadata is persisted via
-/// <see cref="IRoleMetadataStore"/>. If the metadata write fails the GranitRole is
-/// deleted so the invariant "every Granit-managed role has matching metadata" converges.
+/// Two execution paths, selected per-call:
 /// </para>
-/// <para>
-/// This avoids the MSDTC escalation hazard of <c>TransactionScope</c> on Linux with
-/// Npgsql and works regardless of whether both DbContexts share a physical database.
-/// Deployments that guarantee both contexts target the same database and can expose their
-/// connection across assemblies may replace this with a shared-connection EF Core
-/// transaction (<c>Database.OpenConnectionAsync</c> / <c>SetDbConnection</c> /
-/// <c>BeginTransactionAsync</c> / <c>UseTransactionAsync</c>).
-/// </para>
+/// <list type="number">
+/// <item>
+/// <b>Atomic</b> — when both <see cref="IIdentityDbContextAccessor"/> and
+/// <see cref="IAuthorizationHostDbContextAccessor"/> are registered, both contexts are
+/// relational, and their connection strings are equivalent. A single EF Core transaction
+/// wraps both writes via <c>Database.OpenConnectionAsync</c> + <c>SetDbConnection</c> on a
+/// fresh host context + <c>BeginTransactionAsync</c> / <c>UseTransactionAsync</c>, all inside
+/// an <see cref="IExecutionStrategy"/> so the Npgsql / SQL Server retry-on-failure policy
+/// still applies.
+/// </item>
+/// <item>
+/// <b>Compensating</b> (fallback) — creates the <see cref="GranitRole"/> first, then the
+/// <see cref="RoleMetadata"/>; on metadata failure, deletes the orphaned role so the
+/// invariant "every Granit-managed role has matching metadata" converges. Used when the
+/// accessors aren't wired (e.g., applications without Granit.OpenIddict) or when the two
+/// DbContexts target different physical databases.
+/// </item>
+/// </list>
 /// </remarks>
 internal sealed partial class GranitRoleOrchestrator(
     RoleManager<GranitRole> roleManager,
     IRoleMetadataStore roleMetadataStore,
     IGuidGenerator guidGenerator,
-    ILogger<GranitRoleOrchestrator> logger) : IGranitRoleOrchestrator
+    ILogger<GranitRoleOrchestrator> logger,
+    IIdentityDbContextAccessor? identityDbContextAccessor = null,
+    IAuthorizationHostDbContextAccessor? authorizationHostDbContextAccessor = null) : IGranitRoleOrchestrator
 {
     /// <inheritdoc />
     public async Task<RoleMetadata> CreateAsync(
@@ -42,6 +55,362 @@ internal sealed partial class GranitRoleOrchestrator(
     {
         ArgumentNullException.ThrowIfNull(command);
 
+        AtomicResolution atomic = await TryResolveAtomicContextsAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (atomic.IsAtomic)
+        {
+            await using (atomic.HostContext)
+            {
+                return await ExecuteAtomicCreateAsync(
+                    atomic.IdentityContext!, atomic.HostContext!, command, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        return await ExecuteCompensatingCreateAsync(command, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<RoleMetadata> RenameAsync(
+        Guid roleId,
+        string newName,
+        string? newDescription,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(newName);
+
+        AtomicResolution atomic = await TryResolveAtomicContextsAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (atomic.IsAtomic)
+        {
+            await using (atomic.HostContext)
+            {
+                return await ExecuteAtomicRenameAsync(
+                    atomic.IdentityContext!, atomic.HostContext!, roleId, newName, newDescription, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        return await ExecuteCompensatingRenameAsync(roleId, newName, newDescription, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteAsync(Guid roleId, CancellationToken cancellationToken = default)
+    {
+        AtomicResolution atomic = await TryResolveAtomicContextsAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (atomic.IsAtomic)
+        {
+            await using (atomic.HostContext)
+            {
+                await ExecuteAtomicDeleteAsync(
+                    atomic.IdentityContext!, atomic.HostContext!, roleId, cancellationToken)
+                    .ConfigureAwait(false);
+                return;
+            }
+        }
+
+        await ExecuteCompensatingDeleteAsync(roleId, cancellationToken).ConfigureAwait(false);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Atomic path selection
+    // ────────────────────────────────────────────────────────────────────
+
+    private async Task<AtomicResolution> TryResolveAtomicContextsAsync(CancellationToken cancellationToken)
+    {
+        if (identityDbContextAccessor is null || authorizationHostDbContextAccessor is null)
+        {
+            LogAtomicPathUnavailable(logger, "accessor not registered");
+            return AtomicResolution.NotAtomic;
+        }
+
+        DbContext idCtx = identityDbContextAccessor.DbContext;
+        DbContext hostCtx;
+        try
+        {
+            hostCtx = await authorizationHostDbContextAccessor
+                .CreateFreshDbContextAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogAtomicPathUnavailable(logger, $"host factory failed: {ex.GetType().Name}");
+            return AtomicResolution.NotAtomic;
+        }
+
+        if (!idCtx.Database.IsRelational() || !hostCtx.Database.IsRelational())
+        {
+            await hostCtx.DisposeAsync().ConfigureAwait(false);
+            LogAtomicPathUnavailable(logger, "provider is not relational");
+            return AtomicResolution.NotAtomic;
+        }
+
+        if (!ConnectionStringsEquivalent(idCtx, hostCtx))
+        {
+            await hostCtx.DisposeAsync().ConfigureAwait(false);
+            LogAtomicPathUnavailable(logger, "connection strings diverge");
+            return AtomicResolution.NotAtomic;
+        }
+
+        LogAtomicPathSelected(logger);
+        return new AtomicResolution(true, idCtx, hostCtx);
+    }
+
+    // ADO.NET-agnostic semantic comparison: DbConnectionStringBuilder parses
+    // key/value pairs regardless of order and ignores whitespace. Works for
+    // Npgsql, SQL Server, SQLite, MySQL, any provider that stores its
+    // configuration in a connection string.
+    private static bool ConnectionStringsEquivalent(DbContext a, DbContext b)
+    {
+        try
+        {
+            DbConnectionStringBuilder aBuilder = new()
+            {
+                ConnectionString = a.Database.GetDbConnection().ConnectionString,
+            };
+            DbConnectionStringBuilder bBuilder = new()
+            {
+                ConnectionString = b.Database.GetDbConnection().ConnectionString,
+            };
+            return aBuilder.EquivalentTo(bBuilder);
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Atomic path — shared connection, single transaction
+    // ────────────────────────────────────────────────────────────────────
+
+    private async Task<RoleMetadata> ExecuteAtomicCreateAsync(
+        DbContext idCtx,
+        DbContext hostCtx,
+        CreateRoleCommand command,
+        CancellationToken cancellationToken)
+    {
+        Guid roleId = guidGenerator.Create();
+        RoleMetadata? created = null;
+
+        IExecutionStrategy strategy = idCtx.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
+        {
+            idCtx.ChangeTracker.Clear();
+            hostCtx.ChangeTracker.Clear();
+
+            await idCtx.Database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                hostCtx.Database.SetDbConnection(idCtx.Database.GetDbConnection());
+                await using IDbContextTransaction tx = await idCtx.Database
+                    .BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+                await hostCtx.Database.UseTransactionAsync(tx.GetDbTransaction(), cancellationToken)
+                    .ConfigureAwait(false);
+
+                try
+                {
+                    GranitRole granitRole = new()
+                    {
+                        Id = roleId,
+                        Name = command.Name,
+                        Description = command.Description,
+                    };
+                    IdentityResult createResult = await roleManager.CreateAsync(granitRole)
+                        .ConfigureAwait(false);
+                    if (!createResult.Succeeded)
+                    {
+                        throw new InvalidOperationException(
+                            $"Failed to create GranitRole '{command.Name}': " +
+                            string.Join("; ", createResult.Errors.Select(e => $"{e.Code}: {e.Description}")));
+                    }
+
+                    var metadata = RoleMetadata.Create(
+                        roleId,
+                        command.Name,
+                        command.MultiTenancySide,
+                        command.TenantId,
+                        command.ClientId,
+                        command.Description,
+                        command.IsSystem);
+                    hostCtx.Set<RoleMetadata>().Add(metadata);
+                    await hostCtx.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+                    await tx.CommitAsync(cancellationToken).ConfigureAwait(false);
+                    created = metadata;
+                }
+                catch
+                {
+                    LogAtomicTransactionRolledBack(logger, roleId, command.Name);
+                    await tx.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+                    throw;
+                }
+            }
+            finally
+            {
+                await idCtx.Database.CloseConnectionAsync().ConfigureAwait(false);
+            }
+        }).ConfigureAwait(false);
+
+        return created!;
+    }
+
+    private async Task<RoleMetadata> ExecuteAtomicRenameAsync(
+        DbContext idCtx,
+        DbContext hostCtx,
+        Guid roleId,
+        string newName,
+        string? newDescription,
+        CancellationToken cancellationToken)
+    {
+        RoleMetadata? updated = null;
+
+        IExecutionStrategy strategy = idCtx.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
+        {
+            idCtx.ChangeTracker.Clear();
+            hostCtx.ChangeTracker.Clear();
+
+            await idCtx.Database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                hostCtx.Database.SetDbConnection(idCtx.Database.GetDbConnection());
+                await using IDbContextTransaction tx = await idCtx.Database
+                    .BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+                await hostCtx.Database.UseTransactionAsync(tx.GetDbTransaction(), cancellationToken)
+                    .ConfigureAwait(false);
+
+                try
+                {
+                    RoleMetadata metadata = await hostCtx.Set<RoleMetadata>()
+                        .FirstOrDefaultAsync(r => r.Id == roleId, cancellationToken)
+                        .ConfigureAwait(false)
+                        ?? throw new InvalidOperationException($"No RoleMetadata found for id {roleId:D}.");
+
+                    if (metadata.IsSystem)
+                    {
+                        throw new InvalidOperationException(
+                            $"Role '{metadata.Name}' is a system role and cannot be renamed.");
+                    }
+
+                    GranitRole granitRole = await roleManager.FindByIdAsync(roleId.ToString("D"))
+                        .ConfigureAwait(false)
+                        ?? throw new InvalidOperationException($"No GranitRole found for id {roleId:D}.");
+
+                    granitRole.Name = newName;
+                    granitRole.Description = newDescription;
+                    IdentityResult updateResult = await roleManager.UpdateAsync(granitRole)
+                        .ConfigureAwait(false);
+                    if (!updateResult.Succeeded)
+                    {
+                        throw new InvalidOperationException(
+                            $"Failed to update GranitRole '{roleId:D}': " +
+                            string.Join("; ", updateResult.Errors.Select(e => $"{e.Code}: {e.Description}")));
+                    }
+
+                    metadata.Rename(newName, newDescription);
+                    await hostCtx.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+                    await tx.CommitAsync(cancellationToken).ConfigureAwait(false);
+                    updated = metadata;
+                }
+                catch
+                {
+                    LogAtomicTransactionRolledBack(logger, roleId, newName);
+                    await tx.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+                    throw;
+                }
+            }
+            finally
+            {
+                await idCtx.Database.CloseConnectionAsync().ConfigureAwait(false);
+            }
+        }).ConfigureAwait(false);
+
+        return updated!;
+    }
+
+    private async Task ExecuteAtomicDeleteAsync(
+        DbContext idCtx,
+        DbContext hostCtx,
+        Guid roleId,
+        CancellationToken cancellationToken)
+    {
+        IExecutionStrategy strategy = idCtx.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
+        {
+            idCtx.ChangeTracker.Clear();
+            hostCtx.ChangeTracker.Clear();
+
+            await idCtx.Database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                hostCtx.Database.SetDbConnection(idCtx.Database.GetDbConnection());
+                await using IDbContextTransaction tx = await idCtx.Database
+                    .BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+                await hostCtx.Database.UseTransactionAsync(tx.GetDbTransaction(), cancellationToken)
+                    .ConfigureAwait(false);
+
+                try
+                {
+                    RoleMetadata metadata = await hostCtx.Set<RoleMetadata>()
+                        .FirstOrDefaultAsync(r => r.Id == roleId, cancellationToken)
+                        .ConfigureAwait(false)
+                        ?? throw new InvalidOperationException($"No RoleMetadata found for id {roleId:D}.");
+
+                    if (metadata.IsSystem)
+                    {
+                        throw new InvalidOperationException(
+                            $"Role '{metadata.Name}' is a system role and cannot be deleted.");
+                    }
+
+                    GranitRole? granitRole = await roleManager.FindByIdAsync(roleId.ToString("D"))
+                        .ConfigureAwait(false);
+
+                    metadata.MarkAsDeleted();
+                    hostCtx.Set<RoleMetadata>().Remove(metadata);
+                    await hostCtx.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+                    if (granitRole is not null)
+                    {
+                        IdentityResult deleteResult = await roleManager.DeleteAsync(granitRole)
+                            .ConfigureAwait(false);
+                        if (!deleteResult.Succeeded)
+                        {
+                            throw new InvalidOperationException(
+                                $"Failed to delete GranitRole '{metadata.Name}': " +
+                                string.Join("; ", deleteResult.Errors.Select(e => $"{e.Code}: {e.Description}")));
+                        }
+                    }
+
+                    await tx.CommitAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch
+                {
+                    LogAtomicTransactionRolledBack(logger, roleId, roleName: null);
+                    await tx.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+                    throw;
+                }
+            }
+            finally
+            {
+                await idCtx.Database.CloseConnectionAsync().ConfigureAwait(false);
+            }
+        }).ConfigureAwait(false);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Compensating-write path — original Phase 1 behaviour, preserved verbatim
+    // ────────────────────────────────────────────────────────────────────
+
+    private async Task<RoleMetadata> ExecuteCompensatingCreateAsync(
+        CreateRoleCommand command,
+        CancellationToken cancellationToken)
+    {
         Guid roleId = guidGenerator.Create();
         GranitRole granitRole = new()
         {
@@ -80,15 +449,12 @@ internal sealed partial class GranitRoleOrchestrator(
         }
     }
 
-    /// <inheritdoc />
-    public async Task<RoleMetadata> RenameAsync(
+    private async Task<RoleMetadata> ExecuteCompensatingRenameAsync(
         Guid roleId,
         string newName,
         string? newDescription,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(newName);
-
         RoleMetadata? existingMetadata = await roleMetadataStore.FindByIdAsync(roleId, cancellationToken)
             .ConfigureAwait(false)
             ?? throw new InvalidOperationException($"No RoleMetadata found for id {roleId:D}.");
@@ -99,7 +465,7 @@ internal sealed partial class GranitRoleOrchestrator(
                 $"Role '{existingMetadata.Name}' is a system role and cannot be renamed.");
         }
 
-        GranitRole? granitRole = await roleManager.FindByIdAsync(roleId.ToString("D"))
+        GranitRole granitRole = await roleManager.FindByIdAsync(roleId.ToString("D"))
             .ConfigureAwait(false)
             ?? throw new InvalidOperationException($"No GranitRole found for id {roleId:D}.");
 
@@ -140,8 +506,7 @@ internal sealed partial class GranitRoleOrchestrator(
         }
     }
 
-    /// <inheritdoc />
-    public async Task DeleteAsync(Guid roleId, CancellationToken cancellationToken = default)
+    private async Task ExecuteCompensatingDeleteAsync(Guid roleId, CancellationToken cancellationToken)
     {
         RoleMetadata? metadata = await roleMetadataStore.FindByIdAsync(roleId, cancellationToken)
             .ConfigureAwait(false)
@@ -189,6 +554,23 @@ internal sealed partial class GranitRoleOrchestrator(
         }
     }
 
+    // ────────────────────────────────────────────────────────────────────
+    // Logging
+    // ────────────────────────────────────────────────────────────────────
+
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "GranitRoleOrchestrator: atomic shared-connection transaction path selected.")]
+    private static partial void LogAtomicPathSelected(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "GranitRoleOrchestrator: atomic path unavailable ({Reason}); falling back to compensating-write strategy.")]
+    private static partial void LogAtomicPathUnavailable(ILogger logger, string reason);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "GranitRoleOrchestrator: atomic transaction rolled back for role {RoleId} ('{RoleName}'); neither Identity nor metadata rows persisted.")]
+    private static partial void LogAtomicTransactionRolledBack(
+        ILogger logger, Guid roleId, string? roleName);
+
     [LoggerMessage(Level = LogLevel.Error,
         Message = "RoleMetadata creation failed for role {RoleId} ('{RoleName}') — compensating by deleting GranitRole.")]
     private static partial void LogMetadataFailedCompensating(
@@ -203,4 +585,13 @@ internal sealed partial class GranitRoleOrchestrator(
         Message = "Compensation action failed for role {RoleId} — manual cleanup required (orphan GranitRole or RoleMetadata row).")]
     private static partial void LogCompensationFailed(
         ILogger logger, Exception? exception, Guid roleId);
+
+    // ────────────────────────────────────────────────────────────────────
+    // Types
+    // ────────────────────────────────────────────────────────────────────
+
+    private readonly record struct AtomicResolution(bool IsAtomic, DbContext? IdentityContext, DbContext? HostContext)
+    {
+        public static readonly AtomicResolution NotAtomic = new(false, null, null);
+    }
 }

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Extensions/OpenIddictEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -7,6 +7,7 @@ using Granit.OpenIddict.EntityFrameworkCore.Internal;
 using Granit.OpenIddict.Options;
 using Granit.OpenIddict.Server.Extensions;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
+using Granit.Persistence.EntityFrameworkCore.SharedConnection;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -86,6 +87,12 @@ public static class OpenIddictEntityFrameworkCoreHostApplicationBuilderExtension
 
         // 5. Register group store — required by AspNetIdentityProvider
         builder.Services.TryAddScoped<ILocalIdentityGroupStore, OpenIddictGroupStore>();
+
+        // 6. Accessor exposing the scoped OpenIddictDbContext as IIdentityDbContextAccessor —
+        //    consumed by IGranitRoleOrchestrator to share the Identity transaction
+        //    with the host authorization DbContext when both target the same database.
+        builder.Services.TryAddScoped<IIdentityDbContextAccessor,
+            OpenIddictIdentityDbContextAccessor>();
 
         return builder;
     }

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Internal/OpenIddictIdentityDbContextAccessor.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Internal/OpenIddictIdentityDbContextAccessor.cs
@@ -1,0 +1,16 @@
+using Granit.Persistence.EntityFrameworkCore.SharedConnection;
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.OpenIddict.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Exposes the scoped <see cref="OpenIddictDbContext"/> through the neutral
+/// <see cref="IIdentityDbContextAccessor"/> contract, so consumers in sibling
+/// modules (<c>Granit.Identity.Local.AspNetIdentity</c>) can reach the Identity
+/// DbContext without taking a hard reference to this package's internal types.
+/// </summary>
+internal sealed class OpenIddictIdentityDbContextAccessor(OpenIddictDbContext context)
+    : IIdentityDbContextAccessor
+{
+    public DbContext DbContext => context;
+}

--- a/src/Granit.Persistence.EntityFrameworkCore/SharedConnection/IAuthorizationHostDbContextAccessor.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/SharedConnection/IAuthorizationHostDbContextAccessor.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Persistence.EntityFrameworkCore.SharedConnection;
+
+/// <summary>
+/// Factory-style accessor for the host application's authorization <see cref="DbContext"/>
+/// — the one that implements <c>IPermissionGrantDbContext</c> and owns
+/// <c>authorization_role_metadata</c> + <c>authorization_permission_grants</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike <see cref="IIdentityDbContextAccessor"/> which exposes the scoped
+/// instance, this accessor returns a <b>fresh</b> DbContext on every call, built via
+/// <see cref="IDbContextFactory{TContext}"/>. The reason:
+/// <c>IGranitRoleOrchestrator</c> swaps the underlying <c>DbConnection</c> on the
+/// host context to share the Identity transaction. Calling
+/// <c>Database.SetDbConnection(...)</c> on a DbContext that has already executed
+/// queries in the current scope can throw <see cref="System.InvalidOperationException"/>
+/// ("The connection was already initialized"). A fresh context is guaranteed not to
+/// be "warm", so the swap is always safe.
+/// </para>
+/// <para>
+/// Callers own the returned context — it must be disposed (<c>await using</c>).
+/// </para>
+/// <para>
+/// This accessor requires the host application's DbContext to be registered via
+/// <c>AddDbContextFactory&lt;THost&gt;</c> (which <c>AddGranitDbContext</c> does by
+/// default). Applications wired with <c>AddDbContext&lt;THost&gt;</c> only will not
+/// have the factory available; in that case the orchestrator's atomic path is
+/// unavailable and it falls back to the compensating-write strategy.
+/// </para>
+/// </remarks>
+public interface IAuthorizationHostDbContextAccessor
+{
+    /// <summary>Creates a fresh host DbContext. The caller owns disposal.</summary>
+    Task<DbContext> CreateFreshDbContextAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Persistence.EntityFrameworkCore/SharedConnection/IIdentityDbContextAccessor.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/SharedConnection/IIdentityDbContextAccessor.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Granit.Persistence.EntityFrameworkCore.SharedConnection;
+
+/// <summary>
+/// Exposes the ASP.NET Core Identity <see cref="DbContext"/> instance associated
+/// with the current request scope.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Consumed by <c>IGranitRoleOrchestrator</c> to open a connection-scope transaction
+/// shared with the host-application DbContext (which exposes
+/// <c>IPermissionGrantDbContext</c>) — enabling true atomic dual writes across the
+/// Identity schema (<c>AspNet*</c> tables, <c>GranitRole</c>) and the authorization
+/// schema (<c>authorization_role_metadata</c>, <c>authorization_permission_grants</c>)
+/// without escalating to a distributed transaction manager (MSDTC).
+/// </para>
+/// <para>
+/// The returned context is the same scoped instance consumed by
+/// <see cref="Microsoft.AspNetCore.Identity.RoleManager{T}"/> and
+/// <see cref="Microsoft.AspNetCore.Identity.UserManager{T}"/>. Callers that need a
+/// fresh context for shared-connection plumbing on the host side must use a factory
+/// (see <see cref="IAuthorizationHostDbContextAccessor"/>) — but the Identity side
+/// intentionally stays scoped because Identity's <c>RoleStore</c> / <c>UserStore</c>
+/// bind to whatever scoped instance the DI container resolved at store construction.
+/// </para>
+/// </remarks>
+public interface IIdentityDbContextAccessor
+{
+    /// <summary>The scoped Identity <see cref="DbContext"/> instance for the current request.</summary>
+    DbContext DbContext { get; }
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorAtomicTestApplication.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorAtomicTestApplication.cs
@@ -1,0 +1,107 @@
+using Granit.Authorization.EntityFrameworkCore.Extensions;
+using Granit.Guids.Extensions;
+using Granit.Identity.Local.AspNetIdentity.Internal;
+using Granit.Identity.Local.Domain;
+using Granit.Identity.Local.Services;
+using Granit.Persistence.EntityFrameworkCore.SharedConnection;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// Collection fixture that wires the <see cref="GranitRoleOrchestrator"/> in its
+/// <b>atomic shared-connection transaction</b> mode — both
+/// <see cref="IIdentityDbContextAccessor"/> and <see cref="IAuthorizationHostDbContextAccessor"/>
+/// are registered, and the host DbContext is provided via
+/// <see cref="IDbContextFactory{TContext}"/> (required by the accessor).
+/// </summary>
+/// <remarks>
+/// Complements <see cref="RoleOrchestratorTestApplication"/> which exercises the
+/// compensating-write fallback (no accessors registered).
+/// </remarks>
+public sealed class RoleOrchestratorAtomicTestApplication : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres = new();
+    private ServiceProvider? _services;
+
+    public IServiceProvider Services =>
+        _services ?? throw new InvalidOperationException("Fixture not initialized.");
+
+    public async ValueTask InitializeAsync()
+    {
+        await _postgres.InitializeAsync();
+
+        ServiceCollection services = [];
+
+        services.AddLogging(builder => builder.AddDebug());
+
+        // Identity DbContext registered as scoped (required by RoleManager's RoleStore)
+        // AND as a factory so the shared-connection accessor can ... actually the identity
+        // accessor exposes the scoped instance, so AddDbContext is enough here.
+        services.AddDbContext<TestIdentityDbContext>(opts =>
+            opts.UseNpgsql(_postgres.ConnectionString));
+
+        // Host DbContext registered via factory — the atomic path's IAuthorizationHostDbContextAccessor
+        // requires IDbContextFactory<THost> to create a fresh context for SetDbConnection.
+        services.AddDbContextFactory<TestHostDbContext>(opts =>
+            opts.UseNpgsql(_postgres.ConnectionString));
+
+        services.AddIdentityCore<GranitUser>()
+            .AddRoles<GranitRole>()
+            .AddEntityFrameworkStores<TestIdentityDbContext>();
+
+        services.AddGranitAuthorizationEntityFrameworkCore<TestHostDbContext>();
+        services.AddGranitGuids();
+        services.AddScoped<IGranitRoleOrchestrator, GranitRoleOrchestrator>();
+
+        // Wire the two accessors so the atomic path activates.
+        services.AddScoped<IIdentityDbContextAccessor, TestIdentityDbContextAccessor>();
+        // IAuthorizationHostDbContextAccessor<TestHostDbContext> is already registered
+        // by AddGranitAuthorizationEntityFrameworkCore<TestHostDbContext>() above.
+
+        _services = services.BuildServiceProvider();
+
+        await using AsyncServiceScope scope = _services.CreateAsyncScope();
+        TestIdentityDbContext idCtx = scope.ServiceProvider.GetRequiredService<TestIdentityDbContext>();
+        IDbContextFactory<TestHostDbContext> hostFactory = scope.ServiceProvider
+            .GetRequiredService<IDbContextFactory<TestHostDbContext>>();
+        await using TestHostDbContext hostCtx = await hostFactory.CreateDbContextAsync();
+        await idCtx.Database.EnsureCreatedAsync();
+        await hostCtx.GetService<IRelationalDatabaseCreator>().CreateTablesAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_services is not null)
+        {
+            await _services.DisposeAsync();
+        }
+        await _postgres.DisposeAsync();
+    }
+
+    public async Task ResetDatabaseAsync()
+    {
+        await using AsyncServiceScope scope = Services.CreateAsyncScope();
+        TestIdentityDbContext idCtx = scope.ServiceProvider.GetRequiredService<TestIdentityDbContext>();
+        IDbContextFactory<TestHostDbContext> hostFactory = scope.ServiceProvider
+            .GetRequiredService<IDbContextFactory<TestHostDbContext>>();
+        await using TestHostDbContext hostCtx = await hostFactory.CreateDbContextAsync();
+
+        await hostCtx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE authorization_role_metadata, authorization_permission_grants RESTART IDENTITY CASCADE;");
+        await idCtx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE \"AspNetUserRoles\", \"AspNetRoleClaims\", \"AspNetUserClaims\", \"AspNetUserLogins\", \"AspNetUserTokens\", \"AspNetUsers\", \"AspNetRoles\" RESTART IDENTITY CASCADE;");
+    }
+
+    // Minimal accessor impl that targets the test Identity DbContext.
+    private sealed class TestIdentityDbContextAccessor(TestIdentityDbContext context) : IIdentityDbContextAccessor
+    {
+        public DbContext DbContext => context;
+    }
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorAtomicTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleOrchestratorAtomicTests.cs
@@ -1,0 +1,125 @@
+using Granit.Authorization;
+using Granit.Authorization.Domain;
+using Granit.Identity.Local.Domain;
+using Granit.Identity.Local.Services;
+using Granit.MultiTenancy;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// End-to-end tests for <see cref="GranitRoleOrchestrator"/>'s <b>atomic</b> execution
+/// path — the shared-connection EF Core transaction that commits Identity + metadata
+/// in a single Postgres transaction. Complements <see cref="RoleOrchestratorTests"/>
+/// which exercises the compensating-write fallback.
+/// </summary>
+public sealed class RoleOrchestratorAtomicTests
+    : IClassFixture<RoleOrchestratorAtomicTestApplication>, IAsyncLifetime
+{
+    private readonly RoleOrchestratorAtomicTestApplication _app;
+
+    public RoleOrchestratorAtomicTests(RoleOrchestratorAtomicTestApplication app) => _app = app;
+
+    public ValueTask InitializeAsync() => new(_app.ResetDatabaseAsync());
+
+    public ValueTask DisposeAsync() => default;
+
+    [Fact]
+    public async Task CreateAsync_HappyPath_PersistsBothRowsInSingleTransaction()
+    {
+        await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
+        IGranitRoleOrchestrator orchestrator = scope.ServiceProvider
+            .GetRequiredService<IGranitRoleOrchestrator>();
+        RoleManager<GranitRole> roleManager = scope.ServiceProvider
+            .GetRequiredService<RoleManager<GranitRole>>();
+        IRoleMetadataStore store = scope.ServiceProvider.GetRequiredService<IRoleMetadataStore>();
+
+        RoleMetadata created = await orchestrator.CreateAsync(
+            new CreateRoleCommand(
+                Name: "AtomicManager",
+                MultiTenancySide: MultiTenancySide.Both,
+                TenantId: null,
+                Description: "Verifies atomic commit."),
+            TestContext.Current.CancellationToken);
+
+        created.Name.ShouldBe("AtomicManager");
+
+        GranitRole? identityRole = await roleManager.FindByIdAsync(created.Id.ToString("D"));
+        identityRole.ShouldNotBeNull();
+        identityRole.Name.ShouldBe("AtomicManager");
+
+        RoleMetadata? metadata = await store.FindByIdAsync(created.Id, TestContext.Current.CancellationToken);
+        metadata.ShouldNotBeNull();
+        metadata.Name.ShouldBe("AtomicManager");
+    }
+
+    [Fact]
+    public async Task CreateAsync_MetadataUniqueViolation_RollsBackWithoutCompensation()
+    {
+        // Seed a metadata-only row (via direct factory context, not orchestrator) so the
+        // orchestrator's metadata INSERT later hits the (Name, TenantId, ClientId) unique
+        // index and the whole transaction rolls back atomically.
+        await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
+        IDbContextFactory<TestHostDbContext> hostFactory = scope.ServiceProvider
+            .GetRequiredService<IDbContextFactory<TestHostDbContext>>();
+        await using (TestHostDbContext hostCtx = await hostFactory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            hostCtx.Set<RoleMetadata>().Add(RoleMetadata.Create(
+                Guid.NewGuid(), "Collide", MultiTenancySide.Both, tenantId: null));
+            await hostCtx.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        IGranitRoleOrchestrator orchestrator = scope.ServiceProvider
+            .GetRequiredService<IGranitRoleOrchestrator>();
+        RoleManager<GranitRole> roleManager = scope.ServiceProvider
+            .GetRequiredService<RoleManager<GranitRole>>();
+
+        await Should.ThrowAsync<DbUpdateException>(async () =>
+            await orchestrator.CreateAsync(
+                new CreateRoleCommand("Collide", MultiTenancySide.Both, TenantId: null),
+                TestContext.Current.CancellationToken));
+
+        // Atomic invariant: the Identity INSERT rolled back with the transaction.
+        // There should be ZERO orphan GranitRole — the compensating delete path is
+        // NOT invoked (the transaction rollback handled it natively).
+        GranitRole? orphan = await roleManager.FindByNameAsync("Collide");
+        orphan.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RenameAsync_HappyPath_UpdatesBothRowsAtomically()
+    {
+        // Seed via orchestrator happy path first.
+        await using AsyncServiceScope createScope = _app.Services.CreateAsyncScope();
+        IGranitRoleOrchestrator createOrchestrator = createScope.ServiceProvider
+            .GetRequiredService<IGranitRoleOrchestrator>();
+        RoleMetadata created = await createOrchestrator.CreateAsync(
+            new CreateRoleCommand("Alpha", MultiTenancySide.Both, TenantId: null),
+            TestContext.Current.CancellationToken);
+
+        // Rename in a fresh scope (mirrors production request-per-scope semantics).
+        await using AsyncServiceScope renameScope = _app.Services.CreateAsyncScope();
+        IGranitRoleOrchestrator renameOrchestrator = renameScope.ServiceProvider
+            .GetRequiredService<IGranitRoleOrchestrator>();
+        RoleManager<GranitRole> roleManager = renameScope.ServiceProvider
+            .GetRequiredService<RoleManager<GranitRole>>();
+        IRoleMetadataStore store = renameScope.ServiceProvider.GetRequiredService<IRoleMetadataStore>();
+
+        await renameOrchestrator.RenameAsync(
+            created.Id, newName: "AlphaPrime", newDescription: "renamed",
+            TestContext.Current.CancellationToken);
+
+        GranitRole? identityRole = await roleManager.FindByIdAsync(created.Id.ToString("D"));
+        identityRole.ShouldNotBeNull();
+        identityRole.Name.ShouldBe("AlphaPrime");
+
+        RoleMetadata? metadata = await store.FindByIdAsync(created.Id, TestContext.Current.CancellationToken);
+        metadata.ShouldNotBeNull();
+        metadata.Name.ShouldBe("AlphaPrime");
+        metadata.Description.ShouldBe("renamed");
+    }
+}


### PR DESCRIPTION
## Summary

Upgrades `IGranitRoleOrchestrator` from compensating-write only to a **dual-path** strategy: prefers a true atomic EF Core transaction when both DbContexts target the same physical database; keeps the compensating-write path unchanged as the fallback for deployments that don't satisfy the precondition.

Closes #1097. Full design rationale in [ADR-024](docs-site/src/content/docs/dotnet/architecture/adr/024-role-orchestrator-shared-connection-transaction.md).

## Design highlights

- **Two accessor interfaces** in `Granit.Persistence.EntityFrameworkCore.SharedConnection` — no public exposure of `OpenIddictDbContext`.
- **Asymmetric** accessors: Identity is scoped (RoleManager's RoleStore references the same scoped instance) ; host is **factory-style** (`CreateFreshDbContextAsync`) — eliminates by design the "`SetDbConnection` on warm context" `InvalidOperationException` risk that Gemini flagged during plan review.
- **Provider-agnostic** connection-string comparison via `DbConnectionStringBuilder.EquivalentTo` — works on Npgsql, SQL Server, SQLite, MySQL, any ADO.NET provider.
- Atomic block wrapped in `IExecutionStrategy.ExecuteAsync` so both providers' unconditional `EnableRetryOnFailure(3, 30s)` still applies.
- `ChangeTracker.Clear()` on both contexts at the start of each strategy attempt — retries restart from clean state.
- **Graceful fallback** when: accessors not registered, host factory unresolvable, non-relational provider, or connection strings diverge. Zero regression for Phase 1 deployments.

## BREAKING

None at API level. The orchestrator constructor gains two **optional** parameters with default `null`.

## Documentation update (Gemini follow-up)

Added an explicit caveat to `IRoleMetadataStore` documentation: the orchestrator's atomic path bypasses the store's write methods by design. Consumers adding business logic to `AddAsync` / `UpdateAsync` / `RemoveAsync` must extract it into a domain service called upstream so it runs on both paths.

## Test plan

- [x] `Granit.Identity.Local.AspNetIdentity.Tests.Integration` — 19/19 passing:
  - 3 new atomic scenarios (`RoleOrchestratorAtomicTests`): happy-path persistence, unique-index rollback without compensation, rename happy path.
  - 16 existing tests unchanged (compensating path + endpoints).
- [x] `Granit.Authorization.Tests` — 223 passing.
- [x] `dotnet format --verify-no-changes` on all 5 touched projects: clean.
- [x] `npx markdownlint-cli2` on ADR-024: 0 errors.
- [x] Full-solution `dotnet build`: 0 errors.
- [ ] CI green across all shards (awaits remote run).

## Providers covered

| Provider | Integration tested here |
| -------- | ----------------------- |
| PostgreSQL (Npgsql) | ✅ Testcontainers PG 17 |
| SQL Server | ⚠️ same EF API, smoke test is follow-up (no Granit integration test exercises this path on SQL Server yet) |
| Other relational (SQLite, MySQL Pomelo, …) | Covered by `IExecutionStrategy` abstraction, not explicitly tested |