### PR TITLE
fix(identity): 8 quick-win security fixes from Identity audit (Q2-Q9)

### DIFF
--- a/.github/shard-filters/security.slnf
+++ b/.github/shard-filters/security.slnf
@@ -43,6 +43,7 @@
       "src/Granit.Http.Cookies/Granit.Http.Cookies.csproj",
       "src/Granit.Http.ExceptionHandling/Granit.Http.ExceptionHandling.csproj",
       "src/Granit.Http.Resilience/Granit.Http.Resilience.csproj",
+      "src/Granit.Http.SecurityHeaders/Granit.Http.SecurityHeaders.csproj",
       "src/Granit.Identity.Endpoints/Granit.Identity.Endpoints.csproj",
       "src/Granit.Identity.Federated.Cognito/Granit.Identity.Federated.Cognito.csproj",
       "src/Granit.Identity.Federated.EntityFrameworkCore/Granit.Identity.Federated.EntityFrameworkCore.csproj",

--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -926,6 +926,7 @@
         "Granit.Caching",
         "Granit.Http.Abstractions",
         "Granit.Http.ApiDocumentation",
+        "Granit.Http.SecurityHeaders",
         "Granit.Identity.Local",
         "Granit.Settings",
         "Granit.Validation"
@@ -16979,6 +16980,22 @@
       ]
     },
     {
+      "name": "RouteHandlerBuilderNoStoreExtensions",
+      "fqn": "Granit.Http.SecurityHeaders.Extensions.RouteHandlerBuilderNoStoreExtensions",
+      "kind": "class",
+      "project": "Granit.Http.SecurityHeaders",
+      "file": "src/Granit.Http.SecurityHeaders/Extensions/RouteHandlerBuilderNoStoreExtensions.cs",
+      "line": 11,
+      "members": [
+        {
+          "name": "WithNoStoreResponse",
+          "kind": "method",
+          "signature": "WithNoStoreResponse(this RouteHandlerBuilder builder)",
+          "returnType": "RouteHandlerBuilder"
+        }
+      ]
+    },
+    {
       "name": "SecurityApplicationBuilderExtensions",
       "fqn": "Granit.Http.SecurityHeaders.Extensions.SecurityApplicationBuilderExtensions",
       "kind": "class",
@@ -17007,6 +17024,22 @@
           "kind": "method",
           "signature": "AddGranitHttpSecurity(this IHostApplicationBuilder builder)",
           "returnType": "IHostApplicationBuilder"
+        }
+      ]
+    },
+    {
+      "name": "NoStoreEndpointFilter",
+      "fqn": "Granit.Http.SecurityHeaders.Filters.NoStoreEndpointFilter",
+      "kind": "class",
+      "project": "Granit.Http.SecurityHeaders",
+      "file": "src/Granit.Http.SecurityHeaders/Filters/NoStoreEndpointFilter.cs",
+      "line": 28,
+      "members": [
+        {
+          "name": "InvokeAsync",
+          "kind": "method",
+          "signature": "InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)",
+          "returnType": "ValueTask<object?>"
         }
       ]
     },
@@ -17101,6 +17134,15 @@
           "returnType": "string?"
         }
       ]
