### PR TITLE
feat(query-engine): add optional Lookup descriptor to FilterableField metadata (PR 2/7)

### DIFF
--- a/.github/shard-filters/api-data.slnf
+++ b/.github/shard-filters/api-data.slnf
@@ -23,6 +23,7 @@
       "src/Granit.Caching.StackExchangeRedis/Granit.Caching.StackExchangeRedis.csproj",
       "src/Granit.Caching/Granit.Caching.csproj",
       "src/Granit.DataExchange.Abstractions/Granit.DataExchange.Abstractions.csproj",
+      "src/Granit.DataLookup.Abstractions/Granit.DataLookup.Abstractions.csproj",
       "src/Granit.Encryption/Granit.Encryption.csproj",
       "src/Granit.Events/Granit.Events.csproj",
       "src/Granit.Features/Granit.Features.csproj",

--- a/.github/shard-filters/architecture.slnf
+++ b/.github/shard-filters/architecture.slnf
@@ -65,6 +65,7 @@
       "src/Granit.DataExchange.EntityFrameworkCore/Granit.DataExchange.EntityFrameworkCore.csproj",
       "src/Granit.DataExchange.Excel/Granit.DataExchange.Excel.csproj",
       "src/Granit.DataExchange/Granit.DataExchange.csproj",
+      "src/Granit.DataLookup.Abstractions/Granit.DataLookup.Abstractions.csproj",
       "src/Granit.Diagnostics.Endpoints/Granit.Diagnostics.Endpoints.csproj",
       "src/Granit.Diagnostics/Granit.Diagnostics.csproj",
       "src/Granit.DocumentGeneration.Excel/Granit.DocumentGeneration.Excel.csproj",

--- a/.github/shard-filters/core-ai.slnf
+++ b/.github/shard-filters/core-ai.slnf
@@ -22,6 +22,7 @@
       "src/Granit.DataExchange.AI/Granit.DataExchange.AI.csproj",
       "src/Granit.DataExchange.Abstractions/Granit.DataExchange.Abstractions.csproj",
       "src/Granit.DataExchange/Granit.DataExchange.csproj",
+      "src/Granit.DataLookup.Abstractions/Granit.DataLookup.Abstractions.csproj",
       "src/Granit.Diagnostics.Endpoints/Granit.Diagnostics.Endpoints.csproj",
       "src/Granit.Diagnostics/Granit.Diagnostics.csproj",
       "src/Granit.DocumentGeneration.Excel/Granit.DocumentGeneration.Excel.csproj",

--- a/.github/shard-filters/infrastructure.slnf
+++ b/.github/shard-filters/infrastructure.slnf
@@ -12,6 +12,7 @@
       "src/Granit.BlobStorage/Granit.BlobStorage.csproj",
       "src/Granit.Caching/Granit.Caching.csproj",
       "src/Granit.DataExchange.Abstractions/Granit.DataExchange.Abstractions.csproj",
+      "src/Granit.DataLookup.Abstractions/Granit.DataLookup.Abstractions.csproj",
       "src/Granit.Diagnostics/Granit.Diagnostics.csproj",
       "src/Granit.Encryption/Granit.Encryption.csproj",
       "src/Granit.Events.Wolverine/Granit.Events.Wolverine.csproj",

--- a/.github/shard-filters/saas.slnf
+++ b/.github/shard-filters/saas.slnf
@@ -12,6 +12,7 @@
       "src/Granit.CustomerBalance.EntityFrameworkCore/Granit.CustomerBalance.EntityFrameworkCore.csproj",
       "src/Granit.CustomerBalance/Granit.CustomerBalance.csproj",
       "src/Granit.DataExchange.Abstractions/Granit.DataExchange.Abstractions.csproj",
+      "src/Granit.DataLookup.Abstractions/Granit.DataLookup.Abstractions.csproj",
       "src/Granit.DocumentGeneration/Granit.DocumentGeneration.csproj",
       "src/Granit.Features/Granit.Features.csproj",
       "src/Granit.Guids/Granit.Guids.csproj",

--- a/.github/shard-filters/security.slnf
+++ b/.github/shard-filters/security.slnf
@@ -29,6 +29,7 @@
       "src/Granit.BlobStorage/Granit.BlobStorage.csproj",
       "src/Granit.Caching/Granit.Caching.csproj",
       "src/Granit.DataExchange.Abstractions/Granit.DataExchange.Abstractions.csproj",
