### PR TITLE
feat(data-lookup): first backend adopters (Tenant, Meter, AuditEntry) (PR 6/7)

### DIFF
--- a/.github/shard-filters/api-data.slnf
+++ b/.github/shard-filters/api-data.slnf
@@ -24,6 +24,8 @@
       "src/Granit.Caching/Granit.Caching.csproj",
       "src/Granit.DataExchange.Abstractions/Granit.DataExchange.Abstractions.csproj",
       "src/Granit.DataLookup.Abstractions/Granit.DataLookup.Abstractions.csproj",
+      "src/Granit.DataLookup.EntityFrameworkCore/Granit.DataLookup.EntityFrameworkCore.csproj",
+      "src/Granit.DataLookup/Granit.DataLookup.csproj",
       "src/Granit.Encryption/Granit.Encryption.csproj",
       "src/Granit.Events/Granit.Events.csproj",
       "src/Granit.Features/Granit.Features.csproj",

--- a/.github/shard-filters/architecture.slnf
+++ b/.github/shard-filters/architecture.slnf
@@ -66,6 +66,7 @@
       "src/Granit.DataExchange.Excel/Granit.DataExchange.Excel.csproj",
       "src/Granit.DataExchange/Granit.DataExchange.csproj",
       "src/Granit.DataLookup.Abstractions/Granit.DataLookup.Abstractions.csproj",
+      "src/Granit.DataLookup.EntityFrameworkCore/Granit.DataLookup.EntityFrameworkCore.csproj",
       "src/Granit.DataLookup/Granit.DataLookup.csproj",
       "src/Granit.Diagnostics.Endpoints/Granit.Diagnostics.Endpoints.csproj",
       "src/Granit.Diagnostics/Granit.Diagnostics.csproj",

--- a/.github/shard-filters/infrastructure.slnf
+++ b/.github/shard-filters/infrastructure.slnf
@@ -13,6 +13,8 @@
       "src/Granit.Caching/Granit.Caching.csproj",
       "src/Granit.DataExchange.Abstractions/Granit.DataExchange.Abstractions.csproj",
       "src/Granit.DataLookup.Abstractions/Granit.DataLookup.Abstractions.csproj",
+      "src/Granit.DataLookup.EntityFrameworkCore/Granit.DataLookup.EntityFrameworkCore.csproj",
+      "src/Granit.DataLookup/Granit.DataLookup.csproj",
       "src/Granit.Diagnostics/Granit.Diagnostics.csproj",
       "src/Granit.Encryption/Granit.Encryption.csproj",
       "src/Granit.Events.Wolverine/Granit.Events.Wolverine.csproj",

--- a/.github/shard-filters/saas.slnf
+++ b/.github/shard-filters/saas.slnf
@@ -13,6 +13,8 @@
       "src/Granit.CustomerBalance/Granit.CustomerBalance.csproj",
       "src/Granit.DataExchange.Abstractions/Granit.DataExchange.Abstractions.csproj",
       "src/Granit.DataLookup.Abstractions/Granit.DataLookup.Abstractions.csproj",