+    },
+    {
+      "name": "MinimumResponseTimeGuard",
+      "fqn": "Granit.Http.Timing.MinimumResponseTimeGuard",
+      "kind": "struct",
+      "project": "Granit.Http.Abstractions",
+      "file": "src/Granit.Http.Abstractions/Timing/MinimumResponseTimeGuard.cs",
+      "line": 26,
+      "members": []
     },
     {
       "name": "IdentityMetrics",
@@ -17493,7 +17535,7 @@
       "kind": "record",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/Events/IdentityUserCreatedEto.cs",
-      "line": 11,
+      "line": 18,
       "members": []
     },
     {
@@ -18588,7 +18630,7 @@
       "kind": "class",
       "project": "Granit.Identity.Local.AspNetIdentity",
       "file": "src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs",
-      "line": 31,
+      "line": 32,
       "members": [
         {
           "name": "ConfigureServices",
@@ -20547,7 +20589,7 @@
       "kind": "record",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/Models/IdentityUserUpdate.cs",
-      "line": 14,
+      "line": 22,
       "members": []
     },
     {

--- a/.slnf/security.slnf
+++ b/.slnf/security.slnf
@@ -41,6 +41,7 @@
       "src/Granit.Http.Cookies/Granit.Http.Cookies.csproj",
       "src/Granit.Http.ExceptionHandling/Granit.Http.ExceptionHandling.csproj",
       "src/Granit.Http.Resilience/Granit.Http.Resilience.csproj",
+      "src/Granit.Http.SecurityHeaders/Granit.Http.SecurityHeaders.csproj",
       "src/Granit.Identity.Endpoints/Granit.Identity.Endpoints.csproj",
       "src/Granit.Identity.Federated.Cognito/Granit.Identity.Federated.Cognito.csproj",
       "src/Granit.Identity.Federated.EntityFrameworkCore/Granit.Identity.Federated.EntityFrameworkCore.csproj",

--- a/src/Granit.Http.Abstractions/Timing/MinimumResponseTimeGuard.cs
+++ b/src/Granit.Http.Abstractions/Timing/MinimumResponseTimeGuard.cs
@@ -1,0 +1,69 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+
+namespace Granit.Http.Timing;
+
+/// <summary>
+/// Pads a request handler's elapsed time to a randomised minimum floor so that
+/// timing-sensitive failure paths (user-not-found vs wrong-password vs
+/// account-locked) become indistinguishable to a remote attacker.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Usage:
+/// </para>
+/// <code>
+/// await using MinimumResponseTimeGuard floor = MinimumResponseTimeGuard.Begin(500, 700);
+/// // ... handler logic ...
+/// </code>
+/// <para>
+/// On <see cref="DisposeAsync"/>, the guard delays for whatever portion of the
+/// floor remains. The floor is picked uniformly at random in
+/// <c>[minimumMs, maximumMs]</c> using a cryptographic RNG so an attacker
+/// cannot fingerprint a fixed threshold across requests.
+/// </para>
+/// </remarks>
+public readonly struct MinimumResponseTimeGuard : IAsyncDisposable
+{
+    private readonly long _startTimestamp;
+    private readonly int _floorMs;
+
+    private MinimumResponseTimeGuard(long startTimestamp, int floorMs)
+    {
+        _startTimestamp = startTimestamp;
+        _floorMs = floorMs;
+    }
+
+    /// <summary>
+    /// Starts a new minimum-response-time guard. Pick a per-request floor
+    /// uniformly at random in <c>[minimumMs, maximumMs]</c>.
+    /// </summary>
+    /// <param name="minimumMs">Lower bound of the floor (inclusive). Must be ≥ 0.</param>
+    /// <param name="maximumMs">Upper bound of the floor (inclusive). Must be ≥ <paramref name="minimumMs"/>.</param>
+    public static MinimumResponseTimeGuard Begin(int minimumMs, int maximumMs)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(minimumMs);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maximumMs, minimumMs);
+
+        int floorMs = minimumMs == maximumMs
+            ? minimumMs
+            : RandomNumberGenerator.GetInt32(minimumMs, maximumMs + 1);
+
+        return new MinimumResponseTimeGuard(Stopwatch.GetTimestamp(), floorMs);
+    }
+
+    /// <summary>
+    /// Pads the elapsed time to the per-request floor. No-op if the handler
+    /// already took at least <see cref="_floorMs"/> milliseconds.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        TimeSpan elapsed = Stopwatch.GetElapsedTime(_startTimestamp);
+        int remainingMs = _floorMs - (int)elapsed.TotalMilliseconds;
+
+        if (remainingMs > 0)
+        {
+            await Task.Delay(remainingMs).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Granit.Http.SecurityHeaders/Extensions/RouteHandlerBuilderNoStoreExtensions.cs
+++ b/src/Granit.Http.SecurityHeaders/Extensions/RouteHandlerBuilderNoStoreExtensions.cs
@@ -1,0 +1,35 @@
+using Granit.Http.SecurityHeaders.Filters;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Granit.Http.SecurityHeaders.Extensions;
+
+/// <summary>
+/// Convenience extensions for marking a route as <c>Cache-Control: no-store</c>.
+/// </summary>
+public static class RouteHandlerBuilderNoStoreExtensions
+{
+    /// <summary>
+    /// Attaches a <see cref="NoStoreEndpointFilter"/> so the response is never
+    /// cached by browsers, proxies, or CDN intermediaries.
+    /// </summary>
+    /// <param name="builder">The route handler to harden.</param>
+    /// <returns>The same route handler for chaining.</returns>
+    public static RouteHandlerBuilder WithNoStoreResponse(this RouteHandlerBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        return builder.AddEndpointFilter<NoStoreEndpointFilter>();
+    }
+
+    /// <summary>
+    /// Attaches a <see cref="NoStoreEndpointFilter"/> to every endpoint in the group.
+    /// </summary>
+    /// <param name="builder">The route group to harden.</param>
+    /// <returns>The same route group for chaining.</returns>
+    public static RouteGroupBuilder WithNoStoreResponse(this RouteGroupBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        return builder.AddEndpointFilter<NoStoreEndpointFilter>();
+    }
+}

--- a/src/Granit.Http.SecurityHeaders/Filters/NoStoreEndpointFilter.cs
+++ b/src/Granit.Http.SecurityHeaders/Filters/NoStoreEndpointFilter.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
+
+namespace Granit.Http.SecurityHeaders.Filters;
+
+/// <summary>
+/// Endpoint filter that prevents an endpoint's response from being stored by
+/// browsers, proxies, or CDN caches. Use on endpoints that emit secrets,
+/// short-lived tokens, or other content that must never appear in a cache.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Sets all three cache-suppression headers so HTTP/1.0 intermediaries (older
+/// corporate proxies, some load balancers) that ignore <c>Cache-Control</c>
+/// still bypass their caches:
+/// </para>
+/// <list type="bullet">
+///   <item><c>Cache-Control: no-store, no-cache, must-revalidate, max-age=0</c> (HTTP/1.1)</item>
+///   <item><c>Pragma: no-cache</c> (HTTP/1.0 fallback)</item>
+///   <item><c>Expires: 0</c> (HTTP/1.0 fallback — RFC 7234 §5.3 treats invalid dates as expired)</item>
+/// </list>
+/// <para>
+/// The headers are only set on success responses (2xx). Error responses keep
+/// their default cache headers so clients may apply normal retry semantics.
+/// </para>
+/// </remarks>
+public sealed class NoStoreEndpointFilter : IEndpointFilter
+{
+    private const string CacheControlValue = "no-store, no-cache, must-revalidate, max-age=0";
+    private const string PragmaValue = "no-cache";
+    private const string ExpiresValue = "0";
+
+    /// <inheritdoc />
+    public async ValueTask<object?> InvokeAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next)
+    {
+        object? result = await next(context).ConfigureAwait(false);
+
+        HttpResponse response = context.HttpContext.Response;
+        if (response.StatusCode is >= 200 and < 300)
+        {
+            response.Headers[HeaderNames.CacheControl] = new StringValues(CacheControlValue);
+            response.Headers[HeaderNames.Pragma] = new StringValues(PragmaValue);
+            response.Headers[HeaderNames.Expires] = new StringValues(ExpiresValue);
+        }
+
+        return result;
+    }
+}

--- a/src/Granit.Identity.Endpoints/Extensions/IdentityEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Identity.Endpoints/Extensions/IdentityEndpointRouteBuilderExtensions.cs
@@ -36,38 +36,33 @@ public static class IdentityEndpointRouteBuilderExtensions
         IdentityEndpointsOptions options = new();
         configure?.Invoke(options);
 
-        RouteGroupBuilder group = endpoints
+        // Each permission scope gets its own RouteGroupBuilder. Reusing the same group
+        // and stacking RequireAuthorization() accumulates policies (AND semantics), which
+        // would force every endpoint to satisfy every previously-registered permission —
+        // making sync and GDPR endpoints unreachable without the union of all permissions.
+        RouteGroupBuilder readGroup = endpoints
             .MapGranitGroup(options.RoutePrefix)
-            .WithTags(options.TagName);
+            .WithTags(options.TagName)
+            .RequireAuthorization(IdentityPermissions.Users.Read);
+        readGroup.MapCapabilitiesEndpoints();
+        readGroup.MapReadEndpoints();
+        readGroup.MapStatsEndpoints();
 
-        // Capabilities endpoint
-        group
-            .RequireAuthorization(IdentityPermissions.Users.Read)
-            .MapCapabilitiesEndpoints();
+        RouteGroupBuilder syncGroup = endpoints
+            .MapGranitGroup(options.RoutePrefix)
+            .WithTags(options.TagName)
+            .RequireAuthorization(IdentityPermissions.Users.Sync);
+        syncGroup.MapSyncEndpoints();
 
-        // Read endpoints (list, get, batch)
-        group
-            .RequireAuthorization(IdentityPermissions.Users.Read)
-            .MapReadEndpoints();
-
-        // Stats endpoint
-        group
-            .RequireAuthorization(IdentityPermissions.Users.Read)
-            .MapStatsEndpoints();
-
-        // Sync endpoints
-        group
-            .RequireAuthorization(IdentityPermissions.Users.Sync)
-            .MapSyncEndpoints();
-
-        // GDPR endpoints
-        group
-            .RequireAuthorization(IdentityPermissions.Users.Delete)
-            .MapGdprEndpoints();
+        RouteGroupBuilder gdprGroup = endpoints
+            .MapGranitGroup(options.RoutePrefix)
+            .WithTags(options.TagName)
+            .RequireAuthorization(IdentityPermissions.Users.Delete);
+        gdprGroup.MapGdprEndpoints();
 
         // Webhook endpoint (outside the authorized group — uses signature validation)
         endpoints.MapWebhookEndpoint("", options.WebhookTagName);
 
-        return group;
+        return readGroup;
     }
 }

--- a/src/Granit.Identity.Federated.Cognito/Internal/CognitoIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.Cognito/Internal/CognitoIdentityProvider.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 using Amazon.CognitoIdentityProvider;
 using Amazon.CognitoIdentityProvider.Model;
 using Granit.Events;