+      "src/Granit.DataLookup.Abstractions/Granit.DataLookup.Abstractions.csproj",
       "src/Granit.Diagnostics/Granit.Diagnostics.csproj",
       "src/Granit.Encryption.BackgroundJobs/Granit.Encryption.BackgroundJobs.csproj",
       "src/Granit.Encryption.EntityFrameworkCore/Granit.Encryption.EntityFrameworkCore.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1754,7 +1754,8 @@
     {
       "name": "Granit.QueryEngine.Abstractions",
       "deps": [
-        "Granit"
+        "Granit",
+        "Granit.DataLookup.Abstractions"
       ],
       "framework": "net10.0"
     },
@@ -35563,7 +35564,7 @@
       "kind": "class",
       "project": "Granit.QueryEngine.Abstractions",
       "file": "src/Granit.QueryEngine.Abstractions/ColumnBuilder.cs",
-      "line": 7,
+      "line": 9,
       "members": []
     },
     {
@@ -35572,7 +35573,7 @@
       "kind": "class",
       "project": "Granit.QueryEngine.Abstractions",
       "file": "src/Granit.QueryEngine.Abstractions/ColumnDescriptor.cs",
-      "line": 6,
+      "line": 8,
       "members": [
         {
           "name": "PropertyName",
@@ -35969,7 +35970,7 @@
       "kind": "record",
       "project": "Granit.QueryEngine.Abstractions",
       "file": "src/Granit.QueryEngine.Abstractions/Meta/FilterableField.cs",
-      "line": 16,
+      "line": 24,
       "members": []
     },
     {

--- a/.slnf/ai.slnf
+++ b/.slnf/ai.slnf
@@ -16,6 +16,7 @@
       "src/Granit.Authorization/Granit.Authorization.csproj",
       "src/Granit.Caching/Granit.Caching.csproj",
       "src/Granit.DataExchange.Abstractions/Granit.DataExchange.Abstractions.csproj",
+      "src/Granit.DataLookup.Abstractions/Granit.DataLookup.Abstractions.csproj",
       "src/Granit.Guids/Granit.Guids.csproj",
       "src/Granit.Http.ApiDocumentation/Granit.Http.ApiDocumentation.csproj",
       "src/Granit.Http.ApiVersioning/Granit.Http.ApiVersioning.csproj",

--- a/.slnf/application.slnf
+++ b/.slnf/application.slnf
@@ -16,6 +16,7 @@
       "src/Granit.DataExchange.EntityFrameworkCore/Granit.DataExchange.EntityFrameworkCore.csproj",
       "src/Granit.DataExchange.Excel/Granit.DataExchange.Excel.csproj",
       "src/Granit.DataExchange/Granit.DataExchange.csproj",
+      "src/Granit.DataLookup.Abstractions/Granit.DataLookup.Abstractions.csproj",
       "src/Granit.DocumentGeneration.Excel/Granit.DocumentGeneration.Excel.csproj",
       "src/Granit.DocumentGeneration.Pdf/Granit.DocumentGeneration.Pdf.csproj",
       "src/Granit.DocumentGeneration/Granit.DocumentGeneration.csproj",

--- a/.slnf/compliance.slnf
+++ b/.slnf/compliance.slnf
@@ -15,6 +15,7 @@
       "src/Granit.BlobStorage/Granit.BlobStorage.csproj",
       "src/Granit.Caching/Granit.Caching.csproj",
       "src/Granit.DataExchange.Abstractions/Granit.DataExchange.Abstractions.csproj",
+      "src/Granit.DataLookup.Abstractions/Granit.DataLookup.Abstractions.csproj",
       "src/Granit.Encryption/Granit.Encryption.csproj",
       "src/Granit.Events/Granit.Events.csproj",
       "src/Granit.Features/Granit.Features.csproj",

--- a/.slnf/infrastructure.slnf
+++ b/.slnf/infrastructure.slnf
@@ -24,6 +24,7 @@
       "src/Granit.Caching.StackExchangeRedis/Granit.Caching.StackExchangeRedis.csproj",
       "src/Granit.Caching/Granit.Caching.csproj",
       "src/Granit.DataExchange.Abstractions/Granit.DataExchange.Abstractions.csproj",
+      "src/Granit.DataLookup.Abstractions/Granit.DataLookup.Abstractions.csproj",
       "src/Granit.Encryption/Granit.Encryption.csproj",
       "src/Granit.Events.Wolverine/Granit.Events.Wolverine.csproj",
       "src/Granit.Events/Granit.Events.csproj",

--- a/.slnf/notifications.slnf
+++ b/.slnf/notifications.slnf
@@ -9,6 +9,7 @@
       "src/Granit.BlobStorage/Granit.BlobStorage.csproj",
       "src/Granit.Caching/Granit.Caching.csproj",
       "src/Granit.DataExchange.Abstractions/Granit.DataExchange.Abstractions.csproj",
+      "src/Granit.DataLookup.Abstractions/Granit.DataLookup.Abstractions.csproj",
       "src/Granit.Diagnostics/Granit.Diagnostics.csproj",
       "src/Granit.Encryption/Granit.Encryption.csproj",
       "src/Granit.Guids/Granit.Guids.csproj",

--- a/.slnf/security.slnf
+++ b/.slnf/security.slnf
@@ -28,6 +28,7 @@
       "src/Granit.BlobStorage/Granit.BlobStorage.csproj",
       "src/Granit.Caching/Granit.Caching.csproj",
       "src/Granit.DataExchange.Abstractions/Granit.DataExchange.Abstractions.csproj",
+      "src/Granit.DataLookup.Abstractions/Granit.DataLookup.Abstractions.csproj",
       "src/Granit.Diagnostics/Granit.Diagnostics.csproj",
       "src/Granit.Encryption.BackgroundJobs/Granit.Encryption.BackgroundJobs.csproj",
       "src/Granit.Encryption.EntityFrameworkCore/Granit.Encryption.EntityFrameworkCore.csproj",

--- a/.slnf/tooling.slnf
+++ b/.slnf/tooling.slnf
@@ -4,6 +4,7 @@
     "projects": [
       "src/Granit.Analyzers.CodeFixes/Granit.Analyzers.CodeFixes.csproj",
       "src/Granit.Analyzers/Granit.Analyzers.csproj",
+      "src/Granit.DataLookup.Abstractions/Granit.DataLookup.Abstractions.csproj",
       "src/Granit.Guids/Granit.Guids.csproj",
       "src/Granit.Http.ExceptionHandling/Granit.Http.ExceptionHandling.csproj",
       "src/Granit.Persistence.EntityFrameworkCore/Granit.Persistence.EntityFrameworkCore.csproj",

--- a/src/Granit.Authorization/packages.lock.json
+++ b/src/Granit.Authorization/packages.lock.json
@@ -27,10 +27,17 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.queryengine.abstractions": {
+      "granit.datalookup.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {

--- a/src/Granit.Localization/packages.lock.json
+++ b/src/Granit.Localization/packages.lock.json
@@ -91,10 +91,17 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.queryengine.abstractions": {
+      "granit.datalookup.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {

--- a/src/Granit.Metering.Endpoints/packages.lock.json
+++ b/src/Granit.Metering.Endpoints/packages.lock.json
@@ -58,6 +58,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -126,7 +132,8 @@
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Granit": "[0.1.0-dev, )"
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.queryengine.aspnetcore": {

--- a/src/Granit.Metering/packages.lock.json
+++ b/src/Granit.Metering/packages.lock.json
@@ -60,6 +60,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.metering.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -69,7 +75,8 @@
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Granit": "[0.1.0-dev, )"
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {

--- a/src/Granit.Persistence.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Persistence.EntityFrameworkCore/packages.lock.json
@@ -128,6 +128,12 @@
       "granit": {
         "type": "Project"
       },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -151,7 +157,8 @@
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Granit": "[0.1.0-dev, )"
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {

--- a/src/Granit.QueryEngine.Abstractions/ColumnBuilder.cs
+++ b/src/Granit.QueryEngine.Abstractions/ColumnBuilder.cs
@@ -1,3 +1,5 @@
+using Granit.DataLookup.Descriptors;
+
 namespace Granit.QueryEngine;
 
 /// <summary>
@@ -13,6 +15,7 @@ public sealed class ColumnBuilder<TEntity> where TEntity : class
     internal bool IsFilterableValue { get; private set; }
     internal bool IsVisibleValue { get; private set; } = true;
     internal string? FormatValue { get; private set; }
+    internal LookupDescriptor? LookupValue { get; private set; }
 
     /// <summary>
     /// Sets the user-facing label for this column.
@@ -83,6 +86,49 @@ public sealed class ColumnBuilder<TEntity> where TEntity : class
     public ColumnBuilder<TEntity> Format(string format)
     {
         FormatValue = format;
+        return this;
+    }
+
+    /// <summary>
+    /// Declares a data-lookup source for this column by registry name. The frontend
+    /// renders a typeahead picker backed by
+    /// <c>GET /api/granit/lookups/{name}</c> instead of a free-text filter input.
+    /// </summary>
+    /// <remarks>
+    /// Preferred form when the backing source is registered in the central
+    /// <c>ILookupRegistry</c>. For one-off lookups pointing to an ad-hoc HTTP
+    /// endpoint, use the overload accepting a full <see cref="LookupDescriptor"/>.
+    /// </remarks>
+    /// <param name="name">Registry key of the lookup (e.g. <c>"tenants"</c>).</param>
+    /// <param name="kind">Kind of backing source — informational, helps the UI pick an affordance.</param>
+    /// <param name="requiredPermission">Permission the caller must hold to open the picker.</param>
+    /// <param name="scopeKeys">Scope keys the source requires (e.g. <c>["tenantId"]</c>).</param>
+    public ColumnBuilder<TEntity> Lookup(
+        string name,
+        LookupKind kind = LookupKind.QueryEngine,
+        string? requiredPermission = null,
+        IReadOnlyList<string>? scopeKeys = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        LookupValue = new LookupDescriptor(
+            Name: name,
+            Kind: kind,
+            RequiredPermission: requiredPermission,
+            ScopeKeys: scopeKeys);
+        return this;
+    }
+
+    /// <summary>
+    /// Declares a data-lookup source for this column via a full
+    /// <see cref="LookupDescriptor"/>. Use when pointing to a custom URL
+    /// (<see cref="LookupDescriptor.Endpoint"/>) or when overriding the default
+    /// <see cref="LookupDescriptor.SearchParam"/>.
+    /// </summary>
+    /// <param name="descriptor">The descriptor to attach to this column.</param>
+    public ColumnBuilder<TEntity> Lookup(LookupDescriptor descriptor)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        LookupValue = descriptor;
         return this;
     }
 }

--- a/src/Granit.QueryEngine.Abstractions/ColumnDescriptor.cs
+++ b/src/Granit.QueryEngine.Abstractions/ColumnDescriptor.cs
@@ -1,3 +1,5 @@
+using Granit.DataLookup.Descriptors;
+
 namespace Granit.QueryEngine;
 
 /// <summary>
@@ -38,4 +40,11 @@ public sealed class ColumnDescriptor
     /// direct member access.
     /// </summary>
     public bool IsShadowProperty { get; init; }
+
+    /// <summary>
+    /// Optional data-lookup descriptor propagated to <c>FilterableField.Lookup</c> in the
+    /// query metadata. Set via <see cref="ColumnBuilder{TEntity}.Lookup(string, LookupKind, string?, IReadOnlyList{string}?)"/>
+    /// or the <see cref="LookupDescriptor"/> overload.
+    /// </summary>
+    public LookupDescriptor? Lookup { get; init; }
 }

--- a/src/Granit.QueryEngine.Abstractions/Granit.QueryEngine.Abstractions.csproj
+++ b/src/Granit.QueryEngine.Abstractions/Granit.QueryEngine.Abstractions.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit\Granit.csproj" />
+    <ProjectReference Include="..\Granit.DataLookup.Abstractions\Granit.DataLookup.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.QueryEngine.Abstractions/Meta/FilterableField.cs
+++ b/src/Granit.QueryEngine.Abstractions/Meta/FilterableField.cs
@@ -1,3 +1,4 @@
+using Granit.DataLookup.Descriptors;
 using Granit.QueryEngine.Filtering;
 
 namespace Granit.QueryEngine.Meta;
@@ -13,8 +14,16 @@ namespace Granit.QueryEngine.Meta;
 /// <see langword="null"/> for non-enum fields. Lets the frontend render a dropdown of
 /// suggestions instead of a free-text input when entering the filter value.
 /// </param>
+/// <param name="Lookup">
+/// Optional descriptor pointing to a data-lookup source (see <c>Granit.DataLookup</c>).
+/// When set, the frontend renders a server-backed typeahead picker instead of a
+/// free-text input — useful for GUID foreign keys (<c>tenantId</c>, <c>userId</c>) or
+/// reference-data codes where the set of valid values is unbounded or user-specific.
+/// <see langword="null"/> for fields without a declared lookup source.
+/// </param>
 public sealed record FilterableField(
     string Name,
     string Type,
     IReadOnlyList<FilterOperator> Operators,
-    IReadOnlyList<string>? EnumValues = null);
+    IReadOnlyList<string>? EnumValues = null,
+    LookupDescriptor? Lookup = null);

--- a/src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs
+++ b/src/Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs
@@ -66,6 +66,7 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
             IsFilterable = builder.IsFilterableValue,
             IsVisible = builder.IsVisibleValue,
             Format = builder.FormatValue,
+            Lookup = builder.LookupValue,
         });
 
         return this;