+      "src/Granit.DataLookup.EntityFrameworkCore/Granit.DataLookup.EntityFrameworkCore.csproj",
+      "src/Granit.DataLookup/Granit.DataLookup.csproj",
       "src/Granit.DocumentGeneration/Granit.DocumentGeneration.csproj",
       "src/Granit.Features/Granit.Features.csproj",
       "src/Granit.Guids/Granit.Guids.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1144,6 +1144,7 @@
     {
       "name": "Granit.Metering.EntityFrameworkCore",
       "deps": [
+        "Granit.DataLookup.EntityFrameworkCore",
         "Granit.Persistence.EntityFrameworkCore",
         "Granit.Metering"
       ],
@@ -1172,6 +1173,7 @@
       "name": "Granit.MultiTenancy.EntityFrameworkCore",
       "deps": [
         "Granit.DataExchange.Abstractions",
+        "Granit.DataLookup.EntityFrameworkCore",
         "Granit.Events",
         "Granit.MultiTenancy",
         "Granit.Persistence.EntityFrameworkCore",
@@ -23630,7 +23632,7 @@
       "kind": "class",
       "project": "Granit.Metering.EntityFrameworkCore",
       "file": "src/Granit.Metering.EntityFrameworkCore/Extensions/MeteringEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 15,
+      "line": 16,
       "members": [
         {
           "name": "AddGranitMeteringEntityFrameworkCore",
@@ -24360,7 +24362,7 @@
       "kind": "class",
       "project": "Granit.MultiTenancy.EntityFrameworkCore",
       "file": "src/Granit.MultiTenancy.EntityFrameworkCore/Extensions/MultiTenancyEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 18,
+      "line": 19,
       "members": [
         {
           "name": "AddGranitMultiTenancyEntityFrameworkCore",

--- a/.slnf/infrastructure.slnf
+++ b/.slnf/infrastructure.slnf
@@ -25,6 +25,8 @@
       "src/Granit.Caching/Granit.Caching.csproj",
       "src/Granit.DataExchange.Abstractions/Granit.DataExchange.Abstractions.csproj",
       "src/Granit.DataLookup.Abstractions/Granit.DataLookup.Abstractions.csproj",
+      "src/Granit.DataLookup.EntityFrameworkCore/Granit.DataLookup.EntityFrameworkCore.csproj",
+      "src/Granit.DataLookup/Granit.DataLookup.csproj",
       "src/Granit.Encryption/Granit.Encryption.csproj",
       "src/Granit.Events.Wolverine/Granit.Events.Wolverine.csproj",
       "src/Granit.Events/Granit.Events.csproj",

--- a/src/Granit.Auditing/Queries/AuditEntryQueryDefinition.cs
+++ b/src/Granit.Auditing/Queries/AuditEntryQueryDefinition.cs
@@ -17,7 +17,12 @@ public sealed class AuditEntryQueryDefinition : QueryDefinition<AuditEntry>
     protected override void Configure(QueryDefinitionBuilder<AuditEntry> builder)
     {
         builder
-            .Column(e => e.TenantId, c => c.Label("Tenant").LabelKey("Auditing.Columns.Tenant").Filterable().Sortable())
+            .Column(e => e.TenantId, c => c
+                .Label("Tenant")
+                .LabelKey("Auditing.Columns.Tenant")
+                .Filterable()
+                .Sortable()
+                .Lookup("tenants", requiredPermission: "Platform.Tenants.Read"))
             .Column(e => e.Timestamp, c => c.Label("Timestamp").LabelKey("Auditing.Columns.Timestamp").Sortable())
             .Column(e => e.Category, c => c.Label("Category").LabelKey("Auditing.Columns.Category").Filterable().Sortable())
             .Column(e => e.UserId, c => c.Label("User ID").LabelKey("Auditing.Columns.UserId").Filterable().Sortable())

--- a/src/Granit.Metering.EntityFrameworkCore/Extensions/MeteringEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Extensions/MeteringEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.DataLookup.EntityFrameworkCore.Extensions;
 using Granit.Metering.Domain;
 using Granit.Metering.EntityFrameworkCore.Internal;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
@@ -36,6 +37,16 @@ public static class MeteringEntityFrameworkCoreHostApplicationBuilderExtensions
         // Queryable sources for MapGranitQuery (host bypasses tenant filter for cross-tenant review).
         builder.Services.AddScoped<IQueryableSource<MeterDefinition>, EfMeterDefinitionQueryableSource>();
         builder.Services.AddScoped<IQueryableSource<UsageAggregate>, EfUsageAggregateQueryableSource>();
+
+        // Granit.DataLookup source: expose MeterDefinition as the "meter-definitions" lookup.
+        // Scoped by tenantId so UsageAggregate filters (and edit-form pickers elsewhere)
+        // only show meters belonging to the currently-selected tenant.
+        builder.Services.AddQueryableLookup<MeterDefinition, MeteringDbContext>(
+            name: "meter-definitions",
+            valueSelector: m => m.Id,
+            labelSelector: m => m.Name,
+            searchPredicate: (m, search) => m.Name.Contains(search) || m.Unit.Contains(search),
+            scopeKeys: ["tenantId"]);
 
         return builder;
     }

--- a/src/Granit.Metering.EntityFrameworkCore/Granit.Metering.EntityFrameworkCore.csproj
+++ b/src/Granit.Metering.EntityFrameworkCore/Granit.Metering.EntityFrameworkCore.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.DataLookup.EntityFrameworkCore\Granit.DataLookup.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.Metering\Granit.Metering.csproj" />
   </ItemGroup>

--- a/src/Granit.Metering.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Metering.EntityFrameworkCore/packages.lock.json
@@ -43,6 +43,15 @@
         "resolved": "10.0.7",
         "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -96,8 +105,29 @@
         "resolved": "10.0.7",
         "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
       },
       "granit.dataexchange.abstractions": {
         "type": "Project",
@@ -105,10 +135,28 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.datalookup": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
+        }
+      },
       "granit.datalookup.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
         }
       },
       "granit.guids": {
@@ -123,6 +171,18 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
         }
       },
       "granit.metering": {
@@ -212,6 +272,16 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -241,6 +311,24 @@
           "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -258,6 +346,62 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
           "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.14.0",
+        "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
         }
       }
     }

