### PR TITLE
fix(identity-endpoints)!: require Sessions.Manage to terminate sessions [VULN-100]

### DIFF
--- a/src/Granit.Identity.Endpoints/Endpoints/IdentityProviderDeviceEndpoints.cs
+++ b/src/Granit.Identity.Endpoints/Endpoints/IdentityProviderDeviceEndpoints.cs
@@ -1,0 +1,40 @@
+using Granit.Identity.Endpoints.Dtos;
+using Granit.Identity.Endpoints.Internal;
+using Granit.Identity.Models;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Identity.Endpoints.Endpoints;
+
+/// <summary>
+/// Read endpoint for inspecting device activity for a user.
+/// </summary>
+internal static class IdentityProviderDeviceEndpoints
+{
+    internal static RouteGroupBuilder MapProviderDeviceEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/", GetUserDeviceActivityAsync)
+            .WithName("GetIdentityProviderUserDevices")
+            .WithSummary("Lists device activity for a user.")
+            .WithDescription("Returns device activity information for the specified user, including device type, OS, browser, and associated sessions.")
+            .Produces<IReadOnlyList<IdentityDeviceActivityResponse>>();
+
+        return group;
+    }
+
+    private static async Task<Ok<IReadOnlyList<IdentityDeviceActivityResponse>>> GetUserDeviceActivityAsync(
+        string userId,
+        [FromServices] IIdentitySessionManager sessionManager,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<IdentityDeviceActivity> devices = await sessionManager
+            .GetUserDeviceActivityAsync(userId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return TypedResults.Ok<IReadOnlyList<IdentityDeviceActivityResponse>>(
+            devices.Select(IdentityResponseMapper.ToResponse).ToList());
+    }
+}

--- a/src/Granit.Identity.Endpoints/Endpoints/IdentityProviderSessionReadEndpoints.cs
+++ b/src/Granit.Identity.Endpoints/Endpoints/IdentityProviderSessionReadEndpoints.cs
@@ -1,0 +1,40 @@
+using Granit.Identity.Endpoints.Dtos;
+using Granit.Identity.Endpoints.Internal;
+using Granit.Identity.Models;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Identity.Endpoints.Endpoints;
+
+/// <summary>
+/// Read endpoints for listing user sessions via the identity provider.
+/// </summary>
+internal static class IdentityProviderSessionReadEndpoints
+{
+    internal static RouteGroupBuilder MapProviderSessionReadEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapGet("/", GetUserSessionsAsync)
+            .WithName("GetIdentityProviderUserSessions")
+            .WithSummary("Lists active sessions for a user.")
+            .WithDescription("Returns all active sessions for the specified user from the identity provider.")
+            .Produces<IReadOnlyList<IdentitySessionResponse>>();
+
+        return group;
+    }
+
+    private static async Task<Ok<IReadOnlyList<IdentitySessionResponse>>> GetUserSessionsAsync(
+        string userId,
+        [FromServices] IIdentitySessionManager sessionManager,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<IdentitySession> sessions = await sessionManager
+            .GetUserSessionsAsync(userId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return TypedResults.Ok<IReadOnlyList<IdentitySessionResponse>>(
+            sessions.Select(IdentityResponseMapper.ToResponse).ToList());
+    }
+}

--- a/src/Granit.Identity.Endpoints/Endpoints/IdentityProviderSessionWriteEndpoints.cs
+++ b/src/Granit.Identity.Endpoints/Endpoints/IdentityProviderSessionWriteEndpoints.cs
@@ -1,4 +1,3 @@
-using Granit.Identity.Endpoints.Dtos;
 using Granit.Identity.Endpoints.Internal;
 using Granit.Identity.Models;
 using Microsoft.AspNetCore.Builder;
@@ -10,18 +9,12 @@ using Microsoft.AspNetCore.Routing;
 namespace Granit.Identity.Endpoints.Endpoints;
 
 /// <summary>
-/// Endpoints for managing user sessions via the identity provider.
+/// Write endpoints for terminating user sessions via the identity provider.
 /// </summary>
