### PR TITLE
fix(http-idempotency): filter replay headers, tombstone oversized responses, bound key length, fail race with 409

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -16681,6 +16681,12 @@
           "returnType": "TimeSpan CompletedTtl { get; set; } = TimeSpan."
         },
         {
+          "name": "FromHours",
+          "kind": "method",
+          "signature": "FromHours(24)",
+          "returnType": "TimeSpan TombstoneTtl { get; set; } = TimeSpan."
+        },
+        {
           "name": "FromSeconds",
           "kind": "method",
           "signature": "FromSeconds(30)",
@@ -16699,10 +16705,28 @@
           "returnType": "int"
         },
         {
+          "name": "MaxResponseSizeBytes",
+          "kind": "property",
+          "signature": "int MaxResponseSizeBytes",
+          "returnType": "int"
+        },
+        {
+          "name": "MaxKeyLength",
+          "kind": "property",
+          "signature": "int MaxKeyLength",
+          "returnType": "int"
+        },
+        {
           "name": "is",
           "kind": "method",
           "signature": "is(>= 200 and < 300)",
           "returnType": "Func<int, bool> ShouldCacheStatusCode { get; set; } = sc => sc"
+        },
+        {
+          "name": "new",
+          "kind": "method",
+          "signature": "new(StringComparer.OrdinalIgnoreCase)",
+          "returnType": "HashSet<string> ExcludedResponseHeaders { get; } ="
         }
       ]
     },
@@ -16713,6 +16737,15 @@
       "project": "Granit.Http.Idempotency",
       "file": "src/Granit.Http.Idempotency/Models/IdempotencyState.cs",
       "line": 6,
