### PR TITLE
feat(identity-federated-*)!: client-role write operations (#1122)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -18613,7 +18613,7 @@
       "kind": "interface",
       "project": "Granit.Identity",
       "file": "src/Granit.Identity/IIdentityClientRoleManager.cs",
-      "line": 26,
+      "line": 29,
       "members": [
         {
           "name": "GetClientsAsync",
@@ -18632,6 +18632,24 @@
           "kind": "method",
           "signature": "GetUserClientRolesAsync(string userId, string clientId, CancellationToken cancellationToken = default)",
           "returnType": "Task<IReadOnlyList<IdentityRole>>"
+        },
+        {
+          "name": "CreateClientRoleAsync",
+          "kind": "method",
+          "signature": "CreateClientRoleAsync(string clientId, string name, string? description, CancellationToken cancellationToken = default)",
+          "returnType": "Task<IdentityRole>"
+        },
+        {
+          "name": "AssignClientRoleAsync",
+          "kind": "method",
+          "signature": "AssignClientRoleAsync(string userId, string clientId, string roleName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
+        },
+        {
+          "name": "RemoveClientRoleAsync",
+          "kind": "method",
+          "signature": "RemoveClientRoleAsync(string userId, string clientId, string roleName, CancellationToken cancellationToken = default)",
+          "returnType": "Task"
         }
       ]
     },
@@ -18735,6 +18753,12 @@
           "kind": "property",
           "signature": "string ProviderName",
           "returnType": "string"
+        },
+        {
+          "name": "SupportsClientRoleWrites",
+          "kind": "property",
+          "signature": "bool SupportsClientRoleWrites",
+          "returnType": "bool"
         }
       ]
     },

--- a/docs-site/src/content/docs/dotnet/architecture/adr/031-client-role-write-operations.md
+++ b/docs-site/src/content/docs/dotnet/architecture/adr/031-client-role-write-operations.md
@@ -1,0 +1,229 @@
+---
+title: "ADR-031: Client-role write operations on IIdentityClientRoleManager"
+description: "Extend the read-only Phase 2 IIdentityClientRoleManager with CreateClientRoleAsync / AssignClientRoleAsync / RemoveClientRoleAsync so admin UIs can author client-scoped roles directly, using each provider's native admin surface"
+sidebar:
+  order: 31
+  label: "031 - Client-role writes"
+---
+
+> **Date:** 2026-04-23
+> **Authors:** Jean-Francois Meyers
+> **Scope:** `Granit.Identity`, `Granit.Identity.Federated.Keycloak`,
+> `Granit.Identity.Federated.EntraId`, `Granit.Identity.Federated.Cognito`
+
+## Context
+
+Phase 2 (ADR-025 / ADR-026 / ADR-027) introduced `IIdentityClientRoleManager`
+with three read-only methods — `GetClientsAsync`, `GetClientRolesAsync`,
+`GetUserClientRolesAsync` — plus a boot-time sync that mirrored upstream
+client roles into `RoleMetadata`. Phase 3 (ADR-029 orphan cleanup,
+ADR-030 scheduled re-sync) closed the drift gap but kept the model
+**upstream-authoritative**: an admin had to log into Keycloak / Azure /
+AWS consoles to author or grant a role, and Granit mirrored the result.
+
+For Granit-first deployments — where the showcase admin UI is the
+intended source of truth and upstream IaC is either absent or driven
+**by** Granit — that loop is painful: the admin UI can display roles
+but cannot create, grant or revoke them. This ADR turns the provider
+abstraction into a **write surface** so the admin UI can stay the only
+pane of glass.
+
+## Decision
+
+### Interface extension, not a new interface
+
+`IIdentityClientRoleManager` gains three methods — `CreateClientRoleAsync`,
+`AssignClientRoleAsync`, `RemoveClientRoleAsync`. Alternatives considered:
+
+1. **New `IIdentityClientRoleWriter` interface** — explicit separation
+   of reads vs writes, but forces callers to inject two interfaces for
+   a single conceptual capability and doubles the DI registration.
+2. **Chosen:** extend the existing interface. All three federated
+   providers already have the natural implementation; there is no
+   provider that implements reads but cannot implement writes today.
+   A capability flag (`SupportsClientRoleWrites`) handles opt-out.
+
+### Capability flag for opt-out
+
+`IIdentityProviderCapabilities.SupportsClientRoleWrites` is added as a
+DIM defaulting to `false`. Each federated provider overrides to `true`.
+Providers that want to remain read-only (e.g. a future SCIM-backed
+provider where writes go through a different channel) can keep the
+default and throw `NotSupportedException` from the write methods —
+callers that respect the flag never reach those paths.
+
+Concretely, endpoints that expose these operations should guard on the
+flag before dispatching:
+
+```csharp
+if (!capabilities.SupportsClientRoleWrites)
+{
+    return TypedResults.Problem(
+        "Provider does not support client-role writes.",
+        StatusCodes.Status501NotImplemented);
+}
+```
+
+### Per-provider implementation choices
+
+Each provider maps the three operations to its native admin surface.
+The abstraction is intentionally thin — there is no provider-neutral
+"role lifecycle event" emitted from the provider layer; event
+emission is the responsibility of callers (endpoints, the admin UI
+service, the orchestrator) that know the domain context.
+
+#### Keycloak
+
+Direct HTTP calls against the Keycloak Admin REST API:
+
+- **Create** — resolve the client UUID, then
+  `POST /admin/realms/{realm}/clients/{uuid}/roles` with a
+  `KeycloakRoleRepresentation` where `ContainerId = {uuid}` and
+  `ClientRole = true`. Refetch via
+  `GET /admin/realms/{realm}/clients/{uuid}/roles/{name}` to obtain
+  the server-assigned id (Keycloak returns a 201 with no body).
+- **Assign** — resolve the client UUID, fetch the role by name, then
+  `POST /admin/realms/{realm}/users/{userId}/role-mappings/clients/{uuid}`
+  with the single role representation.
+- **Remove** — same resolution, then `DELETE` on the same endpoint.
+
+Required service-account permissions:
+`realm-management: manage-clients, manage-users, view-clients`.
+
+#### Entra ID (Microsoft Graph)
+
+App Roles live on the **Application** object, not the Service
+Principal. The implementation:
+
+- **Create** — `GET /v1.0/applications?$filter=appId eq '{clientId}'`
+  to resolve the application object id + existing `appRoles` array,
+  then `PATCH /v1.0/applications/{objectId}` with
+  `{ "appRoles": [...existing, newRole] }`. New role id is minted
+  locally via `IGuidGenerator` (Graph does not assign ids for inline
+  app roles).
+- **Assign** — resolve the Service Principal (via `appId`),
+  `POST /v1.0/users/{userId}/appRoleAssignments` with
+  `{ principalId, resourceId = spObjectId, appRoleId }`.
+- **Remove** — resolve SP, list user's `appRoleAssignments` filtered
+  by the SP's object id, find the assignment with the matching
+  `appRoleId`, then `DELETE` it. No-op if no match (matches the
+  interface contract).
+
+**Concurrency caveat:** the create path is **not concurrency-safe**.
+Two parallel `CreateClientRoleAsync` calls on the same application
+will both read the pre-mutation `appRoles` array, both PATCH their
+own delta, and whichever lands second wins — the first role is lost.
+Graph does not expose per-role insert / `ETag` precondition semantics
+for `appRoles`. This is acceptable for the showcase admin UI
+(single-admin authoring) but must be documented in the operator
+README. Mitigation for high-concurrency deployments: gate calls at
+the orchestrator layer with a per-`appId` lock, or move to upstream
+IaC for role authoring and keep only assign / remove writes.
+
+Required Graph permissions:
+`Application.ReadWrite.All` (for create),
+`AppRoleAssignment.ReadWrite.All` (for assign / remove).
+
+#### AWS Cognito
+
+Cognito has no native client-scoped roles — Granit uses the
+`{appClientId}{Delimiter}{roleName}` group-naming convention from
+ADR-027 to infer scope. Writes mirror reads:
+
+- **Create** — `CreateGroup` with the prefixed name.
+- **Assign** — `AdminAddUserToGroup` with the prefixed name.
+- **Remove** — `AdminRemoveUserFromGroup` with the prefixed name.
+
+The delimiter is read from `CognitoClientRoleSyncOptions.Delimiter`
+(default `:`), so create and sync stay consistent by construction.
+
+Required IAM:
+`cognito-idp:CreateGroup`, `cognito-idp:AdminAddUserToGroup`,
+`cognito-idp:AdminRemoveUserFromGroup`.
+
+### Eventing and audit
+
+No domain / integration events are emitted from the provider layer
+for these operations. Rationale:
+
+- The provider layer is not the right surface for domain events —
+  callers (endpoints, orchestrator) know the domain context
+  (tenant, initiating admin, audit purpose) and already have access
+  to the event bus.
+- The existing realm-role `AssignRoleAsync` / `RemoveRoleAsync`
+  methods on `IIdentityProvider` do publish `IdentityRoleAssignedEto`
+  / `IdentityRoleRemovedEto`. Those are kept as-is. For client-role
+  writes, if a future story needs a parallel event (`IdentityClientRoleAssignedEto`),
+  it can be added without re-opening this ADR — the abstraction is
+  already the right shape.
+
+### Observability
+
+All six new code paths (3 methods × 3 providers) start a dedicated
+`Activity` via each provider's `ActivitySource`:
+
+- Keycloak: `client_role.create`, `client_role.assign`,
+  `client_role.remove`.
+- Entra ID: `client_role.create`, `client_role.assign`,
+  `client_role.remove`.
+- Cognito: `client_role.create`, `client_role.assign`,
+  `client_role.remove`.
+
+Tags: `user_id`, `client_id` where relevant. This matches the
+existing naming pattern for read operations (`GetClientRoles` /
+`GetUserClientRoles`).
+
+## Consequences
+
+### Positive
+
+- Granit-first deployments can close the admin UI loop for client
+  roles — create / grant / revoke without leaving the Granit pane.
+- All three federated providers reach parity on the write surface;
+  downstream code can rely on `SupportsClientRoleWrites` as a
+  uniform check.
+- The provider abstraction is now symmetric with the realm-role
+  surface on `IIdentityProvider` (`AssignRoleAsync` /
+  `RemoveRoleAsync`) — less cognitive load for new contributors.
+
+### Negative
+
+- Entra ID create is inherently not concurrency-safe. Documented
+  in the per-method remarks and in this ADR; accepted trade-off for
+  v1. Callers expecting high-concurrency authoring need to serialize
+  at the orchestrator layer.
+- New IAM / Graph / Keycloak permissions are required. Deployments
+  upgrading from Phase 2 must grant
+  `Application.ReadWrite.All`, `manage-clients`, or `CreateGroup`
+  (depending on provider) before enabling the admin UI features
+  that call these methods.
+
+### Neutral
+
+- The `IGuidGenerator` dependency added to
+  `EntraIdIdentityProvider` formalizes a rule already in force
+  (GRSEC002 bans `Guid.NewGuid()`). All tests inject
+  `SimpleGuidGenerator`; production hosts get the tenant-aware
+  generator through `AddGranitGuids`.
+
+## Rollout
+
+1. **This PR** (#1122): interface extension, 3 provider
+   implementations, 9 unit tests (3 × 3), this ADR. No endpoint
+   changes — the admin-UI endpoint work is a separate frontend /
+   backend PR pair.
+2. **Follow-up (admin UI endpoints)**: `Granit.Identity.Endpoints`
+   will expose POST / DELETE routes that dispatch to the provider
+   via the orchestrator, guarded by `SupportsClientRoleWrites`.
+3. **Follow-up (orchestrator-level serialization)**: if the Entra
+   concurrency caveat bites in practice, introduce a per-`appId`
+   lock at the orchestrator layer. Not shipped here to avoid
+   premature complexity.
+
+## References
+
+- ADR-025 / ADR-026 / ADR-027 — Phase 2 read-only client-role sync.
+- ADR-029 — Orphan cleanup policy.
+- ADR-030 — Scheduled re-sync.
+- #1114 — RoleMetadata Phase 2b / 3 epic.
+- #1122 — this ADR's implementing PR (story).

--- a/docs-site/src/data/constants.ts
+++ b/docs-site/src/data/constants.ts
@@ -5,4 +5,4 @@ export const CULTURE_COUNT = 18;
 export const BASE_LANGUAGE_COUNT = 15;
 export const REGIONAL_VARIANT_COUNT = 3;
 export const PATTERN_COUNT = 58;
-export const ADR_COUNT = 30;
+export const ADR_COUNT = 31;

--- a/src/Granit.Identity.Federated.Cognito.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Identity.Federated.Cognito.BackgroundJobs/packages.lock.json
@@ -138,6 +138,24 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -163,6 +181,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Identity.Federated.Cognito/Diagnostics/IdentityCognitoActivitySource.cs
+++ b/src/Granit.Identity.Federated.Cognito/Diagnostics/IdentityCognitoActivitySource.cs
@@ -28,6 +28,9 @@ internal static class IdentityCognitoActivitySource
         public const string ListUserPoolClients = "cognito.list-user-pool-clients";
         public const string GetClientRoles = "cognito.get-client-roles";
         public const string GetUserClientRoles = "cognito.get-user-client-roles";
+        public const string CreateClientRole = "cognito.create-client-role";
+        public const string AssignClientRole = "cognito.assign-client-role";
+        public const string RemoveClientRole = "cognito.remove-client-role";
 #pragma warning disable GRSEC003 // Operation names, not secrets
         public const string SetPassword = "cognito.set-password";
         public const string ResetPassword = "cognito.reset-password";

--- a/src/Granit.Identity.Federated.Cognito/Internal/CognitoIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.Cognito/Internal/CognitoIdentityProvider.cs
@@ -800,6 +800,105 @@ internal sealed partial class CognitoIdentityProvider(
         }
     }
 
