### PR TITLE
docs(data-lookup): ADR-027 and pattern guide (PR 7/7)

### DIFF
--- a/docs-site/src/content/docs/dotnet/architecture/adr/027-unified-data-lookup.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/027-unified-data-lookup.md
@@ -1,0 +1,261 @@
+---
+title: "ADR-027: Unified Data Lookup for QueryEngine Filters and Form Dropdowns"
+description: "Introduce Granit.DataLookup — a single declarative primitive that feeds typeahead pickers across QueryEngine filter bars, edit-form dropdowns, and ReferenceData sets. Backed by a scoped registry, a canonical LookupItem shape, and a server-side label projection honoring 18 cultures."
+sidebar:
+  order: 27
+  label: "027 - Unified Data Lookup"
+---
+
+> **Date:** 2026-04-23
+> **Status:** Accepted
+> **Authors:** Jean-Francois Meyers
+> **Scope:** `Granit.DataLookup.Abstractions`, `Granit.DataLookup`,
+> `Granit.DataLookup.EntityFrameworkCore`, `Granit.DataLookup.Endpoints`,
+> `Granit.QueryEngine.Abstractions`, `Granit.QueryEngine.EntityFrameworkCore`,
+> `Granit.ReferenceData`, `Granit.ReferenceData.EntityFrameworkCore`,
+> `@granit/data-lookup`, `@granit/react-data-lookup`,
+> `@granit/react-query-engine` (SmartFilter wiring), plus first adopters
+> `Granit.MultiTenancy`, `Granit.Metering`, `Granit.Auditing`.
+
+## Context
+
+Two adjacent but historically disjoint problems plagued every admin surface
+in Granit:
+
+1. **Filter pickers** — columns in a grid that store foreign keys (`tenantId`,
+   `userId`, `meterDefinitionId`) forced users to type a GUID by hand in
+   `SmartFilterBar` because `FilterableField.Operators` told the frontend
+   "here is an `Eq` / `In` operator", but offered no guidance on *which*
+   values were valid.
+2. **Edit-form dropdowns** — selects in create/edit forms (e.g. "choose a
+   meter definition for this usage aggregate", "pick a tenant for this
+   user") were either hard-coded constants (enums duplicated TS-side), or
+   wired with per-form ad-hoc hooks and endpoints (`GET /api/v1/meters` with
+   a custom projection). No convention, no cache consistency, no
+   authorization gate, no localization story.
+
+`Granit.ReferenceData` already shipped multilingual code lists (countries,
+document types) with 15 `Label{Culture}` columns and its own endpoint, but
+only for fixed taxonomies — not for dynamic cross-aggregate lookups, and
+with no frontend primitive that could consume it uniformly with other
+sources.
+
+Both problems deserve the same shape: "fetch a paginated, searchable list
+of `{ value, label }` from a source that the backend declares, enforce
+auth, localize the label". Solving them in one concept is cheaper to
+maintain, easier to document, and makes every module's pickers consistent
+from day one.
+
+Prior art to copy: PR #1092 added `EnumValues` to `FilterableField` for
+enum-typed columns. Additive optional property, populated at metadata-emission
+time, consumed by the frontend with zero mapping. The lookup descriptor
+mirrors that pattern.
+
+## Decision
+
+Introduce a new framework module — **`Granit.DataLookup`** — that defines
+a scoped registry of named sources and a canonical wire shape consumed
+uniformly from QueryEngine filter metadata and edit-form components.
+
+### 1. Canonical shapes
+
+All sources project to a single shape — the frontend never re-maps:
+
+```csharp
+public sealed record LookupItem(
+    object Value,
+    string Label,                              // already localized server-side
+    IReadOnlyDictionary<string, object?>? Extra = null);
+
+public sealed record LookupResult(
+    IReadOnlyList<LookupItem> Items,
+    int? TotalCount = null,
+    string? ContinuationToken = null);
+
+public sealed record LookupDescriptor(
+    string? Name = null,                       // registry key, preferred
+    string? Endpoint = null,                   // custom URL, fallback
+    LookupKind Kind = LookupKind.QueryEngine,  // QueryEngine | Simple | ReferenceData | Enum
+    string? RequiredPermission = null,
+    string? SearchParam = "search",
+    IReadOnlyList<string>? ScopeKeys = null);
+```
+
+### 2. Registry and adapters
+
+`ILookupRegistry` is a scoped service aggregating every `ILookupSource`
+registered in DI. Three built-in adapters:
+
+| Adapter | Package | Backing source |
+| --- | --- | --- |
+| `EnumLookupSource<TEnum>` | `Granit.DataLookup` | CLR enum + `Enum:{TypeName}.{Value}` localization keys (zero DB roundtrip) |
+| `QueryableLookupSource<TEntity>` | `Granit.DataLookup.EntityFrameworkCore` | `IQueryable<TEntity>` with caller-supplied value/label selectors |
+| `ReferenceDataLookupSource<TEntity>` | `Granit.ReferenceData` | auto-registered for every reference-data type under `ref-{kebab-case-name}` |
+
+Custom adapters implement `ILookupSource` directly (external APIs,
+computed lists, multi-source aggregators).
+
+### 3. Endpoint contract
+
+Mapped once at host startup via `app.MapGranitDataLookups()`:
+
+| Method | Route | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/granit/lookups` | Discovery manifest of every registered source |
+| `GET` | `/api/granit/lookups/{name}` | Paginated typeahead search (`search`, `page`, `pageSize`, `scope.*`) |
+| `GET` | `/api/granit/lookups/{name}/resolve?value=…` | Single-item resolve for rehydrating a persisted FK value |
+
+Every response honors the `Accept-Language` header (labels projected
+server-side), the ambient `ICurrentTenant`, and the per-source
+`RequiredPermission` (auto-injected `401`/`403` from
+`ProblemDetailsResponseOperationTransformer`).
+
+### 4. QueryEngine integration
+
+`FilterableField` gains `LookupDescriptor? Lookup` — additive, null by
+default, emitted in `/meta` when the column declares
+`.Lookup("name", …)` on its `ColumnBuilder`. No impact on existing
+fields. Frontend receives it as `FilterableField.lookup` in the TS type.
+
+### 5. Scoped lookups — Empty Scope Trap mitigation
+
+A scoped lookup (e.g. `meter-definitions` filtered by `tenantId`) declares
+its required scope keys. **Both layers enforce the guard**:
+
+- **Backend**: the endpoint validates that every declared scope key is
+  present and non-empty in the query string. Missing keys return
+  `400 Bad Request` with a `problem+json` body — no silent full-table scan.
+- **Frontend**: `useLookup` flips `enabled: false` as long as any declared
+  scope key is unresolved. No HTTP call fires, and the picker component
+  surfaces `missingScopeKey` so the UI can render an informative
+  placeholder (*"Select a tenant first"*) rather than an open picker with
+  a pending spinner.
+
+This pattern is what makes cascading pickers safe — selecting a tenant
+automatically unlocks its meter-definitions dropdown, and the user never
+sees cross-tenant data.
+
+### 6. Frontend SDK
+
+Two new workspace packages:
+
+- **`@granit/data-lookup`** — framework-agnostic types and axios helpers.
+  Shared `findMissingScopeKey` / `isScopeSatisfied` guards usable outside
+  React.
+- **`@granit/react-data-lookup`** — React Query hooks (`useLookup`,
+  `useLookupResolve`) and three headless render-prop components
+  (`<LookupSelect>`, `<LookupPicker>`, `<LookupBadge>`). Culture-segmented
+  cache keys so switching language invalidates the previously fetched
+  labels.
+
+`@granit/react-query-engine`'s `useSmartFilter` exposes
+`selectedFieldLookup` so consumers branch to `<LookupPicker>` during the
+`enterValue` phase whenever the selected field declares a lookup —
+otherwise the existing enum / boolean / free-text flow runs.
+
+### 7. Label localization
+
+A single path: the server projects the label in the caller's
+`CultureInfo.CurrentUICulture` before sending. `EnumLookupSource` uses
+`IStringLocalizer` keyed by `Enum:{TypeName}.{Value}`;
+`ReferenceDataLookupSource` reuses the existing virtual
+`ReferenceDataEntity.Label` property which resolves
+`Label{Culture}` → `LabelEn` → `Code`; `QueryableLookupSource` honors
+whatever the caller's label selector resolves to. Eighteen cultures
+supported end-to-end (15 base + 3 regional variants).
+
+## Evaluated alternatives
+
+- **Frontend-side registry keyed by source URL.** Each form imports its
+  own hook pointing at a per-module endpoint. Rejected: drifts from the
+  backend contract, fragments permission/localization logic across the UI.
+- **Embed lookup items inline in `/meta`.** Doesn't scale (lookup tables
+  can hold thousands of tenants), breaks when permissions filter the set
+  at user boundary, and bloats every metadata payload.
+- **GraphQL schema with reference types.** Over-engineers the REST+JSON
+  contract Granit already ships; requires a second runtime and tooling.
+- **Scoped lookups resolved by DSL in the descriptor** (e.g.
+  `scope: { tenantId: "@parent.tenantId" }`). Rejected: pushes string
+  parsing into the SDK, complicates testing, and couples the hook to a
+  specific form library. The `scopeKeys` + `<LookupSelect cascadeFrom>`
+  pattern keeps the SDK dumb and lets React Hook Form (or any alternative)
+  own the form-field subscription.
+
+## Justification
+
+- **Declarative and co-located.** The same `ColumnBuilder.Lookup(...)`
+  call both declares the picker shape and documents the intent next to the
+  column it governs. `FilterableField.lookup` then flows end-to-end
+  without custom wiring.
+- **Reuses existing machinery.** `QueryableLookupSource<T>` is a thin
+  projection over any `IQueryable<T>`; `ReferenceDataLookupSource<T>`
+  reuses the already-paginated reference-data reader; `EnumLookupSource`
+  is zero-IO. No new database concept.
+- **Additive and null-tolerant.** `FilterableField.Lookup` is optional;
+  frontends that ignore it keep working. A missing registration simply
+  yields a `404` on the endpoint with no server-side side effect.
+- **Permission-safe.** Per-source `RequiredPermission` is enforced by the
+  dispatch handler before the source is invoked; the frontend uses the
+  manifest to hide pickers from users without the permission.
+- **Multilingual by default.** The label is already in the caller's
+  culture by the time the frontend sees it. No fallback logic, no key
+  leakage.
+
+## Consequences
+
+**Positive:**
+
+- Uniform UX across every admin page — filter pickers, edit-form selects,
+  and read-only value badges all share the same lookup infrastructure.
+- Zero per-form boilerplate for new adopters (one registration + one
+  fluent `.Lookup("name")` in the existing `QueryDefinition`).
+- Cross-language cache segmentation out of the box — switching locale
+  invalidates stale labels automatically.
+
+**Negative / constraints:**
+
+- **Authorization coupling:** the lookup endpoint must be reachable by any
+  principal who can filter by the column. Mitigated by the explicit
+  `RequiredPermission` declaration; enforced twice (manifest + dispatch).
+- **Latency per field.** Each picker round-trips on every keystroke
+  (debounced). React Query cache and the 30s default `staleTime` hide
+  most of that, but offline/ultra-low-bandwidth use cases remain limited.
+- **Naming discipline.** Source names are a magic string matched at
+  runtime; a rename breaks every consumer. Tests enforce uniqueness at
+  registration time, and the manifest endpoint makes orphaned
+  descriptors easy to detect in CI.
+
+## Follow-up work
+
+Delivered in seven sequential PRs (all merged as of 2026-04-23):
+
+1. Foundation — 4 packages + 4 test projects (36 tests).
+2. QueryEngine integration — `FilterableField.Lookup`,
+   `ColumnBuilder.Lookup()`, metadata propagation (12 new tests).
+3. ReferenceData bridge — auto-register every refdata type as a lookup
+   source under `ref-{kebab}` (18 new tests).
+4. Frontend SDK — `@granit/data-lookup` + `@granit/react-data-lookup`
+   (47 tests after coverage follow-up).
+5. SmartFilter wiring — `selectedFieldLookup` on `useSmartFilter`
+   (5 new tests).
+6. First backend adopters — Tenant, MeterDefinition (source), TenantId +
+   MeterDefinitionId (consumer), AuditEntry.TenantId (consumer).
+7. Documentation — this ADR + `docs/guide/patterns/data-lookup.md`.
+
+Follow-up items explicitly out of scope:
+
+- User lookup (requires Identity.Federated and Identity.Local to agree on
+  a shared projection).
+- Showcase migrations (`meter-form.tsx`, `create-invoice-dialog.tsx`) —
+  depend on enum lookup sources being registered in the showcase host.
+- Cursor-based lookup sources for datasets over 50k rows.
+
+## Related
+
+- [ADR-020: Declarative definitions placement](/dotnet/architecture/adr/020-declarative-definitions-placement/)
+  — why `QueryDefinition` lives in base modules (applies to
+  `AsLookup`-decorated definitions too).
+- [`/dotnet/business/data-lookup/`](/dotnet/business/data-lookup/) —
+  module documentation page.
+- [`/dotnet/guide/patterns/data-lookup/`](/dotnet/guide/patterns/data-lookup/)
+  — adoption guide with recipes.

--- a/docs-site/src/content/docs/dotnet/architecture/patterns/data-lookup.md
+++ b/docs-site/src/content/docs/dotnet/architecture/patterns/data-lookup.md
@@ -1,0 +1,272 @@
+---
+title: "Data Lookup Pattern — Unified Typeahead Pickers"
+description: "One declarative primitive (Granit.DataLookup) feeds QueryEngine filter pickers, edit-form dropdowns, and ReferenceData sets from a single registry. Server-side label localization, scoped dependencies, and zero frontend boilerplate."
+sidebar:
+  label: Data Lookup
+  order: 58
+---
+
+## Definition
+
+The **Data Lookup pattern** centralizes the "pick a value from a remote
+set" interaction across every admin surface. A backend registry maps
+named sources (`tenants`, `meter-definitions`, `ref-countries`,
+`enum-aggregation-type`) to concrete implementations; a canonical wire
+shape carries `{ value, label, extra? }` to the frontend; a headless SDK
+renders combobox-style pickers wired to React Query with automatic
+scope-dependency handling.
+
+Same primitive, three consumption sites:
+
+1. **QueryEngine filter bar** — a filterable column declares
+   `.Lookup("name")` and `SmartFilter` routes the "enter value" phase to
+   the registry-backed picker.
+2. **Edit-form dropdowns** — forms use `<LookupSelect lookup="name" />`
+   with scope bound to sibling form fields via `cascadeFrom`.
+3. **Read-only projections** — detail views use `<LookupBadge />` to
+   rehydrate a stored foreign-key value into a localized label.
+
+## Diagram
+
+```mermaid
+flowchart LR
+    subgraph Backend["Granit.DataLookup"]
+        Reg[ILookupRegistry<br/>scoped]
+        SE[QueryableLookupSource&lt;T&gt;]
+        RE[ReferenceDataLookupSource&lt;T&gt;]
+        EE[EnumLookupSource&lt;TEnum&gt;]
+        Reg --> SE
+        Reg --> RE
+        Reg --> EE
+    end
+
+    EP[GET /api/granit/lookups/&#123;name&#125;]
+    MF[FilterableField.Lookup<br/>in /meta]
+
+    Reg --> EP
+    EE -.label: Enum:TypeName.Value.-> Loc[IStringLocalizer]
+    RE -.Label&#123;Culture&#125; column.-> Loc
+
+    subgraph Frontend["@granit/react-data-lookup"]
+        UL[useLookup]
+        LS[&lt;LookupSelect&gt;]
+        LP[&lt;LookupPicker&gt;]
+        LB[&lt;LookupBadge&gt;]
+        LS --> UL
+        LP --> UL
+        LB --> ULR[useLookupResolve]
+    end
+
+    EP --> UL
+    EP --> ULR
+    MF --> LP
+```
+
+## Canonical shapes
+
+The backend returns exactly one response shape regardless of source kind:
+
+```csharp
+public sealed record LookupItem(
+    object Value,
+    string Label,                              // already localized server-side
+    IReadOnlyDictionary<string, object?>? Extra = null);
+
+public sealed record LookupResult(
+    IReadOnlyList<LookupItem> Items,
+    int? TotalCount = null,
+    string? ContinuationToken = null);
+```
+
+The descriptor that modules emit alongside column / field metadata:
+
+```csharp
+public sealed record LookupDescriptor(
+    string? Name = null,                       // registry key, preferred
+    string? Endpoint = null,                   // custom URL, fallback
+    LookupKind Kind = LookupKind.QueryEngine,  // QueryEngine | Simple | ReferenceData | Enum
+    string? RequiredPermission = null,
+    string? SearchParam = "search",
+    IReadOnlyList<string>? ScopeKeys = null);
+```
+
+## Backend adoption — three recipes
+
+### Recipe 1 — expose a DbSet as a lookup source
+
+Host-level registration inside the module's `.EntityFrameworkCore`
+builder extension:
+
+```csharp
+builder.Services.AddQueryableLookup<Tenant, MultiTenancyDbContext>(
+    name: "tenants",
+    valueSelector: t => t.Id,
+    labelSelector: t => t.Name,
+    searchPredicate: (t, search) => t.Name.Contains(search) || t.Identifier.Contains(search),
+    requiredPermission: "Platform.Tenants.Read");
+```
+
+### Recipe 2 — scoped lookup (cascading pickers)
+
+A source whose result set depends on a parent field declares its required
+scope keys; the runtime enforces they are provided on every request:
+
+```csharp
+builder.Services.AddQueryableLookup<MeterDefinition, MeteringDbContext>(
+    name: "meter-definitions",
+    valueSelector: m => m.Id,
+    labelSelector: m => m.Name,
+    searchPredicate: (m, search) => m.Name.Contains(search) || m.Unit.Contains(search),
+    scopeKeys: ["tenantId"]);
+```
+
+A query column then chains the dependency:
+
+```csharp
+.Column(u => u.MeterDefinitionId, c => c
+    .Label("Meter")
+    .Filterable()
+    .Lookup("meter-definitions", scopeKeys: ["tenantId"]))
+```
+
+### Recipe 3 — CLR enum as a lookup
+
+Enums stay source-of-truth in code; the runtime resolves their labels via
+localization keys (`Enum:{TypeName}.{Value}` across 18 cultures):
+
+```csharp
+services.AddEnumLookup<AggregationType>(
+    name: "enum-aggregation-type",
+    requiredPermission: "Metering.Meters.Read");
+```
+
+## Consuming a lookup from a QueryEngine column
+
+A single fluent call on any `ColumnBuilder<T>`:
+
+```csharp
+.Column(m => m.TenantId, c => c
+    .Label("Tenant")
+    .LabelKey("Metering.Columns.Tenant")
+    .Filterable()
+    .Sortable()
+    .Lookup("tenants", requiredPermission: "Platform.Tenants.Read"))
+```
+
+The descriptor rides `FilterableField.Lookup` into the `GET /meta`
+payload; `SmartFilter` (headless React hook) surfaces it as
+`selectedFieldLookup`, and the calling component routes the "enter
+value" phase to `<LookupPicker>`.
+
+## Frontend — headless render-prop components
+
+```tsx
+import { LookupSelect } from '@granit/react-data-lookup';
+
+<LookupSelect
+  descriptor={{ name: 'tenants' }}
+  value={tenantId}
+  onChange={setTenantId}
+  client={axios}
+  culture={i18n.resolvedLanguage}
+  render={({ items, search, setSearch, selectedItem, onChange, missingScopeKey }) =>
+    missingScopeKey ? (
+      <span>Select {missingScopeKey} first.</span>
+    ) : (
+      <Combobox value={selectedItem?.value} onChange={onChange}>
+        <Combobox.Input value={search} onChange={(e) => setSearch(e.target.value)} />
+        <Combobox.Options>
+          {items.map((item) => (
+            <Combobox.Option key={String(item.value)} value={item.value}>
+              {item.label}
+            </Combobox.Option>
+          ))}
+        </Combobox.Options>
+      </Combobox>
+    )
+  }
+/>
+```
+
+### Cascading picker with `react-hook-form`
+
+```tsx
+const { watch } = useFormContext();
+const tenantId = watch('tenantId');
+
+<LookupSelect
+  descriptor={{ name: 'meter-definitions', scopeKeys: ['tenantId'] }}
+  value={meterId}
+  onChange={setMeterId}
+  scope={{ tenantId }}  // re-renders when tenantId changes
+  client={axios}
+  render={/* consumer UI */}
+/>
+```
+
+When `tenantId` is empty, the SDK disables the request entirely —
+`useLookup` flips `enabled: false`, no HTTP call fires, and the render
+prop receives `missingScopeKey = "tenantId"` so the UI can render an
+informative placeholder.
+
+## Empty Scope Trap — defensive design
+
+Scoped sources are dangerous if the frontend forgets to provide the
+scope value: the backend would otherwise either return an unrelated
+full list (multi-tenant leak!) or 500. The pattern enforces the guard
+twice:
+
+- **Backend** — the endpoint validates every declared scope key before
+  invoking the source; missing keys return `400 Bad Request` with a
+  `problem+json` listing the missing names.
+- **Frontend** — `useLookup` checks `ScopeKeys` against the incoming
+  `scope` object and keeps React Query `enabled: false` until every key
+  has a non-empty value. No HTTP call is ever emitted against an
+  incomplete scope.
+
+## Localization — server-side projection
+
+The label is always resolved by the server in the caller's
+`CultureInfo.CurrentUICulture` (honoring the `Accept-Language` header)
+before being serialized. The frontend never re-translates.
+
+| Source | Label resolution |
+| --- | --- |
+| `EnumLookupSource<TEnum>` | `IStringLocalizer[$"Enum:{TypeName}.{Value}"]`, falls back to enum name |
+| `ReferenceDataLookupSource<T>` | Virtual `ReferenceDataEntity.Label` — switches on `TwoLetterISOLanguageName`, falls back to `LabelEn`, then `Code` |
+| `QueryableLookupSource<T>` | Whatever the caller's `labelSelector` returns |
+
+React Query's `queryKey` in `@granit/react-data-lookup` includes the
+culture so caches are per-language; a locale switch invalidates stale
+labels automatically.
+
+## When to use vs when to avoid
+
+**Use Data Lookup when:**
+
+- A filterable column stores a foreign key (`Guid tenantId`, `string countryCode`).
+- An edit form needs a dropdown whose options aren't hardcoded enums in
+  TypeScript.
+- A detail view shows a FK value and needs a localized label.
+- A reference-data taxonomy (countries, document types) has to be
+  exposed uniformly with other pickers.
+
+**Avoid when:**
+
+- The candidate set has fewer than ~20 items **and** is never tenant- or
+  permission-scoped — inline `<SelectItem>` tags beat a round-trip.
+- The source comes from an external API with no authorization model and
+  no multi-tenant isolation — wire the external client directly.
+- The "value" is a complex object that cannot be serialized as JSON
+  (`Value` is typed as `object`, but stringified round-trip is assumed).
+
+## Related
+
+- [ADR-027: Unified Data Lookup](/dotnet/architecture/adr/027-unified-data-lookup/)
+  — architectural rationale and alternatives evaluated.
+- [`/dotnet/business/data-lookup/`](/dotnet/business/data-lookup/) —
+  module reference with full API surface.
+- [`/dotnet/business/query-engine/`](/dotnet/business/query-engine/) —
+  how `FilterableField.Lookup` fits into the metadata pipeline.
+- [`/dotnet/business/reference-data/`](/dotnet/business/reference-data/) —
+  auto-registered `ref-*` sources for code lists.

--- a/docs-site/src/data/constants.ts
+++ b/docs-site/src/data/constants.ts
@@ -4,5 +4,5 @@ export const FRONTEND_PACKAGE_COUNT = 49;
 export const CULTURE_COUNT = 18;
 export const BASE_LANGUAGE_COUNT = 15;
 export const REGIONAL_VARIANT_COUNT = 3;
-export const PATTERN_COUNT = 57;
-export const ADR_COUNT = 26;
+export const PATTERN_COUNT = 58;
+export const ADR_COUNT = 27;


### PR DESCRIPTION
## Summary

Final wrap-up of the Data Lookup initiative (PRs 1–6 merged). This PR captures
the decision as **ADR-027 (Accepted)** and publishes a framework pattern guide
with adoption recipes.

## New files

### \`docs-site/.../architecture/adr/027-unified-data-lookup.md\`

- Status: **Accepted** — 2026-04-23.
- Covers:
  - **Context** — two disjoint problems: filter pickers forcing bare GUID input, and hardcoded/ad-hoc form dropdowns.
  - **Decision** — canonical \`LookupItem\` shape, three built-in adapters (\`EnumLookupSource\`, \`QueryableLookupSource\`, \`ReferenceDataLookupSource\`), hybrid registry+URL endpoint, **Empty Scope Trap** two-layer mitigation, server-side label projection across 18 cultures.
  - **Evaluated alternatives** — frontend registry, inline metadata payload, GraphQL schema, string-based scope DSL — all rejected with rationale.
  - **Consequences** — both positive (uniform UX, zero boilerplate, culture-segmented cache) and negative (auth coupling, per-field latency, naming discipline).
  - **Follow-up work** — the seven-PR plan with all items checked.

### \`docs-site/.../architecture/patterns/data-lookup.md\`

- Pattern guide with a **Mermaid diagram** of the end-to-end flow.
- Three backend recipes:
  - \`DbSet\` → lookup source via \`AddQueryableLookup<T, TDb>\`.
  - Scoped cascading source via \`scopeKeys\` + column-level \`.Lookup(\"name\", scopeKeys: …)\`.
  - CLR enum via \`AddEnumLookup<TEnum>\`.
- Three frontend recipes:
  - Headless render-prop \`<LookupSelect>\`.
  - \`cascadeFrom\` with \`react-hook-form\`.
  - Read-only \`<LookupBadge>\` for detail views.
- When to use / when to avoid checklist.

### \`docs-site/src/data/constants.ts\`

- \`PATTERN_COUNT\` 57 → 58.
- \`ADR_COUNT\` 26 → 27.

## Test plan

- [x] \`markdownlint-cli2\` clean on both new files.
- [x] Counters reflect the real directory contents (\`ls architecture/patterns | wc -l\`, \`ls architecture/adr | wc -l\`).
- [ ] CI \`docs-site\` Astro build green.
- [ ] Cloudflare Pages preview rendering verified.

## Context — the 7-PR rollout

| PR | Scope | Status |
| --- | --- | --- |
| [#1124](https://github.com/granit-fx/granit-dotnet/pull/1124) | Foundation (4 backend packages + 36 tests) | MERGED |
| [#1125](https://github.com/granit-fx/granit-dotnet/pull/1125) | Audit fixes follow-up | MERGED |
| [#1127](https://github.com/granit-fx/granit-dotnet/pull/1127) | \`FilterableField.Lookup\` in QueryEngine metadata | MERGED |
| [#1128](https://github.com/granit-fx/granit-dotnet/pull/1128) | ReferenceData auto-bridge (18 tests) | MERGED |
| granit-front [#205](https://github.com/granit-fx/granit-front/pull/205) | Frontend SDK (\`@granit/data-lookup\`, \`@granit/react-data-lookup\`) | MERGED |
| granit-front [#206](https://github.com/granit-fx/granit-front/pull/206) | SmartFilter wiring | REVIEW |
| granit-front [#207](https://github.com/granit-fx/granit-front/pull/207) | Coverage follow-up for PR 4 components | REVIEW |
| [#1129](https://github.com/granit-fx/granit-dotnet/pull/1129) | First backend adopters (Tenant, Meter, AuditEntry) | MERGED |
| **this PR** | ADR-027 + pattern guide | — |

## Scope discipline

| ✅ In this PR | ❌ Deferred |
| --- | --- |
| ADR-027 Accepted + pattern guide | Showcase adopters (\`meter-form.tsx\`, \`create-invoice-dialog.tsx\`) — depend on \`EnumLookupSource\` being wired in the showcase host |
| Counter bumps | User lookup adopter (requires Identity.Federated + Local projection alignment) |
|  | Cursor-based lookups for 50k+ item sources |