### PR TITLE
feat(identity-federated-entraid)!: Entra ID App Role distinction + boot-time sync (#1099)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -818,9 +818,12 @@
     {
       "name": "Granit.Identity.Federated.EntraId",
       "deps": [
+        "Granit.Authorization",
         "Granit.Diagnostics",
+        "Granit.Guids",
         "Granit.Http.Resilience",
         "Granit.Identity.Federated",
+        "Granit.Persistence.EntityFrameworkCore",
         "Granit.Timing"
       ],
       "framework": "net10.0"
@@ -17345,7 +17348,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.EntraId",
       "file": "src/Granit.Identity.Federated.EntraId/Extensions/IdentityEntraIdServiceCollectionExtensions.cs",
-      "line": 17,
+      "line": 19,
       "members": [
         {
           "name": "AddGranitIdentityEntraId",
@@ -17436,6 +17439,28 @@
           "kind": "method",
           "signature": "GetTokenEndpoint()",
           "returnType": "string? RopcClientId { get; set; } internal string"
+        }
+      ]
+    },
+    {
+      "name": "EntraIdClientRoleSyncOptions",
+      "fqn": "Granit.Identity.Federated.EntraId.Options.EntraIdClientRoleSyncOptions",
+      "kind": "class",
+      "project": "Granit.Identity.Federated.EntraId",
+      "file": "src/Granit.Identity.Federated.EntraId/Options/EntraIdClientRoleSyncOptions.cs",
+      "line": 9,
+      "members": [
+        {
+          "name": "Enabled",
+          "kind": "property",
+          "signature": "bool Enabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "TrackedAppIds",
+          "kind": "property",
+          "signature": "IReadOnlyList<string> TrackedAppIds",
+          "returnType": "IReadOnlyList<string>"
         }
       ]
     },

--- a/docs-site/src/content/docs/dotnet/architecture/adr/026-entraid-app-role-sync.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/026-entraid-app-role-sync.md
@@ -1,0 +1,162 @@
+---
+title: "ADR-026: Entra ID App Role distinction and boot-time sync"
+description: "Apply the ADR-025 client-role template to Microsoft Entra ID via the Graph API"
+sidebar:
+  order: 26
+  label: "026 - Entra ID app roles"
+---
+
+> **Date:** 2026-04-22
+> **Authors:** Jean-Francois Meyers
+> **Scope:** `Granit.Identity.Federated.EntraId`
+
+## Context
+
+ADR-025 introduced the `IIdentityClientRoleManager` capability interface, the
+additive `IdentityRole.ClientId` property, and the
+`IHostDataSeedContributor`-driven sync pipeline that upserts `RoleMetadata`
+rows with a non-null `ClientId`. Keycloak was the first implementer.
+
+Microsoft Entra ID exposes an equivalent concept — **App Roles** declared on
+an application registration, surfaced at runtime on the associated **Service
+Principal** in the tenant. Assignments live on
+`users/{id}/appRoleAssignments` scoped by `resourceId` (the Service Principal
+object id). This ADR plugs Entra into the ADR-025 template.
+
+## Decision
+
+### Apply the ADR-025 template 1-for-1
+
+`EntraIdIdentityProvider` now implements `IIdentityClientRoleManager` in
+addition to `IIdentityProvider`. `SupportsClientRoles` on
+`EntraIdIdentityProviderCapabilities` returns `true`. Nothing about the
+interface shape, the DIM, or the `IdentityRole.ClientId` field changes — this
+ADR records the Entra-specific bindings only.
+
+### Two-step resolution: appId → Service Principal object id
+
+Entra has two distinct GUIDs for the same app:
+
+- **`appId`** — the OIDC `client_id` (stable across tenants for multi-tenant
+  apps; the one configured in `KeycloakAdmin:ClientRoleSync:TrackedAppIds`).
+- **Service Principal `id`** — the object id of the instantiation of the
+  application in the tenant (used in every Graph URL that touches app roles
+  or assignments).
+
+`GetClientRolesAsync` and `GetUserClientRolesAsync` therefore issue a
+resolution call first:
+
+```text
+GET /v1.0/servicePrincipals
+    ?$filter=appId eq '{appId}'
+    &$select=id,appId,appRoles
+```
+
+The payload carries both `id` (object id) and the inline `appRoles` array, so
+`GetClientRolesAsync` returns without a second round-trip. `GetUserClientRolesAsync`
+re-uses the resolved object id in:
+
+```text
+GET /v1.0/users/{userId}/appRoleAssignments?$filter=resourceId eq {sp.id}
+```
+
+Unknown `appId` → `EntraIdClientNotFoundException` — the sibling of
+`KeycloakClientNotFoundException`. The sync catches it and logs a Warning.
+
+### Disabled App Roles are filtered out
+
+Entra App Roles carry an `isEnabled` flag (admins can deprecate a role
+without deleting it). `GetClientRolesAsync` filters to `isEnabled = true` —
+we only mirror active roles into `RoleMetadata`. Assignments targeting a
+disabled role are silently dropped by `GetUserClientRolesAsync` because the
+role is not in the active role map.
+
+### Configuration — `EntraIdClientRoleSyncOptions`
+
+Bound to `EntraIdAdmin:ClientRoleSync`. Same shape as Keycloak, but the
+tracked list is `appId` GUIDs rather than human client ids:
+
+```json
+{
+  "EntraIdAdmin": {
+    "ClientRoleSync": {
+      "Enabled": true,
+      "TrackedAppIds": [
+        "11111111-1111-1111-1111-111111111111"
+      ]
+    }
+  }
+}
+```
+
+Explicit opt-in is important: Entra tenants host thousands of Service
+Principals — Microsoft built-ins (Office 365, Teams, Defender...), other
+SaaS integrations — none of which are relevant here. Enumerating all of them
+would flood `RoleMetadata`.
+
+### DI — single scoped instance shared across facets
+
+```csharp
+services.AddIdentityProvider<EntraIdIdentityProvider>();  // scoped
+services.TryAddScoped<IIdentityClientRoleManager>(sp =>
+    sp.GetRequiredService<IIdentityProvider>() as IIdentityClientRoleManager
+    ?? throw new InvalidOperationException("..."));
+```
+
+Same pattern as ADR-025; locked by unit test
+`IdentityProvider_And_ClientRoleManager_ResolveToSameScopedInstance`. Sharing
+matters because `EntraIdAdminTokenService` (singleton) caches the admin
+token — doubling the provider would double the token-acquisition traffic and
+split internal scoped state.
+
+### Failure policy — log & skip (identical to ADR-025)
+
+Sync never crashes host startup. Per-app failures:
+
+- Graph unreachable (`HttpRequestException` / `TaskCanceledException`) → log Warning, continue.
+- 403 Forbidden on `/servicePrincipals` → log **Error** with the required
+  Graph permissions (`Application.Read.All`, `AppRoleAssignment.ReadWrite.All`),
+  continue.
+- `EntraIdClientNotFoundException` (tracked appId not in the tenant) → log Warning, continue.
+
+## Required Microsoft Graph application permissions
+
+The admin client configured via `EntraIdAdmin:ClientId` / `ClientSecret`
+needs the following **Application** permissions (not Delegated), granted with
+admin consent:
+
+| Permission | Purpose |
+| ---------- | ------- |
+| `Application.Read.All` | List Service Principals and project their `appRoles`. |
+| `AppRoleAssignment.ReadWrite.All` | Read user App Role assignments (phase 2a); also covers future assignment writes. |
+
+Existing `EntraIdAdminOptions` remarks already document the broader permission
+set required by the provider — this ADR adds no new permission on top.
+
+## Consequences
+
+### Positive
+
+- Entra App Roles now round-trip cleanly through the authorization engine
+  just like Keycloak client roles.
+- `Granit.Identity.Federated.EntraId` stays aligned with the ADR-025 template —
+  Cognito (#1100) will drop in the same way.
+- Disabled App Roles are never written to `RoleMetadata`, so Entra admins can
+  deprecate roles without orphaning grants immediately (grants on a
+  now-disabled role remain but lookups stop resolving — matches Entra's own
+  runtime behavior).
+
+### Negative
+
+- `Granit.Identity.Federated.EntraId` gains project references to
+  `Granit.Authorization`, `Granit.Guids`, and `Granit.Persistence.EntityFrameworkCore`
+  to host the sync service — same trade-off as ADR-025.
+- An extra Graph call per tracked app at boot (`servicePrincipals?$filter=appId eq ...`).
+  Acceptable given the opt-in model and the low cardinality of the tracked list.
+
+## References
+
+- ADR-025 — Keycloak client-role sync (the template this ADR follows).
+- #1099 — this ADR's implementing PR.
+- [Microsoft Graph — servicePrincipal resource type](https://learn.microsoft.com/graph/api/resources/serviceprincipal)
+- [Microsoft Graph — appRoleAssignment resource type](https://learn.microsoft.com/graph/api/resources/approleassignment)

--- a/docs-site/src/data/constants.ts
+++ b/docs-site/src/data/constants.ts
@@ -5,4 +5,4 @@ export const CULTURE_COUNT = 18;
 export const BASE_LANGUAGE_COUNT = 15;
 export const REGIONAL_VARIANT_COUNT = 3;
 export const PATTERN_COUNT = 57;
-export const ADR_COUNT = 25;
+export const ADR_COUNT = 26;

--- a/src/Granit.Identity.Federated.EntraId/Diagnostics/IdentityEntraIdActivitySource.cs
+++ b/src/Granit.Identity.Federated.EntraId/Diagnostics/IdentityEntraIdActivitySource.cs
@@ -25,6 +25,9 @@ internal static class IdentityEntraIdActivitySource
 
     internal const string GetUsers = "identity.entraid.get-users";
     internal const string GetUser = "identity.entraid.get-user";
+    internal const string GetClients = "identity.entraid.get-clients";
+    internal const string GetClientRoles = "identity.entraid.get-client-roles";
+    internal const string GetUserClientRoles = "identity.entraid.get-user-client-roles";
     internal const string SetUserEnabled = "identity.entraid.set-user-enabled";
     internal const string UpdateUser = "identity.entraid.update-user";
     internal const string GetUserSessions = "identity.entraid.get-user-sessions";
@@ -47,6 +50,7 @@ internal static class IdentityEntraIdActivitySource
     internal const string TagUserId = "identity.user_id";
     internal const string TagRoleName = "identity.role_name";
     internal const string TagGroupId = "identity.group_id";
+    internal const string TagClientId = "identity.client_id";
 
 #pragma warning disable GRSEC003 // Operation name constants, not secrets
     internal const string GetPasswordChangedAt = "identity.entraid.get-password-changed-at";

--- a/src/Granit.Identity.Federated.EntraId/Exceptions/EntraIdClientNotFoundException.cs
+++ b/src/Granit.Identity.Federated.EntraId/Exceptions/EntraIdClientNotFoundException.cs
@@ -1,0 +1,21 @@
+namespace Granit.Identity.Federated.EntraId.Exceptions;
+
+/// <summary>
+/// Thrown by <c>EntraIdIdentityProvider</c> client-role methods when the OIDC
+/// <c>appId</c> passed by the caller does not resolve to any Service Principal in the
+/// configured tenant.
+/// </summary>
+/// <remarks>
+/// Sibling of <c>KeycloakClientNotFoundException</c> in the Keycloak provider — the sync
+/// pipeline catches it and logs a Warning before skipping the client.
+/// </remarks>
+internal sealed class EntraIdClientNotFoundException : Exception
+{
+    public EntraIdClientNotFoundException(string appId)
+        : base($"No Service Principal found with appId '{appId}' in the configured Entra tenant.")
+    {
+        AppId = appId;
+    }
+
+    public string AppId { get; }
+}

--- a/src/Granit.Identity.Federated.EntraId/Extensions/IdentityEntraIdServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.Federated.EntraId/Extensions/IdentityEntraIdServiceCollectionExtensions.cs
@@ -3,7 +3,9 @@ using Granit.Http.Resilience.Extensions;
 using Granit.Identity.Extensions;
 using Granit.Identity.Federated.EntraId.HealthChecks;
 using Granit.Identity.Federated.EntraId.Internal;
+using Granit.Identity.Federated.EntraId.Internal.Sync;
 using Granit.Identity.Federated.EntraId.Options;
+using Granit.Persistence.EntityFrameworkCore.DataSeeding;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -58,6 +60,24 @@ public static class IdentityEntraIdServiceCollectionExtensions
         services.TryAddScoped<IPasswordResetNotifier, NullPasswordResetNotifier>();
         services.AddIdentityProvider<EntraIdIdentityProvider>();
         services.Replace(ServiceDescriptor.Scoped<IIdentityProviderCapabilities, EntraIdIdentityProviderCapabilities>());
+
+        // Client-role capability (Phase 2). Forwards to the scoped IIdentityProvider so
+        // IIdentityProvider and IIdentityClientRoleManager resolve to the SAME scoped
+        // EntraIdIdentityProvider instance — avoids doubling Graph admin-token acquisition
+        // and keeps internal state coherent across the two facets.
+        services.TryAddScoped<IIdentityClientRoleManager>(sp =>
+            sp.GetRequiredService<IIdentityProvider>() as IIdentityClientRoleManager
+            ?? throw new InvalidOperationException(
+                "The registered IIdentityProvider does not implement IIdentityClientRoleManager — " +
+                "AddGranitIdentityEntraId must be the last provider-registration call."));
+
+        // Client-role sync pipeline — enumerates Entra ID App Roles for each tracked appId
+        // at host boot and upserts RoleMetadata rows. See ADR-026 for details.
+        services.AddOptions<EntraIdClientRoleSyncOptions>()
+            .BindConfiguration(EntraIdClientRoleSyncOptions.SectionName);
+
+        services.TryAddScoped<EntraIdClientRoleSyncService>();
+        services.AddTransient<IHostDataSeedContributor, EntraIdClientRoleSyncContributor>();
 
         return services;
     }

--- a/src/Granit.Identity.Federated.EntraId/Granit.Identity.Federated.EntraId.csproj
+++ b/src/Granit.Identity.Federated.EntraId/Granit.Identity.Federated.EntraId.csproj
@@ -18,9 +18,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
     <ProjectReference Include="..\Granit.Diagnostics\Granit.Diagnostics.csproj" />
+    <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
     <ProjectReference Include="..\Granit.Http.Resilience\Granit.Http.Resilience.csproj" />
     <ProjectReference Include="..\Granit.Identity.Federated\Granit.Identity.Federated.csproj" />
+    <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />
   </ItemGroup>
 

--- a/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProvider.cs
@@ -4,9 +4,11 @@ using System.Net.Http.Json;
 using System.Security.Cryptography;
 using Granit.Diagnostics;
 using Granit.Events;
+using Granit.Identity;
 using Granit.Identity.Events;
 using Granit.Identity.Federated;
 using Granit.Identity.Federated.EntraId.Diagnostics;
+using Granit.Identity.Federated.EntraId.Exceptions;
 using Granit.Identity.Federated.EntraId.Options;
 using Granit.Identity.Models;
 using Microsoft.Extensions.Logging;
@@ -35,7 +37,7 @@ internal sealed partial class EntraIdIdentityProvider(
     IOptions<EntraIdAdminOptions> options,
     IPasswordResetNotifier passwordResetNotifier,
     IDistributedEventBus distributedEventBus,
-    ILogger<EntraIdIdentityProvider> logger) : IIdentityProvider
+    ILogger<EntraIdIdentityProvider> logger) : IIdentityProvider, IIdentityClientRoleManager
 {
     /// <inheritdoc/>
     public async Task<IReadOnlyList<IIdentityUser>> GetUsersAsync(
@@ -496,6 +498,120 @@ internal sealed partial class EntraIdIdentityProvider(
         await distributedEventBus.PublishAsync(new IdentityRoleRemovedEto(userId, roleName), cancellationToken).ConfigureAwait(false);
 
         LogRoleRemoved(roleName, userId);
+    }
+
+    // ──── Phase 2: Client role support (IIdentityClientRoleManager) ────
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<string>> GetClientsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        using Activity? activity = IdentityEntraIdActivitySource.Source.StartActivity(IdentityEntraIdActivitySource.GetClients);
+
+        try
+        {
+            HttpClient client = await CreateAuthenticatedClientAsync(cancellationToken).ConfigureAwait(false);
+            string endpoint = EntraIdAdminOptions.GetServicePrincipalsEndpoint();
+
+            GraphCollectionResponse<GraphServicePrincipalRepresentation>? response = await client
+                .GetFromJsonAsync<GraphCollectionResponse<GraphServicePrincipalRepresentation>>(endpoint, cancellationToken)
+                .ConfigureAwait(false);
+
+            return response?.Value is { } sps
+                ? sps.Where(sp => !string.IsNullOrEmpty(sp.AppId)).Select(sp => sp.AppId!).ToList()
+                : [];
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            LogEntraIdGetClientsFailed(ex);
+            return [];
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<IdentityRole>> GetClientRolesAsync(
+        string clientId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
+
+        using Activity? activity = IdentityEntraIdActivitySource.Source.StartActivity(IdentityEntraIdActivitySource.GetClientRoles);
+        activity?.SetTag(IdentityEntraIdActivitySource.TagClientId, clientId);
+
+        HttpClient client = await CreateAuthenticatedClientAsync(cancellationToken).ConfigureAwait(false);
+        GraphServicePrincipalRepresentation sp = await ResolveServicePrincipalAsync(client, clientId, cancellationToken).ConfigureAwait(false);
+
+        if (sp.AppRoles is null or { Count: 0 })
+        {
+            return [];
+        }
+
+        return sp.AppRoles
+            .Where(r => r.IsEnabled)
+            .Select(r => new IdentityRole(r.Id, r.Value, r.Description) { ClientId = clientId })
+            .ToList();
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<IdentityRole>> GetUserClientRolesAsync(
+        string userId,
+        string clientId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
+
+        using Activity? activity = IdentityEntraIdActivitySource.Source.StartActivity(IdentityEntraIdActivitySource.GetUserClientRoles);
+        activity?.SetTag(IdentityEntraIdActivitySource.TagUserId, userId);
+        activity?.SetTag(IdentityEntraIdActivitySource.TagClientId, clientId);
+
+        HttpClient client = await CreateAuthenticatedClientAsync(cancellationToken).ConfigureAwait(false);
+        GraphServicePrincipalRepresentation sp = await ResolveServicePrincipalAsync(client, clientId, cancellationToken).ConfigureAwait(false);
+        var roleMap = (sp.AppRoles ?? [])
+            .ToDictionary(r => r.Id, StringComparer.OrdinalIgnoreCase);
+
+        try
+        {
+            string endpoint = EntraIdAdminOptions.GetUserAppRoleAssignmentsForServicePrincipalEndpoint(userId, sp.Id);
+            GraphCollectionResponse<GraphAppRoleAssignmentRepresentation>? response = await client
+                .GetFromJsonAsync<GraphCollectionResponse<GraphAppRoleAssignmentRepresentation>>(endpoint, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (response?.Value is null)
+            {
+                return [];
+            }
+
+            return response.Value
+                .Select(a => roleMap.TryGetValue(a.AppRoleId, out GraphAppRoleRepresentation? role) ? role : null)
+                .Where(r => r is not null)
+                .Select(r => new IdentityRole(r!.Id, r.Value, r.Description) { ClientId = clientId })
+                .ToList();
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            LogEntraIdGetUserClientRolesFailed(ex, userId, clientId);
+            return [];
+        }
+    }
+
+    private static async Task<GraphServicePrincipalRepresentation> ResolveServicePrincipalAsync(
+        HttpClient client,
+        string appId,
+        CancellationToken cancellationToken)
+    {
+        string endpoint = EntraIdAdminOptions.GetServicePrincipalsEndpoint(appId);
+        GraphCollectionResponse<GraphServicePrincipalRepresentation>? response = await client
+            .GetFromJsonAsync<GraphCollectionResponse<GraphServicePrincipalRepresentation>>(endpoint, cancellationToken)
+            .ConfigureAwait(false);
+
+        GraphServicePrincipalRepresentation? match = response?.Value is { } sps
+            ? sps.FirstOrDefault(sp => string.Equals(sp.AppId, appId, StringComparison.OrdinalIgnoreCase))
+            : null;
+
+        return match ?? throw new EntraIdClientNotFoundException(appId);
     }
 
     // ──── Session termination ────
@@ -970,6 +1086,12 @@ internal sealed partial class EntraIdIdentityProvider(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to get roles for user {UserId} from Entra ID. Returning empty list")]
     private partial void LogGetUserRolesFailed(Exception exception, string userId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to get Service Principals from Entra ID. Returning empty list")]
+    private partial void LogEntraIdGetClientsFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to get app-role assignments for user {UserId} on client {ClientId} from Entra ID. Returning empty list")]
+    private partial void LogEntraIdGetUserClientRolesFailed(Exception exception, string userId, string clientId);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Role {RoleName} assigned to user {UserId} in Entra ID")]
     private partial void LogRoleAssigned(string roleName, string userId);

--- a/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProviderCapabilities.cs
+++ b/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProviderCapabilities.cs
@@ -54,4 +54,12 @@ internal sealed class EntraIdIdentityProviderCapabilities : IIdentityProviderCap
 
     /// <inheritdoc/>
     public bool IsLocalStore => false;
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Entra ID's "client roles" are <b>App Roles</b> declared on an Application /
+    /// Service Principal. Surfaced via <c>IIdentityClientRoleManager</c> on
+    /// <see cref="EntraIdIdentityProvider"/>.
+    /// </remarks>
+    public bool SupportsClientRoles => true;
 }

--- a/src/Granit.Identity.Federated.EntraId/Internal/GraphServicePrincipalRepresentation.cs
+++ b/src/Granit.Identity.Federated.EntraId/Internal/GraphServicePrincipalRepresentation.cs
@@ -3,8 +3,20 @@ using System.Text.Json.Serialization;
 namespace Granit.Identity.Federated.EntraId.Internal;
 
 /// <summary>
-/// Internal DTO for Microsoft Graph API Service Principal representation (subset for appRoles).
+/// Internal DTO for Microsoft Graph API Service Principal representation (subset).
 /// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Id"/> is the Entra <b>object ID</b> (a GUID, stable within the tenant).
+/// <see cref="AppId"/> is the OIDC <b>client_id</b> (also a GUID, shared across tenants for
+/// multi-tenant apps) — this is what Phase 2 client-role sync matches against when resolving
+/// a tracked application to its Service Principal's <see cref="AppRoles"/>.
+/// </para>
+/// </remarks>
 internal sealed record GraphServicePrincipalRepresentation(
     [property: JsonPropertyName("id")] string Id,
-    [property: JsonPropertyName("appRoles")] List<GraphAppRoleRepresentation>? AppRoles = null);
+    [property: JsonPropertyName("appRoles")] List<GraphAppRoleRepresentation>? AppRoles = null)
+{
+    [JsonPropertyName("appId")]
+    public string? AppId { get; init; }
+}

--- a/src/Granit.Identity.Federated.EntraId/Internal/Sync/EntraIdClientRoleSyncContributor.cs
+++ b/src/Granit.Identity.Federated.EntraId/Internal/Sync/EntraIdClientRoleSyncContributor.cs
@@ -1,0 +1,15 @@
+using Granit.Persistence.EntityFrameworkCore.DataSeeding;
+
+namespace Granit.Identity.Federated.EntraId.Internal.Sync;
+
+/// <summary>
+/// Host-level data seed contributor that triggers
+/// <see cref="EntraIdClientRoleSyncService.SyncAsync(CancellationToken)"/> at boot.
+/// Mirrors <c>KeycloakClientRoleSyncContributor</c> (ADR-025).
+/// </summary>
+internal sealed class EntraIdClientRoleSyncContributor(
+    EntraIdClientRoleSyncService syncService) : IHostDataSeedContributor
+{
+    public Task SeedAsync(DataSeedContext context, CancellationToken cancellationToken = default) =>
+        syncService.SyncAsync(cancellationToken);
+}

--- a/src/Granit.Identity.Federated.EntraId/Internal/Sync/EntraIdClientRoleSyncService.cs
+++ b/src/Granit.Identity.Federated.EntraId/Internal/Sync/EntraIdClientRoleSyncService.cs
@@ -1,0 +1,134 @@
+using Granit.Authorization;
+using Granit.Authorization.Domain;
+using Granit.Guids;
+using Granit.Identity;
+using Granit.Identity.Federated.EntraId.Exceptions;
+using Granit.Identity.Federated.EntraId.Options;
+using Granit.Identity.Models;
+using Granit.MultiTenancy;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Identity.Federated.EntraId.Internal.Sync;
+
+/// <summary>
+/// Pure sync logic — enumerates Entra App Roles for every tracked application and
+/// upserts matching <see cref="RoleMetadata"/> rows. Idempotent via the
+/// <c>(Name, TenantId, ClientId)</c> unique index. Failure policy: log &amp; skip.
+/// </summary>
+internal sealed partial class EntraIdClientRoleSyncService(
+    IIdentityClientRoleManager clientRoleManager,
+    IRoleMetadataStore roleMetadataStore,
+    IGuidGenerator guidGenerator,
+    IOptions<EntraIdClientRoleSyncOptions> options,
+    ILogger<EntraIdClientRoleSyncService> logger)
+{
+    public async Task SyncAsync(CancellationToken cancellationToken)
+    {
+        EntraIdClientRoleSyncOptions opts = options.Value;
+
+        if (!opts.Enabled)
+        {
+            LogDisabled(logger);
+            return;
+        }
+
+        if (opts.TrackedAppIds.Count == 0)
+        {
+            LogNoTrackedApps(logger);
+            return;
+        }
+
+        foreach (string appId in opts.TrackedAppIds)
+        {
+            await SyncAppAsync(appId, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task SyncAppAsync(string appId, CancellationToken cancellationToken)
+    {
+        IReadOnlyList<IdentityRole> roles;
+        try
+        {
+            roles = await clientRoleManager.GetClientRolesAsync(appId, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (EntraIdClientNotFoundException)
+        {
+            LogAppNotFound(logger, appId);
+            return;
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Forbidden)
+        {
+            LogForbidden(logger, ex, appId);
+            return;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            LogAppSyncFailed(logger, ex, appId);
+            return;
+        }
+
+        int added = 0;
+        int updated = 0;
+        int unchanged = 0;
+
+        foreach (IdentityRole role in roles)
+        {
+            RoleMetadata? existing = await roleMetadataStore
+                .FindByNameAsync(role.Name, tenantId: null, clientId: appId, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (existing is null)
+            {
+                var metadata = RoleMetadata.Create(
+                    id: guidGenerator.Create(),
+                    name: role.Name,
+                    multiTenancySide: MultiTenancySide.Host,
+                    tenantId: null,
+                    clientId: appId,
+                    description: role.Description,
+                    isSystem: false);
+
+                await roleMetadataStore.AddAsync(metadata, cancellationToken).ConfigureAwait(false);
+                added++;
+            }
+            else if (!string.Equals(existing.Description, role.Description, StringComparison.Ordinal))
+            {
+                existing.Rename(existing.Name, role.Description);
+                await roleMetadataStore.UpdateAsync(existing, cancellationToken).ConfigureAwait(false);
+                updated++;
+            }
+            else
+            {
+                unchanged++;
+            }
+        }
+
+        LogAppSynced(logger, appId, added, updated, unchanged);
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "Entra ID client-role sync disabled — skipping.")]
+    private static partial void LogDisabled(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Entra ID client-role sync enabled but no TrackedAppIds configured — skipping.")]
+    private static partial void LogNoTrackedApps(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Entra ID: no Service Principal found for appId '{AppId}' — skipping sync for this app.")]
+    private static partial void LogAppNotFound(ILogger logger, string appId);
+
+    [LoggerMessage(Level = LogLevel.Error,
+        Message = "Microsoft Graph returned 403 for appId '{AppId}'. The service principal needs Application permissions: Application.Read.All (for listing), AppRoleAssignment.ReadWrite.All (for user assignments).")]
+    private static partial void LogForbidden(ILogger logger, Exception exception, string appId);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Entra ID client-role sync failed for appId '{AppId}'; continuing with the next tracked app.")]
+    private static partial void LogAppSyncFailed(ILogger logger, Exception exception, string appId);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Entra ID client-role sync for '{AppId}' completed: {Added} added, {Updated} updated, {Unchanged} unchanged.")]
+    private static partial void LogAppSynced(ILogger logger, string appId, int added, int updated, int unchanged);
+}

--- a/src/Granit.Identity.Federated.EntraId/Options/EntraIdAdminOptions.cs
+++ b/src/Granit.Identity.Federated.EntraId/Options/EntraIdAdminOptions.cs
@@ -152,6 +152,31 @@ public sealed class EntraIdAdminOptions
     internal static string GetUserAppRoleAssignmentsEndpoint(string userId) =>
         $"/v1.0/users/{Uri.EscapeDataString(userId)}/appRoleAssignments";
 
+    // ──── Client-role sync (Phase 2) ────
+
+    /// <summary>
+    /// Builds the Graph API URL for listing Service Principals. Optionally filters by
+    /// <paramref name="appId"/> to resolve the Service Principal <c>id</c> (object id) from an
+    /// OIDC <c>appId</c>. Returns `$select=id,appId,appRoles` so the caller can project
+    /// both the object id and the inline <c>appRoles</c> array without a second call.
+    /// </summary>
+    internal static string GetServicePrincipalsEndpoint(string? appId = null)
+    {
+        const string select = "$select=id,appId,appRoles";
+        return appId is null
+            ? $"/v1.0/servicePrincipals?{select}"
+            : $"/v1.0/servicePrincipals?$filter=appId eq '{Uri.EscapeDataString(appId)}'&{select}";
+    }
+
+    /// <summary>
+    /// Builds the Graph API URL for listing App Role assignments of a user scoped to a given
+    /// Service Principal (identified by its object id — NOT the OIDC <c>appId</c>).
+    /// </summary>
+    internal static string GetUserAppRoleAssignmentsForServicePrincipalEndpoint(
+        string userId, string servicePrincipalObjectId) =>
+        $"/v1.0/users/{Uri.EscapeDataString(userId)}/appRoleAssignments" +
+        $"?$filter=resourceId eq {servicePrincipalObjectId}";
+
     // ──── Sessions ────
 
     /// <summary>

--- a/src/Granit.Identity.Federated.EntraId/Options/EntraIdClientRoleSyncOptions.cs
+++ b/src/Granit.Identity.Federated.EntraId/Options/EntraIdClientRoleSyncOptions.cs
@@ -1,0 +1,27 @@
+namespace Granit.Identity.Federated.EntraId.Options;
+
+/// <summary>
+/// Configuration for the Entra ID app-role sync pipeline. Populates
+/// <c>RoleMetadata.ClientId</c> with the App Roles declared on the listed
+/// applications — so grants can target them and <c>IGranitRoleLookup.FindByNameAsync</c>
+/// can distinguish realm-style roles from app-scope roles.
+/// </summary>
+public sealed class EntraIdClientRoleSyncOptions
+{
+    /// <summary>Configuration section: <c>EntraIdAdmin:ClientRoleSync</c>.</summary>
+    public const string SectionName = "EntraIdAdmin:ClientRoleSync";
+
+    /// <summary>
+    /// When <see langword="false"/>, the sync contributor becomes a no-op even if tracked
+    /// app ids are configured. Default: <see langword="true"/>.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// OIDC <c>appId</c>s (GUID strings, as seen in the application registration) whose
+    /// App Roles should be mirrored into <c>RoleMetadata</c>. Opt-in: the sync never
+    /// enumerates every Service Principal in the tenant — Entra has thousands of them
+    /// (Microsoft's built-in apps, other SaaS integrations) that have no relevance here.
+    /// </summary>
+    public IReadOnlyList<string> TrackedAppIds { get; set; } = [];
+}

--- a/src/Granit.Identity.Federated.EntraId/packages.lock.json
+++ b/src/Granit.Identity.Federated.EntraId/packages.lock.json
@@ -11,41 +11,51 @@
       "Microsoft.Extensions.Diagnostics.HealthChecks": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "G6AVN2vs66Gu8IkB2FwsVJRpIkkTmPJ+NmAUH7+N+VGGI6qK38OXMZLipjCaOYdj2DW6ge2IIXdwZjhNJefD0w==",
+        "resolved": "10.0.7",
+        "contentHash": "hs9YULcNhj1UiPjhNoJIDBWS92GvAVzT6DyuvbkoxvDcASZUQFVwQ9EAKtgrOfTaI0Vy6U6RwycXko1SIESM8w==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "FbWxJqgUUQosm/tZEnjbdS2EfE+kBT5C8AQdWJsOtpgAR82gNGdfnYF4ZyHReGa7wpNltBB/GFKWMr9GlVuZbw==",
+        "resolved": "10.0.7",
+        "contentHash": "1wbd+RPhRo3hJKNJhdGEO5ls0LGe55Ho4BUjlFtRUrWxDVVBd7g0Ydq9fbNy86pmvx/j7AGcSPo7YNCo1IRI6Q==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Diagnostics": "10.0.6",
-          "Microsoft.Extensions.Logging": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Direct",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "O7xt1vYMxku2+/WpFkh6X8RzUtYbKR+XCt0KOO0W9TbRbFeQdfb9Nry/CdVq57kOyOKS3Z4qD1xqV/8LpJQ0Xw==",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
@@ -68,27 +78,27 @@
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "lYQ9S1FGXIWIU7243RimdAXQYsFDeLhSSZvbSDwbeI/kCzZ4MIYXpp3kMQ+bDJXwl9pzMRIYkd4f9zGqcYxfAQ==",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "a7bA7IT3ngIgcOMb/2MVH5CcfSxUCeQ6QXWS1Vt6oFpzLTH3U1+J2Xtc64Uw3whX9akYG8eR/UQeEzxo64zZLg==",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "poUvwtf92bEs8uBH3aRRs/ZgiAw+Z485EU7TtVPBt//MmD0uMPERe7+v3Ur7lpD8XgIEDL9sDoTBcW1LMG97CQ==",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection.AutoActivation": {
@@ -101,21 +111,21 @@
       },
       "Microsoft.Extensions.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "vbigpAOKX+Bbm2uJQ/AqXqONEPPB3ZYkynRT24vo5ZWF1rzKPtVjpkQkJx5qTGp2dqNV5In9QqboayqmKdvGUA==",
+        "resolved": "10.0.7",
+        "contentHash": "l+smp1qPlU0OUXD0OGfdp7OUFrbdq7ZaP5T7m2WpfZ4RFKD7iG73BAT7tjSMxNmbSXkhAn1jYHOAqzYG1r9sNg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.6",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.6"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L98Xe5C+xyKytLNLiEyQ0rcY8GNXAeAn1xKsE0YDxPx/mXBYYtRoj8pC2cnbSFQUlOzBkyO90ivMSV22SRETFg==",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
@@ -128,15 +138,15 @@
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "ChhUF6HVSz9DwBgTyHtWbGzH8kWMbEFS7gqrqBnZQhHJFFK7L1k5BX7UCiIHiCap5HEDS6bZYks79JK4c+H0GQ=="
+        "resolved": "10.0.7",
+        "contentHash": "8Oq/03og7ihwbfx+EjfWhYCdMldClxqnqB9w5ZI4KxuhoiUVDxZYVl06K7fhROOoelhKOtnCUtATCqTCrqSGmA=="
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "iU/lPyrjHVA4jJ7Bl/VpXvgsAD4qJWc4oPSVJjMBeZjmv7IIo8wBKxnOUoXdZcSCUJ6MeBMs3WpXNfncO7OzRg==",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http.Diagnostics": {
@@ -150,12 +160,12 @@
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "ZjpnbMD88IcZQE2pE9lcGv3mkH2mlApPWNh88ya1wJpcxZLp7p4aN7twI2FpawGPAsXNpmMgtKaz3o796YWKWQ==",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging.Configuration": {
@@ -180,8 +190,8 @@
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L8P21mqaG+CXvPheLndean/cHCOcItJqH8nx+0YQnK7wAiOR0G1IOC418ZSzTMD2D6Gmo0f2M5WR70XtpX2B8g=="
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
       "Microsoft.Extensions.Resilience": {
         "type": "Transitive",
@@ -251,6 +261,30 @@
       "granit": {
         "type": "Project"
       },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -261,6 +295,20 @@
         "type": "Project",
         "dependencies": {
           "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.http.resilience": {
@@ -285,6 +333,27 @@
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -299,33 +368,90 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "h22Fm4VxRmr4ty9rxJaW0i51xD56Bl5QhQ2hsGY2vl+6FioWmBhkpg3B78XQaK25N+hE41gZLZuYKGQS+OGbdw==",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.6",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "w+dX4SIr1X9yegX2yX2dU1XtP4JAUVNdvOG/Evn+H+ndn96YzfIPX52FALXChrRNWFR9l77FQyg1mB7WQo6iOA=="
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
+        }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "x3C8tgsX+xWvV5u76LFm24/U7sSnCRjuudBkbFsMV/DIqCA85te7YGg6dpa7lBToDhi4Lry9E7Arpy0laUw5AQ==",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.6",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http.Resilience": {
@@ -342,20 +468,54 @@
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "1YgBO3wAy0dlpQyVTKWBSPND/t0yZHsvd3shGpbeEwH8JSb2hnFI2pNFrOOUi/stsp+T/dqwqmRIGh47ibo9bw==",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "v5RTWm+3Gdub21ADJeRG5bunOOxutFNBZk6qGH6Az4L5nyRZoLe3Kse7jfAyUcdEoiKp72XpNw/wGR+9wP+MtQ==",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.14.0",
+        "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
         }
       }
     }

--- a/src/Granit.Identity.Federated.Keycloak/Exceptions/KeycloakClientNotFoundException.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Exceptions/KeycloakClientNotFoundException.cs
@@ -1,4 +1,4 @@
-namespace Granit.Identity.Federated.Keycloak.Internal;
+namespace Granit.Identity.Federated.Keycloak.Exceptions;
 
 /// <summary>
 /// Thrown by <c>KeycloakIdentityProvider</c> client-role methods when the OIDC <c>client_id</c>

--- a/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
@@ -7,6 +7,7 @@ using Granit.Identity.Diagnostics;
 using Granit.Identity.Events;
 using Granit.Identity.Federated;
 using Granit.Identity.Federated.Keycloak.Diagnostics;
+using Granit.Identity.Federated.Keycloak.Exceptions;
 using Granit.Identity.Federated.Keycloak.Options;
 using Granit.Identity.Models;
 using Microsoft.Extensions.Logging;

--- a/src/Granit.Identity.Federated.Keycloak/Internal/Sync/KeycloakClientRoleSyncService.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Internal/Sync/KeycloakClientRoleSyncService.cs
@@ -2,6 +2,7 @@ using Granit.Authorization;
 using Granit.Authorization.Domain;
 using Granit.Guids;
 using Granit.Identity;
+using Granit.Identity.Federated.Keycloak.Exceptions;
 using Granit.Identity.Federated.Keycloak.Options;
 using Granit.Identity.Models;
 using Granit.MultiTenancy;

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -23,11 +23,11 @@
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
-        "resolved": "18.4.0",
-        "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
+        "resolved": "18.5.0",
+        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.4.0",
-          "Microsoft.TestPlatform.TestHost": "18.4.0"
+          "Microsoft.CodeCoverage": "18.5.0",
+          "Microsoft.TestPlatform.TestHost": "18.5.0"
         }
       },
       "Shouldly": {
@@ -533,8 +533,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "9O0BtCfzCWrkAmK187ugKdq72HHOXoOUjuWFDVc2LsZZ0pOnA9bTt+Sg9q4cF+MoAaUU+MuWtvBuFsnduviJow=="
+        "resolved": "18.5.0",
+        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
       },
       "Microsoft.Data.SqlClient": {
         "type": "Transitive",
@@ -788,15 +788,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "4L6m2kS2pY5uJ9cpeRxzW22opr6ttScIRqsOpMDQpgENp/ZwxkkQCcmc6LRSURo2dFaaSW5KVflQZvroiJ7Wzg=="
+        "resolved": "18.5.0",
+        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "gZsCHI+zOmZCcKZieIL4Jg14qKD2OGZOmX5DehuIk1EA9BN6Crm0+taXQNEuajOH1G9CCyBxw8VWR4t5tumcng==",
+        "resolved": "18.5.0",
+        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -2147,9 +2147,12 @@
       "granit.identity.federated.entraid": {
         "type": "Project",
         "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Diagnostics": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.Resilience": "[0.1.0-dev, )",
           "Granit.Identity.Federated": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
@@ -2163,9 +2166,12 @@
       "granit.identity.federated.keycloak": {
         "type": "Project",
         "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Diagnostics": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.Resilience": "[0.1.0-dev, )",
           "Granit.Identity.Federated": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },

--- a/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdClientRoleTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdClientRoleTests.cs
@@ -1,0 +1,170 @@
+using System.Diagnostics;
+using Granit.Events;
+using Granit.Identity;
+using Granit.Identity.Federated.EntraId.Exceptions;
+using Granit.Identity.Federated.EntraId.Internal;
+using Granit.Identity.Federated.EntraId.Options;
+using Granit.Identity.Models;
+using Granit.Timing;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Federated.EntraId.Tests;
+
+/// <summary>
+/// Covers Phase 2 <see cref="IIdentityClientRoleManager"/> methods on
+/// <see cref="EntraIdIdentityProvider"/> — HTTP mock-based, same pattern as
+/// <c>EntraIdIdentityProviderTests</c>.
+/// </summary>
+[Collection("EntraIdActivitySource")]
+public sealed class EntraIdClientRoleTests : IDisposable
+{
+    private readonly EntraIdAdminOptions _options = new()
+    {
+        TenantId = "test-tenant-id",
+        ClientId = "admin-service",
+        ClientSecret = "secret",
+        ServicePrincipalObjectId = "sp-object-id",
+    };
+
+    private readonly IHttpClientFactory _httpClientFactory = Substitute.For<IHttpClientFactory>();
+    private readonly IPasswordResetNotifier _passwordResetNotifier = Substitute.For<IPasswordResetNotifier>();
+    private readonly IDistributedEventBus _distributedEventBus = Substitute.For<IDistributedEventBus>();
+    private readonly ActivityListener _activityListener;
+
+    public EntraIdClientRoleTests()
+    {
+        _activityListener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Granit.Identity.EntraId",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+        };
+        ActivitySource.AddActivityListener(_activityListener);
+    }
+
+    public void Dispose() => _activityListener.Dispose();
+
+    private EntraIdIdentityProvider BuildProvider(params string[] responses)
+    {
+        MockSequenceHttpMessageHandler handler = new(responses);
+        HttpClient httpClient = new(handler) { BaseAddress = new Uri("https://graph.microsoft.com/") };
+        _httpClientFactory.CreateClient("MicrosoftGraph").Returns(httpClient);
+
+        MockHttpMessageHandler tokenHandler = new()
+        {
+            ResponseBody = """{"access_token":"fake-token","expires_in":300}""",
+        };
+        HttpClient tokenClient = new(tokenHandler) { BaseAddress = new Uri("https://graph.microsoft.com/") };
+        IHttpClientFactory tokenFactory = Substitute.For<IHttpClientFactory>();
+        tokenFactory.CreateClient("MicrosoftGraph").Returns(tokenClient);
+
+        IClock clock = Substitute.For<IClock>();
+        clock.Now.Returns(DateTimeOffset.UtcNow);
+
+        EntraIdAdminTokenService tokenService = new(
+            tokenFactory,
+            Microsoft.Extensions.Options.Options.Create(_options),
+            clock,
+            NullLogger<EntraIdAdminTokenService>.Instance);
+
+        return new EntraIdIdentityProvider(
+            tokenService,
+            _httpClientFactory,
+            Microsoft.Extensions.Options.Options.Create(_options),
+            _passwordResetNotifier,
+            _distributedEventBus,
+            NullLogger<EntraIdIdentityProvider>.Instance);
+    }
+
+    [Fact]
+    public async Task GetClientsAsync_ReturnsAppIds_SkippingNullAppIds()
+    {
+        const string response = """
+            {"value":[
+              {"id":"sp-1","appId":"11111111-1111-1111-1111-111111111111","appRoles":[]},
+              {"id":"sp-2","appId":"22222222-2222-2222-2222-222222222222","appRoles":[]},
+              {"id":"sp-3","appId":null,"appRoles":[]}
+            ]}
+            """;
+        EntraIdIdentityProvider provider = BuildProvider(response);
+
+        IReadOnlyList<string> clients = await provider.GetClientsAsync(TestContext.Current.CancellationToken);
+
+        clients.ShouldBe([
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+        ]);
+    }
+
+    [Fact]
+    public async Task GetClientRolesAsync_ResolvesServicePrincipal_ProjectsEnabledAppRoles()
+    {
+        const string appId = "11111111-1111-1111-1111-111111111111";
+        string resolveResponse = $$"""
+            {"value":[{
+              "id":"sp-object-id-1",
+              "appId":"{{appId}}",
+              "appRoles":[
+                {"id":"r1","displayName":"Editor","value":"Editor","description":"Edit docs","isEnabled":true},
+                {"id":"r2","displayName":"Viewer","value":"Viewer","description":null,"isEnabled":true},
+                {"id":"r3","displayName":"Disabled","value":"Disabled","description":null,"isEnabled":false}
+              ]
+            }]}
+            """;
+        EntraIdIdentityProvider provider = BuildProvider(resolveResponse);
+
+        IReadOnlyList<IdentityRole> roles = await provider.GetClientRolesAsync(
+            appId, TestContext.Current.CancellationToken);
+
+        roles.Count.ShouldBe(2);
+        roles[0].Name.ShouldBe("Editor");
+        roles[0].ClientId.ShouldBe(appId);
+        roles[0].Description.ShouldBe("Edit docs");
+        roles[1].Name.ShouldBe("Viewer");
+        roles[1].ClientId.ShouldBe(appId);
+    }
+
+    [Fact]
+    public async Task GetClientRolesAsync_UnknownAppId_Throws()
+    {
+        const string emptyResolve = """{"value":[]}""";
+        EntraIdIdentityProvider provider = BuildProvider(emptyResolve);
+
+        EntraIdClientNotFoundException ex = await Should.ThrowAsync<EntraIdClientNotFoundException>(
+            async () => await provider.GetClientRolesAsync(
+                "nonexistent-app-id", TestContext.Current.CancellationToken));
+
+        ex.AppId.ShouldBe("nonexistent-app-id");
+    }
+
+    [Fact]
+    public async Task GetUserClientRolesAsync_ResolvesThenMapsAssignments()
+    {
+        const string appId = "22222222-2222-2222-2222-222222222222";
+        string resolveResponse = $$"""
+            {"value":[{
+              "id":"sp-object-id-2",
+              "appId":"{{appId}}",
+              "appRoles":[
+                {"id":"r-admin","displayName":"Admin","value":"Admin","description":null,"isEnabled":true},
+                {"id":"r-view","displayName":"Viewer","value":"Viewer","description":null,"isEnabled":true}
+              ]
+            }]}
+            """;
+        const string assignmentsResponse = """
+            {"value":[
+              {"id":"a1","appRoleId":"r-admin","principalId":"user-42","resourceId":"sp-object-id-2"}
+            ]}
+            """;
+        EntraIdIdentityProvider provider = BuildProvider(resolveResponse, assignmentsResponse);
+
+        IReadOnlyList<IdentityRole> roles = await provider.GetUserClientRolesAsync(
+            "user-42", appId, TestContext.Current.CancellationToken);
+
+        roles.Count.ShouldBe(1);
+        roles[0].Name.ShouldBe("Admin");
+        roles[0].ClientId.ShouldBe(appId);
+    }
+}

--- a/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdClientRoleTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdClientRoleTests.cs
@@ -33,6 +33,8 @@ public sealed class EntraIdClientRoleTests : IDisposable
     private readonly IPasswordResetNotifier _passwordResetNotifier = Substitute.For<IPasswordResetNotifier>();
     private readonly IDistributedEventBus _distributedEventBus = Substitute.For<IDistributedEventBus>();
     private readonly ActivityListener _activityListener;
+    private HttpClient? _graphHttpClient;
+    private HttpClient? _tokenHttpClient;
 
     public EntraIdClientRoleTests()
     {
@@ -44,21 +46,29 @@ public sealed class EntraIdClientRoleTests : IDisposable
         ActivitySource.AddActivityListener(_activityListener);
     }
 
-    public void Dispose() => _activityListener.Dispose();
+    public void Dispose()
+    {
+        _activityListener.Dispose();
+        _graphHttpClient?.Dispose();
+        _tokenHttpClient?.Dispose();
+    }
 
     private EntraIdIdentityProvider BuildProvider(params string[] responses)
     {
+        _graphHttpClient?.Dispose();
+        _tokenHttpClient?.Dispose();
+
         MockSequenceHttpMessageHandler handler = new(responses);
-        HttpClient httpClient = new(handler) { BaseAddress = new Uri("https://graph.microsoft.com/") };
-        _httpClientFactory.CreateClient("MicrosoftGraph").Returns(httpClient);
+        _graphHttpClient = new HttpClient(handler) { BaseAddress = new Uri("https://graph.microsoft.com/") };
+        _httpClientFactory.CreateClient("MicrosoftGraph").Returns(_graphHttpClient);
 
         MockHttpMessageHandler tokenHandler = new()
         {
             ResponseBody = """{"access_token":"fake-token","expires_in":300}""",
         };
-        HttpClient tokenClient = new(tokenHandler) { BaseAddress = new Uri("https://graph.microsoft.com/") };
+        _tokenHttpClient = new HttpClient(tokenHandler) { BaseAddress = new Uri("https://graph.microsoft.com/") };
         IHttpClientFactory tokenFactory = Substitute.For<IHttpClientFactory>();
-        tokenFactory.CreateClient("MicrosoftGraph").Returns(tokenClient);
+        tokenFactory.CreateClient("MicrosoftGraph").Returns(_tokenHttpClient);
 
         IClock clock = Substitute.For<IClock>();
         clock.Now.Returns(DateTimeOffset.UtcNow);

--- a/tests/Granit.Identity.Federated.EntraId.Tests/IdentityEntraIdServiceCollectionExtensionsClientRoleTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/IdentityEntraIdServiceCollectionExtensionsClientRoleTests.cs
@@ -1,0 +1,54 @@
+using Granit.Events;
+using Granit.Identity;
+using Granit.Identity.Extensions;
+using Granit.Identity.Federated.EntraId.Extensions;
+using Granit.Timing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Federated.EntraId.Tests;
+
+/// <summary>
+/// Locks the invariant that <see cref="IIdentityProvider"/> and
+/// <see cref="IIdentityClientRoleManager"/> resolve to the SAME scoped instance —
+/// required so <c>EntraIdAdminTokenService</c> caching and any internal state stay
+/// coherent across the two facets of the provider. Plain ServiceProvider test, no
+/// architecture test dependency.
+/// </summary>
+public sealed class IdentityEntraIdServiceCollectionExtensionsClientRoleTests
+{
+    [Fact]
+    public void IdentityProvider_And_ClientRoleManager_ResolveToSameScopedInstance()
+    {
+        ServiceCollection services = [];
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["EntraIdAdmin:TenantId"] = "test-tenant-id",
+                ["EntraIdAdmin:ClientId"] = "admin-service",
+                ["EntraIdAdmin:ClientSecret"] = "secret",
+                ["EntraIdAdmin:ServicePrincipalObjectId"] = "sp-object-id",
+            }).Build());
+
+        services.AddLogging();
+        services.AddSingleton(Substitute.For<IClock>());
+        services.AddSingleton(Substitute.For<IDistributedEventBus>());
+        services.AddGranitIdentity();
+        services.AddGranitIdentityEntraId();
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        using IServiceScope scope = sp.CreateScope();
+
+        IIdentityProvider provider = scope.ServiceProvider.GetRequiredService<IIdentityProvider>();
+        IIdentityClientRoleManager clientRoleManager =
+            scope.ServiceProvider.GetRequiredService<IIdentityClientRoleManager>();
+
+        object.ReferenceEquals(provider, clientRoleManager).ShouldBeTrue(
+            "IIdentityProvider and IIdentityClientRoleManager must resolve to the same " +
+            "scoped EntraIdIdentityProvider instance — see ADR-026 and the DI block " +
+            "in AddGranitIdentityEntraId.");
+    }
+}

--- a/tests/Granit.Identity.Federated.EntraId.Tests/Sync/EntraIdClientRoleSyncServiceTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/Sync/EntraIdClientRoleSyncServiceTests.cs
@@ -1,0 +1,135 @@
+using Granit.Authorization;
+using Granit.Authorization.Domain;
+using Granit.Guids;
+using Granit.Identity;
+using Granit.Identity.Federated.EntraId.Exceptions;
+using Granit.Identity.Federated.EntraId.Internal.Sync;
+using Granit.Identity.Models;
+using Granit.MultiTenancy;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using EntraSyncOpts = Granit.Identity.Federated.EntraId.Options.EntraIdClientRoleSyncOptions;
+
+namespace Granit.Identity.Federated.EntraId.Tests.Sync;
+
+public sealed class EntraIdClientRoleSyncServiceTests
+{
+    private readonly IIdentityClientRoleManager _clientRoleManager =
+        Substitute.For<IIdentityClientRoleManager>();
+    private readonly IRoleMetadataStore _store = Substitute.For<IRoleMetadataStore>();
+    private readonly IGuidGenerator _guidGenerator = Substitute.For<IGuidGenerator>();
+
+    public EntraIdClientRoleSyncServiceTests()
+    {
+        _guidGenerator.Create().Returns(_ => Guid.NewGuid());
+    }
+
+    private EntraIdClientRoleSyncService BuildSut(params string[] trackedAppIds)
+    {
+        EntraSyncOpts opts = new()
+        {
+            Enabled = true,
+            TrackedAppIds = trackedAppIds,
+        };
+        return new EntraIdClientRoleSyncService(
+            _clientRoleManager, _store, _guidGenerator,
+            Microsoft.Extensions.Options.Options.Create(opts),
+            NullLogger<EntraIdClientRoleSyncService>.Instance);
+    }
+
+    [Fact]
+    public async Task SyncAsync_Disabled_NoCall()
+    {
+        EntraSyncOpts opts = new() { Enabled = false, TrackedAppIds = ["11111111-1111-1111-1111-111111111111"] };
+        EntraIdClientRoleSyncService sut = new(
+            _clientRoleManager, _store, _guidGenerator, Microsoft.Extensions.Options.Options.Create(opts),
+            NullLogger<EntraIdClientRoleSyncService>.Instance);
+
+        await sut.SyncAsync(TestContext.Current.CancellationToken);
+
+        await _clientRoleManager.DidNotReceive().GetClientRolesAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SyncAsync_HappyPath_InsertsNewRoles()
+    {
+        const string appId = "11111111-1111-1111-1111-111111111111";
+        EntraIdClientRoleSyncService sut = BuildSut(appId);
+        _clientRoleManager.GetClientRolesAsync(appId, Arg.Any<CancellationToken>())
+            .Returns([
+                new IdentityRole("r1", "Editor", "Edit docs") { ClientId = appId },
+                new IdentityRole("r2", "Viewer", null) { ClientId = appId },
+            ]);
+        _store.FindByNameAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<string>(),
+            Arg.Any<CancellationToken>()).Returns((RoleMetadata?)null);
+
+        await sut.SyncAsync(TestContext.Current.CancellationToken);
+
+        await _store.Received(2).AddAsync(
+            Arg.Is<RoleMetadata>(r => r.ClientId == appId && r.MultiTenancySide == MultiTenancySide.Host
+                && !r.IsSystem && r.TenantId == null),
+            Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SyncAsync_Idempotent_SecondRunNoOpsWhenUnchanged()
+    {
+        const string appId = "22222222-2222-2222-2222-222222222222";
+        EntraIdClientRoleSyncService sut = BuildSut(appId);
+        var existing = RoleMetadata.Create(
+            Guid.NewGuid(), "Editor", MultiTenancySide.Host,
+            tenantId: null, clientId: appId, description: "Edit docs");
+        _clientRoleManager.GetClientRolesAsync(appId, Arg.Any<CancellationToken>())
+            .Returns([new IdentityRole("r1", "Editor", "Edit docs") { ClientId = appId }]);
+        _store.FindByNameAsync("Editor", null, appId, Arg.Any<CancellationToken>())
+            .Returns(existing);
+
+        await sut.SyncAsync(TestContext.Current.CancellationToken);
+
+        await _store.DidNotReceive().AddAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SyncAsync_DescriptionDrift_CallsUpdate()
+    {
+        const string appId = "33333333-3333-3333-3333-333333333333";
+        EntraIdClientRoleSyncService sut = BuildSut(appId);
+        var existing = RoleMetadata.Create(
+            Guid.NewGuid(), "Editor", MultiTenancySide.Host,
+            tenantId: null, clientId: appId, description: "OLD description");
+        _clientRoleManager.GetClientRolesAsync(appId, Arg.Any<CancellationToken>())
+            .Returns([new IdentityRole("r1", "Editor", "NEW description") { ClientId = appId }]);
+        _store.FindByNameAsync("Editor", null, appId, Arg.Any<CancellationToken>())
+            .Returns(existing);
+
+        await sut.SyncAsync(TestContext.Current.CancellationToken);
+
+        await _store.Received(1).UpdateAsync(
+            Arg.Is<RoleMetadata>(r => r.Description == "NEW description"),
+            Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().AddAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SyncAsync_AppNotFound_LogsAndContinues()
+    {
+        const string missing = "00000000-0000-0000-0000-000000000000";
+        const string appB = "44444444-4444-4444-4444-444444444444";
+        EntraIdClientRoleSyncService sut = BuildSut(missing, appB);
+        _clientRoleManager.GetClientRolesAsync(missing, Arg.Any<CancellationToken>())
+            .Returns<Task<IReadOnlyList<IdentityRole>>>(_ => throw new EntraIdClientNotFoundException(missing));
+        _clientRoleManager.GetClientRolesAsync(appB, Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        await sut.SyncAsync(TestContext.Current.CancellationToken);
+
+        // Second app still queried despite first one throwing.
+        await _clientRoleManager.Received(1).GetClientRolesAsync(appB, Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Granit.Identity.Federated.EntraId.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/packages.lock.json
@@ -23,11 +23,11 @@
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",
-        "resolved": "18.4.0",
-        "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
+        "resolved": "18.5.0",
+        "contentHash": "25WwwrAqPk8ZjUZchC0xlg0B89eHP4mGDOQwfwnM45/idYnIOQMT8NKWa8tY0HwRPTdFpdoPRBaoB7xU9lR+BA==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.4.0",
-          "Microsoft.TestPlatform.TestHost": "18.4.0"
+          "Microsoft.CodeCoverage": "18.5.0",
+          "Microsoft.TestPlatform.TestHost": "18.5.0"
         }
       },
       "NSubstitute": {
@@ -98,8 +98,18 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "9O0BtCfzCWrkAmK187ugKdq72HHOXoOUjuWFDVc2LsZZ0pOnA9bTt+Sg9q4cF+MoAaUU+MuWtvBuFsnduviJow=="
+        "resolved": "18.5.0",
+        "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
       },
       "Microsoft.Extensions.AmbientMetadata.Application": {
         "type": "Transitive",
@@ -122,27 +132,27 @@
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "lYQ9S1FGXIWIU7243RimdAXQYsFDeLhSSZvbSDwbeI/kCzZ4MIYXpp3kMQ+bDJXwl9pzMRIYkd4f9zGqcYxfAQ==",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "a7bA7IT3ngIgcOMb/2MVH5CcfSxUCeQ6QXWS1Vt6oFpzLTH3U1+J2Xtc64Uw3whX9akYG8eR/UQeEzxo64zZLg==",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "poUvwtf92bEs8uBH3aRRs/ZgiAw+Z485EU7TtVPBt//MmD0uMPERe7+v3Ur7lpD8XgIEDL9sDoTBcW1LMG97CQ==",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection.AutoActivation": {
@@ -155,21 +165,21 @@
       },
       "Microsoft.Extensions.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "vbigpAOKX+Bbm2uJQ/AqXqONEPPB3ZYkynRT24vo5ZWF1rzKPtVjpkQkJx5qTGp2dqNV5In9QqboayqmKdvGUA==",
+        "resolved": "10.0.7",
+        "contentHash": "l+smp1qPlU0OUXD0OGfdp7OUFrbdq7ZaP5T7m2WpfZ4RFKD7iG73BAT7tjSMxNmbSXkhAn1jYHOAqzYG1r9sNg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.6",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.6"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L98Xe5C+xyKytLNLiEyQ0rcY8GNXAeAn1xKsE0YDxPx/mXBYYtRoj8pC2cnbSFQUlOzBkyO90ivMSV22SRETFg==",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
@@ -182,15 +192,15 @@
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "ChhUF6HVSz9DwBgTyHtWbGzH8kWMbEFS7gqrqBnZQhHJFFK7L1k5BX7UCiIHiCap5HEDS6bZYks79JK4c+H0GQ=="
+        "resolved": "10.0.7",
+        "contentHash": "8Oq/03og7ihwbfx+EjfWhYCdMldClxqnqB9w5ZI4KxuhoiUVDxZYVl06K7fhROOoelhKOtnCUtATCqTCrqSGmA=="
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "iU/lPyrjHVA4jJ7Bl/VpXvgsAD4qJWc4oPSVJjMBeZjmv7IIo8wBKxnOUoXdZcSCUJ6MeBMs3WpXNfncO7OzRg==",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http.Diagnostics": {
@@ -204,12 +214,12 @@
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "ZjpnbMD88IcZQE2pE9lcGv3mkH2mlApPWNh88ya1wJpcxZLp7p4aN7twI2FpawGPAsXNpmMgtKaz3o796YWKWQ==",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging.Configuration": {
@@ -234,8 +244,8 @@
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "10.0.6",
-        "contentHash": "L8P21mqaG+CXvPheLndean/cHCOcItJqH8nx+0YQnK7wAiOR0G1IOC418ZSzTMD2D6Gmo0f2M5WR70XtpX2B8g=="
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
       "Microsoft.Extensions.Resilience": {
         "type": "Transitive",
@@ -305,15 +315,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "4L6m2kS2pY5uJ9cpeRxzW22opr6ttScIRqsOpMDQpgENp/ZwxkkQCcmc6LRSURo2dFaaSW5KVflQZvroiJ7Wzg=="
+        "resolved": "18.5.0",
+        "contentHash": "8f6BFQZEk8EvQ4xTo5QpNwgOfoMs28/iZ81+2pWKtB+S/PiI49W0Cvj+apHxJH3ttnKPlGlhKSn070Ise8ETlg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "gZsCHI+zOmZCcKZieIL4Jg14qKD2OGZOmX5DehuIk1EA9BN6Crm0+taXQNEuajOH1G9CCyBxw8VWR4t5tumcng==",
+        "resolved": "18.5.0",
+        "contentHash": "vDo0CJKJqa1fgJkXWtwLbx7SMPSp6KkLk6jkJKe8rH1EG8SCD26vaPaEsxhd17+CazffDohWIGkO6yir85C45A==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.0",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -444,6 +454,30 @@
       "granit": {
         "type": "Project"
       },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -454,6 +488,20 @@
         "type": "Project",
         "dependencies": {
           "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.http.resilience": {
@@ -481,13 +529,37 @@
       "granit.identity.federated.entraid": {
         "type": "Project",
         "dependencies": {
+          "Granit.Authorization": "[0.1.0-dev, )",
           "Granit.Diagnostics": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Http.Resilience": "[0.1.0-dev, )",
           "Granit.Identity.Federated": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks": "[10.*, )",
           "Microsoft.Extensions.Http": "[10.*, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -504,59 +576,116 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "h22Fm4VxRmr4ty9rxJaW0i51xD56Bl5QhQ2hsGY2vl+6FioWmBhkpg3B78XQaK25N+hE41gZLZuYKGQS+OGbdw==",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.6",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "w+dX4SIr1X9yegX2yX2dU1XtP4JAUVNdvOG/Evn+H+ndn96YzfIPX52FALXChrRNWFR9l77FQyg1mB7WQo6iOA=="
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "G6AVN2vs66Gu8IkB2FwsVJRpIkkTmPJ+NmAUH7+N+VGGI6qK38OXMZLipjCaOYdj2DW6ge2IIXdwZjhNJefD0w==",
+        "resolved": "10.0.7",
+        "contentHash": "hs9YULcNhj1UiPjhNoJIDBWS92GvAVzT6DyuvbkoxvDcASZUQFVwQ9EAKtgrOfTaI0Vy6U6RwycXko1SIESM8w==",
         "dependencies": {
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "x3C8tgsX+xWvV5u76LFm24/U7sSnCRjuudBkbFsMV/DIqCA85te7YGg6dpa7lBToDhi4Lry9E7Arpy0laUw5AQ==",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.6",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "FbWxJqgUUQosm/tZEnjbdS2EfE+kBT5C8AQdWJsOtpgAR82gNGdfnYF4ZyHReGa7wpNltBB/GFKWMr9GlVuZbw==",
+        "resolved": "10.0.7",
+        "contentHash": "1wbd+RPhRo3hJKNJhdGEO5ls0LGe55Ho4BUjlFtRUrWxDVVBd7g0Ydq9fbNy86pmvx/j7AGcSPo7YNCo1IRI6Q==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Diagnostics": "10.0.6",
-          "Microsoft.Extensions.Logging": "10.0.6",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Http.Resilience": {
@@ -573,33 +702,67 @@
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "1YgBO3wAy0dlpQyVTKWBSPND/t0yZHsvd3shGpbeEwH8JSb2hnFI2pNFrOOUi/stsp+T/dqwqmRIGh47ibo9bw==",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "v5RTWm+3Gdub21ADJeRG5bunOOxutFNBZk6qGH6Az4L5nyRZoLe3Kse7jfAyUcdEoiKp72XpNw/wGR+9wP+MtQ==",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.6",
-        "contentHash": "O7xt1vYMxku2+/WpFkh6X8RzUtYbKR+XCt0KOO0W9TbRbFeQdfb9Nry/CdVq57kOyOKS3Z4qD1xqV/8LpJQ0Xw==",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.6",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.6",
-          "Microsoft.Extensions.Options": "10.0.6",
-          "Microsoft.Extensions.Primitives": "10.0.6"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.14.0",
+        "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
         }
       }
     }

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakClientRoleTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakClientRoleTests.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.Metrics;
 using Granit.Events;
 using Granit.Identity;
 using Granit.Identity.Diagnostics;
+using Granit.Identity.Federated.Keycloak.Exceptions;
 using Granit.Identity.Federated.Keycloak.Internal;
 using Granit.Identity.Models;
 using Granit.Timing;

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/Sync/KeycloakClientRoleSyncServiceTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/Sync/KeycloakClientRoleSyncServiceTests.cs
@@ -2,7 +2,7 @@ using Granit.Authorization;
 using Granit.Authorization.Domain;
 using Granit.Guids;
 using Granit.Identity;
-using Granit.Identity.Federated.Keycloak.Internal;
+using Granit.Identity.Federated.Keycloak.Exceptions;
 using Granit.Identity.Federated.Keycloak.Internal.Sync;
 using Granit.Identity.Models;
 using Granit.MultiTenancy;


### PR DESCRIPTION
Closes #1099.

## Context

ADR-025 introduced the `IIdentityClientRoleManager` capability interface, the
additive `IdentityRole.ClientId` property, and the `IHostDataSeedContributor`
sync pipeline. Keycloak was the first implementer (#1098). This PR applies
the same template to Microsoft Entra ID via the Graph API, closing
Phase 2 story #1099.

## Changes

**Provider (`Granit.Identity.Federated.EntraId`)**

- `EntraIdIdentityProvider` now implements `IIdentityClientRoleManager`:
  - `GetClientsAsync` → `GET /v1.0/servicePrincipals?$select=id,appId,appRoles`, projects `appId` strings (skipping nulls).
  - `GetClientRolesAsync(appId)` → resolves the Service Principal via `$filter=appId eq '...'`, projects inline `appRoles` (filtering `isEnabled=false`), populates `IdentityRole.ClientId` with `appId`.
  - `GetUserClientRolesAsync(userId, appId)` → reuses the resolved object id to query `/users/{id}/appRoleAssignments?$filter=resourceId eq ...`, joins assignments with the role map by `appRoleId`.
- `EntraIdClientNotFoundException` raised when a tracked `appId` does not resolve.
- `SupportsClientRoles` flips to `true` on `EntraIdIdentityProviderCapabilities`.
- New activity tags / operation names (`GetClients`, `GetClientRoles`, `GetUserClientRoles`, `TagClientId`).

**Sync pipeline**

- `EntraIdClientRoleSyncOptions` (`EntraIdAdmin:ClientRoleSync`): `Enabled` + `TrackedAppIds` (GUID list — opt-in because Entra tenants host thousands of Microsoft built-in Service Principals).
- `EntraIdClientRoleSyncService` mirrors `KeycloakClientRoleSyncService`: FindByName → Add / UpdateOnDescriptionDrift / no-op, idempotent via the `(Name, TenantId, ClientId)` unique index. No orphan deletion (same rationale as #1098 — cascades onto `PermissionGrant`).
- `EntraIdClientRoleSyncContributor : IHostDataSeedContributor` runs the sync at host boot.
- Failure policy: log & skip per app (unreachable / 403 / unknown app), never crashes startup.

**DI**

```csharp
services.AddIdentityProvider<EntraIdIdentityProvider>();  // scoped
services.TryAddScoped<IIdentityClientRoleManager>(sp =>
    sp.GetRequiredService<IIdentityProvider>() as IIdentityClientRoleManager ?? throw ...);
```

Single scoped instance forwarded to both facets — same pattern as #1098, locked by a `ReferenceEquals` DI test.

**Housekeeping**

- Moved `KeycloakClientNotFoundException` and the new `EntraIdClientNotFoundException` into `Exceptions/` subfolders. `FileOrganizationTests.Exception_classes_should_reside_in_Exceptions_folder` was failing on develop after #1098 merged — fixed here to satisfy the rule for both files.
- ADR-026 documents Entra-specific bindings and required Graph permissions (`Application.Read.All`, `AppRoleAssignment.ReadWrite.All`).
- `ADR_COUNT` 25 → 26.

## Tests

- **5 sync service tests** (`EntraIdClientRoleSyncServiceTests`): disabled / happy-path / idempotent / description drift / app-not-found-continues.
- **4 HTTP provider tests** (`EntraIdClientRoleTests`): clients / client roles (with `isEnabled=false` filter) / unknown appId throws / user assignments mapped to roles.
- **1 DI test** (`IdentityEntraIdServiceCollectionExtensionsClientRoleTests`): `IIdentityProvider` and `IIdentityClientRoleManager` resolve to the same scoped instance.

Totals: 124/124 EntraId tests, 169/169 Keycloak tests, 117/117 architecture tests — all green locally.

## Test plan

- [x] `dotnet build src/Granit.Identity.Federated.EntraId` — 0 warnings.
- [x] `dotnet test tests/Granit.Identity.Federated.EntraId.Tests` — 124 passed.
- [x] `dotnet test tests/Granit.Identity.Federated.Keycloak.Tests` — 169 passed (regression after moving exception file).
- [x] `dotnet test tests/Granit.ArchitectureTests` — 117/117 (fixes pre-existing violation).
- [x] `dotnet format --verify-no-changes` on all touched projects.
- [x] `npx markdownlint-cli2 docs-site/src/content/docs/dotnet/architecture/adr/026-entraid-app-role-sync.md` — 0 errors.
- [ ] Integration smoke against a real Entra tenant with a tracked `appId` — deferred to follow-up (no WireMock/Testcontainers equivalent for Graph in this PR).

## Follow-ups

- Integration tests (WireMock for Graph) — tracked separately.
- Frontend display disambiguation for duplicate role names across clients — `granit-showcase-admin-react`.
- Cognito (#1100) — last Phase 2 story, same template.
