### PR TITLE
fix(identity-federated)!: encrypt user_cache_entries PII at rest (S2)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -831,6 +831,7 @@
       "name": "Granit.Identity.Federated",
       "deps": [
         "Granit.DataExchange.Abstractions",
+        "Granit.Encryption.EntityFrameworkCore",
         "Granit.Identity",
         "Granit.QueryEngine.Abstractions"
       ],
@@ -17491,6 +17492,12 @@
           "kind": "property",
           "signature": "string SignatureHeaderName",
           "returnType": "string"
+        },
+        {
+          "name": "FromMinutes",
+          "kind": "method",
+          "signature": "FromMinutes(5)",
+          "returnType": "TimeSpan ReplayWindow { get; set; } = TimeSpan."
         }
       ]
     },
@@ -17795,7 +17802,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated",
       "file": "src/Granit.Identity.Federated/Domain/UserCacheEntry.cs",
-      "line": 23,
+      "line": 24,
       "members": [
         {
           "name": "ExternalUserId",
@@ -18071,6 +18078,15 @@
       ]
     },
     {
+      "name": "IdentityTokenExchangedEto",
+      "fqn": "Granit.Identity.Federated.Events.IdentityTokenExchangedEto",
+      "kind": "record",
+      "project": "Granit.Identity.Federated",
+      "file": "src/Granit.Identity.Federated/Events/IdentityTokenExchangedEto.cs",
+      "line": 26,
+      "members": []
+    },
+    {
       "name": "IdentityUserDeletedEto",
       "fqn": "Granit.Identity.Federated.Events.IdentityUserDeletedEto",
       "kind": "record",
@@ -18095,6 +18111,15 @@
       "project": "Granit.Identity.Federated",
       "file": "src/Granit.Identity.Federated/Events/UserCacheEntryErasedEvent.cs",
       "line": 11,
+      "members": []
+    },
+    {
+      "name": "IdentityProviderUnauthorizedException",
+      "fqn": "Granit.Identity.Federated.Exceptions.IdentityProviderUnauthorizedException",
+      "kind": "class",
+      "project": "Granit.Identity.Federated",
+      "file": "src/Granit.Identity.Federated/Exceptions/IdentityProviderUnauthorizedException.cs",
+      "line": 20,
       "members": []
     },
     {
@@ -18188,7 +18213,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated",
       "file": "src/Granit.Identity.Federated/GranitIdentityFederatedModule.cs",
-      "line": 18,
+      "line": 22,
       "members": [
         {
           "name": "ConfigureServices",
@@ -18254,7 +18279,7 @@
       "kind": "class",
       "project": "Granit.Identity.Federated.Keycloak",
       "file": "src/Granit.Identity.Federated.Keycloak/Extensions/IdentityKeycloakServiceCollectionExtensions.cs",
-      "line": 18,
+      "line": 19,
       "members": [
         {
           "name": "AddGranitIdentityKeycloak",
@@ -18367,6 +18392,22 @@
           "kind": "method",
           "signature": "SyncAsync(CancellationToken cancellationToken)",
           "returnType": "Task"
+        }
+      ]
+    },
+    {
+      "name": "UserCacheHasherOptions",
+      "fqn": "Granit.Identity.Federated.Options.UserCacheHasherOptions",
+      "kind": "class",
+      "project": "Granit.Identity.Federated",
+      "file": "src/Granit.Identity.Federated/Options/UserCacheHasherOptions.cs",
+      "line": 21,
+      "members": [
+        {
+          "name": "EmailLookupPepper",
+          "kind": "property",
+          "signature": "string EmailLookupPepper",
+          "returnType": "string"
         }
       ]
     },
@@ -18493,6 +18534,60 @@
           "kind": "property",
           "signature": "string Name",
           "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "ITokenExchangeRateLimiter",
+      "fqn": "Granit.Identity.Federated.RateLimiting.ITokenExchangeRateLimiter",
+      "kind": "interface",
+      "project": "Granit.Identity.Federated",
+      "file": "src/Granit.Identity.Federated/RateLimiting/ITokenExchangeRateLimiter.cs",
+      "line": 17,
+      "members": [
+        {
+          "name": "CheckAsync",
+          "kind": "method",
+          "signature": "CheckAsync(string targetUserId, CancellationToken cancellationToken)",
+          "returnType": "Task<TokenExchangeRateLimitDecision>"
+        }
+      ]
+    },
+    {
+      "name": "NullTokenExchangeRateLimiter",
+      "fqn": "Granit.Identity.Federated.RateLimiting.NullTokenExchangeRateLimiter",
+      "kind": "class",
+      "project": "Granit.Identity.Federated",
+      "file": "src/Granit.Identity.Federated/RateLimiting/NullTokenExchangeRateLimiter.cs",
+      "line": 8,
+      "members": [
+        {
+          "name": "CheckAsync",
+          "kind": "method",
+          "signature": "CheckAsync(string targetUserId, CancellationToken cancellationToken)",
+          "returnType": "Task<TokenExchangeRateLimitDecision>"
+        }
+      ]
+    },
+    {
+      "name": "struct",
+      "fqn": "Granit.Identity.Federated.RateLimiting.struct",
+      "kind": "record",
+      "project": "Granit.Identity.Federated",
+      "file": "src/Granit.Identity.Federated/RateLimiting/ITokenExchangeRateLimiter.cs",
+      "line": 35,
+      "members": [
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(true, TimeSpan.Zero)",
+          "returnType": "TokenExchangeRateLimitDecision Allowed =>"
+        },
+        {
+          "name": "Denied",
+          "kind": "method",
+          "signature": "Denied(TimeSpan retryAfter)",
+          "returnType": "TokenExchangeRateLimitDecision"
         }
       ]
     },
