### PR TITLE
fix(http-exception-handling): mask 4xx messages and sanitize validation errors (VULN-202, VULN-203)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -16453,7 +16453,7 @@
       "kind": "class",
       "project": "Granit.Http.ExceptionHandling",
       "file": "src/Granit.Http.ExceptionHandling/Extensions/ExceptionHandlingServiceCollectionExtensions.cs",
-      "line": 11,
+      "line": 14,
       "members": [
         {
           "name": "AddGranitExceptionHandling",

--- a/src/Granit.Http.ExceptionHandling/Extensions/ExceptionHandlingServiceCollectionExtensions.cs
+++ b/src/Granit.Http.ExceptionHandling/Extensions/ExceptionHandlingServiceCollectionExtensions.cs
@@ -1,7 +1,10 @@
+using System.Reflection;
+using Granit.DataProtection;
 using Granit.Http.ExceptionHandling.Internal;
 using Granit.Http.ExceptionHandling.Options;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Granit.Http.ExceptionHandling.Extensions;
 
@@ -31,6 +34,17 @@ public static class ExceptionHandlingServiceCollectionExtensions
         services.AddProblemDetails();
         services.AddExceptionHandler<GranitExceptionHandler>();
         services.AddSingleton<IExceptionStatusCodeMapper, DefaultExceptionStatusCodeMapper>();
+
+        // SensitivePropertyRegistry is a cross-cutting primitive (MCP, audit,
+        // and now ProblemDetails sanitization). TryAdd guards against
+        // duplicate registration when the consumer also uses Granit.Mcp.
+        services.TryAddSingleton(_ =>
+        {
+            IEnumerable<Assembly> assemblies = AppDomain.CurrentDomain.GetAssemblies()
+                .Where(a => a.GetName().Name?.StartsWith("Granit", StringComparison.Ordinal) == true);
+            return new SensitivePropertyRegistry(assemblies);
+        });
+        services.TryAddSingleton<ValidationErrorsSanitizer>();
 
         if (configure is not null)
         {

--- a/src/Granit.Http.ExceptionHandling/Internal/GranitExceptionHandler.cs
+++ b/src/Granit.Http.ExceptionHandling/Internal/GranitExceptionHandler.cs
@@ -33,9 +33,20 @@ internal sealed partial class GranitExceptionHandler(
     IProblemDetailsService problemDetailsService,
     IOptions<ExceptionHandlingOptions> options,
     ILoggerFactory loggerFactory,
+    ValidationErrorsSanitizer validationErrorsSanitizer,
     IStringLocalizerFactory? localizerFactory = null) : IExceptionHandler
 {
-    private static readonly string FallbackTitle = "An unexpected error occurred.";
+    private const string FallbackTitle = "An unexpected error occurred.";
+
+    // Generic 4xx titles — returned when ExposeInternalErrorDetails is false
+    // and the exception is not IUserFriendlyException. Avoids leaking business
+    // logic details, PII, or tenant identifiers embedded in raw exception
+    // messages (ISO 27001, GDPR Art. 32, OWASP ASVS V7.4.1).
+    private const string FallbackTitle404 = "Resource not found.";
+    private const string FallbackTitle403 = "Forbidden.";
+    private const string FallbackTitle409 = "Conflict.";
+    private const string FallbackTitle422 = "Validation failed.";
+    private const string FallbackTitle4xx = "Invalid request.";
 
     private readonly ILogger _logger = loggerFactory.CreateLogger<GranitExceptionHandler>();
 
@@ -134,7 +145,8 @@ internal sealed partial class GranitExceptionHandler(
 
         if (exception is IHasValidationErrors hasValidationErrors)
         {
-            problemDetails.Extensions["errors"] = hasValidationErrors.ValidationErrors;
+            problemDetails.Extensions["errors"] =
+                validationErrorsSanitizer.Sanitize(hasValidationErrors.ValidationErrors);
         }
 
         return problemDetails;
@@ -165,15 +177,26 @@ internal sealed partial class GranitExceptionHandler(
             return exception.Message;
         }
 
-        // For internal errors (5xx): mask the message in production.
-        // Only expose if ExposeInternalErrorDetails is true (development/staging).
-        if (statusCode >= 500)
+        // Dev/staging: expose raw message for debugging (all status codes).
+        if (options.Value.ExposeInternalErrorDetails)
         {
-            return options.Value.ExposeInternalErrorDetails ? exception.Message : FallbackTitle;
+            return exception.Message;
         }
 
-        // For 4xx without user-friendly marker: use the message (technical but not sensitive).
-        return exception.Message;
+        // Production: mask messages for both 5xx AND 4xx non-user-friendly.
+        // 4xx exception messages may contain internal context (user ids, tenant
+        // ids, SQL fragments, internal paths) that must not reach the client.
+        // Opt into exposing a specific 4xx message by implementing
+        // IUserFriendlyException on the exception type.
+        return statusCode switch
+        {
+            >= 500 => FallbackTitle,
+            StatusCodes.Status404NotFound => FallbackTitle404,
+            StatusCodes.Status403Forbidden => FallbackTitle403,
+            StatusCodes.Status409Conflict => FallbackTitle409,
+            StatusCodes.Status422UnprocessableEntity => FallbackTitle422,
+            _ => FallbackTitle4xx,
+        };
     }
 
     /// <summary>

--- a/src/Granit.Http.ExceptionHandling/Internal/ValidationErrorsSanitizer.cs
+++ b/src/Granit.Http.ExceptionHandling/Internal/ValidationErrorsSanitizer.cs
@@ -1,0 +1,109 @@
+using Granit.DataProtection;
+
+namespace Granit.Http.ExceptionHandling.Internal;
+
+/// <summary>
+/// Redacts sensitive field values from validation error payloads before they
+/// are serialized into the <c>ProblemDetails.Extensions["errors"]</c> object.
+/// </summary>
+/// <remarks>
+/// <para>
+/// FluentValidation and ModelState commonly echo the offending value in the
+/// error message (<c>"'Password' must not equal 'hunter2'"</c>,
+/// <c>"Email 'alice@x.com' is not a valid address"</c>). If the field is marked
+/// <see cref="SensitiveDataAttribute"/>, the value ends up in the client
+/// response — a GDPR Art. 32 confidentiality violation and a vector for PII
+/// or credential disclosure.
+/// </para>
+/// <para>
+/// This sanitizer preserves the error key so the front-end keeps its
+/// field-error binding, but replaces each message with a neutral
+/// <c>"Invalid value."</c> when any segment of the property path matches a
+/// registered sensitive property. Property paths support both MVC ModelState
+/// (<c>"Address.SecretCode"</c>) and FluentValidation collection syntax
+/// (<c>"Users[0].Password"</c>, <c>"Items[3].Card.Cvv"</c>); purely numeric
+/// segments (collection indices) are skipped.
+/// </para>
+/// </remarks>
+internal sealed class ValidationErrorsSanitizer(SensitivePropertyRegistry? registry)
+{
+    private const string RedactedMessage = "Invalid value.";
+
+    private static readonly char[] PathSeparators = ['.', '[', ']'];
+
+    public IReadOnlyDictionary<string, string[]> Sanitize(
+        IReadOnlyDictionary<string, string[]> errors)
+    {
+        if (registry is null || errors.Count == 0)
+        {
+            return errors;
+        }
+
+        // Two-pass: detect whether any key needs redaction before allocating.
+        // Preserves the original dictionary instance when nothing is sensitive
+        // (common case for non-PII endpoints), and avoids the ordering bug
+        // where a sensitive key found after non-sensitive keys would leave the
+        // earlier ones out of the rebuilt dictionary.
+        bool hasSensitive = false;
+        foreach (string key in errors.Keys)
+        {
+            if (IsPathSensitive(key))
+            {
+                hasSensitive = true;
+                break;
+            }
+        }
+
+        if (!hasSensitive)
+        {
+            return errors;
+        }
+
+        Dictionary<string, string[]> sanitized = new(errors.Count, StringComparer.Ordinal);
+        foreach (KeyValuePair<string, string[]> pair in errors)
+        {
+            sanitized[pair.Key] = IsPathSensitive(pair.Key)
+                ? [RedactedMessage]
+                : pair.Value;
+        }
+
+        return sanitized;
+    }
+
+    private bool IsPathSensitive(string errorKey)
+    {
+        foreach (string segment in errorKey.Split(PathSeparators, StringSplitOptions.RemoveEmptyEntries))
+        {
+            // Skip purely-numeric segments (collection indices like "0" in "Users[0].Password").
+            if (IsPurelyNumeric(segment))
+            {
+                continue;
+            }
+
+            if (registry!.IsSensitiveAtLevel(segment, Sensitivity.Confidential, out _))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsPurelyNumeric(string segment)
+    {
+        if (segment.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (char c in segment)
+        {
+            if (c is < '0' or > '9')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/Granit.Http.ExceptionHandling.Tests/GranitExceptionHandlerTests.cs
+++ b/tests/Granit.Http.ExceptionHandling.Tests/GranitExceptionHandlerTests.cs
@@ -469,14 +469,47 @@ public sealed class GranitExceptionHandlerTests
     }
 
     // -------------------------------------------------------------------------
-    // 4xx non-user-friendly: title uses exception message
+    // 4xx non-user-friendly: title is masked in production (VULN-202)
     // -------------------------------------------------------------------------
+    // Exception messages from non-IUserFriendlyException exceptions may carry
+    // internal context (user ids, tenant ids, SQL fragments, internal paths).
+    // In production (ExposeInternalErrorDetails = false) we return a generic
+    // per-status title. Dev/staging still exposes the raw message for
+    // debugging.
 
     [Fact]
-    public async Task TryHandleAsync_4xxNonUserFriendly_TitleUsesExceptionMessage()
+    public async Task TryHandleAsync_4xxNonUserFriendly_Production_TitleIsGeneric()
     {
         // UnauthorizedAccessException is not IUserFriendlyException but maps to 403
-        using ServiceProvider sp = BuildServiceProvider();
+        using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = false);
+
+        (_, _, string? title, _) = await InvokeHandlerAsync(
+            sp, new UnauthorizedAccessException("User 'alice@x.com' denied tenant 'acme'"));
+
+        title.ShouldBe("Forbidden.");
+        title!.ShouldNotContain("alice@x.com");
+        title!.ShouldNotContain("acme");
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_4xxNonUserFriendly_Timeout_Production_TitleIsGeneric()
+    {
+        // TimeoutException (.NET built-in) is NOT IUserFriendlyException — its
+        // message may reference internal service URLs, SQL fragments, etc.
+        // Maps to 408 via DefaultExceptionStatusCodeMapper.
+        using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = false);
+
+        (_, _, string? title, _) = await InvokeHandlerAsync(
+            sp, new TimeoutException("SQL query to 'internal-db-01' timed out after 30s"));
+
+        title.ShouldBe("Invalid request.");
+        title!.ShouldNotContain("internal-db-01");
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_4xxNonUserFriendly_Development_TitleExposesMessage()
+    {
+        using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = true);
 
         (_, _, string? title, _) = await InvokeHandlerAsync(
             sp, new UnauthorizedAccessException("Access denied to resource X"));
@@ -493,6 +526,19 @@ public sealed class GranitExceptionHandlerTests
             sp, new UnauthorizedAccessException("Access denied"));
 
         detail.ShouldBeNull("detail should be null for 4xx non-user-friendly exceptions");
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_UserFriendly4xx_Production_KeepsMessage()
+    {
+        // IUserFriendlyException is deliberately exposed even in production — the
+        // opt-in contract for messages that are safe to show to the client.
+        using ServiceProvider sp = BuildServiceProvider(opts => opts.ExposeInternalErrorDetails = false);
+
+        (_, _, string? title, _) = await InvokeHandlerAsync(
+            sp, new BusinessException("Appointment:SlotUnavailable", "Slot already booked."));
+
+        title.ShouldBe("Slot already booked.");
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Granit.Http.ExceptionHandling.Tests/ValidationErrorsSanitizerTests.cs
+++ b/tests/Granit.Http.ExceptionHandling.Tests/ValidationErrorsSanitizerTests.cs
@@ -1,0 +1,243 @@
+// =============================================================================
+// Tests - ValidationErrorsSanitizer (VULN-203)
+// =============================================================================
+// Verifies that ProblemDetails.Extensions["errors"] redacts messages for
+// fields marked [SensitiveData(Level >= Confidential)]. Property paths
+// support top-level fields, nested objects ("Address.Cvv"), and
+// collection indexing ("Users[0].Password", "Items[3].Card.Cvv").
+// Purely-numeric path segments are skipped (they are collection indices,
+// not property names).
+// =============================================================================
+
+using System.Reflection;
+using Granit.DataProtection;
+using Granit.Http.ExceptionHandling.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Http.ExceptionHandling.Tests;
+
+public sealed class ValidationErrorsSanitizerTests
+{
+    // Fixture types with sensitive property declarations scanned by the registry.
+    private sealed class PaymentFixture
+    {
+        public string? Amount { get; set; }
+
+        [SensitiveData(Level = Sensitivity.Restricted)]
+        public string? Cvv { get; set; }
+
+        [SensitiveData(Level = Sensitivity.Restricted)]
+        public string? Password { get; set; }
+
+        [SensitiveData(Level = Sensitivity.Confidential)]
+        public string? SecretCode { get; set; }
+
+        // Internal sensitivity < Confidential threshold — must NOT be redacted.
+        [SensitiveData(Level = Sensitivity.Internal)]
+        public string? FirstName { get; set; }
+    }
+
+    private static ValidationErrorsSanitizer BuildSanitizer() =>
+        new(new SensitivePropertyRegistry([typeof(PaymentFixture).Assembly]));
+
+    // -------------------------------------------------------------------------
+    // Top-level fields
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Sanitize_TopLevel_SensitiveField_ReplacesMessage()
+    {
+        ValidationErrorsSanitizer sanitizer = BuildSanitizer();
+        Dictionary<string, string[]> errors = new()
+        {
+            ["Cvv"] = ["'Cvv' must equal '1234'"],
+        };
+
+        IReadOnlyDictionary<string, string[]> result = sanitizer.Sanitize(errors);
+
+        result["Cvv"].ShouldBe(["Invalid value."]);
+        result["Cvv"][0].ShouldNotContain("1234");
+    }
+
+    [Fact]
+    public void Sanitize_TopLevel_NonSensitiveField_IsUnchanged()
+    {
+        ValidationErrorsSanitizer sanitizer = BuildSanitizer();
+        Dictionary<string, string[]> errors = new()
+        {
+            ["Amount"] = ["'Amount' must be greater than 0"],
+        };
+
+        IReadOnlyDictionary<string, string[]> result = sanitizer.Sanitize(errors);
+
+        result["Amount"].ShouldBe(["'Amount' must be greater than 0"]);
+    }
+
+    [Fact]
+    public void Sanitize_InternalSensitivity_BelowConfidentialThreshold_IsUnchanged()
+    {
+        // FirstName is [SensitiveData(Level = Internal)] — below the
+        // Confidential threshold the sanitizer uses, so it stays intact.
+        ValidationErrorsSanitizer sanitizer = BuildSanitizer();
+        Dictionary<string, string[]> errors = new()
+        {
+            ["FirstName"] = ["'FirstName' must not be empty"],
+        };
+
+        IReadOnlyDictionary<string, string[]> result = sanitizer.Sanitize(errors);
+
+        result["FirstName"].ShouldBe(["'FirstName' must not be empty"]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Nested property paths
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Sanitize_NestedPath_SensitiveLeaf_IsRedacted()
+    {
+        ValidationErrorsSanitizer sanitizer = BuildSanitizer();
+        Dictionary<string, string[]> errors = new()
+        {
+            ["Address.SecretCode"] = ["'SecretCode' 'abc-xyz' is invalid"],
+        };
+
+        IReadOnlyDictionary<string, string[]> result = sanitizer.Sanitize(errors);
+
+        result["Address.SecretCode"].ShouldBe(["Invalid value."]);
+        result["Address.SecretCode"][0].ShouldNotContain("abc-xyz");
+    }
+
+    [Fact]
+    public void Sanitize_CollectionIndex_NumericSegmentIsSkipped_SensitiveLeafRedacted()
+    {
+        ValidationErrorsSanitizer sanitizer = BuildSanitizer();
+        Dictionary<string, string[]> errors = new()
+        {
+            ["Users[0].Password"] = ["'Password' must equal 'hunter2'"],
+        };
+
+        IReadOnlyDictionary<string, string[]> result = sanitizer.Sanitize(errors);
+
+        result["Users[0].Password"].ShouldBe(["Invalid value."]);
+        result["Users[0].Password"][0].ShouldNotContain("hunter2");
+    }
+
+    [Fact]
+    public void Sanitize_DeepNesting_SensitiveLeafRedacted()
+    {
+        ValidationErrorsSanitizer sanitizer = BuildSanitizer();
+        Dictionary<string, string[]> errors = new()
+        {
+            ["Items[3].Card.Cvv"] = ["'Cvv' '987' is invalid"],
+        };
+
+        IReadOnlyDictionary<string, string[]> result = sanitizer.Sanitize(errors);
+
+        result["Items[3].Card.Cvv"].ShouldBe(["Invalid value."]);
+        result["Items[3].Card.Cvv"][0].ShouldNotContain("987");
+    }
+
+    [Fact]
+    public void Sanitize_RootPathWithoutSensitiveSegment_NoFalsePositive()
+    {
+        // "Address" alone is not sensitive; only "Address.Cvv" or similar would be.
+        ValidationErrorsSanitizer sanitizer = BuildSanitizer();
+        Dictionary<string, string[]> errors = new()
+        {
+            ["Address"] = ["'Address' must not be empty"],
+        };
+
+        IReadOnlyDictionary<string, string[]> result = sanitizer.Sanitize(errors);
+
+        result["Address"].ShouldBe(["'Address' must not be empty"]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Mixed payloads
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Sanitize_MixedPayload_OnlySensitiveKeysRedacted()
+    {
+        ValidationErrorsSanitizer sanitizer = BuildSanitizer();
+        Dictionary<string, string[]> errors = new()
+        {
+            ["Amount"] = ["Amount must be > 0"],
+            ["Cvv"] = ["Cvv 'secret' is invalid"],
+            ["Users[0].Password"] = ["Password 'hunter2' is weak"],
+            ["Email"] = ["Email format invalid"],
+        };
+
+        IReadOnlyDictionary<string, string[]> result = sanitizer.Sanitize(errors);
+
+        result["Amount"].ShouldBe(["Amount must be > 0"]);
+        result["Cvv"].ShouldBe(["Invalid value."]);
+        result["Users[0].Password"].ShouldBe(["Invalid value."]);
+        result["Email"].ShouldBe(["Email format invalid"]); // Email not declared on fixture
+    }
+
+    // -------------------------------------------------------------------------
+    // Edge cases
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Sanitize_EmptyDictionary_ReturnsInputInstance()
+    {
+        ValidationErrorsSanitizer sanitizer = BuildSanitizer();
+        Dictionary<string, string[]> errors = [];
+
+        IReadOnlyDictionary<string, string[]> result = sanitizer.Sanitize(errors);
+
+        result.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Sanitize_NoSensitiveKeys_ReturnsOriginalInstance()
+    {
+        ValidationErrorsSanitizer sanitizer = BuildSanitizer();
+        Dictionary<string, string[]> errors = new()
+        {
+            ["Amount"] = ["too small"],
+            ["Quantity"] = ["too large"],
+        };
+
+        IReadOnlyDictionary<string, string[]> result = sanitizer.Sanitize(errors);
+
+        // Performance invariant: no allocation when nothing to redact.
+        result.ShouldBeSameAs(errors);
+    }
+
+    [Fact]
+    public void Sanitize_NullRegistry_NoOp()
+    {
+        // Absence of registry (e.g. Granit.DataProtection not wired) must not
+        // break the exception handler — sanitization becomes a no-op pass-through.
+        ValidationErrorsSanitizer sanitizer = new(registry: null);
+        Dictionary<string, string[]> errors = new()
+        {
+            ["Cvv"] = ["Cvv 'secret' is invalid"],
+        };
+
+        IReadOnlyDictionary<string, string[]> result = sanitizer.Sanitize(errors);
+
+        result["Cvv"].ShouldBe(["Cvv 'secret' is invalid"]);
+    }
+
+    [Fact]
+    public void Sanitize_CaseInsensitiveMatch_RedactsEvenWithDifferentCasing()
+    {
+        // Registry uses OrdinalIgnoreCase; ModelState may produce paths with
+        // different casing than the declared property name.
+        ValidationErrorsSanitizer sanitizer = BuildSanitizer();
+        Dictionary<string, string[]> errors = new()
+        {
+            ["users[0].password"] = ["password 'abc' invalid"],
+        };
+
+        IReadOnlyDictionary<string, string[]> result = sanitizer.Sanitize(errors);
+
+        result["users[0].password"].ShouldBe(["Invalid value."]);
+    }
+}


### PR DESCRIPTION
## Summary

Security audit fixes **VULN-202** and **VULN-203** (both MEDIUM).

- **VULN-202** — non-`IUserFriendlyException` 4xx exception messages are now masked with per-status generic titles ("Forbidden.", "Conflict.", etc.) when `ExposeInternalErrorDetails = false`. Prior behaviour echoed the raw message, which could leak user ids, tenant ids, SQL fragments, or internal paths embedded in the text (ISO 27001 / GDPR Art. 32 / OWASP ASVS V7.4.1). Dev/staging still sees the raw message via `ExposeInternalErrorDetails = true`.
- **VULN-203** — `ProblemDetails.Extensions["errors"]` is now routed through a new `ValidationErrorsSanitizer` that replaces messages with `"Invalid value."` for any field path whose segment matches a property marked `[SensitiveData(Level >= Confidential)]`. Supports nested paths (`Address.Cvv`) and FluentValidation collection syntax (`Users[0].Password`), skipping purely-numeric segments. Two-pass, no-allocation when nothing is sensitive.
- `SensitivePropertyRegistry` is now registered by `AddGranitExceptionHandling` via `TryAddSingleton` so apps without `Granit.Mcp` still benefit. Sanitization is a null-safe no-op when the registry is absent.

Non-breaking. Unblocker for every consumer currently echoing apology-style exception messages and validator-reflected PII.

## Test plan

- [x] `dotnet test tests/Granit.Http.ExceptionHandling.Tests` — 85 tests pass
- [x] `dotnet test tests/Granit.ArchitectureTests` — 119 tests pass
- [x] `dotnet format --verify-no-changes` clean
- [ ] Smoke-test the 4xx masking path in `granit-showcase-dotnet`
