### PR TITLE
feat(identity-federated-cognito)!: app-client group sync via naming prefix (#1100) — resubmit

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -839,7 +839,10 @@
     {
       "name": "Granit.Identity.Federated.Cognito",
       "deps": [
-        "Granit.Identity.Federated"
+        "Granit.Authorization",
+        "Granit.Guids",
+        "Granit.Identity.Federated",
+        "Granit.Persistence.EntityFrameworkCore"
       ],
       "framework": "net10.0"
     },
@@ -17540,7 +17543,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.Cognito",
       "file": "src/Granit.Identity.Federated.Cognito/Extensions/IdentityCognitoServiceCollectionExtensions.cs",
-      "line": 17,
+      "line": 19,
       "members": [
         {
           "name": "AddGranitIdentityCognito",
@@ -17591,6 +17594,34 @@
           "kind": "property",
           "signature": "string? AppClientId",
           "returnType": "string?"
+        }
+      ]
+    },
+    {
+      "name": "CognitoClientRoleSyncOptions",
+      "fqn": "Granit.Identity.Federated.Cognito.Options.CognitoClientRoleSyncOptions",
+      "kind": "class",
+      "project": "Granit.Identity.Federated.Cognito",
+      "file": "src/Granit.Identity.Federated.Cognito/Options/CognitoClientRoleSyncOptions.cs",
+      "line": 23,
+      "members": [
+        {
+          "name": "Enabled",
+          "kind": "property",
+          "signature": "bool Enabled",
+          "returnType": "bool"
+        },
+        {
+          "name": "TrackedAppClientIds",
+          "kind": "property",
+          "signature": "IReadOnlyList<string> TrackedAppClientIds",
+          "returnType": "IReadOnlyList<string>"
+        },
+        {
+          "name": "Delimiter",
+          "kind": "property",
+          "signature": "string Delimiter",
+          "returnType": "string"
         }
       ]
     },