--- a/src/Granit.Metering/Queries/MeterDefinitionQueryDefinition.cs
+++ b/src/Granit.Metering/Queries/MeterDefinitionQueryDefinition.cs
@@ -16,7 +16,12 @@ public sealed class MeterDefinitionQueryDefinition : QueryDefinition<MeterDefini
     protected override void Configure(QueryDefinitionBuilder<MeterDefinition> builder)
     {
         builder
-            .Column(m => m.TenantId, c => c.Label("Tenant").LabelKey("Metering.Columns.Tenant").Filterable().Sortable())
+            .Column(m => m.TenantId, c => c
+                .Label("Tenant")
+                .LabelKey("Metering.Columns.Tenant")
+                .Filterable()
+                .Sortable()
+                .Lookup("tenants", requiredPermission: "Platform.Tenants.Read"))
             .Column(m => m.Name, c => c.Label("Name").LabelKey("Metering.Columns.Name").Filterable().Sortable())
             .Column(m => m.Unit, c => c.Label("Unit").LabelKey("Metering.Columns.Unit").Filterable().Sortable())
             .Column(m => m.AggregationType, c => c.Label("Aggregation").LabelKey("Metering.Columns.AggregationType").Filterable().Sortable())

--- a/src/Granit.Metering/Queries/UsageAggregateQueryDefinition.cs
+++ b/src/Granit.Metering/Queries/UsageAggregateQueryDefinition.cs
@@ -16,8 +16,18 @@ public sealed class UsageAggregateQueryDefinition : QueryDefinition<UsageAggrega
     protected override void Configure(QueryDefinitionBuilder<UsageAggregate> builder)
     {
         builder
-            .Column(u => u.TenantId, c => c.Label("Tenant").LabelKey("Metering.Columns.Tenant").Filterable().Sortable())
-            .Column(u => u.MeterDefinitionId, c => c.Label("Meter").LabelKey("Metering.Columns.MeterDefinition").Filterable().Sortable())
+            .Column(u => u.TenantId, c => c
+                .Label("Tenant")
+                .LabelKey("Metering.Columns.Tenant")
+                .Filterable()
+                .Sortable()
+                .Lookup("tenants", requiredPermission: "Platform.Tenants.Read"))
+            .Column(u => u.MeterDefinitionId, c => c
+                .Label("Meter")
+                .LabelKey("Metering.Columns.MeterDefinition")
+                .Filterable()
+                .Sortable()
+                .Lookup("meter-definitions", scopeKeys: ["tenantId"]))
             .Column(u => u.Period, c => c.Label("Period").LabelKey("Metering.Columns.Period").Filterable().Sortable())
             .Column(u => u.PeriodStart, c => c.Label("Period Start").LabelKey("Metering.Columns.PeriodStart").Sortable())
             .Column(u => u.PeriodEnd, c => c.Label("Period End").LabelKey("Metering.Columns.PeriodEnd").Sortable())

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Extensions/MultiTenancyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Extensions/MultiTenancyEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Granit.DataLookup.EntityFrameworkCore.Extensions;
 using Granit.Events.Extensions;
 using Granit.MultiTenancy.Domain;
 using Granit.MultiTenancy.EntityFrameworkCore.Internal;
@@ -42,6 +43,16 @@ public static class MultiTenancyEntityFrameworkCoreHostApplicationBuilderExtensi
 
         // Queryable source for the Granit query engine (filtering, pagination, sort over Tenant).
         builder.Services.TryAddScoped<IQueryableSource<Tenant>, EfTenantQueryableSource>();
+
+        // Granit.DataLookup source: exposes Tenant as the "tenants" lookup so admin
+        // UIs (QueryEngine filter picker + edit-form dropdowns) can pick a tenant by
+        // name without typing a GUID. Host-scope only — gated by Platform.Tenants.Read.
+        builder.Services.AddQueryableLookup<Tenant, MultiTenancyDbContext>(
+            name: "tenants",
+            valueSelector: t => t.Id,
+            labelSelector: t => t.Name,
+            searchPredicate: (t, search) => t.Name.Contains(search) || t.Identifier.Contains(search),
+            requiredPermission: "Platform.Tenants.Read");
 
         return builder;
     }

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/Granit.MultiTenancy.EntityFrameworkCore.csproj
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/Granit.MultiTenancy.EntityFrameworkCore.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
+    <ProjectReference Include="..\Granit.DataLookup.EntityFrameworkCore\Granit.DataLookup.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.Events\Granit.Events.csproj" />
     <ProjectReference Include="..\Granit.MultiTenancy\Granit.MultiTenancy.csproj" />
     <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />

--- a/src/Granit.MultiTenancy.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.MultiTenancy.EntityFrameworkCore/packages.lock.json
@@ -30,6 +30,15 @@
         "resolved": "10.0.7",
         "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -83,8 +92,29 @@
         "resolved": "10.0.7",
         "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
       },
       "granit.dataexchange.abstractions": {
         "type": "Project",
@@ -92,10 +122,28 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.datalookup": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
+        }
+      },
       "granit.datalookup.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
         }
       },
       "granit.events": {
@@ -118,6 +166,18 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
         }
       },
       "granit.multitenancy": {
@@ -206,6 +266,16 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -248,6 +318,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -265,6 +353,62 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
           "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.14.0",
+        "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
         }
       }
     }