+    // ── Phase 3: Client-role writes (ADR-031) ──────────────────────────────
+
+    /// <inheritdoc/>
+    public async Task<IdentityRole> CreateClientRoleAsync(
+        string clientId,
+        string name,
+        string? description,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        using Activity? activity = IdentityCognitoActivitySource.Source.StartActivity(
+            IdentityCognitoActivitySource.Operations.CreateClientRole);
+        activity?.SetTag(IdentityCognitoActivitySource.Tags.ClientId, clientId);
+
+        string groupName = clientId + _clientRoleSyncOptions.Delimiter + name;
+
+        CreateGroupRequest request = new()
+        {
+            UserPoolId = _options.UserPoolId,
+            GroupName = groupName,
+            Description = description,
+        };
+
+        CreateGroupResponse response = await cognitoClient
+            .CreateGroupAsync(request, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Cognito "roles" are groups; the group name carries the Granit id semantics —
+        // there is no separate id. Returning the group name as Id preserves the contract
+        // that downstream code can round-trip the role.
+        return new IdentityRole(
+            Id: response.Group.GroupName,
+            Name: name,
+            Description: response.Group.Description)
+        { ClientId = clientId };
+    }
+
+    /// <inheritdoc/>
+    public async Task AssignClientRoleAsync(
+        string userId,
+        string clientId,
+        string roleName,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(roleName);
+
+        using Activity? activity = IdentityCognitoActivitySource.Source.StartActivity(
+            IdentityCognitoActivitySource.Operations.AssignClientRole);
+        activity?.SetTag(IdentityCognitoActivitySource.Tags.UserId, userId);
+        activity?.SetTag(IdentityCognitoActivitySource.Tags.ClientId, clientId);
+
+        string groupName = clientId + _clientRoleSyncOptions.Delimiter + roleName;
+
+        AdminAddUserToGroupRequest request = new()
+        {
+            UserPoolId = _options.UserPoolId,
+            Username = userId,
+            GroupName = groupName,
+        };
+
+        await cognitoClient
+            .AdminAddUserToGroupAsync(request, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task RemoveClientRoleAsync(
+        string userId,
+        string clientId,
+        string roleName,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(roleName);
+
+        using Activity? activity = IdentityCognitoActivitySource.Source.StartActivity(
+            IdentityCognitoActivitySource.Operations.RemoveClientRole);
+        activity?.SetTag(IdentityCognitoActivitySource.Tags.UserId, userId);
+        activity?.SetTag(IdentityCognitoActivitySource.Tags.ClientId, clientId);
+
+        string groupName = clientId + _clientRoleSyncOptions.Delimiter + roleName;
+
+        AdminRemoveUserFromGroupRequest request = new()
+        {
+            UserPoolId = _options.UserPoolId,
+            Username = userId,
+            GroupName = groupName,
+        };
+
+        await cognitoClient
+            .AdminRemoveUserFromGroupAsync(request, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     // ── Mapping helpers ────────────────────────────────────────────────────
 
     private static FederatedIdentityUser ToIdentityUser(UserType user)

--- a/src/Granit.Identity.Federated.Cognito/Internal/CognitoIdentityProviderCapabilities.cs
+++ b/src/Granit.Identity.Federated.Cognito/Internal/CognitoIdentityProviderCapabilities.cs
@@ -54,4 +54,14 @@ internal sealed class CognitoIdentityProviderCapabilities : IIdentityProviderCap
     /// see <see cref="Options.CognitoClientRoleSyncOptions"/> and ADR-027.
     /// </remarks>
     public bool SupportsClientRoles => true;
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Backed by <c>CreateGroup</c> (with <c>{clientId}{Delimiter}{name}</c> naming per
+    /// ADR-027), <c>AdminAddUserToGroup</c>, and <c>AdminRemoveUserFromGroup</c>.
+    /// Requires IAM permissions <c>cognito-idp:CreateGroup</c>,
+    /// <c>cognito-idp:AdminAddUserToGroup</c>, and <c>cognito-idp:AdminRemoveUserFromGroup</c>
+    /// on the target User Pool.
+    /// </remarks>
+    public bool SupportsClientRoleWrites => true;
 }

--- a/src/Granit.Identity.Federated.EntraId.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Identity.Federated.EntraId.BackgroundJobs/packages.lock.json
@@ -278,6 +278,24 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -310,6 +328,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Identity.Federated.EntraId/Diagnostics/IdentityEntraIdActivitySource.cs
+++ b/src/Granit.Identity.Federated.EntraId/Diagnostics/IdentityEntraIdActivitySource.cs
@@ -28,6 +28,9 @@ internal static class IdentityEntraIdActivitySource
     internal const string GetClients = "identity.entraid.get-clients";
     internal const string GetClientRoles = "identity.entraid.get-client-roles";
     internal const string GetUserClientRoles = "identity.entraid.get-user-client-roles";
+    internal const string CreateClientRole = "identity.entraid.create-client-role";
+    internal const string AssignClientRole = "identity.entraid.assign-client-role";
+    internal const string RemoveClientRole = "identity.entraid.remove-client-role";
     internal const string SetUserEnabled = "identity.entraid.set-user-enabled";
     internal const string UpdateUser = "identity.entraid.update-user";
     internal const string GetUserSessions = "identity.entraid.get-user-sessions";

--- a/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProvider.cs
@@ -39,6 +39,7 @@ internal sealed partial class EntraIdIdentityProvider(
     IOptions<EntraIdAdminOptions> options,
     IPasswordResetNotifier passwordResetNotifier,
     IDistributedEventBus distributedEventBus,
+    Granit.Guids.IGuidGenerator guidGenerator,
     ILogger<EntraIdIdentityProvider> logger) : IIdentityProvider, IIdentityClientRoleManager
 {
     private const string ProviderName = "entra-id";
@@ -632,6 +633,137 @@ internal sealed partial class EntraIdIdentityProvider(
             : null;
 
         return match ?? throw new EntraIdClientNotFoundException(appId);
+    }
+
+    // ──── Phase 3: Client-role writes (ADR-031) ────
+
+    /// <inheritdoc/>
+    public async Task<IdentityRole> CreateClientRoleAsync(
+        string clientId,
+        string name,
+        string? description,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        using Activity? activity = IdentityEntraIdActivitySource.Source.StartActivity(IdentityEntraIdActivitySource.CreateClientRole);
+        activity?.SetTag(IdentityEntraIdActivitySource.TagClientId, clientId);
+
+        HttpClient client = await CreateAuthenticatedClientAsync(cancellationToken).ConfigureAwait(false);
+
+        // App Roles live on the Application object, not the Service Principal — fetch the
+        // app, append to appRoles, PATCH the whole array back. Not concurrency-safe against
+        // parallel writers; see ADR-031 for the trade-off.
+        GraphCollectionResponse<GraphApplicationRepresentation>? response = await client
+            .GetFromJsonAsync<GraphCollectionResponse<GraphApplicationRepresentation>>(
+                EntraIdAdminOptions.GetApplicationsEndpoint(clientId), cancellationToken)
+            .ConfigureAwait(false);
+
+        GraphApplicationRepresentation app = response?.Value?.FirstOrDefault()
+            ?? throw new EntraIdClientNotFoundException(clientId);
+
+        string newRoleId = guidGenerator.Create().ToString();
+        GraphAppRoleRepresentation newRole = new(
+            Id: newRoleId,
+            DisplayName: name,
+            Value: name,
+            Description: description,
+            IsEnabled: true)
+        {
+            AllowedMemberTypes = ["User"],
+        };
+
+        List<GraphAppRoleRepresentation> existing = app.AppRoles ?? [];
+        existing.Add(newRole);
+
+        using HttpResponseMessage patch = await client.PatchAsJsonAsync(
+            EntraIdAdminOptions.GetApplicationEndpoint(app.Id),
+            new { appRoles = existing },
+            cancellationToken).ConfigureAwait(false);
+        patch.EnsureSuccessStatusCode();
+
+        return new IdentityRole(newRoleId, name, description) { ClientId = clientId };
+    }
+
+    /// <inheritdoc/>
+    public async Task AssignClientRoleAsync(
+        string userId,
+        string clientId,
+        string roleName,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(roleName);
+
+        using Activity? activity = IdentityEntraIdActivitySource.Source.StartActivity(IdentityEntraIdActivitySource.AssignClientRole);
+        activity?.SetTag(IdentityEntraIdActivitySource.TagUserId, userId);
+        activity?.SetTag(IdentityEntraIdActivitySource.TagClientId, clientId);
+
+        HttpClient client = await CreateAuthenticatedClientAsync(cancellationToken).ConfigureAwait(false);
+        GraphServicePrincipalRepresentation sp = await ResolveServicePrincipalAsync(client, clientId, cancellationToken).ConfigureAwait(false);
+        GraphAppRoleRepresentation role = FindAppRoleByName(sp, clientId, roleName);
+
+        using HttpResponseMessage post = await client.PostAsJsonAsync(
+            EntraIdAdminOptions.GetUserAppRoleAssignmentsEndpoint(userId),
+            new
+            {
+                principalId = userId,
+                resourceId = sp.Id,
+                appRoleId = role.Id,
+            },
+            cancellationToken).ConfigureAwait(false);
+        post.EnsureSuccessStatusCode();
+    }
+
+    /// <inheritdoc/>
+    public async Task RemoveClientRoleAsync(
+        string userId,
+        string clientId,
+        string roleName,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(roleName);
+
+        using Activity? activity = IdentityEntraIdActivitySource.Source.StartActivity(IdentityEntraIdActivitySource.RemoveClientRole);
+        activity?.SetTag(IdentityEntraIdActivitySource.TagUserId, userId);
+        activity?.SetTag(IdentityEntraIdActivitySource.TagClientId, clientId);
+
+        HttpClient client = await CreateAuthenticatedClientAsync(cancellationToken).ConfigureAwait(false);
+        GraphServicePrincipalRepresentation sp = await ResolveServicePrincipalAsync(client, clientId, cancellationToken).ConfigureAwait(false);
+        GraphAppRoleRepresentation role = FindAppRoleByName(sp, clientId, roleName);
+
+        string listEndpoint = EntraIdAdminOptions.GetUserAppRoleAssignmentsForServicePrincipalEndpoint(userId, sp.Id);
+        GraphCollectionResponse<GraphAppRoleAssignmentRepresentation>? list = await client
+            .GetFromJsonAsync<GraphCollectionResponse<GraphAppRoleAssignmentRepresentation>>(listEndpoint, cancellationToken)
+            .ConfigureAwait(false);
+
+        GraphAppRoleAssignmentRepresentation? assignment = list?.Value?
+            .FirstOrDefault(a => string.Equals(a.AppRoleId, role.Id, StringComparison.OrdinalIgnoreCase));
+
+        if (assignment is null)
+        {
+            // No-op: the user did not carry the role — matches the interface contract.
+            return;
+        }
+
+        using HttpResponseMessage delete = await client.DeleteAsync(
+            EntraIdAdminOptions.GetUserAppRoleAssignmentEndpoint(userId, assignment.Id),
+            cancellationToken).ConfigureAwait(false);
+        delete.EnsureSuccessStatusCode();
+    }
+
+    private static GraphAppRoleRepresentation FindAppRoleByName(
+        GraphServicePrincipalRepresentation sp, string clientId, string roleName)
+    {
+        GraphAppRoleRepresentation? role = sp.AppRoles?
+            .FirstOrDefault(r => string.Equals(r.Value, roleName, StringComparison.Ordinal));
+
+        return role ?? throw new InvalidOperationException(
+            $"Entra ID App Role '{roleName}' not found on appId '{clientId}'.");
     }
 
     // ──── Session termination ────

--- a/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProviderCapabilities.cs
+++ b/src/Granit.Identity.Federated.EntraId/Internal/EntraIdIdentityProviderCapabilities.cs
@@ -62,4 +62,14 @@ internal sealed class EntraIdIdentityProviderCapabilities : IIdentityProviderCap
     /// <see cref="EntraIdIdentityProvider"/>.
     /// </remarks>
     public bool SupportsClientRoles => true;
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Supported via Graph API: <c>CreateClientRoleAsync</c> PATCHes the Application's
+    /// <c>appRoles</c> array (not concurrency-safe); <c>AssignClientRoleAsync</c> /
+    /// <c>RemoveClientRoleAsync</c> operate on <c>appRoleAssignments</c>. Requires the
+    /// <c>Application.ReadWrite.All</c> and <c>AppRoleAssignment.ReadWrite.All</c>
+    /// Graph application permissions.
+    /// </remarks>
+    public bool SupportsClientRoleWrites => true;
 }

--- a/src/Granit.Identity.Federated.EntraId/Internal/GraphAppRoleRepresentation.cs
+++ b/src/Granit.Identity.Federated.EntraId/Internal/GraphAppRoleRepresentation.cs
@@ -10,4 +10,13 @@ internal sealed record GraphAppRoleRepresentation(
     [property: JsonPropertyName("displayName")] string DisplayName,
     [property: JsonPropertyName("value")] string Value,
     [property: JsonPropertyName("description")] string? Description = null,
-    [property: JsonPropertyName("isEnabled")] bool IsEnabled = true);
+    [property: JsonPropertyName("isEnabled")] bool IsEnabled = true)
+{
+    /// <summary>
+    /// Microsoft Graph requires <c>allowedMemberTypes</c> on every App Role. Defaults to
+    /// <c>["User"]</c> — the only value Granit uses today; Graph also accepts
+    /// <c>"Application"</c> for service-to-service roles but Granit does not manage those.
+    /// </summary>
+    [JsonPropertyName("allowedMemberTypes")]
+    public IReadOnlyList<string> AllowedMemberTypes { get; init; } = ["User"];
+}

--- a/src/Granit.Identity.Federated.EntraId/Internal/GraphApplicationRepresentation.cs
+++ b/src/Granit.Identity.Federated.EntraId/Internal/GraphApplicationRepresentation.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace Granit.Identity.Federated.EntraId.Internal;
+
+/// <summary>
+/// Internal DTO for Microsoft Graph <c>Application</c> resource. Used by the Phase 3
+/// <c>CreateClientRoleAsync</c> path: App Roles are authored on the Application, not on
+/// the Service Principal, so the write flow fetches the app + its current appRoles,
+/// appends, and PATCHes the whole array back.
+/// </summary>
+internal sealed record GraphApplicationRepresentation(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("appId")] string AppId)
+{
+    [JsonPropertyName("appRoles")]
+    public List<GraphAppRoleRepresentation>? AppRoles { get; init; }
+}

--- a/src/Granit.Identity.Federated.EntraId/Options/EntraIdAdminOptions.cs
+++ b/src/Granit.Identity.Federated.EntraId/Options/EntraIdAdminOptions.cs
@@ -177,6 +177,30 @@ public sealed class EntraIdAdminOptions
         $"/v1.0/users/{Uri.EscapeDataString(userId)}/appRoleAssignments" +
         $"?$filter=resourceId eq {servicePrincipalObjectId}";
 
+    // ──── Client-role writes (Phase 3, ADR-031) ────
+
+    /// <summary>
+    /// Builds the Graph API URL for listing / projecting Applications filtered by
+    /// <paramref name="appId"/>. App Roles are authored on the <c>Application</c> object, NOT
+    /// on the Service Principal — Phase 3 <c>CreateClientRoleAsync</c> fetches the application
+    /// to learn its <c>id</c> and current <c>appRoles</c> array before PATCHing.
+    /// </summary>
+    internal static string GetApplicationsEndpoint(string appId) =>
+        $"/v1.0/applications?$filter=appId eq '{Uri.EscapeDataString(appId)}'&$select=id,appId,appRoles";
+
+    /// <summary>
+    /// Builds the Graph API URL for a specific Application by its object id. Used by Phase 3
+    /// <c>CreateClientRoleAsync</c> to PATCH the updated <c>appRoles</c> array.
+    /// </summary>
+    internal static string GetApplicationEndpoint(string applicationObjectId) =>
+        $"/v1.0/applications/{Uri.EscapeDataString(applicationObjectId)}";
+
+    /// <summary>
+    /// Builds the Graph API URL for deleting a single App Role assignment on a user.
+    /// </summary>
+    internal static string GetUserAppRoleAssignmentEndpoint(string userId, string assignmentId) =>
+        $"/v1.0/users/{Uri.EscapeDataString(userId)}/appRoleAssignments/{Uri.EscapeDataString(assignmentId)}";
+
     // ──── Sessions ────
 
     /// <summary>

--- a/src/Granit.Identity.Federated.Keycloak.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Identity.Federated.Keycloak.BackgroundJobs/packages.lock.json
@@ -278,6 +278,24 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -310,6 +328,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }

--- a/src/Granit.Identity.Federated.Keycloak/Diagnostics/IdentityKeycloakActivitySource.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Diagnostics/IdentityKeycloakActivitySource.cs
@@ -28,6 +28,9 @@ internal static class IdentityKeycloakActivitySource
     internal const string GetClients = "identity.keycloak.get-clients";
     internal const string GetClientRoles = "identity.keycloak.get-client-roles";
     internal const string GetUserClientRoles = "identity.keycloak.get-user-client-roles";
+    internal const string CreateClientRole = "identity.keycloak.create-client-role";
+    internal const string AssignClientRole = "identity.keycloak.assign-client-role";
+    internal const string RemoveClientRole = "identity.keycloak.remove-client-role";
     internal const string SetUserEnabled = "identity.keycloak.set-user-enabled";
     internal const string UpdateUser = "identity.keycloak.update-user";
     internal const string GetUserSessions = "identity.keycloak.get-user-sessions";

--- a/src/Granit.Identity.Federated.Keycloak/Extensions/IdentityKeycloakServiceCollectionExtensions.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Extensions/IdentityKeycloakServiceCollectionExtensions.cs
@@ -53,6 +53,13 @@ public static class IdentityKeycloakServiceCollectionExtensions
             client.Timeout = TimeSpan.FromSeconds(opts.TimeoutSeconds);
         });
 