@@ -50,6 +51,16 @@ internal sealed partial class CognitoIdentityProvider(
             if (!string.IsNullOrEmpty(search))
             {
                 // Cognito Filter supports: username, email, phone_number, name, given_name, family_name, preferred_username, cognito:user_status, status, sub
+                // Reject anything outside the safe character set: a stray quote in the search
+                // term would let a caller break out of the username prefix filter syntax (e.g.
+                // search="x\" or attribute=\"y" would change the predicate). The whitelist
+                // covers the characters legitimately used in Cognito usernames and emails.
+                if (!ValidSearchPattern().IsMatch(search))
+                {
+                    LogInvalidSearchInput(search.Length);
+                    return [];
+                }
+
                 // For broad search, filter on username prefix
                 request.Filter = $"username ^= \"{search}\"";
             }
@@ -811,4 +822,15 @@ internal sealed partial class CognitoIdentityProvider(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Credential verification failed")]
     private partial void LogCredentialVerificationFailed(Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Rejected Cognito ListUsers search input ({Length} chars) — failed character whitelist")]
+    private partial void LogInvalidSearchInput(int length);
+
+    /// <summary>
+    /// Whitelist for Cognito <c>ListUsers</c> search input. Limited to characters that
+    /// legitimately appear in usernames and emails so a stray quote cannot break out of
+    /// the <c>username ^= "…"</c> filter syntax. Bounded length to limit DoS surface.
+    /// </summary>
+    [GeneratedRegex(@"^[A-Za-z0-9._@+\-]{1,128}$")]
+    private static partial Regex ValidSearchPattern();
 }

--- a/src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/GranitIdentityLocalAspNetIdentityModule.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Identity.Local.AspNetIdentity;
 
@@ -75,6 +76,13 @@ public sealed partial class GranitIdentityLocalAspNetIdentityModule : GranitModu
         context.Services.TryAddScoped<IPasswordResetService, AspNetPasswordResetService>();
         context.Services.TryAddScoped<IEmailChangeService, AspNetEmailChangeService>();
         context.Services.TryAddScoped<IEmailConfirmationService, AspNetEmailConfirmationService>();
+
+        // Defense-in-depth: fail startup if a host opts out of unique-email enforcement
+        // without registering a tenant resolver. The headless login/2FA handlers disable
+        // the multi-tenant query filter when no tenant context is active and rely on
+        // unique emails to deterministically resolve the user across tenants.
+        context.Services.TryAddSingleton<IValidateOptions<IdentityOptions>, RequireUniqueEmailValidator>();
+        context.Services.AddOptions<IdentityOptions>().ValidateOnStart();
     }
 
     /// <inheritdoc/>

--- a/src/Granit.Identity.Local.AspNetIdentity/Internal/RequireUniqueEmailValidator.cs
+++ b/src/Granit.Identity.Local.AspNetIdentity/Internal/RequireUniqueEmailValidator.cs
@@ -1,0 +1,65 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Identity.Local.AspNetIdentity.Internal;
+
+/// <summary>
+/// Fails startup when <see cref="IdentityOptions.User"/>.<c>RequireUniqueEmail</c> is
+/// disabled while no <c>ITenantResolver</c> is registered.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The headless login and 2FA handlers disable the multi-tenant query filter when no
+/// tenant context is active so they can resolve a user across tenants by email.
+/// That cross-tenant lookup relies on <c>RequireUniqueEmail = true</c> to guarantee a
+/// single deterministic match. Without unique emails, multiple users with the same
+/// address can exist across tenants and the lookup becomes non-deterministic — an
+/// attacker who knows a victim's email can occasionally land in a different tenant's
+/// account, target the wrong lockout counter, or trick the 2FA challenge into
+/// resolving the wrong user.
+/// </para>
+/// <para>
+/// When at least one <c>ITenantResolver</c> is registered, the cross-tenant lookup
+/// is bypassed (the tenant context is set before login), so non-unique emails are safe.
+/// This validator therefore only fails when both conditions are violated.
+/// </para>
+/// </remarks>
+internal sealed class RequireUniqueEmailValidator(IServiceProvider services)
+    : IValidateOptions<IdentityOptions>
+{
+    private const string TenantResolverTypeName = "Granit.MultiTenancy.Resolvers.ITenantResolver";
+
+    public ValidateOptionsResult Validate(string? name, IdentityOptions options)
+    {
+        if (options.User.RequireUniqueEmail)
+        {
+            return ValidateOptionsResult.Success;
+        }
+
+        if (HasTenantResolverRegistered())
+        {
+            return ValidateOptionsResult.Success;
+        }
+
+        return ValidateOptionsResult.Fail(
+            "IdentityOptions.User.RequireUniqueEmail is false but no ITenantResolver is " +
+            "registered. The cross-tenant login/2FA lookup that disables the IMultiTenant " +
+            "filter cannot deterministically resolve a user when emails are not unique. " +
+            "Either set IdentityOptions.User.RequireUniqueEmail = true (recommended) or " +
+            "register an ITenantResolver so the tenant context is established before login.");
+    }
+
+    private bool HasTenantResolverRegistered()
+    {
+        // Soft dependency on Granit.MultiTenancy — resolved by full type name so this
+        // module does not need a hard project reference. When Granit.MultiTenancy is
+        // not loaded into the app domain, the type lookup returns null and the check
+        // fails closed (no tenant resolver assumed).
+        var tenantResolverType = Type.GetType(
+            $"{TenantResolverTypeName}, Granit.MultiTenancy",
+            throwOnError: false);
+
+        return tenantResolverType is not null
+            && services.GetService(tenantResolverType) is not null;
+    }
+}

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountExternalLoginEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountExternalLoginEndpoints.cs
@@ -2,11 +2,13 @@ using Granit.Http.Idempotency.Attributes;
 using Granit.Identity.Local.Endpoints.Dtos;
 using Granit.Identity.Local.Endpoints.Internal;
 using Granit.Identity.Local.Services;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using IdentityConstants = Microsoft.AspNetCore.Identity.IdentityConstants;
 
 namespace Granit.Identity.Local.Endpoints.Endpoints;
 
@@ -104,22 +106,32 @@ internal static class AccountExternalLoginEndpoints
         [FromServices] IExternalLoginService externalLoginService,
         CancellationToken cancellationToken)
     {
-        // The auth server's client middleware populates HttpContext.User with the external
-        // provider's claims after a successful OAuth callback. The provider name is
-        // available from the authentication scheme or a query parameter.
-        string provider = httpContext.Request.Query["provider"].ToString();
+        // Resolve the provider from the external auth ticket — never from the query
+        // string. The query string is attacker-controlled: a malicious caller could
+        // target the Google OAuth callback URL with ?provider=GitHub and cause the
+        // link table to mis-attribute the resulting external login. ASP.NET Core
+        // Identity stores the originating scheme in
+        // AuthenticationProperties.Items["LoginProvider"] under the well-known
+        // IdentityConstants.ExternalScheme cookie.
+        AuthenticateResult authResult = await httpContext
+            .AuthenticateAsync(IdentityConstants.ExternalScheme)
+            .ConfigureAwait(false);
 
-        if (string.IsNullOrEmpty(provider))
+        if (!authResult.Succeeded
+            || authResult.Principal is null
+            || authResult.Properties is null
+            || !authResult.Properties.Items.TryGetValue("LoginProvider", out string? provider)
+            || string.IsNullOrEmpty(provider))
         {
             return TypedResults.Problem(
-                detail: "Missing 'provider' query parameter.",
+                detail: "External login callback did not carry an authentication scheme.",
                 statusCode: StatusCodes.Status400BadRequest);
         }
 
         try
         {
             ProcessCallbackResult result = await externalLoginService
-                .ProcessCallbackAsync(httpContext.User, provider, cancellationToken)
+                .ProcessCallbackAsync(authResult.Principal, provider, cancellationToken)
                 .ConfigureAwait(false);
             return TypedResults.Ok(result);
         }

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using Granit.DataFiltering;
 using Granit.Domain;
 using Granit.Events;
+using Granit.Http.Timing;
 using Granit.Identity.Local.Diagnostics;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Endpoints.Dtos;
@@ -71,24 +72,21 @@ internal static partial class AccountLoginEndpoints
         HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        long startTicks = Stopwatch.GetTimestamp();
-
-        using Activity? activity = IdentityLocalActivitySource.Source.StartActivity(
-            IdentityLocalActivitySource.UserAuthentication);
-        activity?.SetTag(IdentityLocalActivitySource.TagProvider, "password");
-
-        Results<Ok<AccountLoginResponse>, ProblemHttpResult> response = await HandleLoginCoreAsync(
-            request, signInManager, userManager, httpContext, cancellationToken)
-            .ConfigureAwait(false);
-
         // Enforce a minimum response time to prevent timing side-channels.
         // Without this, an attacker can distinguish "user not found" (~310ms with
         // dummy hash) from "wrong password on existing account" (~450ms with hash
         // + DB writes for lockout counter). The floor is randomized per request
         // (500-700ms) so an attacker cannot fingerprint a fixed threshold.
-        await EnforceMinimumResponseTimeAsync(startTicks).ConfigureAwait(false);
+        await using var floor = MinimumResponseTimeGuard.Begin(
+            MinResponseFloorMs, MaxResponseFloorMs);
 
-        return response;
+        using Activity? activity = IdentityLocalActivitySource.Source.StartActivity(
+            IdentityLocalActivitySource.UserAuthentication);
+        activity?.SetTag(IdentityLocalActivitySource.TagProvider, "password");
+
+        return await HandleLoginCoreAsync(
+            request, signInManager, userManager, httpContext, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private static async Task<Results<Ok<AccountLoginResponse>, ProblemHttpResult>> HandleLoginCoreAsync(
@@ -325,12 +323,16 @@ internal static partial class AccountLoginEndpoints
     // ──── Timing attack mitigation ────
 
     /// <summary>
-    /// Minimum response time range (milliseconds) for the login endpoint.
-    /// A random floor between these bounds is picked per request so that
-    /// an attacker cannot fingerprint a fixed threshold.
+    /// Lower bound of the per-request response-time floor used by the login endpoints.
+    /// Shared with <c>AccountPasswordEndpoints.ForgotPasswordAsync</c> so credential
+    /// recovery and login present the same timing surface.
     /// </summary>
-    private const int MinResponseFloorMs = 500;
-    private const int MaxResponseFloorMs = 700;
+    internal const int MinResponseFloorMs = 500;
+
+    /// <summary>
+    /// Upper bound of the per-request response-time floor.
+    /// </summary>
+    internal const int MaxResponseFloorMs = 700;
 
     /// <summary>
     /// Pre-computed BCrypt/Argon2 hash used for dummy verification when the user
@@ -350,24 +352,6 @@ internal static partial class AccountLoginEndpoints
         // Use a random password each time to introduce natural timing jitter
         // and avoid a constant, fingerprint-able verification pattern.
         hasher.VerifyHashedPassword(null!, DummyPasswordHash, RandomNumberGenerator.GetHexString(32));
-    }
-
-    /// <summary>
-    /// Pads the response time to a randomized minimum floor (500-700ms) so that
-    /// all failure paths (user not found, wrong password, locked out) are
-    /// indistinguishable by timing. If the handler already took longer than the
-    /// floor, no delay is added.
-    /// </summary>
-    private static async Task EnforceMinimumResponseTimeAsync(long startTicks)
-    {
-        int floorMs = RandomNumberGenerator.GetInt32(MinResponseFloorMs, MaxResponseFloorMs + 1);
-        TimeSpan elapsed = Stopwatch.GetElapsedTime(startTicks);
-        int remainingMs = floorMs - (int)elapsed.TotalMilliseconds;
-
-        if (remainingMs > 0)
-        {
-            await Task.Delay(remainingMs).ConfigureAwait(false);
-        }
     }
 
     // ──── Lockout event publishing ────

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountPasskeyEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountPasskeyEndpoints.cs
@@ -1,4 +1,5 @@
 using Granit.Http.Idempotency.Attributes;
+using Granit.Http.SecurityHeaders.Extensions;
 using Granit.Identity.Local.Diagnostics;
 using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Endpoints.Dtos;
@@ -23,7 +24,8 @@ internal static class AccountPasskeyEndpoints
             .WithSummary("Lists registered passkeys.")
             .WithDescription("Returns the list of WebAuthn passkeys registered for the authenticated user.")
             .Produces<IReadOnlyList<PasskeyInfoResponse>>()
-            .RequireAuthorization();
+            .RequireAuthorization()
+            .WithNoStoreResponse();
 
         group.MapPost("/passkeys/register/begin", BeginRegistrationAsync)
             .WithName("BeginPasskeyRegistration")
@@ -33,7 +35,8 @@ internal static class AccountPasskeyEndpoints
                 + "for browser-native passkey autofill support.")
             .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces<string>(StatusCodes.Status200OK, "application/json")
-            .RequireAuthorization();
+            .RequireAuthorization()
+            .WithNoStoreResponse();
 
         group.MapPost("/passkeys/register/complete", CompleteRegistrationAsync)
             .WithName("CompletePasskeyRegistration")
@@ -52,7 +55,8 @@ internal static class AccountPasskeyEndpoints
                 + "and empty allowCredentials for Conditional UI autofill.")
             .Produces<string>(StatusCodes.Status200OK, "application/json")
             .AllowAnonymous()