@@ -19029,7 +19124,7 @@
       "kind": "record",
       "project": "Granit.Identity.Local.Endpoints",
       "file": "src/Granit.Identity.Local.Endpoints/Dtos/AccountChangeEmailRequest.cs",
-      "line": 7,
+      "line": 11,
       "members": []
     },
     {

--- a/src/Granit.Identity.Federated.Cognito/packages.lock.json
+++ b/src/Granit.Identity.Federated.Cognito/packages.lock.json
@@ -146,6 +146,24 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -171,6 +189,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Identity.Federated.EntityFrameworkCore/DbContext/UserCacheModelBuilderExtensions.cs
+++ b/src/Granit.Identity.Federated.EntityFrameworkCore/DbContext/UserCacheModelBuilderExtensions.cs
@@ -24,25 +24,36 @@ public static class UserCacheModelBuilderExtensions
             entity.HasKey(e => e.Id);
 
             entity.Property(e => e.ExternalUserId).HasMaxLength(256).IsRequired();
-            entity.Property(e => e.Username).HasMaxLength(256);
-            entity.Property(e => e.Email).HasMaxLength(512);
-            entity.Property(e => e.FirstName).HasMaxLength(256);
-            entity.Property(e => e.LastName).HasMaxLength(256);
+
+            // PII columns are encrypted at rest via [Encrypted] — the value converter
+            // is attached by ApplyEncryptionConventions. Ciphertext is longer than
+            // plaintext, so the column widths are widened. 2048 comfortably holds an
+            // AES-GCM envelope wrapping the previous plaintext max plus base64 overhead.
+            entity.Property(e => e.Username).HasMaxLength(2048);
+            entity.Property(e => e.Email).HasMaxLength(2048);
+            entity.Property(e => e.FirstName).HasMaxLength(2048);
+            entity.Property(e => e.LastName).HasMaxLength(2048);
+
+            // EmailHash is a lookup digest (HMAC-SHA256 hex = 64 chars). It is NOT
+            // a secret and NOT a rainbow-prone plain hash (peppered HMAC). Indexed
+            // with TenantId for exact-match admin search on the encrypted email column.
+            entity.Property(e => e.EmailHash).HasMaxLength(64);
 
             // Unique: one cache entry per user per tenant
             entity.HasIndex(e => new { e.TenantId, e.ExternalUserId })
                   .IsUnique()
                   .HasDatabaseName($"uq_{GranitIdentityDbProperties.DbTablePrefix}user_cache_tenant_external_id");
 
-            // Search indexes
-            entity.HasIndex(e => new { e.TenantId, e.Username })
-                  .HasDatabaseName($"ix_{GranitIdentityDbProperties.DbTablePrefix}user_cache_tenant_username");
+            // Exact-match search index — replaces the prior LIKE-scan over plaintext
+            // (broken once Email became ciphertext).
+            entity.HasIndex(e => new { e.TenantId, e.EmailHash })
+                  .HasDatabaseName($"ix_{GranitIdentityDbProperties.DbTablePrefix}user_cache_tenant_email_hash");
 
-            entity.HasIndex(e => new { e.TenantId, e.Email })
-                  .HasDatabaseName($"ix_{GranitIdentityDbProperties.DbTablePrefix}user_cache_tenant_email");
-
-            entity.HasIndex(e => new { e.TenantId, e.LastName, e.FirstName })
-                  .HasDatabaseName($"ix_{GranitIdentityDbProperties.DbTablePrefix}user_cache_tenant_name");
+            // NOTE: after encryption-at-rest was enabled the Username / Email / (LastName,FirstName)
+            // indexes are dropped. LIKE-scans over encrypted columns would require
+            // decrypting every row on every query — unusable on directories with 100k+
+            // users. Free-text name search is no longer supported; the admin UI can
+            // query by exact email instead.
         });
 
         return builder;

--- a/src/Granit.Identity.Federated.EntityFrameworkCore/Internal/EfCoreUserCacheStore.cs
+++ b/src/Granit.Identity.Federated.EntityFrameworkCore/Internal/EfCoreUserCacheStore.cs
@@ -9,7 +9,7 @@ namespace Granit.Identity.Federated.EntityFrameworkCore.Internal;
 /// EF Core implementation of <see cref="IUserCacheStore"/>.
 /// All read operations use <c>AsNoTracking</c> for performance.
 /// </summary>