@@ -98,6 +99,7 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
             IsFilterable = builder.IsFilterableValue,
             IsVisible = builder.IsVisibleValue,
             Format = builder.FormatValue,
+            Lookup = builder.LookupValue,
             IsShadowProperty = true,
         });
 
@@ -132,6 +134,7 @@ public sealed class QueryDefinitionBuilder<TEntity> where TEntity : class
             IsFilterable = builder.IsFilterableValue,
             IsVisible = builder.IsVisibleValue,
             Format = builder.FormatValue,
+            Lookup = builder.LookupValue,
             IsShadowProperty = true,
         });
 

--- a/src/Granit.QueryEngine.Abstractions/packages.lock.json
+++ b/src/Granit.QueryEngine.Abstractions/packages.lock.json
@@ -10,6 +10,12 @@
       },
       "granit": {
         "type": "Project"
+      },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
       }
     }
   }

--- a/src/Granit.QueryEngine.AspNetCore/packages.lock.json
+++ b/src/Granit.QueryEngine.AspNetCore/packages.lock.json
@@ -58,6 +58,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -107,7 +113,8 @@
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Granit": "[0.1.0-dev, )"
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {

--- a/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs
@@ -270,7 +270,8 @@ internal sealed class QueryEngine<TEntity>(
                     c.PropertyName,
                     c.ClrType.Name,
                     FilterOperatorInference.GetOperators(c.ClrType),
-                    GetEnumValues(c.ClrType)))
+                    GetEnumValues(c.ClrType),
+                    c.Lookup))
                 .ToList(),
             SortableFields = _builder.Columns
                 .Where(c => c.IsSortable)