-            .RequireRateLimiting("authentication");
+            .RequireRateLimiting("authentication")
+            .WithNoStoreResponse();
 
         group.MapPost("/passkeys/assertion/complete", CompleteAssertionAsync)
             .WithName("CompletePasskeyAssertion")

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountPasswordEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountPasswordEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Granit.Events;
 using Granit.Http.Idempotency.Attributes;
+using Granit.Http.Timing;
 using Granit.Identity;
 using Granit.Identity.Local.Diagnostics;
 using Granit.Identity.Local.Endpoints.Dtos;
@@ -104,6 +105,13 @@ internal static class AccountPasswordEndpoints
         [FromServices] IPasswordResetService passwordResetService,
         CancellationToken cancellationToken)
     {
+        // Pad the response to the same 500-700 ms floor as login. Without this, an
+        // attacker can enumerate registered emails by timing: a hit hashes a token
+        // and writes an outbox row, a miss returns immediately. Reuse the login
+        // bounds so /login and /forgot-password present the same surface.
+        await using var floor = MinimumResponseTimeGuard.Begin(
+            AccountLoginEndpoints.MinResponseFloorMs, AccountLoginEndpoints.MaxResponseFloorMs);
+
         using Activity? activity = IdentityLocalActivitySource.Source.StartActivity(
             IdentityLocalActivitySource.PasswordReset);
         activity?.SetTag(IdentityLocalActivitySource.TagProvider, "forgot");

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountSessionEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountSessionEndpoints.cs
@@ -1,3 +1,4 @@
+using Granit.Http.SecurityHeaders.Extensions;
 using Granit.Identity.Local.Endpoints.Dtos;
 using Granit.Identity.Local.Endpoints.Internal;
 using Granit.Identity.Local.Extensions;
@@ -38,7 +39,8 @@ internal static class AccountSessionEndpoints
                 + "Returns 400 if the current token is not an impersonation token.")
             .Produces<ImpersonationResponse>()
             .ProducesProblem(StatusCodes.Status400BadRequest)