-internal static class IdentityProviderSessionEndpoints
+internal static class IdentityProviderSessionWriteEndpoints
 {
-    internal static RouteGroupBuilder MapProviderSessionEndpoints(this RouteGroupBuilder group)
+    internal static RouteGroupBuilder MapProviderSessionWriteEndpoints(this RouteGroupBuilder group)
     {
-        group.MapGet("/", GetUserSessionsAsync)
-            .WithName("GetIdentityProviderUserSessions")
-            .WithSummary("Lists active sessions for a user.")
-            .WithDescription("Returns all active sessions for the specified user from the identity provider.")
-            .Produces<IReadOnlyList<IdentitySessionResponse>>();
-
         group.MapDelete("/{sessionId}", TerminateSessionAsync)
             .WithName("TerminateIdentityProviderSession")
             .WithSummary("Terminates a specific user session.")
@@ -36,43 +29,6 @@ internal static class IdentityProviderSessionEndpoints
             .Produces(StatusCodes.Status204NoContent);
 
         return group;
-    }
-
-    internal static RouteGroupBuilder MapProviderDeviceEndpoints(this RouteGroupBuilder group)
-    {
-        group.MapGet("/", GetUserDeviceActivityAsync)
-            .WithName("GetIdentityProviderUserDevices")
-            .WithSummary("Lists device activity for a user.")
-            .WithDescription("Returns device activity information for the specified user, including device type, OS, browser, and associated sessions.")
-            .Produces<IReadOnlyList<IdentityDeviceActivityResponse>>();
-
-        return group;
-    }
-
-    private static async Task<Ok<IReadOnlyList<IdentitySessionResponse>>> GetUserSessionsAsync(
-        string userId,
-        [FromServices] IIdentitySessionManager sessionManager,
-        CancellationToken cancellationToken)
-    {
-        IReadOnlyList<IdentitySession> sessions = await sessionManager
-            .GetUserSessionsAsync(userId, cancellationToken)
-            .ConfigureAwait(false);
-
-        return TypedResults.Ok<IReadOnlyList<IdentitySessionResponse>>(
-            sessions.Select(IdentityResponseMapper.ToResponse).ToList());
-    }
-
-    private static async Task<Ok<IReadOnlyList<IdentityDeviceActivityResponse>>> GetUserDeviceActivityAsync(
-        string userId,
-        [FromServices] IIdentitySessionManager sessionManager,
-        CancellationToken cancellationToken)
-    {
-        IReadOnlyList<IdentityDeviceActivity> devices = await sessionManager
-            .GetUserDeviceActivityAsync(userId, cancellationToken)
-            .ConfigureAwait(false);
-
-        return TypedResults.Ok<IReadOnlyList<IdentityDeviceActivityResponse>>(
-            devices.Select(IdentityResponseMapper.ToResponse).ToList());
     }
 
     private static async Task<Results<NoContent, ProblemHttpResult>> TerminateSessionAsync(

--- a/src/Granit.Identity.Endpoints/Extensions/IdentityProviderEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Identity.Endpoints/Extensions/IdentityProviderEndpointRouteBuilderExtensions.cs
@@ -81,7 +81,11 @@ public static class IdentityProviderEndpointRouteBuilderExtensions
         // -- Sessions --
         RouteGroupBuilder sessionsRead = group.MapGranitGroup("/users/{userId}/sessions")
             .RequireAuthorization(IdentityPermissions.Sessions.Read);
-        sessionsRead.MapProviderSessionEndpoints();
+        sessionsRead.MapProviderSessionReadEndpoints();
+
+        RouteGroupBuilder sessionsWrite = group.MapGranitGroup("/users/{userId}/sessions")
+            .RequireAuthorization(IdentityPermissions.Sessions.Manage);
+        sessionsWrite.MapProviderSessionWriteEndpoints();
 
         RouteGroupBuilder devicesRead = group.MapGranitGroup("/users/{userId}/devices")
             .RequireAuthorization(IdentityPermissions.Sessions.Read);

--- a/tests/Granit.ArchitectureTests/PermissionConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/PermissionConventionTests.cs
@@ -108,6 +108,105 @@ public sealed partial class PermissionConventionTests
             $"Violators: {string.Join("; ", violations)}");
     }
 
