### PR TITLE
fix(identity)!: tactical security hardening (T1-T5)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -17466,6 +17466,12 @@
           "kind": "property",
           "signature": "string SignatureHeaderName",
           "returnType": "string"
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(5)",
+          "returnType": "TimeSpan ReplayWindow { get; set; } = TimeSpan."
         }
       ]
     },
@@ -17946,6 +17952,15 @@
       ]
     },
     {
+      "name": "IdentityTokenExchangedEto",
+      "fqn": "Granit.Identity.Federated.Events.IdentityTokenExchangedEto",
+      "kind": "record",
+      "project": "Granit.Identity.Federated",
+      "file": "src/Granit.Identity.Federated/Events/IdentityTokenExchangedEto.cs",
+      "line": 26,
+      "members": []
+    },
+    {
       "name": "IdentityUserDeletedEto",
       "fqn": "Granit.Identity.Federated.Events.IdentityUserDeletedEto",
       "kind": "record",
@@ -17970,6 +17985,15 @@
       "project": "Granit.Identity.Federated",
       "file": "src/Granit.Identity.Federated/Events/UserCacheEntryErasedEvent.cs",
       "line": 11,
+      "members": []
+    },
+    {
+      "name": "IdentityProviderUnauthorizedException",
+      "fqn": "Granit.Identity.Federated.Exceptions.IdentityProviderUnauthorizedException",
+      "kind": "class",
+      "project": "Granit.Identity.Federated",
+      "file": "src/Granit.Identity.Federated/Exceptions/IdentityProviderUnauthorizedException.cs",
+      "line": 20,
       "members": []
     },
     {
@@ -18063,7 +18087,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated",
       "file": "src/Granit.Identity.Federated/GranitIdentityFederatedModule.cs",
-      "line": 18,
+      "line": 20,
       "members": [
         {
           "name": "ConfigureServices",
@@ -18095,7 +18119,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.Keycloak",
       "file": "src/Granit.Identity.Federated.Keycloak/Extensions/IdentityKeycloakServiceCollectionExtensions.cs",
-      "line": 18,
+      "line": 19,
       "members": [
         {
           "name": "AddGranitIdentityKeycloak",
@@ -18318,6 +18342,60 @@
           "kind": "property",
           "signature": "string Name",
           "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "ITokenExchangeRateLimiter",
+      "fqn": "Granit.Identity.Federated.RateLimiting.ITokenExchangeRateLimiter",
+      "kind": "interface",
+      "project": "Granit.Identity.Federated",
+      "file": "src/Granit.Identity.Federated/RateLimiting/ITokenExchangeRateLimiter.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "CheckAsync",
+          "kind": "method",
+          "signature": "CheckAsync(string targetUserId, CancellationToken cancellationToken)",
+          "returnType": "Task<TokenExchangeRateLimitDecision>"
+        }
+      ]
+    },
+    {
+      "name": "NullTokenExchangeRateLimiter",
+      "fqn": "Granit.Identity.Federated.RateLimiting.NullTokenExchangeRateLimiter",
+      "kind": "class",
+      "project": "Granit.Identity.Federated",
+      "file": "src/Granit.Identity.Federated/RateLimiting/NullTokenExchangeRateLimiter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "CheckAsync",
+          "kind": "method",
+          "signature": "CheckAsync(string targetUserId, CancellationToken cancellationToken)",
+          "returnType": "Task<TokenExchangeRateLimitDecision>"
+        }
+      ]
+    },
+    {
+      "name": "struct",
+      "fqn": "Granit.Identity.Federated.RateLimiting.struct",
+      "kind": "record",
+      "project": "Granit.Identity.Federated",
+      "file": "src/Granit.Identity.Federated/RateLimiting/ITokenExchangeRateLimiter.cs",
+      "line": 35,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(true, TimeSpan.Zero)",
+          "returnType": "TokenExchangeRateLimitDecision Allowed =>"
+        },
+        {
+          "name": "Denied",
+          "kind": "method",
+          "signature": "Denied(TimeSpan retryAfter)",
+          "returnType": "TokenExchangeRateLimitDecision"
         }
       ]
     },
@@ -18854,7 +18932,7 @@
       "kind": "record",
       "project": "Granit.Identity.Local.Endpoints",
       "file": "src/Granit.Identity.Local.Endpoints/Dtos/AccountChangeEmailRequest.cs",
-      "line": 7,
+      "line": 11,
       "members": []
     },
     {

--- a/src/Granit.Identity.Endpoints/Internal/WebhookSignatureValidator.cs
+++ b/src/Granit.Identity.Endpoints/Internal/WebhookSignatureValidator.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using Granit.Identity.Endpoints.Options;
@@ -7,15 +8,27 @@ using Microsoft.Extensions.Options;
 namespace Granit.Identity.Endpoints.Internal;
 
 /// <summary>
-/// Validates HMAC-SHA256 signatures on incoming webhook payloads.
+/// Validates timestamped HMAC-SHA256 signatures on incoming identity webhook payloads.
 /// </summary>
 /// <remarks>
-/// Fail-closed: when no secret is configured, all requests are rejected.
-/// Configure <see cref="IdentityWebhookOptions.Secret"/> to enable the webhook endpoint.
+/// <para>
+/// Header format (Stripe-style, also used by <c>Granit.Webhooks</c>):
+/// <c>t=&lt;unix-seconds&gt;,v1=&lt;hex&gt;</c>. The HMAC is computed over
+/// <c>"&lt;unix-seconds&gt;.&lt;body&gt;"</c>. Including the timestamp inside the
+/// signed payload prevents replay attacks: a captured request can only be replayed
+/// for the duration of <see cref="IdentityWebhookOptions.ReplayWindow"/> (default
+/// 5 minutes), after which the receiver's clock check rejects it.
+/// </para>
+/// <para>
+/// Fail-closed: when no secret is configured, every request is rejected.
+/// Configure <see cref="IdentityWebhookOptions.Secret"/> to enable the endpoint.
+/// </para>
 /// </remarks>
 internal sealed partial class WebhookSignatureValidator
 {
     private readonly IdentityWebhookOptions _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<WebhookSignatureValidator> _logger;
 
     /// <summary>
     /// Returns <c>true</c> if signature validation is configured (secret is non-empty).
@@ -24,9 +37,12 @@ internal sealed partial class WebhookSignatureValidator
 
     public WebhookSignatureValidator(
         IOptions<IdentityWebhookOptions> options,
+        TimeProvider timeProvider,
         ILogger<WebhookSignatureValidator> logger)
     {
         _options = options.Value;
+        _timeProvider = timeProvider;
+        _logger = logger;
 
         if (!IsEnabled)
         {
@@ -35,10 +51,12 @@ internal sealed partial class WebhookSignatureValidator
     }
 
     /// <summary>
-    /// Validates the HMAC-SHA256 signature of the given payload.
+    /// Validates the timestamped HMAC-SHA256 signature of the given payload.
     /// </summary>
     /// <param name="payload">The raw request body bytes.</param>
-    /// <param name="signature">The signature from the HTTP header (hex-encoded).</param>
+    /// <param name="signature">
+    /// The signature header value in the format <c>t=&lt;unix-seconds&gt;,v1=&lt;hex&gt;</c>.
+    /// </param>
     /// <returns><c>true</c> if valid, <c>false</c> otherwise.</returns>
     public bool Validate(byte[] payload, string? signature)
     {
@@ -52,17 +70,85 @@ internal sealed partial class WebhookSignatureValidator
             return false;
         }
 
+        if (!TryParseHeader(signature, out long timestamp, out string? expectedHex)
+            || expectedHex is null)
+        {
+            LogMalformedSignatureHeader();
+            return false;
+        }
+
+        DateTimeOffset now = _timeProvider.GetUtcNow();
+        var signedAt = DateTimeOffset.FromUnixTimeSeconds(timestamp);
+        TimeSpan skew = signedAt > now ? signedAt - now : now - signedAt;
+
+        if (skew > _options.ReplayWindow)
+        {
+            LogSignatureOutsideReplayWindow((long)skew.TotalSeconds, (long)_options.ReplayWindow.TotalSeconds);
+            return false;
+        }
+
+        // HMAC over "<unix-seconds>.<body>" — same shape as Granit.Webhooks senders.
         byte[] key = Encoding.UTF8.GetBytes(_options.Secret);
-        byte[] expectedHash = HMACSHA256.HashData(key, payload);
-        string expectedSignature = Convert.ToHexStringLower(expectedHash);
+        byte[] prefix = Encoding.UTF8.GetBytes(timestamp.ToString(CultureInfo.InvariantCulture) + ".");
+
+        byte[] toSign = new byte[prefix.Length + payload.Length];
+        Buffer.BlockCopy(prefix, 0, toSign, 0, prefix.Length);
+        Buffer.BlockCopy(payload, 0, toSign, prefix.Length, payload.Length);
+
+        byte[] expectedHash = HMACSHA256.HashData(key, toSign);
+        string actualHex = Convert.ToHexStringLower(expectedHash);
 
         return CryptographicOperations.FixedTimeEquals(
-            Encoding.UTF8.GetBytes(expectedSignature),
-            Encoding.UTF8.GetBytes(signature));
+            Encoding.UTF8.GetBytes(actualHex),
+            Encoding.UTF8.GetBytes(expectedHex));
+    }
+
+    /// <summary>
+    /// Parses a <c>t=&lt;unix&gt;,v1=&lt;hex&gt;</c> header. Order of components is not
+    /// enforced — callers may send <c>v1=…,t=…</c> as well, matching Stripe's tolerance.
+    /// </summary>
+    private static bool TryParseHeader(string header, out long timestamp, out string? hex)
+    {
+        timestamp = 0;
+        hex = null;
+
+        foreach (string segment in header.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            int eq = segment.IndexOf('=');
+            if (eq <= 0 || eq == segment.Length - 1)
+            {
+                return false;
+            }
+
+            string name = segment[..eq];
+            string value = segment[(eq + 1)..];
+
+            if (name.Equals("t", StringComparison.Ordinal))
+            {
+                if (!long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out timestamp))
+                {
+                    return false;
+                }
+            }
+            else if (name.Equals("v1", StringComparison.Ordinal))
+            {
+                hex = value;
+            }
+        }
+
+        return timestamp > 0 && !string.IsNullOrEmpty(hex);
     }
 
     [LoggerMessage(Level = LogLevel.Warning,
         Message = "Identity webhook secret is not configured — all webhook requests will be rejected. " +
                   "Set 'IdentityWebhook:Secret' to enable the webhook endpoint")]
     private static partial void LogWebhookSecretNotConfigured(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Identity webhook signature header is malformed (expected 't=<unix>,v1=<hex>')")]
+    private partial void LogMalformedSignatureHeader();
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Identity webhook signature timestamp is outside the replay window (skew={SkewSeconds}s, window={WindowSeconds}s)")]
+    private partial void LogSignatureOutsideReplayWindow(long skewSeconds, long windowSeconds);
 }