--- a/docs-site/src/content/docs/dotnet/architecture/adr/027-cognito-app-client-group-sync.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/027-cognito-app-client-group-sync.md
@@ -1,0 +1,176 @@
+---
+title: "ADR-027: Cognito app-client group sync via naming-prefix convention"
+description: "Apply the ADR-025 client-role template to AWS Cognito User Pools using a {appClientId}:role naming prefix, since Cognito has no native group-to-app-client binding"
+sidebar:
+  order: 27
+  label: "027 - Cognito app-client groups"
+---
+
+> **Date:** 2026-04-23
+> **Authors:** Jean-Francois Meyers
+> **Scope:** `Granit.Identity.Federated.Cognito`
+
+## Context
+
+ADR-025 introduced the `IIdentityClientRoleManager` capability interface, the
+additive `IdentityRole.ClientId` property, and the `IHostDataSeedContributor`
+sync pipeline. Keycloak (#1098 / ADR-025) and Entra ID (#1099 / ADR-026)
+implemented it against native provider constructs — Keycloak client roles,
+Entra App Roles. This ADR plugs AWS Cognito User Pools into the same
+template, closing the Phase 2 story #1100.
+
+AWS Cognito does **not** offer a native "client role" concept. The available
+primitives are:
+
+- **Groups** — a flat list per User Pool. Each group carries a name,
+  a description, a precedence, and an optional IAM Role ARN (used only by
+  **Cognito Identity Pools** for AWS credential federation, not by User Pool
+  app clients).
+- **App Clients** — OIDC clients registered in a User Pool. No link to groups
+  is exposed by the Cognito API.
+
+The "group bound to a specific app client" concept mentioned in #1100 is
+therefore a **Granit-level convention**, not a Cognito feature.
+
+## Decision
+
+### Naming-prefix convention: `{appClientId}{Delimiter}{roleName}`
+
+A Cognito group whose name matches `{TrackedAppClientId}{Delimiter}{RoleName}`
+is treated as a client-scoped role. `{Delimiter}` defaults to `":"` and can
+be overridden via `CognitoClientRoleSyncOptions.Delimiter`. The stripped
+`{RoleName}` is what lands in `IdentityRole.Name` and `RoleMetadata.Name`;
+`{appClientId}` lands in `IdentityRole.ClientId` and `RoleMetadata.ClientId`.
+
+**Why a naming prefix (not description tags, not external mapping):**
+
+- **Infrastructure as truth** — a DevOps engineer opening the Cognito console
+  sees `orders-api:admin` and immediately understands the scope. No second
+  source of config.
+- **No split-brain** — an external `appsettings` mapping would let admins
+  create a group in Cognito that the Granit config forgets to mention
+  (or vice-versa). Prefixes eliminate that class of drift.
+- **Resilient** — descriptions are free-form strings that Terraform scripts,
+  admin notes, or automation routinely overwrite.
+- **Aligned with common practice** — tenants that already namespace their
+  Cognito groups for other reasons (per-product, per-environment) can adopt
+  this convention by setting `Delimiter` to whatever separator they use.
+
+### Un-prefixed groups stay on the realm path
+
+Cognito's existing `GetRolesAsync` (via `IIdentityRoleManager`) already
+enumerates **every** group as a realm-equivalent `IdentityRole`. The role
+orchestrator consumes that output to write `RoleMetadata` rows with
+`ClientId = null`.
+
+The client-role sync introduced here does **not** touch un-prefixed groups —
+processing them would double-write and collide on the
+`(Name, TenantId, ClientId)` unique index for same-named realm rows. Strict
+filtering is the only correct default; there is no "lenient mode".
+
+### `IIdentityClientRoleManager` on `CognitoIdentityProvider`
+
+- `GetClientsAsync` → `ListUserPoolClientsAsync` (paginated), projects every
+  app client id in the User Pool. Caller (sync service) filters against
+  `TrackedAppClientIds`.
+- `GetClientRolesAsync(appClientId)` → `ListGroupsAsync` (paginated),
+  keeps groups whose name starts with `{appClientId}{Delimiter}`, strips
+  the prefix, returns as `IdentityRole` with `ClientId = appClientId`.
+- `GetUserClientRolesAsync(userId, appClientId)` → `AdminListGroupsForUserAsync`
+  (paginated), same prefix filter.
+
+The provider reads the delimiter from `IOptions<CognitoClientRoleSyncOptions>` —
+it is the single place where Granit's naming convention is encoded.
+`SupportsClientRoles` on `CognitoIdentityProviderCapabilities` returns
+`true`.
+
+### Configuration — `CognitoClientRoleSyncOptions`
+
+Bound to `CognitoAdmin:ClientRoleSync`:
+
+```json
+{
+  "CognitoAdmin": {
+    "ClientRoleSync": {
+      "Enabled": true,
+      "Delimiter": ":",
+      "TrackedAppClientIds": [
+        "ordersApiClient",
+        "customerPortalClient"
+      ]
+    }
+  }
+}
+```
+
+Opt-in on `TrackedAppClientIds` — the sync never walks groups for untracked
+clients. Default `Delimiter` is `":"`.
+
+### DI — single scoped instance shared across facets
+
+```csharp
+services.AddIdentityProvider<CognitoIdentityProvider>();  // scoped
+services.TryAddScoped<IIdentityClientRoleManager>(sp =>
+    sp.GetRequiredService<IIdentityProvider>() as IIdentityClientRoleManager
+    ?? throw new InvalidOperationException("..."));
+```
+
+Same pattern as ADR-025 / ADR-026. Locked by
+`IdentityProvider_And_ClientRoleManager_ResolveToSameScopedInstance`.
+
+### Failure policy — log & skip
+
+- `NotAuthorizedException` from AWS → log **Error** with the required IAM
+  actions (`cognito-idp:ListGroups`, `cognito-idp:AdminListGroupsForUser`,
+  `cognito-idp:ListUserPoolClients`), continue.
+- Other `AmazonCognitoIdentityProviderException` → log Warning, continue.
+
+The host never crashes on sync failure; the next boot is a natural retry.
+
+## Required AWS IAM actions
+
+The IAM principal configured on the Cognito SDK client (`AccessKeyId` /
+`SecretAccessKey` or implicit IAM role) needs the following actions on the
+target User Pool:
+
+| Action | Purpose |
+| ------ | ------- |
+| `cognito-idp:ListUserPoolClients` | `GetClientsAsync` — enumerate app clients. |
+| `cognito-idp:ListGroups` | `GetClientRolesAsync` — enumerate groups and prefix-filter. |
+| `cognito-idp:AdminListGroupsForUser` | `GetUserClientRolesAsync` — per-user group membership. |
+
+These are additive to the existing Cognito admin permissions already required
+by `CognitoIdentityProvider` (`ListUsersAsync`, `AdminGetUserAsync`, etc.)
+
+## Consequences
+
+### Positive
+
+- Cognito reaches feature parity with Keycloak and Entra for the Phase 2
+  client-role picture — `RoleMetadata.ClientId` is now populated for all
+  three federated providers.
+- Naming prefix keeps Cognito as the single source of truth; no split-brain
+  between Cognito state and Granit configuration.
+- The ADR-025 DI template ports cleanly, so future providers will drop in the
+  same way.
+
+### Negative
+
+- `Granit.Identity.Federated.Cognito` gains project references to
+  `Granit.Authorization`, `Granit.Guids`, and
+  `Granit.Persistence.EntityFrameworkCore` to host the sync service — same
+  trade-off as ADR-025 and ADR-026.
+- Existing customers whose Cognito groups already use a colon in their names
+  for another purpose (rare, but legal in Cognito — group names accept
+  Unicode punctuation) must override `Delimiter` before enabling the sync.
+- Cognito does not expose "active vs disabled" flags on groups the way Entra
+  App Roles do (`isEnabled`). A group that needs to be retired must be
+  deleted or renamed out of the prefix scope — there is no half-state.
+
+## References
+
+- ADR-025 — Keycloak client-role sync (template).
+- ADR-026 — Entra ID App Role sync (parallel implementation).
+- #1100 — this ADR's implementing PR.
+- [AWS Cognito — Adding groups to a user pool](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-user-groups.html)
+- [AWS Cognito — `ListGroups`](https://docs.aws.amazon.com/cognitoidentityprovider/latest/APIReference/API_ListGroups.html)

--- a/docs-site/src/data/constants.ts
+++ b/docs-site/src/data/constants.ts
@@ -5,4 +5,4 @@ export const CULTURE_COUNT = 18;
 export const BASE_LANGUAGE_COUNT = 15;
 export const REGIONAL_VARIANT_COUNT = 3;
 export const PATTERN_COUNT = 57;
-export const ADR_COUNT = 26;
+export const ADR_COUNT = 27;

--- a/src/Granit.Identity.Federated.Cognito/Diagnostics/IdentityCognitoActivitySource.cs
+++ b/src/Granit.Identity.Federated.Cognito/Diagnostics/IdentityCognitoActivitySource.cs
@@ -25,6 +25,9 @@ internal static class IdentityCognitoActivitySource
         public const string AddUserToGroup = "cognito.add-user-to-group";
         public const string RemoveUserFromGroup = "cognito.remove-user-from-group";
         public const string GlobalSignOut = "cognito.global-sign-out";
+        public const string ListUserPoolClients = "cognito.list-user-pool-clients";
+        public const string GetClientRoles = "cognito.get-client-roles";
+        public const string GetUserClientRoles = "cognito.get-user-client-roles";
 #pragma warning disable GRSEC003 // Operation names, not secrets
         public const string SetPassword = "cognito.set-password";
         public const string ResetPassword = "cognito.reset-password";
@@ -37,5 +40,6 @@ internal static class IdentityCognitoActivitySource
     {
         public const string UserPoolId = "cognito.user_pool_id";
         public const string UserId = "cognito.user_id";
+        public const string ClientId = "cognito.client_id";
     }
 }

--- a/src/Granit.Identity.Federated.Cognito/Extensions/IdentityCognitoServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.Federated.Cognito/Extensions/IdentityCognitoServiceCollectionExtensions.cs
@@ -4,7 +4,9 @@ using Amazon.Runtime;
 using Granit.Diagnostics;
 using Granit.Identity.Extensions;
 using Granit.Identity.Federated.Cognito.Internal;
+using Granit.Identity.Federated.Cognito.Internal.Sync;
 using Granit.Identity.Federated.Cognito.Options;
+using Granit.Persistence.EntityFrameworkCore.DataSeeding;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -52,6 +54,24 @@ public static class IdentityCognitoServiceCollectionExtensions
 
         services.AddIdentityProvider<CognitoIdentityProvider>();
         services.Replace(ServiceDescriptor.Scoped<IIdentityProviderCapabilities, CognitoIdentityProviderCapabilities>());
+
+        // Client-role capability (Phase 2). Forwards to the scoped IIdentityProvider so
+        // IIdentityProvider and IIdentityClientRoleManager resolve to the SAME scoped
+        // CognitoIdentityProvider instance — keeps internal state coherent across the
+        // two facets. See ADR-027.
+        services.TryAddScoped<IIdentityClientRoleManager>(sp =>
+            sp.GetRequiredService<IIdentityProvider>() as IIdentityClientRoleManager
+            ?? throw new InvalidOperationException(
+                "The registered IIdentityProvider does not implement IIdentityClientRoleManager — " +
+                "AddGranitIdentityCognito must be the last provider-registration call."));
+
+        // Client-role sync pipeline — enumerates prefix-matching Cognito groups for each
+        // tracked app-client id at host boot and upserts RoleMetadata rows.
+        services.AddOptions<CognitoClientRoleSyncOptions>()
+            .BindConfiguration(CognitoClientRoleSyncOptions.SectionName);
+
+        services.TryAddScoped<CognitoClientRoleSyncService>();
+        services.AddTransient<IHostDataSeedContributor, CognitoClientRoleSyncContributor>();
 
         return services;
     }

--- a/src/Granit.Identity.Federated.Cognito/Granit.Identity.Federated.Cognito.csproj
+++ b/src/Granit.Identity.Federated.Cognito/Granit.Identity.Federated.Cognito.csproj
@@ -17,7 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Granit.Authorization\Granit.Authorization.csproj" />
+    <ProjectReference Include="..\Granit.Guids\Granit.Guids.csproj" />
     <ProjectReference Include="..\Granit.Identity.Federated\Granit.Identity.Federated.csproj" />
