### PR TITLE
fix(privacy)!: rename saga *Async methods so Wolverine SagaChain discovers them

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -34101,9 +34101,9 @@
           "returnType": "DateTimeOffset"
         },
         {
-          "name": "StartAsync",
+          "name": "Start",
           "kind": "method",
-          "signature": "StartAsync(DeletionDeferredEto @event, IOptions<GranitPrivacyOptions> options, IMessageContext context, IDeletionRequestTrackerWriter tracker, PrivacyMetrics metrics)",
+          "signature": "Start(DeletionDeferredEto @event, IOptions<GranitPrivacyOptions> options, IMessageContext context, IDeletionRequestTrackerWriter tracker, PrivacyMetrics metrics)",
           "returnType": "string? TenantId { get; set; } public bool ReminderSent { get; set; } public Task"
         }
       ]
@@ -34277,9 +34277,9 @@
           "returnType": "string"
         },
         {
-          "name": "StartAsync",
+          "name": "Start",
           "kind": "method",
-          "signature": "StartAsync(PersonalDataRequestedEto @event, IDataProviderRegistry registry, IOptions<GranitPrivacyOptions> options, IMessageContext context, PrivacyMetrics metrics)",
+          "signature": "Start(PersonalDataRequestedEto @event, IDataProviderRegistry registry, IOptions<GranitPrivacyOptions> options, IMessageContext context, PrivacyMetrics metrics)",
           "returnType": "string? TenantId { get; set; } public DateTimeOffset RequestedAt { get; set; } public Task<ExportCompletedEto?>"
         }
       ]

--- a/src/Granit.Privacy/DataDeletion/PersonalDataDeletionSaga.cs
+++ b/src/Granit.Privacy/DataDeletion/PersonalDataDeletionSaga.cs
@@ -64,7 +64,10 @@ public sealed class PersonalDataDeletionSaga : Saga
     /// Starts the Saga when a user defers their deletion request.
     /// Schedules a reminder notification and the actual deletion deadline.
     /// </summary>
