### PR TITLE
chore(data-lookup): address framework audit findings

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -12376,8 +12376,8 @@
       "fqn": "Granit.DataLookup.Endpoints.Dtos.LookupManifestEntryResponse",
       "kind": "record",
       "project": "Granit.DataLookup.Endpoints",
-      "file": "src/Granit.DataLookup.Endpoints/Dtos/LookupManifestResponse.cs",
-      "line": 14,
+      "file": "src/Granit.DataLookup.Endpoints/Dtos/LookupManifestEntryResponse.cs",
+      "line": 10,
       "members": []
     },
     {
@@ -12386,7 +12386,7 @@
       "kind": "record",
       "project": "Granit.DataLookup.Endpoints",
       "file": "src/Granit.DataLookup.Endpoints/Dtos/LookupManifestResponse.cs",
-      "line": 7,
+      "line": 5,
       "members": []
     },
     {
@@ -12553,7 +12553,7 @@
       "kind": "interface",
       "project": "Granit.DataLookup.Abstractions",
       "file": "src/Granit.DataLookup.Abstractions/Registry/ILookupRegistry.cs",
-      "line": 15,
+      "line": 14,
       "members": [
         {
           "name": "Resolve",
@@ -12574,8 +12574,8 @@
       "fqn": "Granit.DataLookup.Registry.LookupManifestEntry",
       "kind": "record",
       "project": "Granit.DataLookup.Abstractions",
-      "file": "src/Granit.DataLookup.Abstractions/Registry/ILookupRegistry.cs",
-      "line": 34,
+      "file": "src/Granit.DataLookup.Abstractions/Registry/LookupManifestEntry.cs",
+      "line": 13,
       "members": []
     },
     {
@@ -12600,7 +12600,7 @@
       "kind": "interface",
       "project": "Granit.DataLookup.Abstractions",
       "file": "src/Granit.DataLookup.Abstractions/Sources/ILookupSource.cs",
-      "line": 32,
+      "line": 45,
       "members": [
         {
           "name": "SearchAsync",

--- a/docs-site/src/content/docs/dotnet/business/data-lookup.mdx
+++ b/docs-site/src/content/docs/dotnet/business/data-lookup.mdx
@@ -1,0 +1,163 @@
+---
+title: "Data Lookup — Unified Pickers for Filters and Forms"
+description: Declarative registry of named lookup sources — feeds QueryEngine filter pickers and edit-form dropdowns from a single contract with server-side label localization.
+sidebar:
+  label: Data Lookup
+  order: 17
+---
+
+import { FileTree } from "@astrojs/starlight/components";
+
+Granit.DataLookup provides a unified primitive for typeahead pickers across the
+framework. A single `ILookupSource` contract powers QueryEngine filter bars, edit-form
+dropdowns, and any custom UI that needs a paginated, searchable list of values —
+no duplication between backend declarations and frontend components.
+
+## Why
+
+- **Filter pickers** — foreign-key columns in a grid (`TenantId`, `UserId`,
+  `MeterDefinitionId`) currently force users to type a GUID by hand. A lookup source
+  turns them into typeahead comboboxes.
+- **Edit forms** — selects in create/edit forms are often hardcoded (enums, constants)
+  or wired ad-hoc (one-off hooks). A registry-backed lookup consolidates them.
+- **Reference data** — code lists (countries, document types) already backed by
+  `Granit.ReferenceData` can be exposed as lookup sources with localized labels
+  without duplicating endpoints.
+
+## Package structure
+
+<FileTree>
+- Granit.DataLookup.Abstractions/ Contracts: LookupDescriptor, LookupItem, LookupResult, ILookupSource, ILookupRegistry
+  - Granit.DataLookup/ Runtime: scoped registry, EnumLookupSource&lt;TEnum&gt;, metrics, ActivitySource
+    - Granit.DataLookup.EntityFrameworkCore QueryableLookupSource&lt;T&gt; — wraps an IQueryable with value/label selectors
+    - Granit.DataLookup.Endpoints Minimal API: /api/granit/lookups manifest, search, resolve
+</FileTree>
+
+| Package | Role | Depends on |
+| ------- | ---- | ---------- |
+| `Granit.DataLookup.Abstractions` | Pure contracts (descriptors, DTOs, interfaces) | `Granit` |
+| `Granit.DataLookup` | `ILookupRegistry`, `EnumLookupSource<TEnum>`, metrics | `.Abstractions`, `Granit.Localization` |
+| `Granit.DataLookup.EntityFrameworkCore` | `QueryableLookupSource<T>` over `IQueryable<T>` | `Granit.DataLookup`, `Granit.Persistence` |
+| `Granit.DataLookup.Endpoints` | `/api/granit/lookups` minimal API, permissions, auth | `Granit.DataLookup`, `Granit.Authorization`, `Granit.Validation` |
+
+## Canonical shapes
+
+All sources project to a single response shape — the frontend never re-maps.
+
+```csharp
+public sealed record LookupItem(
+    object Value,
+    string Label,                              // already localized server-side
+    IReadOnlyDictionary<string, object?>? Extra = null);
+
+public sealed record LookupResult(
+    IReadOnlyList<LookupItem> Items,
+    int? TotalCount = null,
+    string? ContinuationToken = null);
+```
+
+The `LookupDescriptor` is emitted alongside column / field metadata:
+
+```csharp
+public sealed record LookupDescriptor(
+    string? Name = null,                       // registry key, preferred
+    string? Endpoint = null,                   // custom URL, fallback
+    LookupKind Kind = LookupKind.QueryEngine,  // QueryEngine | Simple | ReferenceData | Enum
+    string? RequiredPermission = null,
+    string? SearchParam = "search",
+    IReadOnlyList<string>? ScopeKeys = null);  // e.g. ["tenantId"] — frontend pushes values
+```
+
+## Declaring a source
+
+### CLR enum — zero DB roundtrip
+
+```csharp
+services.AddEnumLookup<AggregationType>(
+    name: "enum-aggregation-type",
+    requiredPermission: "Metering.Meters.Read");
+```
+
+Labels resolved via `Enum:{TypeName}.{Value}` localization keys across the 18
+cultures Granit supports.
+
+### `IQueryable<T>` — any entity with EF Core
+
+```csharp
+services.AddQueryableLookup<Tenant, PlatformDbContext>(
+    name: "tenants",
+    valueSelector: t => t.Id,
+    labelSelector: t => t.Name,
+    searchPredicate: (t, search) => t.Name.Contains(search),
+    requiredPermission: "Platform.Tenants.Read");
+```
+
+The source is resolved from DI per request and honors tenant filters,
+soft-delete filters, and any convention applied by `ApplyGranitConventions`.
+
+### Custom implementation
+
+Implement `ILookupSource` directly for non-database sources (external APIs,
+computed values, in-memory collections).
+
+## Endpoints
+
+Mapped once at startup:
+
+```csharp
+app.MapGranitDataLookups(opts =>
+{
+    opts.RoutePrefix = "api/granit/lookups";
+    opts.TagName = "Data Lookup";
+});
+```
+
+| Method | Route | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/granit/lookups` | Manifest of every registered source |
+| `GET` | `/api/granit/lookups/{name}` | Paginated search (`search`, `page`, `pageSize`, `scope.*`) |
+| `GET` | `/api/granit/lookups/{name}/resolve?value=…` | Resolve a single value for rehydration |
+
+Every response honors:
+
+- **`Accept-Language` header** — labels projected in the caller's culture server-side.
+- **Ambient `ICurrentTenant`** — sources see the tenant-filtered queryable.
+- **`RequiredPermission`** — enforced by the dispatch handler, with the framework's
+  auto-injected `401` / `403` responses.
+
+## Empty Scope Trap — two-layer mitigation
+
+Scoped lookups (e.g., `meters` filtered by `tenantId`) declare their required scope
+keys. Missing values are caught at both layers to avoid silent full-table scans:
+
+- **Backend** — the endpoint validates that every declared scope key is present and
+  non-empty. Missing keys return `400 Bad Request` with a `problem+json` body.
+- **Frontend** — `useLookup` checks `ScopeKeys` before emitting the HTTP request.
+  When a key is unresolved, React-Query is set to `enabled: false` and no request is sent.
+
+## Authorization
+
+The group policy `DataLookup.Lookups.Read` gates the entire module. Per-source
+`RequiredPermission` values layer on top and are enforced before the source is invoked.
+
+## Diagnostics
+
+| Meter / metric | Purpose |
+| --- | --- |
+| `Granit.DataLookup` | Meter name |
+| `granit.data_lookup.search.executed` | Successful search counter |
+| `granit.data_lookup.search.duration` | Search latency histogram (seconds) |
+| `granit.data_lookup.resolve.executed` | Single-value resolve counter |
+| `granit.data_lookup.scope.missing` | Rejected queries due to missing scope keys |
+
+All tags include `tenant_id` (coalesced to `"global"`) and `lookup_name`.
+Distributed tracing is emitted via the `Granit.DataLookup` `ActivitySource`.
+
+## See also
+
+- [QueryEngine](/dotnet/business/query-engine/) — declarative search; filter pickers
+  consume the `LookupDescriptor` emitted on `FilterableField.Lookup`.
+- [ReferenceData](/dotnet/business/reference-data/) — code lists exposed as
+  lookup sources with localized labels.
+- [ADR-023](/dotnet/architecture/adr/023-queryengine-reference-data-lookup/) —
+  architectural rationale and scope.

--- a/src/Granit.DataLookup.Abstractions/Registry/ILookupRegistry.cs
+++ b/src/Granit.DataLookup.Abstractions/Registry/ILookupRegistry.cs
@@ -1,4 +1,3 @@
-using Granit.DataLookup.Descriptors;
 using Granit.DataLookup.Sources;
 
 namespace Granit.DataLookup.Registry;
@@ -23,16 +22,3 @@ public interface ILookupRegistry
     /// </summary>
     IReadOnlyList<LookupManifestEntry> GetManifest();
 }
-
-/// <summary>
-/// Public metadata about a registered lookup source.
-/// </summary>
-/// <param name="Name">Registry key.</param>
-/// <param name="Kind">Kind of backing source.</param>
-/// <param name="RequiredPermission">Permission required to invoke the source, if any.</param>
-/// <param name="ScopeKeys">Scope keys this source requires.</param>
-public sealed record LookupManifestEntry(
-    string Name,
-    LookupKind Kind,
-    string? RequiredPermission,
-    IReadOnlyList<string> ScopeKeys);

--- a/src/Granit.DataLookup.Abstractions/Registry/LookupManifestEntry.cs
+++ b/src/Granit.DataLookup.Abstractions/Registry/LookupManifestEntry.cs
@@ -1,0 +1,17 @@
+using Granit.DataLookup.Descriptors;
+
+namespace Granit.DataLookup.Registry;
+
+/// <summary>
+/// Public metadata about a registered lookup source — one entry per registered
+/// <see cref="Sources.ILookupSource"/> in the <c>GET /api/granit/lookups</c> manifest.
+/// </summary>
+/// <param name="Name">Registry key.</param>
+/// <param name="Kind">Kind of backing source.</param>
+/// <param name="RequiredPermission">Permission required to invoke the source, if any.</param>
+/// <param name="ScopeKeys">Scope keys this source requires.</param>
+public sealed record LookupManifestEntry(
+    string Name,
+    LookupKind Kind,
+    string? RequiredPermission,
+    IReadOnlyList<string> ScopeKeys);

--- a/src/Granit.DataLookup.Abstractions/Sources/ILookupSource.cs
+++ b/src/Granit.DataLookup.Abstractions/Sources/ILookupSource.cs
@@ -18,14 +18,27 @@ namespace Granit.DataLookup.Sources;
 ///   before projecting to <see cref="LookupItem.Label"/>.
 ///   </description></item>
 ///   <item><description>
-///   Validate that every scope key declared in <see cref="ScopeKeys"/> is present and
-///   non-empty in <see cref="LookupQuery.Scope"/>. Missing keys are a client error
-///   (400), not a fallback to an unscoped query.
+///   Respect the ambient <c>ICurrentTenant</c> for multi-tenant isolation.
+///   </description></item>
+/// </list>
+/// <para>
+/// <b>Cross-cutting concerns — not enforced by the source itself.</b> Two responsibilities
+/// live in the endpoint layer (<c>Granit.DataLookup.Endpoints</c>) rather than in every
+/// source implementation:
+/// </para>
+/// <list type="bullet">
+///   <item><description>
+///   <b>Authorization</b> — <see cref="RequiredPermission"/> is checked by the dispatch
+///   handler before <see cref="SearchAsync"/> is invoked. Programmatic consumers that
+///   bypass the endpoints (e.g. server-side jobs, tests) take responsibility for
+///   enforcing the declared permission themselves.
 ///   </description></item>
 ///   <item><description>
-///   Respect the ambient <c>ICurrentTenant</c> for multi-tenant isolation. Authorization
-///   (<see cref="RequiredPermission"/>) is enforced by the endpoint layer before the
-///   source is invoked.
+///   <b>Scope validation</b> — the endpoint validates that every key declared in
+///   <see cref="ScopeKeys"/> is present and non-empty in <see cref="LookupQuery.Scope"/>,
+///   returning <c>400 Bad Request</c> on any missing value (no silent full-table scans).
+///   Programmatic consumers MUST apply the same check before calling
+///   <see cref="SearchAsync"/> directly.
 ///   </description></item>
 /// </list>
 /// </remarks>

--- a/src/Granit.DataLookup.Endpoints/Dtos/LookupManifestEntryResponse.cs
+++ b/src/Granit.DataLookup.Endpoints/Dtos/LookupManifestEntryResponse.cs
@@ -1,0 +1,14 @@
+using Granit.DataLookup.Descriptors;
+
+namespace Granit.DataLookup.Endpoints.Dtos;
+
+/// <summary>A single entry in the lookup manifest.</summary>
+/// <param name="Name">Registry key.</param>
+/// <param name="Kind">Kind of backing source.</param>
+/// <param name="RequiredPermission">Permission required to invoke the source, if any.</param>
+/// <param name="ScopeKeys">Scope keys the source requires with every query.</param>
+public sealed record LookupManifestEntryResponse(
+    string Name,
+    LookupKind Kind,
+    string? RequiredPermission,
+    IReadOnlyList<string> ScopeKeys);

--- a/src/Granit.DataLookup.Endpoints/Dtos/LookupManifestResponse.cs
+++ b/src/Granit.DataLookup.Endpoints/Dtos/LookupManifestResponse.cs
@@ -1,18 +1,5 @@
-using Granit.DataLookup.Descriptors;
-
 namespace Granit.DataLookup.Endpoints.Dtos;
 
 /// <summary>Response shape for <c>GET /api/granit/lookups</c> — discovery manifest.</summary>
 /// <param name="Lookups">Sorted list of registered lookups.</param>
 public sealed record LookupManifestResponse(IReadOnlyList<LookupManifestEntryResponse> Lookups);
-
-/// <summary>A single entry in the lookup manifest.</summary>
-/// <param name="Name">Registry key.</param>
-/// <param name="Kind">Kind of backing source.</param>
-/// <param name="RequiredPermission">Permission required to invoke the source, if any.</param>
-/// <param name="ScopeKeys">Scope keys the source requires with every query.</param>
-public sealed record LookupManifestEntryResponse(
-    string Name,
-    LookupKind Kind,
-    string? RequiredPermission,
-    IReadOnlyList<string> ScopeKeys);

--- a/src/Granit.DataLookup.Endpoints/Endpoints/LookupEndpointHandlers.cs
+++ b/src/Granit.DataLookup.Endpoints/Endpoints/LookupEndpointHandlers.cs
@@ -91,13 +91,21 @@ public static class LookupEndpointHandlers
     /// <summary>GET /api/granit/lookups/{name}/resolve?value=… — single item lookup for rehydration.</summary>
     public static async Task<Results<Ok<LookupItemResponse>, NotFound, ForbidHttpResult, ProblemHttpResult>> ResolveAsync(
         string name,
-        [FromQuery] string value,
+        [FromQuery] string? value,
         [FromServices] ILookupRegistry registry,
         [FromServices] IPermissionChecker permissionChecker,
         [FromServices] DataLookupMetrics metrics,
         [FromServices] Granit.MultiTenancy.ICurrentTenant currentTenant,
         CancellationToken cancellationToken)
     {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return TypedResults.Problem(
+                detail: "Missing required 'value' query parameter.",
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Missing lookup value");
+        }
+
         ILookupSource? source = registry.Resolve(name);
         if (source is null)
         {

--- a/src/Granit.DataLookup.Endpoints/Extensions/DataLookupEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.DataLookup.Endpoints/Extensions/DataLookupEndpointRouteBuilderExtensions.cs
@@ -55,7 +55,6 @@ public static class DataLookupEndpointRouteBuilderExtensions
                 "context and any scope parameters declared by the source (scope.* query string).")
             .Produces<LookupResultResponse>()
             .ProducesProblem(StatusCodes.Status400BadRequest)
-            .ProducesProblem(StatusCodes.Status403Forbidden)
             .ProducesProblem(StatusCodes.Status404NotFound);
 
         group.MapGet("/{name}/resolve", LookupEndpointHandlers.ResolveAsync)
@@ -65,7 +64,7 @@ public static class DataLookupEndpointRouteBuilderExtensions
                 "Used by clients to rehydrate a previously selected value into a " +
                 "human-readable label. Returns 404 if the value is not present in the source.")
             .Produces<LookupItemResponse>()
-            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound);
 
         return group;

--- a/src/Granit.DataLookup/Diagnostics/DataLookupMetrics.cs
+++ b/src/Granit.DataLookup/Diagnostics/DataLookupMetrics.cs
@@ -23,19 +23,19 @@ public sealed class DataLookupMetrics
         Meter meter = meterFactory.Create(MeterName);
 
         _searches = meter.CreateCounter<long>(
-            "granit.datalookup.search.executed",
+            "granit.data_lookup.search.executed",
             description: "Number of lookup search queries executed.");
 
         _resolves = meter.CreateCounter<long>(
-            "granit.datalookup.resolve.executed",
+            "granit.data_lookup.resolve.executed",
             description: "Number of single-value resolve lookups executed.");
 
         _missingScope = meter.CreateCounter<long>(
-            "granit.datalookup.scope.missing",
+            "granit.data_lookup.scope.missing",
             description: "Lookup queries rejected because one or more declared scope keys were missing.");
 
         _searchDuration = meter.CreateHistogram<double>(
-            "granit.datalookup.search.duration",
+            "granit.data_lookup.search.duration",
             unit: "s",
             description: "Duration of lookup search execution in seconds.");
     }

--- a/src/Granit.DataLookup/Registry/IKindProviderLookupSource.cs
+++ b/src/Granit.DataLookup/Registry/IKindProviderLookupSource.cs
@@ -1,0 +1,15 @@
+using Granit.DataLookup.Descriptors;
+
+namespace Granit.DataLookup.Registry;
+
+/// <summary>
+/// Optional marker for <see cref="Sources.ILookupSource"/> implementations that want to
+/// advertise a specific <see cref="LookupKind"/> in the <c>GET /api/granit/lookups</c>
+/// manifest. Implementations that do not implement this interface default to
+/// <see cref="LookupKind.Simple"/>.
+/// </summary>
+internal interface IKindProviderLookupSource
+{
+    /// <summary>The kind advertised for this source in the manifest.</summary>
+    LookupKind Kind { get; }
+}

--- a/src/Granit.DataLookup/Registry/LookupRegistry.cs
+++ b/src/Granit.DataLookup/Registry/LookupRegistry.cs
@@ -57,12 +57,3 @@ internal sealed class LookupRegistry : ILookupRegistry
     private static LookupKind InferKind(ILookupSource source) =>
         source is IKindProviderLookupSource provider ? provider.Kind : LookupKind.Simple;
 }
-
-/// <summary>
-/// Optional marker for <see cref="ILookupSource"/> implementations that want to
-/// advertise a specific <see cref="LookupKind"/> in the manifest.
-/// </summary>
-internal interface IKindProviderLookupSource
-{
-    LookupKind Kind { get; }
-}


### PR DESCRIPTION
## Summary

Follow-up to #1124. The `/audit` framework check flagged 7 findings across 4 categories; this PR resolves all of them without changing the public contract in an incompatible way.

### Metrics naming (CONVENTION)

- Renamed `granit.datalookup.*` → `granit.data_lookup.*` to match the snake-case module convention used by sibling packages (`granit.query_engine.*`, `granit.data_exchange.*`). Meter name stays PascalCase `Granit.DataLookup`.

### File organization (CONVENTION × 3)

Architecture test `File_should_contain_a_type_matching_its_name`:

- `ILookupRegistry.cs` → extracted `LookupManifestEntry` into its own file.
- `LookupRegistry.cs` → extracted `IKindProviderLookupSource` into its own file.
- `LookupManifestResponse.cs` → extracted `LookupManifestEntryResponse` into its own file.

### OpenAPI (CLEANUP × 2)

- Removed redundant `.ProducesProblem(403)` on manifest and resolve endpoints — auto-injected by `ProblemDetailsResponseOperationTransformer` when `[Authorize]` is present (checklist §5o).
- Added a legitimate 400 path in `ResolveAsync` for empty `value` query parameter. The `ProblemHttpResult` branch of the `Results<...>` union now has a matching handler path (no cosmetic branch). Extension emits `.ProducesProblem(400)`.

### Documentation (CONVENTION)

- New Astro docs page at `docs/dotnet/business/data-lookup.mdx` covering:
  - Why (filter pickers + edit form dropdowns from one contract)
  - Package layout
  - Canonical shapes (`LookupItem`, `LookupResult`, `LookupDescriptor`)
  - Registration patterns (Enum / IQueryable / custom)
  - Endpoints, authorization, Empty Scope Trap mitigation
  - Diagnostics (metrics, ActivitySource)

### Contract documentation (IMPROVEMENT)

- Clarified in `ILookupSource` XML docs that **authorization and scope-key validation are cross-cutting concerns** enforced by the endpoint layer. Programmatic consumers bypassing the endpoints must apply both checks themselves before invoking `SearchAsync`.

## Test plan

- [x] `dotnet build` clean on all 4 DataLookup src packages (0 warnings)
- [x] `dotnet test` green: 36 tests (3 + 21 + 5 + 7)
- [x] `dotnet format --verify-no-changes` passes on each project
- [x] `markdownlint-cli2` clean on the new doc page (only the tolerated `<FileTree>` inline-HTML warning shared with sibling docs)
- [ ] CI `business` + `architecture` shards green