### PR TITLE
refactor(identity): audit fixes + rename RGPD to GDPR solution-wide

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -17513,7 +17513,7 @@
       "kind": "class",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/Extensions/IdentityServiceCollectionExtensions.cs",
-      "line": 11,
+      "line": 12,
       "members": [
         {
           "name": "AddGranitIdentity",
@@ -17866,7 +17866,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.GoogleCloud",
       "file": "src/Granit.Identity.Federated.GoogleCloud/Extensions/IdentityGoogleCloudServiceCollectionExtensions.cs",
-      "line": 17,
+      "line": 19,
       "members": [
         {
           "name": "AddGranitIdentityGoogleCloud",
@@ -19283,7 +19283,7 @@
       "kind": "class",
       "project": "Granit.Identity.Local",
       "file": "src/Granit.Identity.Local/GranitIdentityLocalModule.cs",
-      "line": 34,
+      "line": 35,
       "members": [
         {
           "name": "ConfigureServices",

--- a/docs-site/src/content/docs/dotnet/security/identity.mdx
+++ b/docs-site/src/content/docs/dotnet/security/identity.mdx
@@ -19,29 +19,37 @@ with GDPR erasure and pseudonymization built in.
 <FileTree>
 - Granit.Identity/ Abstractions (7 interfaces), null defaults
   - Granit.Identity.Federated/ Federated identity abstractions
-    - Granit.Identity.Federated.Keycloak Keycloak Admin API implementation
+    - Granit.Identity.Federated.Keycloak Keycloak Admin API implementation (+ realm-vs-client role distinction)
+    - Granit.Identity.Federated.EntraId Microsoft Graph API implementation (+ Entra ID App Role distinction)
     - Granit.Identity.Federated.Cognito AWS Cognito User Pool API implementation
     - Granit.Identity.Federated.GoogleCloud Google Cloud Identity Platform (Firebase Auth) implementation
     - Granit.Identity.Federated.EntityFrameworkCore User cache (cache-aside, login-time sync)
+    - Granit.Identity.Federated.Privacy Personal-data export provider for the federated user cache
   - Granit.Identity.Local/ Shared domain types for self-hosted identity providers
-    - Granit.Identity.Local.AspNetIdentity IIdentityProvider bridge for OpenIddict (local store)
+    - Granit.Identity.Local.AspNetIdentity ASP.NET Core Identity provider (GranitUser + role orchestration + tenant-aware lookup)
+    - Granit.Identity.Local.Endpoints Account self-service endpoints (login, register, profile, 2FA, passkey) + role CRUD + admin impersonation
     - Granit.Identity.Local.Notifications 9 security notifications (welcome, password reset, 2FA, email change, impersonation)
-  - Granit.Identity.Endpoints Minimal API endpoints (CRUD, sync, GDPR, webhook)
+    - Granit.Identity.Local.Privacy Personal-data export provider for the local identity store
+  - Granit.Identity.Endpoints Minimal API endpoints (provider CRUD, user cache sync, GDPR, webhook)
 </FileTree>
 
 | Package | Role | Depends on |
 |---------|------|------------|
 | `Granit.Identity` | Abstractions, null defaults | — |
 | `Granit.Identity.Federated` | Federated identity abstractions | `Granit.Identity` |
-| `Granit.Identity.Federated.Keycloak` | Keycloak Admin API implementation | `Granit.Identity.Federated` |
+| `Granit.Identity.Federated.Keycloak` | Keycloak Admin API implementation (+ realm-vs-client role distinction) | `Granit.Identity.Federated` |
+| `Granit.Identity.Federated.EntraId` | Microsoft Graph API implementation (+ App Role boot-time sync) | `Granit.Identity.Federated` |
 | `Granit.Identity.Federated.Cognito` | AWS Cognito User Pool API implementation | `Granit.Identity.Federated` |
 | `Granit.Identity.Federated.GoogleCloud` | Firebase Auth implementation (Firebase Admin SDK) | `Granit.Identity.Federated` |
 | `Granit.Authentication.JwtBearer.GoogleCloud` | JWT Bearer for Firebase Auth + claims transformation | `Granit.Authentication.JwtBearer` |
 | `Granit.Identity.Federated.EntityFrameworkCore` | EF Core user cache | `Granit.Identity.Federated`, `Granit.Persistence` |
+| `Granit.Identity.Federated.Privacy` | Personal-data export provider for the federated user cache | `Granit.Identity.Federated`, `Granit.Privacy.BlobStorage` |
 | `Granit.Identity.Local` | Shared domain types for self-hosted identity providers | `Granit.Identity`, `Granit.Events`, `Granit.Guids`, `Granit.Settings`, `Granit.Timing` |
-| `Granit.Identity.Local.AspNetIdentity` | IIdentityProvider bridge for OpenIddict (local store) | `Granit.Identity.Local` |
+| `Granit.Identity.Local.AspNetIdentity` | ASP.NET Core Identity provider, role orchestration, tenant-aware role lookup | `Granit.Identity.Local`, `Granit.Persistence.EntityFrameworkCore` |
+| `Granit.Identity.Local.Endpoints` | Account self-service + role CRUD + admin impersonation REST endpoints | `Granit.Identity.Local`, `Granit.Authorization` |
 | `Granit.Identity.Local.Notifications` | 9 security email/in-app notifications (17 cultures) | `Granit.Identity.Local`, `Granit.Notifications.Abstractions`, `Granit.Templating` |
-| `Granit.Identity.Endpoints` | REST endpoints for user cache | `Granit.Identity`, `Granit.Authorization` |
+| `Granit.Identity.Local.Privacy` | Personal-data export provider for the local identity store | `Granit.Identity.Local`, `Granit.Privacy.BlobStorage` |
+| `Granit.Identity.Endpoints` | REST endpoints for user cache + provider CRUD + GDPR | `Granit.Identity`, `Granit.Authorization` |
 
 ## Dependency graph
 
@@ -50,19 +58,26 @@ graph TD
     I[Granit.Identity] --> C[Granit]
     IF[Granit.Identity.Federated] --> I
     IK[Granit.Identity.Federated.Keycloak] --> IF
+    IEI[Granit.Identity.Federated.EntraId] --> IF
     IC[Granit.Identity.Federated.Cognito] --> IF
     IGC[Granit.Identity.Federated.GoogleCloud] --> IF
     AGC[Granit.Authentication.JwtBearer.GoogleCloud] --> JB[Granit.Authentication.JwtBearer]
     IEF[Granit.Identity.Federated.EntityFrameworkCore] --> IF
     IEF --> P[Granit.Persistence]
+    IFP[Granit.Identity.Federated.Privacy] --> IF
+    IFP --> PR[Granit.Privacy.BlobStorage]
     IL[Granit.Identity.Local] --> I
     IL --> S[Granit.Settings]
     ILA[Granit.Identity.Local.AspNetIdentity] --> IL
+    ILE[Granit.Identity.Local.Endpoints] --> IL
+    ILE --> AZ[Granit.Authorization]
     ILN[Granit.Identity.Local.Notifications] --> IL
     ILN --> N[Granit.Notifications.Abstractions]
     ILN --> T[Granit.Templating]
+    ILP[Granit.Identity.Local.Privacy] --> IL
+    ILP --> PR
     IE[Granit.Identity.Endpoints] --> I
-    IE --> AZ[Granit.Authorization]
+    IE --> AZ
 ```
 
 ## Setup

--- a/docs-site/src/content/docs/frontend/security/cookies.mdx
+++ b/docs-site/src/content/docs/frontend/security/cookies.mdx
@@ -8,7 +8,7 @@ sidebar:
 
 import { Tabs, TabItem, FileTree } from "@astrojs/starlight/components";
 
-`@granit/cookies` defines an abstract `CookieConsentProvider` interface and RGPD
+`@granit/cookies` defines an abstract `CookieConsentProvider` interface and GDPR
 category types — mirroring `Granit.Http.Cookies` on the .NET backend.
 `@granit/react-cookies` wraps this into a React context. `@granit/cookies-klaro`
 provides a concrete Klaro CMP adapter.
@@ -21,7 +21,7 @@ The architecture is pluggable: swap `@granit/cookies-klaro` for any other CMP
 ## Package structure
 
 <FileTree>
-- @granit/cookies/ CMP interface, RGPD categories, backend DTOs (framework-agnostic)
+- @granit/cookies/ CMP interface, GDPR categories, backend DTOs (framework-agnostic)
   - @granit/react-cookies CookieConsentProvider component, useCookieConsent hook
   - @granit/cookies-klaro Klaro CMP adapter (static or dynamic config)
 </FileTree>

--- a/docs-site/src/data/constants.ts
+++ b/docs-site/src/data/constants.ts
@@ -1,5 +1,5 @@
 /** Single source of truth for documentation-wide constants. */
-export const PACKAGE_COUNT = 281;
+export const PACKAGE_COUNT = 269;
 export const FRONTEND_PACKAGE_COUNT = 49;
 export const CULTURE_COUNT = 18;
 export const BASE_LANGUAGE_COUNT = 15;

--- a/src/Granit.Analyzers/DirectCookieAccessAnalyzer.cs
+++ b/src/Granit.Analyzers/DirectCookieAccessAnalyzer.cs
@@ -11,7 +11,7 @@ namespace Granit.Analyzers;
 /// <c>IGranitCookieManager</c>.
 /// </summary>
 /// <remarks>
-/// Direct cookie manipulation bypasses the Strict Registry Pattern and RGPD consent checks.
+/// Direct cookie manipulation bypasses the Strict Registry Pattern and GDPR consent checks.
 /// Use <c>IGranitCookieManager.SetCookieAsync()</c> or <c>IGranitCookieManager.DeleteCookie()</c> instead.
 /// Opt-in: only activates when <c>Granit.Http.Cookies.IGranitCookieManager</c> is present in the compilation.
 /// </remarks>
@@ -25,12 +25,12 @@ public sealed class DirectCookieAccessAnalyzer : SingleRuleAnalyzerBase
         DiagnosticId,
         title: "Avoid direct IResponseCookies access — use IGranitCookieManager",
         messageFormat: "Use IGranitCookieManager instead of directly calling IResponseCookies.{0}() "
-            + "to enforce the Strict Registry Pattern and RGPD consent checks",
+            + "to enforce the Strict Registry Pattern and GDPR consent checks",
         category: "Security",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "Direct calls to IResponseCookies.Append() or Delete() bypass the cookie registry "
-            + "and RGPD consent checks. Use IGranitCookieManager.SetCookieAsync() or DeleteCookie() instead.");
+            + "and GDPR consent checks. Use IGranitCookieManager.SetCookieAsync() or DeleteCookie() instead.");
 
     /// <inheritdoc/>
     protected override DiagnosticDescriptor Rule => _rule;

--- a/src/Granit.Analyzers/HardcodedSecretAnalyzer.cs
+++ b/src/Granit.Analyzers/HardcodedSecretAnalyzer.cs
@@ -11,7 +11,7 @@ namespace Granit.Analyzers;
 /// or property whose name suggests a secret (password, token, API key, etc.).
 /// </summary>
 /// <remarks>
-/// Hardcoded secrets violate ISO 27001 and RGPD compliance. Use Granit.Vault or
+/// Hardcoded secrets violate ISO 27001 and GDPR compliance. Use Granit.Vault or
 /// secure configuration (environment variables, Key Vault) instead.
 /// Always active — no opt-in needed.
 /// </remarks>
@@ -47,7 +47,7 @@ public sealed class HardcodedSecretAnalyzer : SingleRuleAnalyzerBase
         category: "Security",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "Hardcoded secrets violate ISO 27001 and RGPD compliance requirements. "
+        description: "Hardcoded secrets violate ISO 27001 and GDPR compliance requirements. "
             + "Store secrets in HashiCorp Vault via Granit.Vault or use secure "
             + "configuration providers.");
 

--- a/src/Granit.Authorization/Services/PermissionManager.cs
+++ b/src/Granit.Authorization/Services/PermissionManager.cs
@@ -72,7 +72,7 @@ internal sealed partial class PermissionManager(
         // DomainEventDispatcherInterceptor after SaveChanges commits. No manual publish here.
 
         // ISO 27001 audit trail: emitted as structured log → Serilog → OTLP → Loki (3-year retention)
-        // RGPD: no personal data — only provider key, permission name, tenant scope
+        // GDPR: no personal data — only provider key, permission name, tenant scope
         LogPermissionChange(
             isGranted ? "Granted" : "Revoked", permissionName, providerName, providerKey, tenantId);
     }

--- a/src/Granit.BackgroundJobs/Domain/JobStoreMode.cs
+++ b/src/Granit.BackgroundJobs/Domain/JobStoreMode.cs
@@ -15,7 +15,7 @@ public enum JobStoreMode
 
     /// <summary>
     /// Jobs are persisted in a relational database via EF Core.
-    /// Supports SQL Server and PostgreSQL (RGPD/ISO 27001 compliant).
+    /// Supports SQL Server and PostgreSQL (GDPR/ISO 27001 compliant).
     /// Requires <see cref="BackgroundJobsOptions.ConnectionString"/>.
     /// </summary>
     Durable = 1,

--- a/src/Granit.BlobStorage.Endpoints/Dtos/BlobDeleteRequest.cs
+++ b/src/Granit.BlobStorage.Endpoints/Dtos/BlobDeleteRequest.cs
@@ -4,7 +4,7 @@ namespace Granit.BlobStorage.Endpoints.Dtos;
 /// Request to delete a blob.
 /// </summary>
 /// <param name="ContainerName">Logical container the blob belongs to.</param>
-/// <param name="DeletionReason">Audit trail reason (e.g. "RGPD Art. 17 erasure").</param>
+/// <param name="DeletionReason">Audit trail reason (e.g. "GDPR Art. 17 erasure").</param>
 public sealed record BlobDeleteRequest(
     string ContainerName,
     string? DeletionReason = null);

--- a/src/Granit.BlobStorage.Endpoints/Internal/BlobStorageSchemaExampleProvider.cs
+++ b/src/Granit.BlobStorage.Endpoints/Internal/BlobStorageSchemaExampleProvider.cs
@@ -39,7 +39,7 @@ internal sealed class BlobStorageSchemaExampleProvider : ISchemaExampleProvider
             [typeof(BlobDeleteRequest)] = new JsonObject
             {
                 ["containerName"] = "medical-images",
-                ["deletionReason"] = "RGPD Art. 17 erasure request",
+                ["deletionReason"] = "GDPR Art. 17 erasure request",
             },
             [typeof(BlobDownloadUrlRequest)] = new JsonObject
             {

--- a/src/Granit.BlobStorage/Domain/BlobDescriptor.cs
+++ b/src/Granit.BlobStorage/Domain/BlobDescriptor.cs
@@ -17,7 +17,7 @@ namespace Granit.BlobStorage.Domain;
 /// <c>Pending -> Uploading -> Rejected</c>.
 /// </para>
 /// <para>
-/// RGPD /ISO 27001: records are <b>never deleted from the database</b>.
+/// GDPR /ISO 27001: records are <b>never deleted from the database</b>.
 /// <see cref="BlobStatus.Deleted"/> means the S3 bytes are gone; the audit row remains for 3 years.
 /// </para>
 /// </remarks>
@@ -99,7 +99,7 @@ public sealed class BlobDescriptor : AggregateRoot, IMultiTenant
     /// <summary>Human-readable reason for rejection; null unless <see cref="BlobStatus.Rejected"/>.</summary>
     public string? RejectionReason { get; private set; }
 
-    /// <summary>Human-readable reason for deletion (e.g. "RGPD Art. 17 request"); null unless <see cref="BlobStatus.Deleted"/>.</summary>
+    /// <summary>Human-readable reason for deletion (e.g. "GDPR Art. 17 request"); null unless <see cref="BlobStatus.Deleted"/>.</summary>
     public string? DeletionReason { get; private set; }
 
     /// <summary>
@@ -169,7 +169,7 @@ public sealed class BlobDescriptor : AggregateRoot, IMultiTenant
     /// The record is retained in the database for ISO 27001 audit compliance.
     /// </summary>
     /// <param name="deletedAt">UTC instant of deletion.</param>
-    /// <param name="reason">Optional human-readable reason (e.g. "RGPD Art. 17 erasure request").</param>
+    /// <param name="reason">Optional human-readable reason (e.g. "GDPR Art. 17 erasure request").</param>
     /// <exception cref="InvalidOperationException">When current status is not <see cref="BlobStatus.Valid"/>.</exception>
     public void MarkAsDeleted(DateTimeOffset deletedAt, string? reason = null)
     {

--- a/src/Granit.BlobStorage/Domain/BlobStatus.cs
+++ b/src/Granit.BlobStorage/Domain/BlobStatus.cs
@@ -21,7 +21,7 @@ public enum BlobStatus
     Rejected,
 
     /// <summary>
-    /// RGPD Art. 17 erasure: S3 object physically deleted.
+    /// GDPR Art. 17 erasure: S3 object physically deleted.
     /// The <see cref="BlobDescriptor"/> record is retained for the ISO 27001 3-year audit trail.
     /// </summary>
     Deleted,

--- a/src/Granit.BlobStorage/IBlobDescriptorReader.cs
+++ b/src/Granit.BlobStorage/IBlobDescriptorReader.cs
@@ -39,7 +39,7 @@ public interface IBlobDescriptorReader
     /// created before <paramref name="cutoff"/>, limited to <paramref name="batchSize"/> results.
     /// </summary>
     /// <remarks>
-    /// Used by RGPD cleanup background jobs to purge temporary containers (e.g. GDPR export archives)
+    /// Used by GDPR cleanup background jobs to purge temporary containers (e.g. GDPR export archives)
     /// after the retention period expires.
     /// </remarks>
     /// <param name="containerName">The blob container to search.</param>

--- a/src/Granit.BlobStorage/IBlobDescriptorWriter.cs
+++ b/src/Granit.BlobStorage/IBlobDescriptorWriter.cs
@@ -7,7 +7,7 @@ namespace Granit.BlobStorage;
 /// </summary>
 /// <remarks>
 /// Implemented by <c>Granit.BlobStorage.EntityFrameworkCore</c>.
-/// No hard-delete method exists by design (RGPD/ISO 27001: audit rows are retained for 3 years).
+/// No hard-delete method exists by design (GDPR/ISO 27001: audit rows are retained for 3 years).
 /// </remarks>
 public interface IBlobDescriptorWriter
 {

--- a/src/Granit.BlobStorage/IBlobStorage.cs
+++ b/src/Granit.BlobStorage/IBlobStorage.cs
@@ -63,7 +63,7 @@ public interface IBlobStorage
     /// </remarks>
     /// <param name="containerName">Logical container the blob belongs to.</param>
     /// <param name="blobId">Blob identifier.</param>
-    /// <param name="deletionReason">Optional reason for the audit trail (e.g. "RGPD Art. 17 erasure").</param>
+    /// <param name="deletionReason">Optional reason for the audit trail (e.g. "GDPR Art. 17 erasure").</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <exception cref="Exceptions.BlobNotFoundException">Blob not found for the current tenant.</exception>
     Task DeleteAsync(

--- a/src/Granit.DataExchange/Import/Mapping/ISemanticMappingService.cs
+++ b/src/Granit.DataExchange/Import/Mapping/ISemanticMappingService.cs
@@ -5,7 +5,7 @@ namespace Granit.DataExchange.Import.Mapping;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>RGPD/ISO 27001 compliance</b>: this interface receives <b>only</b> column header names
+/// <b>GDPR/ISO 27001 compliance</b>: this interface receives <b>only</b> column header names
 /// and <see cref="ImportFieldMetadata"/> (property names, CLR types, display names).
 /// It <b>never</b> receives <c>RawImportRow.Values</c> or any business data.
 /// </para>

--- a/src/Granit.DataExchange/Import/Mapping/ImportFieldMetadata.cs
+++ b/src/Granit.DataExchange/Import/Mapping/ImportFieldMetadata.cs
@@ -2,7 +2,7 @@ namespace Granit.DataExchange.Import.Mapping;
 
 /// <summary>
 /// Metadata about a target entity property, used for mapping suggestions.
-/// Contains only schema information — never business data (RGPD/ISO 27001 safe).
+/// Contains only schema information — never business data (GDPR/ISO 27001 safe).
 /// </summary>
 /// <param name="PropertyPath">Property path on the entity (e.g. <c>"Email"</c>, <c>"Lines.ProductName"</c>).</param>
 /// <param name="ClrTypeName">CLR type name (e.g. <c>"String"</c>, <c>"DateTimeOffset"</c>).</param>

--- a/src/Granit.DataExchange/Import/Mapping/MappingConfidence.cs
+++ b/src/Granit.DataExchange/Import/Mapping/MappingConfidence.cs
@@ -18,6 +18,6 @@ public enum MappingConfidence
     /// <summary>Fuzzy match (Levenshtein distance within threshold).</summary>
     Fuzzy = 3,
 
-    /// <summary>AI-assisted semantic match (header metadata only, RGPD-safe).</summary>
+    /// <summary>AI-assisted semantic match (header metadata only, GDPR-safe).</summary>
     Semantic = 4,
 }

--- a/src/Granit.Diagnostics/ResponseWriters/GranitHealthCheckWriter.cs
+++ b/src/Granit.Diagnostics/ResponseWriters/GranitHealthCheckWriter.cs
@@ -12,7 +12,7 @@ namespace Granit.Diagnostics.ResponseWriters;
 /// <remarks>
 /// <para>
 /// The response never contains stack traces, connection strings, tokens, or any PII,
-/// in compliance with ISO 27001 and RGPD constraints.
+/// in compliance with ISO 27001 and GDPR constraints.
 /// </para>
 /// <para>
 /// Two writers are available:

--- a/src/Granit.Http.Cookies.Endpoints/Dtos/CookieConsentConfigResponse.cs
+++ b/src/Granit.Http.Cookies.Endpoints/Dtos/CookieConsentConfigResponse.cs
@@ -14,7 +14,7 @@ public sealed record CookieConsentConfigResponse(
 /// API response for an internal cookie definition.
 /// </summary>
 /// <param name="Name">Cookie name.</param>
-/// <param name="Category">RGPD consent category (snake_case).</param>
+/// <param name="Category">GDPR consent category (snake_case).</param>
 /// <param name="RetentionDays">Maximum retention period in days.</param>
 /// <param name="Purpose">Human-readable purpose description.</param>
 public sealed record CookieDefinitionResponse(
@@ -27,7 +27,7 @@ public sealed record CookieDefinitionResponse(
 /// API response for a third-party service that sets cookies.
 /// </summary>
 /// <param name="Name">Service identifier (e.g. "matomo", "hubspot").</param>
-/// <param name="Category">RGPD consent category (snake_case).</param>
+/// <param name="Category">GDPR consent category (snake_case).</param>
 /// <param name="CookiePatterns">Regex patterns matching cookies set by this service.</param>
 public sealed record ThirdPartyServiceResponse(
     string Name,

--- a/src/Granit.Http.Cookies.Endpoints/Extensions/CookieConsentEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Http.Cookies.Endpoints/Extensions/CookieConsentEndpointRouteBuilderExtensions.cs
@@ -32,7 +32,7 @@ public static class CookieConsentEndpointRouteBuilderExtensions
             .WithName("GetCookieConsentConfig")
             .WithTags(options.TagName)
             .WithSummary("Returns the cookie consent configuration for CMP setup.")
-            .WithDescription("Returns the full list of internal cookies and third-party services registered in the application, categorized for RGPD consent management. The front-end CMP (Consent Management Platform) uses this response to render the cookie banner. Response is cached for 1 hour (Cache-Control: public, max-age=3600). Anonymous — no authentication required.")
+            .WithDescription("Returns the full list of internal cookies and third-party services registered in the application, categorized for GDPR consent management. The front-end CMP (Consent Management Platform) uses this response to render the cookie banner. Response is cached for 1 hour (Cache-Control: public, max-age=3600). Anonymous — no authentication required.")
             .Produces<CookieConsentConfigResponse>();
 
         return endpoints;

--- a/src/Granit.Http.Cookies.Endpoints/README.md
+++ b/src/Granit.Http.Cookies.Endpoints/README.md
@@ -2,7 +2,7 @@
 
 Minimal API endpoints for `Granit.Http.Cookies`: exposes registered cookies and third-party
 service definitions to the front-end for CMP configuration. Public, anonymous endpoint.
-RGPD/ISO 27001 compliant.
+GDPR/ISO 27001 compliant.
 
 Part of the [granit](https://granit-fx.dev) framework.
 

--- a/src/Granit.Http.Cookies.Klaro/Granit.Http.Cookies.Klaro.csproj
+++ b/src/Granit.Http.Cookies.Klaro/Granit.Http.Cookies.Klaro.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Granit.Http.Cookies.Klaro</PackageId>
     <Description>Klaro CMP integration for Granit.Http.Cookies: reads the Klaro consent cookie,
-    maps Klaro services to RGPD categories, and implements IConsentResolver.
+    maps Klaro services to GDPR categories, and implements IConsentResolver.
     GDPR/ISO 27001 compliant.</Description>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/src/Granit.Http.Cookies.Klaro/README.md
+++ b/src/Granit.Http.Cookies.Klaro/README.md
@@ -1,7 +1,7 @@
 # Granit.Http.Cookies.Klaro
 
 Klaro CMP integration for Granit.Http.Cookies. Implements `IConsentResolver` by parsing
-the Klaro consent cookie and mapping per-service consent to RGPD `CookieCategory`.
+the Klaro consent cookie and mapping per-service consent to GDPR `CookieCategory`.
 
 Part of the [granit](https://granit-fx.dev) framework.
 

--- a/src/Granit.Http.Cookies/CookieDefinition.cs
+++ b/src/Granit.Http.Cookies/CookieDefinition.cs
@@ -7,10 +7,10 @@ namespace Granit.Http.Cookies;
 /// Every cookie must be declared at startup via the registry.
 /// </summary>
 /// <param name="Name">Unique cookie name.</param>
-/// <param name="Category">RGPD consent category.</param>
+/// <param name="Category">GDPR consent category.</param>
 /// <param name="RetentionDays">Maximum retention period in days.</param>
 /// <param name="IsHttpOnly">Whether the cookie is inaccessible to JavaScript.</param>
-/// <param name="Purpose">Human-readable purpose for RGPD audit trail.</param>
+/// <param name="Purpose">Human-readable purpose for GDPR audit trail.</param>
 public sealed record CookieDefinition(
     string Name,
     CookieCategory Category,

--- a/src/Granit.Http.Cookies/GranitCookiesBuilder.cs
+++ b/src/Granit.Http.Cookies/GranitCookiesBuilder.cs
@@ -25,7 +25,7 @@ public sealed class GranitCookiesBuilder(IServiceCollection services)
     }
 
     /// <summary>
-    /// Registers the ASP.NET Core session cookie in the RGPD registry and overrides
+    /// Registers the ASP.NET Core session cookie in the GDPR registry and overrides
     /// the default cookie name to avoid leaking the technology stack.
     /// Call this when the application uses <c>AddSession()</c> / <c>UseSession()</c>.
     /// </summary>

--- a/src/Granit.Http.Cookies/GranitHttpCookiesModule.cs
+++ b/src/Granit.Http.Cookies/GranitHttpCookiesModule.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Hosting;
 namespace Granit.Http.Cookies;
 
 /// <summary>
-/// Granit module for RGPD-compliant cookie management.
+/// Granit module for GDPR-compliant cookie management.
 /// Ensures the cookie infrastructure (registry, manager, consent resolver) is available
 /// even if the application host does not call <c>AddGranitCookies()</c> explicitly.
 /// </summary>

--- a/src/Granit.Http.Cookies/IGranitCookieManager.cs
+++ b/src/Granit.Http.Cookies/IGranitCookieManager.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Http;
 namespace Granit.Http.Cookies;
 
 /// <summary>
-/// Managed cookie operations that enforce the Strict Registry Pattern and RGPD consent.
+/// Managed cookie operations that enforce the Strict Registry Pattern and GDPR consent.
 /// All cookie writes must go through this interface (enforced by analyzer GRSEC004).
 /// </summary>
 public interface IGranitCookieManager

--- a/src/Granit.Http.Cookies/Options/GranitCookiesOptions.cs
+++ b/src/Granit.Http.Cookies/Options/GranitCookiesOptions.cs
@@ -45,7 +45,7 @@ public sealed class ThirdPartyServiceOptions
     /// <summary>Unique service identifier (e.g. "matomo", "hubspot").</summary>
     public required string Name { get; set; }
 
-    /// <summary>RGPD consent category.</summary>
+    /// <summary>GDPR consent category.</summary>
     public required CookieCategory Category { get; set; }
 
     /// <summary>

--- a/src/Granit.Http.Cookies/ThirdPartyServiceDefinition.cs
+++ b/src/Granit.Http.Cookies/ThirdPartyServiceDefinition.cs
@@ -5,7 +5,7 @@ namespace Granit.Http.Cookies;
 /// Declared in configuration and exposed to the front-end for CMP setup.
 /// </summary>
 /// <param name="Name">Unique service identifier (e.g. "matomo", "hubspot").</param>
-/// <param name="Category">RGPD consent category this service belongs to.</param>
+/// <param name="Category">GDPR consent category this service belongs to.</param>
 /// <param name="CookiePatterns">
 /// Optional regex patterns matching the cookies set by this service (e.g. "^_pk_").
 /// Used by CMPs to clean up cookies when consent is revoked.

--- a/src/Granit.Identity.Endpoints/Endpoints/IdentityProviderUserWriteEndpoints.cs
+++ b/src/Granit.Identity.Endpoints/Endpoints/IdentityProviderUserWriteEndpoints.cs
@@ -40,6 +40,7 @@ internal static class IdentityProviderUserWriteEndpoints
 
     private static async Task<Results<Created<IdentityUserResponse>, ProblemHttpResult>> CreateUserAsync(
         IdentityUserCreateRequest request,
+        HttpContext httpContext,
         [FromServices] IIdentityUserWriter userWriter,
         [FromServices] IIdentityProviderCapabilities capabilities,
         CancellationToken cancellationToken)
@@ -64,7 +65,8 @@ internal static class IdentityProviderUserWriteEndpoints
             .ConfigureAwait(false);
 
         IdentityUserResponse response = IdentityResponseMapper.ToResponse(created);
-        return TypedResults.Created($"/identity/provider/users/{response.UserId}", response);
+        string basePath = httpContext.Request.Path.Value!.TrimEnd('/');
+        return TypedResults.Created($"{basePath}/{response.UserId}", response);
     }
 
     private static async Task<NoContent> UpdateUserAsync(

--- a/src/Granit.Identity.Endpoints/Endpoints/IdentityUserCacheGdprEndpoints.cs
+++ b/src/Granit.Identity.Endpoints/Endpoints/IdentityUserCacheGdprEndpoints.cs
@@ -7,22 +7,22 @@ using Microsoft.AspNetCore.Routing;
 namespace Granit.Identity.Endpoints.Endpoints;
 
 /// <summary>
-/// RGPD endpoints for erasing or pseudonymizing cached user data.
+/// GDPR endpoints for erasing or pseudonymizing cached user data.
 /// </summary>
-internal static class IdentityUserCacheRgpdEndpoints
+internal static class IdentityUserCacheGdprEndpoints
 {
-    internal static RouteGroupBuilder MapRgpdEndpoints(this RouteGroupBuilder group)
+    internal static RouteGroupBuilder MapGdprEndpoints(this RouteGroupBuilder group)
     {
         group.MapDelete("/{userId}", EraseAsync)
             .WithName("EraseIdentityUserCache")
-            .WithSummary("RGPD Art. 17 — permanently deletes the cached entry for a user.")
-            .WithDescription("Implements the RGPD right to erasure (Article 17). Permanently removes the user's cached identity data. This does not affect the upstream identity provider — the data will be re-cached if the user is looked up again. For full erasure, also delete in the identity provider.")
+            .WithSummary("GDPR Art. 17 — permanently deletes the cached entry for a user.")
+            .WithDescription("Implements the GDPR right to erasure (Article 17). Permanently removes the user's cached identity data. This does not affect the upstream identity provider — the data will be re-cached if the user is looked up again. For full erasure, also delete in the identity provider.")
             .Produces(StatusCodes.Status204NoContent);
 
         group.MapPatch("/{userId}/pseudonymize", PseudonymizeAsync)
             .WithName("PseudonymizeIdentityUserCache")
-            .WithSummary("RGPD Art. 18 — replaces PII with anonymized data in the cached entry.")
-            .WithDescription("Implements the RGPD right to restriction of processing (Article 18). Replaces all personally identifiable information (name, email, etc.) with anonymized placeholders while preserving the entry for referential integrity. Irreversible.")
+            .WithSummary("GDPR Art. 18 — replaces PII with anonymized data in the cached entry.")
+            .WithDescription("Implements the GDPR right to restriction of processing (Article 18). Replaces all personally identifiable information (name, email, etc.) with anonymized placeholders while preserving the entry for referential integrity. Irreversible.")
             .Produces(StatusCodes.Status204NoContent);
 
         return group;

--- a/src/Granit.Identity.Endpoints/Extensions/IdentityEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Identity.Endpoints/Extensions/IdentityEndpointRouteBuilderExtensions.cs
@@ -21,7 +21,7 @@ public static class IdentityEndpointRouteBuilderExtensions
     /// <list type="bullet">
     /// <item>Search, get by ID, batch resolve (<c>Identity.Users.Read</c> permission)</item>
     /// <item>Sync, sync-all (<c>Identity.Users.Sync</c> permission)</item>
-    /// <item>RGPD erase, pseudonymize (<c>Identity.Users.Delete</c> permission)</item>
+    /// <item>GDPR erase, pseudonymize (<c>Identity.Users.Delete</c> permission)</item>
     /// <item>Stats (<c>Identity.Users.Read</c> permission)</item>
     /// <item>Webhook (signature-validated, no user authentication required)</item>
     /// </list>
@@ -60,10 +60,10 @@ public static class IdentityEndpointRouteBuilderExtensions
             .RequireAuthorization(IdentityPermissions.Users.Sync)
             .MapSyncEndpoints();
 
-        // RGPD endpoints
+        // GDPR endpoints
         group
             .RequireAuthorization(IdentityPermissions.Users.Delete)
-            .MapRgpdEndpoints();
+            .MapGdprEndpoints();
 
         // Webhook endpoint (outside the authorized group — uses signature validation)
         endpoints.MapWebhookEndpoint("", options.WebhookTagName);

--- a/src/Granit.Identity.Endpoints/Granit.Identity.Endpoints.csproj
+++ b/src/Granit.Identity.Endpoints/Granit.Identity.Endpoints.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Granit.Identity.Endpoints</PackageId>
-    <Description>Minimal API endpoints for identity user cache management. Provides list, search, batch resolve, sync, RGPD erasure/pseudonymization, webhook reception, stats, and health check endpoints.</Description>
+    <Description>Minimal API endpoints for identity user cache management. Provides list, search, batch resolve, sync, GDPR erasure/pseudonymization, webhook reception, stats, and health check endpoints.</Description>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Granit.Identity.Endpoints/Permissions/IdentityPermissions.cs
+++ b/src/Granit.Identity.Endpoints/Permissions/IdentityPermissions.cs
@@ -24,7 +24,7 @@ public static class IdentityPermissions
         /// <summary>Grants access to force sync (single or full) from the identity provider.</summary>
         public const string Sync = "Identity.Users.Sync";
 
-        /// <summary>Grants access to RGPD erasure and pseudonymization.</summary>
+        /// <summary>Grants access to GDPR erasure and pseudonymization.</summary>
         public const string Delete = "Identity.Users.Delete";
     }
 

--- a/src/Granit.Identity.Endpoints/README.md
+++ b/src/Granit.Identity.Endpoints/README.md
@@ -1,7 +1,7 @@
 # Granit.Identity.Endpoints
 
 Minimal API endpoints for identity user cache management. Provides list, search, batch resolve,
-full sync, incremental stale sync, RGPD erasure/pseudonymization, webhook reception, stats,
+full sync, incremental stale sync, GDPR erasure/pseudonymization, webhook reception, stats,
 and health check endpoints.
 
 Part of the [granit](https://granit-fx.dev) framework.

--- a/src/Granit.Identity.Federated.EntityFrameworkCore/Internal/EfCoreUserCacheStore.cs
+++ b/src/Granit.Identity.Federated.EntityFrameworkCore/Internal/EfCoreUserCacheStore.cs
@@ -165,7 +165,7 @@ internal sealed class EfCoreUserCacheStore<TContext>(TContext context)
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    // -- RGPD --
+    // -- GDPR --
 
     public async Task DeleteByExternalIdAsync(
         string externalUserId, Guid? tenantId, CancellationToken cancellationToken = default)

--- a/src/Granit.Identity.Federated.GoogleCloud/Extensions/IdentityGoogleCloudServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.Federated.GoogleCloud/Extensions/IdentityGoogleCloudServiceCollectionExtensions.cs
@@ -3,10 +3,12 @@ using FirebaseAdmin.Auth;
 using Google.Apis.Auth.OAuth2;
 using Granit.Diagnostics;
 using Granit.Identity.Extensions;
+using Granit.Identity.Federated.GoogleCloud.HealthChecks;
 using Granit.Identity.Federated.GoogleCloud.Internal;
 using Granit.Identity.Federated.GoogleCloud.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 
 namespace Granit.Identity.Federated.GoogleCloud.Extensions;
@@ -54,5 +56,31 @@ public static class IdentityGoogleCloudServiceCollectionExtensions
         services.Replace(ServiceDescriptor.Scoped<IIdentityProviderCapabilities, GoogleCloudIdentityProviderCapabilities>());
 
         return services;
+    }
+
+    /// <summary>
+    /// Adds a Google Cloud Identity Platform connectivity health check tagged
+    /// <c>"readiness"</c> and <c>"startup"</c>. Verifies that the Firebase Admin SDK
+    /// can authenticate and reach Identity Toolkit by reading the first user page
+    /// with <c>PageSize = 1</c>.
+    /// </summary>
+    /// <param name="builder">The health checks builder.</param>
+    /// <param name="name">Check name. Defaults to <c>"googlecloud-identity"</c>.</param>
+    /// <param name="failureStatus">Status on failure. Defaults to <see cref="HealthStatus.Unhealthy"/>.</param>
+    /// <param name="timeout">Check timeout. Defaults to 10 seconds.</param>
+    public static IHealthChecksBuilder AddGranitGoogleCloudIdentityHealthCheck(
+        this IHealthChecksBuilder builder,
+        string name = "googlecloud-identity",
+        HealthStatus? failureStatus = null,
+        TimeSpan? timeout = null)
+    {
+        builder.Services.AddSingleton<GoogleCloudIdentityHealthCheck>();
+
+        return builder.Add(new HealthCheckRegistration(
+            name,
+            sp => sp.GetRequiredService<GoogleCloudIdentityHealthCheck>(),
+            failureStatus,
+            ["readiness", "startup"],
+            timeout ?? TimeSpan.FromSeconds(10)));
     }
 }

--- a/src/Granit.Identity.Federated.GoogleCloud/HealthChecks/GoogleCloudIdentityHealthCheck.cs
+++ b/src/Granit.Identity.Federated.GoogleCloud/HealthChecks/GoogleCloudIdentityHealthCheck.cs
@@ -1,3 +1,5 @@
+using FirebaseAdmin.Auth;
+using Granit.Identity.Federated.GoogleCloud.Internal;
 using Granit.Identity.Federated.GoogleCloud.Options;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
@@ -5,30 +7,47 @@ using Microsoft.Extensions.Options;
 namespace Granit.Identity.Federated.GoogleCloud.HealthChecks;
 
 /// <summary>
-/// Health check that verifies Google Cloud Identity Platform configuration.
+/// Health check that verifies Google Cloud Identity Platform connectivity by issuing a
+/// minimal <see cref="IFirebaseAuthTransport.PingAsync"/> call (reads the first page of
+/// users with <c>PageSize = 1</c>).
 /// </summary>
+/// <remarks>
+/// <list type="bullet">
+///   <item>Ping succeeds (any response, even an empty page) → <see cref="HealthCheckResult.Healthy"/></item>
+///   <item><see cref="FirebaseAuthException"/> → <see cref="HealthCheckResult.Unhealthy"/> (auth or service error)</item>
+///   <item>Other exception (network, timeout, misconfiguration) → <see cref="HealthCheckResult.Unhealthy"/></item>
+/// </list>
+/// The response never exposes credentials, project IDs, or stack traces.
+/// </remarks>
 internal sealed class GoogleCloudIdentityHealthCheck(
+    IFirebaseAuthTransport transport,
     IOptions<GoogleCloudIdentityOptions> options) : IHealthCheck
 {
     /// <inheritdoc />
-    public Task<HealthCheckResult> CheckHealthAsync(
+    public async Task<HealthCheckResult> CheckHealthAsync(
         HealthCheckContext context,
         CancellationToken cancellationToken = default)
     {
+        if (string.IsNullOrWhiteSpace(options.Value.ProjectId))
+        {
+            return HealthCheckResult.Unhealthy("Firebase Auth ProjectId is not configured.");
+        }
+
         try
         {
-            GoogleCloudIdentityOptions opts = options.Value;
-
-            if (string.IsNullOrWhiteSpace(opts.ProjectId))
-            {
-                return Task.FromResult(HealthCheckResult.Unhealthy("Firebase Auth ProjectId is not configured."));
-            }
-
-            return Task.FromResult(HealthCheckResult.Healthy());
+            await transport.PingAsync(cancellationToken).ConfigureAwait(false);
+            return HealthCheckResult.Healthy();
+        }
+        catch (FirebaseAuthException ex)
+        {
+            return HealthCheckResult.Unhealthy(
+                $"Firebase Auth probe failed: {ex.AuthErrorCode}");
         }
         catch (Exception ex)
         {
-            return Task.FromResult(HealthCheckResult.Unhealthy($"Firebase Auth health check failed: {ex.GetType().Name}"));
+            // Sanitize: never expose credentials, project IDs, or stack traces.
+            return HealthCheckResult.Unhealthy(
+                $"Firebase Auth probe failed: {ex.GetType().Name}");
         }
     }
 }

--- a/src/Granit.Identity.Federated.GoogleCloud/Internal/FirebaseAuthTransport.cs
+++ b/src/Granit.Identity.Federated.GoogleCloud/Internal/FirebaseAuthTransport.cs
@@ -39,6 +39,26 @@ internal sealed class FirebaseAuthTransport(FirebaseAuth auth) : IFirebaseAuthTr
     }
 
     /// <inheritdoc />
+    public async Task PingAsync(CancellationToken cancellationToken = default)
+    {
+        ListUsersOptions options = new() { PageSize = 1 };
+        PagedAsyncEnumerable<ExportedUserRecords, ExportedUserRecord> pagedEnumerable = auth.ListUsersAsync(options);
+
+        IAsyncEnumerator<ExportedUserRecord> enumerator = pagedEnumerable.GetAsyncEnumerator(cancellationToken);
+        try
+        {
+            // Trigger the first network call. We don't care whether the project has users —
+            // a successful round-trip (even with an empty page) confirms the service account
+            // can authenticate and reach Identity Toolkit.
+            await enumerator.MoveNextAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            await enumerator.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
     public Task<UserRecord> CreateUserAsync(UserRecordArgs args, CancellationToken cancellationToken = default) =>
         auth.CreateUserAsync(args, cancellationToken);
 

--- a/src/Granit.Identity.Federated.GoogleCloud/Internal/IFirebaseAuthTransport.cs
+++ b/src/Granit.Identity.Federated.GoogleCloud/Internal/IFirebaseAuthTransport.cs
@@ -11,6 +11,15 @@ internal interface IFirebaseAuthTransport
 
     Task<IReadOnlyList<ExportedUserRecord>> ListUsersAsync(CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Issues a minimal Identity Toolkit call to verify connectivity and credentials.
+    /// </summary>
+    /// <remarks>
+    /// Reads the first page of users with <c>PageSize = 1</c>. Empty projects return
+    /// an empty page (still a successful round-trip).
+    /// </remarks>
+    Task PingAsync(CancellationToken cancellationToken = default);
+
     Task<UserRecord> CreateUserAsync(UserRecordArgs args, CancellationToken cancellationToken = default);
 
     Task UpdateUserAsync(UserRecordArgs args, CancellationToken cancellationToken = default);

--- a/src/Granit.Identity.Federated.Privacy/DataExport/IdentityFederatedPrivacyDataProvider.cs
+++ b/src/Granit.Identity.Federated.Privacy/DataExport/IdentityFederatedPrivacyDataProvider.cs
@@ -45,7 +45,7 @@ public sealed class IdentityFederatedPrivacyDataProvider(
             return ReadOnlyMemory<byte>.Empty;
         }
 
-        IdentityFederatedExportDto dto = new(
+        IdentityFederatedExportResponse dto = new(
             CacheEntryId: entry.Id,
             ExternalUserId: entry.ExternalUserId,
             Username: entry.Username,
@@ -68,7 +68,7 @@ public sealed class IdentityFederatedPrivacyDataProvider(
     };
 }
 
-internal sealed record IdentityFederatedExportDto(
+internal sealed record IdentityFederatedExportResponse(
     Guid CacheEntryId,
     string ExternalUserId,
     string? Username,

--- a/src/Granit.Identity.Federated/Domain/UserCacheEntry.cs
+++ b/src/Granit.Identity.Federated/Domain/UserCacheEntry.cs
@@ -16,7 +16,7 @@ namespace Granit.Identity.Federated.Domain;
 /// a cache entry per tenant in shared-realm deployments.
 /// </para>
 /// <para>
-/// No <c>ISoftDeletable</c>: cache entries are hard-deleted on RGPD erasure requests.
+/// No <c>ISoftDeletable</c>: cache entries are hard-deleted on GDPR erasure requests.
 /// The audit fields on <see cref="AuditedEntity"/> satisfy ISO 27001 requirements for the cache entry itself.
 /// </para>
 /// </remarks>

--- a/src/Granit.Identity.Federated/Events/IdentityUserDeletedEto.cs
+++ b/src/Granit.Identity.Federated/Events/IdentityUserDeletedEto.cs
@@ -6,7 +6,7 @@ namespace Granit.Identity.Federated.Events;
 /// Wolverine message published when an identity provider user is deleted.
 /// Provider-agnostic: the application host translates provider-specific webhooks
 /// (Keycloak admin events, Entra ID change notifications, etc.) into this event.
-/// Triggers a hard delete of the corresponding cache entry (RGPD Art. 17).
+/// Triggers a hard delete of the corresponding cache entry (GDPR Art. 17).
 /// </summary>
 /// <param name="UserId">The external user ID in the identity provider.</param>
 /// <param name="TenantId">Optional tenant scope for the deletion. Null deletes across all tenants.</param>

--- a/src/Granit.Identity.Federated/Events/UserCacheEntryErasedEvent.cs
+++ b/src/Granit.Identity.Federated/Events/UserCacheEntryErasedEvent.cs
@@ -3,7 +3,7 @@ using Granit.Events;
 namespace Granit.Identity.Federated.Events;
 
 /// <summary>
-/// Raised when a user cache entry is hard-deleted (RGPD Art. 17 erasure).
+/// Raised when a user cache entry is hard-deleted (GDPR Art. 17 erasure).
 /// Enables audit trail of personal data deletion for ISO 27001 compliance.
 /// </summary>
 /// <param name="ExternalUserId">The identity provider user identifier.</param>

--- a/src/Granit.Identity.Federated/Handlers/IdentityUserEventHandler.cs
+++ b/src/Granit.Identity.Federated/Handlers/IdentityUserEventHandler.cs
@@ -29,7 +29,7 @@ internal sealed partial class IdentityUserEventHandler(
     }
 
     /// <summary>
-    /// Handles a user deleted event by hard-deleting the cache entry (RGPD Art. 17).
+    /// Handles a user deleted event by hard-deleting the cache entry (GDPR Art. 17).
     /// </summary>
     public async Task HandleAsync(IdentityUserDeletedEto @event, CancellationToken cancellationToken)
     {
@@ -109,6 +109,6 @@ internal sealed partial class IdentityUserEventHandler(
     [LoggerMessage(Level = LogLevel.Information, Message = "[AUDIT] User cache entry updated via {Source} for user {UserId}")]
     private partial void LogUserCacheUpdated(string userId, string source);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "[AUDIT] RGPD: user cache entry deleted via webhook for user {UserId}")]
+    [LoggerMessage(Level = LogLevel.Information, Message = "[AUDIT] GDPR: user cache entry deleted via webhook for user {UserId}")]
     private partial void LogUserCacheDeleted(string userId);
 }

--- a/src/Granit.Identity.Federated/Internal/CachedUserLookupService.cs
+++ b/src/Granit.Identity.Federated/Internal/CachedUserLookupService.cs
@@ -235,20 +235,20 @@ internal sealed partial class CachedUserLookupService(
         return refreshed;
     }
 
-    // -- RGPD --
+    // -- GDPR --
 
     public async Task DeleteByIdAsync(string userId, CancellationToken cancellationToken = default)
     {
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
         await store.DeleteByExternalIdAsync(userId, tenantId, cancellationToken).ConfigureAwait(false);
-        LogRgpdDelete(userId);
+        LogGdprDelete(userId);
     }
 
     public async Task PseudonymizeByIdAsync(string userId, CancellationToken cancellationToken = default)
     {
         Guid? tenantId = currentTenant.IsAvailable ? currentTenant.Id : null;
         await store.PseudonymizeAsync(userId, tenantId, cancellationToken).ConfigureAwait(false);
-        LogRgpdPseudonymize(userId);
+        LogGdprPseudonymize(userId);
     }
 
     // -- Helpers --
@@ -282,9 +282,9 @@ internal sealed partial class CachedUserLookupService(
     [LoggerMessage(Level = LogLevel.Information, Message = "[AUDIT] Incremental user cache refresh completed: {Refreshed}/{Total} stale entries refreshed")]
     private partial void LogRefreshStaleCompleted(int refreshed, int total);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "[AUDIT] RGPD erasure: user cache entry deleted for user {UserId}")]
-    private partial void LogRgpdDelete(string userId);
+    [LoggerMessage(Level = LogLevel.Information, Message = "[AUDIT] GDPR erasure: user cache entry deleted for user {UserId}")]
+    private partial void LogGdprDelete(string userId);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "[AUDIT] RGPD pseudonymization: user cache entry anonymized for user {UserId}")]
-    private partial void LogRgpdPseudonymize(string userId);
+    [LoggerMessage(Level = LogLevel.Information, Message = "[AUDIT] GDPR pseudonymization: user cache entry anonymized for user {UserId}")]
+    private partial void LogGdprPseudonymize(string userId);
 }

--- a/src/Granit.Identity.Federated/Internal/IUserCacheStore.cs
+++ b/src/Granit.Identity.Federated/Internal/IUserCacheStore.cs
@@ -4,7 +4,7 @@ namespace Granit.Identity.Federated.Internal;
 
 /// <summary>
 /// Internal data access layer for identity user cache entries.
-/// Provides CRUD, search, RGPD, and diagnostic operations on <see cref="UserCacheEntry"/>.
+/// Provides CRUD, search, GDPR, and diagnostic operations on <see cref="UserCacheEntry"/>.
 /// </summary>
 internal interface IUserCacheStore
 {
@@ -50,14 +50,14 @@ internal interface IUserCacheStore
     /// <summary>Inserts or updates multiple cache entries in batch.</summary>
     Task UpsertManyAsync(IReadOnlyList<UserCacheEntry> entries, CancellationToken cancellationToken = default);
 
-    // -- RGPD --
+    // -- GDPR --
 
-    /// <summary>Permanently deletes the cache entry for a user (RGPD Art. 17).</summary>
+    /// <summary>Permanently deletes the cache entry for a user (GDPR Art. 17).</summary>
     Task DeleteByExternalIdAsync(string externalUserId, Guid? tenantId, CancellationToken cancellationToken = default);
 
     /// <summary>Purges all cache entries for a tenant.</summary>
     Task DeleteAllByTenantAsync(Guid? tenantId, CancellationToken cancellationToken = default);
 
-    /// <summary>Replaces PII with anonymized data (RGPD Art. 18).</summary>
+    /// <summary>Replaces PII with anonymized data (GDPR Art. 18).</summary>
     Task PseudonymizeAsync(string externalUserId, Guid? tenantId, CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountDeletionEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountDeletionEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Granit.Http.Idempotency.Attributes;
 using Granit.Identity.Local.Diagnostics;
 using Granit.Identity.Local.Endpoints.Dtos;
@@ -39,6 +40,9 @@ internal static class AccountDeletionEndpoints
 [FromServices] IAccountDeletionService deletionService,
         CancellationToken cancellationToken)
     {
+        using Activity? activity = IdentityLocalActivitySource.Source.StartActivity(
+            IdentityLocalActivitySource.AccountDeletion);
+
         string userId = httpContext.User.FindFirst("sub")!.Value;
         string? username = httpContext.User.FindFirst("preferred_username")?.Value
                            ?? httpContext.User.FindFirst("name")?.Value;

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
@@ -73,6 +73,10 @@ internal static partial class AccountLoginEndpoints
     {
         long startTicks = Stopwatch.GetTimestamp();
 
+        using Activity? activity = IdentityLocalActivitySource.Source.StartActivity(
+            IdentityLocalActivitySource.UserAuthentication);
+        activity?.SetTag(IdentityLocalActivitySource.TagProvider, "password");
+
         Results<Ok<AccountLoginResponse>, ProblemHttpResult> response = await HandleLoginCoreAsync(
             request, signInManager, userManager, httpContext, cancellationToken)
             .ConfigureAwait(false);
@@ -200,6 +204,11 @@ internal static partial class AccountLoginEndpoints
         HttpContext httpContext,
         CancellationToken cancellationToken)
     {
+        using Activity? activity = IdentityLocalActivitySource.Source.StartActivity(
+            IdentityLocalActivitySource.TwoFactorChallenge);
+        activity?.SetTag(IdentityLocalActivitySource.TagProvider,
+            request.UseRecoveryCode ? "recovery_code" : "totp");
+
         ILogger logger = httpContext.RequestServices
             .GetRequiredService<ILoggerFactory>()
             .CreateLogger("Granit.Identity.Local.Endpoints.AccountLoginEndpoints");

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountPasswordEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountPasswordEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Granit.Events;
 using Granit.Http.Idempotency.Attributes;
 using Granit.Identity;
@@ -103,6 +104,10 @@ internal static class AccountPasswordEndpoints
         [FromServices] IPasswordResetService passwordResetService,
         CancellationToken cancellationToken)
     {
+        using Activity? activity = IdentityLocalActivitySource.Source.StartActivity(
+            IdentityLocalActivitySource.PasswordReset);
+        activity?.SetTag(IdentityLocalActivitySource.TagProvider, "forgot");
+
         // Always return 202 regardless of whether the email exists (prevents enumeration).
         // IPasswordResetService.RequestResetAsync publishes PasswordResetRequestedEto
         // which a subscriber (Granit.Notifications or app-level) consumes to send the email.
@@ -118,6 +123,10 @@ internal static class AccountPasswordEndpoints
         [FromServices] IPasswordResetService passwordResetService,
         CancellationToken cancellationToken)
     {
+        using Activity? activity = IdentityLocalActivitySource.Source.StartActivity(
+            IdentityLocalActivitySource.PasswordReset);
+        activity?.SetTag(IdentityLocalActivitySource.TagProvider, "reset-token");
+
         try
         {
             await passwordResetService.ResetPasswordAsync(

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountRegistrationEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountRegistrationEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Granit.Events;
 using Granit.Http.Idempotency.Attributes;
 using Granit.Identity;
@@ -32,7 +33,6 @@ internal static class AccountRegistrationEndpoints
             .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces(StatusCodes.Status202Accepted)
             .ProducesProblem(StatusCodes.Status403Forbidden)
-            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .ProducesValidationProblem()
             .AllowAnonymous()
             .RequireRateLimiting("authentication");
@@ -68,6 +68,9 @@ internal static class AccountRegistrationEndpoints
         [FromServices] IdentityLocalMetrics metrics,
         CancellationToken cancellationToken)
     {
+        using Activity? activity = IdentityLocalActivitySource.Source.StartActivity(
+            IdentityLocalActivitySource.UserRegistration);
+
         string? allowed = await settingProvider
             .GetOrNullAsync(IdentityLocalSettingNames.AllowSelfRegistration, cancellationToken)
             .ConfigureAwait(false);

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AdminImpersonationEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AdminImpersonationEndpoints.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using Granit.Http.Idempotency.Attributes;
+using Granit.Identity.Local.Diagnostics;
 using Granit.Identity.Local.Endpoints.Dtos;
 using Granit.Identity.Local.Endpoints.Internal;
 using Granit.Identity.Local.Endpoints.Permissions;
@@ -35,6 +37,9 @@ internal static class AdminImpersonationEndpoints
         [FromServices] IImpersonationService impersonationService,
         CancellationToken cancellationToken = default)
     {
+        using Activity? activity = IdentityLocalActivitySource.Source.StartActivity(
+            IdentityLocalActivitySource.Impersonation);
+
         // Guard: cannot chain-impersonate
         if (httpContext.User.FindFirst("impersonator_id") is not null)
         {

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
@@ -111,6 +111,7 @@ internal static class GranitRoleEndpoints
 
     private static async Task<Results<Created<RoleResponse>, ProblemHttpResult>> CreateAsync(
         [FromBody] RoleCreateRequest request,
+        HttpContext httpContext,
         [FromServices] IGranitRoleOrchestrator orchestrator,
         [FromServices] ICurrentTenant currentTenant,
         [FromServices] IOptions<RoleEndpointsOptions> options,
@@ -165,7 +166,8 @@ internal static class GranitRoleEndpoints
             return TypedResults.Problem(statusCode: StatusCodes.Status409Conflict, detail: ex.Message);
         }
 
-        return TypedResults.Created($"/admin/roles/{created.Id:D}", Map(created));
+        string basePath = httpContext.Request.Path.Value!.TrimEnd('/');
+        return TypedResults.Created($"{basePath}/{created.Id:D}", Map(created));
     }
 
     private static async Task<Results<Ok<RoleResponse>, ProblemHttpResult>> RenameAsync(

--- a/src/Granit.Identity.Local.Endpoints/Extensions/AccountEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Identity.Local.Endpoints/Extensions/AccountEndpointRouteBuilderExtensions.cs
@@ -34,6 +34,9 @@ public static class AccountEndpointRouteBuilderExtensions
         configure?.Invoke(options);
 
         // ──── Account self-service (/api/account) — split into feature sub-tags ────
+        // Each MapGroup(string.Empty) below adds no route prefix; its only purpose is to attach a
+        // distinct OpenAPI tag. The auto-validation filter from MapGranitGroup propagates to the
+        // children, so MapGranitGroup is not needed at this level.
         RouteGroupBuilder accountGroup = endpoints.MapGranitGroup(options.AccountRoutePrefix);
 
         accountGroup.MapGroup(string.Empty).WithTags(options.LoginTagName).MapAccountLoginEndpoints();
@@ -57,10 +60,11 @@ public static class AccountEndpointRouteBuilderExtensions
         endpoints.MapGranitAccountConfig(options.AccountRoutePrefix, options.ConfigTagName);
 
         // ──── Admin management (/api/admin) ────
+        // Each endpoint declares its own permission via RequireAuthorization(IdentityLocalPermissions.Users.*),
+        // so a parent-level RequireAuthorization() would be redundant.
         RouteGroupBuilder adminGroup = endpoints
             .MapGranitGroup(options.AdminRoutePrefix)
-            .WithTags(options.ImpersonationTagName)
-            .RequireAuthorization();
+            .WithTags(options.ImpersonationTagName);
 
         adminGroup.MapAdminImpersonationEndpoints();
 

--- a/src/Granit.Identity.Local.Endpoints/Extensions/RoleEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Identity.Local.Endpoints/Extensions/RoleEndpointRouteBuilderExtensions.cs
@@ -27,9 +27,10 @@ public static class RoleEndpointRouteBuilderExtensions
 
         RouteGroupBuilder group = endpoints
             .MapGranitGroup(options.RolesRoutePrefix)
-            .WithTags(options.TagName)
-            .RequireAuthorization();
+            .WithTags(options.TagName);
 
+        // Each endpoint declares its own permission via RequireAuthorization(IdentityLocalPermissions.Roles.*),
+        // so a parent-level RequireAuthorization() would be redundant.
         group.MapGranitRoleEndpoints();
         return group;
     }

--- a/src/Granit.Identity.Local.Privacy/DataExport/IdentityLocalPrivacyDataProvider.cs
+++ b/src/Granit.Identity.Local.Privacy/DataExport/IdentityLocalPrivacyDataProvider.cs
@@ -38,7 +38,7 @@ public sealed class IdentityLocalPrivacyDataProvider(UserManager<GranitUser> use
 
         IList<string> roles = await userManager.GetRolesAsync(user).ConfigureAwait(false);
 
-        IdentityLocalExportDto dto = new(
+        IdentityLocalExportResponse dto = new(
             Id: user.Id,
             UserName: user.UserName,
             Email: user.Email,
@@ -70,8 +70,8 @@ public sealed class IdentityLocalPrivacyDataProvider(UserManager<GranitUser> use
     };
 }
 
-/// <summary>Data transfer record written to the <c>identity-local.json</c> fragment.</summary>
-internal sealed record IdentityLocalExportDto(
+/// <summary>Export record written to the <c>identity-local.json</c> fragment.</summary>
+internal sealed record IdentityLocalExportResponse(
     Guid Id,
     string? UserName,
     string? Email,

--- a/src/Granit.Identity.Local/Diagnostics/IdentityLocalActivitySource.cs
+++ b/src/Granit.Identity.Local/Diagnostics/IdentityLocalActivitySource.cs
@@ -6,8 +6,9 @@ namespace Granit.Identity.Local.Diagnostics;
 /// Central <see cref="ActivitySource"/> for Granit.Identity.Local distributed tracing.
 /// </summary>
 /// <remarks>
-/// <c>Granit.Observability</c> adds this source automatically via
-/// <c>GranitActivitySourceRegistry</c> when both packages are used.
+/// Registered with <c>GranitActivitySourceRegistry</c> by
+/// <c>GranitIdentityLocalModule.ConfigureServices</c> so OpenTelemetry exporters
+/// configured via <c>WithTracing(...)</c> pick it up automatically.
 /// </remarks>
 internal static class IdentityLocalActivitySource
 {

--- a/src/Granit.Identity.Local/Granit.Identity.Local.csproj
+++ b/src/Granit.Identity.Local/Granit.Identity.Local.csproj
@@ -8,6 +8,15 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.Identity.Local.Tests" />
+    <InternalsVisibleTo Include="Granit.Identity.Local.AspNetIdentity" />
+    <InternalsVisibleTo Include="Granit.Identity.Local.AspNetIdentity.Tests" />
+    <InternalsVisibleTo Include="Granit.Identity.Local.AspNetIdentity.Tests.Integration" />
+    <InternalsVisibleTo Include="Granit.Identity.Local.Endpoints" />
+    <InternalsVisibleTo Include="Granit.Identity.Local.Endpoints.Tests" />
+    <InternalsVisibleTo Include="Granit.Identity.Local.Notifications" />
+    <InternalsVisibleTo Include="Granit.Identity.Local.Notifications.Tests" />
+    <InternalsVisibleTo Include="Granit.Identity.Local.Privacy" />
+    <InternalsVisibleTo Include="Granit.Identity.Local.Privacy.Tests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 

--- a/src/Granit.Identity.Local/GranitIdentityLocalModule.cs
+++ b/src/Granit.Identity.Local/GranitIdentityLocalModule.cs
@@ -1,4 +1,5 @@
 using Granit.DataExchange.Extensions;
+using Granit.Diagnostics;
 using Granit.Events;
 using Granit.Guids;
 using Granit.Identity;
@@ -36,6 +37,8 @@ public sealed class GranitIdentityLocalModule : GranitModule
     /// <inheritdoc/>
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
+        GranitActivitySourceRegistry.Register(IdentityLocalActivitySource.Name);
+
         context.Services.TryAddSingleton<IdentityLocalMetrics>();
 
         // Query + Export definitions (ADR-020: owned by the base module).

--- a/src/Granit.Identity/Diagnostics/IdentityActivitySource.cs
+++ b/src/Granit.Identity/Diagnostics/IdentityActivitySource.cs
@@ -1,0 +1,20 @@
+using System.Diagnostics;
+
+namespace Granit.Identity.Diagnostics;
+
+/// <summary>
+/// Central <see cref="ActivitySource"/> for the Granit.Identity abstractions.
+/// </summary>
+/// <remarks>
+/// Registered with <c>GranitActivitySourceRegistry</c> by <c>AddGranitIdentity()</c>
+/// so OpenTelemetry exporters configured via <c>WithTracing(...)</c> pick it up
+/// automatically.
+/// </remarks>
+internal static class IdentityActivitySource
+{
+    /// <summary>The name of the Granit.Identity <see cref="ActivitySource"/>.</summary>
+    internal const string Name = "Granit.Identity";
+
+    /// <summary>The singleton <see cref="ActivitySource"/> instance.</summary>
+    internal static readonly ActivitySource Source = new(Name);
+}

--- a/src/Granit.Identity/Extensions/IdentityServiceCollectionExtensions.cs
+++ b/src/Granit.Identity/Extensions/IdentityServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.Diagnostics;
 using Granit.Identity.Diagnostics;
 using Granit.Identity.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,6 +20,8 @@ public static class IdentityServiceCollectionExtensions
     public static IServiceCollection AddGranitIdentity(
         this IServiceCollection services)
     {
+        GranitActivitySourceRegistry.Register(IdentityActivitySource.Name);
+
         services.TryAddSingleton<IdentityMetrics>();
         services.TryAddScoped<IIdentityProvider, NullIdentityProvider>();
         RegisterFineGrainedInterfaces(services);

--- a/src/Granit.Identity/IUserLookupService.cs
+++ b/src/Granit.Identity/IUserLookupService.cs
@@ -79,10 +79,10 @@ public interface IUserLookupService
     /// <returns>The number of users refreshed.</returns>
     Task<int> RefreshStaleAsync(CancellationToken cancellationToken = default);
 
-    // -- RGPD --
+    // -- GDPR --
 
     /// <summary>
-    /// Permanently deletes the cached entry for a user (RGPD Art. 17 — right to erasure).
+    /// Permanently deletes the cached entry for a user (GDPR Art. 17 — right to erasure).
     /// </summary>
     /// <param name="userId">The user ID to erase.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -90,7 +90,7 @@ public interface IUserLookupService
 
     /// <summary>
     /// Replaces personally identifiable information in the cached entry with anonymized data
-    /// (RGPD Art. 18 — right to restriction of processing).
+    /// (GDPR Art. 18 — right to restriction of processing).
     /// </summary>
     /// <param name="userId">The user ID to pseudonymize.</param>
     /// <param name="cancellationToken">Cancellation token.</param>

--- a/src/Granit.Notifications.Abstractions/Abstractions/INotificationDeliveryWriter.cs
+++ b/src/Granit.Notifications.Abstractions/Abstractions/INotificationDeliveryWriter.cs
@@ -7,7 +7,7 @@ namespace Granit.Notifications.Abstractions;
 /// </summary>
 /// <remarks>
 /// Records are INSERT-only during the HDS retention period (default 3 years).
-/// After retention expires, <see cref="DeleteBeforeAsync"/> enables RGPD-compliant
+/// After retention expires, <see cref="DeleteBeforeAsync"/> enables GDPR-compliant
 /// data minimization by purging obsolete records in batches.
 /// </remarks>
 public interface INotificationDeliveryWriter
@@ -30,7 +30,7 @@ public interface INotificationDeliveryWriter
     /// </para>
     /// <para>
     /// ISO 27001: deletion is permitted after the mandatory retention period has elapsed.
-    /// RGPD Art. 5(1)(e): storage limitation requires deletion of data no longer necessary.
+    /// GDPR Art. 5(1)(e): storage limitation requires deletion of data no longer necessary.
     /// </para>
     /// </remarks>
     /// <param name="cutoff">Only attempts that occurred before this instant are deleted.</param>

--- a/src/Granit.Notifications.Abstractions/NotificationDefinition.cs
+++ b/src/Granit.Notifications.Abstractions/NotificationDefinition.cs
@@ -25,7 +25,7 @@ public sealed class NotificationDefinition
 
     /// <summary>
     /// When <c>false</c>, the notification is always sent regardless of user preferences
-    /// (e.g., security alerts, RGPD breach notifications).
+    /// (e.g., security alerts, GDPR breach notifications).
     /// </summary>
     public bool AllowUserOptOut { get; init; } = true;
 

--- a/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreNotificationDeliveryStore.cs
+++ b/src/Granit.Notifications.EntityFrameworkCore/Internal/EfCoreNotificationDeliveryStore.cs
@@ -11,7 +11,7 @@ namespace Granit.Notifications.EntityFrameworkCore.Internal;
 /// <remarks>
 /// <para>
 /// Records are INSERT-only during the HDS retention period. After retention expires,
-/// <see cref="DeleteBeforeAsync"/> enables RGPD-compliant data minimization.
+/// <see cref="DeleteBeforeAsync"/> enables GDPR-compliant data minimization.
 /// </para>
 /// </remarks>
 internal sealed class EfCoreNotificationDeliveryStore(

--- a/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/Extensions/ModelBuilderExtensions.cs
@@ -206,7 +206,7 @@ public static class ModelBuilderExtensions
             .HasMaxLength(20)
             .IsRequired();
 
-        // FK: Translation.ParentId → Parent.Id, cascade delete (RGPD/ISO 27001 compliance)
+        // FK: Translation.ParentId → Parent.Id, cascade delete (GDPR/ISO 27001 compliance)
         builder.HasOne(t => t.Parent)
             .WithMany()
             .HasForeignKey(t => t.ParentId)

--- a/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/TenantPerDatabaseDbContextFactory.cs
+++ b/src/Granit.Persistence.EntityFrameworkCore/MultiTenancy/TenantPerDatabaseDbContextFactory.cs
@@ -18,7 +18,7 @@ namespace Granit.Persistence.EntityFrameworkCore.MultiTenancy;
 /// <para>
 /// Throws <see cref="InvalidOperationException"/> when no tenant is active.
 /// There is no silent fallback: accessing data without a tenant context would violate
-/// RGPD/ISO 27001 inter-tenant isolation requirements.
+/// GDPR/ISO 27001 inter-tenant isolation requirements.
 /// </para>
 /// <para>
 /// <see cref="AuditedEntityInterceptor"/> is wired automatically when available in DI,

--- a/src/Granit.Privacy.Endpoints/Internal/PrivacySchemaExampleProvider.cs
+++ b/src/Granit.Privacy.Endpoints/Internal/PrivacySchemaExampleProvider.cs
@@ -28,7 +28,7 @@ internal sealed class PrivacySchemaExampleProvider : ISchemaExampleProvider
             {
                 ["documentId"] = "privacy-policy",
                 ["displayName"] = "Privacy Policy",
-                ["description"] = "Initial draft based on RGPD Art. 13 disclosure requirements.",
+                ["description"] = "Initial draft based on GDPR Art. 13 disclosure requirements.",
                 ["templateName"] = "PrivacyPolicy",
             },
             [typeof(LegalDocumentUpdateRequest)] = new JsonObject

--- a/src/Granit.Privacy/DataDeletion/DeletionRequestState.cs
+++ b/src/Granit.Privacy/DataDeletion/DeletionRequestState.cs
@@ -1,7 +1,7 @@
 namespace Granit.Privacy.DataDeletion;
 
 /// <summary>
-/// State of a deferred personal data deletion request (RGPD Art. 17 cooling-off period).
+/// State of a deferred personal data deletion request (GDPR Art. 17 cooling-off period).
 /// </summary>
 public enum DeletionRequestState
 {

--- a/src/Granit.Privacy/LegalAgreements/Domain/LegalAgreementBase.cs
+++ b/src/Granit.Privacy/LegalAgreements/Domain/LegalAgreementBase.cs
@@ -4,7 +4,7 @@ using Granit.Domain;
 namespace Granit.Privacy.LegalAgreements.Domain;
 
 /// <summary>
-/// Abstract base entity for legal agreement records (RGPD Art. 7 — proof of consent).
+/// Abstract base entity for legal agreement records (GDPR Art. 7 — proof of consent).
 /// Applications must create a concrete entity inheriting this class and map it in their DbContext.
 /// </summary>
 /// <remarks>
@@ -26,7 +26,7 @@ public abstract class LegalAgreementBase : CreationAuditedEntity
     public DateTimeOffset AcceptedAt { get; set; }
 
     /// <summary>
-    /// IP address of the user at the time of acceptance (pseudonymized — last octet masked, RGPD).
+    /// IP address of the user at the time of acceptance (pseudonymized — last octet masked, GDPR).
     /// </summary>
     [SensitiveData(Level = Sensitivity.Confidential)]
     public string? IpAddress { get; set; }

--- a/src/Granit.Privacy/LegalAgreements/Events/LegalAgreementAcceptedEto.cs
+++ b/src/Granit.Privacy/LegalAgreements/Events/LegalAgreementAcceptedEto.cs
@@ -3,7 +3,7 @@ using Granit.Events;
 namespace Granit.Privacy.LegalAgreements.Events;
 
 /// <summary>
-/// Published when a user accepts a legal agreement (RGPD Art. 7 consent proof).
+/// Published when a user accepts a legal agreement (GDPR Art. 7 consent proof).
 /// Enables cross-service consent tracking and audit trail.
 /// </summary>
 /// <param name="UserId">The user who consented.</param>

--- a/src/Granit.Timeline.Endpoints/Endpoints/TimelineEntryEndpoints.cs
+++ b/src/Granit.Timeline.Endpoints/Endpoints/TimelineEntryEndpoints.cs
@@ -35,7 +35,7 @@ internal static class TimelineEntryEndpoints
         group.MapDelete("/{entityType}/{entityId}/entries/{entryId:guid}", DeleteEntryAsync)
             .RequireAuthorization(TimelinePermissions.Entries.Manage)
             .WithName("DeleteTimelineEntry")
-            .WithSummary("Soft-deletes a comment or internal note (RGPD right to erasure).")
+            .WithSummary("Soft-deletes a comment or internal note (GDPR right to erasure).")
             .WithDescription("Performs a soft-delete on the timeline entry. Only the author or users with Timeline.Entries.Manage permission can delete. SystemLog entries are immutable (ISO 27001). Returns 404 if the entry does not exist.")
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound);

--- a/src/Granit.Timeline.Endpoints/Extensions/TimelineEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Timeline.Endpoints/Extensions/TimelineEndpointRouteBuilderExtensions.cs
@@ -25,7 +25,7 @@ public static class TimelineEndpointRouteBuilderExtensions
     /// <list type="bullet">
     ///   <item><c>GET /{entityType}/{entityId}</c> — paginated activity stream</item>
     ///   <item><c>POST /{entityType}/{entityId}/entries</c> — post comment/note</item>
-    ///   <item><c>DELETE /{entityType}/{entityId}/entries/{id}</c> — soft-delete (RGPD)</item>
+    ///   <item><c>DELETE /{entityType}/{entityId}/entries/{id}</c> — soft-delete (GDPR)</item>
     ///   <item><c>POST /{entityType}/{entityId}/follow</c> — follow entity</item>
     ///   <item><c>DELETE /{entityType}/{entityId}/follow</c> — unfollow entity</item>
     ///   <item><c>GET /{entityType}/{entityId}/followers</c> — list followers</item>

--- a/src/Granit.Timeline.Endpoints/README.md
+++ b/src/Granit.Timeline.Endpoints/README.md
@@ -1,7 +1,7 @@
 # Granit.Timeline.Endpoints
 
 Minimal API endpoints for Granit.Timeline. Exposes paginated activity stream,
-comment/note posting, soft-delete (RGPD), and follower management REST endpoints.
+comment/note posting, soft-delete (GDPR), and follower management REST endpoints.
 
 Part of the [granit](https://granit-fx.dev) framework.
 

--- a/src/Granit.Timeline/Abstractions/ITimelineWriter.cs
+++ b/src/Granit.Timeline/Abstractions/ITimelineWriter.cs
@@ -17,7 +17,7 @@ public interface ITimelineWriter
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Soft-deletes a comment or internal note (RGPD right to erasure).
+    /// Soft-deletes a comment or internal note (GDPR right to erasure).
     /// Throws <see cref="InvalidOperationException"/> for <see cref="TimelineEntryType.SystemLog"/>
     /// entries because they are immutable (ISO 27001 audit trail).
     /// </summary>

--- a/src/Granit.Timeline/Domain/TimelineEntry.cs
+++ b/src/Granit.Timeline/Domain/TimelineEntry.cs
@@ -9,7 +9,7 @@ namespace Granit.Timeline.Domain;
 /// A single entry in the activity stream for any <see cref="ITimelined"/> entity.
 /// Three entry types coexist in the same table:
 /// <list type="bullet">
-///   <item><see cref="TimelineEntryType.Comment"/> — human-authored, soft-deletable (RGPD).</item>
+///   <item><see cref="TimelineEntryType.Comment"/> — human-authored, soft-deletable (GDPR).</item>
 ///   <item><see cref="TimelineEntryType.InternalNote"/> — human-authored, staff-only, soft-deletable.</item>
 ///   <item><see cref="TimelineEntryType.SystemLog"/> — auto-generated, INSERT-only immutable (ISO 27001).</item>
 /// </list>

--- a/src/Granit.Timeline/Domain/TimelineEntryType.cs
+++ b/src/Granit.Timeline/Domain/TimelineEntryType.cs
@@ -6,12 +6,12 @@ namespace Granit.Timeline.Domain;
 /// </summary>
 public enum TimelineEntryType
 {
-    /// <summary>Human-authored comment visible to all followers. Soft-deletable (RGPD).</summary>
+    /// <summary>Human-authored comment visible to all followers. Soft-deletable (GDPR).</summary>
     Comment = 0,
 
     /// <summary>Auto-generated immutable system log. INSERT-only for ISO 27001 audit trail.</summary>
     SystemLog = 1,
 
-    /// <summary>Human-authored internal note visible only to staff. Soft-deletable (RGPD).</summary>
+    /// <summary>Human-authored internal note visible only to staff. Soft-deletable (GDPR).</summary>
     InternalNote = 2,
 }

--- a/src/Granit.Timeline/Events/TimelineEntrySoftDeletedEvent.cs
+++ b/src/Granit.Timeline/Events/TimelineEntrySoftDeletedEvent.cs
@@ -3,7 +3,7 @@ using Granit.Events;
 namespace Granit.Timeline.Events;
 
 /// <summary>
-/// Raised when a timeline entry is soft-deleted (RGPD right to erasure).
+/// Raised when a timeline entry is soft-deleted (GDPR right to erasure).
 /// System log entries cannot be deleted (ISO 27001 audit trail).
 /// </summary>
 public sealed record TimelineEntrySoftDeletedEvent(

--- a/src/Granit.Webhooks.EntityFrameworkCore/Configurations/WebhookDeliveryAttemptConfiguration.cs
+++ b/src/Granit.Webhooks.EntityFrameworkCore/Configurations/WebhookDeliveryAttemptConfiguration.cs
@@ -69,7 +69,7 @@ internal sealed class WebhookDeliveryAttemptConfiguration : IEntityTypeConfigura
         builder.HasIndex(e => new { e.SubscriptionId, e.OccurredAt })
             .HasDatabaseName($"ix_{GranitWebhooksDbProperties.DbTablePrefix}delivery_attempts_subscriptionid_occurredat");
 
-        // RGPD: enables bulk export and erasure by tenant.
+        // GDPR: enables bulk export and erasure by tenant.
         builder.HasIndex(e => new { e.TenantId, e.OccurredAt })
             .HasDatabaseName($"ix_{GranitWebhooksDbProperties.DbTablePrefix}delivery_attempts_tenantid_occurredat");
 

--- a/src/Granit.Webhooks/Abstractions/IWebhookDeliveryWriter.cs
+++ b/src/Granit.Webhooks/Abstractions/IWebhookDeliveryWriter.cs
@@ -50,7 +50,7 @@ public interface IWebhookDeliveryWriter
     /// up to <paramref name="batchSize"/> rows per call.
     /// </summary>
     /// <remarks>
-    /// RGPD Art. 5(1)(e) data minimisation: after the ISO 27001 retention period (3 years),
+    /// GDPR Art. 5(1)(e) data minimisation: after the ISO 27001 retention period (3 years),
     /// delivery records must be purged. Called by archival background jobs in a batch-delete loop.
     /// </remarks>
     /// <returns>The number of rows actually deleted.</returns>

--- a/src/Granit.Webhooks/Abstractions/IWebhookSecretProtector.cs
+++ b/src/Granit.Webhooks/Abstractions/IWebhookSecretProtector.cs
@@ -6,7 +6,7 @@ namespace Granit.Webhooks.Abstractions;
 /// <remarks>
 /// <para>
 /// The default implementation is <c>NoOpWebhookSecretProtector</c> which stores secrets in plain text.
-/// For production (RGPD/ISO 27001), replace with a Vault-backed implementation via
+/// For production (GDPR/ISO 27001), replace with a Vault-backed implementation via
 /// <c>AddGranitWebhooksWithVaultSecrets(keyName)</c> or register a custom implementation.
 /// </para>
 /// <para>

--- a/src/Granit.Webhooks/Domain/WebhookDeliveryAttempt.cs
+++ b/src/Granit.Webhooks/Domain/WebhookDeliveryAttempt.cs
@@ -75,7 +75,7 @@ public sealed class WebhookDeliveryAttempt : Entity, IMultiTenant
     /// </summary>
     /// <remarks>
     /// When stored, this field contains health data in clear text. Encryption at rest
-    /// must be enabled on the database and RGPD validation by the DPO is required.
+    /// must be enabled on the database and GDPR validation by the DPO is required.
     /// </remarks>
     public string? Payload { get; set; }
 }

--- a/src/Granit.Webhooks/Internal/NoOpWebhookSecretProtector.cs
+++ b/src/Granit.Webhooks/Internal/NoOpWebhookSecretProtector.cs
@@ -7,7 +7,7 @@ namespace Granit.Webhooks.Internal;
 /// in plain text. Suitable for development and tests only.
 /// </summary>
 /// <remarks>
-/// For production (RGPD/ISO 27001), register a Vault-backed protector via
+/// For production (GDPR/ISO 27001), register a Vault-backed protector via
 /// <c>AddGranitWebhooksWithVaultSecrets(keyName)</c>.
 /// </remarks>
 internal sealed class NoOpWebhookSecretProtector : IWebhookSecretProtector

--- a/src/Granit.Webhooks/Options/WebhooksOptions.cs
+++ b/src/Granit.Webhooks/Options/WebhooksOptions.cs
@@ -34,7 +34,7 @@ public sealed class WebhooksOptions
     /// <remarks>
     /// Enabling this option stores health data in clear text in the audit trail.
     /// Ensure encryption at rest is configured on the database and that your DPO has validated
-    /// this setting against RGPD data-minimization requirements.
+    /// this setting against GDPR data-minimization requirements.
     /// </remarks>
     public bool StorePayload { get; set; }
 }

--- a/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine.Postgresql/Extensions/WolverinePostgresqlHostApplicationBuilderExtensions.cs
@@ -59,7 +59,7 @@ public static class WolverinePostgresqlHostApplicationBuilderExtensions
 
     /// <summary>
     /// Adds per-tenant database support for Wolverine: each tenant has its own isolated
-    /// PostgreSQL database, required for the strictest RGPD/ISO 27001 physical isolation mandates.
+    /// PostgreSQL database, required for the strictest GDPR/ISO 27001 physical isolation mandates.
     /// </summary>
     /// <typeparam name="TContext">The tenant-specific <see cref="DbContext"/> type.</typeparam>
     /// <param name="builder">The host application builder.</param>

--- a/src/Granit.Wolverine.SqlServer/Extensions/WolverineSqlServerHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Wolverine.SqlServer/Extensions/WolverineSqlServerHostApplicationBuilderExtensions.cs
@@ -56,7 +56,7 @@ public static class WolverineSqlServerHostApplicationBuilderExtensions
 
     /// <summary>
     /// Adds per-tenant database support for Wolverine: each tenant has its own isolated
-    /// SQL Server database, required for the strictest RGPD/ISO 27001 physical isolation mandates.
+    /// SQL Server database, required for the strictest GDPR/ISO 27001 physical isolation mandates.
     /// </summary>
     /// <typeparam name="TContext">The tenant-specific <see cref="DbContext"/> type.</typeparam>
     /// <param name="builder">The host application builder.</param>

--- a/src/Granit.Workflow.EntityFrameworkCore/Configurations/WorkflowTransitionRecordConfiguration.cs
+++ b/src/Granit.Workflow.EntityFrameworkCore/Configurations/WorkflowTransitionRecordConfiguration.cs
@@ -55,7 +55,7 @@ internal sealed class WorkflowTransitionRecordConfiguration
         builder.HasIndex(e => new { e.EntityType, e.EntityId, e.TransitionedAt })
             .HasDatabaseName($"ix_{GranitWorkflowDbProperties.DbTablePrefix}transition_records_entity_type_id_at");
 
-        // RGPD: enables bulk export and erasure by tenant
+        // GDPR: enables bulk export and erasure by tenant
         builder.HasIndex(e => new { e.TenantId, e.TransitionedAt })
             .HasDatabaseName($"ix_{GranitWorkflowDbProperties.DbTablePrefix}transition_records_tenantid_at");
 

--- a/src/Granit/Domain/FullAuditedAggregateRoot.cs
+++ b/src/Granit/Domain/FullAuditedAggregateRoot.cs
@@ -1,7 +1,7 @@
 namespace Granit.Domain;
 
 /// <summary>
-/// Aggregate root with full audit trail including soft delete (RGPD).
+/// Aggregate root with full audit trail including soft delete (GDPR).
 /// Inherits from <see cref="AuditedAggregateRoot"/> and implements <see cref="ISoftDeletable"/>.
 /// </summary>
 public abstract class FullAuditedAggregateRoot : AuditedAggregateRoot, ISoftDeletable

--- a/src/Granit/Domain/IProcessingRestrictable.cs
+++ b/src/Granit/Domain/IProcessingRestrictable.cs
@@ -1,7 +1,7 @@
 namespace Granit.Domain;
 
 /// <summary>
-/// Interface for RGPD processing restriction (Art. 18/21).
+/// Interface for GDPR processing restriction (Art. 18/21).
 /// Marked entities are excluded from standard queries (analytics, marketing, etc.)
 /// but remain in the database — no physical deletion.
 /// </summary>

--- a/tests/Granit.ArchitectureTests/SourceCodeAntiPatternTests.cs
+++ b/tests/Granit.ArchitectureTests/SourceCodeAntiPatternTests.cs
@@ -230,7 +230,7 @@ public sealed partial class SourceCodeAntiPatternTests
 
     /// <summary>
     /// Direct calls to <c>IResponseCookies.Append()</c> or <c>IResponseCookies.Delete()</c>
-    /// bypass the Strict Registry Pattern and RGPD consent checks enforced by
+    /// bypass the Strict Registry Pattern and GDPR consent checks enforced by
     /// <c>IGranitCookieManager</c>. Only <c>GranitCookieManager</c> (the manager implementation
     /// itself) is allowed to call these methods directly.
     /// Complements the <c>GRSEC004</c> Roslyn analyzer which is opt-in per project.
@@ -276,7 +276,7 @@ public sealed partial class SourceCodeAntiPatternTests
 
         violations.ShouldBeEmpty(
             "Direct calls to Response.Cookies.Append() / Delete() bypass the Strict Registry Pattern "
-            + "and RGPD consent checks. Use IGranitCookieManager.SetCookieAsync() or DeleteCookie() instead. "
+            + "and GDPR consent checks. Use IGranitCookieManager.SetCookieAsync() or DeleteCookie() instead. "
             + "If this is the cookie manager implementation itself, name the file GranitCookieManager.cs. "
             + $"Violators: {string.Join(", ", violations)}");
     }

--- a/tests/Granit.BlobStorage.Endpoints.Tests/Dtos/BlobEndpointsDtoTests.cs
+++ b/tests/Granit.BlobStorage.Endpoints.Tests/Dtos/BlobEndpointsDtoTests.cs
@@ -87,9 +87,9 @@ public sealed class BlobEndpointsDtoTests
     [Fact]
     public void BlobDeleteRequest_WithReason_SetsReason()
     {
-        BlobDeleteRequest request = new("docs", "RGPD Art. 17");
+        BlobDeleteRequest request = new("docs", "GDPR Art. 17");
 
-        request.DeletionReason.ShouldBe("RGPD Art. 17");
+        request.DeletionReason.ShouldBe("GDPR Art. 17");
     }
 
     // ── BlobDownloadUrlRequest ───────────────────────────────────────────────

--- a/tests/Granit.BlobStorage.Endpoints.Tests/Validators/BlobDeleteRequestValidatorTests.cs
+++ b/tests/Granit.BlobStorage.Endpoints.Tests/Validators/BlobDeleteRequestValidatorTests.cs
@@ -12,7 +12,7 @@ public sealed class BlobDeleteRequestValidatorTests
     [Fact]
     public void Valid_request_should_pass()
     {
-        BlobDeleteRequest request = new("medical-images", "RGPD Art. 17");
+        BlobDeleteRequest request = new("medical-images", "GDPR Art. 17");
         _validator.TestValidate(request).ShouldNotHaveAnyValidationErrors();
     }
 

--- a/tests/Granit.BlobStorage.EntityFrameworkCore.Tests/EfBlobDescriptorStoreTests.cs
+++ b/tests/Granit.BlobStorage.EntityFrameworkCore.Tests/EfBlobDescriptorStoreTests.cs
@@ -231,15 +231,15 @@ public sealed class EfBlobDescriptorStoreTests
 
         BlobDescriptor? valid = await store.FindAsync(blobId, TestContext.Current.CancellationToken);
         DateTimeOffset deletedAt = new(2026, 2, 23, 12, 0, 0, TimeSpan.Zero);
-        valid!.MarkAsDeleted(deletedAt, "RGPD Art. 17 erasure request");
+        valid!.MarkAsDeleted(deletedAt, "GDPR Art. 17 erasure request");
         await store.UpdateAsync(valid, TestContext.Current.CancellationToken);
 
-        // RGPD /ISO 27001: the audit row must remain in the database after deletion.
+        // GDPR /ISO 27001: the audit row must remain in the database after deletion.
         BlobDescriptor? deleted = await store.FindAsync(blobId, TestContext.Current.CancellationToken);
         deleted.ShouldNotBeNull("ISO 27001 requires the audit record to be retained for 3 years");
         deleted!.Status.ShouldBe(BlobStatus.Deleted);
         deleted.DeletedAt.ShouldBe(deletedAt);
-        deleted.DeletionReason.ShouldBe("RGPD Art. 17 erasure request");
+        deleted.DeletionReason.ShouldBe("GDPR Art. 17 erasure request");
     }
 
     // =========================================================================

--- a/tests/Granit.BlobStorage.Tests/BlobDescriptorTests.cs
+++ b/tests/Granit.BlobStorage.Tests/BlobDescriptorTests.cs
@@ -145,11 +145,11 @@ public sealed class BlobDescriptorTests
         descriptor.MarkAsValid("image/jpeg", 512_000, Now.AddMinutes(1));
         DateTimeOffset deletedAt = Now.AddDays(30);
 
-        descriptor.MarkAsDeleted(deletedAt, "RGPD Art. 17 erasure request");
+        descriptor.MarkAsDeleted(deletedAt, "GDPR Art. 17 erasure request");
 
         descriptor.Status.ShouldBe(BlobStatus.Deleted);
         descriptor.DeletedAt.ShouldBe(deletedAt);
-        descriptor.DeletionReason.ShouldBe("RGPD Art. 17 erasure request");
+        descriptor.DeletionReason.ShouldBe("GDPR Art. 17 erasure request");
         // Audit fields must be preserved — the DB record is never removed.
         descriptor.Id.ShouldNotBe(Guid.Empty);
         descriptor.TenantId.ShouldBe(TestTenantId);
@@ -246,12 +246,12 @@ public sealed class BlobDescriptorTests
         descriptor.MarkAsValid("image/jpeg", 512_000, Now);
         descriptor.ClearDomainEvents();
 
-        descriptor.MarkAsDeleted(Now.AddDays(1), "RGPD Art. 17");
+        descriptor.MarkAsDeleted(Now.AddDays(1), "GDPR Art. 17");
 
         BlobDeletedEvent evt = descriptor.DomainEvents.ShouldHaveSingleItem().ShouldBeOfType<BlobDeletedEvent>();
         evt.BlobId.ShouldBe(descriptor.Id);
         evt.ContainerName.ShouldBe("medical-images");
-        evt.DeletionReason.ShouldBe("RGPD Art. 17");
+        evt.DeletionReason.ShouldBe("GDPR Art. 17");
     }
 
     [Fact]

--- a/tests/Granit.BlobStorage.Tests/DefaultBlobStorageTests.cs
+++ b/tests/Granit.BlobStorage.Tests/DefaultBlobStorageTests.cs
@@ -238,7 +238,7 @@ public sealed class DefaultBlobStorageTests
         _keyStrategy.ResolveBucketName("medical-images").Returns("granit-blobs");
 
         // Act
-        await _sut.DeleteAsync("medical-images", blobId, "RGPD Art. 17", TestContext.Current.CancellationToken);
+        await _sut.DeleteAsync("medical-images", blobId, "GDPR Art. 17", TestContext.Current.CancellationToken);
 
         // Assert — S3 physically deleted
         await _storeProvider.Received(1).DeleteAsync("granit-blobs", descriptor.ObjectKey, Arg.Any<CancellationToken>());
@@ -246,7 +246,7 @@ public sealed class DefaultBlobStorageTests
         await _writer.Received(1).UpdateAsync(
             Arg.Is<BlobDescriptor>(d =>
                 d.Status == BlobStatus.Deleted &&
-                d.DeletionReason == "RGPD Art. 17" &&
+                d.DeletionReason == "GDPR Art. 17" &&
                 d.DeletedAt == Now),
             Arg.Any<CancellationToken>());
     }
@@ -285,14 +285,14 @@ public sealed class DefaultBlobStorageTests
     [Fact]
     public async Task DeleteAsync_ShouldPreserveAuditRecord_AfterS3Delete()
     {
-        // Arrange — validates the RGPD/ISO 27001 constraint: the DB row must survive deletion
+        // Arrange — validates the GDPR/ISO 27001 constraint: the DB row must survive deletion
         var blobId = Guid.NewGuid();
         BlobDescriptor descriptor = BuildValidDescriptor(blobId);
         _reader.FindAsync(blobId, Arg.Any<CancellationToken>()).Returns(descriptor);
         _keyStrategy.ResolveBucketName(Arg.Any<string>()).Returns("granit-blobs");
 
         // Act
-        await _sut.DeleteAsync("medical-images", blobId, "RGPD erasure", TestContext.Current.CancellationToken);
+        await _sut.DeleteAsync("medical-images", blobId, "GDPR erasure", TestContext.Current.CancellationToken);
 
         // Assert — UpdateAsync called (not a delete from DB)
         await _writer.Received(1).UpdateAsync(Arg.Any<BlobDescriptor>(), Arg.Any<CancellationToken>());

--- a/tests/Granit.BlobStorage.Tests/Events/BlobEventsTests.cs
+++ b/tests/Granit.BlobStorage.Tests/Events/BlobEventsTests.cs
@@ -81,11 +81,11 @@ public sealed class BlobEventsTests
     {
         var blobId = Guid.NewGuid();
 
-        BlobDeletedEvent evt = new(blobId, "docs", "RGPD Art. 17");
+        BlobDeletedEvent evt = new(blobId, "docs", "GDPR Art. 17");
 
         evt.BlobId.ShouldBe(blobId);
         evt.ContainerName.ShouldBe("docs");
-        evt.DeletionReason.ShouldBe("RGPD Art. 17");
+        evt.DeletionReason.ShouldBe("GDPR Art. 17");
     }
 
     [Fact]

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityUserCacheGdprEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityUserCacheGdprEndpointsTests.cs
@@ -13,9 +13,9 @@ using Xunit;
 namespace Granit.Identity.Endpoints.Tests;
 
 /// <summary>
-/// Integration tests for identity user cache RGPD endpoints (erase, pseudonymize).
+/// Integration tests for identity user cache GDPR endpoints (erase, pseudonymize).
 /// </summary>
-public sealed class IdentityUserCacheRgpdEndpointsTests : IAsyncDisposable
+public sealed class IdentityUserCacheGdprEndpointsTests : IAsyncDisposable
 {
     private const string AdminRole = "granit-identity-admin";
     private const string Prefix = "/identity/users";
@@ -26,7 +26,7 @@ public sealed class IdentityUserCacheRgpdEndpointsTests : IAsyncDisposable
     private readonly HttpClient _adminClient;
     private readonly HttpClient _userClient;
 
-    public IdentityUserCacheRgpdEndpointsTests()
+    public IdentityUserCacheGdprEndpointsTests()
     {
         WebApplicationBuilder builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();

--- a/tests/Granit.Identity.Federated.GoogleCloud.Tests/GoogleCloudIdentityHealthCheckTests.cs
+++ b/tests/Granit.Identity.Federated.GoogleCloud.Tests/GoogleCloudIdentityHealthCheckTests.cs
@@ -1,7 +1,10 @@
 using Granit.Identity.Federated.GoogleCloud.HealthChecks;
+using Granit.Identity.Federated.GoogleCloud.Internal;
 using Granit.Identity.Federated.GoogleCloud.Options;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Shouldly;
 using Xunit;
 
@@ -9,11 +12,14 @@ namespace Granit.Identity.Federated.GoogleCloud.Tests;
 
 public sealed class GoogleCloudIdentityHealthCheckTests
 {
+    private readonly IFirebaseAuthTransport _transport = Substitute.For<IFirebaseAuthTransport>();
+
     [Fact]
-    public async Task CheckHealthAsync_ReturnsHealthy_WhenProjectIdConfigured()
+    public async Task CheckHealthAsync_ReturnsHealthy_WhenPingSucceeds()
     {
         GoogleCloudIdentityOptions opts = new() { ProjectId = "my-project" };
-        GoogleCloudIdentityHealthCheck sut = new(Microsoft.Extensions.Options.Options.Create(opts));
+        _transport.PingAsync(Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        GoogleCloudIdentityHealthCheck sut = new(_transport, Microsoft.Extensions.Options.Options.Create(opts));
 
         HealthCheckResult result = await sut.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
 
@@ -27,10 +33,24 @@ public sealed class GoogleCloudIdentityHealthCheckTests
     public async Task CheckHealthAsync_ReturnsUnhealthy_WhenProjectIdMissing(string? projectId)
     {
         GoogleCloudIdentityOptions opts = new() { ProjectId = projectId! };
-        GoogleCloudIdentityHealthCheck sut = new(Microsoft.Extensions.Options.Options.Create(opts));
+        GoogleCloudIdentityHealthCheck sut = new(_transport, Microsoft.Extensions.Options.Options.Create(opts));
 
         HealthCheckResult result = await sut.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
 
         result.Status.ShouldBe(HealthStatus.Unhealthy);
+        await _transport.DidNotReceive().PingAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsUnhealthy_WhenGenericExceptionThrown()
+    {
+        GoogleCloudIdentityOptions opts = new() { ProjectId = "my-project" };
+        _transport.PingAsync(Arg.Any<CancellationToken>()).ThrowsAsync(new HttpRequestException("network down"));
+        GoogleCloudIdentityHealthCheck sut = new(_transport, Microsoft.Extensions.Options.Options.Create(opts));
+
+        HealthCheckResult result = await sut.CheckHealthAsync(new HealthCheckContext(), TestContext.Current.CancellationToken);
+
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Description.ShouldBe("Firebase Auth probe failed: HttpRequestException");
     }
 }


### PR DESCRIPTION
## Summary

Apply findings from `/audit Granit.Identity.*` and a solution-wide `RGPD → GDPR` standardization.

### Architecture
- **Wire `IdentityLocalActivitySource`** into 6 handlers (login, 2FA, register, password forgot/reset, account deletion, impersonation); register it via `GranitActivitySourceRegistry` in `GranitIdentityLocalModule`; expose to satellites via `InternalsVisibleTo`. Previously the source existed but was dead — no spans were ever emitted for the local identity flows.
- **`GoogleCloudIdentityHealthCheck` is now a real probe**: calls `IFirebaseAuthTransport.PingAsync` (reads first user page, `PageSize = 1`) instead of only checking that `ProjectId` is set. New extension `AddGranitGoogleCloudIdentityHealthCheck()` with `["readiness", "startup"]` tags + 10s timeout (parity with Keycloak/EntraId).

### Convention
- Add `IdentityActivitySource` to `Granit.Identity` abstractions and register it.
- Rename `IdentityFederatedExportDto` / `IdentityLocalExportDto` → `*Response` (no `*Dto` suffix per `CLAUDE.md`).
- Drop redundant `.ProducesProblem(422)` on `AccountRegistration.RegisterAsync` (auto-injected by `ProblemDetailsResponseOperationTransformer` for endpoints with a request body).
- **RGPD → GDPR rename across the entire solution** — 61 files in `Granit.Identity.*`, `Granit.BlobStorage*`, `Granit.Http.Cookies*`, `Granit.Privacy*`, `Granit.Webhooks*`, `Granit.Timeline*`, `Granit.Notifications*`, `Granit.DataExchange`, `Granit.Workflow.EntityFrameworkCore`, `Granit.Authorization`, `Granit.BackgroundJobs`, `Granit.Persistence.EntityFrameworkCore`, `Granit.Wolverine.{Postgresql,SqlServer}`, `Granit.Diagnostics`, `Granit.Analyzers`, `Granit/Domain` and `docs-site/src/content/docs/frontend/security/cookies.mdx`. Touches XML docs, comments, log message templates, csproj `<Description>`, README. Localization JSON files in `fr*/es*/pt*/it/pt-BR` are intentionally left as `RGPD` (canonical local term).

### Cleanup
- Update `docs-site/.../security/identity.mdx`: 4 missing packages added to FileTree, dependency table and Mermaid graph (`Federated.EntraId`, `Federated.Privacy`, `Local.Endpoints`, `Local.Privacy`).
- `PACKAGE_COUNT`: 281 → 269 (matches `ls src/ | grep '^Granit\.' | wc -l`).
- Remove redundant parent `RequireAuthorization()` on `RoleEndpointRouteBuilderExtensions` and `AccountEndpoint` admin group — children carry the policy.
- Replace hardcoded `Location` URLs (`/identity/provider/users/...`, `/admin/roles/...`) with `httpContext.Request.Path` so the header tracks the configured route prefix.

### Improvement
- Comment intent of `MapGroup(string.Empty).WithTags(...)` sub-groups in `AccountEndpointRouteBuilderExtensions` (sub-groups exist only to attach distinct OpenAPI tags; auto-validation propagates from the parent `MapGranitGroup`).

## Why

- Tighten ISO 27001 / GDPR observability surface: the local identity flows now emit OpenTelemetry spans, and Google Cloud reports an actionable readiness signal instead of a fake "always healthy" result.
- Standardize the regulation acronym in the public API surface (logs, NuGet `<Description>`, XML docs) to match the rest of the framework — `Granit.Privacy` already uses GDPR exclusively.

## Test plan

- [x] `dotnet build Granit.slnx` — 0 warning, 0 error
- [x] `dotnet test` on all 14 Identity test projects: 1191/1191 passed
- [x] `dotnet test` on `Granit.BlobStorage*` (impacted by RGPD rename in XML docs): 202/202 passed
- [x] `dotnet test tests/Granit.ArchitectureTests`: 117/117 passed
- [x] `dotnet format --verify-no-changes` on touched abstractions/endpoints: clean
- [x] `grep -rn "RGPD\|Rgpd" src/ tests/ docs-site/src/` (excluding `.xml`, `/Localization/`, `/.astro/`, `/dist/`): 0 occurrence