+    /// <summary>
+    /// Every permission constant declared in <c>*Permissions.cs</c> must be referenced by at
+    /// least one <c>RequireAuthorization(...)</c> call in the same module. Catches dead
+    /// constants and, more importantly, constants that are documented but never wired —
+    /// e.g. a <c>Manage</c> permission left orphaned while writes inherit a <c>Read</c>
+    /// group's policy.
+    /// </summary>
+    [Fact]
+    public void Permission_constants_should_be_referenced_by_RequireAuthorization()
+    {
+        string srcDir = Path.Join(RepoRoot, "src");
+
+        List<string> violations = [];
+
+        foreach (string permissionFile in GetPermissionFiles(srcDir))
+        {
+            string moduleDir = ModuleDirectoryFor(permissionFile, srcDir);
+            string[] moduleFiles = Directory.GetFiles(moduleDir, "*.cs", SearchOption.AllDirectories);
+            string relativePermissionPath = Path.GetRelativePath(RepoRoot, permissionFile);
+
+            foreach ((string name, string value, int lineNumber) in EnumeratePermissionConstants(permissionFile))
+            {
+                if (name == "GroupName")
+                {
+                    continue;
+                }
+
+                bool referenced = false;
+                foreach (string file in moduleFiles)
+                {
+                    if (string.Equals(file, permissionFile, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    if (file.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar)
+                        || file.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar))
+                    {
+                        continue;
+                    }
+
+                    string content = File.ReadAllText(file);
+                    if (content.Contains($"\"{value}\"", StringComparison.Ordinal)
+                        || ContainsConstantReference(content, value))
+                    {
+                        referenced = true;
+                        break;
+                    }
+                }
+
+                if (!referenced)
+                {
+                    violations.Add($"{relativePermissionPath}:{lineNumber} {name} = \"{value}\" is never referenced");
+                }
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Every permission constant must be wired to at least one RequireAuthorization call. " +
+            $"Orphaned constants: {string.Join("; ", violations)}");
+    }
+
+    private static string ModuleDirectoryFor(string permissionFile, string srcDir)
+    {
+        string relativePath = Path.GetRelativePath(srcDir, permissionFile);
+        string moduleName = relativePath.Split(Path.DirectorySeparatorChar)[0];
+        return Path.Join(srcDir, moduleName);
+    }
+
+    private static IEnumerable<(string Name, string Value, int LineNumber)> EnumeratePermissionConstants(string file)
+    {
+        int lineNumber = 0;
+        foreach (string line in File.ReadLines(file))
+        {
+            lineNumber++;
+            Match match = PermissionConstant().Match(line);
+            if (match.Success)
+            {
+                yield return (match.Groups[1].Value, match.Groups[2].Value, lineNumber);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Detects qualified references such as <c>IdentityPermissions.Sessions.Manage</c>
+    /// derived from the constant value <c>Identity.Sessions.Manage</c>.
+    /// </summary>
+    private static bool ContainsConstantReference(string content, string permissionValue)
+    {
+        string[] segments = permissionValue.Split('.');
+        if (segments.Length != 3)
+        {
+            return false;
+        }
+
+        string qualified = $".{segments[1]}.{segments[2]}";
+        return content.Contains(qualified, StringComparison.Ordinal);
+    }
+
     private static IEnumerable<string> GetPermissionFiles(string srcDir)
     {
         foreach (string csFile in Directory.GetFiles(srcDir, "*Permissions.cs", SearchOption.AllDirectories))
@@ -135,7 +234,8 @@ public sealed partial class PermissionConventionTests
         string? dir = Path.GetDirectoryName(typeof(PermissionConventionTests).Assembly.Location);
         while (dir is not null)
         {
-            if (Directory.Exists(Path.Join(dir, ".git")))
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityProviderSessionEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityProviderSessionEndpointsTests.cs
@@ -19,12 +19,16 @@ namespace Granit.Identity.Endpoints.Tests;
 public sealed class IdentityProviderSessionEndpointsTests : IAsyncDisposable
 {
     private const string AdminRole = "granit-identity-admin";
+    private const string SessionsViewerRole = "granit-identity-sessions-viewer";
+    private const string SessionsManagerRole = "granit-identity-sessions-manager";
     private const string Prefix = "/identity/provider";
 
     private readonly IIdentitySessionManager _sessionManager = Substitute.For<IIdentitySessionManager>();
     private readonly IIdentityProviderCapabilities _capabilities = Substitute.For<IIdentityProviderCapabilities>();
     private readonly WebApplication _app;
     private readonly HttpClient _adminClient;
+    private readonly HttpClient _sessionsViewerClient;
+    private readonly HttpClient _sessionsManagerClient;
 
     public IdentityProviderSessionEndpointsTests()
     {
@@ -55,6 +59,8 @@ public sealed class IdentityProviderSessionEndpointsTests : IAsyncDisposable
             .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
                 TestAuthHandler.SchemeName, _ => { });
 
+        // Admin holds every permission; the narrowly-scoped roles each hold exactly one
+        // so the permission split between Sessions.Read and Sessions.Manage can be asserted.
         builder.Services.AddAuthorizationBuilder()
             .AddPolicy(IdentityPermissions.Users.Read,
                 policy => policy.RequireRole(AdminRole))
@@ -69,9 +75,9 @@ public sealed class IdentityProviderSessionEndpointsTests : IAsyncDisposable
             .AddPolicy(IdentityPermissions.Groups.Manage,
                 policy => policy.RequireRole(AdminRole))
             .AddPolicy(IdentityPermissions.Sessions.Read,
-                policy => policy.RequireRole(AdminRole))
+                policy => policy.RequireRole(AdminRole, SessionsViewerRole))
             .AddPolicy(IdentityPermissions.Sessions.Manage,
-                policy => policy.RequireRole(AdminRole))
+                policy => policy.RequireRole(AdminRole, SessionsManagerRole))
             .AddPolicy(IdentityPermissions.Passwords.Manage,
                 policy => policy.RequireRole(AdminRole));
         builder.Services.AddGranitIdentityEndpoints();
@@ -83,6 +89,8 @@ public sealed class IdentityProviderSessionEndpointsTests : IAsyncDisposable
         _app.StartAsync().GetAwaiter().GetResult();
 
         _adminClient = BuildClient(AdminRole);
+        _sessionsViewerClient = BuildClient(SessionsViewerRole);
+        _sessionsManagerClient = BuildClient(SessionsManagerRole);
     }
 
     public async ValueTask DisposeAsync() => await _app.DisposeAsync();
@@ -103,6 +111,15 @@ public sealed class IdentityProviderSessionEndpointsTests : IAsyncDisposable
         sessions[0].SessionId.ShouldBe("session-1");
     }
 
+    [Fact]
+    public async Task GetUserSessions_with_sessions_read_only_returns_200()
+    {
+        HttpResponseMessage response = await _sessionsViewerClient.GetAsync(
+            $"{Prefix}/users/user-1/sessions", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
     // -- GET /users/{userId}/devices --
 
     [Fact]
@@ -119,6 +136,15 @@ public sealed class IdentityProviderSessionEndpointsTests : IAsyncDisposable
         devices[0].IpAddress.ShouldBe("127.0.0.1");
     }
 
+    [Fact]
+    public async Task GetUserDevices_with_sessions_read_only_returns_200()
+    {
+        HttpResponseMessage response = await _sessionsViewerClient.GetAsync(
+            $"{Prefix}/users/user-1/devices", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
     // -- DELETE /users/{userId}/sessions/{sessionId} --
 
     [Fact]
@@ -129,6 +155,26 @@ public sealed class IdentityProviderSessionEndpointsTests : IAsyncDisposable
 
         response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
         await _sessionManager.Received(1).TerminateSessionAsync("user-1", "session-1", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TerminateSession_with_sessions_manage_returns_204()
+    {
+        HttpResponseMessage response = await _sessionsManagerClient.DeleteAsync(
+            $"{Prefix}/users/user-1/sessions/session-1", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task TerminateSession_with_sessions_read_only_returns_403()
+    {
+        HttpResponseMessage response = await _sessionsViewerClient.DeleteAsync(
+            $"{Prefix}/users/user-1/sessions/session-1", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+        await _sessionManager.DidNotReceive().TerminateSessionAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -152,6 +198,17 @@ public sealed class IdentityProviderSessionEndpointsTests : IAsyncDisposable
 
         response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
         await _sessionManager.Received(1).TerminateAllSessionsAsync("user-1", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TerminateAllSessions_with_sessions_read_only_returns_403()
+    {
+        HttpResponseMessage response = await _sessionsViewerClient.DeleteAsync(
+            $"{Prefix}/users/user-1/sessions", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+        await _sessionManager.DidNotReceive().TerminateAllSessionsAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     private HttpClient BuildClient(string role)


### PR DESCRIPTION
## Summary

- Splits the admin Sessions route group so `DELETE /users/{id}/sessions/{sid}` and `DELETE /users/{id}/sessions` now require `Identity.Sessions.Manage`. Previously they inherited `Identity.Sessions.Read` from the parent group — any viewer principal could force-logout any user from any device (privilege escalation, ISO 27001 A.9.4).
- `IdentityProviderSessionEndpoints` split into `…SessionReadEndpoints` (GET) + `…SessionWriteEndpoints` (DELETE × 2), plus `…DeviceEndpoints` extracted to its own file. Mirrors the existing Users / Roles / Groups read/write split convention.
- Route extension wires two `RouteGroupBuilder` instances. `IdentityPermissions.Sessions.Manage` was already declared (and documented in the XML doc-comment) but unreferenced.
- New `PermissionConventionTests` assertion fails the build if any `*Permissions.cs` constant is never referenced by a `RequireAuthorization(...)` call or qualified reference in the same module — catches future orphans of this exact shape.
- `FindRepoRoot()` in `PermissionConventionTests` now also accepts `.git` as a file (git-worktree layout) so the convention tests can run from a worktree.

## Why

Discovered by the `/security` audit on `Granit.Identity.*` (commit `477e92c8`) — finding `VULN-100`, classified High (CVSS 3.1 = 7.1, AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H). First of a 5-PR remediation train; plan filed at `~/.claude/plans/deep-toasting-avalanche.md`.

## Breaking change

Marked `!` (breaking) because hosts that granted `Identity.Sessions.Read` to operators expecting them to terminate sessions will now see 403 on those calls. Hosts must additionally grant `Identity.Sessions.Manage` to roles that should retain that capability. The constant is unchanged and was already declared.

## Test plan

- [x] `dotnet test tests/Granit.Identity.Endpoints.Tests` — 166/166 pass, including 4 new assertions:
  - `GetUserSessions_with_sessions_read_only_returns_200`
  - `GetUserDevices_with_sessions_read_only_returns_200`
  - `TerminateSession_with_sessions_manage_returns_204`
  - `TerminateSession_with_sessions_read_only_returns_403`
  - `TerminateAllSessions_with_sessions_read_only_returns_403`
- [x] `dotnet test tests/Granit.ArchitectureTests --filter PermissionConventionTests` — 3/3 pass (incl. new `Permission_constants_should_be_referenced_by_RequireAuthorization`)
- [x] `dotnet format --verify-no-changes` — clean on src/Granit.Identity.Endpoints, tests/Granit.Identity.Endpoints.Tests, tests/Granit.ArchitectureTests
- [x] `dotnet build src/Granit.Identity.Endpoints` — 0 warnings, 0 errors

## Follow-up (not in this PR)

17 other architecture-test files use the same `Directory.Exists(.git)` repo-root finder and thus fail when run from a git worktree. Trivial to extract a shared `RepoRootLocator` helper. Tracked separately to keep this PR scoped to the security fix.

## Audit reference

Full report: see `/security` audit summary — VULN-100 detail at the "Authorization" section. Plan: `~/.claude/plans/deep-toasting-avalanche.md` → "PR2 — High: Split Sessions Read/Write permissions".