--- a/src/Granit.QueryEngine.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.QueryEngine.EntityFrameworkCore/packages.lock.json
@@ -111,6 +111,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -157,7 +163,8 @@
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Granit": "[0.1.0-dev, )"
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {

--- a/src/Granit.QueryEngine/packages.lock.json
+++ b/src/Granit.QueryEngine/packages.lock.json
@@ -17,10 +17,17 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
-      "granit.queryengine.abstractions": {
+      "granit.datalookup.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.queryengine.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       }
     }

--- a/src/Granit.Validation/packages.lock.json
+++ b/src/Granit.Validation/packages.lock.json
@@ -61,6 +61,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.http.exceptionhandling": {
         "type": "Project",
         "dependencies": {
@@ -80,7 +86,8 @@
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Granit": "[0.1.0-dev, )"
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {

--- a/src/Granit.Webhooks.Endpoints/packages.lock.json
+++ b/src/Granit.Webhooks.Endpoints/packages.lock.json
@@ -136,6 +136,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.encryption": {
         "type": "Project",
         "dependencies": {
@@ -201,7 +207,8 @@
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Granit": "[0.1.0-dev, )"
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.queryengine.aspnetcore": {

--- a/src/Granit.Webhooks/packages.lock.json
+++ b/src/Granit.Webhooks/packages.lock.json
@@ -110,6 +110,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.encryption": {
         "type": "Project",
         "dependencies": {
@@ -142,7 +148,8 @@
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Granit": "[0.1.0-dev, )"
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.timing": {

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryEngineTests.cs
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/Internal/QueryEngineTests.cs
@@ -1,3 +1,4 @@
+using Granit.DataLookup.Descriptors;
 using Granit.QueryEngine.EntityFrameworkCore.Internal;
 using Granit.QueryEngine.Filtering;
 using Granit.QueryEngine.Meta;
@@ -292,6 +293,81 @@ public sealed class QueryEngineTests : IAsyncLifetime
         FilterableField priceField = metadata.FilterableFields
             .First(f => f.Name == "Price");
         priceField.EnumValues.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetMetadata_emits_lookup_descriptor_when_declared()
+    {
+        LookupDefinition definition = new();
+        QueryEngine<TestProduct> engine = new(definition, NullLogger<QueryEngine<TestProduct>>.Instance, Microsoft.Extensions.Options.Options.Create(new Granit.QueryEngine.Options.QueryEngineOptions()));
+
+        QueryMetadata metadata = engine.GetMetadata();
+
+        FilterableField tenantField = metadata.FilterableFields
+            .First(f => f.Name == "Name");
+        tenantField.Lookup.ShouldNotBeNull();
+        tenantField.Lookup!.Name.ShouldBe("tenants");
+        tenantField.Lookup.Kind.ShouldBe(LookupKind.QueryEngine);
+        tenantField.Lookup.RequiredPermission.ShouldBe("Platform.Tenants.Read");
+    }
+
+    [Fact]
+    public void GetMetadata_lookup_is_null_when_not_declared()
+    {
+        ProductQueryDefinition definition = new();
+        QueryEngine<TestProduct> engine = new(definition, NullLogger<QueryEngine<TestProduct>>.Instance, Microsoft.Extensions.Options.Options.Create(new Granit.QueryEngine.Options.QueryEngineOptions()));
+
+        QueryMetadata metadata = engine.GetMetadata();
+
+        foreach (FilterableField field in metadata.FilterableFields)
+        {
+            field.Lookup.ShouldBeNull();
+        }
+    }
+
+    [Fact]
+    public void GetMetadata_emits_lookup_with_scope_keys_and_endpoint_override()
+    {
+        CustomEndpointLookupDefinition definition = new();
+        QueryEngine<TestProduct> engine = new(definition, NullLogger<QueryEngine<TestProduct>>.Instance, Microsoft.Extensions.Options.Options.Create(new Granit.QueryEngine.Options.QueryEngineOptions()));
+
+        QueryMetadata metadata = engine.GetMetadata();
+
+        FilterableField field = metadata.FilterableFields.First(f => f.Name == "Name");
+        field.Lookup.ShouldNotBeNull();
+        field.Lookup!.Name.ShouldBeNull();
+        field.Lookup.Endpoint.ShouldBe("/api/external/stripe/customers");
+        field.Lookup.ScopeKeys.ShouldBe(["tenantId"]);
+    }
+
+    private sealed class LookupDefinition : QueryDefinition<TestProduct>
+    {
+        public override string Name => "Test.Products.Lookup";
+
+        protected override void Configure(QueryDefinitionBuilder<TestProduct> builder) =>
+            builder
+                .Column(p => p.Name, c => c
+                    .Label("Name")
+                    .Filterable()
+                    .Lookup("tenants", requiredPermission: "Platform.Tenants.Read"))
+                .Column(p => p.Price, c => c.Label("Price").Filterable())
+                .DefaultPageSize(10);
+    }
+
+    private sealed class CustomEndpointLookupDefinition : QueryDefinition<TestProduct>
+    {
+        public override string Name => "Test.Products.CustomLookup";
+
+        protected override void Configure(QueryDefinitionBuilder<TestProduct> builder) =>
+            builder
+                .Column(p => p.Name, c => c
+                    .Label("Name")
+                    .Filterable()
+                    .Lookup(new LookupDescriptor(
+                        Endpoint: "/api/external/stripe/customers",
+                        Kind: LookupKind.Simple,
+                        ScopeKeys: ["tenantId"])))
+                .DefaultPageSize(10);
     }
 
     private sealed class QuickFilterDefinition : QueryDefinition<TestProduct>

--- a/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.QueryEngine.EntityFrameworkCore.Tests/packages.lock.json
@@ -323,6 +323,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -369,7 +375,8 @@
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Granit": "[0.1.0-dev, )"
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       },
       "granit.queryengine.entityframeworkcore": {

--- a/tests/Granit.QueryEngine.Tests/ColumnBuilderTests.cs
+++ b/tests/Granit.QueryEngine.Tests/ColumnBuilderTests.cs
@@ -1,3 +1,4 @@
+using Granit.DataLookup.Descriptors;
 using Shouldly;
 using Xunit;
 
@@ -107,5 +108,65 @@ public sealed class ColumnBuilderTests
             .Format("N2");
 
         result.ShouldBeSameAs(builder);
+    }
+
+    [Fact]
+    public void LookupValue_defaults_to_null()
+    {
+        ColumnBuilder<TestEntity> builder = new();
+
+        builder.LookupValue.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Lookup_by_name_sets_descriptor()
+    {
+        ColumnBuilder<TestEntity> builder = new();
+
+        builder.Lookup("tenants", requiredPermission: "Platform.Tenants.Read");
+
+        builder.LookupValue.ShouldNotBeNull();
+        builder.LookupValue!.Name.ShouldBe("tenants");
+        builder.LookupValue.Kind.ShouldBe(LookupKind.QueryEngine);
+        builder.LookupValue.RequiredPermission.ShouldBe("Platform.Tenants.Read");
+        builder.LookupValue.Endpoint.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Lookup_by_name_accepts_scope_keys()
+    {
+        ColumnBuilder<TestEntity> builder = new();
+
+        builder.Lookup("meter-definitions", scopeKeys: ["tenantId"]);
+
+        builder.LookupValue!.ScopeKeys.ShouldBe(["tenantId"]);
+    }
+
+    [Fact]
+    public void Lookup_by_descriptor_replaces_previous_value()
+    {
+        ColumnBuilder<TestEntity> builder = new();
+        builder.Lookup("tenants");
+
+        LookupDescriptor custom = new(Endpoint: "/api/external", Kind: LookupKind.Simple);
+        builder.Lookup(custom);
+
+        builder.LookupValue.ShouldBe(custom);
+    }
+
+    [Fact]
+    public void Lookup_throws_when_name_is_blank()
+    {
+        ColumnBuilder<TestEntity> builder = new();
+
+        Should.Throw<ArgumentException>(() => builder.Lookup(""));
+    }
+
+    [Fact]
+    public void Lookup_throws_when_descriptor_is_null()
+    {
+        ColumnBuilder<TestEntity> builder = new();
+
+        Should.Throw<ArgumentNullException>(() => builder.Lookup(null!));
     }
 }

--- a/tests/Granit.QueryEngine.Tests/Meta/MetaRecordTests.cs
+++ b/tests/Granit.QueryEngine.Tests/Meta/MetaRecordTests.cs
@@ -272,6 +272,38 @@ public sealed class FilterableFieldEqualityTests
 
         a.ShouldNotBe(b);
     }
+
+    [Fact]
+    public void Lookup_defaults_to_null()
+    {
+        IReadOnlyList<FilterOperator> operators = [FilterOperator.Eq];
+        FilterableField field = new("Name", "String", operators);
+
+        field.Lookup.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Equality_different_lookup_are_not_equal()
+    {
+        IReadOnlyList<FilterOperator> operators = [FilterOperator.Eq];
+        FilterableField a = new("TenantId", "Guid", operators,
+            Lookup: new Granit.DataLookup.Descriptors.LookupDescriptor(Name: "tenants"));
+        FilterableField b = new("TenantId", "Guid", operators,
+            Lookup: new Granit.DataLookup.Descriptors.LookupDescriptor(Name: "organizations"));
+
+        a.ShouldNotBe(b);
+    }
+
+    [Fact]
+    public void Equality_same_lookup_are_equal()
+    {
+        IReadOnlyList<FilterOperator> operators = [FilterOperator.Eq];
+        Granit.DataLookup.Descriptors.LookupDescriptor lookup = new(Name: "tenants");
+        FilterableField a = new("TenantId", "Guid", operators, Lookup: lookup);
+        FilterableField b = new("TenantId", "Guid", operators, Lookup: lookup);
+
+        a.ShouldBe(b);
+    }
 }
 
 public sealed class DateFilterMetaEqualityTests

--- a/tests/Granit.QueryEngine.Tests/packages.lock.json
+++ b/tests/Granit.QueryEngine.Tests/packages.lock.json
@@ -249,6 +249,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.queryengine": {
         "type": "Project",
         "dependencies": {
@@ -260,7 +266,8 @@
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Granit": "[0.1.0-dev, )"
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       }
     }


### PR DESCRIPTION
## Summary

Wires the **Granit.DataLookup** primitive (from #1124) into the QueryEngine
metadata pipeline. Column builders can now declare a typeahead lookup source
per filterable column, and the frontend receives the descriptor on
`FilterableField.Lookup` — additive and null by default, so no existing
caller is affected.

Mirrors the enum-values pattern from PR #1092.

Refs [ADR-023](docs-site/src/content/docs/dotnet/architecture/adr/023-queryengine-reference-data-lookup.md).
This is PR **2 of 7**; PR 3 wires ReferenceData as a lookup source.

### Changes

| File | Change |
| --- | --- |
| `Granit.QueryEngine.Abstractions/Granit.QueryEngine.Abstractions.csproj` | `<ProjectReference>` on `Granit.DataLookup.Abstractions` |
| `Granit.QueryEngine.Abstractions/Meta/FilterableField.cs` | New `LookupDescriptor? Lookup = null` parameter |
| `Granit.QueryEngine.Abstractions/ColumnBuilder.cs` | New `.Lookup(name, …)` fluent method + `.Lookup(LookupDescriptor)` overload |
| `Granit.QueryEngine.Abstractions/ColumnDescriptor.cs` | New `LookupDescriptor? Lookup { get; init; }` |
| `Granit.QueryEngine.Abstractions/QueryDefinitionBuilder.cs` | Propagates `builder.LookupValue` in 3 construction sites |
| `Granit.QueryEngine.EntityFrameworkCore/Internal/QueryEngine.cs` | `GetMetadata()` emits `c.Lookup` alongside `GetEnumValues(c.ClrType)` |

### Usage

```csharp
builder
    .Column(m => m.TenantId, c => c
        .Label("Tenant")
        .Filterable()
        .Lookup("tenants", requiredPermission: "Platform.Tenants.Read"))
    .Column(m => m.MeterDefinitionId, c => c
        .Label("Meter")
        .Filterable()
        .Lookup("meter-definitions", scopeKeys: ["tenantId"]));
```

The frontend consumes `filterableField.lookup` exactly like `enumValues` — no
new metadata endpoint, no new SDK primitive.

### Test plan

- [x] `dotnet build` clean on `Granit.QueryEngine.Abstractions` + `.EntityFrameworkCore` (0 warnings)
- [x] Downstream packages (`Granit.Metering.Endpoints`, `Granit.Webhooks.Endpoints`, `Granit.QueryEngine.AspNetCore`) build clean — confirms the transitive `Granit.DataLookup.Abstractions` reference does not break consumers
- [x] `dotnet test` green:
  - `Granit.QueryEngine.Tests` — 294 tests (includes **6 new ColumnBuilder tests** + **3 new FilterableField equality tests**)
  - `Granit.QueryEngine.EntityFrameworkCore.Tests` — 188 tests (includes **3 new `GetMetadata_*` tests**)
- [x] `dotnet format --verify-no-changes` green
- [ ] CI `business` + `architecture` shards green

### Scope discipline

| ✅ In this PR | ❌ Deferred |
| --- | --- |
| `FilterableField.Lookup` metadata propagation | ReferenceData bridge (PR 3) |
| `ColumnBuilder.Lookup(name, …)` and descriptor overload | Frontend SDK `@granit/data-lookup` + `useLookup` (PR 4) |
| 12 new tests symmetric to PR #1092 | SmartFilterBar routing (PR 5) |
|  | First adopters on Tenant/User/Meter (PR 6) |
|  | Showcase `<LookupSelect>` + ADR-023 → Accepted (PR 7) |