+        // Defensive — KeycloakUserTokenExchangeService depends on TimeProvider for
+        // rate-limit / refresh-token clock decisions (see PR #1139). Register the
+        // system provider so hosts that don't compose Granit.Timing still resolve
+        // cleanly. Production hosts typically get this from AddGranitTiming; the
+        // TryAddSingleton keeps the default when already provided.
+        services.TryAddSingleton(TimeProvider.System);
+
         services.TryAddSingleton<KeycloakAdminTokenService>();
         services.TryAddTransient<KeycloakUserTokenExchangeService>();
 

--- a/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProvider.cs
@@ -564,6 +564,123 @@ internal sealed partial class KeycloakIdentityProvider(
         return match?.Id ?? throw new KeycloakClientNotFoundException(clientId);
     }
 
+    // ──── Phase 3: Client-role writes (ADR-031) ────
+
+    /// <inheritdoc/>
+    public async Task<IdentityRole> CreateClientRoleAsync(
+        string clientId,
+        string name,
+        string? description,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        using Activity? activity = IdentityKeycloakActivitySource.Source.StartActivity(IdentityKeycloakActivitySource.CreateClientRole);
+        activity?.SetTag(IdentityKeycloakActivitySource.TagClientId, clientId);
+
+        HttpClient client = await CreateAuthenticatedClientAsync(cancellationToken).ConfigureAwait(false);
+        string clientUuid = await ResolveClientUuidAsync(client, clientId, cancellationToken).ConfigureAwait(false);
+
+        KeycloakRoleRepresentation payload = new(
+            Id: string.Empty, // server-assigned
+            Name: name,
+            Description: description)
+        {
+            ContainerId = clientUuid,
+            ClientRole = true,
+        };
+
+        using HttpResponseMessage response = await client.PostAsJsonAsync(
+            options.Value.GetClientRolesEndpoint(clientUuid), payload, cancellationToken)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        // Keycloak returns 201 Created with an empty body; re-fetch the role to pick up its id.
+        KeycloakRoleRepresentation? created = await client
+            .GetFromJsonAsync<KeycloakRoleRepresentation>(
+                options.Value.GetClientRoleByNameEndpoint(clientUuid, name), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (created is null)
+        {
+            throw new InvalidOperationException(
+                $"Keycloak created client role '{name}' on '{clientId}' but did not return it on re-fetch.");
+        }
+
+        return new IdentityRole(created.Id, created.Name, created.Description) { ClientId = clientId };
+    }
+
+    /// <inheritdoc/>
+    public async Task AssignClientRoleAsync(
+        string userId,
+        string clientId,
+        string roleName,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(roleName);
+
+        using Activity? activity = IdentityKeycloakActivitySource.Source.StartActivity(IdentityKeycloakActivitySource.AssignClientRole);
+        activity?.SetTag(IdentityKeycloakActivitySource.TagUserId, userId);
+        activity?.SetTag(IdentityKeycloakActivitySource.TagClientId, clientId);
+
+        HttpClient client = await CreateAuthenticatedClientAsync(cancellationToken).ConfigureAwait(false);
+        string clientUuid = await ResolveClientUuidAsync(client, clientId, cancellationToken).ConfigureAwait(false);
+        KeycloakRoleRepresentation role = await LookupClientRoleAsync(client, clientUuid, clientId, roleName, cancellationToken).ConfigureAwait(false);
+
+        using HttpResponseMessage response = await client.PostAsJsonAsync(
+            options.Value.GetUserClientRoleMappingsEndpoint(userId, clientUuid),
+            new[] { role },
+            cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+
+    /// <inheritdoc/>
+    public async Task RemoveClientRoleAsync(
+        string userId,
+        string clientId,
+        string roleName,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(roleName);
+
+        using Activity? activity = IdentityKeycloakActivitySource.Source.StartActivity(IdentityKeycloakActivitySource.RemoveClientRole);
+        activity?.SetTag(IdentityKeycloakActivitySource.TagUserId, userId);
+        activity?.SetTag(IdentityKeycloakActivitySource.TagClientId, clientId);
+
+        HttpClient client = await CreateAuthenticatedClientAsync(cancellationToken).ConfigureAwait(false);
+        string clientUuid = await ResolveClientUuidAsync(client, clientId, cancellationToken).ConfigureAwait(false);
+        KeycloakRoleRepresentation role = await LookupClientRoleAsync(client, clientUuid, clientId, roleName, cancellationToken).ConfigureAwait(false);
+
+        HttpRequestMessage request = new(HttpMethod.Delete,
+            options.Value.GetUserClientRoleMappingsEndpoint(userId, clientUuid))
+        {
+            Content = System.Net.Http.Json.JsonContent.Create(new[] { role }),
+        };
+        using HttpResponseMessage response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+
+    private async Task<KeycloakRoleRepresentation> LookupClientRoleAsync(
+        HttpClient client,
+        string clientUuid,
+        string clientId,
+        string roleName,
+        CancellationToken cancellationToken)
+    {
+        KeycloakRoleRepresentation? role = await client
+            .GetFromJsonAsync<KeycloakRoleRepresentation>(
+                options.Value.GetClientRoleByNameEndpoint(clientUuid, roleName), cancellationToken)
+            .ConfigureAwait(false);
+
+        return role ?? throw new InvalidOperationException(
+            $"Keycloak client role '{roleName}' not found on client '{clientId}'.");
+    }
+
     // ──── Feature 2: Session termination ────
 
     /// <inheritdoc/>

--- a/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProviderCapabilities.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Internal/KeycloakIdentityProviderCapabilities.cs
@@ -42,4 +42,13 @@ internal sealed class KeycloakIdentityProviderCapabilities : IIdentityProviderCa
 
     /// <inheritdoc/>
     public bool SupportsClientRoles => true;
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Keycloak's Admin REST API supports creating client roles and assigning / unassigning
+    /// them on users. The service account must carry <c>manage-clients</c> and
+    /// <c>manage-users</c> roles under <c>realm-management</c> in addition to the read
+    /// roles required by the Phase 2 read path.
+    /// </remarks>
+    public bool SupportsClientRoleWrites => true;
 }

--- a/src/Granit.Identity.Federated.Keycloak/Options/KeycloakAdminOptions.cs
+++ b/src/Granit.Identity.Federated.Keycloak/Options/KeycloakAdminOptions.cs
@@ -189,6 +189,14 @@ public sealed class KeycloakAdminOptions
         $"{BaseUrl.TrimEnd('/')}/admin/realms/{Realm}/clients/{Uri.EscapeDataString(clientUuid)}/roles";
 
     /// <summary>
+    /// Builds the Admin API URL for a specific client role on the given client
+    /// (identified by its internal UUID). Used by the Phase 3 write path to resolve the
+    /// role's provider-assigned id before POSTing / DELETEing role-mapping payloads.
+    /// </summary>
+    internal string GetClientRoleByNameEndpoint(string clientUuid, string roleName) =>
+        $"{BaseUrl.TrimEnd('/')}/admin/realms/{Realm}/clients/{Uri.EscapeDataString(clientUuid)}/roles/{Uri.EscapeDataString(roleName)}";
+
+    /// <summary>
     /// Builds the Admin API URL for listing client-scope role mappings of a user for a given
     /// Keycloak client (identified by its internal UUID).
     /// </summary>

--- a/src/Granit.Identity/IIdentityClientRoleManager.cs
+++ b/src/Granit.Identity/IIdentityClientRoleManager.cs
@@ -17,10 +17,13 @@ namespace Granit.Identity;
 /// guard their code with <c>IIdentityProviderCapabilities.SupportsClientRoles</c>.
 /// </para>
 /// <para>
-/// The read-only shape below is the Phase 2a surface: <c>CreateClientRoleAsync</c> and
-/// user ↔ client-role assignment operations are deferred until a concrete need arises —
-/// most deployments provision client roles via IaC (Keycloak CLI, Terraform, Cognito
-/// console) and expose them in Granit for permission grants only.
+/// Phase 2 shipped the read-only shape; Phase 3 (ADR-031) adds the three write methods
+/// — <see cref="CreateClientRoleAsync"/>, <see cref="AssignClientRoleAsync"/>,
+/// <see cref="RemoveClientRoleAsync"/> — for Granit-first deployments where the admin UI
+/// is the source of truth rather than upstream IaC. Providers that cannot honour
+/// writes (or don't want to, by policy) report
+/// <c>IIdentityProviderCapabilities.SupportsClientRoleWrites = false</c>; callers must
+/// guard on that flag.
 /// </para>
 /// </remarks>
 public interface IIdentityClientRoleManager
@@ -44,5 +47,55 @@ public interface IIdentityClientRoleManager
     Task<IReadOnlyList<IdentityRole>> GetUserClientRolesAsync(
         string userId,
         string clientId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a client-scoped role under <paramref name="clientId"/> with the given
+    /// <paramref name="name"/> and optional <paramref name="description"/>. Returns the
+    /// created <see cref="IdentityRole"/> — its <c>Id</c> is the provider-assigned
+    /// identifier, <c>ClientId</c> is the given <paramref name="clientId"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Provider-specific naming / collision semantics:
+    /// </para>
+    /// <list type="bullet">
+    ///   <item>Keycloak: creates via <c>POST /admin/realms/{realm}/clients/{uuid}/roles</c>.
+    ///         Duplicates return HTTP 409 which the implementation surfaces as the caller's
+    ///         responsibility.</item>
+    ///   <item>Entra ID: App Roles are stored as a single array on the application. The
+    ///         implementation reads the current <c>appRoles</c>, appends the new entry, and
+    ///         PATCHes the whole array back — inherently not safe against concurrent
+    ///         application-level edits.</item>
+    ///   <item>Cognito: creates a group named <c>{clientId}{Delimiter}{name}</c> per
+    ///         ADR-027 naming convention. The provider reads the delimiter from its
+    ///         injected <c>CognitoClientRoleSyncOptions</c>.</item>
+    /// </list>
+    /// </remarks>
+    Task<IdentityRole> CreateClientRoleAsync(
+        string clientId,
+        string name,
+        string? description,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Grants the role identified by <paramref name="roleName"/> on <paramref name="clientId"/>
+    /// to the given user. Idempotent at the provider level when the assignment already
+    /// exists (Keycloak / Entra / Cognito all accept the call as a no-op).
+    /// </summary>
+    Task AssignClientRoleAsync(
+        string userId,
+        string clientId,
+        string roleName,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Revokes a previously granted client-scoped role assignment. No-op if the user
+    /// did not carry the role.
+    /// </summary>
+    Task RemoveClientRoleAsync(
+        string userId,
+        string clientId,
+        string roleName,
         CancellationToken cancellationToken = default);
 }

--- a/src/Granit.Identity/IIdentityProviderCapabilities.cs
+++ b/src/Granit.Identity/IIdentityProviderCapabilities.cs
@@ -64,4 +64,15 @@ public interface IIdentityProviderCapabilities
     /// roles, Cognito app-client groups) override to <see langword="true"/>.
     /// </summary>
     bool SupportsClientRoles => false;
+
+    /// <summary>
+    /// Whether <see cref="IIdentityClientRoleManager"/>'s write methods
+    /// (<c>CreateClientRoleAsync</c>, <c>AssignClientRoleAsync</c>,
+    /// <c>RemoveClientRoleAsync</c>) are backed by a live implementation on this provider.
+    /// Default: <see langword="false"/> (DIM). Providers that want Granit to be the source
+    /// of truth for client-role provisioning override to <see langword="true"/>; read-only
+    /// deployments (upstream IaC owns the roles) keep the default and the admin surfaces
+    /// guard on this flag before exposing create / assign / remove actions. See ADR-031.
+    /// </summary>
+    bool SupportsClientRoleWrites => false;
 }

--- a/tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.BackgroundJobs.Tests/packages.lock.json
@@ -370,6 +370,24 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -395,6 +413,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }

--- a/tests/Granit.Identity.Federated.Cognito.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Cognito.Tests.Integration/packages.lock.json
@@ -1324,6 +1324,24 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -1349,6 +1367,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }

--- a/tests/Granit.Identity.Federated.Cognito.Tests/CognitoClientRoleTests.cs
+++ b/tests/Granit.Identity.Federated.Cognito.Tests/CognitoClientRoleTests.cs
@@ -162,4 +162,101 @@ public sealed class CognitoClientRoleTests
         roles[0].Name.ShouldBe("admin");
         roles[0].ClientId.ShouldBe("clientA");
     }
+
+    // ──── ADR-031 — client-role writes ────────────────────────────────────
+
+    [Fact]
+    public async Task CreateClientRoleAsync_CreatesGroup_WithPrefixedName()
+    {
+        _cognitoClient.CreateGroupAsync(
+                Arg.Any<CreateGroupRequest>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                CreateGroupRequest req = ci.Arg<CreateGroupRequest>();
+                return new CreateGroupResponse
+                {
+                    Group = new GroupType
+                    {
+                        GroupName = req.GroupName,
+                        Description = req.Description,
+                    },
+                };
+            });
+        CognitoIdentityProvider sut = BuildSut();
+
+        IdentityRole created = await sut.CreateClientRoleAsync(
+            "clientA", "editor", "Edit docs", TestContext.Current.CancellationToken);
+
+        created.Id.ShouldBe("clientA:editor");
+        created.Name.ShouldBe("editor");
+        created.ClientId.ShouldBe("clientA");
+        created.Description.ShouldBe("Edit docs");
+
+        await _cognitoClient.Received(1).CreateGroupAsync(
+            Arg.Is<CreateGroupRequest>(r =>
+                r.UserPoolId == "eu-west-1_TEST" &&
+                r.GroupName == "clientA:editor" &&
+                r.Description == "Edit docs"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateClientRoleAsync_CustomDelimiter_UsesDelimiterInGroupName()
+    {
+        _cognitoClient.CreateGroupAsync(
+                Arg.Any<CreateGroupRequest>(), Arg.Any<CancellationToken>())
+            .Returns(ci => new CreateGroupResponse
+            {
+                Group = new GroupType
+                {
+                    GroupName = ci.Arg<CreateGroupRequest>().GroupName,
+                    Description = ci.Arg<CreateGroupRequest>().Description,
+                },
+            });
+        CognitoIdentityProvider sut = BuildSut(delimiter: "__");
+
+        IdentityRole created = await sut.CreateClientRoleAsync(
+            "clientA", "viewer", null, TestContext.Current.CancellationToken);
+
+        created.Id.ShouldBe("clientA__viewer");
+        created.Name.ShouldBe("viewer");
+    }
+
+    [Fact]
+    public async Task AssignClientRoleAsync_AddsUserToPrefixedGroup()
+    {
+        _cognitoClient.AdminAddUserToGroupAsync(
+                Arg.Any<AdminAddUserToGroupRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new AdminAddUserToGroupResponse());
+        CognitoIdentityProvider sut = BuildSut();
+
+        await sut.AssignClientRoleAsync(
+            "user-42", "clientA", "editor", TestContext.Current.CancellationToken);
+
+        await _cognitoClient.Received(1).AdminAddUserToGroupAsync(
+            Arg.Is<AdminAddUserToGroupRequest>(r =>
+                r.UserPoolId == "eu-west-1_TEST" &&
+                r.Username == "user-42" &&
+                r.GroupName == "clientA:editor"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RemoveClientRoleAsync_RemovesUserFromPrefixedGroup()
+    {
+        _cognitoClient.AdminRemoveUserFromGroupAsync(
+                Arg.Any<AdminRemoveUserFromGroupRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new AdminRemoveUserFromGroupResponse());
+        CognitoIdentityProvider sut = BuildSut();
+
+        await sut.RemoveClientRoleAsync(
+            "user-42", "clientA", "editor", TestContext.Current.CancellationToken);
+
+        await _cognitoClient.Received(1).AdminRemoveUserFromGroupAsync(
+            Arg.Is<AdminRemoveUserFromGroupRequest>(r =>
+                r.UserPoolId == "eu-west-1_TEST" &&
+                r.Username == "user-42" &&
+                r.GroupName == "clientA:editor"),
+            Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/Granit.Identity.Federated.EntraId.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntraId.BackgroundJobs.Tests/packages.lock.json
@@ -510,6 +510,24 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -542,6 +560,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }

--- a/tests/Granit.Identity.Federated.EntraId.Tests.Integration/EntraIdClientRoleSyncTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests.Integration/EntraIdClientRoleSyncTests.cs
@@ -75,7 +75,7 @@ public sealed class EntraIdClientRoleSyncTests : IClassFixture<EntraIdWireMockFi
 
         EntraIdIdentityProvider provider = new(
             tokenService, _httpClientFactory, adminOptsWrapper,
-            notifier, eventBus,
+            notifier, eventBus, new SimpleGuidGenerator(),
             NullLogger<EntraIdIdentityProvider>.Instance);
 
         InMemoryRoleMetadataStore store = new();

--- a/tests/Granit.Identity.Federated.EntraId.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.EntraId.Tests.Integration/packages.lock.json
@@ -1440,6 +1440,24 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -1472,6 +1490,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }

--- a/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdClientRoleTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdClientRoleTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Granit.Events;
+using Granit.Guids;
 using Granit.Identity;
 using Granit.Identity.Federated.EntraId.Exceptions;
 using Granit.Identity.Federated.EntraId.Internal;
@@ -35,6 +36,7 @@ public sealed class EntraIdClientRoleTests : IDisposable
     private readonly ActivityListener _activityListener;
     private HttpClient? _graphHttpClient;
     private HttpClient? _tokenHttpClient;
+    private MockSequenceHttpMessageHandler? _graphHandler;
 
     public EntraIdClientRoleTests()
     {
@@ -58,8 +60,8 @@ public sealed class EntraIdClientRoleTests : IDisposable
         _graphHttpClient?.Dispose();
         _tokenHttpClient?.Dispose();
 
-        MockSequenceHttpMessageHandler handler = new(responses);
-        _graphHttpClient = new HttpClient(handler) { BaseAddress = new Uri("https://graph.microsoft.com/") };
+        _graphHandler = new MockSequenceHttpMessageHandler(responses);
+        _graphHttpClient = new HttpClient(_graphHandler) { BaseAddress = new Uri("https://graph.microsoft.com/") };
         _httpClientFactory.CreateClient("MicrosoftGraph").Returns(_graphHttpClient);
 
         MockHttpMessageHandler tokenHandler = new()
@@ -85,6 +87,7 @@ public sealed class EntraIdClientRoleTests : IDisposable
             Microsoft.Extensions.Options.Options.Create(_options),
             _passwordResetNotifier,
             _distributedEventBus,
+            new SimpleGuidGenerator(),
             NullLogger<EntraIdIdentityProvider>.Instance);
     }
 
@@ -176,5 +179,136 @@ public sealed class EntraIdClientRoleTests : IDisposable
         roles.Count.ShouldBe(1);
         roles[0].Name.ShouldBe("Admin");
         roles[0].ClientId.ShouldBe(appId);
+    }
+
+    // ──── ADR-031 — client-role writes ────────────────────────────────────
+
+    [Fact]
+    public async Task CreateClientRoleAsync_GetsApplication_ThenPatchesAppRolesArray()
+    {
+        const string appId = "11111111-1111-1111-1111-111111111111";
+        const string appObjectId = "app-object-id-1";
+        // 1st response = GET /applications (resolve app object id + existing appRoles)
+        string applicationResponse = $$"""
+            {"value":[{
+              "id":"{{appObjectId}}",
+              "appId":"{{appId}}",
+              "appRoles":[
+                {"id":"r1","displayName":"Existing","value":"Existing","description":null,"isEnabled":true,"allowedMemberTypes":["User"]}
+              ]
+            }]}
+            """;
+        // 2nd response = PATCH /applications/{objectId} — body ignored
+        const string patchResponse = "{}";
+        EntraIdIdentityProvider provider = BuildProvider(applicationResponse, patchResponse);
+
+        IdentityRole created = await provider.CreateClientRoleAsync(
+            appId, "Editor", "Edit docs", TestContext.Current.CancellationToken);
+
+        created.Id.ShouldNotBeNullOrWhiteSpace();
+        created.Name.ShouldBe("Editor");
+        created.Description.ShouldBe("Edit docs");
+        created.ClientId.ShouldBe(appId);
+
+        _graphHandler!.Requests.Count.ShouldBe(2);
+        _graphHandler.Requests[0].Method.ShouldBe("GET");
+        _graphHandler.Requests[0].Url.ShouldContain("/v1.0/applications");
+        _graphHandler.Requests[1].Method.ShouldBe("PATCH");
+        _graphHandler.Requests[1].Url.ShouldContain($"/v1.0/applications/{appObjectId}");
+        // Body MUST contain both the pre-existing role AND the new one (concurrency-unsafe PATCH).
+        _graphHandler.Requests[1].Body.ShouldContain("Existing");
+        _graphHandler.Requests[1].Body.ShouldContain("Editor");
+    }
+
+    [Fact]
+    public async Task CreateClientRoleAsync_UnknownAppId_Throws()
+    {
+        const string emptyResolve = """{"value":[]}""";
+        EntraIdIdentityProvider provider = BuildProvider(emptyResolve);
+
+        await Should.ThrowAsync<EntraIdClientNotFoundException>(
+            async () => await provider.CreateClientRoleAsync(
+                "nonexistent-app-id", "Editor", null, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task AssignClientRoleAsync_ResolvesSp_ThenPostsAppRoleAssignment()
+    {
+        const string appId = "11111111-1111-1111-1111-111111111111";
+        string resolveResponse = $$"""
+            {"value":[{
+              "id":"sp-object-id-1",
+              "appId":"{{appId}}",
+              "appRoles":[
+                {"id":"r-editor","displayName":"Editor","value":"Editor","description":null,"isEnabled":true}
+              ]
+            }]}
+            """;
+        const string postResponse = "{}";
+        EntraIdIdentityProvider provider = BuildProvider(resolveResponse, postResponse);
+
+        await provider.AssignClientRoleAsync(
+            "user-42", appId, "Editor", TestContext.Current.CancellationToken);
+
+        _graphHandler!.Requests.Count.ShouldBe(2);
+        _graphHandler.Requests[0].Method.ShouldBe("GET");
+        _graphHandler.Requests[0].Url.ShouldContain("/v1.0/servicePrincipals");
+        _graphHandler.Requests[1].Method.ShouldBe("POST");
+        _graphHandler.Requests[1].Url.ShouldContain("/v1.0/users/user-42/appRoleAssignments");
+        _graphHandler.Requests[1].Body.ShouldContain("r-editor");
+        _graphHandler.Requests[1].Body.ShouldContain("sp-object-id-1");
+    }
+
+    [Fact]
+    public async Task RemoveClientRoleAsync_FindsAssignment_ThenDeletesIt()
+    {
+        const string appId = "11111111-1111-1111-1111-111111111111";
+        string resolveResponse = $$"""
+            {"value":[{
+              "id":"sp-object-id-1",
+              "appId":"{{appId}}",
+              "appRoles":[
+                {"id":"r-editor","displayName":"Editor","value":"Editor","description":null,"isEnabled":true}
+              ]
+            }]}
+            """;
+        const string assignmentsResponse = """
+            {"value":[
+              {"id":"assignment-42","appRoleId":"r-editor","principalId":"user-42","resourceId":"sp-object-id-1"}
+            ]}
+            """;
+        const string deleteResponse = "{}";
+        EntraIdIdentityProvider provider = BuildProvider(resolveResponse, assignmentsResponse, deleteResponse);
+
+        await provider.RemoveClientRoleAsync(
+            "user-42", appId, "Editor", TestContext.Current.CancellationToken);
+
+        _graphHandler!.Requests.Count.ShouldBe(3);
+        _graphHandler.Requests[2].Method.ShouldBe("DELETE");
+        _graphHandler.Requests[2].Url.ShouldContain("/v1.0/users/user-42/appRoleAssignments/assignment-42");
+    }
+
+    [Fact]
+    public async Task RemoveClientRoleAsync_NoMatchingAssignment_Noop()
+    {
+        const string appId = "11111111-1111-1111-1111-111111111111";
+        string resolveResponse = $$"""
+            {"value":[{
+              "id":"sp-object-id-1",
+              "appId":"{{appId}}",
+              "appRoles":[
+                {"id":"r-editor","displayName":"Editor","value":"Editor","description":null,"isEnabled":true}
+              ]
+            }]}
+            """;
+        const string emptyAssignments = """{"value":[]}""";
+        EntraIdIdentityProvider provider = BuildProvider(resolveResponse, emptyAssignments);
+
+        await provider.RemoveClientRoleAsync(
+            "user-42", appId, "Editor", TestContext.Current.CancellationToken);
+
+        // No DELETE issued — only the resolve + list calls.
+        _graphHandler!.Requests.Count.ShouldBe(2);
+        _graphHandler.Requests.ShouldAllBe(r => r.Method != "DELETE");
     }
 }

--- a/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdIdentityProviderAdditionalTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdIdentityProviderAdditionalTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Net;
 using Granit.Events;
+using Granit.Guids;
 using Granit.Identity;
 using Granit.Identity.Events;
 using Granit.Identity.Federated.EntraId.Internal;
@@ -69,6 +70,7 @@ public sealed class EntraIdIdentityProviderAdditionalTests : IDisposable
             Microsoft.Extensions.Options.Options.Create(_options),
             _passwordResetNotifier,
             _distributedEventBus,
+            new SimpleGuidGenerator(),
             NullLogger<EntraIdIdentityProvider>.Instance);
     }
 
@@ -322,6 +324,7 @@ public sealed class EntraIdIdentityProviderAdditionalTests : IDisposable
             Microsoft.Extensions.Options.Options.Create(_options),
             _passwordResetNotifier,
             _distributedEventBus,
+            new SimpleGuidGenerator(),
             NullLogger<EntraIdIdentityProvider>.Instance);
 
         IReadOnlyList<IdentityRole> result = await provider.GetUserRolesAsync(

--- a/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdIdentityProviderTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/EntraIdIdentityProviderTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Net;
 using Granit.Events;
+using Granit.Guids;
 using Granit.Identity;
 using Granit.Identity.Events;
 using Granit.Identity.Federated.EntraId.Internal;
@@ -71,6 +72,7 @@ public sealed class EntraIdIdentityProviderTests : IDisposable
             Microsoft.Extensions.Options.Options.Create(_options),
             _passwordResetNotifier,
             _distributedEventBus,
+            new SimpleGuidGenerator(),
             NullLogger<EntraIdIdentityProvider>.Instance);
     }
 
@@ -229,6 +231,7 @@ public sealed class EntraIdIdentityProviderTests : IDisposable
             Microsoft.Extensions.Options.Options.Create(optionsWithRopc),
             _passwordResetNotifier,
             _distributedEventBus,
+            new SimpleGuidGenerator(),
             NullLogger<EntraIdIdentityProvider>.Instance);
 
         bool result = await provider.VerifyUserCredentialsAsync("admin", "password123",
@@ -270,6 +273,7 @@ public sealed class EntraIdIdentityProviderTests : IDisposable
             Microsoft.Extensions.Options.Options.Create(optionsWithRopc),
             _passwordResetNotifier,
             _distributedEventBus,
+            new SimpleGuidGenerator(),
             NullLogger<EntraIdIdentityProvider>.Instance);
 
         bool result = await provider.VerifyUserCredentialsAsync("admin", "wrong-password",
@@ -330,6 +334,7 @@ public sealed class EntraIdIdentityProviderTests : IDisposable
             Microsoft.Extensions.Options.Options.Create(optionsWithDomain),
             _passwordResetNotifier,
             distributedEventBus,
+            new SimpleGuidGenerator(),
             NullLogger<EntraIdIdentityProvider>.Instance);
 
         IdentityUserCreate newUser = new("alice", "alice@test.com", "Alice", "Doe");

--- a/tests/Granit.Identity.Federated.EntraId.Tests/Granit.Identity.Federated.EntraId.Tests.csproj
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/Granit.Identity.Federated.EntraId.Tests.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Granit.Guids\Granit.Guids.csproj" />
     <ProjectReference Include="..\..\src\Granit.Identity.Federated.EntraId\Granit.Identity.Federated.EntraId.csproj" />
     <ProjectReference Include="..\..\src\Granit.Timing\Granit.Timing.csproj" />
   </ItemGroup>

--- a/tests/Granit.Identity.Federated.EntraId.Tests/IdentityEntraIdActivitySourceTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/IdentityEntraIdActivitySourceTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Net;
 using Granit.Events;
+using Granit.Guids;
 using Granit.Identity;
 using Granit.Identity.Federated.EntraId.Diagnostics;
 using Granit.Identity.Federated.EntraId.Internal;
@@ -74,6 +75,7 @@ public sealed class IdentityEntraIdActivitySourceTests : IDisposable
             MsOptions.Create(options),
             _passwordResetNotifier,
             _distributedEventBus,
+            new SimpleGuidGenerator(),
             NullLogger<EntraIdIdentityProvider>.Instance);
     }
 

