### PR TITLE
feat(identity-local-endpoints)!: lift AllowTenantRoles default (#1095)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -19373,7 +19373,7 @@
       "kind": "record",
       "project": "Granit.Identity.Local.Endpoints",
       "file": "src/Granit.Identity.Local.Endpoints/Dtos/RoleCreateRequest.cs",
-      "line": 17,
+      "line": 18,
       "members": []
     },
     {
@@ -19555,6 +19555,12 @@
           "kind": "property",
           "signature": "string TagName",
           "returnType": "string"
+        },
+        {
+          "name": "AllowTenantRoles",
+          "kind": "property",
+          "signature": "bool AllowTenantRoles",
+          "returnType": "bool"
         }
       ]
     },

--- a/docs-site/src/content/docs/dotnet/security/authorization-roles.mdx
+++ b/docs-site/src/content/docs/dotnet/security/authorization-roles.mdx
@@ -97,7 +97,7 @@ The endpoints live in `Granit.Identity.Local.Endpoints` and map via:
 app.MapGranitRoles(opts =>
 {
     opts.RolesRoutePrefix = "admin/roles"; // default
-    opts.AllowTenantRoles = false;          // default — see below
+    opts.AllowTenantRoles = true;          // default — tenant admins can CRUD tenant roles
 });
 ```
 
@@ -105,7 +105,7 @@ app.MapGranitRoles(opts =>
 | --- | --- | --- | --- |
 | `GET` | `/admin/roles` | `IdentityLocal.Roles.Read` | Scoped to visible roles (matrix below). |
 | `GET` | `/admin/roles/{id}` | `IdentityLocal.Roles.Read` | 404 when not visible. |
-| `POST` | `/admin/roles` | `IdentityLocal.Roles.Manage` | 403 if `AllowTenantRoles = false` and `Side = Tenant`. |
+| `POST` | `/admin/roles` | `IdentityLocal.Roles.Manage` | Tenant admins create in own tenant only. Set `AllowTenantRoles = false` to disable tenant-scope creation entirely. |
 | `PUT` | `/admin/roles/{id}` | `IdentityLocal.Roles.Manage` | Side and tenant scope are immutable. |
 | `DELETE` | `/admin/roles/{id}` | `IdentityLocal.Roles.Delete` | System roles refuse deletion with 403. |
 
@@ -120,33 +120,31 @@ Applied server-side via `ICurrentTenant` — the store never leaks a non-visible
 
 Non-visible roles **always** return 404, never 403 — existence is not disclosed.
 
-## Feature flag: `AllowTenantRoles`
+## Tenant-scope roles
 
-Tenant-scoped roles collide on ASP.NET Core Identity's process-wide unique index on
-`AspNetRoles.NormalizedName` when two tenants create a role with the same display name.
-The solution is `TenantAwareRoleLookupNormalizer`, which prefixes the normalized name
-with `T_{tenantId}_` whenever a tenant context is active — but it changes the
-normalization of **every** `UserManager` / `RoleManager` lookup, so it must be wired
-consciously.
+Tenant admins CRUD tenant-scope roles in their own tenant by default
+(`AllowTenantRoles = true`). Tenant-scope roles would otherwise collide on
+ASP.NET Core Identity's process-wide unique index on `AspNetRoles.NormalizedName`
+when two tenants create a role with the same display name. The solution is
+`TenantAwareRoleLookupNormalizer`, which prefixes the normalized name with
+`T_{tenantId}_` whenever a tenant context is active — it's wired automatically
+by `Granit.Identity.Local.AspNetIdentity` (no action required).
 
-The framework ships the normalizer ready to use but leaves it **unregistered** by
-default. Opt in by flipping the flag and registering the normalizer:
+### Opt-out: host-only deployments
+
+For hosts that don't want to expose tenant-scope role creation at all (e.g. a
+single-tenant product that keeps permission scoping at the Host level only),
+opt out:
 
 ```csharp title="Program.cs"
 app.MapGranitRoles(opts =>
 {
-    opts.AllowTenantRoles = true; // tenant admins can now CRUD tenant-scoped roles
+    opts.AllowTenantRoles = false; // POST / with Side = Tenant now returns 403
 });