-    public async Task StartAsync(
+    // NOTE: Named `Start` (no `Async` suffix) so Wolverine's SagaChain discovers it.
+    // SagaChain.findByNames is strict-match and does NOT strip `Async`, unlike general
+    // handler discovery. An `Async`-suffixed name compiles to a silent no-op handler.
+    public async Task Start(
         DeletionDeferredEto @event,
         IOptions<GranitPrivacyOptions> options,
         IMessageContext context,
@@ -120,7 +123,8 @@ public sealed class PersonalDataDeletionSaga : Saga
     /// <see cref="PersonalDataDeletionRequestedEto"/> and sends a confirmation
     /// via <see cref="DeletionExecutedEto"/>.
     /// </summary>
-    public async Task<object[]> HandleAsync(
+    // NOTE: Named `Handle` (no `Async` suffix) — see the comment on `Start` above.
+    public async Task<object[]> Handle(
         DeletionDeadlineReachedEvent @event,
         IDeletionRequestTrackerWriter tracker,
         PrivacyMetrics metrics,
@@ -143,7 +147,8 @@ public sealed class PersonalDataDeletionSaga : Saga
     /// Handles cancellation — the Saga terminates and future scheduled events
     /// (reminder, deadline) are silently discarded by Wolverine.
     /// </summary>
-    public async Task HandleAsync(
+    // NOTE: Named `Handle` (no `Async` suffix) — see the comment on `Start` above.
+    public async Task Handle(
         DeletionCancelledEto @event,
         IDeletionRequestTrackerWriter tracker,
         PrivacyMetrics metrics)

--- a/src/Granit.Privacy/DataExport/PersonalDataExportSaga.cs
+++ b/src/Granit.Privacy/DataExport/PersonalDataExportSaga.cs
@@ -64,7 +64,10 @@ public sealed class PersonalDataExportSaga : Saga
     /// If no providers are registered, completes immediately.
     /// Otherwise, schedules a timeout to handle unresponsive providers.
     /// </summary>
-    public async Task<ExportCompletedEto?> StartAsync(
+    // NOTE: Named `Start` (no `Async` suffix) so Wolverine's SagaChain discovers it.
+    // SagaChain.findByNames is strict-match and does NOT strip `Async`, unlike general
+    // handler discovery. An `Async`-suffixed name compiles to a silent no-op handler.
+    public async Task<ExportCompletedEto?> Start(
         PersonalDataRequestedEto @event,
         IDataProviderRegistry registry,
         IOptions<GranitPrivacyOptions> options,

--- a/tests/Granit.ArchitectureTests/SagaConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/SagaConventionTests.cs
@@ -23,6 +23,24 @@ public sealed class SagaConventionTests
         "StartsOrHandleAsync",
     ];
 
+    // Base names Wolverine's SagaChain.findByNames matches STRICTLY (no `Async` stripping,
+    // unlike general HandlerDiscovery). Suffixing any of these with `Async` on a Saga
+    // produces a method that's discovered as a handler but silently filtered out of the
+    // generated chain — leading to a saga that's constructed but never initialized
+    // (Id stays Guid.Empty) and then fails lightweight-storage insert at runtime with
+    // `ArgumentOutOfRangeException: You must define the saga id`.
+    //
+    // Upstream reference: SagaChain.DetermineFrames in WolverineFx.
+    private static readonly string[] CodegenBaseNames =
+    [
+        "Start", "Starts",
+        "Handle", "Handles",
+        "Orchestrate", "Orchestrates",
+        "Consume", "Consumes",
+        "StartOrHandle", "StartsOrHandles",
+        "NotFound",
+    ];
+
     /// <summary>
     /// Wolverine resolves the saga id from the initiating message via (in order):
     /// <c>[SagaIdentity]</c>, <c>[SagaIdentityFrom]</c> on the parameter,
@@ -88,6 +106,77 @@ public sealed class SagaConventionTests
             "Every message that starts a Wolverine saga must expose a resolvable saga identity. " +
             "Without it, Wolverine persists the saga with Guid.Empty and the PostgreSQL " +
             "lightweight saga storage throws ArgumentOutOfRangeException at runtime.");
+    }
+
+    /// <summary>
+    /// Wolverine's <c>SagaChain.findByNames</c> matches codegen-relevant method names
+    /// strictly — it does NOT strip the <c>Async</c> suffix the way general
+    /// <c>HandlerDiscovery</c> does. Declaring <c>StartAsync</c> / <c>HandleAsync</c>
+    /// (or <c>OrchestrateAsync</c>, <c>ConsumeAsync</c>, etc.) on a Saga therefore
+    /// produces a silently-skipped handler: the saga is constructed but its method is
+    /// never invoked, so <c>Id</c> stays <see cref="Guid.Empty"/> and lightweight
+    /// saga storage throws at insert time.
+    /// </summary>
+    [Fact]
+    public void Saga_methods_must_not_use_Async_suffix_for_codegen_names()
+    {
+        string outputDir = Path.GetDirectoryName(typeof(SagaConventionTests).Assembly.Location)!;
+
+        Assembly[] granitAssemblies = Directory.GetFiles(outputDir, "Granit.*.dll")
+            .Where(path => !Path.GetFileNameWithoutExtension(path).Contains("Tests"))
+            .Select(TryLoadAssembly)
+            .Where(a => a is not null)
+            .ToArray()!;
+
+        List<string> violations = [];
+
+        foreach (Assembly assembly in granitAssemblies)
+        {
+            Type[] sagaTypes;
+            try
+            {
+                sagaTypes = assembly.GetTypes()
+                    .Where(t => !t.IsAbstract && typeof(Saga).IsAssignableFrom(t))
+                    .ToArray();
+            }
+            catch (ReflectionTypeLoadException)
+            {
+                continue;
+            }
+
+            foreach (Type sagaType in sagaTypes)
+            {
+                MethodInfo[] methods = sagaType.GetMethods(
+                    BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+                foreach (MethodInfo method in methods)
+                {
+                    if (!method.Name.EndsWith("Async", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    string baseName = method.Name[..^"Async".Length];
+                    if (!CodegenBaseNames.Contains(baseName, StringComparer.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    violations.Add(
+                        $"{sagaType.FullName}.{method.Name}: rename to '{baseName}'. " +
+                        "Wolverine's SagaChain.findByNames does not strip the 'Async' suffix, " +
+                        "so this method is silently skipped by codegen even though it's " +
+                        "visible to handler discovery.");
+                }
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            "Saga methods that map to Wolverine codegen slots (Start/Handle/Orchestrate/" +
+            "Consume/NotFound) must NOT carry the 'Async' suffix — SagaChain matches them " +
+            "strictly and silently drops Async-suffixed variants, producing a saga that " +
+            "is persisted with Guid.Empty and then fails lightweight-storage insert at " +
+            "runtime.");
     }
 
     private static IEnumerable<MethodInfo> GetStartMethods(Type sagaType) =>

--- a/tests/Granit.Privacy.Tests/DataDeletion/PersonalDataDeletionSagaTests.cs
+++ b/tests/Granit.Privacy.Tests/DataDeletion/PersonalDataDeletionSagaTests.cs
@@ -58,7 +58,7 @@ public sealed class PersonalDataDeletionSagaTests : IDisposable
         IMessageContext context = Substitute.For<IMessageContext>();
         DeletionDeferredEto evt = CreateDeferredEvent();
 
-        await saga.StartAsync(evt, DefaultOptions(), context, _tracker, _metrics);
+        await saga.Start(evt, DefaultOptions(), context, _tracker, _metrics);
 
         saga.Id.ShouldBe(evt.RequestId);
         saga.UserId.ShouldBe(evt.UserId);
@@ -74,7 +74,7 @@ public sealed class PersonalDataDeletionSagaTests : IDisposable
         IMessageContext context = Substitute.For<IMessageContext>();
         DeletionDeferredEto evt = CreateDeferredEvent();
 
-        await saga.StartAsync(evt, DefaultOptions(), context, _tracker, _metrics);
+        await saga.Start(evt, DefaultOptions(), context, _tracker, _metrics);
 
         await _tracker.Received(1).RecordDeferredAsync(
             evt.RequestId, evt.UserId, evt.Reason, evt.RequestedAt, evt.ScheduledDeletionAt,
@@ -88,7 +88,7 @@ public sealed class PersonalDataDeletionSagaTests : IDisposable
         IMessageContext context = Substitute.For<IMessageContext>();
         DeletionDeferredEto evt = CreateDeferredEvent(graceDays: 30);
 
-        await saga.StartAsync(evt, DefaultOptions(), context, _tracker, _metrics);
+        await saga.Start(evt, DefaultOptions(), context, _tracker, _metrics);
 
         // Two ScheduleAsync calls: reminder + deadline
         await context.Received(2).PublishAsync(
@@ -103,7 +103,7 @@ public sealed class PersonalDataDeletionSagaTests : IDisposable
         IMessageContext context = Substitute.For<IMessageContext>();
         DeletionDeferredEto evt = CreateDeferredEvent(graceDays: 2); // < 3 days reminder
 
-        await saga.StartAsync(evt, DefaultOptions(), context, _tracker, _metrics);
+        await saga.Start(evt, DefaultOptions(), context, _tracker, _metrics);
 
         // Only deadline, no reminder
         await context.Received(1).PublishAsync(
@@ -119,7 +119,7 @@ public sealed class PersonalDataDeletionSagaTests : IDisposable
         PersonalDataDeletionSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
         DeletionDeferredEto startEvt = CreateDeferredEvent();
-        await saga.StartAsync(startEvt, DefaultOptions(), context, _tracker, _metrics);
+        await saga.Start(startEvt, DefaultOptions(), context, _tracker, _metrics);
 
         DeletionReminderDueEto result = saga.Handle(
             new DeletionReminderDueEvent(startEvt.RequestId), _metrics);
@@ -135,7 +135,7 @@ public sealed class PersonalDataDeletionSagaTests : IDisposable
     {
         PersonalDataDeletionSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
-        await saga.StartAsync(CreateDeferredEvent(), DefaultOptions(), context, _tracker, _metrics);
+        await saga.Start(CreateDeferredEvent(), DefaultOptions(), context, _tracker, _metrics);
 
         saga.Handle(new DeletionReminderDueEvent(saga.Id), _metrics);
 
@@ -150,9 +150,9 @@ public sealed class PersonalDataDeletionSagaTests : IDisposable
         PersonalDataDeletionSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
         DeletionDeferredEto startEvt = CreateDeferredEvent();
-        await saga.StartAsync(startEvt, DefaultOptions(), context, _tracker, _metrics);
+        await saga.Start(startEvt, DefaultOptions(), context, _tracker, _metrics);
 
-        object[] results = await saga.HandleAsync(
+        object[] results = await saga.Handle(
             new DeletionDeadlineReachedEvent(startEvt.RequestId),
             _tracker, _metrics, _timeProvider);
 
@@ -166,9 +166,9 @@ public sealed class PersonalDataDeletionSagaTests : IDisposable
     {
         PersonalDataDeletionSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
-        await saga.StartAsync(CreateDeferredEvent(), DefaultOptions(), context, _tracker, _metrics);
+        await saga.Start(CreateDeferredEvent(), DefaultOptions(), context, _tracker, _metrics);
 
-        await saga.HandleAsync(
+        await saga.Handle(
             new DeletionDeadlineReachedEvent(saga.Id),
             _tracker, _metrics, _timeProvider);
 
@@ -183,10 +183,10 @@ public sealed class PersonalDataDeletionSagaTests : IDisposable
     {
         PersonalDataDeletionSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
-        await saga.StartAsync(CreateDeferredEvent(), DefaultOptions(), context, _tracker, _metrics);
+        await saga.Start(CreateDeferredEvent(), DefaultOptions(), context, _tracker, _metrics);
 
         DateTimeOffset cancelledAt = DateTimeOffset.UtcNow;
-        await saga.HandleAsync(
+        await saga.Handle(
             new DeletionCancelledEto(saga.Id, saga.UserId, cancelledAt),
             _tracker, _metrics);
 
@@ -200,9 +200,9 @@ public sealed class PersonalDataDeletionSagaTests : IDisposable
         PersonalDataDeletionSaga saga = new();
         IMessageContext context = Substitute.For<IMessageContext>();
         DeletionDeferredEto startEvt = CreateDeferredEvent();
-        await saga.StartAsync(startEvt, DefaultOptions(), context, _tracker, _metrics);
+        await saga.Start(startEvt, DefaultOptions(), context, _tracker, _metrics);
 
-        await saga.HandleAsync(
+        await saga.Handle(
             new DeletionCancelledEto(saga.Id, saga.UserId, DateTimeOffset.UtcNow),
             _tracker, _metrics);
 

--- a/tests/Granit.Privacy.Tests/PersonalDataExportSagaTests.cs
+++ b/tests/Granit.Privacy.Tests/PersonalDataExportSagaTests.cs
@@ -57,7 +57,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         var userId = Guid.NewGuid();
         PersonalDataRequestedEto evt = new(requestId, userId, DateTimeOffset.UtcNow, "EU_GDPR");
 
-        await saga.StartAsync(evt, registry, DefaultOptions(), context, _metrics);
+        await saga.Start(evt, registry, DefaultOptions(), context, _metrics);
 
         saga.Id.ShouldBe(requestId);
         saga.UserId.ShouldBe(userId);
@@ -75,7 +75,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         var requestId = Guid.NewGuid();
         PersonalDataRequestedEto evt = new(requestId, Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
 
-        await saga.StartAsync(evt, registry, DefaultOptions(), context, _metrics);
+        await saga.Start(evt, registry, DefaultOptions(), context, _metrics);
 
         // ScheduleAsync is an extension method that calls PublishAsync with DeliveryOptions.
         // NSubstitute cannot intercept extension methods, so we verify the underlying PublishAsync call.
@@ -91,7 +91,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         IMessageContext context = Substitute.For<IMessageContext>();
         DataProviderRegistry registry = BuildRegistry("patients", "billing", "appointments");
         PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
-        await saga.StartAsync(startEvt, registry, DefaultOptions(), context, _metrics);
+        await saga.Start(startEvt, registry, DefaultOptions(), context, _metrics);
 
         ExportCompletedEto? result1 = saga.Handle(
             new PersonalDataPreparedEto(startEvt.RequestId, "patients", "blob-1", "application/json"), _metrics);
@@ -111,7 +111,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         IMessageContext context = Substitute.For<IMessageContext>();
         DataProviderRegistry registry = BuildRegistry("patients", "billing");
         PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
-        await saga.StartAsync(startEvt, registry, DefaultOptions(), context, _metrics);
+        await saga.Start(startEvt, registry, DefaultOptions(), context, _metrics);
 
         saga.Handle(new PersonalDataPreparedEto(startEvt.RequestId, "patients", "blob-patients", "application/json"), _metrics);
         ExportCompletedEto? result = saga.Handle(
@@ -138,7 +138,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         IMessageContext context = Substitute.For<IMessageContext>();
         DataProviderRegistry registry = BuildRegistry("patients", "billing", "appointments");
         PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
-        await saga.StartAsync(startEvt, registry, DefaultOptions(), context, _metrics);
+        await saga.Start(startEvt, registry, DefaultOptions(), context, _metrics);
 
         saga.Handle(new PersonalDataPreparedEto(startEvt.RequestId, "patients", "blob-patients", "application/json"), _metrics);
         saga.Handle(new PersonalDataPreparedEto(startEvt.RequestId, "billing", "blob-billing", "application/json"), _metrics);
@@ -162,7 +162,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         DataProviderRegistry emptyRegistry = new();
         PersonalDataRequestedEto evt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
 
-        ExportCompletedEto? result = await saga.StartAsync(evt, emptyRegistry, DefaultOptions(), context, _metrics);
+        ExportCompletedEto? result = await saga.Start(evt, emptyRegistry, DefaultOptions(), context, _metrics);
 
         result.ShouldNotBeNull();
         result!.IsPartial.ShouldBeFalse();
@@ -209,7 +209,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         DataProviderRegistry registry = BuildRegistry("auth");
         PersonalDataRequestedEto evt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
 
-        await saga.StartAsync(evt, registry, options, context, _metrics);
+        await saga.Start(evt, registry, options, context, _metrics);
 
         // ScheduleAsync(message, TimeSpan) sets ScheduleDelay (relative), not ScheduledTime (absolute).
         await context.Received(1).PublishAsync(
@@ -230,7 +230,7 @@ public sealed class PersonalDataExportSagaTests : IDisposable
         IMessageContext context = Substitute.For<IMessageContext>();
         DataProviderRegistry registry = BuildRegistry("auth");
         PersonalDataRequestedEto startEvt = new(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, "EU_GDPR");
-        await saga.StartAsync(startEvt, registry, DefaultOptions(), context, _metrics);
+        await saga.Start(startEvt, registry, DefaultOptions(), context, _metrics);
 
         ExportCompletedEto? result = saga.Handle(
             new PersonalDataPreparedEto(startEvt.RequestId, "auth", "blob-auth", "application/json"), _metrics);

--- a/tests/Granit.Privacy.Tests/PrivacySagaWolverineCodegenTests.cs
+++ b/tests/Granit.Privacy.Tests/PrivacySagaWolverineCodegenTests.cs
@@ -1,0 +1,107 @@
+using Granit.Privacy.DataDeletion;
+using Granit.Privacy.DataDeletion.Events;
+using Granit.Privacy.DataExport;
+using Granit.Privacy.DataExport.Events;
+using Granit.Privacy.DataExport.Internal;
+using Granit.Privacy.Diagnostics;
+using Granit.Privacy.LegalAgreements;
+using Granit.Privacy.Options;
+using JasperFx.CodeGeneration.Model;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NSubstitute;
+using Shouldly;
+using Wolverine;
+using Wolverine.Persistence.Sagas;
+using Wolverine.Runtime;
+using Wolverine.Runtime.Handlers;
+using Xunit;
+
+namespace Granit.Privacy.Tests;
+
+// Regression coverage for the Wolverine SagaChain `*Async` suffix bug.
+//
+// The direct unit tests in PersonalDataExportSagaTests / PersonalDataDeletionSagaTests
+// invoke saga methods by hand — they pass whether or not Wolverine's codegen actually
+// wires the method into the generated chain. These tests boot a real Wolverine host
+// and inspect `SagaChain.StartingCalls` / `ExistingCalls` (populated by
+// SagaChain.findByNames). If a saga method is named with an `Async` suffix,
+// findByNames silently drops it and these arrays come back empty — which is exactly
+// what led to the production `ArgumentOutOfRangeException: You must define the saga id`
+// crash on the showcase app.
+public sealed class PrivacySagaWolverineCodegenTests
+{
+    [Fact]
+    public async Task ExportSaga_start_chain_wires_Start_method()
+    {
+        using IHost host = await BuildHostAsync();
+        SagaChain chain = GetSagaChain(host, typeof(PersonalDataRequestedEto));
+
+        chain.StartingCalls.ShouldNotBeEmpty();
+        chain.StartingCalls.ShouldContain(c => c.Method.Name == "Start");
+    }
+
+    [Fact]
+    public async Task ExportSaga_prepared_fragment_chain_wires_Handle_method()
+    {
+        using IHost host = await BuildHostAsync();
+        SagaChain chain = GetSagaChain(host, typeof(PersonalDataPreparedEto));
+
+        chain.ExistingCalls.ShouldNotBeEmpty();
+        chain.ExistingCalls.ShouldContain(c => c.Method.Name == "Handle");
+    }
+
+    [Fact]
+    public async Task DeletionSaga_start_chain_wires_Start_method()
+    {
+        using IHost host = await BuildHostAsync();
+        SagaChain chain = GetSagaChain(host, typeof(DeletionDeferredEto));
+
+        chain.StartingCalls.ShouldNotBeEmpty();
+        chain.StartingCalls.ShouldContain(c => c.Method.Name == "Start");
+    }
+
+    [Fact]
+    public async Task DeletionSaga_cancel_chain_wires_Handle_method()
+    {
+        using IHost host = await BuildHostAsync();
+        SagaChain chain = GetSagaChain(host, typeof(DeletionCancelledEto));
+
+        chain.ExistingCalls.ShouldNotBeEmpty();
+        chain.ExistingCalls.ShouldContain(c => c.Method.Name == "Handle");
+    }
+
+    private static Task<IHost> BuildHostAsync() =>
+        Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IDataProviderRegistry>(new DataProviderRegistry());
+                services.AddSingleton(Substitute.For<IDeletionRequestTrackerWriter>());
+                services.AddSingleton(TimeProvider.System);
+                services.AddSingleton(Substitute.For<ILegalDocumentRegistry>());
+                services.AddMetrics();
+                services.AddSingleton<PrivacyMetrics>();
+                services.Configure<GranitPrivacyOptions>(_ => { });
+            })
+            .UseWolverine(opts =>
+            {
+                opts.ApplicationAssembly = typeof(PersonalDataExportSaga).Assembly;
+            })
+            .StartAsync();
+
+    private static SagaChain GetSagaChain(IHost host, Type messageType)
+    {
+        var runtime = (WolverineRuntime)host.Services.GetRequiredService<IWolverineRuntime>();
+
+        // HandlerFor(...) forces the chain to be compiled (DetermineFrames runs,
+        // populating SagaChain.StartingCalls / ExistingCalls). ChainFor(...) alone
+        // returns the chain object with empty call arrays — so the assertion would
+        // always fail without this step.
+        runtime.Handlers.HandlerFor(messageType).ShouldNotBeNull(
+            $"Wolverine could not compile a handler for {messageType.Name}.");
+
+        HandlerChain? chain = runtime.Handlers.ChainFor(messageType);
+        chain.ShouldNotBeNull($"Wolverine did not discover a handler chain for {messageType.Name}.");
+        return chain.ShouldBeOfType<SagaChain>();
+    }
+}


### PR DESCRIPTION
## Summary

- Rename `StartAsync` / `HandleAsync` on `PersonalDataExportSaga` and `PersonalDataDeletionSaga` to `Start` / `Handle`. Wolverine's `SagaChain.findByNames` matches saga-role method names **strictly** (it does NOT strip the `Async` suffix the way general `HandlerDiscovery` does), so `*Async` methods were silently dropped from `StartingCalls` / `ExistingCalls`. The generated chain constructed the saga but never invoked the method, leaving `Id == Guid.Empty` and crashing lightweight saga storage with `ArgumentOutOfRangeException: You must define the saga id`.
- Two regression guards so this class of bug fails loud next time:
  - **Architecture test** (fast, reflection-only): `SagaConventionTests.Saga_methods_must_not_use_Async_suffix_for_codegen_names` — scans every `Saga` subclass across `Granit.*.dll` and flags any `*Async` method whose base name is in Wolverine's codegen list (`Start/Starts/Handle/Handles/Orchestrate/Orchestrates/Consume/Consumes/StartOrHandle/StartsOrHandles/NotFound`).
  - **Wolverine codegen test**: `PrivacySagaWolverineCodegenTests` — boots a real Wolverine host, forces chain compilation via `HandlerGraph.HandlerFor(msg)` (compilation is lazy; `ChainFor` alone returns empty arrays), casts the chain to `SagaChain`, asserts `StartingCalls` / `ExistingCalls` wire the expected method. Direct-method unit tests could not catch this — they bypass the Wolverine pipeline entirely.
- Upstream issue: JasperFx/wolverine#2578 (proposed fix: strip `Async` in `SagaChain.findByNames` to match `HandlerDiscovery`, or fail fast with a descriptive error).

Original production symptom (from the showcase app's GDPR export flow):

```
System.ArgumentOutOfRangeException: You must define the saga id when using the
    lightweight saga storage (Parameter 'saga')
  at DatabaseSagaSchema`2.InsertAsync(T saga, ...)
  at Internal.Generated.WolverineHandlers.PersonalDataRequestedEtoHandler.HandleAsync(...)
```

## Test plan

- [x] `dotnet build` — clean
- [x] `dotnet test tests/Granit.Privacy.Tests` — 143 passed (existing 139 + 4 new codegen tests)
- [x] `dotnet test tests/Granit.ArchitectureTests --filter SagaConventionTests` — 2 passed (existing + new Async-suffix guard)
- [x] `dotnet format Granit.slnx --verify-no-changes` on touched files — clean
- [x] Regression guards sanity-checked: temporarily reintroduced `StartAsync` on `PersonalDataExportSaga` → **both guards fail** with clear messages (arch test names the method, codegen test reports empty `StartingCalls`). Rename reverted.
- [ ] Showcase GDPR export flow end-to-end on the downstream app (follow-up in granit-showcase-dotnet — the saga bits there may also want the same rename check).