--- a/tests/Granit.Identity.Federated.EntraId.Tests/IdentityEntraIdServiceCollectionExtensionsClientRoleTests.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/IdentityEntraIdServiceCollectionExtensionsClientRoleTests.cs
@@ -1,4 +1,5 @@
 using Granit.Events;
+using Granit.Guids.Extensions;
 using Granit.Identity;
 using Granit.Identity.Extensions;
 using Granit.Identity.Federated.EntraId.Extensions;
@@ -36,6 +37,7 @@ public sealed class IdentityEntraIdServiceCollectionExtensionsClientRoleTests
         services.AddLogging();
         services.AddSingleton(Substitute.For<IClock>());
         services.AddSingleton(Substitute.For<IDistributedEventBus>());
+        services.AddGranitGuids();
         services.AddGranitIdentity();
         services.AddGranitIdentityEntraId();
 

--- a/tests/Granit.Identity.Federated.EntraId.Tests/MockHttpMessageHandler.cs
+++ b/tests/Granit.Identity.Federated.EntraId.Tests/MockHttpMessageHandler.cs
@@ -44,13 +44,22 @@ internal sealed class MockSequenceHttpMessageHandler(IReadOnlyList<string> respo
     /// <summary>Number of HTTP calls made through this handler.</summary>
     public int CallCount => _callIndex;
 
-    protected override Task<HttpResponseMessage> SendAsync(
+    /// <summary>Captured requests as (Method, Url, Body) tuples — in the order sent.</summary>
+    public List<(string Method, string Url, string Body)> Requests { get; } = [];
+
+    protected override async Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request, CancellationToken cancellationToken)
     {
+        string body = request.Content is not null
+            ? await request.Content.ReadAsStringAsync(cancellationToken)
+            : string.Empty;
+
+        Requests.Add((request.Method.Method, request.RequestUri?.ToString() ?? "", body));
+
         int index = Math.Min(_callIndex++, responses.Count - 1);
-        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        return new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(responses[index], System.Text.Encoding.UTF8, "application/json"),
-        });
+        };
     }
 }