+    <ProjectReference Include="..\Granit.Persistence.EntityFrameworkCore\Granit.Persistence.EntityFrameworkCore.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.Identity.Federated.Cognito/Internal/CognitoIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.Cognito/Internal/CognitoIdentityProvider.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Amazon.CognitoIdentityProvider;
 using Amazon.CognitoIdentityProvider.Model;
 using Granit.Events;
+using Granit.Identity;
 using Granit.Identity.Events;
 using Granit.Identity.Federated;
 using Granit.Identity.Federated.Cognito.Diagnostics;
@@ -19,14 +20,16 @@ namespace Granit.Identity.Federated.Cognito.Internal;
 internal sealed partial class CognitoIdentityProvider(
     IAmazonCognitoIdentityProvider cognitoClient,
     IOptions<CognitoAdminOptions> options,
+    IOptions<CognitoClientRoleSyncOptions> clientRoleSyncOptions,
     IDistributedEventBus distributedEventBus,
-    ILogger<CognitoIdentityProvider> logger) : IIdentityProvider
+    ILogger<CognitoIdentityProvider> logger) : IIdentityProvider, IIdentityClientRoleManager
 {
     private const string EmailAttribute = "email";
     private const string GivenNameAttribute = "given_name";
     private const string FamilyNameAttribute = "family_name";
 
     private readonly CognitoAdminOptions _options = options.Value;
+    private readonly CognitoClientRoleSyncOptions _clientRoleSyncOptions = clientRoleSyncOptions.Value;
 
     // ── IIdentityUserReader ────────────────────────────────────────────────
 
@@ -577,6 +580,184 @@ internal sealed partial class CognitoIdentityProvider(
         {
             LogCredentialVerificationFailed(ex);
             return false;
+        }
+    }
+
+    // ── IIdentityClientRoleManager (Phase 2) ───────────────────────────────
+    // Cognito groups are flat per User Pool with no native client binding. Granit
+    // infers client scope from a naming prefix: a group named
+    // "{appClientId}{Delimiter}{roleName}" is treated as a client role whose
+    // ClientId is {appClientId}. Un-prefixed groups keep flowing through the
+    // existing realm-role path — see ADR-027.
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<string>> GetClientsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        using Activity? activity = IdentityCognitoActivitySource.Source.StartActivity(
+            IdentityCognitoActivitySource.Operations.ListUserPoolClients);
+
+        try
+        {
+            List<string> clientIds = [];
+            string? paginationToken = null;
+
+            do
+            {
+                ListUserPoolClientsRequest request = new()
+                {
+                    UserPoolId = _options.UserPoolId,
+                    MaxResults = 60,
+                    NextToken = paginationToken,
+                };
+
+                ListUserPoolClientsResponse response = await cognitoClient
+                    .ListUserPoolClientsAsync(request, cancellationToken)
+                    .ConfigureAwait(false);
+
+                clientIds.AddRange(response.UserPoolClients.Select(c => c.ClientId));
+                paginationToken = response.NextToken;
+            }
+            while (!string.IsNullOrEmpty(paginationToken));
+
+            return clientIds;
+        }
+        catch (Exception ex)
+        {
+            LogOperationFailed("ListUserPoolClients", ex);
+            return [];
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<IdentityRole>> GetClientRolesAsync(
+        string clientId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
+
+        using Activity? activity = IdentityCognitoActivitySource.Source.StartActivity(
+            IdentityCognitoActivitySource.Operations.GetClientRoles);
+        activity?.SetTag(IdentityCognitoActivitySource.Tags.ClientId, clientId);
+
+        string prefix = clientId + _clientRoleSyncOptions.Delimiter;
+
+        try
+        {
+            List<IdentityRole> roles = [];
+            string? paginationToken = null;
+
+            do
+            {
+                ListGroupsRequest request = new()
+                {
+                    UserPoolId = _options.UserPoolId,
+                    Limit = 60,
+                    NextToken = paginationToken,
+                };
+
+                ListGroupsResponse response = await cognitoClient
+                    .ListGroupsAsync(request, cancellationToken)
+                    .ConfigureAwait(false);
+
+                foreach (GroupType group in response.Groups)
+                {
+                    if (!group.GroupName.StartsWith(prefix, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    string roleName = group.GroupName[prefix.Length..];
+                    if (string.IsNullOrEmpty(roleName))
+                    {
+                        continue;
+                    }
+
+                    roles.Add(new IdentityRole(
+                        Id: group.GroupName,
+                        Name: roleName,
+                        Description: group.Description)
+                    { ClientId = clientId });
+                }
+
+                paginationToken = response.NextToken;
+            }
+            while (!string.IsNullOrEmpty(paginationToken));
+
+            return roles;
+        }
+        catch (Exception ex)
+        {
+            LogOperationFailed("GetClientRoles", ex);
+            return [];
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<IdentityRole>> GetUserClientRolesAsync(
+        string userId,
+        string clientId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
+
+        using Activity? activity = IdentityCognitoActivitySource.Source.StartActivity(
+            IdentityCognitoActivitySource.Operations.GetUserClientRoles);
+        activity?.SetTag(IdentityCognitoActivitySource.Tags.UserId, userId);
+        activity?.SetTag(IdentityCognitoActivitySource.Tags.ClientId, clientId);
+
+        string prefix = clientId + _clientRoleSyncOptions.Delimiter;
+
+        try
+        {
+            List<IdentityRole> roles = [];
+            string? paginationToken = null;
+
+            do
+            {
+                AdminListGroupsForUserRequest request = new()
+                {
+                    UserPoolId = _options.UserPoolId,
+                    Username = userId,
+                    Limit = 60,
+                    NextToken = paginationToken,
+                };
+
+                AdminListGroupsForUserResponse response = await cognitoClient
+                    .AdminListGroupsForUserAsync(request, cancellationToken)
+                    .ConfigureAwait(false);
+
+                foreach (GroupType group in response.Groups)
+                {
+                    if (!group.GroupName.StartsWith(prefix, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    string roleName = group.GroupName[prefix.Length..];
+                    if (string.IsNullOrEmpty(roleName))
+                    {
+                        continue;
+                    }
+
+                    roles.Add(new IdentityRole(
+                        Id: group.GroupName,
+                        Name: roleName,
+                        Description: group.Description)
+                    { ClientId = clientId });
+                }
+
+                paginationToken = response.NextToken;
+            }
+            while (!string.IsNullOrEmpty(paginationToken));
+
+            return roles;
+        }
+        catch (Exception ex)
+        {
+            LogOperationFailed("GetUserClientRoles", ex);
+            return [];
         }
     }
 

--- a/src/Granit.Identity.Federated.Cognito/Internal/CognitoIdentityProviderCapabilities.cs
+++ b/src/Granit.Identity.Federated.Cognito/Internal/CognitoIdentityProviderCapabilities.cs
@@ -46,4 +46,12 @@ internal sealed class CognitoIdentityProviderCapabilities : IIdentityProviderCap
 
     /// <inheritdoc/>
     public bool IsLocalStore => false;
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Cognito groups are a flat list per User Pool with no native "client scope". Granit
+    /// infers client-scoped roles by matching the <c>{appClientId}:</c> naming prefix —
+    /// see <see cref="Options.CognitoClientRoleSyncOptions"/> and ADR-027.
+    /// </remarks>
+    public bool SupportsClientRoles => true;
 }

--- a/src/Granit.Identity.Federated.Cognito/Internal/Sync/CognitoClientRoleSyncContributor.cs
+++ b/src/Granit.Identity.Federated.Cognito/Internal/Sync/CognitoClientRoleSyncContributor.cs
@@ -1,0 +1,16 @@
+using Granit.Persistence.EntityFrameworkCore.DataSeeding;
+
+namespace Granit.Identity.Federated.Cognito.Internal.Sync;
+
+/// <summary>
+/// Host-level data seed contributor that triggers
+/// <see cref="CognitoClientRoleSyncService.SyncAsync(CancellationToken)"/> at boot.
+/// Mirrors <c>KeycloakClientRoleSyncContributor</c> and <c>EntraIdClientRoleSyncContributor</c>
+/// (ADR-025 / ADR-026 / ADR-027).
+/// </summary>
+internal sealed class CognitoClientRoleSyncContributor(
+    CognitoClientRoleSyncService syncService) : IHostDataSeedContributor
+{
+    public Task SeedAsync(DataSeedContext context, CancellationToken cancellationToken = default) =>
+        syncService.SyncAsync(cancellationToken);
+}

--- a/src/Granit.Identity.Federated.Cognito/Internal/Sync/CognitoClientRoleSyncService.cs
+++ b/src/Granit.Identity.Federated.Cognito/Internal/Sync/CognitoClientRoleSyncService.cs
@@ -1,0 +1,142 @@
+using Amazon.CognitoIdentityProvider;
+using Amazon.CognitoIdentityProvider.Model;
+using Granit.Authorization;
+using Granit.Authorization.Domain;
+using Granit.Guids;
+using Granit.Identity;
+using Granit.Identity.Federated.Cognito.Options;
+using Granit.Identity.Models;
+using Granit.MultiTenancy;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace Granit.Identity.Federated.Cognito.Internal.Sync;
+
+/// <summary>
+/// Pure sync logic — enumerates Cognito groups matching the
+/// <c>{appClientId}{Delimiter}*</c> naming convention for every tracked app-client id
+/// and upserts matching <see cref="RoleMetadata"/> rows. Idempotent via the
+/// <c>(Name, TenantId, ClientId)</c> unique index with <c>NULLS NOT DISTINCT</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Un-prefixed Cognito groups keep flowing through the existing realm-role path
+/// (<c>IIdentityRoleManager.GetRolesAsync</c> + role orchestrator) and surface as
+/// <c>ClientId = null</c>. This sync only processes groups whose name starts with a
+/// tracked-client prefix — no double-write.
+/// </para>
+/// <para>
+/// Failure policy: log &amp; skip. AWS unreachable, missing IAM permission, or an
+/// un-tracked client id in the configuration — each produces a log entry and moves on.
+/// The host never crashes on sync failure; the next boot is a natural retry. See
+/// ADR-027.
+/// </para>
+/// </remarks>
+internal sealed partial class CognitoClientRoleSyncService(
+    IIdentityClientRoleManager clientRoleManager,
+    IRoleMetadataStore roleMetadataStore,
+    IGuidGenerator guidGenerator,
+    IOptions<CognitoClientRoleSyncOptions> options,
+    ILogger<CognitoClientRoleSyncService> logger)
+{
+    public async Task SyncAsync(CancellationToken cancellationToken)
+    {
+        CognitoClientRoleSyncOptions opts = options.Value;
+
+        if (!opts.Enabled)
+        {
+            LogDisabled(logger);
+            return;
+        }
+
+        if (opts.TrackedAppClientIds.Count == 0)
+        {
+            LogNoTrackedClients(logger);
+            return;
+        }
+
+        foreach (string clientId in opts.TrackedAppClientIds)
+        {
+            await SyncClientAsync(clientId, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task SyncClientAsync(string clientId, CancellationToken cancellationToken)
+    {
+        IReadOnlyList<IdentityRole> roles;
+        try
+        {
+            roles = await clientRoleManager.GetClientRolesAsync(clientId, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (NotAuthorizedException ex)
+        {
+            LogForbidden(logger, ex, clientId);
+            return;
+        }
+        catch (AmazonCognitoIdentityProviderException ex)
+        {
+            LogClientSyncFailed(logger, ex, clientId);
+            return;
+        }
+
+        int added = 0;
+        int updated = 0;
+        int unchanged = 0;
+
+        foreach (IdentityRole role in roles)
+        {
+            RoleMetadata? existing = await roleMetadataStore
+                .FindByNameAsync(role.Name, tenantId: null, clientId: clientId, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (existing is null)
+            {
+                var metadata = RoleMetadata.Create(
+                    id: guidGenerator.Create(),
+                    name: role.Name,
+                    multiTenancySide: MultiTenancySide.Host,
+                    tenantId: null,
+                    clientId: clientId,
+                    description: role.Description,
+                    isSystem: false);
+
+                await roleMetadataStore.AddAsync(metadata, cancellationToken).ConfigureAwait(false);
+                added++;
+            }
+            else if (!string.Equals(existing.Description, role.Description, StringComparison.Ordinal))
+            {
+                existing.Rename(existing.Name, role.Description);
+                await roleMetadataStore.UpdateAsync(existing, cancellationToken).ConfigureAwait(false);
+                updated++;
+            }
+            else
+            {
+                unchanged++;
+            }
+        }
+
+        LogClientSynced(logger, clientId, added, updated, unchanged);
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "Cognito client-role sync disabled — skipping.")]
+    private static partial void LogDisabled(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Cognito client-role sync enabled but no TrackedAppClientIds configured — skipping.")]
+    private static partial void LogNoTrackedClients(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Error,
+        Message = "AWS Cognito returned NotAuthorized for client '{ClientId}'. The admin IAM principal needs: cognito-idp:ListGroups, cognito-idp:AdminListGroupsForUser, cognito-idp:ListUserPoolClients on the User Pool.")]
+    private static partial void LogForbidden(ILogger logger, Exception exception, string clientId);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Cognito client-role sync failed for client '{ClientId}'; continuing with the next tracked client.")]
+    private static partial void LogClientSyncFailed(ILogger logger, Exception exception, string clientId);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Cognito client-role sync for '{ClientId}' completed: {Added} added, {Updated} updated, {Unchanged} unchanged.")]
+    private static partial void LogClientSynced(ILogger logger, string clientId, int added, int updated, int unchanged);
+}

--- a/src/Granit.Identity.Federated.Cognito/Options/CognitoClientRoleSyncOptions.cs
+++ b/src/Granit.Identity.Federated.Cognito/Options/CognitoClientRoleSyncOptions.cs
@@ -1,0 +1,53 @@
+namespace Granit.Identity.Federated.Cognito.Options;
+
+/// <summary>
+/// Configuration for the Cognito app-client group-sync pipeline. Populates
+/// <c>RoleMetadata.ClientId</c> with Cognito groups whose names follow the
+/// <c>{appClientId}{Delimiter}{roleName}</c> naming convention — so grants can target
+/// them and <c>IGranitRoleLookup.FindByNameAsync</c> can distinguish realm-style roles
+/// (un-prefixed groups) from app-scope roles (prefixed groups).
+/// </summary>
+/// <remarks>
+/// <para>
+/// AWS Cognito has no native binding between groups and User Pool app clients: groups
+/// are a flat list within a User Pool. Granit therefore relies on a <b>naming prefix</b>
+/// convention to scope groups to a specific app client — see ADR-027.
+/// </para>
+/// <para>
+/// <b>Strict-by-design:</b> only groups matching a tracked-client prefix are synced here.
+/// Un-prefixed groups keep flowing through the existing realm-role path
+/// (<c>IIdentityRoleManager.GetRolesAsync</c> + role orchestrator) and surface as
+/// <c>ClientId = null</c> — no double-write.
+/// </para>
+/// </remarks>
+public sealed class CognitoClientRoleSyncOptions
+{
+    /// <summary>Configuration section: <c>CognitoAdmin:ClientRoleSync</c>.</summary>
+    public const string SectionName = "CognitoAdmin:ClientRoleSync";
+
+    /// <summary>
+    /// When <see langword="false"/>, the sync contributor becomes a no-op even if
+    /// tracked app-client ids are configured. Default: <see langword="true"/>.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Cognito User Pool app-client IDs whose prefix-matching groups should be mirrored
+    /// into <c>RoleMetadata</c> with <c>ClientId</c> set. Opt-in — the sync never walks
+    /// groups for un-tracked clients.
+    /// </summary>
+    public IReadOnlyList<string> TrackedAppClientIds { get; set; } = [];
+
+    /// <summary>
+    /// Character that separates the app-client id from the role name inside a group
+    /// name. A group called <c>{TrackedAppClientIds[0]}{Delimiter}editor</c> becomes
+    /// an <c>IdentityRole("editor") { ClientId = TrackedAppClientIds[0] }</c>.
+    /// Default: <c>":"</c>.
+    /// </summary>
+    /// <remarks>
+    /// Cognito group names accept Unicode letters, marks, symbols, numbers, and
+    /// punctuation — so colons, hyphens, underscores, etc. are all legal. Override
+    /// when an existing deployment already uses a different separator.
+    /// </remarks>
+    public string Delimiter { get; set; } = ":";
+}

--- a/src/Granit.Identity.Federated.Cognito/packages.lock.json
+++ b/src/Granit.Identity.Federated.Cognito/packages.lock.json
@@ -35,6 +35,16 @@
         "resolved": "4.0.3.32",
         "contentHash": "Z+FDac2Sb5dRImj87wVcgsj5PbE34CXDPGFodk11AKTx5B30/NgsnYynZH2NYS/uPZylzcX23NEjGbcMSbqAwQ=="
       },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -52,6 +62,46 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "8Oq/03og7ihwbfx+EjfWhYCdMldClxqnqB9w5ZI4KxuhoiUVDxZYVl06K7fhROOoelhKOtnCUtATCqTCrqSGmA=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -60,6 +110,30 @@
       "granit": {
         "type": "Project"
       },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -67,6 +141,20 @@
         }
       },
       "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
@@ -87,11 +175,86 @@
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
@@ -110,6 +273,51 @@
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
       },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "hs9YULcNhj1UiPjhNoJIDBWS92GvAVzT6DyuvbkoxvDcASZUQFVwQ9EAKtgrOfTaI0Vy6U6RwycXko1SIESM8w==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Options": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -118,6 +326,40 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
           "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.14.0",
+        "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
         }
       }
     }

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -1914,6 +1914,16 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.datalookup.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.diagnostics": {
         "type": "Project",
         "dependencies": {
@@ -2433,6 +2443,7 @@
       "granit.metering.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.DataLookup.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Metering": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )"
@@ -2459,6 +2470,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2147,7 +2147,10 @@
         "type": "Project",
         "dependencies": {
           "AWSSDK.CognitoIdentityProvider": "[4.*, )",
-          "Granit.Identity.Federated": "[0.1.0-dev, )"
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Identity.Federated": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )"
         }
       },
       "granit.identity.federated.entityframeworkcore": {

--- a/tests/Granit.Identity.Federated.Cognito.Tests/CognitoClientRoleTests.cs
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/CognitoClientRoleTests.cs
@@ -1,0 +1,165 @@
+using Amazon.CognitoIdentityProvider;
+using Amazon.CognitoIdentityProvider.Model;
+using Granit.Events;
+using Granit.Identity;
+using Granit.Identity.Federated.Cognito.Internal;
+using Granit.Identity.Federated.Cognito.Options;
+using Granit.Identity.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Federated.Cognito.Tests;
+
+/// <summary>
+/// Covers Phase 2 <see cref="IIdentityClientRoleManager"/> methods on
+/// <see cref="CognitoIdentityProvider"/> — mock-based (same pattern as
+/// <see cref="CognitoIdentityProviderTests"/>).
+/// </summary>
+public sealed class CognitoClientRoleTests
+{
+    private readonly IAmazonCognitoIdentityProvider _cognitoClient =
+        Substitute.For<IAmazonCognitoIdentityProvider>();
+    private readonly IDistributedEventBus _distributedEventBus =
+        Substitute.For<IDistributedEventBus>();
+
+    private CognitoIdentityProvider BuildSut(string delimiter = ":")
+    {
+        CognitoAdminOptions adminOpts = new()
+        {
+            Region = "eu-west-1",
+            UserPoolId = "eu-west-1_TEST",
+            AppClientId = "admin-client",
+        };
+        CognitoClientRoleSyncOptions syncOpts = new()
+        {
+            Delimiter = delimiter,
+        };
+        return new CognitoIdentityProvider(
+            _cognitoClient,
+            Microsoft.Extensions.Options.Options.Create(adminOpts),
+            Microsoft.Extensions.Options.Options.Create(syncOpts),
+            _distributedEventBus,
+            NullLogger<CognitoIdentityProvider>.Instance);
+    }
+
+    [Fact]
+    public async Task GetClientsAsync_ReturnsAppClientIds_FromListUserPoolClients()
+    {
+        _cognitoClient.ListUserPoolClientsAsync(
+                Arg.Any<ListUserPoolClientsRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ListUserPoolClientsResponse
+            {
+                UserPoolClients =
+                [
+                    new UserPoolClientDescription { ClientId = "clientA", ClientName = "App A" },
+                    new UserPoolClientDescription { ClientId = "clientB", ClientName = "App B" },
+                ],
+                NextToken = null,
+            });
+        CognitoIdentityProvider sut = BuildSut();
+
+        IReadOnlyList<string> clients = await sut.GetClientsAsync(
+            TestContext.Current.CancellationToken);
+
+        clients.ShouldBe(["clientA", "clientB"]);
+    }
+
+    [Fact]
+    public async Task GetClientRolesAsync_FiltersByPrefix_StripsAndPopulatesClientId()
+    {
+        _cognitoClient.ListGroupsAsync(
+                Arg.Any<ListGroupsRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ListGroupsResponse
+            {
+                Groups =
+                [
+                    new GroupType { GroupName = "clientA:editor", Description = "Edit docs" },
+                    new GroupType { GroupName = "clientA:viewer", Description = null },
+                    new GroupType { GroupName = "clientB:admin", Description = null },
+                    new GroupType { GroupName = "platform-admins", Description = "Realm role" },
+                ],
+                NextToken = null,
+            });
+        CognitoIdentityProvider sut = BuildSut();
+
+        IReadOnlyList<IdentityRole> roles = await sut.GetClientRolesAsync(
+            "clientA", TestContext.Current.CancellationToken);
+
+        roles.Count.ShouldBe(2);
+        roles[0].Name.ShouldBe("editor");
+        roles[0].ClientId.ShouldBe("clientA");
+        roles[0].Description.ShouldBe("Edit docs");
+        roles[1].Name.ShouldBe("viewer");
+        roles[1].ClientId.ShouldBe("clientA");
+    }
+
+    [Fact]
+    public async Task GetClientRolesAsync_CustomDelimiter_StripsCorrectly()
+    {
+        _cognitoClient.ListGroupsAsync(
+                Arg.Any<ListGroupsRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ListGroupsResponse
+            {
+                Groups =
+                [
+                    new GroupType { GroupName = "clientA__admin", Description = null },
+                    new GroupType { GroupName = "clientA:editor", Description = null },
+                ],
+                NextToken = null,
+            });
+        CognitoIdentityProvider sut = BuildSut(delimiter: "__");
+
+        IReadOnlyList<IdentityRole> roles = await sut.GetClientRolesAsync(
+            "clientA", TestContext.Current.CancellationToken);
+
+        roles.Count.ShouldBe(1);
+        roles[0].Name.ShouldBe("admin");
+    }
+
+    [Fact]
+    public async Task GetClientRolesAsync_NoMatchingGroups_ReturnsEmpty()
+    {
+        _cognitoClient.ListGroupsAsync(
+                Arg.Any<ListGroupsRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ListGroupsResponse
+            {
+                Groups =
+                [
+                    new GroupType { GroupName = "realm-only-group" },
+                ],
+                NextToken = null,
+            });
+        CognitoIdentityProvider sut = BuildSut();
+
+        IReadOnlyList<IdentityRole> roles = await sut.GetClientRolesAsync(
+            "clientA", TestContext.Current.CancellationToken);
+
+        roles.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetUserClientRolesAsync_FiltersByPrefix_PopulatesClientId()
+    {
+        _cognitoClient.AdminListGroupsForUserAsync(
+                Arg.Any<AdminListGroupsForUserRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new AdminListGroupsForUserResponse
+            {
+                Groups =
+                [
+                    new GroupType { GroupName = "clientA:admin", Description = null },
+                    new GroupType { GroupName = "platform-admins", Description = null },
+                ],
+                NextToken = null,
+            });
+        CognitoIdentityProvider sut = BuildSut();
+
+        IReadOnlyList<IdentityRole> roles = await sut.GetUserClientRolesAsync(
+            "user-42", "clientA", TestContext.Current.CancellationToken);
+
+        roles.Count.ShouldBe(1);
+        roles[0].Name.ShouldBe("admin");
+        roles[0].ClientId.ShouldBe("clientA");
+    }
+}

--- a/tests/Granit.Identity.Federated.Cognito.Tests/CognitoIdentityProviderTests.cs
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/CognitoIdentityProviderTests.cs
@@ -33,6 +33,7 @@ public sealed class CognitoIdentityProviderTests
         _sut = new CognitoIdentityProvider(
             _cognitoClient,
             Microsoft.Extensions.Options.Options.Create(options),
+            Microsoft.Extensions.Options.Options.Create(new CognitoClientRoleSyncOptions()),
             _distributedEventBus,
             NullLogger<CognitoIdentityProvider>.Instance);
     }

--- a/tests/Granit.Identity.Federated.Cognito.Tests/IdentityCognitoServiceCollectionExtensionsClientRoleTests.cs
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/IdentityCognitoServiceCollectionExtensionsClientRoleTests.cs
@@ -1,0 +1,49 @@
+using Granit.Events;
+using Granit.Identity;
+using Granit.Identity.Extensions;
+using Granit.Identity.Federated.Cognito.Extensions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Federated.Cognito.Tests;
+
+/// <summary>
+/// Locks the invariant that <see cref="IIdentityProvider"/> and
+/// <see cref="IIdentityClientRoleManager"/> resolve to the SAME scoped instance —
+/// required so internal provider state (option snapshots, internal client handles)
+/// stays coherent across the two facets. Same pattern as Keycloak/Entra. See ADR-027.
+/// </summary>
+public sealed class IdentityCognitoServiceCollectionExtensionsClientRoleTests
+{
+    [Fact]
+    public void IdentityProvider_And_ClientRoleManager_ResolveToSameScopedInstance()
+    {
+        ServiceCollection services = [];
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["CognitoAdmin:Region"] = "eu-west-1",
+                ["CognitoAdmin:UserPoolId"] = "eu-west-1_TEST",
+            }).Build());
+
+        services.AddLogging();
+        services.AddSingleton(Substitute.For<IDistributedEventBus>());
+        services.AddGranitIdentity();
+        services.AddGranitIdentityCognito();
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        using IServiceScope scope = sp.CreateScope();
+
+        IIdentityProvider provider = scope.ServiceProvider.GetRequiredService<IIdentityProvider>();
+        IIdentityClientRoleManager clientRoleManager =
+            scope.ServiceProvider.GetRequiredService<IIdentityClientRoleManager>();
+
+        object.ReferenceEquals(provider, clientRoleManager).ShouldBeTrue(
+            "IIdentityProvider and IIdentityClientRoleManager must resolve to the same " +
+            "scoped CognitoIdentityProvider instance — see ADR-027 and the DI block " +
+            "in AddGranitIdentityCognito.");
+    }
+}

--- a/tests/Granit.Identity.Federated.Cognito.Tests/Sync/CognitoClientRoleSyncServiceTests.cs
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/Sync/CognitoClientRoleSyncServiceTests.cs
@@ -1,0 +1,131 @@
+using Granit.Authorization;
+using Granit.Authorization.Domain;
+using Granit.Guids;
+using Granit.Identity;
+using Granit.Identity.Federated.Cognito.Internal.Sync;
+using Granit.Identity.Models;
+using Granit.MultiTenancy;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+using CgSyncOpts = Granit.Identity.Federated.Cognito.Options.CognitoClientRoleSyncOptions;
+
+namespace Granit.Identity.Federated.Cognito.Tests.Sync;
+
+public sealed class CognitoClientRoleSyncServiceTests
+{
+    private readonly IIdentityClientRoleManager _clientRoleManager =
+        Substitute.For<IIdentityClientRoleManager>();
+    private readonly IRoleMetadataStore _store = Substitute.For<IRoleMetadataStore>();
+    private readonly IGuidGenerator _guidGenerator = Substitute.For<IGuidGenerator>();
+
+    public CognitoClientRoleSyncServiceTests()
+    {
+        _guidGenerator.Create().Returns(_ => Guid.NewGuid());
+    }
+
+    private CognitoClientRoleSyncService BuildSut(params string[] trackedAppClientIds)
+    {
+        CgSyncOpts opts = new()
+        {
+            Enabled = true,
+            TrackedAppClientIds = trackedAppClientIds,
+        };
+        return new CognitoClientRoleSyncService(
+            _clientRoleManager, _store, _guidGenerator,
+            Microsoft.Extensions.Options.Options.Create(opts),
+            NullLogger<CognitoClientRoleSyncService>.Instance);
+    }
+
+    [Fact]
+    public async Task SyncAsync_Disabled_NoCall()
+    {
+        CgSyncOpts opts = new() { Enabled = false, TrackedAppClientIds = ["client-a"] };
+        CognitoClientRoleSyncService sut = new(
+            _clientRoleManager, _store, _guidGenerator,
+            Microsoft.Extensions.Options.Options.Create(opts),
+            NullLogger<CognitoClientRoleSyncService>.Instance);
+
+        await sut.SyncAsync(TestContext.Current.CancellationToken);
+
+        await _clientRoleManager.DidNotReceive().GetClientRolesAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SyncAsync_HappyPath_InsertsNewRoles()
+    {
+        CognitoClientRoleSyncService sut = BuildSut("client-a");
+        _clientRoleManager.GetClientRolesAsync("client-a", Arg.Any<CancellationToken>())
+            .Returns([
+                new IdentityRole("client-a:editor", "editor", "Edit docs") { ClientId = "client-a" },
+                new IdentityRole("client-a:viewer", "viewer", null) { ClientId = "client-a" },
+            ]);
+        _store.FindByNameAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<string>(),
+            Arg.Any<CancellationToken>()).Returns((RoleMetadata?)null);
+
+        await sut.SyncAsync(TestContext.Current.CancellationToken);
+
+        await _store.Received(2).AddAsync(
+            Arg.Is<RoleMetadata>(r => r.ClientId == "client-a"
+                && r.MultiTenancySide == MultiTenancySide.Host
+                && !r.IsSystem && r.TenantId == null),
+            Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SyncAsync_Idempotent_SecondRunNoOpsWhenUnchanged()
+    {
+        CognitoClientRoleSyncService sut = BuildSut("client-a");
+        var existing = RoleMetadata.Create(
+            Guid.NewGuid(), "editor", MultiTenancySide.Host,
+            tenantId: null, clientId: "client-a", description: "Edit docs");
+        _clientRoleManager.GetClientRolesAsync("client-a", Arg.Any<CancellationToken>())
+            .Returns([new IdentityRole("client-a:editor", "editor", "Edit docs") { ClientId = "client-a" }]);
+        _store.FindByNameAsync("editor", null, "client-a", Arg.Any<CancellationToken>())
+            .Returns(existing);
+
+        await sut.SyncAsync(TestContext.Current.CancellationToken);
+
+        await _store.DidNotReceive().AddAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().UpdateAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SyncAsync_DescriptionDrift_CallsUpdate()
+    {
+        CognitoClientRoleSyncService sut = BuildSut("client-a");
+        var existing = RoleMetadata.Create(
+            Guid.NewGuid(), "editor", MultiTenancySide.Host,
+            tenantId: null, clientId: "client-a", description: "OLD description");
+        _clientRoleManager.GetClientRolesAsync("client-a", Arg.Any<CancellationToken>())
+            .Returns([new IdentityRole("client-a:editor", "editor", "NEW description") { ClientId = "client-a" }]);
+        _store.FindByNameAsync("editor", null, "client-a", Arg.Any<CancellationToken>())
+            .Returns(existing);
+
+        await sut.SyncAsync(TestContext.Current.CancellationToken);
+
+        await _store.Received(1).UpdateAsync(
+            Arg.Is<RoleMetadata>(r => r.Description == "NEW description"),
+            Arg.Any<CancellationToken>());
+        await _store.DidNotReceive().AddAsync(Arg.Any<RoleMetadata>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SyncAsync_FailureOnFirstClient_LogsAndContinuesToSecond()
+    {
+        CognitoClientRoleSyncService sut = BuildSut("broken", "client-b");
+        _clientRoleManager.GetClientRolesAsync("broken", Arg.Any<CancellationToken>())
+            .Returns<Task<IReadOnlyList<IdentityRole>>>(_ =>
+                throw new Amazon.CognitoIdentityProvider.Model.NotAuthorizedException("denied"));
+        _clientRoleManager.GetClientRolesAsync("client-b", Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        await sut.SyncAsync(TestContext.Current.CancellationToken);
+
+        await _clientRoleManager.Received(1).GetClientRolesAsync("client-b", Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Granit.Identity.Federated.Cognito.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/packages.lock.json
@@ -106,6 +106,16 @@
         "resolved": "18.5.0",
         "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
       },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -121,6 +131,46 @@
         "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "8Oq/03og7ihwbfx+EjfWhYCdMldClxqnqB9w5ZI4KxuhoiUVDxZYVl06K7fhROOoelhKOtnCUtATCqTCrqSGmA=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Primitives": {
@@ -270,6 +320,30 @@
       "granit": {
         "type": "Project"
       },
+      "granit.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
@@ -277,6 +351,20 @@
         }
       },
       "granit.datalookup.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
@@ -301,8 +389,32 @@
         "type": "Project",
         "dependencies": {
           "AWSSDK.CognitoIdentityProvider": "[4.*, )",
+          "Granit.Authorization": "[0.1.0-dev, )",
+          "Granit.Guids": "[0.1.0-dev, )",
           "Granit.Identity.Federated": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -312,6 +424,14 @@
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
       "AWSSDK.CognitoIdentityProvider": {
         "type": "CentralTransitive",
         "requested": "[4.*, )",
@@ -319,6 +439,52 @@
         "contentHash": "xIY+rbbrlsLAo4uX1oi23hUKv1FL70LAeDpZha/KL+1bsKfJzrPfGCIaNM6bNUGObwWyoVipgUro06CGrAwqrA==",
         "dependencies": {
           "AWSSDK.Core": "[4.0.3.32, 5.0.0)"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
@@ -336,6 +502,51 @@
         "requested": "[10.*, )",
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "hs9YULcNhj1UiPjhNoJIDBWS92GvAVzT6DyuvbkoxvDcASZUQFVwQ9EAKtgrOfTaI0Vy6U6RwycXko1SIESM8w==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
       },
       "Microsoft.Extensions.Options": {
         "type": "CentralTransitive",
@@ -358,6 +569,40 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
           "Microsoft.Extensions.Options": "10.0.7",
           "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.14.0",
+        "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
         }
       }
     }

--- a/tests/Granit.Metering.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Metering.EntityFrameworkCore.Tests/packages.lock.json
@@ -122,6 +122,15 @@
         "resolved": "10.0.7",
         "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -314,8 +323,29 @@
           "xunit.v3.runner.common": "[3.2.2]"
         }
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
+      },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
       },
       "granit.dataexchange.abstractions": {
         "type": "Project",
@@ -323,10 +353,28 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.datalookup": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
+        }
+      },
       "granit.datalookup.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
         }
       },
       "granit.guids": {
@@ -341,6 +389,18 @@
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
         }
       },
       "granit.metering": {
@@ -363,6 +423,7 @@
       "granit.metering.entityframeworkcore": {
         "type": "Project",
         "dependencies": {
+          "Granit.DataLookup.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Metering": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
@@ -451,6 +512,16 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -493,6 +564,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -510,6 +599,62 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
           "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.14.0",
+        "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
         }
       }
     }

--- a/tests/Granit.Persistence.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Persistence.EntityFrameworkCore.Tests/packages.lock.json
@@ -617,6 +617,11 @@
           "xunit.v3.runner.common": "[3.2.2]"
         }
       },