-internal sealed class EfCoreUserCacheStore<TContext>(TContext context)
+internal sealed class EfCoreUserCacheStore<TContext>(TContext context, IUserLookupHasher hasher)
     : IUserCacheStore
     where TContext : Microsoft.EntityFrameworkCore.DbContext, IUserCacheDbContext
 {
@@ -41,21 +41,29 @@ internal sealed class EfCoreUserCacheStore<TContext>(TContext context)
     public async Task<(IReadOnlyList<UserCacheEntry> Items, int TotalCount)> SearchAsync(
         string term, Guid? tenantId, int page, int pageSize, CancellationToken cancellationToken = default)
     {
-        string pattern = $"%{term}%";
+        // Encrypted columns can't be LIKE-scanned. Admin search now only supports
+        // exact-match on email, resolved via the lookup hash. Anything else returns
+        // empty — the admin UI should direct operators to enter a full email.
+        if (string.IsNullOrWhiteSpace(term) || !term.Contains('@'))
+        {
+            return ([], 0);
+        }
+
+        string? hash = hasher.ComputeEmailHash(term);
+        if (hash is null)
+        {
+            return ([], 0);
+        }
 
         IQueryable<UserCacheEntry> query = context.UserCacheEntries
             .AsNoTracking()
-            .Where(e => e.TenantId == tenantId
-                && (EF.Functions.Like(e.Username ?? "", pattern)
-                    || EF.Functions.Like(e.Email ?? "", pattern)
-                    || EF.Functions.Like(e.FirstName ?? "", pattern)
-                    || EF.Functions.Like(e.LastName ?? "", pattern)));
+            .Where(e => e.TenantId == tenantId && e.EmailHash == hash);
 
         int totalCount = await query.CountAsync(cancellationToken).ConfigureAwait(false);
 
         int skip = (page - 1) * pageSize;
         List<UserCacheEntry> items = await query
-            .OrderBy(e => e.LastName).ThenBy(e => e.FirstName)
+            .OrderBy(e => e.ExternalUserId)
             .Skip(skip)
             .Take(pageSize)
             .ToListAsync(cancellationToken).ConfigureAwait(false);
@@ -108,6 +116,11 @@ internal sealed class EfCoreUserCacheStore<TContext>(TContext context)
 
     public async Task UpsertAsync(UserCacheEntry entry, CancellationToken cancellationToken = default)
     {
+        // Keep EmailHash in sync with Email so admin search finds the row. Callers
+        // may pre-compute this (CachedUserLookupService does), but the store also
+        // recomputes defensively so direct consumers of UpsertAsync stay correct.
+        entry.EmailHash = hasher.ComputeEmailHash(entry.Email);
+
         UserCacheEntry? existing = await context.UserCacheEntries
             .FirstOrDefaultAsync(
                 e => e.TenantId == entry.TenantId && e.ExternalUserId == entry.ExternalUserId,
@@ -121,6 +134,7 @@ internal sealed class EfCoreUserCacheStore<TContext>(TContext context)
         {
             existing.Username = entry.Username;
             existing.Email = entry.Email;
+            existing.EmailHash = entry.EmailHash;
             existing.FirstName = entry.FirstName;
             existing.LastName = entry.LastName;
             existing.Enabled = entry.Enabled;
@@ -138,6 +152,12 @@ internal sealed class EfCoreUserCacheStore<TContext>(TContext context)
             return;
         }
 
+        // Compute hashes up front so we don't hit the hasher per-entry under lock.
+        foreach (UserCacheEntry entry in entries)
+        {
+            entry.EmailHash = hasher.ComputeEmailHash(entry.Email);
+        }
+
         var externalIds = entries.Select(e => e.ExternalUserId).ToHashSet();
         Guid? tenantId = entries[0].TenantId;
 
@@ -151,6 +171,7 @@ internal sealed class EfCoreUserCacheStore<TContext>(TContext context)
             {
                 existing.Username = entry.Username;
                 existing.Email = entry.Email;
+                existing.EmailHash = entry.EmailHash;
                 existing.FirstName = entry.FirstName;
                 existing.LastName = entry.LastName;
                 existing.Enabled = entry.Enabled;
@@ -203,6 +224,10 @@ internal sealed class EfCoreUserCacheStore<TContext>(TContext context)
 
         entry.Username = "anonymized";
         entry.Email = "anonymized@anonymized.local";
+        // Null the hash — pseudonymised rows should not be discoverable via email
+        // lookup, and every pseudonymised row sharing the same constant email would
+        // otherwise collide on the same hash (harmless, but noisy in the index).
+        entry.EmailHash = null;
         entry.FirstName = "Anonymized";
         entry.LastName = "User";
         entry.Enabled = false;

--- a/src/Granit.Identity.Federated.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Identity.Federated.EntityFrameworkCore/packages.lock.json
@@ -43,6 +43,21 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -66,6 +81,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Identity.Federated.EntraId/packages.lock.json
+++ b/src/Granit.Identity.Federated.EntraId/packages.lock.json
@@ -303,6 +303,24 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -335,6 +353,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Identity.Federated.GoogleCloud/packages.lock.json
+++ b/src/Granit.Identity.Federated.GoogleCloud/packages.lock.json
@@ -81,6 +81,16 @@
         "resolved": "6.0.0",
         "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
       },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -96,6 +106,46 @@
         "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "8Oq/03og7ihwbfx+EjfWhYCdMldClxqnqB9w5ZI4KxuhoiUVDxZYVl06K7fhROOoelhKOtnCUtATCqTCrqSGmA=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Primitives": {
@@ -136,6 +186,38 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {
@@ -147,8 +229,30 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -156,6 +260,60 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
@@ -173,6 +331,51 @@
         "requested": "[10.*, )",
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "hs9YULcNhj1UiPjhNoJIDBWS92GvAVzT6DyuvbkoxvDcASZUQFVwQ9EAKtgrOfTaI0Vy6U6RwycXko1SIESM8w==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
       },
       "Microsoft.Extensions.Options": {
         "type": "CentralTransitive",

--- a/src/Granit.Identity.Federated.Keycloak/packages.lock.json
+++ b/src/Granit.Identity.Federated.Keycloak/packages.lock.json
@@ -303,6 +303,24 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -335,6 +353,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Identity.Federated.Privacy/packages.lock.json
+++ b/src/Granit.Identity.Federated.Privacy/packages.lock.json
@@ -157,6 +157,16 @@
           "System.Composition": "9.0.0"
         }
       },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -228,10 +238,10 @@
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics": {
@@ -255,8 +265,8 @@
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "jAhZbzDa117otUBMuQQ6JzSfuDbBBrfOs5jw5l7l9hKpzt+LjYKVjSauXG2yV9u7BqUSLUtKLwcerDQDeQ+0Xw=="
+        "resolved": "10.0.7",
+        "contentHash": "8Oq/03og7ihwbfx+EjfWhYCdMldClxqnqB9w5ZI4KxuhoiUVDxZYVl06K7fhROOoelhKOtnCUtATCqTCrqSGmA=="
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
@@ -312,12 +322,12 @@
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "BStFkd5CcnEtarlcgYDBcFzGYCuuNMzPs02wN3WBsOFoYIEmYoUdAiU+au6opzoqfTYJsMTW00AeqDdnXH2CvA==",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging.Configuration": {
@@ -494,12 +504,36 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.identity": {
@@ -513,8 +547,30 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
       "granit.privacy": {
@@ -586,26 +642,50 @@
           "System.Composition": "9.0.0"
         }
       },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.0",
-        "contentHash": "Zcoy6H9mSoGyvr7UvlGokEZrlZkcPCICPZr8mCsSt9U/N8eeCwCXwKF5bShdA66R0obxBCwP4AxomQHvVkC/uA==",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.0",
-        "contentHash": "krK19MKp0BNiR9rpBDW7PKSrTMLVlifS9am3CVc4O1Jq6GWz0o4F+sw5OSL4L3mVd56W8l6JRgghUa2KB51vOw==",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
@@ -623,6 +703,29 @@
         "requested": "[10.*, )",
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "hs9YULcNhj1UiPjhNoJIDBWS92GvAVzT6DyuvbkoxvDcASZUQFVwQ9EAKtgrOfTaI0Vy6U6RwycXko1SIESM8w==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
+        }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",

--- a/src/Granit.Identity.Federated/Domain/UserCacheEntry.cs
+++ b/src/Granit.Identity.Federated/Domain/UserCacheEntry.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using System.Text.Json;
 using Granit.DataProtection;
 using Granit.Domain;
+using Granit.Encryption.EntityFrameworkCore;
 
 namespace Granit.Identity.Federated.Domain;
 
@@ -26,20 +27,35 @@ public sealed class UserCacheEntry : AuditedEntity, IMultiTenant, IIdentityUser
     /// <summary>User identifier in the external identity provider (e.g. Keycloak sub). Max 256 characters.</summary>
     public string ExternalUserId { get; set; } = string.Empty;
 
-    /// <summary>Login name. Max 256 characters.</summary>
+    /// <summary>Login name. Max 256 characters. Encrypted at rest.</summary>
     [SensitiveData]
+    [Encrypted]
     public string? Username { get; set; }
 
-    /// <summary>Email address. Max 512 characters.</summary>
+    /// <summary>
+    /// Email address. Max 512 characters. Encrypted at rest — the
+    /// admin search path looks up users via <see cref="EmailHash"/> instead of
+    /// scanning the ciphertext.
+    /// </summary>
     [SensitiveData(Level = Sensitivity.Confidential)]
+    [Encrypted]
     public string? Email { get; set; }
 
-    /// <summary>First name. Max 256 characters.</summary>
+    /// <summary>
+    /// HMAC-SHA256 of <c>email.ToLowerInvariant()</c> computed with a dedicated
+    /// lookup pepper. Indexed alongside <see cref="TenantId"/> for exact-match
+    /// search on encrypted data. Never surfaced to callers.
+    /// </summary>
+    public string? EmailHash { get; set; }
+
+    /// <summary>First name. Max 256 characters. Encrypted at rest.</summary>
     [SensitiveData]
+    [Encrypted]
     public string? FirstName { get; set; }
 
-    /// <summary>Last name. Max 256 characters.</summary>
+    /// <summary>Last name. Max 256 characters. Encrypted at rest.</summary>
     [SensitiveData]
+    [Encrypted]
     public string? LastName { get; set; }
 
     /// <summary>Whether the user account is active in the identity provider.</summary>

--- a/src/Granit.Identity.Federated/Granit.Identity.Federated.csproj
+++ b/src/Granit.Identity.Federated/Granit.Identity.Federated.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Granit.DataExchange.Abstractions\Granit.DataExchange.Abstractions.csproj" />
+    <ProjectReference Include="..\Granit.Encryption.EntityFrameworkCore\Granit.Encryption.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Granit.Identity\Granit.Identity.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
   </ItemGroup>

--- a/src/Granit.Identity.Federated/GranitIdentityFederatedModule.cs
+++ b/src/Granit.Identity.Federated/GranitIdentityFederatedModule.cs
@@ -2,6 +2,8 @@ using Granit.DataExchange.Extensions;
 using Granit.Identity;
 using Granit.Identity.Federated.Domain;
 using Granit.Identity.Federated.Exports;
+using Granit.Identity.Federated.Internal;
+using Granit.Identity.Federated.Options;
 using Granit.Identity.Federated.Queries;
 using Granit.Identity.Federated.RateLimiting;
 using Granit.Modularity;
@@ -28,7 +30,19 @@ public sealed class GranitIdentityFederatedModule : GranitModule
 
         // Default to a no-op rate limiter on token-exchange. Hosts that wire
         // Granit.RateLimiting can replace this registration with a distributed-store
-        // implementation to enforce per-user quotas across pods (VULN-207).
+        // implementation to enforce per-user quotas across pods.
         context.Services.TryAddSingleton<ITokenExchangeRateLimiter, NullTokenExchangeRateLimiter>();
+
+        // Lookup hasher for email-based admin search over encrypted PII.
+        // Startup-validated via UserCacheHasherOptions.EmailLookupPepper.
+        context.Services.AddOptions<UserCacheHasherOptions>()
+            .BindConfiguration(UserCacheHasherOptions.SectionName)
+            .Validate(o => !string.IsNullOrWhiteSpace(o.EmailLookupPepper),
+                $"{UserCacheHasherOptions.SectionName}:EmailLookupPepper is required when " +
+                "Granit.Identity.Federated is loaded. Generate 32 bytes of entropy " +
+                "(openssl rand -hex 32) and store it in Vault or an equivalent secret store — " +
+                "NEVER bake it into source-controlled appsettings.json.")
+            .ValidateOnStart();
+        context.Services.TryAddSingleton<IUserLookupHasher, HmacUserLookupHasher>();
     }
 }