--- a/tests/Granit.Identity.Federated.Keycloak.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Keycloak.BackgroundJobs.Tests/packages.lock.json
@@ -510,6 +510,24 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -542,6 +560,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }

--- a/tests/Granit.Identity.Federated.Keycloak.Tests.Integration/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests.Integration/packages.lock.json
@@ -723,6 +723,24 @@
           "Granit.Timing": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
@@ -755,6 +773,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }

--- a/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakClientRoleTests.cs
+++ b/tests/Granit.Identity.Federated.Keycloak.Tests/KeycloakClientRoleTests.cs
@@ -163,4 +163,50 @@ public sealed class KeycloakClientRoleTests : IDisposable
         roles[0].Name.ShouldBe("admin");
         roles[0].ClientId.ShouldBe("app-a");
     }
+
+    // ──── ADR-031 — client-role writes ────────────────────────────────────
+
+    [Fact]
+    public async Task CreateClientRoleAsync_Resolves_PostsRole_Refetches()
+    {
+        const string resolveResponse = """[{"id":"client-uuid","clientId":"app-a"}]""";
+        // 2nd response = POST /roles (empty 201), 3rd = re-fetch returning the new role.
+        const string postResponse = "{}";
+        const string refetchResponse = """{"id":"role-new","name":"editor","description":"Edit"}""";
+        KeycloakIdentityProvider provider = BuildProvider(resolveResponse, postResponse, refetchResponse);
+
+        IdentityRole created = await provider.CreateClientRoleAsync(
+            "app-a", "editor", "Edit", TestContext.Current.CancellationToken);
+
+        created.Id.ShouldBe("role-new");
+        created.Name.ShouldBe("editor");
+        created.ClientId.ShouldBe("app-a");
+        created.Description.ShouldBe("Edit");
+    }
+
+    [Fact]
+    public async Task AssignClientRoleAsync_LooksUpRole_PostsMapping()
+    {
+        const string resolveResponse = """[{"id":"client-uuid","clientId":"app-a"}]""";
+        const string roleResponse = """{"id":"r1","name":"editor","description":null}""";
+        // 3rd response = POST /role-mappings, body ignored by mock.
+        const string postResponse = "{}";
+        KeycloakIdentityProvider provider = BuildProvider(resolveResponse, roleResponse, postResponse);
+
+        // Should not throw.
+        await provider.AssignClientRoleAsync(
+            "user-42", "app-a", "editor", TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task RemoveClientRoleAsync_LooksUpRole_DeletesMapping()
+    {
+        const string resolveResponse = """[{"id":"client-uuid","clientId":"app-a"}]""";
+        const string roleResponse = """{"id":"r1","name":"editor","description":null}""";
+        const string deleteResponse = "{}";
+        KeycloakIdentityProvider provider = BuildProvider(resolveResponse, roleResponse, deleteResponse);
+
+        await provider.RemoveClientRoleAsync(
+            "user-42", "app-a", "editor", TestContext.Current.CancellationToken);
+    }
 }

--- a/tests/Granit.Identity.Federated.Privacy.Tests/packages.lock.json
+++ b/tests/Granit.Identity.Federated.Privacy.Tests/packages.lock.json
@@ -245,6 +245,16 @@
         "resolved": "18.5.0",
         "contentHash": "6SR2NJFwMvobXs5FhuKdpxhzotlhy/OJzSZv4fhxnN5snHIHfrCUzpZ1k0fffFx9fkLb+GB4+sRptpTfWeu2TQ=="
       },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "10.0.7",
