### PR TITLE
test(identity-local-endpoints-integration): permission-grant enforcement tests on /admin/roles (#1102)

### DIFF
--- a/src/Granit.Identity.Local.Endpoints/Granit.Identity.Local.Endpoints.csproj
+++ b/src/Granit.Identity.Local.Endpoints/Granit.Identity.Local.Endpoints.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Granit.Identity.Local.Endpoints.Tests" />
+    <InternalsVisibleTo Include="Granit.Identity.Local.AspNetIdentity.Tests.Integration" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/GranitRoleEndpointsPermissionTests.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/GranitRoleEndpointsPermissionTests.cs
@@ -1,0 +1,286 @@
+using System.Net;
+using System.Net.Http.Json;
+using Granit.Authorization;
+using Granit.Authorization.Domain;
+using Granit.Identity.Local.Endpoints.Permissions;
+using Granit.MultiTenancy;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// HTTP-level tests that exercise the REAL permission-grant enforcement pipeline
+/// (<c>DynamicPermissionPolicyProvider</c> → <c>PermissionAuthorizationHandler</c>
+/// → <c>PermissionChecker</c>) against the <c>/admin/roles</c> endpoints.
+/// </summary>
+/// <remarks>
+/// The companion <see cref="GranitRoleEndpointsTests"/> focuses on visibility /
+/// validation logic with a permissive policy provider; this class proves the
+/// authorization layer matches the route × permission contract declared on each
+/// endpoint via <c>RequireAuthorization(...)</c> and that grant scoping
+/// (<c>TenantId</c>) is honored.
+/// </remarks>
+public sealed class GranitRoleEndpointsPermissionTests
+    : IClassFixture<RoleEndpointsPermissionTestApplication>, IAsyncLifetime
+{
+    private readonly RoleEndpointsPermissionTestApplication _app;
+    private readonly Guid _tenantA = Guid.NewGuid();
+    private readonly Guid _tenantB = Guid.NewGuid();
+
+    public GranitRoleEndpointsPermissionTests(RoleEndpointsPermissionTestApplication app) => _app = app;
+
+    public ValueTask InitializeAsync() => new(_app.ResetAsync());
+
+    public ValueTask DisposeAsync() => default;
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Unauthenticated
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Unauthenticated_Get_Returns401()
+    {
+        using HttpClient client = _app.HttpClient;
+
+        HttpResponseMessage response = await client.GetAsync(
+            "/admin/roles", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Unauthenticated_Post_Returns401()
+    {
+        using HttpClient client = _app.HttpClient;
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/admin/roles",
+            new { name = "Auditor", multiTenancySide = (int)MultiTenancySide.Host },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Authenticated, no grant
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Authenticated_NoGrant_Get_Returns403()
+    {
+        HttpClient client = AuthenticatedClient(userId: "alice");
+
+        HttpResponseMessage response = await client.GetAsync(
+            "/admin/roles", TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Authenticated_NoGrant_Post_Returns403()
+    {
+        HttpClient client = AuthenticatedClient(userId: "alice");
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/admin/roles",
+            new { name = "Auditor", multiTenancySide = (int)MultiTenancySide.Host },
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // IdentityLocal.Roles.Read — grants GET but not POST
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ReadGrant_Get_Returns200_Post_Returns403()
+    {
+        await _app.SeedUserGrantAsync("reader", IdentityLocalPermissions.Roles.Read);
+        HttpClient client = AuthenticatedClient(userId: "reader");
+
+        HttpResponseMessage get = await client.GetAsync(
+            "/admin/roles", TestContext.Current.CancellationToken);
+        get.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        HttpResponseMessage post = await client.PostAsJsonAsync(
+            "/admin/roles",
+            new { name = "Auditor", multiTenancySide = (int)MultiTenancySide.Host },
+            TestContext.Current.CancellationToken);
+        post.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // IdentityLocal.Roles.Manage — grants POST/PUT but not DELETE
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ManageGrant_Post_Returns201_Delete_Returns403()
+    {
+        await _app.SeedUserGrantAsync("manager", IdentityLocalPermissions.Roles.Manage);
+        HttpClient client = AuthenticatedClient(userId: "manager");
+
+        HttpResponseMessage post = await client.PostAsJsonAsync(
+            "/admin/roles",
+            new { name = "Auditor", multiTenancySide = (int)MultiTenancySide.Host },
+            TestContext.Current.CancellationToken);
+        post.StatusCode.ShouldBe(HttpStatusCode.Created);
+
+        RoleResponseLite? created = await post.Content
+            .ReadFromJsonAsync<RoleResponseLite>(TestContext.Current.CancellationToken);
+        created.ShouldNotBeNull();
+
+        HttpResponseMessage delete = await client.DeleteAsync(
+            $"/admin/roles/{created.Id:D}", TestContext.Current.CancellationToken);
+        delete.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ManageGrant_Put_Returns200()
+    {
+        await _app.SeedUserGrantAsync("manager", IdentityLocalPermissions.Roles.Manage);
+        HttpClient client = AuthenticatedClient(userId: "manager");
+
+        HttpResponseMessage post = await client.PostAsJsonAsync(
+            "/admin/roles",
+            new { name = "Auditor", multiTenancySide = (int)MultiTenancySide.Host },
+            TestContext.Current.CancellationToken);
+        post.StatusCode.ShouldBe(HttpStatusCode.Created);
+        RoleResponseLite? created = await post.Content
+            .ReadFromJsonAsync<RoleResponseLite>(TestContext.Current.CancellationToken);
+
+        HttpResponseMessage put = await client.PutAsJsonAsync(
+            $"/admin/roles/{created!.Id:D}",
+            new { name = "SeniorAuditor" },
+            TestContext.Current.CancellationToken);
+        put.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // IdentityLocal.Roles.Delete — grants DELETE
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteGrant_Delete_Returns204()
+    {
+        // Seed both Manage (to create a role first via the endpoint) and Delete.
+        await _app.SeedUserGrantAsync("destroyer", IdentityLocalPermissions.Roles.Manage);
+        await _app.SeedUserGrantAsync("destroyer", IdentityLocalPermissions.Roles.Delete);
+        HttpClient client = AuthenticatedClient(userId: "destroyer");
+
+        HttpResponseMessage post = await client.PostAsJsonAsync(
+            "/admin/roles",
+            new { name = "Auditor", multiTenancySide = (int)MultiTenancySide.Host },
+            TestContext.Current.CancellationToken);
+        RoleResponseLite? created = await post.Content
+            .ReadFromJsonAsync<RoleResponseLite>(TestContext.Current.CancellationToken);
+
+        HttpResponseMessage delete = await client.DeleteAsync(
+            $"/admin/roles/{created!.Id:D}", TestContext.Current.CancellationToken);
+        delete.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task DeleteGrant_WithoutManage_CannotPostButCanDelete()
+    {
+        await _app.SeedUserGrantAsync("destroyer", IdentityLocalPermissions.Roles.Delete);
+        HttpClient client = AuthenticatedClient(userId: "destroyer");
+
+        // POST is refused with the Delete-only grant.
+        HttpResponseMessage post = await client.PostAsJsonAsync(
+            "/admin/roles",
+            new { name = "Auditor", multiTenancySide = (int)MultiTenancySide.Host },
+            TestContext.Current.CancellationToken);
+        post.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+
+        // Seed a role directly so we can prove DELETE works end-to-end.
+        Guid seededId = await SeedHostRoleDirectlyAsync("Auditor");
+        HttpResponseMessage delete = await client.DeleteAsync(
+            $"/admin/roles/{seededId:D}", TestContext.Current.CancellationToken);
+        delete.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Tenant-scope grant isolation — TenantId on the grant gates the caller's context
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TenantScopedGrant_MatchingTenant_Returns200_OtherTenant_Returns403()
+    {
+        // Grant scoped to tenant A only.
+        await _app.SeedUserGrantAsync("carol", IdentityLocalPermissions.Roles.Read, tenantId: _tenantA);
+        HttpClient client = AuthenticatedClient(userId: "carol");
+
+        // Inside tenant A → allowed.
+        using (_app.CurrentTenant.Change(_tenantA))
+        {
+            HttpResponseMessage okInsideA = await client.GetAsync(
+                "/admin/roles", TestContext.Current.CancellationToken);
+            okInsideA.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        // Inside tenant B → denied (grant doesn't apply).
+        using (_app.CurrentTenant.Change(_tenantB))
+        {
+            HttpResponseMessage forbiddenInsideB = await client.GetAsync(
+                "/admin/roles", TestContext.Current.CancellationToken);
+            forbiddenInsideB.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+        }
+
+        // Host context (null tenant) → denied (tenant-scoped grant doesn't bubble up).
+        using (_app.CurrentTenant.Change(id: null))
+        {
+            HttpResponseMessage forbiddenAtHost = await client.GetAsync(
+                "/admin/roles", TestContext.Current.CancellationToken);
+            forbiddenAtHost.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────
+
+    private HttpClient AuthenticatedClient(string userId, params string[] roles)
+    {
+        HttpClient client = _app.HttpClient;
+        client.DefaultRequestHeaders.Remove(PermissionTestAuthHandler.UserIdHeader);
+        client.DefaultRequestHeaders.Remove(PermissionTestAuthHandler.RolesHeader);
+        client.DefaultRequestHeaders.Add(PermissionTestAuthHandler.UserIdHeader, userId);
+        if (roles.Length > 0)
+        {
+            client.DefaultRequestHeaders.Add(
+                PermissionTestAuthHandler.RolesHeader, string.Join(',', roles));
+        }
+
+        return client;
+    }
+
+    private async Task<Guid> SeedHostRoleDirectlyAsync(string name)
+    {
+        await using AsyncServiceScope scope = _app.Services.CreateAsyncScope();
+        IRoleMetadataStore store = scope.ServiceProvider.GetRequiredService<IRoleMetadataStore>();
+
+        var metadata = RoleMetadata.Create(
+            id: Guid.NewGuid(),
+            name: name,
+            multiTenancySide: MultiTenancySide.Host,
+            tenantId: null,
+            clientId: null,
+            description: null,
+            isSystem: false);
+
+        await store.AddAsync(metadata, TestContext.Current.CancellationToken);
+        return metadata.Id;
+    }
+
+    private sealed record RoleResponseLite(
+        Guid Id,
+        string Name,
+        MultiTenancySide MultiTenancySide,
+        Guid? TenantId,
+        string? ClientId,
+        string? Description,
+        bool IsSystem);
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/HttpContextCurrentUserService.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/HttpContextCurrentUserService.cs
@@ -1,0 +1,34 @@
+using System.Security.Claims;
+using Granit.Users;
+using Microsoft.AspNetCore.Http;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// Test-only <see cref="ICurrentUserService"/> backed by <see cref="IHttpContextAccessor"/>.
+/// Duplicates the shape of <c>Granit.Authentication.JwtBearer.Authentication.CurrentUserService</c>
+/// to avoid pulling that package into the integration test project for a single interface.
+/// </summary>
+internal sealed class HttpContextCurrentUserService(IHttpContextAccessor httpContextAccessor)
+    : ICurrentUserService
+{
+    private ClaimsPrincipal? User => httpContextAccessor.HttpContext?.User;
+
+    public string? UserId => User?.FindFirstValue(ClaimTypes.NameIdentifier)
+                             ?? User?.FindFirstValue("sub");
+
+    public string? UserName => User?.Identity?.Name;
+
+    public string? Email => User?.FindFirstValue(ClaimTypes.Email);
+
+    public string? FirstName => User?.FindFirstValue(ClaimTypes.GivenName);
+
+    public string? LastName => User?.FindFirstValue(ClaimTypes.Surname);
+
+    public bool IsAuthenticated => User?.Identity?.IsAuthenticated ?? false;
+
+    public IReadOnlyList<string> GetRoles() =>
+        User is { } user ? [.. user.FindAll(ClaimTypes.Role).Select(c => c.Value)] : [];
+
+    public bool IsInRole(string role) => User?.IsInRole(role) ?? false;
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/PermissionTestAuthHandler.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/PermissionTestAuthHandler.cs
@@ -1,0 +1,62 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// Test authentication handler driven by request headers so the permission-enforcement
+/// tests can flip the caller identity without rebuilding the server:
+/// <list type="bullet">
+/// <item><c>X-Test-User-Id</c>: overrides the default <c>sub</c> claim when set.</item>
+/// <item><c>X-Test-Roles</c>: comma-separated role claims.</item>
+/// </list>
+/// Returning <see cref="AuthenticateResult.NoResult"/> when neither header is present
+/// lets the tests cover the unauthenticated → 401 path.
+/// </summary>
+internal sealed class PermissionTestAuthHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    public const string SchemeName = "PermissionTest";
+    public const string UserIdHeader = "X-Test-User-Id";
+    public const string RolesHeader = "X-Test-Roles";
+    public const string DefaultTestUserId = "test-user-id";
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        bool hasUserId = Request.Headers.TryGetValue(UserIdHeader, out Microsoft.Extensions.Primitives.StringValues userIdHeader);
+        bool hasRoles = Request.Headers.TryGetValue(RolesHeader, out Microsoft.Extensions.Primitives.StringValues rolesHeader);
+
+        if (!hasUserId && !hasRoles)
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        string userId = hasUserId && !string.IsNullOrWhiteSpace(userIdHeader.ToString())
+            ? userIdHeader.ToString()
+            : DefaultTestUserId;
+
+        string[] roles = hasRoles
+            ? rolesHeader.ToString().Split(',', StringSplitOptions.RemoveEmptyEntries)
+            : [];
+
+        Claim[] claims =
+        [
+            new(ClaimTypes.NameIdentifier, userId),
+            new("sub", userId),
+            new(ClaimTypes.Name, userId),
+            .. roles.Select(r => new Claim(ClaimTypes.Role, r.Trim())),
+        ];
+
+        ClaimsIdentity identity = new(claims, SchemeName);
+        ClaimsPrincipal principal = new(identity);
+        AuthenticationTicket ticket = new(principal, SchemeName);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleEndpointsPermissionTestApplication.cs
+++ b/tests/Granit.Identity.Local.AspNetIdentity.Tests.Integration/RoleEndpointsPermissionTestApplication.cs
@@ -1,0 +1,177 @@
+using Granit.Authorization.Domain;
+using Granit.Authorization.EntityFrameworkCore.Extensions;
+using Granit.Authorization.Extensions;
+using Granit.Guids.Extensions;
+using Granit.Identity.Local.AspNetIdentity.Internal;
+using Granit.Identity.Local.Domain;
+using Granit.Identity.Local.Endpoints.Extensions;
+using Granit.Identity.Local.Services;
+using Granit.MultiTenancy;
+using Granit.Users;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Granit.Identity.Local.AspNetIdentity.Tests.Integration;
+
+/// <summary>
+/// Fixture for the <c>/admin/roles</c> endpoints wired with the REAL
+/// <c>AddGranitAuthorization()</c> + full policy provider / permission-grant
+/// pipeline (<c>DynamicPermissionPolicyProvider</c> →
+/// <c>PermissionAuthorizationHandler</c> → <c>PermissionChecker</c>). Unlike
+/// <see cref="RoleEndpointsTestApplication"/> which uses
+/// <c>PermissiveAuthorizationPolicyProvider</c>, this fixture exercises the
+/// enforcement pipeline end-to-end against real PostgreSQL.
+/// </summary>
+/// <remarks>
+/// Authentication is driven by <see cref="PermissionTestAuthHandler"/> — tests
+/// flip the caller identity via the <c>X-Test-User-Id</c> and
+/// <c>X-Test-Roles</c> headers. Permission grants are seeded directly on the
+/// host DbContext via <see cref="SeedUserGrantAsync"/> and
+/// <see cref="SeedRoleGrantAsync"/>.
+/// </remarks>
+public sealed class RoleEndpointsPermissionTestApplication : IAsyncLifetime
+{
+    private readonly PostgresFixture _postgres = new();
+    private WebApplication? _app;
+    private MutableCurrentTenant? _currentTenant;
+
+    public HttpClient HttpClient =>
+        _app?.GetTestClient() ?? throw new InvalidOperationException("Fixture not initialized.");
+
+    public MutableCurrentTenant CurrentTenant =>
+        _currentTenant ?? throw new InvalidOperationException("Fixture not initialized.");
+
+    public IServiceProvider Services =>
+        _app?.Services ?? throw new InvalidOperationException("Fixture not initialized.");
+
+    public async ValueTask InitializeAsync()
+    {
+        await _postgres.InitializeAsync();
+
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+
+        builder.Services.AddDbContext<TestIdentityDbContext>(opts =>
+            opts.UseNpgsql(_postgres.ConnectionString));
+        builder.Services.AddDbContext<TestHostDbContext>(opts =>
+            opts.UseNpgsql(_postgres.ConnectionString));
+
+        builder.Services.AddIdentityCore<GranitUser>()
+            .AddRoles<GranitRole>()
+            .AddEntityFrameworkStores<TestIdentityDbContext>();
+
+        // Tenant-scope role names require the tenant-aware normalizer (ADR-023).
+        builder.Services.Replace(ServiceDescriptor.Scoped<
+            ILookupNormalizer, TenantAwareRoleLookupNormalizer>());
+
+        builder.Services.AddGranitGuids();
+        builder.Services.AddScoped<IGranitRoleOrchestrator, GranitRoleOrchestrator>();
+
+        _currentTenant = new MutableCurrentTenant();
+        builder.Services.AddSingleton<ICurrentTenant>(_currentTenant);
+
+        // Real permission pipeline — no PermissiveAuthorizationPolicyProvider here.
+        builder.Services.AddGranitAuthorization();
+        builder.Services.AddGranitAuthorizationEntityFrameworkCore<TestHostDbContext>();
+
+        // Register the IPermissionDefinitionProvider that GranitAuthorizationModule would
+        // auto-discover in a module-loader host — here we construct the DI container
+        // manually so the provider needs an explicit registration. The provider is
+        // internal; InternalsVisibleTo from Granit.Identity.Local.Endpoints makes it
+        // reachable.
+        builder.Services.AddSingleton<Granit.Authorization.IPermissionDefinitionProvider,
+            Granit.Identity.Local.Endpoints.Permissions.IdentityLocalPermissionDefinitionProvider>();
+
+        // ICurrentUserService reads the principal populated by PermissionTestAuthHandler.
+        builder.Services.AddHttpContextAccessor();
+        builder.Services.AddScoped<ICurrentUserService, HttpContextCurrentUserService>();
+
+        // FusionCache dependency of PermissionChecker — plain in-memory instance; no
+        // Granit.Caching multi-tenant decorator needed for these tests.
+        builder.Services.AddSingleton<IFusionCache>(new FusionCache(new FusionCacheOptions()));
+
+        builder.Services
+            .AddAuthentication(PermissionTestAuthHandler.SchemeName)
+            .AddScheme<AuthenticationSchemeOptions, PermissionTestAuthHandler>(
+                PermissionTestAuthHandler.SchemeName, _ => { });
+        builder.Services.AddAuthorization();
+
+        _app = builder.Build();
+
+        _app.UseAuthentication();
+        _app.UseAuthorization();
+        _app.MapGranitRoles();
+
+        await using (AsyncServiceScope scope = _app.Services.CreateAsyncScope())
+        {
+            TestIdentityDbContext idCtx = scope.ServiceProvider.GetRequiredService<TestIdentityDbContext>();
+            TestHostDbContext hostCtx = scope.ServiceProvider.GetRequiredService<TestHostDbContext>();
+            await idCtx.Database.EnsureCreatedAsync();
+            await hostCtx.GetService<IRelationalDatabaseCreator>().CreateTablesAsync();
+        }
+
+        await _app.StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_app is not null)
+        {
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+
+        await _postgres.DisposeAsync();
+    }
+
+    /// <summary>Resets DB state, cache entries, and tenant context so each test starts empty.</summary>
+    public async Task ResetAsync()
+    {
+        CurrentTenant.Change(id: null);
+
+        await using AsyncServiceScope scope = Services.CreateAsyncScope();
+        TestIdentityDbContext idCtx = scope.ServiceProvider.GetRequiredService<TestIdentityDbContext>();
+        TestHostDbContext hostCtx = scope.ServiceProvider.GetRequiredService<TestHostDbContext>();
+
+        await hostCtx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE authorization_role_metadata, authorization_permission_grants RESTART IDENTITY CASCADE;");
+        await idCtx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE \"AspNetUserRoles\", \"AspNetRoleClaims\", \"AspNetUserClaims\", \"AspNetUserLogins\", \"AspNetUserTokens\", \"AspNetUsers\", \"AspNetRoles\" RESTART IDENTITY CASCADE;");
+
+        // Drop PermissionChecker's cache so previously-granted entries from the last test
+        // don't leak across the boundary (the cache is a singleton on the fixture).
+        IFusionCache cache = scope.ServiceProvider.GetRequiredService<IFusionCache>();
+        await cache.ClearAsync();
+    }
+
+    /// <summary>Seeds a user-scope permission grant for <paramref name="userId"/>.</summary>
+    public async Task SeedUserGrantAsync(string userId, string permissionName, Guid? tenantId = null)
+    {
+        await using AsyncServiceScope scope = Services.CreateAsyncScope();
+        TestHostDbContext ctx = scope.ServiceProvider.GetRequiredService<TestHostDbContext>();
+
+        var grant = PermissionGrant.Create(
+            id: Guid.NewGuid(),
+            permissionName: permissionName,
+            providerName: "U",
+            providerKey: userId,
+            tenantId: tenantId);
+
+        ctx.PermissionGrants.Add(grant);
+        await ctx.SaveChangesAsync();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a second fixture `RoleEndpointsPermissionTestApplication` that exercises the REAL permission-grant pipeline (`DynamicPermissionPolicyProvider` → `PermissionAuthorizationHandler` → `PermissionChecker`) against real PostgreSQL. The companion `RoleEndpointsTestApplication` keeps its permissive policy provider so the visibility-matrix tests stay isolated.
- New test class `GranitRoleEndpointsPermissionTests` proves every route × permission combination at HTTP level, including tenant-scope grant isolation.
- Fixture registers the internal `IdentityLocalPermissionDefinitionProvider` directly via a new `InternalsVisibleTo` on `Granit.Identity.Local.Endpoints`, instead of relying on the module loader.
- Grants are seeded through the host DbContext via the fixture's `SeedUserGrantAsync` helper; `FusionCache.ClearAsync()` runs in `ResetAsync()` so cached grants don't leak across the class-fixture boundary.

## Test matrix

| Scenario | Endpoint | Expected |
| --- | --- | --- |
| Unauthenticated | `GET /admin/roles` | 401 |
| Unauthenticated | `POST /admin/roles` | 401 |
| Authenticated, no grant | `GET /admin/roles` | 403 |
| Authenticated, no grant | `POST /admin/roles` | 403 |
| `Roles.Read` grant | `GET /admin/roles` | 200 |
| `Roles.Read` grant | `POST /admin/roles` | 403 |
| `Roles.Manage` grant | `POST /admin/roles` | 201 |
| `Roles.Manage` grant | `PUT /admin/roles/{id}` | 200 |
| `Roles.Manage` grant | `DELETE /admin/roles/{id}` | 403 |
| `Roles.Delete` grant only | `POST /admin/roles` | 403 |
| `Roles.Delete` grant only | `DELETE /admin/roles/{id}` | 204 |
| Tenant-scope grant, matching tenant | `GET /admin/roles` | 200 |
| Tenant-scope grant, other tenant | `GET /admin/roles` | 403 |
| Tenant-scope grant, host context | `GET /admin/roles` | 403 |

## Test plan

- [x] `dotnet build` — full test project, 0 warnings / 0 errors
- [x] `dotnet format --verify-no-changes` — clean
- [x] `Granit.Identity.Local.AspNetIdentity.Tests.Integration` — 33/33 (23 existing + 10 new)
- [x] No regression in the companion visibility-matrix tests

## References

- Closes #1102
- Parent epic: #1093 (RoleMetadata Phase 2)