--- a/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.MultiTenancy.EntityFrameworkCore.Tests/packages.lock.json
@@ -122,6 +122,15 @@
         "resolved": "10.0.7",
         "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -314,8 +323,29 @@
           "xunit.v3.runner.common": "[3.2.2]"
         }
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
       },
       "granit.dataexchange.abstractions": {
         "type": "Project",
@@ -323,10 +353,28 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.datalookup": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
+        }
+      },
       "granit.datalookup.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
         }
       },
       "granit.events": {
@@ -351,6 +399,18 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
       "granit.multitenancy": {
         "type": "Project",
         "dependencies": {
@@ -363,6 +423,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
@@ -461,6 +522,16 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -503,6 +574,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -520,6 +609,62 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
           "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.14.0",
+        "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
         }
       }
     }


### PR DESCRIPTION
## Summary

Wires three core modules to the **Granit.DataLookup** primitive introduced
in #1124 / #1127 / #1128. Demonstrates both sides of the contract in a
single PR:

- \`AddQueryableLookup<T, TDbContext>()\` registers an \`ILookupSource\`
  backed by the module's own DbContext (**source**).
- \`ColumnBuilder.Lookup(\"name\", …)\` declares that a filter column points
  to an existing source (**consumer**) — emitted as \`FilterableField.Lookup\`.

Refs [ADR-023](docs-site/src/content/docs/dotnet/architecture/adr/023-queryengine-reference-data-lookup.md).
This is PR **6 of 7**.

## Adopters

### 1. MultiTenancy — \`tenants\`

\`\`\`csharp
builder.Services.AddQueryableLookup<Tenant, MultiTenancyDbContext>(
    name: \"tenants\",
    valueSelector: t => t.Id,
    labelSelector: t => t.Name,
    searchPredicate: (t, search) => t.Name.Contains(search) || t.Identifier.Contains(search),
    requiredPermission: \"Platform.Tenants.Read\");
\`\`\`

- Searchable by Name OR Identifier.
- Gated by \`Platform.Tenants.Read\`.

### 2. Metering — \`meter-definitions\` (source **and** consumer)

\`\`\`csharp
builder.Services.AddQueryableLookup<MeterDefinition, MeteringDbContext>(
    name: \"meter-definitions\",
    valueSelector: m => m.Id,
    labelSelector: m => m.Name,
    searchPredicate: (m, search) => m.Name.Contains(search) || m.Unit.Contains(search),
    scopeKeys: [\"tenantId\"]);
\`\`\`

Consumed by:
- \`MeterDefinitionQueryDefinition.TenantId\` → \`Lookup(\"tenants\")\`.
- \`UsageAggregateQueryDefinition.TenantId\` → \`Lookup(\"tenants\")\`.
- \`UsageAggregateQueryDefinition.MeterDefinitionId\` → \`Lookup(\"meter-definitions\", scopeKeys: [\"tenantId\"])\`.

The **scope-key chain** is what makes this interesting: selecting a tenant
first narrows the meter picker — enforced by the backend (400 on missing
scope key) and the frontend (\`enabled: false\` until parent filled).

### 3. Auditing — consumer only

- \`AuditEntryQueryDefinition.TenantId\` → \`Lookup(\"tenants\")\`.
- \`UserId\` stays free-text for now (user sources live in Identity.Federated /
  Local — adopted in a later PR to keep review scope manageable).

## Effect on existing callers

- **No API break.** \`FilterableField.Lookup\` is an additive optional field;
  frontends that ignore it keep working.
- New \`ILookupSource\` registrations are additive — the DataLookup registry
  aggregates them at scope-resolution time.

## Test plan

- [x] \`dotnet build\` clean on all modified \`*.EntityFrameworkCore\` and base packages (0 warnings).
- [x] \`dotnet test\` green on every touched module:
  - \`Granit.MultiTenancy.Tests\` (93)
  - \`Granit.MultiTenancy.EntityFrameworkCore.Tests\` (33)
  - \`Granit.Metering.Tests\` (37)
  - \`Granit.Auditing.Tests\` (88)
- [x] \`dotnet format --verify-no-changes\` green.
- [x] \`packages.lock.json\` regenerated for all affected projects.
- [ ] CI green (including \`architecture\` shard).

## Scope discipline

| ✅ In this PR | ❌ Deferred |
| --- | --- |
| 3 adopters (Tenant, Meter, AuditEntry) | User sources (Identity.Federated / Local) — later PR |
| Source + consumer pattern demonstrated | Webhook / OpenIddict / Invoicing adopters — optional follow-up |
| scopeKeys chain (tenantId → meter-definitions) | Showcase frontend migrations (\`<LookupSelect>\`) — PR 7 |