@@ -316,10 +326,10 @@
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics": {
@@ -343,8 +353,8 @@
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "jAhZbzDa117otUBMuQQ6JzSfuDbBBrfOs5jw5l7l9hKpzt+LjYKVjSauXG2yV9u7BqUSLUtKLwcerDQDeQ+0Xw=="
+        "resolved": "10.0.7",
+        "contentHash": "8Oq/03og7ihwbfx+EjfWhYCdMldClxqnqB9w5ZI4KxuhoiUVDxZYVl06K7fhROOoelhKOtnCUtATCqTCrqSGmA=="
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
@@ -400,12 +410,12 @@
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "BStFkd5CcnEtarlcgYDBcFzGYCuuNMzPs02wN3WBsOFoYIEmYoUdAiU+au6opzoqfTYJsMTW00AeqDdnXH2CvA==",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging.Configuration": {
@@ -711,12 +721,36 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.encryption": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Options": "[10.*, )",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "[10.*, )"
+        }
+      },
+      "granit.encryption.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )",
+          "Granit.Encryption": "[0.1.0-dev, )",
+          "Granit.Persistence.EntityFrameworkCore": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )"
+        }
+      },
       "granit.guids": {
         "type": "Project",
         "dependencies": {
           "Granit.Timing": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.http.exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
         }
       },
       "granit.identity": {
@@ -730,6 +764,7 @@
         "type": "Project",
         "dependencies": {
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.Encryption.EntityFrameworkCore": "[0.1.0-dev, )",
           "Granit.Identity": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )"
         }