+      "ZString": {
+        "type": "Transitive",
+        "resolved": "2.6.0",
+        "contentHash": "XE8a+11nZg0LRaf+RGABEWaHIf8yGd5w8v/Ra1iWxMBmAVzwuKbW7G21mS0U7w7sh1lYcgckInWGgnz4qyET8A=="
+      },
       "granit": {
         "type": "Project"
       },
@@ -665,16 +670,50 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
+      "granit.caching": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Caching.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Caching.Memory": "[10.*, )",
+          "Microsoft.Extensions.Configuration.Binder": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )",
+          "ZiggyCreatures.FusionCache": "[2.*, )",
+          "ZiggyCreatures.FusionCache.OpenTelemetry": "[2.*, )",
+          "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": "[2.*, )"
+        }
+      },
       "granit.dataexchange.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.datalookup": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup.Abstractions": "[0.1.0-dev, )",
+          "Granit.Localization": "[0.1.0-dev, )"
+        }
+      },
       "granit.datalookup.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.datalookup.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.DataLookup": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
         }
       },
       "granit.events": {
@@ -699,6 +738,18 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.localization": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.Extensions.Localization": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "SmartFormat": "[3.*, )"
+        }
+      },
       "granit.multitenancy": {
         "type": "Project",
         "dependencies": {
@@ -711,6 +762,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.DataLookup.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Events": "[0.1.0-dev, )",
           "Granit.MultiTenancy": "[0.1.0-dev, )",
           "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
@@ -867,6 +919,24 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Localization": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "xUtyqnk0KSTrX1VZ7z++UlNcVqUQAlKgg2/NqTxmQbW9A26Ia3Zvkd1pIX71koue5F8FtV5pCZqsOlJOycvxMA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Localization.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Localization.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "UziyuPCVpRb0PJALYU3enqnYVvyIpdOpfe+DQca81aii1iQTeuxCroaCcOwJpzWUdKBusK9W/9s2G8Zrn+jIXQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -897,6 +967,49 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
           "Microsoft.Extensions.Options": "10.0.7",
           "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.*, )",
+        "resolved": "1.14.0",
+        "contentHash": "foHci6viUw1f3gUB8qzz3Rk02xZIWMo299X0rxK0MoOWok/3dUVru+KKdY7WIoSHwRGpxGKkmAz9jIk2RFNbsQ=="
+      },
+      "SmartFormat": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.6.1",
+        "contentHash": "URa4c3DJcP8B+WNK3jd1AyuBAXmyRKEwTifzJOLeZ9Vud5PcQTGzBG5XkyhebD4tYj+VdyHwwjeBtgwJSIig9A==",
+        "dependencies": {
+          "ZString": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "BCe+/SkwQZfaMpq2ZGDZB2pyx6BdGnP+zxqjMM/5K+4PBuH6hljZeIqH4KVzQ26khSbPsQ7IiYZl0Fve4OZOog==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Memory": "10.0.1"
+        }
+      },
+      "ZiggyCreatures.FusionCache.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "q917DogvL6Y9GamCLz6n/diC56sWUI3rvIuoZsqW7fyw7toWjcVDtSs/5mN8Weafbaj86RQSV5Q5Ysrm1ueJKQ==",
+        "dependencies": {
+          "OpenTelemetry.Api": "1.14.0",
+          "ZiggyCreatures.FusionCache": "2.6.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "CentralTransitive",
+        "requested": "[2.*, )",
+        "resolved": "2.6.0",
+        "contentHash": "A00mNC7xrkC8LUAQMkeB3OtVTfGzyTyHxTgAOwfqaFdazO/54d3fT8LFoekpgSslkvDjKAIPlyafqsFBPLgQIw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.6.0"
         }
       }
     }