+      "members": []
+    },
+    {
+      "name": "IdempotencyTombstoneReason",
+      "fqn": "Granit.Http.Idempotency.Models.IdempotencyTombstoneReason",
+      "kind": "enum",
+      "project": "Granit.Http.Idempotency",
+      "file": "src/Granit.Http.Idempotency/Models/IdempotencyTombstoneReason.cs",
+      "line": 12,
       "members": []
     },
     {

--- a/src/Granit.Http.Idempotency/Internal/IdempotencyMiddleware.cs
+++ b/src/Granit.Http.Idempotency/Internal/IdempotencyMiddleware.cs
@@ -65,6 +65,18 @@ internal sealed partial class IdempotencyMiddleware(
             return;
         }
 
+        // 2b. Reject oversized keys before any hashing or cache lookup. Bounds
+        // the work a single client can force per request; Kestrel's global
+        // header limit is a coarser, pipeline-wide guard.
+        if (idempotencyKey.Length > _opts.MaxKeyLength)
+        {
+            await WriteProblemAsync(context, StatusCodes.Status400BadRequest,
+                "Idempotency Key Too Long",
+                $"The '{_opts.HeaderName}' header value exceeds the maximum allowed length " +
+                $"of {_opts.MaxKeyLength} characters.").ConfigureAwait(false);
+            return;
+        }
+
         // 3. Reject multipart — boundaries are non-deterministic, hashing is unreliable
         if (context.Request.HasFormContentType)
         {
@@ -108,9 +120,19 @@ internal sealed partial class IdempotencyMiddleware(
                 return;
             }
 
-            // Key vanished between acquire failure and re-read (extreme TTL race) — proceed without lock.
-            // SetCompletedAsync (When.Exists) will silently no-op; response is returned but not stored.
+            // Extreme TTL race: key vanished between acquire failure and re-read.
+            // We DO NOT proceed without a lock — doing so would allow two pods to
+            // execute the same idempotent request concurrently (double payment,
+            // double email, etc.) the instant the lock's TTL ticks over. Instead,
+            // return 409 + Retry-After so the client retries in a window where
+            // we can re-acquire cleanly. Preserves the at-most-once guarantee.
+            int retryAfter = (int)_opts.InProgressTtl.TotalSeconds;
+            context.Response.Headers.RetryAfter = retryAfter.ToString();
             LogRaceCondition(_logger, redisKey);
+            await WriteProblemAsync(context, StatusCodes.Status409Conflict,
+                "Idempotency Race",
+                $"Could not acquire the idempotency lock for this request. Retry after {retryAfter}s.").ConfigureAwait(false);
+            return;
         }
 
         // 8. Execute downstream handler and capture the response
@@ -147,8 +169,29 @@ internal sealed partial class IdempotencyMiddleware(
             return;
         }
 
+        // Tombstoned entry: the request ran successfully once but its response
+        // is not replayable. Preserve the at-most-once guarantee by returning
+        // an explicit failure instead of re-executing the handler.
+        if (entry.State == IdempotencyState.Tombstoned)
+        {
+            int statusCode = entry.TombstoneReason switch
+            {
+                IdempotencyTombstoneReason.ResponseTooLarge => StatusCodes.Status413PayloadTooLarge,
+                _ => StatusCodes.Status500InternalServerError,
+            };
+            context.Response.Headers["X-Idempotency-Tombstone"] =
+                entry.TombstoneReason?.ToString() ?? "Unknown";
+            LogTombstoneReplay(_logger, redisKey, entry.TombstoneReason);
+            await WriteProblemAsync(context, statusCode,
+                "Idempotent Response Not Replayable",
+                "The original response for this idempotency key cannot be replayed. " +
+                "The request was executed successfully but its response was not cached " +
+                "(e.g. exceeded the replay size limit). Use a new idempotency key to retry.").ConfigureAwait(false);
+            return;
+        }
+
         // Replay the completed response
-        await ReplayResponseAsync(context, entry).ConfigureAwait(false);
+        await ReplayResponseAsync(context, entry, _opts).ConfigureAwait(false);
         LogReplay(_logger, redisKey, entry.StatusCode, entry.CompletedAt);
 
         // meta may carry per-endpoint TTL overrides — kept as parameter for symmetry
@@ -227,11 +270,36 @@ internal sealed partial class IdempotencyMiddleware(
             return;
         }
 
-        // Capture response headers (excluding hop-by-hop)
+        DateTimeOffset completedAt = _timeProvider.GetUtcNow();
+
+        // Response body too large to cache: store a tombstone so retries see
+        // an explicit "executed once, not replayable" state instead of re-
+        // executing the business handler. The original client has already
+        // received their full response at this point.
+        if (captureStream.Length > _opts.MaxResponseSizeBytes)
+        {
+            IdempotencyEntry tombstoneEntry = new()
+            {
+                State = IdempotencyState.Tombstoned,
+                PayloadHash = payloadHash,
+                CreatedAt = createdAt,
+                StatusCode = statusCode,
+                CompletedAt = completedAt,
+                TombstoneReason = IdempotencyTombstoneReason.ResponseTooLarge,
+            };
+
+            LogResponseTooLarge(_logger, redisKey, captureStream.Length, _opts.MaxResponseSizeBytes);
+            await _store.SetCompletedAsync(redisKey, tombstoneEntry, _opts.TombstoneTtl, CancellationToken.None).ConfigureAwait(false);
+            return;
+        }
+
+        // Capture response headers, filtering anything that must not be
+        // replayed to a later retry (Set-Cookie rotation, WWW-Authenticate
+        // challenges, etc. — see IdempotencyOptions.ExcludedResponseHeaders).
         Dictionary<string, string[]> headers = [];
         foreach (System.Collections.Generic.KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues> h in context.Response.Headers)
         {
-            if (string.Equals(h.Key, "Transfer-Encoding", StringComparison.OrdinalIgnoreCase))
+            if (_opts.ExcludedResponseHeaders.Contains(h.Key))
             {
                 continue;
             }
@@ -258,7 +326,7 @@ internal sealed partial class IdempotencyMiddleware(
             StatusCode = statusCode,
             ResponseHeaders = headers.Count > 0 ? headers : null,
             ResponseBody = responseBody.Length > 0 ? responseBody : null,
-            CompletedAt = _timeProvider.GetUtcNow(),
+            CompletedAt = completedAt,
         };
 
         await _store.SetCompletedAsync(redisKey, completedEntry, completedTtl, CancellationToken.None).ConfigureAwait(false);
@@ -268,7 +336,7 @@ internal sealed partial class IdempotencyMiddleware(
     // Response replay
     // =========================================================================
 
-    private static async Task ReplayResponseAsync(HttpContext context, IdempotencyEntry entry)
+    private static async Task ReplayResponseAsync(HttpContext context, IdempotencyEntry entry, IdempotencyOptions opts)
     {
         context.Response.StatusCode = entry.StatusCode!.Value;
 
@@ -276,7 +344,11 @@ internal sealed partial class IdempotencyMiddleware(
         {
             foreach (System.Collections.Generic.KeyValuePair<string, string[]> h in entry.ResponseHeaders)
             {
-                if (string.Equals(h.Key, "Transfer-Encoding", StringComparison.OrdinalIgnoreCase))
+                // Defense in depth: the capture path filters the same headers
+                // but entries written before the exclusion list existed (or by
+                // a future option override during admin downgrade) must still
+                // be filtered at replay time.
+                if (opts.ExcludedResponseHeaders.Contains(h.Key))
                 {
                     continue;
                 }
@@ -408,6 +480,14 @@ internal sealed partial class IdempotencyMiddleware(
     [LoggerMessage(Level = LogLevel.Warning,
         Message = "HTTP 499: client disconnected for key {Key}. InProgress lock expires naturally in {TtlSeconds}s.")]
     private static partial void LogClientDisconnected(ILogger logger, string key, int ttlSeconds);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Idempotency response for key {Key} ({SizeBytes} bytes) exceeds MaxResponseSizeBytes ({MaxSizeBytes}). Storing tombstone; replays will return 413.")]
+    private static partial void LogResponseTooLarge(ILogger logger, string key, long sizeBytes, int maxSizeBytes);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Idempotency replay for tombstoned key {Key} (reason: {Reason}). Request was executed once; response is not replayable.")]
+    private static partial void LogTombstoneReplay(ILogger logger, string key, IdempotencyTombstoneReason? reason);
 
     // =========================================================================
     // Problem response helper (Utf8JsonWriter directly to response body — no MVC dependency)

--- a/src/Granit.Http.Idempotency/Internal/IdempotencyOptionsValidator.cs
+++ b/src/Granit.Http.Idempotency/Internal/IdempotencyOptionsValidator.cs
@@ -28,6 +28,21 @@ internal sealed class IdempotencyOptionsValidator : IValidateOptions<Idempotency
             failures.Add($"{nameof(options.MaxBodySizeBytes)} must be greater than 0.");
         }
 
+        if (options.MaxResponseSizeBytes <= 0)
+        {
+            failures.Add($"{nameof(options.MaxResponseSizeBytes)} must be greater than 0.");
+        }
+
+        if (options.MaxKeyLength <= 0)
+        {
+            failures.Add($"{nameof(options.MaxKeyLength)} must be greater than 0.");
+        }
+
+        if (options.TombstoneTtl <= TimeSpan.Zero)
+        {
+            failures.Add($"{nameof(options.TombstoneTtl)} must be greater than zero.");
+        }
+
         if (options.ExecutionTimeout >= options.InProgressTtl)
         {
             failures.Add(

--- a/src/Granit.Http.Idempotency/Models/IdempotencyEntry.cs
+++ b/src/Granit.Http.Idempotency/Models/IdempotencyEntry.cs
@@ -25,4 +25,10 @@ public sealed record IdempotencyEntry
 
     /// <summary>UTC timestamp when the entry transitioned to Completed. <see langword="null"/> while InProgress.</summary>
     public DateTimeOffset? CompletedAt { get; init; }
+
+    /// <summary>
+    /// Reason the entry was tombstoned. Non-<see langword="null"/> only when
+    /// <see cref="State"/> is <see cref="IdempotencyState.Tombstoned"/>.
+    /// </summary>
+    public IdempotencyTombstoneReason? TombstoneReason { get; init; }
 }

--- a/src/Granit.Http.Idempotency/Models/IdempotencyOptions.cs
+++ b/src/Granit.Http.Idempotency/Models/IdempotencyOptions.cs
@@ -23,6 +23,14 @@ public sealed class IdempotencyOptions
     public TimeSpan CompletedTtl { get; set; } = TimeSpan.FromHours(24);
 
     /// <summary>
+    /// TTL for tombstone entries (responses that ran successfully but cannot
+    /// be replayed, e.g. oversized). Default: 24 hours — matches
+    /// <see cref="CompletedTtl"/> so a client that retries within the
+    /// normal window sees a deterministic 413 instead of re-executing.
+    /// </summary>
+    public TimeSpan TombstoneTtl { get; set; } = TimeSpan.FromHours(24);
+
+    /// <summary>
     /// TTL for the InProgress lock. Must be strictly greater than <see cref="ExecutionTimeout"/>.
     /// Default: 30 seconds.
     /// </summary>
@@ -39,9 +47,54 @@ public sealed class IdempotencyOptions
     public int MaxBodySizeBytes { get; set; } = 1 * 1024 * 1024;
 
     /// <summary>
+    /// Maximum response body size stored for replay. Default: 256 KiB.
+    /// When the captured response exceeds this limit, the client still
+    /// receives the full response, but the entry is written as a
+    /// tombstone (<see cref="IdempotencyState.Tombstoned"/>) so retries
+    /// return HTTP 413 instead of re-executing the handler.
+    /// </summary>
+    public int MaxResponseSizeBytes { get; set; } = 256 * 1024;
+
+    /// <summary>
+    /// Maximum length of the client-supplied idempotency key header value.
+    /// Values longer than this limit are rejected with HTTP 400 before any
+    /// hashing or cache lookup. Default: 256 — accommodates a UUIDv4 plus
+    /// a tenant/correlation prefix.
+    /// </summary>
+    public int MaxKeyLength { get; set; } = 256;
+
+    /// <summary>
     /// Predicate that controls which HTTP status codes are cached for replay.
     /// Default: 2xx + {400, 404, 409, 410, 422}. 401/403 are never cached.
     /// </summary>
     public Func<int, bool> ShouldCacheStatusCode { get; set; } =
         static sc => sc is (>= 200 and < 300) or 400 or 404 or 409 or 410 or 422;
+
+    /// <summary>
+    /// Response headers that must NOT be captured during execution and NOT
+    /// re-emitted during replay. Protects against re-issuing per-request
+    /// security artefacts (CSRF tokens, rotating session cookies,
+    /// authentication challenges) when the cached response is replayed for
+    /// a later retry.
+    /// </summary>
+    /// <remarks>
+    /// The set uses case-insensitive comparison. Additional entries can be
+    /// added via options configuration:
+    /// <code>
+    /// services.Configure&lt;IdempotencyOptions&gt;(opts =&gt;
+    ///     opts.ExcludedResponseHeaders.Add("X-Custom-Session-Token"));
+    /// </code>
+    /// </remarks>
+    public HashSet<string> ExcludedResponseHeaders { get; } =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "Set-Cookie",
+            "Set-Cookie2",
+            "WWW-Authenticate",
+            "Proxy-Authenticate",
+            "Authorization",
+            "Server",
+            "Date",
+            "Transfer-Encoding",
+        };
 }

--- a/src/Granit.Http.Idempotency/Models/IdempotencyState.cs
+++ b/src/Granit.Http.Idempotency/Models/IdempotencyState.cs
@@ -10,4 +10,14 @@ public enum IdempotencyState : byte
 
     /// <summary>Request completed. Response stored for replay.</summary>
     Completed = 1,
+
+    /// <summary>
+    /// Request completed but its response cannot be replayed (e.g. exceeded
+    /// <see cref="IdempotencyOptions.MaxResponseSizeBytes"/>). The original
+    /// caller received the response normally; retries with the same key
+    /// receive an explicit failure instead of re-executing the business
+    /// logic. Preserves the at-most-once idempotency guarantee when the
+    /// response itself is not cacheable.
+    /// </summary>
+    Tombstoned = 2,
 }

--- a/src/Granit.Http.Idempotency/Models/IdempotencyTombstoneReason.cs
+++ b/src/Granit.Http.Idempotency/Models/IdempotencyTombstoneReason.cs
@@ -1,0 +1,19 @@
+namespace Granit.Http.Idempotency.Models;
+
+/// <summary>
+/// Reason a completed idempotency entry was tombstoned instead of fully cached.
+/// </summary>
+/// <remarks>
+/// Tombstones record that the request ran successfully once but its response
+/// is not replayable. The enum is extensible so new cases can be added
+/// (non-deterministic response, explicit opt-out, etc.) without changing the
+/// shape of <see cref="IdempotencyEntry"/>.
+/// </remarks>
+public enum IdempotencyTombstoneReason : byte
+{
+    /// <summary>
+    /// Response body exceeded <see cref="IdempotencyOptions.MaxResponseSizeBytes"/>.
+    /// Replays return HTTP 413 Payload Too Large.
+    /// </summary>
+    ResponseTooLarge = 0,
+}

--- a/tests/Granit.Http.Idempotency.Tests/IdempotencyMiddlewareTests.cs
+++ b/tests/Granit.Http.Idempotency.Tests/IdempotencyMiddlewareTests.cs
@@ -445,25 +445,26 @@ public sealed class IdempotencyMiddlewareTests
     }
 
     // =========================================================================
-    // Scenario 8: Race condition — TryAcquire fails, re-read returns null
+    // Scenario 8: Race condition — TryAcquire fails, re-read returns null (VULN-301)
     // =========================================================================
 
     [Fact]
-    public async Task GivenRaceCondition_WhenAcquireFailsAndReReadNull_ProceedsWithoutLock()
+    public async Task GivenRaceCondition_WhenAcquireFailsAndReReadNull_Returns409()
     {
+        // Under an extreme TTL race (the lock vanishes between TryAcquire
+        // failure and the re-read), the middleware must NOT proceed without
+        // a lock — doing so would allow two pods to execute the same
+        // idempotent request concurrently. Returning 409 with Retry-After
+        // preserves the at-most-once guarantee; the client retries in a
+        // window where the lock can be re-acquired cleanly.
+
         IIdempotencyStore store = Substitute.For<IIdempotencyStore>();
 
-        // First GetAsync: null (no entry)
-        // TryAcquire: fails
-        // Second GetAsync (re-read): null (vanished)
         store.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
              .Returns(Task.FromResult<IdempotencyEntry?>(null));
 
         store.TryAcquireAsync(Arg.Any<string>(), Arg.Any<IdempotencyEntry>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
              .Returns(Task.FromResult(false));
-
-        store.SetCompletedAsync(Arg.Any<string>(), Arg.Any<IdempotencyEntry>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
-             .Returns(Task.CompletedTask);
 
         (HttpClient client, IHost host) = await BuildTestHostAsync(store);
 
@@ -471,8 +472,19 @@ public sealed class IdempotencyMiddlewareTests
         {
             HttpResponseMessage response = await client.SendAsync(BuildRequest(), TestContext.Current.CancellationToken);
 
-            // Handler still executes despite acquire failure
-            response.StatusCode.ShouldBe(HttpStatusCode.Created);
+            response.StatusCode.ShouldBe(HttpStatusCode.Conflict);
+            response.Headers.RetryAfter.ShouldNotBeNull();
+
+            string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            body.ShouldContain("Idempotency Race");
+
+            // Business handler MUST NOT have been invoked — the lock race
+            // is surfaced before any side effects can occur.
+            await store.DidNotReceive().SetCompletedAsync(
+                Arg.Any<string>(),
+                Arg.Any<IdempotencyEntry>(),
+                Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>());
         }
         finally
         {
@@ -855,4 +867,233 @@ public sealed class IdempotencyMiddlewareTests
             host.Dispose();
         }
     }
+
+    // =========================================================================
+    // Scenario 16: Set-Cookie NOT replayed (VULN-200)
+    // =========================================================================
+
+    [Fact]
+    public async Task GivenFirstRequestSetsCookie_WhenReplayed_DoesNotReEmitSetCookie()
+    {
+        // Capture path must strip Set-Cookie from stored headers so a replay
+        // does not re-emit a CSRF token / rotating session cookie that was
+        // meant for the original caller only.
+
+        IIdempotencyStore store = Substitute.For<IIdempotencyStore>();
+        IdempotencyEntry? captured = null;
+
+        store.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+             .Returns(_ => Task.FromResult<IdempotencyEntry?>(captured));
+
+        store.TryAcquireAsync(Arg.Any<string>(), Arg.Any<IdempotencyEntry>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+             .Returns(Task.FromResult(true));
+
+        store.SetCompletedAsync(
+                Arg.Any<string>(),
+                Arg.Do<IdempotencyEntry>(e => captured = e),
+                Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+             .Returns(Task.CompletedTask);
+
+        RequestDelegate cookieSettingHandler = async ctx =>
+        {
+            ctx.Response.StatusCode = StatusCodes.Status200OK;
+            ctx.Response.ContentType = "application/json";
+            ctx.Response.Headers.Append("Set-Cookie", "csrf=abc123; Path=/; HttpOnly; Secure");
+            ctx.Response.Headers["X-Request-Id"] = "req-42";
+            await ctx.Response.WriteAsync("""{"ok":true}""");
+        };
+
+        (HttpClient client, IHost host) = await BuildTestHostAsync(store, endpointHandler: cookieSettingHandler);
+
+        try
+        {
+            // First request: handler runs, Set-Cookie emitted normally
+            HttpResponseMessage first = await client.SendAsync(BuildRequest(), TestContext.Current.CancellationToken);
+            first.StatusCode.ShouldBe(HttpStatusCode.OK);
+            first.Headers.Contains("Set-Cookie").ShouldBeTrue("original caller must receive the cookie");
+
+            // Captured entry must NOT carry Set-Cookie in its stored headers
+            captured.ShouldNotBeNull();
+            captured.ResponseHeaders.ShouldNotBeNull();
+            captured.ResponseHeaders.Keys.ShouldNotContain(
+                k => string.Equals(k, "Set-Cookie", StringComparison.OrdinalIgnoreCase),
+                "Set-Cookie must be excluded from the stored replay headers");
+            captured.ResponseHeaders.ShouldContainKey("X-Request-Id");
+
+            // Second request (replay): the original caller's cookie must NOT
+            // be re-emitted to this new request.
+            HttpResponseMessage second = await client.SendAsync(BuildRequest(), TestContext.Current.CancellationToken);
+            second.StatusCode.ShouldBe(HttpStatusCode.OK);
+            second.Headers.Contains("X-Idempotency-Replayed").ShouldBeTrue();
+            second.Headers.Contains("Set-Cookie").ShouldBeFalse(
+                "replay must not leak the original caller's cookie to a subsequent retry");
+        }
+        finally
+        {
+            host.Dispose();
+        }
+    }
+
+    // =========================================================================
+    // Scenario 17: Oversized response → tombstone + replay returns 413 (VULN-201)
+    // =========================================================================
+
+    [Fact]
+    public async Task GivenResponseExceedsMaxSize_WhenCaptured_StoresTombstoneEntry()
+    {
+        IIdempotencyStore store = Substitute.For<IIdempotencyStore>();
+        IdempotencyEntry? captured = null;
+
+        store.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+             .Returns(Task.FromResult<IdempotencyEntry?>(null));
+
+        store.TryAcquireAsync(Arg.Any<string>(), Arg.Any<IdempotencyEntry>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+             .Returns(Task.FromResult(true));
+
+        store.SetCompletedAsync(
+                Arg.Any<string>(),
+                Arg.Do<IdempotencyEntry>(e => captured = e),
+                Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+             .Returns(Task.CompletedTask);
+
+        // Handler returns 2 KiB — greater than the 1 KiB limit we configure.
+        string largeBody = new('x', 2 * 1024);
+        RequestDelegate largeResponseHandler = async ctx =>
+        {
+            ctx.Response.StatusCode = StatusCodes.Status200OK;
+            ctx.Response.ContentType = "text/plain";
+            await ctx.Response.WriteAsync(largeBody);
+        };
+
+        (HttpClient client, IHost host) = await BuildTestHostAsync(
+            store,
+            configureOptions: opts =>
+            {
+                opts.MaxResponseSizeBytes = 1024;
+                opts.TombstoneTtl = TimeSpan.FromMinutes(10);
+            },
+            endpointHandler: largeResponseHandler);
+
+        try
+        {
+            // First request: caller receives the full 2 KiB response
+            HttpResponseMessage first = await client.SendAsync(BuildRequest(), TestContext.Current.CancellationToken);
+            first.StatusCode.ShouldBe(HttpStatusCode.OK);
+            string firstBody = await first.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            firstBody.Length.ShouldBe(largeBody.Length);
+
+            // Stored entry must be a tombstone (not a full Completed entry)
+            captured.ShouldNotBeNull();
+            captured.State.ShouldBe(IdempotencyState.Tombstoned);
+            captured.TombstoneReason.ShouldBe(IdempotencyTombstoneReason.ResponseTooLarge);
+            captured.ResponseBody.ShouldBeNull("tombstones must not carry a response body");
+            captured.ResponseHeaders.ShouldBeNull("tombstones must not carry response headers");
+        }
+        finally
+        {
+            host.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task GivenTombstonedEntry_WhenRetriedWithSameBody_Returns413WithTombstoneHeader()
+    {
+        // Rather than seeding a tombstone by hand (the payload-hash match
+        // would require replicating the middleware's composite hashing),
+        // let the middleware itself tombstone on first request, then
+        // submit an identical second request to exercise the replay path.
+
+        IIdempotencyStore store = Substitute.For<IIdempotencyStore>();
+        IdempotencyEntry? captured = null;
+
+        store.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+             .Returns(_ => Task.FromResult<IdempotencyEntry?>(captured));
+
+        store.TryAcquireAsync(Arg.Any<string>(), Arg.Any<IdempotencyEntry>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+             .Returns(Task.FromResult(true));
+
+        store.SetCompletedAsync(
+                Arg.Any<string>(),
+                Arg.Do<IdempotencyEntry>(e => captured = e),
+                Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+             .Returns(Task.CompletedTask);
+
+        string largeBody = new('x', 2 * 1024);
+        int handlerCalls = 0;
+        RequestDelegate largeHandler = async ctx =>
+        {
+            handlerCalls++;
+            ctx.Response.StatusCode = StatusCodes.Status200OK;
+            await ctx.Response.WriteAsync(largeBody);
+        };
+
+        (HttpClient client, IHost host) = await BuildTestHostAsync(
+            store,
+            configureOptions: opts => opts.MaxResponseSizeBytes = 1024,
+            endpointHandler: largeHandler);
+
+        try
+        {
+            // First request: tombstone is stored by the capture path
+            HttpResponseMessage first = await client.SendAsync(BuildRequest(), TestContext.Current.CancellationToken);
+            first.StatusCode.ShouldBe(HttpStatusCode.OK);
+            captured.ShouldNotBeNull();
+            captured.State.ShouldBe(IdempotencyState.Tombstoned);
+
+            // Second request: must hit the tombstone path, return 413, and
+            // NOT re-execute the handler
+            HttpResponseMessage second = await client.SendAsync(BuildRequest(), TestContext.Current.CancellationToken);
+
+            second.StatusCode.ShouldBe(HttpStatusCode.RequestEntityTooLarge);
+            second.Headers.Contains("X-Idempotency-Tombstone").ShouldBeTrue();
+            second.Headers.GetValues("X-Idempotency-Tombstone")
+                .ShouldContain(nameof(IdempotencyTombstoneReason.ResponseTooLarge));
+
+            string body = await second.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            body.ShouldContain("Not Replayable");
+
+            handlerCalls.ShouldBe(1, "tombstoned replays must NOT re-execute the business handler");
+        }
+        finally
+        {
+            host.Dispose();
+        }
+    }
+
+    // =========================================================================
+    // Scenario 18: Oversized idempotency key → 400 (VULN-300)
+    // =========================================================================
+
+    [Fact]
+    public async Task GivenIdempotencyKeyExceedsMaxLength_Returns400()
+    {
+        IIdempotencyStore store = Substitute.For<IIdempotencyStore>();
+
+        (HttpClient client, IHost host) = await BuildTestHostAsync(
+            store,
+            configureOptions: opts => opts.MaxKeyLength = 32);
+
+        try
+        {
+            string oversized = new('k', 64);
+            HttpResponseMessage response = await client.SendAsync(BuildRequest(oversized), TestContext.Current.CancellationToken);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+            string body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+            body.ShouldContain("Too Long");
+
+            // Must reject before any store interaction
+            await store.DidNotReceive().GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+            await store.DidNotReceive().TryAcquireAsync(
+                Arg.Any<string>(), Arg.Any<IdempotencyEntry>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            host.Dispose();
+        }
+    }
+
 }

--- a/tests/Granit.Http.Idempotency.Tests/IdempotencyStateTests.cs
+++ b/tests/Granit.Http.Idempotency.Tests/IdempotencyStateTests.cs
@@ -13,12 +13,16 @@ public sealed class IdempotencyStateTests
     public void Completed_HasValue1() => ((byte)IdempotencyState.Completed).ShouldBe((byte)1);
 
     [Fact]
-    public void Enum_HasExactlyTwoValues()
+    public void Tombstoned_HasValue2() => ((byte)IdempotencyState.Tombstoned).ShouldBe((byte)2);
+
+    [Fact]
+    public void Enum_HasInProgressCompletedTombstoned()
     {
         string[] names = Enum.GetNames<IdempotencyState>();
 
-        names.Length.ShouldBe(2);
+        names.Length.ShouldBe(3);
         names.ShouldContain("InProgress");
         names.ShouldContain("Completed");
+        names.ShouldContain("Tombstoned");
     }
 }


### PR DESCRIPTION
## Summary

Security audit fixes **VULN-200, VULN-201, VULN-300, VULN-301**.

- **VULN-200** — captured response headers now filter `Set-Cookie`, `WWW-Authenticate`, `Authorization`, etc. via a new `IdempotencyOptions.ExcludedResponseHeaders`. Prior behaviour replayed every header except `Transfer-Encoding`, so a replay re-emitted the original caller's rotating CSRF cookie or auth challenge to any later retry.
- **VULN-201** — responses larger than `IdempotencyOptions.MaxResponseSizeBytes` (256 KiB default) are now stored as a tombstone (new `IdempotencyState.Tombstoned` + `IdempotencyTombstoneReason`). The original caller receives their full response; retries receive HTTP 413 with `X-Idempotency-Tombstone` and **do not re-execute** the business handler — preserves the at-most-once guarantee when the response itself can't be cached.
- **VULN-300** — `Idempotency-Key` values longer than `MaxKeyLength` (256 default) are rejected with HTTP 400 before any hashing or lookup.
- **VULN-301** — the extreme TTL race (TryAcquire fails AND re-read returns null) no longer proceeds without a lock. Returns HTTP 409 + `Retry-After` instead of allowing two pods to execute the same idempotent request.

Mostly non-breaking (additive defaults). The 409 on race is a tighter behavior — correct but surfaces a failure mode that used to silently double-execute.

## Test plan

- [x] `dotnet test tests/Granit.Http.Idempotency.Tests` — 110 tests pass
- [x] `dotnet test tests/Granit.ArchitectureTests` — 119 tests pass
- [x] `dotnet format --verify-no-changes` clean
- [ ] Smoke-test tombstone + 413 replay path in a consumer app
- [ ] Verify that existing cached entries (pre-upgrade) still replay cleanly — capture-side filter is primary; replay-side filter is defense in depth