@@ -739,6 +774,27 @@
         "dependencies": {
           "Granit.Identity.Federated": "[0.1.0-dev, )",
           "Granit.Privacy.BlobStorage": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence": {
+        "type": "Project",
+        "dependencies": {
+          "Granit": "[0.1.0-dev, )"
+        }
+      },
+      "granit.persistence.entityframeworkcore": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Guids": "[0.1.0-dev, )",
+          "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
+          "Granit.Persistence": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.*, )",
+          "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
       "granit.privacy": {
@@ -810,26 +866,50 @@
           "System.Composition": "9.0.0"
         }
       },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.0",
-        "contentHash": "Zcoy6H9mSoGyvr7UvlGokEZrlZkcPCICPZr8mCsSt9U/N8eeCwCXwKF5bShdA66R0obxBCwP4AxomQHvVkC/uA==",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",
-        "resolved": "10.0.0",
-        "contentHash": "krK19MKp0BNiR9rpBDW7PKSrTMLVlifS9am3CVc4O1Jq6GWz0o4F+sw5OSL4L3mVd56W8l6JRgghUa2KB51vOw==",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
@@ -847,6 +927,29 @@
         "requested": "[10.*, )",
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "hs9YULcNhj1UiPjhNoJIDBWS92GvAVzT6DyuvbkoxvDcASZUQFVwQ9EAKtgrOfTaI0Vy6U6RwycXko1SIESM8w==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "jB9/rxTI0c1n7ynagvyJCLVcY1yA47Ngu8Ef9YBEDQ/3O/fNTgGMRd9aRK9tthtMZ40W9P7ih8423ePsyZc/2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.7"
+        }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Summary