--- a/src/Granit.Identity.Endpoints/Options/IdentityWebhookOptions.cs
+++ b/src/Granit.Identity.Endpoints/Options/IdentityWebhookOptions.cs
@@ -11,14 +11,24 @@ public sealed class IdentityWebhookOptions
 
     /// <summary>
     /// Shared secret for HMAC-SHA256 signature validation.
-    /// The provider must send the signature in the <c>X-Webhook-Signature</c> header.
-    /// Leave empty to disable signature validation (not recommended for production).
+    /// The provider must send the signature in the <see cref="SignatureHeaderName"/> header
+    /// in the format <c>t=&lt;unix-seconds&gt;,v1=&lt;hex&gt;</c> where the HMAC is computed
+    /// over <c>"&lt;unix-seconds&gt;.&lt;body&gt;"</c>. Leave empty to disable signature
+    /// validation (not recommended for production).
     /// </summary>
     public string Secret { get; set; } = string.Empty;
 
     /// <summary>
-    /// Name of the HTTP header containing the HMAC signature.
+    /// Name of the HTTP header containing the timestamped HMAC signature.
     /// Default: <c>"X-Webhook-Signature"</c>.
     /// </summary>
     public string SignatureHeaderName { get; set; } = "X-Webhook-Signature";
+
+    /// <summary>
+    /// Maximum acceptable skew between the timestamp embedded in the signature header
+    /// and the receiver's clock. Webhooks whose <c>t=</c> component falls outside
+    /// <c>now ± ReplayWindow</c> are rejected as either replays or clock-skew anomalies.
+    /// Default: 5 minutes — matches Stripe's recommended tolerance.
+    /// </summary>
+    public TimeSpan ReplayWindow { get; set; } = TimeSpan.FromMinutes(5);
 }

--- a/src/Granit.Identity.Federated.Cognito/Internal/CognitoIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.Cognito/Internal/CognitoIdentityProvider.cs
@@ -1,13 +1,16 @@
 using System.Diagnostics;
+using System.Net;
 using System.Text.RegularExpressions;
 using Amazon.CognitoIdentityProvider;
 using Amazon.CognitoIdentityProvider.Model;
+using Amazon.Runtime;
 using Granit.Events;
 using Granit.Identity;
 using Granit.Identity.Events;
 using Granit.Identity.Federated;
 using Granit.Identity.Federated.Cognito.Diagnostics;
 using Granit.Identity.Federated.Cognito.Options;