-            .RequireAuthorization();
+            .RequireAuthorization()
+            .WithNoStoreResponse();
 
         return group;
     }

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountTwoFactorEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountTwoFactorEndpoints.cs
@@ -1,5 +1,6 @@
 using Granit.Events;
 using Granit.Http.Idempotency.Attributes;
+using Granit.Http.SecurityHeaders.Extensions;
 using Granit.Identity;
 using Granit.Identity.Local.Endpoints.Dtos;
 using Granit.Identity.Local.Events;
@@ -33,7 +34,8 @@ internal static class AccountTwoFactorEndpoints
                 "Generates or returns the existing TOTP shared key for the user. "
                 + "The QR code URI can be rendered by the frontend for authenticator app scanning.")
             .Produces<AccountAuthenticatorKeyResponse>()
-            .RequireAuthorization();
+            .RequireAuthorization()
+            .WithNoStoreResponse();
 
         group.MapPost("/two-factor/enable", EnableAsync)
             .WithName("EnableTwoFactor")
@@ -46,7 +48,8 @@ internal static class AccountTwoFactorEndpoints
             .Produces<AccountTwoFactorEnableResponse>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesValidationProblem()
-            .RequireAuthorization();
+            .RequireAuthorization()
+            .WithNoStoreResponse();
 
         group.MapPost("/two-factor/disable", DisableAsync)
             .WithName("DisableTwoFactor")
@@ -71,7 +74,8 @@ internal static class AccountTwoFactorEndpoints
             .Produces<AccountRecoveryCodesResponse>()
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesValidationProblem()
-            .RequireAuthorization();
+            .RequireAuthorization()
+            .WithNoStoreResponse();
 
         return group;
     }

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AdminImpersonationEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AdminImpersonationEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Granit.Http.Idempotency.Attributes;
+using Granit.Http.SecurityHeaders.Extensions;
 using Granit.Identity.Local.Diagnostics;
 using Granit.Identity.Local.Endpoints.Dtos;
 using Granit.Identity.Local.Endpoints.Internal;
@@ -26,7 +27,8 @@ internal static class AdminImpersonationEndpoints
             .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces<ImpersonationResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
-            .RequireAuthorization(IdentityLocalPermissions.Users.Impersonate);
+            .RequireAuthorization(IdentityLocalPermissions.Users.Impersonate)
+            .WithNoStoreResponse();
 
         return group;
     }

--- a/src/Granit.Identity.Local.Endpoints/Granit.Identity.Local.Endpoints.csproj
+++ b/src/Granit.Identity.Local.Endpoints/Granit.Identity.Local.Endpoints.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\Granit.Caching\Granit.Caching.csproj" />
     <ProjectReference Include="..\Granit.Http.Abstractions\Granit.Http.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Http.ApiDocumentation\Granit.Http.ApiDocumentation.csproj" />
+    <ProjectReference Include="..\Granit.Http.SecurityHeaders\Granit.Http.SecurityHeaders.csproj" />
     <ProjectReference Include="..\Granit.Identity.Local\Granit.Identity.Local.csproj" />
     <ProjectReference Include="..\Granit.Settings\Granit.Settings.csproj" />
     <ProjectReference Include="..\Granit.Validation\Granit.Validation.csproj" />

--- a/src/Granit.Identity.Local.Endpoints/packages.lock.json
+++ b/src/Granit.Identity.Local.Endpoints/packages.lock.json
@@ -107,6 +107,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.http.securityheaders": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {

--- a/src/Granit.Identity.Local.Privacy/DataExport/IdentityLocalPrivacyDataProvider.cs
+++ b/src/Granit.Identity.Local.Privacy/DataExport/IdentityLocalPrivacyDataProvider.cs
@@ -38,6 +38,9 @@ public sealed class IdentityLocalPrivacyDataProvider(UserManager<GranitUser> use
 
         IList<string> roles = await userManager.GetRolesAsync(user).ConfigureAwait(false);
 
+        // CreatedBy / ModifiedBy intentionally omitted — those columns store administrator
+        // user identifiers, which are third-party personal data and would expose admin
+        // identities to the data subject (GDPR Art. 5(1)(c) — data minimisation).
         IdentityLocalExportResponse dto = new(
             Id: user.Id,
             UserName: user.UserName,
@@ -53,9 +56,7 @@ public sealed class IdentityLocalPrivacyDataProvider(UserManager<GranitUser> use
             AccessFailedCount: user.AccessFailedCount,
             TenantId: user.TenantId,
             CreatedAt: user.CreatedAt,
-            CreatedBy: user.CreatedBy,
             ModifiedAt: user.ModifiedAt,
-            ModifiedBy: user.ModifiedBy,
             IsDeleted: user.IsDeleted,
             DeletedAt: user.DeletedAt,
             CustomAttributesJson: user.CustomAttributesJson,
@@ -70,7 +71,12 @@ public sealed class IdentityLocalPrivacyDataProvider(UserManager<GranitUser> use
     };
 }
 
-/// <summary>Export record written to the <c>identity-local.json</c> fragment.</summary>
+/// <summary>
+/// Export record written to the <c>identity-local.json</c> fragment.
+/// Excludes the audit-trail attribution fields (<c>CreatedBy</c> / <c>ModifiedBy</c>)
+/// so administrator user identifiers — third-party personal data — do not leak via
+/// the data subject's GDPR Art. 15 export.
+/// </summary>
 internal sealed record IdentityLocalExportResponse(
     Guid Id,
     string? UserName,
@@ -86,9 +92,7 @@ internal sealed record IdentityLocalExportResponse(
     int AccessFailedCount,
     Guid? TenantId,
     DateTimeOffset CreatedAt,
-    string CreatedBy,
     DateTimeOffset? ModifiedAt,
-    string? ModifiedBy,
     bool IsDeleted,
     DateTimeOffset? DeletedAt,
     string? CustomAttributesJson,

--- a/src/Granit.Identity/Events/IdentityUserCreatedEto.cs
+++ b/src/Granit.Identity/Events/IdentityUserCreatedEto.cs
@@ -1,3 +1,4 @@
+using Granit.DataProtection;
 using Granit.Events;
 
 namespace Granit.Identity.Events;
@@ -5,7 +6,18 @@ namespace Granit.Identity.Events;
 /// <summary>
 /// Published after a new user is created in the identity provider.
 /// </summary>
+/// <remarks>
+/// <see cref="Username"/> and <see cref="Email"/> are PII. They are marked
+/// <see cref="SensitiveDataAttribute"/> so they are redacted in audit logs, MCP
+/// output, and diagnostics. The Wolverine outbox should be pruned frequently to
+/// minimise plaintext exposure of these fields in the database.
+/// </remarks>
 /// <param name="UserId">The provider-assigned user ID.</param>
 /// <param name="Username">The username of the created user (may be null).</param>
 /// <param name="Email">The email of the created user (may be null).</param>
-public sealed record IdentityUserCreatedEto(string UserId, string? Username, string? Email) : IIntegrationEvent;
+public sealed record IdentityUserCreatedEto(
+    string UserId,
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask)]
+    string? Username,
+    [property: SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit)]
+    string? Email) : IIntegrationEvent;

--- a/src/Granit.Identity/Models/IdentityUserUpdate.cs
+++ b/src/Granit.Identity/Models/IdentityUserUpdate.cs
@@ -1,9 +1,17 @@
+using Granit.DataProtection;
+
 namespace Granit.Identity.Models;
 
 /// <summary>
 /// Represents the fields that can be updated on an identity provider user.
 /// All properties are optional — only non-null values are applied.
 /// </summary>
+/// <remarks>
+/// Embedded in <c>IdentityUserProfileUpdatedEto</c>, which is published through the
+/// Wolverine outbox. The PII properties (<see cref="Email"/>, <see cref="FirstName"/>,
+/// <see cref="LastName"/>) are marked <see cref="SensitiveDataAttribute"/> so they are
+/// redacted in audit logs, MCP output, and diagnostics.
+/// </remarks>
 /// <param name="Email">New email address, or <c>null</c> to leave unchanged.</param>
 /// <param name="FirstName">New first name, or <c>null</c> to leave unchanged.</param>
 /// <param name="LastName">New last name, or <c>null</c> to leave unchanged.</param>
@@ -12,7 +20,10 @@ namespace Granit.Identity.Models;
 /// Only provided attributes are modified — existing attributes not in the dictionary are left unchanged.
 /// </param>
 public sealed record IdentityUserUpdate(
+    [property: SensitiveData(Level = Sensitivity.Restricted, Mode = SensitiveDataMode.Omit)]
     string? Email = null,
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask)]
     string? FirstName = null,