- Adds `CreateClientRoleAsync` / `AssignClientRoleAsync` / `RemoveClientRoleAsync` to `IIdentityClientRoleManager` — the Phase 3 write surface that closes the admin-UI loop for Granit-first deployments (authors stay in Granit instead of logging into Keycloak / Azure / AWS consoles).
- Implements all three on each federated provider:
  - **Keycloak**: Admin REST `POST/DELETE` on `clients/{uuid}/roles` + `users/{id}/role-mappings/clients/{uuid}`.
  - **Entra ID**: `PATCH /applications/{objectId}` for create (reads full `appRoles` array, appends, PATCHes back — **not concurrency-safe**, see ADR-031), `POST`/`DELETE` on `/users/{id}/appRoleAssignments` for assign/remove.
  - **Cognito**: `CreateGroup` / `AdminAddUserToGroup` / `AdminRemoveUserFromGroup` with the existing `{clientId}{Delimiter}{roleName}` naming convention from ADR-027.
- New `SupportsClientRoleWrites` capability DIM (defaults `false`) — each federated provider overrides to `true`. Callers must guard on the flag.
- New ADR-031 documents the decision, per-provider semantics, the Entra concurrency caveat, required permissions, and eventing trade-offs.

## Provider-specific semantics

| Provider | Create | Assign | Remove |
| -------- | ------ | ------ | ------ |
| Keycloak | `POST /admin/realms/{realm}/clients/{uuid}/roles`, refetch by name | `POST /users/{id}/role-mappings/clients/{uuid}` | `DELETE /users/{id}/role-mappings/clients/{uuid}` |
| Entra ID | PATCH whole `appRoles` array on Application (id minted via `IGuidGenerator`) | `POST /users/{id}/appRoleAssignments` | `DELETE /users/{id}/appRoleAssignments/{assignmentId}` |
| Cognito | `CreateGroup` with prefixed name | `AdminAddUserToGroup` | `AdminRemoveUserFromGroup` |

## Breaking change

`IIdentityClientRoleManager` gains 3 required methods. External implementers must add them. All in-repo providers (Keycloak, Entra ID, Cognito) are updated. No endpoint changes in this PR — the admin-UI endpoints are a follow-up.

## Test plan

- [x] `dotnet build` — full solution, 0 warnings / 0 errors
- [x] `dotnet format --verify-no-changes` — clean
- [x] Keycloak unit tests — 177/177 (incl. 3 new write tests)
- [x] Entra ID unit tests — 134/134 (incl. 5 new write tests: create happy-path + not-found, assign, remove + no-match no-op)
- [x] Cognito unit tests — 69/69 (incl. 4 new write tests: create default delimiter + custom delimiter, assign, remove)
- [x] Architecture tests — 118/118
- [x] `markdownlint-cli2` on ADR-031 — clean

## References

- Closes #1122
- Depends on: ADR-025 / ADR-026 / ADR-027 (Phase 2), ADR-029, ADR-030
- Parent epic: #1114