--- a/src/Granit.Identity.Federated/Internal/HmacUserLookupHasher.cs
+++ b/src/Granit.Identity.Federated/Internal/HmacUserLookupHasher.cs
@@ -1,0 +1,62 @@
+using System.Security.Cryptography;
+using System.Text;
+using Granit.Identity.Federated.Options;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Identity.Federated.Internal;
+
+/// <summary>
+/// HMAC-SHA256 <see cref="IUserLookupHasher"/>. The pepper comes from
+/// <see cref="UserCacheHasherOptions.EmailLookupPepper"/> and is validated at
+/// startup — an unset pepper fails startup so production deployments cannot
+/// accidentally run with a known-zero key.
+/// </summary>
+internal sealed class HmacUserLookupHasher(IOptions<UserCacheHasherOptions> options) : IUserLookupHasher
+{
+    private readonly byte[] _pepper = ResolvePepper(options.Value);
+
+    public string? ComputeEmailHash(string? email)
+    {
+        if (string.IsNullOrEmpty(email))
+        {
+            return null;
+        }
+
+        // Canonicalise for case-insensitive exact-match lookup. The same
+        // normalisation happens on the search path so the two agree.
+        byte[] payload = Encoding.UTF8.GetBytes(email.Trim().ToLowerInvariant());
+        byte[] digest = HMACSHA256.HashData(_pepper, payload);
+        return Convert.ToHexStringLower(digest);
+    }
+
+    private static byte[] ResolvePepper(UserCacheHasherOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.EmailLookupPepper))
+        {
+            throw new InvalidOperationException(
+                "UserCacheHasher:EmailLookupPepper is required when at-rest encryption is enabled " +
+                "on Granit.Identity.Federated. The pepper must be at least 32 bytes of high-entropy " +
+                "random data (e.g. produced by openssl rand -hex 32) and stored separately from the " +
+                "encryption key ring so the two can be rotated independently.");
+        }
+
+        // Accept either hex or raw UTF-8 — hex if it parses cleanly as pairs of [0-9a-f].
+        string pepper = options.EmailLookupPepper.Trim();
+        if (pepper.Length % 2 == 0 && pepper.All(IsHexDigit))
+        {
+            try
+            {
+                return Convert.FromHexString(pepper);
+            }
+            catch (FormatException)
+            {
+                // fall through to UTF-8 interpretation
+            }
+        }
+
+        return Encoding.UTF8.GetBytes(pepper);
+    }
+
+    private static bool IsHexDigit(char c) =>
+        (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}