### PR DESCRIPTION
Closes #1100.

**Re-submission** of the Cognito Phase 2 work. The original PR #1113 was
merged into the stacked base branch `feat/entraid-app-role-sync`, which
was deleted after `#1112` squash-merged into `develop`. The Cognito
commits on top never made it to `develop`. This PR re-lands them as a
clean branch off current `develop` with lockfiles regenerated.

## Context

ADR-025 (Keycloak, #1098) and ADR-026 (Entra ID, #1099) plugged two
federated providers into `IIdentityClientRoleManager` using each
provider's native client-role construct. AWS Cognito has **no such
construct** — User Pool groups are a flat list with no binding to app
clients. This PR closes the Phase 2 picture by inferring the binding
from a Granit-level naming convention.

## Changes

**Provider (`Granit.Identity.Federated.Cognito`)**

- `CognitoIdentityProvider` now implements `IIdentityClientRoleManager`:
  - `GetClientsAsync` → `ListUserPoolClientsAsync` (paginated).
  - `GetClientRolesAsync(appClientId)` → `ListGroupsAsync`, keeps groups
    named `{appClientId}{Delimiter}*`, strips the prefix.
  - `GetUserClientRolesAsync(userId, appClientId)` →
    `AdminListGroupsForUserAsync`, same prefix filter.
- `SupportsClientRoles` flips to `true`.
- Constructor gains `IOptions<CognitoClientRoleSyncOptions>` to read the
  configured `Delimiter` (single place where the convention is encoded).

**Sync pipeline**

- `CognitoClientRoleSyncOptions` (`CognitoAdmin:ClientRoleSync`):
  `Enabled`, `TrackedAppClientIds`, `Delimiter` (default `":"`).
- `CognitoClientRoleSyncService` mirrors the Keycloak/Entra upsert
  semantics with Cognito-specific failure logging
  (`NotAuthorizedException` → Error with required IAM actions).
- `CognitoClientRoleSyncContributor : IHostDataSeedContributor` runs at
  host boot.
- **Strict-by-design**: un-prefixed groups stay on the realm path
  (existing `GetRolesAsync` + role orchestrator). Processing them here
  would double-write and collide on the
  `(Name, TenantId, ClientId)` unique index.

**DI**

```csharp
services.AddIdentityProvider<CognitoIdentityProvider>();  // scoped
services.TryAddScoped<IIdentityClientRoleManager>(sp =>
    sp.GetRequiredService<IIdentityProvider>() as IIdentityClientRoleManager ?? throw ...);
```

Single scoped instance forwarded to both facets, locked by
`ReferenceEquals` DI test — same pattern as #1098 / #1099.

**Docs**

- ADR-027 — naming-prefix convention, no-double-write rationale,
  required IAM actions
  (`cognito-idp:ListGroups`, `AdminListGroupsForUser`, `ListUserPoolClients`).
- `ADR_COUNT` 26 → 27.

## Tests

60/60 Cognito unit tests green locally (10 new + existing). 117/117
architecture tests green.

## Test plan

- [x] `dotnet build src/Granit.Identity.Federated.Cognito` — 0 warnings.
- [x] `dotnet test tests/Granit.Identity.Federated.Cognito.Tests` — 60 passed.
- [x] `dotnet test tests/Granit.ArchitectureTests` — 117/117.
- [x] `packages.lock.json` regenerated against current `develop`.

## Follow-up

Integration tests tracked in #1117 (LocalStack Pro / WireMock / live AWS
spike).