+    [property: SensitiveData(Level = Sensitivity.Confidential, Mode = SensitiveDataMode.Mask)]
     string? LastName = null,
     IReadOnlyDictionary<string, string?>? Attributes = null);

--- a/tests/Granit.ArchitectureTests/ActivitySourcePiiConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/ActivitySourcePiiConventionTests.cs
@@ -163,7 +163,7 @@ public sealed partial class ActivitySourcePiiConventionTests
         string? dir = Path.GetDirectoryName(typeof(ActivitySourcePiiConventionTests).Assembly.Location);
         while (dir is not null)
         {
-            if (Directory.Exists(Path.Join(dir, ".git")))
+            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/ApiConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/ApiConventionTests.cs
@@ -430,7 +430,7 @@ public sealed partial class ApiConventionTests
         string? dir = Path.GetDirectoryName(typeof(ApiConventionTests).Assembly.Location);
         while (dir is not null)
         {
-            if (Directory.Exists(Path.Join(dir, ".git")))
+            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/AuditPiiConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/AuditPiiConventionTests.cs
@@ -154,7 +154,7 @@ public sealed partial class AuditPiiConventionTests
         string? dir = Path.GetDirectoryName(typeof(AuditPiiConventionTests).Assembly.Location);
         while (dir is not null)
         {
-            if (Directory.Exists(Path.Join(dir, ".git")))
+            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/BackgroundJobConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/BackgroundJobConventionTests.cs
@@ -116,7 +116,7 @@ public sealed partial class BackgroundJobConventionTests
         string? dir = Path.GetDirectoryName(typeof(BackgroundJobConventionTests).Assembly.Location);
         while (dir is not null)
         {
-            if (Directory.Exists(Path.Join(dir, ".git")))
+            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/CachingConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/CachingConventionTests.cs
@@ -100,12 +100,18 @@ public sealed partial class CachingConventionTests
     private static string FindRepoRoot()
     {
         string dir = AppContext.BaseDirectory;
-        while (dir is not null && !Directory.Exists(Path.Join(dir, ".git")))
+        while (dir is not null)
         {
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return dir;
+            }
+
             dir = Path.GetDirectoryName(dir)!;
         }
 
-        return dir ?? throw new InvalidOperationException("Could not find repository root.");
+        throw new InvalidOperationException("Could not find repository root.");
     }
 
     [GeneratedRegex(@"\bIDistributedCache\b", RegexOptions.None, matchTimeoutMilliseconds: 1000)]

--- a/tests/Granit.ArchitectureTests/EndpointParameterBindingTests.cs
+++ b/tests/Granit.ArchitectureTests/EndpointParameterBindingTests.cs
@@ -257,7 +257,7 @@ public sealed partial class EndpointParameterBindingTests
         string? dir = Path.GetDirectoryName(typeof(EndpointParameterBindingTests).Assembly.Location);
         while (dir is not null)
         {
-            if (Directory.Exists(Path.Join(dir, ".git")))
+            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/FileOrganizationTests.cs
+++ b/tests/Granit.ArchitectureTests/FileOrganizationTests.cs
@@ -716,7 +716,7 @@ public sealed partial class FileOrganizationTests
         string? dir = Path.GetDirectoryName(typeof(FileOrganizationTests).Assembly.Location);
         while (dir is not null)
         {
-            if (Directory.Exists(Path.Join(dir, ".git")))
+            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/FrameworkBoundaryTests.cs
+++ b/tests/Granit.ArchitectureTests/FrameworkBoundaryTests.cs
@@ -57,7 +57,7 @@ public sealed class FrameworkBoundaryTests
         string? dir = Path.GetDirectoryName(typeof(FrameworkBoundaryTests).Assembly.Location);
         while (dir is not null)
         {
-            if (Directory.Exists(Path.Join(dir, ".git")))
+            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/IdempotencyConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/IdempotencyConventionTests.cs
@@ -204,7 +204,7 @@ public sealed partial class IdempotencyConventionTests
         string? dir = Path.GetDirectoryName(typeof(IdempotencyConventionTests).Assembly.Location);
         while (dir is not null)
         {
-            if (Directory.Exists(Path.Join(dir, ".git")))
+            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/IsolatedDbContextTests.cs
+++ b/tests/Granit.ArchitectureTests/IsolatedDbContextTests.cs
@@ -258,7 +258,7 @@ public sealed partial class IsolatedDbContextTests
         string? dir = Path.GetDirectoryName(typeof(IsolatedDbContextTests).Assembly.Location);
         while (dir is not null)
         {
-            if (Directory.Exists(Path.Join(dir, ".git")))
+            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/LoggerMessagePiiConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/LoggerMessagePiiConventionTests.cs
@@ -191,7 +191,7 @@ public sealed partial class LoggerMessagePiiConventionTests
         string? dir = Path.GetDirectoryName(typeof(LoggerMessagePiiConventionTests).Assembly.Location);
         while (dir is not null)
         {
-            if (Directory.Exists(Path.Join(dir, ".git")))
+            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/MetricsPiiConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/MetricsPiiConventionTests.cs
@@ -119,7 +119,7 @@ public sealed partial class MetricsPiiConventionTests
         string? dir = Path.GetDirectoryName(typeof(MetricsPiiConventionTests).Assembly.Location);
         while (dir is not null)
         {
-            if (Directory.Exists(Path.Join(dir, ".git")))
+            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/NamingHomogeneityTests.cs
+++ b/tests/Granit.ArchitectureTests/NamingHomogeneityTests.cs
@@ -233,7 +233,8 @@ public sealed partial class NamingHomogeneityTests
         string? dir = Path.GetDirectoryName(typeof(NamingHomogeneityTests).Assembly.Location);
         while (dir is not null)
         {
-            if (Directory.Exists(Path.Combine(dir, ".git")))
+            string gitPath = Path.Combine(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/ProjectDependencyTests.cs
+++ b/tests/Granit.ArchitectureTests/ProjectDependencyTests.cs
@@ -94,7 +94,7 @@ public sealed partial class ProjectDependencyTests
         string? dir = Path.GetDirectoryName(typeof(ProjectDependencyTests).Assembly.Location);
         while (dir is not null)
         {
-            if (Directory.Exists(Path.Join(dir, ".git")))
+            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/SourceCodeAntiPatternTests.cs
+++ b/tests/Granit.ArchitectureTests/SourceCodeAntiPatternTests.cs
@@ -332,7 +332,7 @@ public sealed partial class SourceCodeAntiPatternTests
         string? dir = Path.GetDirectoryName(typeof(SourceCodeAntiPatternTests).Assembly.Location);
         while (dir is not null)
         {
-            if (Directory.Exists(Path.Join(dir, ".git")))
+            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/TestProjectConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/TestProjectConventionTests.cs
@@ -83,7 +83,7 @@ public sealed class TestProjectConventionTests
         string? dir = Path.GetDirectoryName(typeof(TestProjectConventionTests).Assembly.Location);
         while (dir is not null)
         {
-            if (Directory.Exists(Path.Join(dir, ".git")))
+            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/ValidationConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/ValidationConventionTests.cs
@@ -275,7 +275,7 @@ public sealed partial class ValidationConventionTests
         string? dir = Path.GetDirectoryName(typeof(ValidationConventionTests).Assembly.Location);
         while (dir is not null)
         {
-            if (Directory.Exists(Path.Join(dir, ".git")))
+            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2239,6 +2239,7 @@
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.Http.SecurityHeaders": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"

--- a/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsIntegrationTests.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsIntegrationTests.cs
@@ -829,11 +829,32 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task ExternalLoginCallback_MissingProvider_Returns400()
     {
+        // No external auth ticket and no query string — endpoint cannot resolve a provider
+        // and rejects with 400. This guards the post-VULN-214 behaviour: query-string
+        // provider is no longer trusted, so a missing IdentityConstants.ExternalScheme
+        // ticket must fail closed.
         HttpResponseMessage response = await _server.AnonymousClient.GetAsync(
             "/account/external-logins/callback",
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ExternalLoginCallback_QueryStringIgnored_Returns400()
+    {
+        // The query string is attacker-controlled; the post-VULN-214 endpoint reads the
+        // provider from the IdentityConstants.ExternalScheme ticket only. A request that
+        // carries only ?provider=Google with no external ticket must be rejected.
+        HttpResponseMessage response = await _server.AnonymousClient.GetAsync(
+            "/account/external-logins/callback?provider=Google",
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+        await _server.ExternalLoginService.DidNotReceive().ProcessCallbackAsync(
+            Arg.Any<System.Security.Claims.ClaimsPrincipal>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -843,9 +864,11 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
             .ProcessCallbackAsync(Arg.Any<System.Security.Claims.ClaimsPrincipal>(), "Google", Arg.Any<CancellationToken>())
             .Returns(new ProcessCallbackResult(AccountEndpointsTestServer.TestUserId, false));
 
-        HttpResponseMessage response = await _server.AuthenticatedClient.GetAsync(
-            "/account/external-logins/callback?provider=Google",
-            TestContext.Current.CancellationToken);
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/account/external-logins/callback");
+        request.Headers.Add(TestExternalAuthHandler.ProviderHeader, "Google");
+
+        HttpResponseMessage response = await _server.AnonymousClient.SendAsync(
+            request, TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
@@ -857,9 +880,11 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
             .ProcessCallbackAsync(Arg.Any<System.Security.Claims.ClaimsPrincipal>(), "Google", Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("DuplicateEmail: email already in use."));
 
-        HttpResponseMessage response = await _server.AuthenticatedClient.GetAsync(
-            "/account/external-logins/callback?provider=Google",
-            TestContext.Current.CancellationToken);
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/account/external-logins/callback");
+        request.Headers.Add(TestExternalAuthHandler.ProviderHeader, "Google");
+
+        HttpResponseMessage response = await _server.AnonymousClient.SendAsync(
+            request, TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.Conflict);
     }
@@ -871,11 +896,40 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
             .ProcessCallbackAsync(Arg.Any<System.Security.Claims.ClaimsPrincipal>(), "GitHub", Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("User not found for external login."));
 
-        HttpResponseMessage response = await _server.AuthenticatedClient.GetAsync(
-            "/account/external-logins/callback?provider=GitHub",
-            TestContext.Current.CancellationToken);
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/account/external-logins/callback");
+        request.Headers.Add(TestExternalAuthHandler.ProviderHeader, "GitHub");
+
+        HttpResponseMessage response = await _server.AnonymousClient.SendAsync(
+            request, TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ExternalLoginCallback_QueryProviderIgnoredWhenSchemeDiffers_UsesScheme()
+    {
+        // VULN-214: even when the query string says "GitHub", the actual scheme on the
+        // external ticket ("Google") wins. Otherwise an attacker who lands an OAuth
+        // callback for one provider could mis-attribute the resulting external login.
+        _server.ExternalLoginService
+            .ProcessCallbackAsync(Arg.Any<System.Security.Claims.ClaimsPrincipal>(), "Google", Arg.Any<CancellationToken>())
+            .Returns(new ProcessCallbackResult(AccountEndpointsTestServer.TestUserId, false));
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/account/external-logins/callback?provider=GitHub");
+        request.Headers.Add(TestExternalAuthHandler.ProviderHeader, "Google");
+
+        HttpResponseMessage response = await _server.AnonymousClient.SendAsync(
+            request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        await _server.ExternalLoginService.Received(1).ProcessCallbackAsync(
+            Arg.Any<System.Security.Claims.ClaimsPrincipal>(),
+            "Google",
+            Arg.Any<CancellationToken>());
+        await _server.ExternalLoginService.DidNotReceive().ProcessCallbackAsync(
+            Arg.Any<System.Security.Claims.ClaimsPrincipal>(),
+            "GitHub",
+            Arg.Any<CancellationToken>());
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsTestServer.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsTestServer.cs
@@ -170,11 +170,14 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
         builder.WebHost.UseTestServer();
         builder.Logging.ClearProviders();
 
-        // Authentication
+        // Authentication — primary scheme for app sessions, plus a stub external
+        // scheme so /external-logins/callback can verify provider resolution.
         builder.Services
             .AddAuthentication(TestAuthHandler.SchemeName)
             .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
-                TestAuthHandler.SchemeName, _ => { });
+                TestAuthHandler.SchemeName, _ => { })
+            .AddScheme<AuthenticationSchemeOptions, TestExternalAuthHandler>(
+                IdentityConstants.ExternalScheme, _ => { });
 
         // Authorization policies matching the permission names used by the endpoints
         builder.Services.AddAuthorizationBuilder()
@@ -298,6 +301,46 @@ internal sealed class TestAuthHandler(
         ClaimsPrincipal principal = new(identity);
         AuthenticationTicket ticket = new(principal, SchemeName);
 
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}
+
+/// <summary>
+/// Fake authentication handler bound to <see cref="IdentityConstants.ExternalScheme"/>.
+/// Authenticates when the <c>X-Test-External-Provider</c> header is present, and
+/// stores its value as the <c>LoginProvider</c> property item — the well-known key
+/// ASP.NET Core Identity reads via <c>SignInManager.GetExternalLoginInfoAsync</c>.
+/// </summary>
+internal sealed class TestExternalAuthHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    public const string ProviderHeader = "X-Test-External-Provider";
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue(ProviderHeader, out Microsoft.Extensions.Primitives.StringValues providerHeader)
+            || string.IsNullOrEmpty(providerHeader.ToString()))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        string provider = providerHeader.ToString();
+
+        Claim[] claims =
+        [
+            new(ClaimTypes.NameIdentifier, "external-user-key"),
+            new(ClaimTypes.Email, "external@example.com"),
+        ];
+
+        ClaimsIdentity identity = new(claims, IdentityConstants.ExternalScheme);
+        ClaimsPrincipal principal = new(identity);
+
+        AuthenticationProperties properties = new();
+        properties.Items["LoginProvider"] = provider;
+
+        AuthenticationTicket ticket = new(principal, properties, IdentityConstants.ExternalScheme);
         return Task.FromResult(AuthenticateResult.Success(ticket));
     }
 }

--- a/tests/Granit.Identity.Local.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/packages.lock.json
@@ -600,6 +600,12 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.http.securityheaders": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {
@@ -628,6 +634,7 @@
           "Granit.Caching": "[0.1.0-dev, )",
           "Granit.Http.Abstractions": "[0.1.0-dev, )",
           "Granit.Http.ApiDocumentation": "[0.1.0-dev, )",
+          "Granit.Http.SecurityHeaders": "[0.1.0-dev, )",
           "Granit.Identity.Local": "[0.1.0-dev, )",
           "Granit.Settings": "[0.1.0-dev, )",
           "Granit.Validation": "[0.1.0-dev, )"


### PR DESCRIPTION
## Summary

Closes 8 medium-severity findings from the `Granit.Identity.*` security audit (commit `477e92c8`). Each fix is independent and small; bundled here per the audit remediation plan (PR3, Quick Wins).

| ID | VULN | Fix |
|----|------|-----|
| Q2 | VULN-202 | Stop stacking `RequireAuthorization` on the user-cache route group — each permission scope gets its own `RouteGroupBuilder` so GDPR endpoints require `Users.Delete` alone, not the union with `Users.Read` + `Users.Sync`. |
| Q3 | VULN-205 | Drop `CreatedBy` / `ModifiedBy` from the Identity.Local privacy export — admin user IDs were being disclosed to data subjects via GDPR Art. 15 archives. |
| Q4 | VULN-206 | Annotate `IdentityUserCreatedEto.Email`/`Username` and `IdentityUserUpdate.Email`/`FirstName`/`LastName` with `[SensitiveData]` so PII is redacted in audit logs, MCP output, and Wolverine outbox diagnostics. |
| Q5 | VULN-208 | New `NoStoreEndpointFilter` + `WithNoStoreResponse()` extension in `Granit.Http.SecurityHeaders`. Sets the full `Cache-Control` + `Pragma` + `Expires` triplet so HTTP/1.0 proxies are also covered. Applied to TOTP authenticator-key/recovery-codes, passkey list/begin endpoints, impersonation token, and back-to-impersonator response. |
| Q6 | VULN-210 | Extracted `MinimumResponseTimeGuard` into `Granit.Http.Abstractions`; replaced the local helper in `AccountLoginEndpoints` and applied the same 500-700 ms randomised floor to `/forgot-password` so credential recovery and login present the same timing surface. |
| Q7 | VULN-212 | Whitelist regex on Cognito `ListUsers` search input — rejects quotes and other characters that could break out of the `username ^= "…"` filter syntax. |
| Q8 | VULN-214 | Read external-login provider from `IdentityConstants.ExternalScheme` ticket instead of the attacker-controllable `?provider=` query string. New `TestExternalAuthHandler` in the integration test harness verifies the scheme always wins over the query string. |
| Q9 | VULN-213 | `RequireUniqueEmailValidator` fails startup when `IdentityOptions.User.RequireUniqueEmail` is disabled and no `ITenantResolver` is registered — defense-in-depth for the cross-tenant login lookup that disables the `IMultiTenant` filter when no tenant context is active. Soft-deps on `Granit.MultiTenancy` via type-name resolution per CLAUDE.md. |

## Why

These eight findings together form the audit's "Quick Wins" tier — each landed independently is low-risk, but together they meaningfully shrink the medium-severity surface (timing leaks, PII in event payloads, OAuth callback misattribution, missing cache headers, unbound filter input, broken authorization scoping, third-party PII leak in subject-access exports).

Plan reference: `~/.claude/plans/deep-toasting-avalanche.md` → "PR3 — Quick Wins (Q1-Q9)".

## Bonus: architecture tests now run from a git worktree

17 `*ConventionTests.cs` files duplicated a `FindRepoRoot()` that only accepted `.git` as a directory and so failed when the test suite ran from a `git worktree`. Each call site now also accepts `.git` as a file (worktree layout). Noted as follow-up in PR #1132 — folded in here so the new helpers (`MinimumResponseTimeGuard`, `NoStoreEndpointFilter`) can be verified locally end-to-end before merge. Not a behaviour change for CI runners.

## Test plan

- [x] `dotnet test tests/Granit.Identity.Endpoints.Tests` — 161/161 pass
- [x] `dotnet test tests/Granit.Identity.Local.Endpoints.Tests` — 144/144 pass (incl. 6 new external-login callback assertions covering query-string-ignored, scheme-wins-over-query)
- [x] `dotnet test tests/Granit.Identity.Local.AspNetIdentity.Tests` — 181/181 pass
- [x] `dotnet test tests/Granit.Identity.Local.Privacy.Tests` — 6/6 pass
- [x] `dotnet test tests/Granit.Identity.Federated.Cognito.Tests` — 60/60 pass
- [x] `dotnet test tests/Granit.Identity.Tests` — 142/142 pass
- [x] `dotnet test tests/Granit.ArchitectureTests` — 117/117 pass
- [x] `dotnet format --verify-no-changes` — clean across all 10 touched projects

## Breaking change?

No. None of the public API surface is renamed or removed. Behaviour changes are:
- GDPR endpoints become reachable with `Users.Delete` alone (previously required also `Users.Read` + `Users.Sync` due to a stacked-policy bug)
- `/forgot-password` now consistently takes ≥500 ms
- TOTP / passkey / impersonation responses carry stricter cache headers
- External-login callback rejects requests that arrive without an `IdentityConstants.ExternalScheme` ticket

Hosts that disabled `RequireUniqueEmail` without registering an `ITenantResolver` will now fail at startup — that misconfiguration was always unsafe; the validator surfaces it.

## Audit reference

Full report and remediation plan: see `/security` audit summary. PR3 in the 5-PR train; PR2 (`Sessions` permission split, VULN-100) is open as #1132.