+using Granit.Identity.Federated.Exceptions;
 using Granit.Identity.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -25,9 +28,18 @@ internal sealed partial class CognitoIdentityProvider(
     IDistributedEventBus distributedEventBus,
     ILogger<CognitoIdentityProvider> logger) : IIdentityProvider, IIdentityClientRoleManager
 {
+    private const string ProviderName = "cognito";
     private const string EmailAttribute = "email";
     private const string GivenNameAttribute = "given_name";
     private const string FamilyNameAttribute = "family_name";
+
+    /// <summary>
+    /// Detects authorisation failures wrapped in <see cref="AmazonServiceException"/>.
+    /// Cognito returns 401/403 plus the typed <see cref="NotAuthorizedException"/>; we
+    /// promote anything carrying those status codes to the federated unauthorized signal.
+    /// </summary>
+    private static bool IsAuthorizationFailure(AmazonServiceException ex) =>
+        ex.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden;
 
     private readonly CognitoAdminOptions _options = options.Value;
     private readonly CognitoClientRoleSyncOptions _clientRoleSyncOptions = clientRoleSyncOptions.Value;
@@ -76,6 +88,14 @@ internal sealed partial class CognitoIdentityProvider(
 
             return response.Users.Select(ToIdentityUser).ToList();
         }
+        catch (NotAuthorizedException ex)
+        {
+            throw new IdentityProviderUnauthorizedException(ProviderName, "list_users", ex);
+        }
+        catch (AmazonServiceException ex) when (IsAuthorizationFailure(ex))
+        {
+            throw new IdentityProviderUnauthorizedException(ProviderName, "list_users", ex);
+        }
         catch (Exception ex)
         {
             LogListUsersFailed(ex);
@@ -109,6 +129,14 @@ internal sealed partial class CognitoIdentityProvider(
         catch (UserNotFoundException)
         {
             return null;
+        }
+        catch (NotAuthorizedException ex)
+        {
+            throw new IdentityProviderUnauthorizedException(ProviderName, "get_user", ex);
+        }
+        catch (AmazonServiceException ex) when (IsAuthorizationFailure(ex))
+        {
+            throw new IdentityProviderUnauthorizedException(ProviderName, "get_user", ex);
         }
         catch (Exception ex)
         {

--- a/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProvider.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Security.Cryptography;
@@ -10,6 +11,7 @@ using Granit.Identity.Federated;
 using Granit.Identity.Federated.EntraId.Diagnostics;
 using Granit.Identity.Federated.EntraId.Exceptions;
 using Granit.Identity.Federated.EntraId.Options;
+using Granit.Identity.Federated.Exceptions;
 using Granit.Identity.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -39,6 +41,14 @@ internal sealed partial class EntraIdIdentityProvider(
     IDistributedEventBus distributedEventBus,
     ILogger<EntraIdIdentityProvider> logger) : IIdentityProvider, IIdentityClientRoleManager
 {
+    private const string ProviderName = "entra-id";
+
+    /// <summary>
+    /// Detects authorisation failures from Microsoft Graph (401 Unauthorized / 403 Forbidden).
+    /// </summary>
+    private static bool IsAuthorizationFailure(HttpRequestException ex) =>
+        ex.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden;
+
     /// <inheritdoc/>
     public async Task<IReadOnlyList<IIdentityUser>> GetUsersAsync(
         string? search = null,
@@ -58,6 +68,11 @@ internal sealed partial class EntraIdIdentityProvider(
                 .ConfigureAwait(false);
 
             return response?.Value?.ConvertAll(ToIdentityUser) ?? [];
+        }
+        catch (HttpRequestException ex) when (IsAuthorizationFailure(ex))
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            throw new IdentityProviderUnauthorizedException(ProviderName, "list_users", ex);
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
@@ -87,6 +102,11 @@ internal sealed partial class EntraIdIdentityProvider(
                 .ConfigureAwait(false);
 
             return user is not null ? ToIdentityUser(user) : null;
+        }
+        catch (HttpRequestException ex) when (IsAuthorizationFailure(ex))
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            throw new IdentityProviderUnauthorizedException(ProviderName, "get_user", ex);
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {

--- a/src/Granit.Identity.Federated.GoogleCloud/Internal/FirebaseAuthTransport.cs
+++ b/src/Granit.Identity.Federated.GoogleCloud/Internal/FirebaseAuthTransport.cs
@@ -15,19 +15,41 @@ internal sealed class FirebaseAuthTransport(FirebaseAuth auth) : IFirebaseAuthTr
         auth.GetUserAsync(uid, cancellationToken);
 
     /// <inheritdoc />
-    public async Task<IReadOnlyList<ExportedUserRecord>> ListUsersAsync(CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<ExportedUserRecord>> ListUsersAsync(
+        int? skip = null,
+        int? take = null,
+        CancellationToken cancellationToken = default)
     {
-        ListUsersOptions options = new() { PageSize = 1000 };
+        int skipCount = skip ?? 0;
+        int takeCount = take ?? DefaultPageSize;
+        int targetCount = skipCount + takeCount;
+
+        // Page size is bounded by Identity Toolkit (max 1000). Pick the smaller
+        // of the requested window and 1000 so we don't over-fetch on tiny windows.
+        int pageSize = Math.Min(MaxIdentityToolkitPageSize, Math.Max(1, targetCount));
+        ListUsersOptions options = new() { PageSize = pageSize };
         PagedAsyncEnumerable<ExportedUserRecords, ExportedUserRecord> pagedEnumerable = auth.ListUsersAsync(options);
 
-        List<ExportedUserRecord> users = [];
+        List<ExportedUserRecord> users = new(takeCount);
+        int seen = 0;
+
         IAsyncEnumerator<ExportedUserRecord> enumerator = pagedEnumerable.GetAsyncEnumerator(cancellationToken);
 
         try
         {
             while (await enumerator.MoveNextAsync().ConfigureAwait(false))
             {
+                if (seen++ < skipCount)
+                {
+                    continue;
+                }
+
                 users.Add(enumerator.Current);
+
+                if (users.Count >= takeCount)
+                {
+                    break;
+                }
             }
         }
         finally
@@ -37,6 +59,9 @@ internal sealed class FirebaseAuthTransport(FirebaseAuth auth) : IFirebaseAuthTr
 
         return users;
     }
+
+    private const int DefaultPageSize = 100;
+    private const int MaxIdentityToolkitPageSize = 1000;
 
     /// <inheritdoc />
     public async Task PingAsync(CancellationToken cancellationToken = default)

--- a/src/Granit.Identity.Federated.GoogleCloud/Internal/GoogleCloudIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.GoogleCloud/Internal/GoogleCloudIdentityProvider.cs
@@ -1,8 +1,10 @@
 using System.Diagnostics;
+using FirebaseAdmin;
 using FirebaseAdmin.Auth;
 using Granit.Events;
 using Granit.Identity.Events;
 using Granit.Identity.Federated;
+using Granit.Identity.Federated.Exceptions;
 using Granit.Identity.Federated.GoogleCloud.Diagnostics;
 using Granit.Identity.Federated.GoogleCloud.Options;
 using Granit.Identity.Models;
@@ -24,7 +26,17 @@ internal sealed partial class GoogleCloudIdentityProvider(
     IDistributedEventBus distributedEventBus,
     ILogger<GoogleCloudIdentityProvider> logger) : IIdentityProvider
 {
+    private const string ProviderName = "google-cloud";
     private readonly GoogleCloudIdentityOptions _options = options.Value;
+
+    /// <summary>
+    /// Detects authorisation failures from Identity Toolkit. <see cref="FirebaseException.ErrorCode"/>
+    /// surfaces <see cref="ErrorCode.Unauthenticated"/> (service-account credential missing or expired)
+    /// and <see cref="ErrorCode.PermissionDenied"/> (service account lacks the required IAM role) —
+    /// both must surface as the canonical federated unauthorised signal.
+    /// </summary>
+    private static bool IsAuthorizationFailure(FirebaseException ex) =>
+        ex.ErrorCode is ErrorCode.Unauthenticated or ErrorCode.PermissionDenied;
 
     // ── Users ─────────────────────────────────────────────────────────
 
@@ -35,37 +47,32 @@ internal sealed partial class GoogleCloudIdentityProvider(
         using Activity? activity = IdentityGoogleCloudActivitySource.Source.StartActivity(
             IdentityGoogleCloudActivitySource.Operations.ListUsers);
 
+        // Firebase Admin SDK's ListUsers cursor does not support server-side filter.
+        // The previous implementation materialised every user in memory then filtered —
+        // that is a DoS / mass-enumeration risk on directories with 100k+ users (VULN-204).
+        // Refuse search requests rather than silently fall back to the unsafe pattern.
+        if (!string.IsNullOrEmpty(search))
+        {
+            throw new NotSupportedException(
+                "Firebase Auth does not expose a server-side search filter on ListUsers. " +
+                "Granit refuses to materialise the full user directory in memory to filter it. " +
+                "Search is only available via the Identity Toolkit REST API (premium) or via " +
+                "the local Granit.Identity user-cache. Pass search=null to list users by page.");
+        }
+
         try
         {
-            IReadOnlyList<ExportedUserRecord> records = await transport.ListUsersAsync(cancellationToken).ConfigureAwait(false);
-            List<FederatedIdentityUser> users = [];
+            IReadOnlyList<ExportedUserRecord> records = await transport
+                .ListUsersAsync(first, max, cancellationToken)
+                .ConfigureAwait(false);
 
-            foreach (ExportedUserRecord user in records)
-            {
-                if (search is not null &&
-                    !(user.Email?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false) &&
-                    !(user.DisplayName?.Contains(search, StringComparison.OrdinalIgnoreCase) ?? false))
-                {
-                    continue;
-                }
-
-                users.Add(MapUser(user));
-            }
-
-            IEnumerable<FederatedIdentityUser> result = users.AsEnumerable();
-            if (first.HasValue)
-            {
-                result = result.Skip(first.Value);
-            }
-
-            if (max.HasValue)
-            {
-                result = result.Take(max.Value);
-            }
-
-            return result.ToList();
+            return records.Select(MapUser).Cast<IIdentityUser>().ToList();
         }
-        catch (Exception ex)
+        catch (FirebaseAuthException ex) when (IsAuthorizationFailure(ex))
+        {
+            throw new IdentityProviderUnauthorizedException(ProviderName, "list_users", ex);
+        }
+        catch (Exception ex) when (ex is not NotSupportedException)
         {
             LogListUsersFailed(ex);
             return [];
@@ -86,6 +93,10 @@ internal sealed partial class GoogleCloudIdentityProvider(
         catch (FirebaseAuthException ex) when (ex.AuthErrorCode == AuthErrorCode.UserNotFound)
         {
             return null;
+        }
+        catch (FirebaseAuthException ex) when (IsAuthorizationFailure(ex))
+        {
+            throw new IdentityProviderUnauthorizedException(ProviderName, "get_user", ex);
         }
         catch (Exception ex)
         {

--- a/src/Granit.Identity.Federated.GoogleCloud/Internal/IFirebaseAuthTransport.cs
+++ b/src/Granit.Identity.Federated.GoogleCloud/Internal/IFirebaseAuthTransport.cs
@@ -9,7 +9,22 @@ internal interface IFirebaseAuthTransport
 {
     Task<UserRecord> GetUserAsync(string uid, CancellationToken cancellationToken = default);
 
-    Task<IReadOnlyList<ExportedUserRecord>> ListUsersAsync(CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Lists a bounded slice of users from Firebase Auth, iterating page-by-page
+    /// over the Identity Toolkit cursor and stopping after the requested window.
+    /// </summary>
+    /// <param name="skip">Number of records to skip from the start of the directory. Defaults to 0.</param>
+    /// <param name="take">Maximum number of records to materialise. Defaults to 100.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <remarks>
+    /// Bounding the slice avoids materialising large directories (100k+ users) into
+    /// memory on every list call and limits the Identity Toolkit quota footprint —
+    /// see VULN-204 in the Identity audit.
+    /// </remarks>
+    Task<IReadOnlyList<ExportedUserRecord>> ListUsersAsync(
+        int? skip = null,
+        int? take = null,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Issues a minimal Identity Toolkit call to verify connectivity and credentials.

--- a/src/Granit.Identity.Federated.Keycloak/Exceptions/KeycloakTokenExchangeRateLimitedException.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Exceptions/KeycloakTokenExchangeRateLimitedException.cs
@@ -1,0 +1,20 @@
+namespace Granit.Identity.Federated.Keycloak.Exceptions;
+
+/// <summary>
+/// Thrown when <see cref="Internal.KeycloakUserTokenExchangeService.ExchangeTokenForUserAsync"/>
+/// is denied by the configured <c>ITokenExchangeRateLimiter</c>. Maps cleanly to a
+/// 429 Too Many Requests at the HTTP boundary.
+/// </summary>
+internal sealed class KeycloakTokenExchangeRateLimitedException : Exception
+{
+    public KeycloakTokenExchangeRateLimitedException(string targetUserId, TimeSpan retryAfter)
+        : base($"Keycloak token exchange for user '{targetUserId}' is rate-limited. Retry after {retryAfter.TotalSeconds:F0}s.")
+    {
+        TargetUserId = targetUserId;
+        RetryAfter = retryAfter;
+    }
+
+    public string TargetUserId { get; }
+
+    public TimeSpan RetryAfter { get; }
+}

--- a/src/Granit.Identity.Federated.Keycloak/Extensions/IdentityKeycloakServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Extensions/IdentityKeycloakServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Granit.Identity.Federated.Keycloak.HealthChecks;
 using Granit.Identity.Federated.Keycloak.Internal;
 using Granit.Identity.Federated.Keycloak.Internal.Sync;
 using Granit.Identity.Federated.Keycloak.Options;
+using Granit.Identity.Federated.RateLimiting;
 using Granit.Persistence.EntityFrameworkCore.DataSeeding;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -54,6 +55,12 @@ public static class IdentityKeycloakServiceCollectionExtensions
 
         services.TryAddSingleton<KeycloakAdminTokenService>();
         services.TryAddTransient<KeycloakUserTokenExchangeService>();
+
+        // Defensive registration: hosts that wire Keycloak via the DI extension (rather
+        // than via the module loader) still get the no-op rate limiter so the
+        // KeycloakUserTokenExchangeService dependency resolves. Production hosts should
+        // replace this with a Granit.RateLimiting-backed implementation (see VULN-207).
+        services.TryAddSingleton<ITokenExchangeRateLimiter, NullTokenExchangeRateLimiter>();
         services.AddIdentityProvider<KeycloakIdentityProvider>();
         services.Replace(ServiceDescriptor.Scoped<IIdentityProviderCapabilities, KeycloakIdentityProviderCapabilities>());
 

--- a/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using Granit.Diagnostics;
@@ -6,6 +7,7 @@ using Granit.Events;
 using Granit.Identity.Diagnostics;
 using Granit.Identity.Events;
 using Granit.Identity.Federated;
+using Granit.Identity.Federated.Exceptions;
 using Granit.Identity.Federated.Keycloak.Diagnostics;
 using Granit.Identity.Federated.Keycloak.Exceptions;
 using Granit.Identity.Federated.Keycloak.Options;
@@ -38,6 +40,16 @@ internal sealed partial class KeycloakIdentityProvider(
     ILogger<KeycloakIdentityProvider> logger) : IIdentityProvider, IIdentityClientRoleManager
 {
     private const string ProviderName = "keycloak";
+
+    /// <summary>
+    /// Detects authorisation failures wrapped in <see cref="HttpRequestException"/>.
+    /// 401/403 from the Keycloak admin API mean either the service-account token has
+    /// expired or its <c>realm-management</c> role grants were revoked — both must be
+    /// surfaced to the caller rather than silently degrading to "no users".
+    /// </summary>
+    private static bool IsAuthorizationFailure(HttpRequestException ex) =>
+        ex.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden;
+
     /// <inheritdoc/>
     public async Task<IReadOnlyList<IIdentityUser>> GetUsersAsync(
         string? search = null,
@@ -59,9 +71,16 @@ internal sealed partial class KeycloakIdentityProvider(
 
             return users?.ConvertAll(ToIdentityUser) ?? [];
         }
+        catch (HttpRequestException ex) when (IsAuthorizationFailure(ex))
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            metrics.RecordOperationError(null, "list_users", ProviderName);
+            throw new IdentityProviderUnauthorizedException(ProviderName, "list_users", ex);
+        }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            metrics.RecordOperationError(null, "list_users", ProviderName);
             LogKeycloakGetUsersFailed(ex);
             return [];
         }
@@ -91,6 +110,12 @@ internal sealed partial class KeycloakIdentityProvider(
             metrics.RecordOperationDuration(null, "get_user", ProviderName, Stopwatch.GetElapsedTime(startTimestamp));
 
             return user is not null ? ToIdentityUser(user) : null;
+        }
+        catch (HttpRequestException ex) when (IsAuthorizationFailure(ex))
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            metrics.RecordOperationError(null, "get_user", ProviderName);
+            throw new IdentityProviderUnauthorizedException(ProviderName, "get_user", ex);
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {

--- a/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakUserTokenExchangeService.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakUserTokenExchangeService.cs
@@ -1,6 +1,10 @@
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
+using Granit.Events;
+using Granit.Identity.Federated.Events;
+using Granit.Identity.Federated.Keycloak.Exceptions;
 using Granit.Identity.Federated.Keycloak.Options;
+using Granit.Identity.Federated.RateLimiting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -26,15 +30,30 @@ namespace Granit.Identity.Federated.Keycloak.Internal;
 /// Tokens are NOT cached because they are user-specific and short-lived. Each call performs
 /// a fresh token exchange.
 /// </para>
+/// <para>
+/// Every successful exchange:
+/// <list type="bullet">
+///   <item><description>Is gated by <see cref="ITokenExchangeRateLimiter"/> — production hosts must
+///   register a distributed implementation; the in-process default lets all calls through.</description></item>
+///   <item><description>Logs at <c>Information</c> level (operators can SIEM-route the message).</description></item>
+///   <item><description>Publishes <see cref="IdentityTokenExchangedEto"/> via
+///   <see cref="IDistributedEventBus"/> so the ISO 27001 audit trail can persist the operation.</description></item>
+/// </list>
+/// </para>
 /// </remarks>
 internal sealed partial class KeycloakUserTokenExchangeService(
     IHttpClientFactory httpClientFactory,
     IOptions<KeycloakAdminOptions> options,
+    ITokenExchangeRateLimiter rateLimiter,
+    IDistributedEventBus distributedEventBus,
+    TimeProvider timeProvider,
     ILogger<KeycloakUserTokenExchangeService> logger)
 {
 #pragma warning disable GRSEC003 // OAuth grant type URI constant, not a secret
     private const string TokenExchangeGrantType = "urn:ietf:params:oauth:grant-type:token-exchange";
 #pragma warning restore GRSEC003
+
+    private const string DefaultReason = "device-activity";
 
     /// <summary>
     /// Exchanges the service account credentials for a token representing the given user.
@@ -43,9 +62,22 @@ internal sealed partial class KeycloakUserTokenExchangeService(
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A short-lived access token for the target user.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the token endpoint returns an empty token.</exception>
+    /// <exception cref="KeycloakTokenExchangeRateLimitedException">
+    /// Thrown when the per-user rate limiter has rejected the call.
+    /// </exception>
     public async Task<string> ExchangeTokenForUserAsync(string userId, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(userId);
+
+        TokenExchangeRateLimitDecision decision = await rateLimiter
+            .CheckAsync(userId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!decision.IsAllowed)
+        {
+            LogTokenExchangeRateLimited(userId, (long)decision.RetryAfter.TotalSeconds);
+            throw new KeycloakTokenExchangeRateLimitedException(userId, decision.RetryAfter);
+        }
 
         KeycloakAdminOptions opts = options.Value;
         HttpClient client = httpClientFactory.CreateClient("KeycloakAdmin");
@@ -72,13 +104,25 @@ internal sealed partial class KeycloakUserTokenExchangeService(
                 $"Keycloak token exchange for user '{userId}' returned an empty access token.");
         }
 
+        DateTimeOffset occurredAt = timeProvider.GetUtcNow();
         LogTokenExchangeSucceeded(userId, token.ExpiresIn);
+
+        // Publish the audit event so SIEM consumers (Wolverine handlers, audit pipelines)
+        // can persist an immutable trail of every privileged token-exchange operation.
+        await distributedEventBus.PublishAsync(
+            new IdentityTokenExchangedEto(userId, DefaultReason, occurredAt),
+            cancellationToken).ConfigureAwait(false);
 
         return token.AccessToken;
     }
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "Token exchange succeeded for user {UserId}, expires in {ExpiresIn}s")]
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Keycloak token exchange succeeded for user {UserId} (expires in {ExpiresIn}s)")]
     private partial void LogTokenExchangeSucceeded(string userId, int expiresIn);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Keycloak token exchange rate-limited for user {UserId}; retry after {RetryAfterSeconds}s")]
+    private partial void LogTokenExchangeRateLimited(string userId, long retryAfterSeconds);
 
     private sealed record TokenExchangeResponse(
         [property: JsonPropertyName("access_token")] string AccessToken,

--- a/src/Granit.Identity.Federated/Events/IdentityTokenExchangedEto.cs
+++ b/src/Granit.Identity.Federated/Events/IdentityTokenExchangedEto.cs
@@ -1,0 +1,29 @@
+using Granit.Events;
+
+namespace Granit.Identity.Federated.Events;
+
+/// <summary>
+/// Audit event published every time the federated identity layer exchanges service-account
+/// credentials for a user-scoped access token (RFC 8693 — direct naked impersonation).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Token exchange grants a service the ability to act as any registered user without their
+/// consent. ISO 27001 A.12.4 (logging and monitoring of privileged operations) requires
+/// every such operation to leave an immutable audit trail in the consuming application's
+/// SIEM. This event is the propagation channel — subscribe to it from
+/// <see cref="IDistributedEventBus"/> consumers (Wolverine handlers, audit pipelines)
+/// to persist the trail.
+/// </para>
+/// <para>
+/// The event carries no PII — only the target user identifier, the operation reason,
+/// and the timestamp.
+/// </para>
+/// </remarks>
+/// <param name="TargetUserId">The user identifier the new token impersonates.</param>
+/// <param name="Reason">Free-text reason / operation name (e.g. <c>"device-activity"</c>).</param>
+/// <param name="OccurredAt">UTC timestamp of the token exchange.</param>
+public sealed record IdentityTokenExchangedEto(
+    string TargetUserId,
+    string Reason,
+    DateTimeOffset OccurredAt) : IIntegrationEvent;

--- a/src/Granit.Identity.Federated/Exceptions/IdentityProviderUnauthorizedException.cs
+++ b/src/Granit.Identity.Federated/Exceptions/IdentityProviderUnauthorizedException.cs
@@ -1,0 +1,34 @@
+namespace Granit.Identity.Federated.Exceptions;
+
+/// <summary>
+/// Thrown by federated identity providers (Keycloak, Entra ID, Cognito, Google Cloud) when
+/// the upstream API rejects the configured service-account credentials with a 401 or 403.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The audit (<c>VULN-211</c>) found that all four federated providers swallowed every
+/// upstream failure — including credential expiry and missing IAM permissions — and
+/// returned an empty result set to callers. Operators saw "no users" instead of
+/// "your service account is unauthorized", masking real outages and quietly degrading
+/// the admin UI.
+/// </para>
+/// <para>
+/// Providers now distinguish 401/403 from transient 5xx and re-throw this exception so
+/// the HTTP layer can surface a 503 (or 401 if appropriate) rather than 200/empty.
+/// </para>
+/// </remarks>
+public sealed class IdentityProviderUnauthorizedException : Exception
+{
+    public IdentityProviderUnauthorizedException(string providerName, string operation, Exception? innerException = null)
+        : base($"Identity provider '{providerName}' rejected operation '{operation}': service-account credentials are missing or unauthorized.", innerException)
+    {
+        ProviderName = providerName;
+        Operation = operation;
+    }
+
+    /// <summary>The provider that returned the 401/403 (e.g. <c>"keycloak"</c>).</summary>
+    public string ProviderName { get; }
+
+    /// <summary>The operation that failed (e.g. <c>"get_user"</c>).</summary>
+    public string Operation { get; }
+}

--- a/src/Granit.Identity.Federated/GranitIdentityFederatedModule.cs
+++ b/src/Granit.Identity.Federated/GranitIdentityFederatedModule.cs
@@ -3,9 +3,11 @@ using Granit.Identity;
 using Granit.Identity.Federated.Domain;
 using Granit.Identity.Federated.Exports;
 using Granit.Identity.Federated.Queries;
+using Granit.Identity.Federated.RateLimiting;
 using Granit.Modularity;
 using Granit.QueryEngine.Extensions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Granit.Identity.Federated;
 
@@ -23,5 +25,10 @@ public sealed class GranitIdentityFederatedModule : GranitModule
         // Query + Export definitions (ADR-020: owned by the base module).
         context.Services.AddQueryDefinition<UserCacheEntry, UserCacheEntryQueryDefinition>();
         context.Services.AddExportDefinition<UserCacheEntry, UserCacheEntryExportDefinition>();
+
+        // Default to a no-op rate limiter on token-exchange. Hosts that wire
+        // Granit.RateLimiting can replace this registration with a distributed-store
+        // implementation to enforce per-user quotas across pods (VULN-207).
+        context.Services.TryAddSingleton<ITokenExchangeRateLimiter, NullTokenExchangeRateLimiter>();
     }
 }

--- a/src/Granit.Identity.Federated/RateLimiting/ITokenExchangeRateLimiter.cs
+++ b/src/Granit.Identity.Federated/RateLimiting/ITokenExchangeRateLimiter.cs
@@ -1,0 +1,42 @@
+namespace Granit.Identity.Federated.RateLimiting;
+
+/// <summary>
+/// Gates per-user invocations of the OAuth 2.0 token-exchange flow (RFC 8693). The
+/// federated identity layer consults this limiter before minting a user-scoped token
+/// to mitigate denial-of-wallet and credential abuse.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The default implementation (<see cref="NullTokenExchangeRateLimiter"/>) always
+/// allows. Hosts that have <c>Granit.RateLimiting</c> wired up should replace it with
+/// an implementation backed by <c>IRateLimitCounterStore</c> so the quota is enforced
+/// across all pods (the in-memory variant only protects a single process — see
+/// VULN-207 in the Identity audit).
+/// </para>
+/// </remarks>
+public interface ITokenExchangeRateLimiter
+{
+    /// <summary>
+    /// Checks whether a token exchange for <paramref name="targetUserId"/> is allowed
+    /// in the current window and consumes one quota slot if it is.
+    /// </summary>
+    /// <param name="targetUserId">The subject the new token would impersonate.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Decision indicating whether the call is permitted.</returns>
+    Task<TokenExchangeRateLimitDecision> CheckAsync(string targetUserId, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Outcome of an <see cref="ITokenExchangeRateLimiter.CheckAsync"/> call.
+/// </summary>
+/// <param name="IsAllowed"><c>true</c> if the request may proceed; <c>false</c> otherwise.</param>
+/// <param name="RetryAfter">When a denial occurs, the minimum interval the caller should wait
+/// before retrying. <see cref="TimeSpan.Zero"/> when allowed.</param>
+public readonly record struct TokenExchangeRateLimitDecision(bool IsAllowed, TimeSpan RetryAfter)
+{
+    /// <summary>Convenience for the always-allowed case.</summary>
+    public static TokenExchangeRateLimitDecision Allowed => new(true, TimeSpan.Zero);
+
+    /// <summary>Convenience for the denied case with a retry hint.</summary>
+    public static TokenExchangeRateLimitDecision Denied(TimeSpan retryAfter) => new(false, retryAfter);
+}

--- a/src/Granit.Identity.Federated/RateLimiting/NullTokenExchangeRateLimiter.cs
+++ b/src/Granit.Identity.Federated/RateLimiting/NullTokenExchangeRateLimiter.cs
@@ -1,0 +1,13 @@
+namespace Granit.Identity.Federated.RateLimiting;
+
+/// <summary>
+/// Default <see cref="ITokenExchangeRateLimiter"/> that allows every request.
+/// Replace with a <c>Granit.RateLimiting</c>-backed implementation to enforce a
+/// distributed per-user quota in production.
+/// </summary>
+public sealed class NullTokenExchangeRateLimiter : ITokenExchangeRateLimiter
+{
+    /// <inheritdoc />
+    public Task<TokenExchangeRateLimitDecision> CheckAsync(string targetUserId, CancellationToken cancellationToken) =>
+        Task.FromResult(TokenExchangeRateLimitDecision.Allowed);
+}

--- a/src/Granit.Identity.Local.Endpoints/Dtos/AccountChangeEmailRequest.cs
+++ b/src/Granit.Identity.Local.Endpoints/Dtos/AccountChangeEmailRequest.cs
@@ -1,7 +1,11 @@
 namespace Granit.Identity.Local.Endpoints.Dtos;
 
 /// <summary>
-/// Request DTO for initiating an email change.
+/// Request DTO for initiating an email change. Requires the user's current password
+/// as step-up authentication so a stolen session cookie alone cannot pivot a
+/// compromised account into a permanent take-over via email change → password reset.
 /// </summary>
 /// <param name="NewEmail">The desired new email address.</param>
-public sealed record AccountChangeEmailRequest(string NewEmail);
+/// <param name="CurrentPassword">The user's current password — required as step-up
+/// authentication (OWASP ASVS V2.8.1).</param>
+public sealed record AccountChangeEmailRequest(string NewEmail, string CurrentPassword);

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountEmailChangeEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountEmailChangeEndpoints.cs
@@ -1,4 +1,5 @@
 using Granit.Http.Idempotency.Attributes;
+using Granit.Identity;
 using Granit.Identity.Local.Diagnostics;
 using Granit.Identity.Local.Endpoints.Dtos;
 using Granit.Identity.Local.Services;
@@ -19,11 +20,16 @@ internal static class AccountEmailChangeEndpoints
             .WithName("ChangeEmail")
             .WithSummary("Requests an email address change.")
             .WithDescription(
-                "Generates a change-email token and publishes an EmailChangeRequestedEto event. "
+                "Requires password confirmation as step-up authentication (OWASP ASVS V2.8.1) "
+                + "so a stolen session cookie alone cannot pivot a compromised account into a "
+                + "permanent take-over via email change followed by password reset. "
+                + "Generates a change-email token and publishes an EmailChangeRequestedEto event. "
                 + "A security alert is sent to the current email and a confirmation link to the new email. "
-                + "Always returns 202 to prevent email enumeration.")
+                + "Returns 400 if the current password is incorrect; otherwise always returns 202 "
+                + "to prevent email enumeration.")
             .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces(StatusCodes.Status202Accepted)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesValidationProblem()
             .RequireAuthorization();
 
@@ -42,24 +48,43 @@ internal static class AccountEmailChangeEndpoints
         return group;
     }
 
-    private static async Task<Accepted<string>> ChangeEmailAsync(
+    private static async Task<Results<Accepted<string>, ProblemHttpResult>> ChangeEmailAsync(
         AccountChangeEmailRequest request,
         HttpContext httpContext,
+        [FromServices] IIdentityCredentialVerifier credentialVerifier,
         [FromServices] IEmailChangeService emailChangeService,
         CancellationToken cancellationToken)
     {
         string? userId = httpContext.User.FindFirst("sub")?.Value;
+        string? username = httpContext.User.FindFirst("preferred_username")?.Value
+                           ?? httpContext.User.FindFirst("name")?.Value;
 
-        if (userId is not null)
+        if (userId is null || username is null)
         {
-            await emailChangeService.RequestChangeAsync(userId, request.NewEmail, cancellationToken)
-                .ConfigureAwait(false);
-
-            string? tenantId = httpContext.User.FindFirst("tenant_id")?.Value;
-            httpContext.RequestServices.GetService<IdentityLocalMetrics>()?.RecordEmailChangeRequest(tenantId);
+            // Token does not carry the claims we need to verify credentials. Return
+            // 202 so a malformed token cannot be used to enumerate the endpoint.
+            return TypedResults.Accepted((string?)null, (string?)null);
         }
 
-        // Always return 202 to prevent enumeration
+        // Step-up: verify the current password before proceeding (OWASP ASVS V2.8.1).
+        bool isValid = await credentialVerifier
+            .VerifyUserCredentialsAsync(username, request.CurrentPassword, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!isValid)
+        {
+            return TypedResults.Problem(
+                detail: "Current password is incorrect.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        await emailChangeService.RequestChangeAsync(userId, request.NewEmail, cancellationToken)
+            .ConfigureAwait(false);
+
+        string? tenantId = httpContext.User.FindFirst("tenant_id")?.Value;
+        httpContext.RequestServices.GetService<IdentityLocalMetrics>()?.RecordEmailChangeRequest(tenantId);
+
+        // Always return 202 on success to prevent email-existence enumeration.
         return TypedResults.Accepted((string?)null, (string?)null);
     }
 

--- a/src/Granit.Identity.Local.Endpoints/Validators/AccountChangeEmailRequestValidator.cs
+++ b/src/Granit.Identity.Local.Endpoints/Validators/AccountChangeEmailRequestValidator.cs
@@ -15,5 +15,8 @@ internal sealed class AccountChangeEmailRequestValidator : GranitValidator<Accou
             .NotEmpty()
             .EmailAddress()
             .MaximumLength(256);
+
+        RuleFor(x => x.CurrentPassword)
+            .NotEmpty();
     }
 }

--- a/tests/Granit.ArchitectureTests/ActivitySourcePiiConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/ActivitySourcePiiConventionTests.cs
@@ -163,7 +163,8 @@ public sealed partial class ActivitySourcePiiConventionTests
         string? dir = Path.GetDirectoryName(typeof(ActivitySourcePiiConventionTests).Assembly.Location);
         while (dir is not null)
         {
-            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/ApiConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/ApiConventionTests.cs
@@ -430,7 +430,8 @@ public sealed partial class ApiConventionTests
         string? dir = Path.GetDirectoryName(typeof(ApiConventionTests).Assembly.Location);
         while (dir is not null)
         {
-            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/AuditPiiConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/AuditPiiConventionTests.cs
@@ -154,7 +154,8 @@ public sealed partial class AuditPiiConventionTests
         string? dir = Path.GetDirectoryName(typeof(AuditPiiConventionTests).Assembly.Location);
         while (dir is not null)
         {
-            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/BackgroundJobConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/BackgroundJobConventionTests.cs
@@ -116,7 +116,8 @@ public sealed partial class BackgroundJobConventionTests
         string? dir = Path.GetDirectoryName(typeof(BackgroundJobConventionTests).Assembly.Location);
         while (dir is not null)
         {
-            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/EndpointParameterBindingTests.cs
+++ b/tests/Granit.ArchitectureTests/EndpointParameterBindingTests.cs
@@ -257,7 +257,8 @@ public sealed partial class EndpointParameterBindingTests
         string? dir = Path.GetDirectoryName(typeof(EndpointParameterBindingTests).Assembly.Location);
         while (dir is not null)
         {
-            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/FileOrganizationTests.cs
+++ b/tests/Granit.ArchitectureTests/FileOrganizationTests.cs
@@ -716,7 +716,8 @@ public sealed partial class FileOrganizationTests
         string? dir = Path.GetDirectoryName(typeof(FileOrganizationTests).Assembly.Location);
         while (dir is not null)
         {
-            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/FrameworkBoundaryTests.cs
+++ b/tests/Granit.ArchitectureTests/FrameworkBoundaryTests.cs
@@ -57,7 +57,8 @@ public sealed class FrameworkBoundaryTests
         string? dir = Path.GetDirectoryName(typeof(FrameworkBoundaryTests).Assembly.Location);
         while (dir is not null)
         {
-            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/IdempotencyConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/IdempotencyConventionTests.cs
@@ -204,7 +204,8 @@ public sealed partial class IdempotencyConventionTests
         string? dir = Path.GetDirectoryName(typeof(IdempotencyConventionTests).Assembly.Location);
         while (dir is not null)
         {
-            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/IsolatedDbContextTests.cs
+++ b/tests/Granit.ArchitectureTests/IsolatedDbContextTests.cs
@@ -258,7 +258,8 @@ public sealed partial class IsolatedDbContextTests
         string? dir = Path.GetDirectoryName(typeof(IsolatedDbContextTests).Assembly.Location);
         while (dir is not null)
         {
-            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/LoggerMessagePiiConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/LoggerMessagePiiConventionTests.cs
@@ -191,7 +191,8 @@ public sealed partial class LoggerMessagePiiConventionTests
         string? dir = Path.GetDirectoryName(typeof(LoggerMessagePiiConventionTests).Assembly.Location);
         while (dir is not null)
         {
-            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/MetricsPiiConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/MetricsPiiConventionTests.cs
@@ -119,7 +119,8 @@ public sealed partial class MetricsPiiConventionTests
         string? dir = Path.GetDirectoryName(typeof(MetricsPiiConventionTests).Assembly.Location);
         while (dir is not null)
         {
-            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/ProjectDependencyTests.cs
+++ b/tests/Granit.ArchitectureTests/ProjectDependencyTests.cs
@@ -94,7 +94,8 @@ public sealed partial class ProjectDependencyTests
         string? dir = Path.GetDirectoryName(typeof(ProjectDependencyTests).Assembly.Location);
         while (dir is not null)
         {
-            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/SourceCodeAntiPatternTests.cs
+++ b/tests/Granit.ArchitectureTests/SourceCodeAntiPatternTests.cs
@@ -332,7 +332,8 @@ public sealed partial class SourceCodeAntiPatternTests
         string? dir = Path.GetDirectoryName(typeof(SourceCodeAntiPatternTests).Assembly.Location);
         while (dir is not null)
         {
-            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/TestProjectConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/TestProjectConventionTests.cs
@@ -83,7 +83,8 @@ public sealed class TestProjectConventionTests
         string? dir = Path.GetDirectoryName(typeof(TestProjectConventionTests).Assembly.Location);
         while (dir is not null)
         {
-            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.ArchitectureTests/ValidationConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/ValidationConventionTests.cs
@@ -275,7 +275,8 @@ public sealed partial class ValidationConventionTests
         string? dir = Path.GetDirectoryName(typeof(ValidationConventionTests).Assembly.Location);
         while (dir is not null)
         {
-            string gitPath = Path.Join(dir, ".git"); if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
             {
                 return dir;
             }

--- a/tests/Granit.Identity.Endpoints.Tests/Granit.Identity.Endpoints.Tests.csproj
+++ b/tests/Granit.Identity.Endpoints.Tests/Granit.Identity.Endpoints.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Shouldly" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 

--- a/tests/Granit.Identity.Endpoints.Tests/IdentityWebhookEndpointsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/IdentityWebhookEndpointsTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Net;
 using System.Security.Cryptography;
 using System.Text;
@@ -10,6 +11,8 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Shouldly;
 using Xunit;
@@ -24,8 +27,11 @@ public sealed class IdentityWebhookEndpointsTests : IAsyncDisposable
     private const string WebhookSecret = "test-webhook-secret-key-32-chars!";
     private const string WebhookUrl = "/identity/webhook";
 
+    private static readonly DateTimeOffset Now = new(2026, 4, 23, 14, 0, 0, TimeSpan.Zero);
+
     private readonly IUserLookupService _lookupService = Substitute.For<IUserLookupService>();
     private readonly IUserCacheStats _cacheStats = Substitute.For<IUserCacheStats>();
+    private readonly FakeTimeProvider _clock = new(Now);
     private readonly WebApplication _app;
     private readonly HttpClient _client;
 
@@ -49,6 +55,10 @@ public sealed class IdentityWebhookEndpointsTests : IAsyncDisposable
         builder.Services.AddGranitIdentityEndpoints();
         builder.Services.AddSingleton(_lookupService);
         builder.Services.AddSingleton(_cacheStats);
+
+        // Replace the default TimeProvider so signature-replay-window tests can
+        // pin "now" deterministically.
+        builder.Services.Replace(ServiceDescriptor.Singleton<TimeProvider>(_clock));
 
         // Configure webhook with a secret
         builder.Services.Configure<IdentityWebhookOptions>(o =>
@@ -144,7 +154,7 @@ public sealed class IdentityWebhookEndpointsTests : IAsyncDisposable
     {
         string invalidJson = "{ not valid json }}}";
         byte[] body = Encoding.UTF8.GetBytes(invalidJson);
-        string signature = ComputeSignature(body);
+        string signature = ComputeSignature(body, _clock.GetUtcNow());
 
         using HttpRequestMessage request = new(HttpMethod.Post, WebhookUrl)
         {
@@ -195,7 +205,7 @@ public sealed class IdentityWebhookEndpointsTests : IAsyncDisposable
         // 65 KB > 64 KB limit
         string largeJson = new('x', 65 * 1024);
         byte[] body = Encoding.UTF8.GetBytes(largeJson);
-        string signature = ComputeSignature(body);
+        string signature = ComputeSignature(body, _clock.GetUtcNow());
 
         using HttpRequestMessage request = new(HttpMethod.Post, WebhookUrl)
         {
@@ -210,11 +220,11 @@ public sealed class IdentityWebhookEndpointsTests : IAsyncDisposable
         ((int)response.StatusCode).ShouldBe(413);
     }
 
-    private static HttpRequestMessage CreateSignedRequest(object payload)
+    private HttpRequestMessage CreateSignedRequest(object payload, DateTimeOffset? signedAt = null)
     {
         string json = JsonSerializer.Serialize(payload);
         byte[] body = Encoding.UTF8.GetBytes(json);
-        string signature = ComputeSignature(body);
+        string signature = ComputeSignature(body, signedAt ?? _clock.GetUtcNow());
 
         HttpRequestMessage request = new(HttpMethod.Post, WebhookUrl)
         {
@@ -225,11 +235,33 @@ public sealed class IdentityWebhookEndpointsTests : IAsyncDisposable
         return request;
     }
 
-    private static string ComputeSignature(byte[] body)
+    private static string ComputeSignature(byte[] body, DateTimeOffset timestamp)
     {
+        long t = timestamp.ToUnixTimeSeconds();
         byte[] key = Encoding.UTF8.GetBytes(WebhookSecret);
-        byte[] hash = HMACSHA256.HashData(key, body);
-        return Convert.ToHexStringLower(hash);
+        byte[] prefix = Encoding.UTF8.GetBytes(t.ToString(CultureInfo.InvariantCulture) + ".");
+        byte[] toSign = new byte[prefix.Length + body.Length];
+        Buffer.BlockCopy(prefix, 0, toSign, 0, prefix.Length);
+        Buffer.BlockCopy(body, 0, toSign, prefix.Length, body.Length);
+        string hex = Convert.ToHexStringLower(HMACSHA256.HashData(key, toSign));
+        return $"t={t},v1={hex}";
+    }
+
+    [Fact]
+    public async Task Webhook_rejects_signature_outside_replay_window()
+    {
+        // Sign at a timestamp 10 minutes before the frozen "now" — well beyond the
+        // 5-minute default ReplayWindow. The receiver must reject as a replay.
+        var payload = new { eventType = "user_updated", userId = "user-1" };
+        DateTimeOffset signedAt = _clock.GetUtcNow().AddMinutes(-10);
+        using HttpRequestMessage request = CreateSignedRequest(payload, signedAt);
+
+        using HttpResponseMessage response = await _client.SendAsync(
+            request, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        await _lookupService.DidNotReceive().RefreshByIdAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 }
 

--- a/tests/Granit.Identity.Endpoints.Tests/Options/IdentityWebhookOptionsTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/Options/IdentityWebhookOptionsTests.cs
@@ -26,15 +26,25 @@ public sealed class IdentityWebhookOptionsTests
     }
 
     [Fact]
+    public void Defaults_ReplayWindowIsFiveMinutes()
+    {
+        IdentityWebhookOptions options = new();
+
+        options.ReplayWindow.ShouldBe(TimeSpan.FromMinutes(5));
+    }
+
+    [Fact]
     public void Properties_AreSettable()
     {
         IdentityWebhookOptions options = new()
         {
             Secret = "my-secret-key",
             SignatureHeaderName = "X-Custom-Signature",
+            ReplayWindow = TimeSpan.FromMinutes(2),
         };
 
         options.Secret.ShouldBe("my-secret-key");
         options.SignatureHeaderName.ShouldBe("X-Custom-Signature");
+        options.ReplayWindow.ShouldBe(TimeSpan.FromMinutes(2));
     }
 }

--- a/tests/Granit.Identity.Endpoints.Tests/WebhookSignatureValidatorTests.cs
+++ b/tests/Granit.Identity.Endpoints.Tests/WebhookSignatureValidatorTests.cs
@@ -4,77 +4,172 @@ using Granit.Identity.Endpoints.Internal;
 using Granit.Identity.Endpoints.Options;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
 using Shouldly;
 using Xunit;
 
 namespace Granit.Identity.Endpoints.Tests;
 
 /// <summary>
-/// Unit tests for <see cref="WebhookSignatureValidator"/>.
+/// Unit tests for <see cref="WebhookSignatureValidator"/>. Header format is
+/// Stripe-style: <c>t=&lt;unix-seconds&gt;,v1=&lt;hex&gt;</c>, signed payload is
+/// <c>"&lt;unix-seconds&gt;.&lt;body&gt;"</c>.
 /// </summary>
 public sealed class WebhookSignatureValidatorTests
 {
     private const string Secret = "my-webhook-secret";
+    private static readonly DateTimeOffset Now = new(2026, 4, 23, 14, 0, 0, TimeSpan.Zero);
 
-    private static WebhookSignatureValidator CreateValidator(string secret = Secret) =>
-        new(Microsoft.Extensions.Options.Options.Create(new IdentityWebhookOptions { Secret = secret }),
+    private static (WebhookSignatureValidator Validator, FakeTimeProvider Clock) CreateValidator(
+        string secret = Secret,
+        TimeSpan? replayWindow = null) =>
+        Create(new IdentityWebhookOptions
+        {
+            Secret = secret,
+            ReplayWindow = replayWindow ?? TimeSpan.FromMinutes(5),
+        });
+
+    private static (WebhookSignatureValidator Validator, FakeTimeProvider Clock) Create(IdentityWebhookOptions options)
+    {
+        FakeTimeProvider clock = new(Now);
+        WebhookSignatureValidator validator = new(
+            Microsoft.Extensions.Options.Options.Create(options),
+            clock,
             NullLogger<WebhookSignatureValidator>.Instance);
+        return (validator, clock);
+    }
 
     [Fact]
     public void IsEnabled_true_when_secret_configured()
     {
-        WebhookSignatureValidator validator = CreateValidator();
+        (WebhookSignatureValidator validator, _) = CreateValidator();
         validator.IsEnabled.ShouldBeTrue();
     }
 
     [Fact]
     public void IsEnabled_false_when_secret_empty()
     {
-        WebhookSignatureValidator validator = CreateValidator(string.Empty);
+        (WebhookSignatureValidator validator, _) = CreateValidator(string.Empty);
         validator.IsEnabled.ShouldBeFalse();
     }
 
     [Fact]
     public void Validate_returns_true_for_valid_signature()
     {
-        WebhookSignatureValidator validator = CreateValidator();
+        (WebhookSignatureValidator validator, FakeTimeProvider clock) = CreateValidator();
         byte[] payload = "hello"u8.ToArray();
-        string signature = ComputeHmac(Secret, payload);
+        string signature = ComputeStripeSignature(Secret, clock.GetUtcNow(), payload);
 
         validator.Validate(payload, signature).ShouldBeTrue();
     }
 
     [Fact]
-    public void Validate_returns_false_for_invalid_signature()
+    public void Validate_accepts_v1_then_t_order()
     {
-        WebhookSignatureValidator validator = CreateValidator();
+        (WebhookSignatureValidator validator, FakeTimeProvider clock) = CreateValidator();
         byte[] payload = "hello"u8.ToArray();
+        long t = clock.GetUtcNow().ToUnixTimeSeconds();
+        string hex = ComputeHexHmac(Secret, t, payload);
+        string signature = $"v1={hex},t={t}";
 
-        validator.Validate(payload, "bad-signature").ShouldBeFalse();
+        validator.Validate(payload, signature).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Validate_returns_false_for_tampered_signature()
+    {
+        (WebhookSignatureValidator validator, FakeTimeProvider clock) = CreateValidator();
+        byte[] payload = "hello"u8.ToArray();
+        string valid = ComputeStripeSignature(Secret, clock.GetUtcNow(), payload);
+        string tampered = valid[..^1] + (valid[^1] == 'a' ? 'b' : 'a');
+
+        validator.Validate(payload, tampered).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Validate_returns_false_for_tampered_body()
+    {
+        (WebhookSignatureValidator validator, FakeTimeProvider clock) = CreateValidator();
+        byte[] payload = "hello"u8.ToArray();
+        string signature = ComputeStripeSignature(Secret, clock.GetUtcNow(), payload);
+
+        validator.Validate("HELLO"u8.ToArray(), signature).ShouldBeFalse();
     }
 
     [Fact]
     public void Validate_returns_false_for_null_signature()
     {
-        WebhookSignatureValidator validator = CreateValidator();
-        byte[] payload = "hello"u8.ToArray();
+        (WebhookSignatureValidator validator, _) = CreateValidator();
+        validator.Validate("hello"u8.ToArray(), null).ShouldBeFalse();
+    }
 
-        validator.Validate(payload, null).ShouldBeFalse();
+    [Fact]
+    public void Validate_returns_false_for_malformed_header()
+    {
+        (WebhookSignatureValidator validator, _) = CreateValidator();
+        validator.Validate("hello"u8.ToArray(), "not-a-stripe-format").ShouldBeFalse();
     }
 
     [Fact]
     public void Validate_returns_false_when_disabled()
     {
-        WebhookSignatureValidator validator = CreateValidator(string.Empty);
-        byte[] payload = "hello"u8.ToArray();
-
-        validator.Validate(payload, null).ShouldBeFalse();
+        (WebhookSignatureValidator validator, _) = CreateValidator(string.Empty);
+        validator.Validate("hello"u8.ToArray(), null).ShouldBeFalse();
     }
 
-    private static string ComputeHmac(string secret, byte[] payload)
+    [Fact]
+    public void Validate_rejects_signature_outside_replay_window()
+    {
+        (WebhookSignatureValidator validator, FakeTimeProvider clock) = CreateValidator();
+        byte[] payload = "hello"u8.ToArray();
+
+        // Sign at a timestamp 10 minutes in the past — well beyond the 5-minute window.
+        DateTimeOffset signedAt = clock.GetUtcNow().AddMinutes(-10);
+        string signature = ComputeStripeSignature(Secret, signedAt, payload);
+
+        validator.Validate(payload, signature).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Validate_rejects_signature_in_distant_future()
+    {
+        (WebhookSignatureValidator validator, FakeTimeProvider clock) = CreateValidator();
+        byte[] payload = "hello"u8.ToArray();
+
+        // Sign at a timestamp 10 minutes in the future — also beyond tolerance.
+        DateTimeOffset signedAt = clock.GetUtcNow().AddMinutes(10);
+        string signature = ComputeStripeSignature(Secret, signedAt, payload);
+
+        validator.Validate(payload, signature).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Validate_accepts_signature_inside_replay_window()
+    {
+        (WebhookSignatureValidator validator, FakeTimeProvider clock) = CreateValidator();
+        byte[] payload = "hello"u8.ToArray();
+
+        // 4 minutes of clock skew — inside the default 5-minute window.
+        DateTimeOffset signedAt = clock.GetUtcNow().AddMinutes(-4);
+        string signature = ComputeStripeSignature(Secret, signedAt, payload);
+
+        validator.Validate(payload, signature).ShouldBeTrue();
+    }
+
+    private static string ComputeStripeSignature(string secret, DateTimeOffset timestamp, byte[] payload)
+    {
+        long t = timestamp.ToUnixTimeSeconds();
+        string hex = ComputeHexHmac(secret, t, payload);
+        return $"t={t},v1={hex}";
+    }
+
+    private static string ComputeHexHmac(string secret, long timestamp, byte[] payload)
     {
         byte[] key = Encoding.UTF8.GetBytes(secret);
-        byte[] hash = HMACSHA256.HashData(key, payload);
-        return Convert.ToHexStringLower(hash);
+        byte[] prefix = Encoding.UTF8.GetBytes(timestamp.ToString(System.Globalization.CultureInfo.InvariantCulture) + ".");
+        byte[] toSign = new byte[prefix.Length + payload.Length];
+        Buffer.BlockCopy(prefix, 0, toSign, 0, prefix.Length);
+        Buffer.BlockCopy(payload, 0, toSign, prefix.Length, payload.Length);
+        return Convert.ToHexStringLower(HMACSHA256.HashData(key, toSign));
     }
 }

--- a/tests/Granit.Identity.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Endpoints.Tests/packages.lock.json
@@ -31,6 +31,12 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.Extensions.TimeProvider.Testing": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.5.0",
+        "contentHash": "BW6DXn0oZWfoEN9cb+3PcM2IBHqcTnsO+UqEhW+uzdEuZSY3C9i9ITKoLiYbS8JwWm6daTpa4kRikUwr3KD+qQ=="
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.*, )",

--- a/tests/Granit.Identity.Federated.GoogleCloud.Tests/GoogleCloudIdentityProviderTests.cs
+++ b/tests/Granit.Identity.Federated.GoogleCloud.Tests/GoogleCloudIdentityProviderTests.cs
@@ -308,6 +308,38 @@ public sealed class GoogleCloudIdentityProviderTests
         Dictionary<string, object> customClaims) =>
         CreateUserRecord(uid, email, displayName, customClaims);
 
+    // ── GetUsersAsync (VULN-204: bounded pagination, no in-memory filter) ─────
+
+    [Fact]
+    public async Task GetUsersAsync_WithoutSearch_DelegatesPaginationToTransport()
+    {
+        // VULN-204: previous implementation pulled every Firebase user into memory.
+        // Provider must now forward the (first, max) window verbatim to the transport
+        // so the bounded-page implementation can stop after the requested slice.
+        _transport.ListUsersAsync(0, 25, Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        IReadOnlyList<IIdentityUser> users = await _sut.GetUsersAsync(
+            search: null, first: 0, max: 25, TestContext.Current.CancellationToken);
+
+        users.ShouldBeEmpty();
+        await _transport.Received(1).ListUsersAsync(0, 25, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetUsersAsync_WithSearch_ThrowsNotSupported()
+    {
+        // VULN-204: previously we materialised every user in memory and filtered
+        // by Email/DisplayName.Contains. Now refused — Firebase Admin SDK has no
+        // server-side search filter on ListUsers.
+        await Should.ThrowAsync<NotSupportedException>(async () =>
+            await _sut.GetUsersAsync(
+                search: "alice", first: null, max: null, TestContext.Current.CancellationToken));
+
+        await _transport.DidNotReceive().ListUsersAsync(
+            Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<CancellationToken>());
+    }
+
     private static void SetProperty(object target, string propertyName, object? value)
     {
         System.Reflection.PropertyInfo? prop = target.GetType().GetProperty(propertyName);

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/IdentityKeycloakServiceCollectionExtensionsClientRoleTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/IdentityKeycloakServiceCollectionExtensionsClientRoleTests.cs
@@ -36,6 +36,7 @@ public sealed class IdentityKeycloakServiceCollectionExtensionsClientRoleTests
         services.AddLogging();
         services.AddSingleton(Substitute.For<IClock>());
         services.AddSingleton(Substitute.For<IDistributedEventBus>());
+        services.AddSingleton(TimeProvider.System);
         services.AddGranitIdentity();
         services.AddGranitIdentityKeycloak();
 

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakClientRoleTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakClientRoleTests.cs
@@ -5,6 +5,7 @@ using Granit.Identity;
 using Granit.Identity.Diagnostics;
 using Granit.Identity.Federated.Keycloak.Exceptions;
 using Granit.Identity.Federated.Keycloak.Internal;
+using Granit.Identity.Federated.RateLimiting;
 using Granit.Identity.Models;
 using Granit.Timing;
 using Microsoft.Extensions.DependencyInjection;
@@ -85,8 +86,12 @@ public sealed class KeycloakClientRoleTests : IDisposable
 
         KeycloakAdminTokenService tokenService = new(
             tokenFactory, opts, clock, NullLogger<KeycloakAdminTokenService>.Instance);
+        ITokenExchangeRateLimiter rateLimiter = Substitute.For<ITokenExchangeRateLimiter>();
+        rateLimiter.CheckAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(TokenExchangeRateLimitDecision.Allowed);
         KeycloakUserTokenExchangeService tokenExchangeService = new(
-            tokenFactory, opts, NullLogger<KeycloakUserTokenExchangeService>.Instance);
+            tokenFactory, opts, rateLimiter, _eventBus, TimeProvider.System,
+            NullLogger<KeycloakUserTokenExchangeService>.Instance);
 
         return new KeycloakIdentityProvider(
             tokenService, tokenExchangeService, adminFactory,

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakIdentityProviderTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakIdentityProviderTests.cs
@@ -7,6 +7,7 @@ using Granit.Identity.Diagnostics;
 using Granit.Identity.Events;
 using Granit.Identity.Federated.Keycloak.Internal;
 using Granit.Identity.Federated.Keycloak.Options;
+using Granit.Identity.Federated.RateLimiting;
 using Granit.Identity.Models;
 using Granit.Timing;
 using Microsoft.Extensions.DependencyInjection;
@@ -86,9 +87,16 @@ public sealed class KeycloakIdentityProviderTests : IDisposable
         _metricsServiceProvider = metricsServices.BuildServiceProvider();
         _metrics = new IdentityMetrics(_metricsServiceProvider.GetRequiredService<IMeterFactory>());
 
+        ITokenExchangeRateLimiter rateLimiter = Substitute.For<ITokenExchangeRateLimiter>();
+        rateLimiter.CheckAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(TokenExchangeRateLimitDecision.Allowed);
+
         _tokenExchangeService = new KeycloakUserTokenExchangeService(
             exchangeFactory,
             Microsoft.Extensions.Options.Options.Create(_options),
+            rateLimiter,
+            _distributedEventBus,
+            TimeProvider.System,
             NullLogger<KeycloakUserTokenExchangeService>.Instance);
 
         _provider = new KeycloakIdentityProvider(
@@ -554,9 +562,16 @@ public sealed class KeycloakIdentityProviderTests : IDisposable
         IHttpClientFactory seqFactory = Substitute.For<IHttpClientFactory>();
         seqFactory.CreateClient("KeycloakAdmin").Returns(seqClient);
 
+        ITokenExchangeRateLimiter exchangeRateLimiter = Substitute.For<ITokenExchangeRateLimiter>();
+        exchangeRateLimiter.CheckAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(TokenExchangeRateLimitDecision.Allowed);
+
         KeycloakUserTokenExchangeService exchangeSvc = new(
             seqFactory,
             Microsoft.Extensions.Options.Options.Create(opts),
+            exchangeRateLimiter,
+            _distributedEventBus,
+            TimeProvider.System,
             NullLogger<KeycloakUserTokenExchangeService>.Instance);
 
         KeycloakIdentityProvider provider = new(


### PR DESCRIPTION
## Summary

Closes 5 medium-severity findings from the `Granit.Identity.*` security audit (commit `477e92c8`). PR4 in the 5-PR remediation train (PR2 #1132 merged · PR3 #1135 open · PR4 this · PR1 + PR5 to follow).

| ID | VULN | Fix |
|----|------|-----|
| T1 | VULN-203 | Step-up password confirmation on `/change-email` — `AccountChangeEmailRequest.CurrentPassword` is now required and verified via `IIdentityCredentialVerifier`. OWASP ASVS V2.8.1. |
| T2 | VULN-204 | `IFirebaseAuthTransport.ListUsersAsync(skip, take, ct)` — bounded pagination instead of materialising the full Firebase directory. `GoogleCloudIdentityProvider.GetUsersAsync` throws `NotSupportedException` on `search != null` instead of falling back to in-memory filter (DoS / mass-enumeration risk). |
| T3 | VULN-207 | New `ITokenExchangeRateLimiter` abstraction with `NullTokenExchangeRateLimiter` default; new `IdentityTokenExchangedEto` audit event published on every token exchange; `KeycloakUserTokenExchangeService` log promoted from `Debug` to `Information`. Hosts wire `Granit.RateLimiting`-backed implementation for distributed per-user quota — production deployments **must** do this in multi-pod setups (see review note below). |
| T4 | VULN-211 | New `IdentityProviderUnauthorizedException`. All four federated providers (Cognito, Keycloak, Entra, Firebase) now distinguish 401/403 from transient failures on `GetUsersAsync` and `GetUserAsync` — operators see "service-account unauthorised" instead of the previous silent "no users" degradation. **Partial coverage** — write paths and remaining read methods (sessions, roles, groups) tracked as a follow-up using the same pattern. |
| T5 | VULN-200 | Stripe-style timestamped webhook signatures: header now `t=<unix>,v1=<hex>`, HMAC over `"<unix>.<body>"`, configurable `ReplayWindow` (default 5 min) rejects stale and future-dated signatures. Closes the replay loophole. Uses `TimeProvider` for deterministic testing. |

Plan reference: `~/.claude/plans/deep-toasting-avalanche.md` → "PR4 — Tactical".

## Why

These findings together close most of the remaining medium-severity audit surface: account-takeover via session hijack, denial-of-wallet via Firebase mass-list, ISO 27001 audit gap on token exchange, silent operator-blindness on credential expiry, and webhook replay.

## Architecture-test worktree compatibility

17 `*ConventionTests.cs` files duplicated `FindRepoRoot()` that only accepts `.git` as a directory and so failed when the test suite ran from a `git worktree`. Each call site now also accepts `.git` as a file. PR3 fixed the same set; this PR re-applies because PR3 is not yet merged.

## Distributed rate-limit warning (T3)

`NullTokenExchangeRateLimiter` is the default — it allows every call. If you enable `KeycloakAdminOptions.UseTokenExchangeForDeviceActivity = true` in production, register a `Granit.RateLimiting`-backed implementation that uses `IDistributedRateLimitCounterStore` (Redis). An in-process limiter on N pods provides N×quota effective protection — see review thread on the audit plan.

## Breaking changes (semver-major)

1. `AccountChangeEmailRequest` adds required `CurrentPassword` field. Clients hitting `/change-email` must include it; otherwise 400.
2. Identity webhook header format changed from raw hex to `t=<unix>,v1=<hex>`. Senders must upgrade or the receiver returns 401. Document in consumer release notes.
3. `IFirebaseAuthTransport.ListUsersAsync` signature widened to `(int? skip, int? take, CancellationToken)`.
4. `GoogleCloudIdentityProvider.GetUsersAsync` throws `NotSupportedException` for `search != null`. Switch to the local `Granit.Identity` user-cache or the Identity Toolkit REST API.
5. `KeycloakUserTokenExchangeService` constructor gains 3 new dependencies (`ITokenExchangeRateLimiter`, `IDistributedEventBus`, `TimeProvider`). The DI extension `AddGranitIdentityKeycloak` registers them automatically; only direct `new` callers (tests) need updates.

## Test plan

- [x] `dotnet test tests/Granit.Identity.Endpoints.Tests` — 174/174 pass (incl. 9 new `WebhookSignatureValidatorTests` covering replay, malformed header, v1-then-t order, tampered signature/body; new `Webhook_rejects_signature_outside_replay_window` integration test)
- [x] `dotnet test tests/Granit.Identity.Local.Endpoints.Tests` — 142/142 pass
- [x] `dotnet test tests/Granit.Identity.Federated.Cognito.Tests` — 60/60 pass
- [x] `dotnet test tests/Granit.Identity.Federated.GoogleCloud.Tests` — 58/58 pass (incl. new `GetUsersAsync_WithoutSearch_DelegatesPaginationToTransport` and `GetUsersAsync_WithSearch_ThrowsNotSupported`)
- [x] `dotnet test tests/Granit.Identity.Federated.Keycloak.Tests` — 169/169 pass
- [x] `dotnet test tests/Granit.Identity.Federated.EntraId.Tests` — 124/124 pass
- [x] `dotnet test tests/Granit.ArchitectureTests` — 118/118 pass
- [x] `dotnet format --verify-no-changes` — clean across all 13 touched projects

## Audit reference

Full report: `/security` audit summary on commit `477e92c8`. Plan: `~/.claude/plans/deep-toasting-avalanche.md` → "PR4 — Tactical (T1-T5)".