--- a/src/Granit.Identity.Federated/Internal/IUserLookupHasher.cs
+++ b/src/Granit.Identity.Federated/Internal/IUserLookupHasher.cs
@@ -1,0 +1,30 @@
+namespace Granit.Identity.Federated.Internal;
+
+/// <summary>
+/// Computes a deterministic lookup hash for cache-entry PII so the admin search
+/// path can resolve a user by email without decrypting every row.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Granit.Identity.Federated.Domain.UserCacheEntry.Email"/>
+/// is encrypted at rest via <see cref="Granit.Encryption.EntityFrameworkCore.EncryptedAttribute"/>.
+/// Ciphertext is not <c>LIKE</c>-searchable, so an exact-match lookup index sits
+/// alongside the encrypted column: <c>EmailHash = HMAC-SHA256(pepper, lowered-email)</c>.
+/// </para>
+/// <para>
+/// The pepper MUST be distinct from the encryption key so the two can be rotated
+/// independently. A shared key would leak re-identification risk into the
+/// encryption domain.
+/// </para>
+/// </remarks>
+internal interface IUserLookupHasher
+{
+    /// <summary>
+    /// Computes the deterministic lookup hash for an email address. Returns <c>null</c>
+    /// when <paramref name="email"/> is <c>null</c> or empty so the caller can persist
+    /// it verbatim.
+    /// </summary>
+    /// <param name="email">The email address to hash.</param>
+    /// <returns>Lower-case hex HMAC digest, or <c>null</c>.</returns>
+    string? ComputeEmailHash(string? email);
+}

--- a/src/Granit.Identity.Federated/Options/UserCacheHasherOptions.cs
+++ b/src/Granit.Identity.Federated/Options/UserCacheHasherOptions.cs
@@ -1,0 +1,31 @@
+namespace Granit.Identity.Federated.Options;
+
+/// <summary>
+/// Configuration for the user-cache lookup hasher used when PII is encrypted at rest.
+/// </summary>
+/// <remarks>
+/// <para>
+/// when <see cref="Granit.Identity.Federated.Domain.UserCacheEntry.Email"/>
+/// is encrypted, it can no longer be <c>LIKE</c>-searched. The admin path looks up
+/// users via <c>EmailHash = HMAC-SHA256(pepper, lowered-email)</c> instead. The
+/// pepper configured here MUST:
+/// </para>
+/// <list type="bullet">
+///   <item>Be at least 32 bytes of high-entropy random data</item>
+///   <item>Be stored separately from the encryption key ring (so the two rotate
+///   independently)</item>
+///   <item>Be loaded from a secret store (Vault, Azure Key Vault, environment
+///   variable) — never baked into <c>appsettings.json</c> in source control</item>
+/// </list>
+/// </remarks>
+public sealed class UserCacheHasherOptions
+{
+    /// <summary>Configuration section name for binding from <c>appsettings.json</c>.</summary>
+    public const string SectionName = "Identity:UserCacheHasher";
+
+    /// <summary>
+    /// HMAC pepper for email lookups. Accepts either a hex string (e.g. 64 hex chars
+    /// for 32 bytes) or a raw UTF-8 string. Required — startup fails if unset.
+    /// </summary>
+    public string EmailLookupPepper { get; set; } = string.Empty;
+}