-
-// Wire the normalizer (scoped, depends on ICurrentTenant)
-builder.Services.Replace(ServiceDescriptor.Scoped<
-    ILookupNormalizer,
-    TenantAwareRoleLookupNormalizer>());
 ```
 
-While `AllowTenantRoles` is `false` the CRUD endpoints refuse `Side = Tenant` create
-requests with a 403 `tenant-roles-disabled` problem detail — host and Both roles
-remain fully available.
+When `AllowTenantRoles = false` the CRUD endpoints refuse `Side = Tenant` create
+requests with a 403 problem detail; Host and Both roles remain fully available.
 
 ## Orchestration across two DbContexts
 

--- a/src/Granit.Identity.Local.Endpoints/Dtos/RoleCreateRequest.cs
+++ b/src/Granit.Identity.Local.Endpoints/Dtos/RoleCreateRequest.cs
@@ -6,7 +6,8 @@ namespace Granit.Identity.Local.Endpoints.Dtos;
 /// <param name="Name">Display name of the role (max 256 chars).</param>
 /// <param name="MultiTenancySide">
 /// Host / Tenant / Both applicability. <see cref="MultiTenancySide.Tenant"/> is refused
-/// unless <c>RoleEndpointsOptions.AllowTenantRoles</c> is enabled.
+/// when <c>RoleEndpointsOptions.AllowTenantRoles</c> is explicitly disabled (enabled by
+/// default).
 /// </param>
 /// <param name="TenantId">
 /// Tenant identifier — required iff <paramref name="MultiTenancySide"/> is

--- a/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/GranitRoleEndpoints.cs
@@ -53,7 +53,8 @@ internal static class GranitRoleEndpoints
             .WithSummary("Creates a new local role and its RoleMetadata row.")
             .WithDescription(
                 "Invariants: Host / Both ⇒ TenantId must be null; Tenant ⇒ TenantId required. "
-                + "Side=Tenant requests are refused unless RoleEndpointsOptions.AllowTenantRoles is enabled.")
+                + "Tenant admins may only create Tenant-scope roles in their own tenant. "
+                + "Set RoleEndpointsOptions.AllowTenantRoles = false to disable Tenant-scope creation entirely.")
             .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces<RoleResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem()

--- a/src/Granit.Identity.Local.Endpoints/Options/RoleEndpointsOptions.cs
+++ b/src/Granit.Identity.Local.Endpoints/Options/RoleEndpointsOptions.cs
@@ -12,14 +12,23 @@ public sealed class RoleEndpointsOptions
     public string TagName { get; set; } = "Identity - Roles";
 
     /// <summary>
-    /// When <see langword="false"/> (default), create / rename / delete endpoints refuse
-    /// <see cref="Granit.MultiTenancy.MultiTenancySide.Tenant"/> role requests — only
-    /// host-level and Both roles are creatable.
+    /// When <see langword="true"/> (default), tenant admins can create / rename / delete
+    /// <see cref="Granit.MultiTenancy.MultiTenancySide.Tenant"/>-scoped roles in their
+    /// own tenant. Host and Both roles remain host-admin only regardless of this flag.
     /// </summary>
     /// <remarks>
-    /// Opt-in requires <c>TenantAwareRoleLookupNormalizer</c> to be registered as the
-    /// <c>ILookupNormalizer</c>; otherwise two tenants with the same role display name
-    /// collide on the ASP.NET Core Identity <c>AspNetRoles.NormalizedName</c> unique index.
+    /// <para>
+    /// Requires <c>TenantAwareRoleLookupNormalizer</c> to be registered as the
+    /// <c>ILookupNormalizer</c>, otherwise two tenants with the same role display name
+    /// collide on the ASP.NET Core Identity <c>AspNetRoles.NormalizedName</c> unique
+    /// index. The normalizer is wired automatically by
+    /// <c>Granit.Identity.Local.AspNetIdentity</c>.
+    /// </para>
+    /// <para>
+    /// Set to <see langword="false"/> to opt out and have the endpoints refuse
+    /// Tenant-scope create requests with 403 (useful for host-only deployments that
+    /// want to keep the attack surface minimal).
+    /// </para>
     /// </remarks>
-    public bool AllowTenantRoles { get; set; }
+    public bool AllowTenantRoles { get; set; } = true;
 }

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/GranitRoleEndpointsTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/GranitRoleEndpointsTests.cs
@@ -11,11 +11,10 @@ namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
 
 /// <summary>
 /// HTTP-level integration tests for the <c>/admin/roles</c> CRUD endpoints.
-/// Covers the visibility matrix applied by <c>ICurrentTenant</c>, the
-/// <c>AllowTenantRoles</c> Phase-1 refusal, and the system-role protection
-/// rules. Permission-grant enforcement is deliberately bypassed at the
-/// authorization-policy layer — see <see cref="PermissiveAuthorizationPolicyProvider"/>
-/// for the rationale.
+/// Covers the visibility matrix applied by <c>ICurrentTenant</c>, tenant-scope
+/// role happy paths, and the system-role protection rules. Permission-grant
+/// enforcement is deliberately bypassed at the authorization-policy layer —
+/// see <see cref="PermissiveAuthorizationPolicyProvider"/> for the rationale.
 /// </summary>
 public sealed class GranitRoleEndpointsTests
     : IClassFixture<RoleEndpointsTestApplication>, IAsyncLifetime
@@ -111,11 +110,11 @@ public sealed class GranitRoleEndpointsTests
     }
 
     // ─────────────────────────────────────────────────────────────────────
-    // POST — AllowTenantRoles flag (Phase 1 refusal)
+    // POST — Tenant-scope happy path (AllowTenantRoles = true default)
     // ─────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task Create_SideTenant_AllowTenantRolesFalse_Returns403()
+    public async Task Create_AsTenantAdmin_SideTenant_OwnTenant_Returns201()
     {
         using IDisposable _ = _app.CurrentTenant.Change(_tenantA);
 
@@ -126,10 +125,113 @@ public sealed class GranitRoleEndpointsTests
                 name = "Manager",
                 multiTenancySide = (int)MultiTenancySide.Tenant,
                 tenantId = _tenantA,
+                description = "Tenant-A managers.",
+            },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+
+        RoleResponseLite? created = await response.Content
+            .ReadFromJsonAsync<RoleResponseLite>(TestContext.Current.CancellationToken);
+
+        created.ShouldNotBeNull();
+        created.Name.ShouldBe("Manager");
+        created.MultiTenancySide.ShouldBe(MultiTenancySide.Tenant);
+        created.TenantId.ShouldBe(_tenantA);
+    }
+
+    [Fact]
+    public async Task Create_AsTenantAdmin_SideTenant_ForeignTenant_Returns403()
+    {
+        using IDisposable _ = _app.CurrentTenant.Change(_tenantA);
+
+        HttpResponseMessage response = await _app.HttpClient.PostAsJsonAsync(
+            "/admin/roles",
+            new
+            {
+                name = "Manager",
+                multiTenancySide = (int)MultiTenancySide.Tenant,
+                tenantId = _tenantB,
             },
             TestContext.Current.CancellationToken);
 
         response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Create_AsTenantAdmin_SideTenant_VisibleInOwnList_InvisibleToOtherTenant()
+    {
+        // Create a tenant-A role.
+        using (_app.CurrentTenant.Change(_tenantA))
+        {
+            HttpResponseMessage create = await _app.HttpClient.PostAsJsonAsync(
+                "/admin/roles",
+                new
+                {
+                    name = "Manager",
+                    multiTenancySide = (int)MultiTenancySide.Tenant,
+                    tenantId = _tenantA,
+                },
+                TestContext.Current.CancellationToken);
+
+            create.StatusCode.ShouldBe(HttpStatusCode.Created);
+
+            // Tenant A sees it.
+            HttpResponseMessage listA = await _app.HttpClient.GetAsync(
+                "/admin/roles", TestContext.Current.CancellationToken);
+            RoleResponseLite[]? rolesA = await listA.Content
+                .ReadFromJsonAsync<RoleResponseLite[]>(TestContext.Current.CancellationToken);
+            rolesA!.ShouldContain(r => r.Name == "Manager" && r.TenantId == _tenantA);
+        }
+
+        // Tenant B does not.
+        using (_app.CurrentTenant.Change(_tenantB))
+        {
+            HttpResponseMessage listB = await _app.HttpClient.GetAsync(
+                "/admin/roles", TestContext.Current.CancellationToken);
+            RoleResponseLite[]? rolesB = await listB.Content
+                .ReadFromJsonAsync<RoleResponseLite[]>(TestContext.Current.CancellationToken);
+            rolesB!.ShouldNotContain(r => r.Name == "Manager" && r.TenantId == _tenantA);
+        }
+    }
+
+    [Fact]
+    public async Task Rename_AsTenantAdmin_OwnTenantRole_Returns200()
+    {
+        using IDisposable _ = _app.CurrentTenant.Change(_tenantA);
+
+        Guid roleId = await CreateViaEndpointAsync(
+            "Manager", MultiTenancySide.Tenant, tenantId: _tenantA);
+
+        HttpResponseMessage response = await _app.HttpClient.PutAsJsonAsync(
+            $"/admin/roles/{roleId:D}",
+            new { name = "SeniorManager", description = "Renamed" },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        RoleResponseLite? updated = await response.Content
+            .ReadFromJsonAsync<RoleResponseLite>(TestContext.Current.CancellationToken);
+        updated!.Name.ShouldBe("SeniorManager");
+        updated.Description.ShouldBe("Renamed");
+    }
+
+    [Fact]
+    public async Task Delete_AsTenantAdmin_OwnTenantRole_Returns204()
+    {
+        using IDisposable _ = _app.CurrentTenant.Change(_tenantA);
+
+        Guid roleId = await CreateViaEndpointAsync(
+            "Manager", MultiTenancySide.Tenant, tenantId: _tenantA);
+
+        HttpResponseMessage response = await _app.HttpClient.DeleteAsync(
+            $"/admin/roles/{roleId:D}", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        HttpResponseMessage getAfter = await _app.HttpClient.GetAsync(
+            $"/admin/roles/{roleId:D}", TestContext.Current.CancellationToken);
+        getAfter.StatusCode.ShouldBe(HttpStatusCode.NotFound);
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -214,6 +316,25 @@ public sealed class GranitRoleEndpointsTests
     // ─────────────────────────────────────────────────────────────────────
     // helpers
     // ─────────────────────────────────────────────────────────────────────
+
+    private async Task<Guid> CreateViaEndpointAsync(
+        string name, MultiTenancySide side, Guid? tenantId)
+    {
+        HttpResponseMessage response = await _app.HttpClient.PostAsJsonAsync(
+            "/admin/roles",
+            new
+            {
+                name,
+                multiTenancySide = (int)side,
+                tenantId,
+            },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+        RoleResponseLite? created = await response.Content
+            .ReadFromJsonAsync<RoleResponseLite>(TestContext.Current.CancellationToken);
+        return created!.Id;
+    }
 
     private async Task<RoleMetadata> SeedMetadataAsync(
         string name, MultiTenancySide side, Guid? tenantId, bool isSystem = false)

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleEndpointsTestApplication.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleEndpointsTestApplication.cs
@@ -36,8 +36,14 @@ namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
 /// evaluation pipeline (<c>DynamicPermissionPolicyProvider</c> /
 /// <c>IPermissionChecker</c>) doesn't gate these tests. That surface is covered
 /// by unit tests around <c>PermissionChecker</c>; here we focus on the visibility
-/// matrix, the <c>AllowTenantRoles</c> flag, and the system-role protection rules
-/// applied inside the endpoint handlers.
+/// matrix, tenant-scope role CRUD, and the system-role protection rules applied
+/// inside the endpoint handlers.
+/// </para>
+/// <para>
+/// The fixture wires <see cref="TenantAwareRoleLookupNormalizer"/> as the
+/// <see cref="ILookupNormalizer"/> so tenant-scope role names (e.g. "Manager"
+/// created under both <c>TenantA</c> and <c>TenantB</c>) don't collide on the
+/// ASP.NET Core Identity <c>AspNetRoles.NormalizedName</c> unique index.
 /// </para>
 /// </remarks>
 public sealed class RoleEndpointsTestApplication : IAsyncLifetime
@@ -78,6 +84,13 @@ public sealed class RoleEndpointsTestApplication : IAsyncLifetime
 
         _currentTenant = new MutableCurrentTenant();
         builder.Services.AddSingleton<ICurrentTenant>(_currentTenant);
+
+        // Tenant-scope roles require the tenant-aware normalizer to avoid colliding on
+        // AspNetRoles.NormalizedName across tenants (see ADR-023). Granit wires this in
+        // GranitIdentityLocalAspNetIdentityModule; the fixture replicates that here since
+        // it boots Identity directly with AddIdentityCore.
+        builder.Services.Replace(ServiceDescriptor.Scoped<
+            ILookupNormalizer, TenantAwareRoleLookupNormalizer>());
 
         builder.Services
             .AddAuthentication(TestAuthHandler.SchemeName)


### PR DESCRIPTION
## Summary

- Flips `RoleEndpointsOptions.AllowTenantRoles` default from `false` → `true`. Tenant admins can now CRUD tenant-scope roles in their own tenant out of the box. The flag stays as an explicit opt-out for host-only deployments (`AllowTenantRoles = false`).
- The Phase-1 refusal path is repositioned from "guardrail until #1094" to "first-class opt-out" — docstrings, OpenAPI description, and the security doc page are updated accordingly.
- Prerequisite #1094 is already in develop (`TenantAwareRoleLookupNormalizer` registered by `GranitIdentityLocalAspNetIdentityModule`), so tenant-scope role names no longer collide on `AspNetRoles.NormalizedName`.

## New HTTP integration tests

Added to `GranitRoleEndpointsTests` (covers the full tenant-scope CRUD happy path):

| Test | Expectation |
| --- | --- |
| `Create_AsTenantAdmin_SideTenant_OwnTenant_Returns201` | 201, `TenantId` = caller tenant |
| `Create_AsTenantAdmin_SideTenant_ForeignTenant_Returns403` | Cross-tenant create refused |
| `Create_AsTenantAdmin_SideTenant_VisibleInOwnList_InvisibleToOtherTenant` | Visibility matrix holds end-to-end |
| `Rename_AsTenantAdmin_OwnTenantRole_Returns200` | 200, name/description updated |
| `Delete_AsTenantAdmin_OwnTenantRole_Returns204` | 204, role no longer retrievable |

The fixture now registers `TenantAwareRoleLookupNormalizer` directly (matches what `GranitIdentityLocalAspNetIdentityModule` does in a non-test host) so tenant-scope `Name="Manager"` across tenants doesn't collide.

## Breaking change

`RoleEndpointsOptions.AllowTenantRoles` default flipped from `false` → `true`. Hosts that relied on the implicit Phase-1 refusal must set it explicitly to `false`.

## Test plan

- [x] `dotnet build` — full solution, 0 warnings / 0 errors
- [x] `dotnet format --verify-no-changes` — clean
- [x] `Granit.Identity.Local.AspNetIdentity.Tests.Integration` — 23/23 pass (5 new tests + pre-existing matrix + system-role protection tests)
- [x] `Granit.Identity.Local.AspNetIdentity.Tests` — 140/140 pass (no regression)
- [x] `Granit.OpenIddict.Tests.Integration` — 25/25 pass (no regression)
- [x] Markdownlint on updated docs page — clean

## References

- Closes #1095
- Depends on #1094 (already merged — `TenantAwareRoleLookupNormalizer` wiring)
- Parent epic: #1093