--- a/src/Granit.Identity.Federated/packages.lock.json
+++ b/src/Granit.Identity.Federated/packages.lock.json
@@ -8,6 +8,16 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
       "granit": {
         "type": "Project"
       },
@@ -23,6 +33,33 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {
@@ -30,11 +67,64 @@
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
       },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
         }
       }
     }

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2185,6 +2185,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }

--- a/tests/Granit.Identity.Federated.Cognito.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/packages.lock.json
@@ -356,6 +356,24 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -381,6 +399,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/EfCoreUserCacheStoreTests.cs
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/EfCoreUserCacheStoreTests.cs
@@ -1,6 +1,8 @@
 using Granit.Identity.Federated.Domain;
 using Granit.Identity.Federated.EntityFrameworkCore.Internal;
+using Granit.Identity.Federated.Internal;
 using Microsoft.EntityFrameworkCore;
+using NSubstitute;
 using Shouldly;
 using Xunit;
 
@@ -8,6 +10,24 @@ namespace Granit.Identity.Federated.EntityFrameworkCore.Tests;
 
 public sealed class EfCoreUserCacheStoreTests
 {
+    private static readonly IUserLookupHasher Hasher = CreateHasher();
+
+    private static IUserLookupHasher CreateHasher()
+    {
+        // Deterministic stub — mirrors the real HmacUserLookupHasher's public contract
+        // (null in → null out, otherwise a stable lower-case token). Tests don't need
+        // HMAC semantics, just something that round-trips equality for exact-match.
+        IUserLookupHasher hasher = Substitute.For<IUserLookupHasher>();
+        hasher.ComputeEmailHash(Arg.Any<string?>())
+            .Returns(ci => ci.Arg<string?>() is { Length: > 0 } email
+                ? "hash:" + email.Trim().ToLowerInvariant()
+                : null);
+        return hasher;
+    }
+
+    private static EfCoreUserCacheStore<TestDbContext> CreateStore(TestDbContext context) =>
+        new(context, Hasher);
+
     private static TestDbContext CreateContext() =>
         new(new DbContextOptionsBuilder<TestDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
@@ -36,7 +56,7 @@ public sealed class EfCoreUserCacheStoreTests
     public async Task FindByExternalIdAsync_ReturnsNull_WhenNotFound()
     {
         await using TestDbContext context = CreateContext();
-        var store = new EfCoreUserCacheStore<TestDbContext>(context);
+        EfCoreUserCacheStore<TestDbContext> store = CreateStore(context);
 
         UserCacheEntry? result = await store.FindByExternalIdAsync(
             "nonexistent", null, TestContext.Current.CancellationToken);
@@ -48,7 +68,7 @@ public sealed class EfCoreUserCacheStoreTests
     public async Task UpsertAsync_InsertsNewEntry()
     {
         await using TestDbContext context = CreateContext();
-        var store = new EfCoreUserCacheStore<TestDbContext>(context);
+        EfCoreUserCacheStore<TestDbContext> store = CreateStore(context);
         UserCacheEntry entry = CreateEntry();
 
         await store.UpsertAsync(entry, TestContext.Current.CancellationToken);
@@ -63,7 +83,7 @@ public sealed class EfCoreUserCacheStoreTests
     public async Task UpsertAsync_UpdatesExistingEntry()
     {
         await using TestDbContext context = CreateContext();
-        var store = new EfCoreUserCacheStore<TestDbContext>(context);
+        EfCoreUserCacheStore<TestDbContext> store = CreateStore(context);
         UserCacheEntry entry = CreateEntry();
         await store.UpsertAsync(entry, TestContext.Current.CancellationToken);
 
@@ -81,7 +101,7 @@ public sealed class EfCoreUserCacheStoreTests
     public async Task FindByExternalIdsAsync_ReturnsBatchResults()
     {
         await using TestDbContext context = CreateContext();
-        var store = new EfCoreUserCacheStore<TestDbContext>(context);
+        EfCoreUserCacheStore<TestDbContext> store = CreateStore(context);
 
         await store.UpsertAsync(CreateEntry("user-1"), TestContext.Current.CancellationToken);
         await store.UpsertAsync(CreateEntry("user-2", username: "jane"), TestContext.Current.CancellationToken);
@@ -96,7 +116,7 @@ public sealed class EfCoreUserCacheStoreTests
     public async Task FindFirstByExternalIdAsync_ReturnsEntryRegardlessOfTenant()
     {
         await using TestDbContext context = CreateContext();
-        var store = new EfCoreUserCacheStore<TestDbContext>(context);
+        EfCoreUserCacheStore<TestDbContext> store = CreateStore(context);
         var tenantId = Guid.NewGuid();
 
         await store.UpsertAsync(CreateEntry("user-1", tenantId: tenantId), TestContext.Current.CancellationToken);
@@ -112,7 +132,7 @@ public sealed class EfCoreUserCacheStoreTests
     public async Task MultiTenantIsolation_SameUserDifferentTenants()
     {
         await using TestDbContext context = CreateContext();
-        var store = new EfCoreUserCacheStore<TestDbContext>(context);
+        EfCoreUserCacheStore<TestDbContext> store = CreateStore(context);
         var tenant1 = Guid.NewGuid();
         var tenant2 = Guid.NewGuid();
 
@@ -136,7 +156,7 @@ public sealed class EfCoreUserCacheStoreTests
     public async Task UpsertManyAsync_InsertsAndUpdatesInBatch()
     {
         await using TestDbContext context = CreateContext();
-        var store = new EfCoreUserCacheStore<TestDbContext>(context);
+        EfCoreUserCacheStore<TestDbContext> store = CreateStore(context);
 
         // Pre-insert one entry
         await store.UpsertAsync(CreateEntry("user-1"), TestContext.Current.CancellationToken);
@@ -161,7 +181,7 @@ public sealed class EfCoreUserCacheStoreTests
     public async Task GetCountAsync_ReturnsCorrectCount()
     {
         await using TestDbContext context = CreateContext();
-        var store = new EfCoreUserCacheStore<TestDbContext>(context);
+        EfCoreUserCacheStore<TestDbContext> store = CreateStore(context);
 
         await store.UpsertAsync(CreateEntry("user-1"), TestContext.Current.CancellationToken);
         await store.UpsertAsync(CreateEntry("user-2"), TestContext.Current.CancellationToken);
@@ -174,7 +194,7 @@ public sealed class EfCoreUserCacheStoreTests
     public async Task GetStaleCountAsync_CountsStaleEntries()
     {
         await using TestDbContext context = CreateContext();
-        var store = new EfCoreUserCacheStore<TestDbContext>(context);
+        EfCoreUserCacheStore<TestDbContext> store = CreateStore(context);
 
         UserCacheEntry fresh = CreateEntry("user-fresh");
         fresh.LastSyncedAt = DateTimeOffset.UtcNow;
@@ -194,7 +214,7 @@ public sealed class EfCoreUserCacheStoreTests
     public async Task GetSyncRangeAsync_ReturnsOldestAndNewest()
     {
         await using TestDbContext context = CreateContext();
-        var store = new EfCoreUserCacheStore<TestDbContext>(context);
+        EfCoreUserCacheStore<TestDbContext> store = CreateStore(context);
 
         UserCacheEntry old = CreateEntry("user-old");
         old.LastSyncedAt = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
@@ -215,7 +235,7 @@ public sealed class EfCoreUserCacheStoreTests
     public async Task GetSyncRangeAsync_ReturnsNulls_WhenEmpty()
     {
         await using TestDbContext context = CreateContext();
-        var store = new EfCoreUserCacheStore<TestDbContext>(context);
+        EfCoreUserCacheStore<TestDbContext> store = CreateStore(context);
 
         (DateTimeOffset? oldest, DateTimeOffset? newest) = await store.GetSyncRangeAsync(
             null, TestContext.Current.CancellationToken);
@@ -228,7 +248,7 @@ public sealed class EfCoreUserCacheStoreTests
     public async Task DeleteByExternalIdAsync_RemovesEntry()
     {
         await using TestDbContext context = CreateContext();
-        var store = new EfCoreUserCacheStore<TestDbContext>(context);
+        EfCoreUserCacheStore<TestDbContext> store = CreateStore(context);
 
         await store.UpsertAsync(CreateEntry("user-1"), TestContext.Current.CancellationToken);
         await store.DeleteByExternalIdAsync("user-1", null, TestContext.Current.CancellationToken);
@@ -242,7 +262,7 @@ public sealed class EfCoreUserCacheStoreTests
     public async Task DeleteAllByTenantAsync_RemovesAllTenantEntries()
     {
         await using TestDbContext context = CreateContext();
-        var store = new EfCoreUserCacheStore<TestDbContext>(context);
+        EfCoreUserCacheStore<TestDbContext> store = CreateStore(context);
         var tenantId = Guid.NewGuid();
 
         await store.UpsertAsync(CreateEntry("user-1", tenantId: tenantId), TestContext.Current.CancellationToken);
@@ -262,7 +282,7 @@ public sealed class EfCoreUserCacheStoreTests
     public async Task PseudonymizeAsync_ReplacesPersonalData()
     {
         await using TestDbContext context = CreateContext();
-        var store = new EfCoreUserCacheStore<TestDbContext>(context);
+        EfCoreUserCacheStore<TestDbContext> store = CreateStore(context);
 
         await store.UpsertAsync(CreateEntry("user-1"), TestContext.Current.CancellationToken);
         await store.PseudonymizeAsync("user-1", null, TestContext.Current.CancellationToken);

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/IdentityEfCoreDiRegistrationTests.cs
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/IdentityEfCoreDiRegistrationTests.cs
@@ -24,6 +24,7 @@ public sealed class IdentityEfCoreDiRegistrationTests
         // Add dependencies required by CachedUserLookupService
         services.AddSingleton(TimeProvider.System);
         services.AddSingleton(NSubstitute.Substitute.For<ICurrentTenant>());
+        services.AddSingleton(NSubstitute.Substitute.For<IUserLookupHasher>());
         services.AddLogging();
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
 

--- a/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntityFrameworkCore.Tests/packages.lock.json
@@ -128,6 +128,15 @@
         "resolved": "10.0.7",
         "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -335,6 +344,24 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -360,6 +387,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
@@ -454,6 +482,16 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
@@ -512,6 +550,19 @@
         "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       }

--- a/tests/Granit.Identity.Federated.EntraId.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/packages.lock.json
@@ -496,6 +496,24 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -528,6 +546,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }

--- a/tests/Granit.Identity.Federated.GoogleCloud.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.GoogleCloud.Tests/packages.lock.json
@@ -146,6 +146,16 @@
         "resolved": "18.5.0",
         "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
       },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -161,6 +171,46 @@
         "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "8Oq/03og7ihwbfx+EjfWhYCdMldClxqnqB9w5ZI4KxuhoiUVDxZYVl06K7fhROOoelhKOtnCUtATCqTCrqSGmA=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Primitives": {
@@ -322,6 +372,38 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {
@@ -333,6 +415,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
@@ -345,11 +428,40 @@
           "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
         }
       },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
+        }
+      },
       "granit.queryengine.abstractions": {
         "type": "Project",
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
       "FirebaseAdmin": {
@@ -360,6 +472,52 @@
         "dependencies": {
           "Google.Api.Gax.Rest": "4.13.1",
           "Google.Apis.Auth": "1.73.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
@@ -377,6 +535,51 @@
         "requested": "[10.*, )",
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "hs9YULcNhj1UiPjhNoJIDBWS92GvAVzT6DyuvbkoxvDcASZUQFVwQ9EAKtgrOfTaI0Vy6U6RwycXko1SIESM8w==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
       },
       "Microsoft.Extensions.Options": {
         "type": "CentralTransitive",

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/packages.lock.json
@@ -507,6 +507,24 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -539,6 +557,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }

--- a/tests/Granit.Identity.Federated.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Tests/packages.lock.json
@@ -104,6 +104,16 @@
         "resolved": "18.5.0",
         "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
       },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
         "resolved": "1.9.1",
@@ -253,6 +263,33 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
+      "granit.guids": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Timing": "[0.1.0-dev, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
       "granit.identity": {
         "type": "Project",
         "dependencies": {
@@ -264,8 +301,28 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )"
         }
       },
       "granit.queryengine.abstractions": {
@@ -273,6 +330,40 @@
         "dependencies": {
           "Granit": "[0.1.0-dev, )",
           "Granit.DataLookup.Abstractions": "[0.1.0-dev, )"
+        }
+      },
+      "granit.timing": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7"
         }
       }
     }


### PR DESCRIPTION
## Summary

Closes the at-rest PII exposure finding from the `Granit.Identity.*` security audit. PR5 (final) in the 5-PR remediation train (PR2 merged · PR3 merged · PR4 merged · PR1 open · PR5 this).

**Scope**: encryption-at-rest for `user_cache_entries` PII (audit item S2). **Deferred**: Cognito SRP (audit item S3) — the AWS extension package (`AWSSDK.Extensions.CognitoAuthentication`) is stuck at 0.9.x and has not been ported to AWSSDK v4 which Granit already ships. Hand-rolling RFC 5054 SRP here would balloon scope beyond review; tracked as a focused follow-up (`identity-federated-cognito-srp`).

## What changed

**Encrypt the four PII columns.** `UserCacheEntry.Username`, `Email`, `FirstName`, `LastName` now carry `[Encrypted]`. The value converter attached by `ApplyEncryptionConventions()` transparently AES-encrypts on write and decrypts on materialise; hosts that already call that convention at the end of `OnModelCreating` pick this up without code changes. Column widths grow from 256/512 → 2048 to accommodate the ciphertext envelope.

**Preserve admin-search via a companion lookup hash.** Ciphertext can't be `LIKE`-scanned, so `EmailHash = HMAC-SHA256(pepper, lower(email))` is stored alongside the encrypted email and indexed `(TenantId, EmailHash)`. `SearchAsync` now only supports exact-match by email — anything not looking like an email returns empty. The `(TenantId, Username)` and `(TenantId, LastName, FirstName)` composite indexes are dropped because scanning them would require decrypting every row per query, unusable at scale.

**Startup-validated pepper.** New `UserCacheHasherOptions.EmailLookupPepper` is required, validated with `ValidateOnStart`. Stored separately from the encryption key ring so the two rotate independently. Accepts hex (64 chars for 32 bytes) or raw UTF-8.

**Components added:**
- `IUserLookupHasher` (internal) + `HmacUserLookupHasher`
- `UserCacheHasherOptions` bound from `Identity:UserCacheHasher`
- Registered by `GranitIdentityFederatedModule` as singleton

## Breaking changes

1. **Required config**: `Identity:UserCacheHasher:EmailLookupPepper` must be set (32+ bytes of entropy from a secret store). Startup fails with a clear message otherwise.
2. **Ciphertext materialisation**: host `DbContext`s must call `modelBuilder.ApplyEncryptionConventions()` — the standard Granit persistence convention. Missing that call surfaces as a cast error on first read.
3. **`EfCoreUserCacheStore` constructor** gains `IUserLookupHasher`. Direct test consumers in the tree are updated.
4. **`SearchAsync` semantics change**: non-email terms return empty. Admin UIs that relied on free-text name search should switch to `/identity/provider/users` (live provider search) instead.
5. **Existing rows stay plaintext** after first deploy. A backfill migration re-encrypts them and computes `EmailHash` values; tracked as `identity-federated-encryption-backfill`. **Production deployments MUST run the backfill inside a maintenance window before users hit the admin search path** — un-backfilled rows will return zero results.

## Test plan

- [x] `dotnet test tests/Granit.Identity.Tests` — 142/142 pass
- [x] `dotnet test tests/Granit.Identity.Federated.Tests` — 41/41 pass
- [x] `dotnet test tests/Granit.Identity.Federated.EntityFrameworkCore.Tests` — 32/32 pass
- [x] `dotnet test tests/Granit.Identity.Federated.{Cognito,EntraId,GoogleCloud,Keycloak}.Tests` — 65 + 129 + 58 + 174 pass
- [x] `dotnet test tests/Granit.Identity.Local.*.Tests` — 31 + 181 + 144 pass
- [x] `dotnet test tests/Granit.Identity.Endpoints.Tests` — 174/174 pass
- [x] `dotnet test tests/Granit.ArchitectureTests` — 118/118 pass
- [x] `dotnet format --verify-no-changes` — clean
- [ ] **Backfill migration** (follow-up issue)

## Audit reference

Full report: `/security` audit on commit `477e92c8`. Plan: `~/.claude/plans/deep-toasting-avalanche.md` → "PR5 — Strategic (S2 + S3)".

## Follow-up work

1. `identity-federated-encryption-backfill` — one-shot data migration that re-encrypts existing `user_cache_entries` rows and populates `EmailHash`.
2. `identity-federated-cognito-srp` — migrate Cognito credential verification from `ADMIN_USER_PASSWORD_AUTH` to `USER_SRP_AUTH` once the AWS extension library ships a v4-compatible build (or hand-roll RFC 5054 if the library remains stalled).