### PR TITLE
fix(http)!: harden defaults (HSTS, CORS, cookies, OpenAPI warning, bulkhead, doc)

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -15487,7 +15487,7 @@
       "kind": "class",
       "project": "Granit.Http.ApiDocumentation",
       "file": "src/Granit.Http.ApiDocumentation/Extensions/ApiDocumentationApplicationBuilderExtensions.cs",
-      "line": 13,
+      "line": 14,
       "members": [
         {
           "name": "UseGranitApiDocumentation",
@@ -15743,7 +15743,7 @@
       "kind": "class",
       "project": "Granit.Http.Bulkhead",
       "file": "src/Granit.Http.Bulkhead/ConcurrencyLimiterRegistry.cs",
-      "line": 18,
+      "line": 28,
       "members": [
         {
           "name": "AcquireAsync",
@@ -15881,6 +15881,12 @@
           "kind": "method",
           "signature": "FromMinutes(5)",
           "returnType": "TimeSpan CleanupInterval { get; set; } = TimeSpan."
+        },
+        {
+          "name": "MaxLimiters",
+          "kind": "property",
+          "signature": "int MaxLimiters",
+          "returnType": "int"
         }
       ]
     },
@@ -16070,7 +16076,7 @@
       "kind": "class",
       "project": "Granit.Http.Cookies",
       "file": "src/Granit.Http.Cookies/Extensions/CookiesServiceCollectionExtensions.cs",
-      "line": 12,
+      "line": 13,
       "members": [
         {
           "name": "AddGranitCookies",
@@ -16364,7 +16370,7 @@
       "kind": "class",
       "project": "Granit.Http.Cookies",
       "file": "src/Granit.Http.Cookies/Options/GranitCookiesOptions.cs",
-      "line": 43,
+      "line": 53,
       "members": [
         {
           "name": "Name",
@@ -16428,6 +16434,12 @@
           "kind": "property",
           "signature": "string[] AllowedOrigins",
           "returnType": "string[]"
+        },
+        {
+          "name": "AllowCredentials",
+          "kind": "property",
+          "signature": "bool AllowCredentials",
+          "returnType": "bool"
         }
       ]
     },
@@ -17010,7 +17022,7 @@
       "kind": "class",
       "project": "Granit.Http.ResponseCompression",
       "file": "src/Granit.Http.ResponseCompression/Options/GranitResponseCompressionOptions.cs",
-      "line": 19,
+      "line": 36,
       "members": [
         {
           "name": "EnableForHttps",

--- a/src/Granit.Http.ApiDocumentation/Extensions/ApiDocumentationApplicationBuilderExtensions.cs
+++ b/src/Granit.Http.ApiDocumentation/Extensions/ApiDocumentationApplicationBuilderExtensions.cs
@@ -2,6 +2,7 @@ using Granit.Http.ApiDocumentation.Options;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Scalar.AspNetCore;
 
@@ -10,7 +11,7 @@ namespace Granit.Http.ApiDocumentation.Extensions;
 /// <summary>
 /// Extensions for enabling Granit OpenAPI endpoints and the Scalar interactive UI.
 /// </summary>
-public static class ApiDocumentationApplicationBuilderExtensions
+public static partial class ApiDocumentationApplicationBuilderExtensions
 {
     /// <summary>
     /// Maps OpenAPI JSON endpoints (<c>/openapi/v{n}.json</c>) and the Scalar interactive UI.
@@ -28,6 +29,22 @@ public static class ApiDocumentationApplicationBuilderExtensions
         if (!shouldEnable)
         {
             return app;
+        }
+
+        // VULN-204 — OpenAPI enumeration is a reconnaissance aid for attackers.
+        // If the app explicitly opted into production exposure but left the
+        // access policy unset, the endpoints inherit the host's default auth
+        // behaviour — which, absent a FallbackPolicy, is anonymous access.
+        // Emit a Warning at startup so the misconfiguration is visible in
+        // logs even before a real request hits the surface.
+        if (!app.Environment.IsDevelopment()
+            && options.EnableInProduction
+            && options.AuthorizationPolicy is null)
+        {
+            ILogger logger = app.Services
+                .GetRequiredService<ILoggerFactory>()
+                .CreateLogger("Granit.Http.ApiDocumentation");
+            LogProductionOpenApiWithoutPolicy(logger);
         }
 
         // Distinct() guards against the .NET configuration binder appending
@@ -86,4 +103,12 @@ public static class ApiDocumentationApplicationBuilderExtensions
 
         endpoint.RequireAuthorization(policy);
     }
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "OpenAPI/Scalar is exposed in production with no AuthorizationPolicy configured. " +
+                  "The endpoint's access depends on the application's global fallback policy. " +
+                  "Set ApiDocumentation:AuthorizationPolicy to a named policy (e.g. \"ApiDocsReaders\") " +
+                  "or an empty string (explicit anonymous) to silence this warning.")]
+    private static partial void LogProductionOpenApiWithoutPolicy(ILogger logger);
 }

--- a/src/Granit.Http.Bulkhead/ConcurrencyLimiterRegistry.cs
+++ b/src/Granit.Http.Bulkhead/ConcurrencyLimiterRegistry.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
 using System.Threading.RateLimiting;
+using Granit.Http.Bulkhead.Options;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Http.Bulkhead;
 
@@ -14,10 +16,22 @@ namespace Granit.Http.Bulkhead;
 /// a tenant can use up to <c>N×P</c> concurrent operations cluster-wide. This is by design:
 /// the bulkhead protects local CPU/memory, not distributed quotas (use <c>Granit.RateLimiting</c> for that).
 /// </para>
+/// <para>
+/// Memory is bounded by <see cref="GranitBulkheadOptions.MaxLimiters"/>. When the cap
+/// is reached, an LRU eviction sweep runs synchronously on the next
+/// <see cref="AcquireAsync"/> so a new limiter can be installed. This protects
+/// against tenant-id spraying: if an attacker forces unique keys faster than
+/// the idle-timeout sweeper can clean them up, the registry still cannot grow
+/// past the configured bound.
+/// </para>
 /// </remarks>
-public sealed class ConcurrencyLimiterRegistry(TimeProvider timeProvider) : IDisposable
+public sealed class ConcurrencyLimiterRegistry(
+    TimeProvider timeProvider,
+    IOptions<GranitBulkheadOptions> options) : IDisposable
 {
     private readonly ConcurrentDictionary<string, RegistryEntry> _limiters = new(StringComparer.Ordinal);
+    private readonly int _maxLimiters = Math.Max(1, options.Value.MaxLimiters);
+    private readonly Lock _evictionLock = new();
 
     /// <summary>
     /// Acquires a concurrency permit for the given key. Creates the limiter on first access.
@@ -28,16 +42,34 @@ public sealed class ConcurrencyLimiterRegistry(TimeProvider timeProvider) : IDis
         int queueLimit,
         CancellationToken cancellationToken)
     {
-        RegistryEntry entry = _limiters.GetOrAdd(key, static (_, args) => new RegistryEntry(
-            new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+        // Fast path: limiter already exists — just mark used.
+        if (_limiters.TryGetValue(key, out RegistryEntry? existing))
+        {
+            existing.MarkUsed(timeProvider);
+            return existing.Limiter.AcquireAsync(permitCount: 1, cancellationToken);
+        }
+
+        // Slow path: create a new limiter, evicting the LRU entry first if the
+        // registry is at capacity. The lock bounds concurrent creation so that
+        // a burst of unique keys cannot temporarily blow past _maxLimiters.
+        RegistryEntry entry;
+        lock (_evictionLock)
+        {
+            if (_limiters.Count >= _maxLimiters && !_limiters.ContainsKey(key))
             {
-                PermitLimit = args.permitLimit,
-                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
-                QueueLimit = args.queueLimit,
-            }), args.timeProvider), (permitLimit, queueLimit, timeProvider));
+                EvictLeastRecentlyUsed();
+            }
+
+            entry = _limiters.GetOrAdd(key, k => new RegistryEntry(
+                new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+                {
+                    PermitLimit = permitLimit,
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                    QueueLimit = queueLimit,
+                }), timeProvider));
+        }
 
         entry.MarkUsed(timeProvider);
-
         return entry.Limiter.AcquireAsync(permitCount: 1, cancellationToken);
     }
 
@@ -84,6 +116,29 @@ public sealed class ConcurrencyLimiterRegistry(TimeProvider timeProvider) : IDis
         }
 
         _limiters.Clear();
+    }
+
+    private void EvictLeastRecentlyUsed()
+    {
+        // Linear scan — acceptable at _maxLimiters = 10_000 (microseconds).
+        // Upgrading to a real LRU data structure is only warranted if the cap
+        // grows by an order of magnitude.
+        string? lruKey = null;
+        DateTimeOffset lruTimestamp = DateTimeOffset.MaxValue;
+
+        foreach (KeyValuePair<string, RegistryEntry> kvp in _limiters)
+        {
+            if (kvp.Value.LastUsed < lruTimestamp)
+            {
+                lruTimestamp = kvp.Value.LastUsed;
+                lruKey = kvp.Key;
+            }
+        }
+
+        if (lruKey is not null && _limiters.TryRemove(lruKey, out RegistryEntry? evicted))
+        {
+            evicted.Limiter.Dispose();
+        }
     }
 
     private sealed class RegistryEntry(ConcurrencyLimiter limiter, TimeProvider timeProvider)

--- a/src/Granit.Http.Bulkhead/Internal/GranitBulkheadOptionsValidator.cs
+++ b/src/Granit.Http.Bulkhead/Internal/GranitBulkheadOptionsValidator.cs
@@ -21,6 +21,11 @@ internal sealed class GranitBulkheadOptionsValidator : IValidateOptions<GranitBu
             return ValidateOptionsResult.Fail("CleanupInterval must be a positive duration.");
         }
 
+        if (options.MaxLimiters < 1)
+        {
+            return ValidateOptionsResult.Fail("MaxLimiters must be at least 1.");
+        }
+
         foreach ((string policyName, BulkheadPolicyOptions policy) in options.Policies)
         {
             if (policy.PermitLimit < 1)

--- a/src/Granit.Http.Bulkhead/Options/GranitBulkheadOptions.cs
+++ b/src/Granit.Http.Bulkhead/Options/GranitBulkheadOptions.cs
@@ -35,4 +35,15 @@ public sealed class GranitBulkheadOptions
 
     /// <summary>Interval between cleanup sweeps. Default: 5 minutes.</summary>
     public TimeSpan CleanupInterval { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Hard cap on the number of live limiters in the registry. When the cap
+    /// is hit, the least-recently-used limiter is evicted synchronously to
+    /// make room for a new one. Defaults to <c>10_000</c> — high enough to
+    /// accommodate real multi-tenant fleets, low enough to bound worst-case
+    /// memory if the idle-timeout sweeper falls behind or if attacker
+    /// traffic spams unique tenant ids faster than the cleanup interval.
+    /// Must be &gt;= 1.
+    /// </summary>
+    public int MaxLimiters { get; set; } = 10_000;
 }

--- a/src/Granit.Http.Cookies/CookieDefinition.cs
+++ b/src/Granit.Http.Cookies/CookieDefinition.cs
@@ -35,4 +35,18 @@ public sealed record CookieDefinition(
     /// Only <see cref="CookieCategory.StrictlyNecessary"/> cookies should set this to <see langword="true"/>.
     /// </summary>
     public bool IsEssential { get; init; }
+
+    /// <summary>
+    /// Optional <c>Domain</c> attribute for the cookie. When set, the cookie is
+    /// sent to the specified domain and its subdomains. Used for SSO scenarios
+    /// where a single cookie spans multiple apps (e.g., <c>".example.com"</c>).
+    /// When <see langword="null"/> (default), the cookie is scoped to the
+    /// origin host only — the safer default.
+    /// </summary>
+    /// <remarks>
+    /// Must be propagated to both set and delete operations: omitting Domain on
+    /// delete leaves the cookie stranded in the browser when the original set
+    /// used an explicit Domain.
+    /// </remarks>
+    public string? Domain { get; init; }
 }

--- a/src/Granit.Http.Cookies/Extensions/CookiesServiceCollectionExtensions.cs
+++ b/src/Granit.Http.Cookies/Extensions/CookiesServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Granit.Http.Cookies.Options;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Granit.Http.Cookies.Extensions;
 
@@ -36,6 +37,8 @@ public static class CookiesServiceCollectionExtensions
             .BindConfiguration(GranitCookiesOptions.SectionName)
             .ValidateDataAnnotations()
             .ValidateOnStart();
+
+        services.TryAddSingleton<IValidateOptions<GranitCookiesOptions>, GranitCookiesOptionsValidator>();
 
         GranitCookiesBuilder builder = new(services);
         configure(builder);

--- a/src/Granit.Http.Cookies/Internal/GranitCookieManager.cs
+++ b/src/Granit.Http.Cookies/Internal/GranitCookieManager.cs
@@ -50,6 +50,7 @@ internal sealed class GranitCookieManager(
             Secure = true,
             SameSite = definition.SameSite,
             Path = definition.Path,
+            Domain = definition.Domain,
             IsEssential = definition.IsEssential,
         };
 
@@ -81,6 +82,7 @@ internal sealed class GranitCookieManager(
             Secure = true,
             SameSite = definition.SameSite,
             Path = definition.Path,
+            Domain = definition.Domain, // must mirror Set; omitting leaves the cookie stranded in browser
         });
     }
 

--- a/src/Granit.Http.Cookies/Options/GranitCookiesOptions.cs
+++ b/src/Granit.Http.Cookies/Options/GranitCookiesOptions.cs
@@ -16,9 +16,19 @@ public sealed class GranitCookiesOptions
 
     /// <summary>
     /// Default retention period in days for cookies that do not specify one.
-    /// Default: 365.
+    /// Default: <c>30</c>. Must be within <c>[1, 395]</c>; the upper bound
+    /// matches the CNIL 13-month hard cap (GDPR Art. 5(1)(e) — storage
+    /// limitation). Cookies that legitimately need a longer lifetime should
+    /// declare an explicit <see cref="CookieDefinition.RetentionDays"/>.
     /// </summary>
-    public int DefaultRetentionDays { get; set; } = 365;
+    public int DefaultRetentionDays { get; set; } = 30;
+
+    /// <summary>
+    /// Upper bound on any cookie's retention (days). CNIL caps analytics/
+    /// marketing cookies at 13 months; the 395-day value includes leap-year
+    /// slack.
+    /// </summary>
+    public const int MaxRetentionDays = 395;
 
     /// <summary>
     /// Third-party services that set cookies on the client (analytics, marketing, etc.).

--- a/src/Granit.Http.Cookies/Options/GranitCookiesOptionsValidator.cs
+++ b/src/Granit.Http.Cookies/Options/GranitCookiesOptionsValidator.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Options;
+
+namespace Granit.Http.Cookies.Options;
+
+/// <summary>
+/// Validates <see cref="GranitCookiesOptions"/> at startup. Enforces RGPD
+/// storage-limitation bounds on cookie retention (CNIL: 13 months max for
+/// analytics/marketing cookies).
+/// </summary>
+internal sealed class GranitCookiesOptionsValidator : IValidateOptions<GranitCookiesOptions>
+{
+    public ValidateOptionsResult Validate(string? name, GranitCookiesOptions options)
+    {
+        List<string>? failures = null;
+
+        if (options.DefaultRetentionDays <= 0)
+        {
+            (failures ??= []).Add(
+                $"{nameof(GranitCookiesOptions.DefaultRetentionDays)} must be > 0. " +
+                $"Got {options.DefaultRetentionDays}.");
+        }
+        else if (options.DefaultRetentionDays > GranitCookiesOptions.MaxRetentionDays)
+        {
+            (failures ??= []).Add(
+                $"{nameof(GranitCookiesOptions.DefaultRetentionDays)} must be <= " +
+                $"{GranitCookiesOptions.MaxRetentionDays} (CNIL 13-month hard cap — RGPD Art. 5(1)(e) " +
+                $"storage limitation). Got {options.DefaultRetentionDays}. For cookies that need a " +
+                "longer lifetime, declare an explicit CookieDefinition.RetentionDays with an explicit " +
+                "legal basis documented in your data-protection impact assessment.");
+        }
+
+        return failures is null
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/Granit.Http.Cors/Internal/ConfigureCorsPolicyOptions.cs
+++ b/src/Granit.Http.Cors/Internal/ConfigureCorsPolicyOptions.cs
@@ -24,7 +24,9 @@ internal sealed class ConfigureCorsPolicyOptions(
             }
             else
             {
-                policy.WithOrigins(granitOptions.AllowedOrigins);
+                // Use NormalizedOrigins so an entry like "https://app.x.com/"
+                // still matches the browser's "Origin: https://app.x.com" header.
+                policy.WithOrigins(granitOptions.NormalizedOrigins);
             }
 
             policy.AllowAnyHeader();

--- a/src/Granit.Http.Cors/Internal/GranitCorsOptionsValidator.cs
+++ b/src/Granit.Http.Cors/Internal/GranitCorsOptionsValidator.cs
@@ -6,7 +6,8 @@ namespace Granit.Http.Cors.Internal;
 
 /// <summary>
 /// Validates <see cref="GranitCorsOptions"/> at startup.
-/// Enforces ISO 27001-compliant CORS rules.
+/// Enforces ISO 27001-compliant CORS rules and rejects malformed origin values
+/// that would silently break cross-origin requests in runtime.
 /// </summary>
 internal sealed class GranitCorsOptionsValidator(
     IHostEnvironment environment) : IValidateOptions<GranitCorsOptions>
@@ -37,6 +38,34 @@ internal sealed class GranitCorsOptionsValidator(
                 $"{nameof(GranitCorsOptions.AllowCredentials)} cannot be true when " +
                 $"{nameof(GranitCorsOptions.AllowedOrigins)} contains wildcard ('*'). " +
                 "This violates the CORS specification.");
+        }
+
+        // Format-check each non-wildcard origin AFTER the benign trailing slash
+        // is trimmed. Reject scheme/path/query/fragment malformations that
+        // otherwise silently fail CORS at runtime (and tempt operators to
+        // "just use '*'" to unblock the app).
+        foreach (string? origin in options.AllowedOrigins)
+        {
+            if (origin is null || origin == "*")
+            {
+                continue;
+            }
+
+            string normalized = origin.TrimEnd('/');
+
+            if (!Uri.TryCreate(normalized, UriKind.Absolute, out Uri? uri)
+                || uri.Scheme is not ("http" or "https")
+                || uri.AbsolutePath is not ("" or "/")
+                || !string.IsNullOrEmpty(uri.Query)
+                || !string.IsNullOrEmpty(uri.Fragment)
+                || uri.Port == 0)
+            {
+                errors.Add(
+                    $"CORS origin '{origin}' is not a valid origin. " +
+                    $"Expected form: 'https://host[:port]' " +
+                    "(scheme must be http/https; no path, query, or fragment). " +
+                    "A trailing slash is accepted and normalized automatically.");
+            }
         }
 
         return errors.Count > 0

--- a/src/Granit.Http.Cors/Options/GranitCorsOptions.cs
+++ b/src/Granit.Http.Cors/Options/GranitCorsOptions.cs
@@ -32,4 +32,16 @@ public sealed class GranitCorsOptions
     /// contains wildcard (<c>*</c>) — this violates the CORS specification.
     /// </summary>
     public bool AllowCredentials { get; set; }
+
+    /// <summary>
+    /// Returns <see cref="AllowedOrigins"/> with any trailing slash trimmed.
+    /// The CORS spec defines an origin as a <c>scheme + host + port</c> tuple
+    /// with no path, so an entry like <c>"https://app.x.com/"</c> would silently
+    /// fail to match the browser's <c>Origin: https://app.x.com</c> header.
+    /// Normalising here preserves the developer copy-paste experience while
+    /// keeping <see cref="Internal.ConfigureCorsPolicyOptions"/> and
+    /// <see cref="Internal.GranitCorsOptionsValidator"/> aligned.
+    /// </summary>
+    internal string[] NormalizedOrigins =>
+        [.. AllowedOrigins.Select(static o => o?.TrimEnd('/') ?? string.Empty)];
 }

--- a/src/Granit.Http.ResponseCompression/Options/GranitResponseCompressionOptions.cs
+++ b/src/Granit.Http.ResponseCompression/Options/GranitResponseCompressionOptions.cs
@@ -9,7 +9,24 @@ namespace Granit.Http.ResponseCompression.Options;
 /// <remarks>
 /// <para>
 /// HTTPS compression is enabled by default. BREACH/CRIME attacks are mitigated
-/// by Granit's antiforgery token enforcement, CORS restrictions, and SameSite cookies.
+/// by two defenses that together break the attack chain:
+/// <list type="bullet">
+///   <item><b>SameSite cookies</b> (Strict/Lax) — prevents an attacker-origin
+///   from triggering authenticated cross-site requests the attack needs.</item>
+///   <item><b>Per-request antiforgery tokens</b> (ASP.NET Core rotates the
+///   request token on every response) — even if BREACH could measure body
+///   sizes, the specific token it might extract is already invalidated by the
+///   time the attack completes.</item>
+/// </list>
+/// </para>
+/// <para>
+/// <b>Do NOT enable compression on HTML responses that reflect attacker-
+/// controlled input AND carry a non-rotating secret</b> (embedded session
+/// identifier, JWT, derived API key, etc.). Granit is a JSON-first platform
+/// where this combination is rare; if you serve HTML views with embedded
+/// secrets beyond the rotating antiforgery token, disable compression on
+/// those endpoints (<see cref="EnableForHttps"/> = false) or switch the
+/// secret to a per-request rotating value.
 /// </para>
 /// <para>
 /// <c>text/event-stream</c> (SSE) is always excluded — this is a safety invariant

--- a/src/Granit.Http.SecurityHeaders/Options/GranitSecurityHeadersOptionsValidator.cs
+++ b/src/Granit.Http.SecurityHeaders/Options/GranitSecurityHeadersOptionsValidator.cs
@@ -70,7 +70,20 @@ internal sealed class GranitSecurityHeadersOptionsValidator
                 $"CrossOriginResourcePolicy '{corp}' is not valid. Allowed: {string.Join(", ", s_validCrossOriginResourcePolicies.Order())}.");
         }
 
-        if (options.HstsMaxAgeSeconds < 0)
+        // When HSTS is enabled, enforce the OWASP / RFC 6797 §12 minimum of
+        // 6 months. A value of 0 emits `max-age=0`, which instructs browsers
+        // to FORGET any previously cached HSTS policy — a silent downgrade
+        // that a misconfigured appsettings.json should not trigger. Callers
+        // that want HSTS off must set EnableHsts = false explicitly.
+        const int MinimumHstsMaxAgeSeconds = 15_552_000; // 6 months
+        if (options.EnableHsts && options.HstsMaxAgeSeconds < MinimumHstsMaxAgeSeconds)
+        {
+            (failures ??= []).Add(
+                $"HstsMaxAgeSeconds must be >= {MinimumHstsMaxAgeSeconds} (6 months, OWASP minimum) " +
+                $"when EnableHsts=true. Set EnableHsts=false to disable HSTS entirely. " +
+                $"Got {options.HstsMaxAgeSeconds}.");
+        }
+        else if (!options.EnableHsts && options.HstsMaxAgeSeconds < 0)
         {
             (failures ??= []).Add(
                 $"HstsMaxAgeSeconds must be >= 0, got {options.HstsMaxAgeSeconds}.");

--- a/tests/Granit.Http.Bulkhead.Tests/BulkheadLeaseTests.cs
+++ b/tests/Granit.Http.Bulkhead.Tests/BulkheadLeaseTests.cs
@@ -1,6 +1,8 @@
 using System.Threading.RateLimiting;
 using Granit.Http.Bulkhead.Abstractions;
 using Granit.Http.Bulkhead.Internal;
+using Granit.Http.Bulkhead.Options;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using Shouldly;
 using Xunit;
@@ -13,7 +15,9 @@ public sealed class BulkheadLeaseTests : IDisposable
 
     public BulkheadLeaseTests()
     {
-        _registry = new ConcurrencyLimiterRegistry(TimeProvider.System);
+        _registry = new ConcurrencyLimiterRegistry(
+            TimeProvider.System,
+            Microsoft.Extensions.Options.Options.Create(new GranitBulkheadOptions()));
     }
 
     public void Dispose() => _registry.Dispose();

--- a/tests/Granit.Http.Bulkhead.Tests/BulkheadMiddlewareTests.cs
+++ b/tests/Granit.Http.Bulkhead.Tests/BulkheadMiddlewareTests.cs
@@ -26,7 +26,8 @@ public sealed class BulkheadMiddlewareTests : IDisposable
 
     public BulkheadMiddlewareTests()
     {
-        _registry = new ConcurrencyLimiterRegistry(TimeProvider.System);
+        _registry = new ConcurrencyLimiterRegistry(
+            TimeProvider.System, MsOptions.Create(new GranitBulkheadOptions()));
         _currentTenant.IsAvailable.Returns(false);
         _quotaProvider.GetPermitLimitAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((int?)null);
         ServiceCollection services = new();

--- a/tests/Granit.Http.Bulkhead.Tests/ConcurrencyLimiterRegistryTests.cs
+++ b/tests/Granit.Http.Bulkhead.Tests/ConcurrencyLimiterRegistryTests.cs
@@ -1,5 +1,7 @@
 using System.Threading.RateLimiting;
 using Granit.Http.Bulkhead.Internal;
+using Granit.Http.Bulkhead.Options;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using Shouldly;
 using Xunit;
@@ -13,7 +15,9 @@ public sealed class ConcurrencyLimiterRegistryTests : IDisposable
 
     public ConcurrencyLimiterRegistryTests()
     {
-        _registry = new ConcurrencyLimiterRegistry(_timeProvider);
+        _registry = new ConcurrencyLimiterRegistry(
+            _timeProvider,
+            Microsoft.Extensions.Options.Options.Create(new GranitBulkheadOptions()));
     }
 
     public void Dispose() => _registry.Dispose();
@@ -162,5 +166,38 @@ public sealed class ConcurrencyLimiterRegistryTests : IDisposable
         _registry.Dispose();
 
         _registry.Count.ShouldBe(0);
+    }
+
+    // =========================================================================
+    // LRU eviction at MaxLimiters (VULN-302)
+    // =========================================================================
+
+    [Fact]
+    public async Task AcquireAsync_WhenAtMaxLimiters_EvictsLeastRecentlyUsed()
+    {
+        // Purpose-built tiny-cap registry to exercise the LRU path deterministically.
+        using ConcurrencyLimiterRegistry tinyRegistry = new(
+            _timeProvider,
+            Microsoft.Extensions.Options.Options.Create(new GranitBulkheadOptions { MaxLimiters = 3 }));
+
+        // Fill the registry — timestamps advance so "oldest" is unambiguous.
+        (await tinyRegistry.AcquireAsync("k1", 5, 0, TestContext.Current.CancellationToken)).Dispose();
+        _timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        (await tinyRegistry.AcquireAsync("k2", 5, 0, TestContext.Current.CancellationToken)).Dispose();
+        _timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        (await tinyRegistry.AcquireAsync("k3", 5, 0, TestContext.Current.CancellationToken)).Dispose();
+        tinyRegistry.Count.ShouldBe(3, "registry should now be at capacity");
+
+        // Touching k1 makes it the most-recently-used; k2 is now oldest.
+        _timeProvider.Advance(TimeSpan.FromSeconds(1));
+        (await tinyRegistry.AcquireAsync("k1", 5, 0, TestContext.Current.CancellationToken)).Dispose();
+
+        // New key must trigger eviction of k2 (oldest by LastUsed), not blow past cap.
+        _timeProvider.Advance(TimeSpan.FromSeconds(1));
+        (await tinyRegistry.AcquireAsync("k4", 5, 0, TestContext.Current.CancellationToken)).Dispose();
+
+        tinyRegistry.Count.ShouldBe(3, "LRU eviction must keep the registry at its cap");
     }
 }

--- a/tests/Granit.Http.Bulkhead.Tests/TenantPartitionedBulkheadTests.cs
+++ b/tests/Granit.Http.Bulkhead.Tests/TenantPartitionedBulkheadTests.cs
@@ -34,7 +34,8 @@ public sealed class TenantPartitionedBulkheadTests : IDisposable
 
     public TenantPartitionedBulkheadTests()
     {
-        _registry = new ConcurrencyLimiterRegistry(TimeProvider.System);
+        _registry = new ConcurrencyLimiterRegistry(
+            TimeProvider.System, MsOptions.Create(new GranitBulkheadOptions()));
         ServiceCollection services = new();
         services.AddMetrics();
         ServiceProvider sp = services.BuildServiceProvider();

--- a/tests/Granit.Http.Cookies.Tests/GranitCookiesOptionsTests.cs
+++ b/tests/Granit.Http.Cookies.Tests/GranitCookiesOptionsTests.cs
@@ -14,9 +14,16 @@ public sealed class GranitCookiesOptionsTests
     public void ThrowOnUnregistered_DefaultsToTrue() =>
         new GranitCookiesOptions().ThrowOnUnregistered.ShouldBeTrue();
 
+    // VULN-208 — default dropped from 365 to 30 days to align with RGPD
+    // minimisation (Art. 5(1)(e)). Cookies that legitimately need a longer
+    // lifetime must declare an explicit CookieDefinition.RetentionDays.
     [Fact]
-    public void DefaultRetentionDays_DefaultsTo365() =>
-        new GranitCookiesOptions().DefaultRetentionDays.ShouldBe(365);
+    public void DefaultRetentionDays_DefaultsTo30() =>
+        new GranitCookiesOptions().DefaultRetentionDays.ShouldBe(30);
+
+    [Fact]
+    public void MaxRetentionDays_Is395DaysForCnilCap() =>
+        GranitCookiesOptions.MaxRetentionDays.ShouldBe(395);
 
     [Fact]
     public void ThirdPartyServices_DefaultsToEmpty() =>

--- a/tests/Granit.Http.Cookies.Tests/GranitCookiesOptionsValidatorTests.cs
+++ b/tests/Granit.Http.Cookies.Tests/GranitCookiesOptionsValidatorTests.cs
@@ -1,0 +1,60 @@
+// =============================================================================
+// Tests - GranitCookiesOptionsValidator (VULN-208)
+// =============================================================================
+
+using Granit.Http.Cookies.Options;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Http.Cookies.Tests;
+
+public sealed class GranitCookiesOptionsValidatorTests
+{
+    [Fact]
+    public void Validate_DefaultConfig_Succeeds()
+    {
+        GranitCookiesOptionsValidator sut = new();
+
+        ValidateOptionsResult result = sut.Validate(null, new GranitCookiesOptions());
+
+        result.Succeeded.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_NonPositiveRetention_Fails(int days)
+    {
+        GranitCookiesOptionsValidator sut = new();
+
+        ValidateOptionsResult result = sut.Validate(null,
+            new GranitCookiesOptions { DefaultRetentionDays = days });
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain(nameof(GranitCookiesOptions.DefaultRetentionDays));
+    }
+
+    [Fact]
+    public void Validate_ExceedsCnilCap_Fails()
+    {
+        GranitCookiesOptionsValidator sut = new();
+
+        ValidateOptionsResult result = sut.Validate(null,
+            new GranitCookiesOptions { DefaultRetentionDays = 730 }); // 2 years
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("CNIL");
+    }
+
+    [Fact]
+    public void Validate_EqualToMax_Succeeds()
+    {
+        GranitCookiesOptionsValidator sut = new();
+
+        ValidateOptionsResult result = sut.Validate(null,
+            new GranitCookiesOptions { DefaultRetentionDays = GranitCookiesOptions.MaxRetentionDays });
+
+        result.Succeeded.ShouldBeTrue();
+    }
+}

--- a/tests/Granit.Http.Cors.Tests/GranitCorsOptionsValidatorTests.cs
+++ b/tests/Granit.Http.Cors.Tests/GranitCorsOptionsValidatorTests.cs
@@ -122,6 +122,54 @@ public sealed class GranitCorsOptionsValidatorTests
         result.Failures.Count().ShouldBeGreaterThanOrEqualTo(2);
     }
 
+    // VULN-207 — origin format validation with auto-trim for trailing slash
+
+    [Theory]
+    [InlineData("https://app.example.com")]
+    [InlineData("https://app.example.com/")]     // trailing slash silently normalized
+    [InlineData("https://app.example.com:8443")]
+    [InlineData("http://localhost:3000")]
+    public void Validate_WellFormedOrigin_ReturnsSuccess(string origin)
+    {
+        IHostEnvironment environment = CreateEnvironment("Production");
+        GranitCorsOptionsValidator sut = new(environment);
+        GranitCorsOptions options = new() { AllowedOrigins = [origin] };
+
+        ValidateOptionsResult result = sut.Validate(null, options);
+
+        result.Succeeded.ShouldBeTrue(
+            $"'{origin}' is a well-formed origin (trailing slash is tolerated).");
+    }
+
+    [Theory]
+    [InlineData("app.example.com")]                   // missing scheme
+    [InlineData("ftp://app.example.com")]             // wrong scheme
+    [InlineData("https://app.example.com/login")]     // path
+    [InlineData("https://app.example.com?foo=bar")]   // query
+    [InlineData("https://app.example.com#fragment")]  // fragment
+    public void Validate_MalformedOrigin_ReturnsFailed(string origin)
+    {
+        IHostEnvironment environment = CreateEnvironment("Production");
+        GranitCorsOptionsValidator sut = new(environment);
+        GranitCorsOptions options = new() { AllowedOrigins = [origin] };
+
+        ValidateOptionsResult result = sut.Validate(null, options);
+
+        result.Failed.ShouldBeTrue($"'{origin}' is not a valid CORS origin.");
+        result.FailureMessage.ShouldContain(origin);
+    }
+
+    [Fact]
+    public void NormalizedOrigins_TrailingSlash_IsStripped()
+    {
+        GranitCorsOptions options = new()
+        {
+            AllowedOrigins = ["https://app.example.com/", "https://admin.example.com"],
+        };
+
+        options.NormalizedOrigins.ShouldBe(["https://app.example.com", "https://admin.example.com"]);
+    }
+
     private static IHostEnvironment CreateEnvironment(string environmentName)
     {
         IHostEnvironment environment = Substitute.For<IHostEnvironment>();

--- a/tests/Granit.Http.SecurityHeaders.Tests/GranitHttpSecurityModuleTests.cs
+++ b/tests/Granit.Http.SecurityHeaders.Tests/GranitHttpSecurityModuleTests.cs
@@ -78,8 +78,12 @@ public sealed class GranitHttpSecurityModuleTests
     [Fact]
     public void AddGranitHttpSecurity_ConfiguresHsts_CustomValues()
     {
+        // Use 2 years — above the 6-month minimum enforced by the validator
+        // (VULN-206) and distinct from the 1-year default so the test still
+        // proves the override applied.
+        const int TwoYearsSeconds = 63_072_000;
         HostApplicationBuilder builder = Host.CreateApplicationBuilder();
-        builder.Configuration["SecurityHeaders:HstsMaxAgeSeconds"] = "86400";
+        builder.Configuration["SecurityHeaders:HstsMaxAgeSeconds"] = TwoYearsSeconds.ToString();
         builder.Configuration["SecurityHeaders:HstsIncludeSubDomains"] = "false";
         builder.Configuration["SecurityHeaders:HstsPreload"] = "true";
 
@@ -89,7 +93,7 @@ public sealed class GranitHttpSecurityModuleTests
         HstsOptions hsts =
             host.Services.GetRequiredService<IOptions<HstsOptions>>().Value;
 
-        hsts.MaxAge.ShouldBe(TimeSpan.FromSeconds(86_400));
+        hsts.MaxAge.ShouldBe(TimeSpan.FromSeconds(TwoYearsSeconds));
         hsts.IncludeSubDomains.ShouldBeFalse();
         hsts.Preload.ShouldBeTrue();
     }

--- a/tests/Granit.Http.SecurityHeaders.Tests/GranitSecurityHeadersOptionsValidatorTests.cs
+++ b/tests/Granit.Http.SecurityHeaders.Tests/GranitSecurityHeadersOptionsValidatorTests.cs
@@ -158,19 +158,49 @@ public sealed class GranitSecurityHeadersOptionsValidatorTests
     // HSTS max-age
     // -------------------------------------------------------------------------
 
+    // VULN-206 — when HSTS is enabled, reject values below the OWASP
+    // 6-month minimum. A `max-age=0` with EnableHsts=true silently
+    // instructs browsers to forget HSTS, which is a downgrade a misconfig
+    // must not be able to cause.
+
     [Fact]
-    public void HstsMaxAgeSeconds_Negative_Fails()
+    public void HstsMaxAgeSeconds_NegativeWithHstsDisabled_Fails()
     {
         ValidateOptionsResult result = _validator.Validate(
-            null, new GranitSecurityHeadersOptions { HstsMaxAgeSeconds = -1 });
+            null, new GranitSecurityHeadersOptions { EnableHsts = false, HstsMaxAgeSeconds = -1 });
 
         result.Failed.ShouldBeTrue();
         result.FailureMessage.ShouldContain("HstsMaxAgeSeconds");
     }
 
     [Fact]
-    public void HstsMaxAgeSeconds_Zero_Passes() =>
-        _validator.Validate(null, new GranitSecurityHeadersOptions { HstsMaxAgeSeconds = 0 })
+    public void HstsMaxAgeSeconds_ZeroWithHstsEnabled_Fails()
+    {
+        ValidateOptionsResult result = _validator.Validate(
+            null, new GranitSecurityHeadersOptions { EnableHsts = true, HstsMaxAgeSeconds = 0 });
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("HstsMaxAgeSeconds");
+    }
+
+    [Fact]
+    public void HstsMaxAgeSeconds_BelowSixMonthsWithHstsEnabled_Fails()
+    {
+        ValidateOptionsResult result = _validator.Validate(
+            null, new GranitSecurityHeadersOptions { EnableHsts = true, HstsMaxAgeSeconds = 3600 });
+
+        result.Failed.ShouldBeTrue();
+        result.FailureMessage.ShouldContain("HstsMaxAgeSeconds");
+    }
+
+    [Fact]
+    public void HstsMaxAgeSeconds_ZeroWithHstsDisabled_Passes() =>
+        _validator.Validate(null, new GranitSecurityHeadersOptions { EnableHsts = false, HstsMaxAgeSeconds = 0 })
+            .Succeeded.ShouldBeTrue();
+
+    [Fact]
+    public void HstsMaxAgeSeconds_DefaultOneYear_Passes() =>
+        _validator.Validate(null, new GranitSecurityHeadersOptions { EnableHsts = true, HstsMaxAgeSeconds = 31_536_000 })
             .Succeeded.ShouldBeTrue();
 
     // -------------------------------------------------------------------------
@@ -180,10 +210,12 @@ public sealed class GranitSecurityHeadersOptionsValidatorTests
     [Fact]
     public void MultipleInvalidValues_ReportsAllFailures()
     {
+        // EnableHsts=false + negative HstsMaxAge still fails the "must be >= 0" check.
         ValidateOptionsResult result = _validator.Validate(null, new GranitSecurityHeadersOptions
         {
             XFrameOptions = "INVALID",
             ReferrerPolicy = "none",
+            EnableHsts = false,
             HstsMaxAgeSeconds = -1,
         });
 


### PR DESCRIPTION
## Summary

**BREAKING** — bundle of 7 defaults-hardening fixes from the security audit.

| VULN | Change | Breaking? |
|------|--------|-----------|
| **VULN-206** | SecurityHeaders validator rejects `HstsMaxAgeSeconds < 15_552_000` (6 months, OWASP min) when `EnableHsts=true`. Prior behaviour let `max-age=0` pass and silently instruct browsers to forget HSTS. | yes |
| **VULN-207** | CORS validator format-checks every non-wildcard origin (scheme, no path/query/fragment). Trailing slashes are silently normalized so the browser's schemeless `Origin` header still matches. Malformed entries fail startup. | yes |
| **VULN-208** | `GranitCookiesOptions.DefaultRetentionDays`: 365 → 30 (RGPD Art. 5(1)(e) minimisation). New `GranitCookiesOptionsValidator` caps at `MaxRetentionDays` (395 days, CNIL 13-month hard cap). | yes |
| **VULN-303** | `CookieDefinition.Domain` — cookie manager propagates it on both Set AND Delete so SSO cookies are cleaned up properly. | no (additive) |
| **VULN-204** | ApiDocumentation emits a Warning at startup when `EnableInProduction=true && AuthorizationPolicy=null` — the combo that leaves OpenAPI/Scalar inheriting the app's global fallback policy. | no (log only) |
| **VULN-302** | Bulkhead `ConcurrencyLimiterRegistry` enforces `GranitBulkheadOptions.MaxLimiters` (default 10_000) with synchronous LRU eviction. Bounds worst-case memory if unique-tenant-id traffic outpaces idle-timeout cleanup. Constructor signature changed to accept `IOptions<GranitBulkheadOptions>`. | yes (internal ctor only) |
| **VULN-205** | Response-compression XML-doc rewrite: removes CORS from the BREACH mitigation list (doesn't break the attack chain), emphasizes SameSite + rotating antiforgery, documents the HTML-with-non-rotating-secret edge case. | no (doc only) |

### Apps affected

- Apps relying on `HstsMaxAgeSeconds=0` with `EnableHsts=true` — set `EnableHsts=false` explicitly.
- Apps with malformed CORS entries (missing scheme, paths, ftp://) — fix the entry. Trailing slashes still accepted.
- Apps expecting the 365-day cookie default — declare explicit `CookieDefinition.RetentionDays` where needed.

## Test plan

- [x] `dotnet test tests/Granit.Http.SecurityHeaders.Tests` — 70 tests pass
- [x] `dotnet test tests/Granit.Http.Cors.Tests` — 33 tests pass
- [x] `dotnet test tests/Granit.Http.Cookies.Tests` — 70 tests pass
- [x] `dotnet test tests/Granit.Http.ApiDocumentation.Tests` — 114 tests pass
- [x] `dotnet test tests/Granit.Http.Bulkhead.Tests` — 58 tests pass (inc. new LRU eviction test)
- [x] `dotnet test tests/Granit.Http.ResponseCompression.Tests` — 22 tests pass
- [x] `dotnet test tests/Granit.ArchitectureTests` — 119 tests pass
- [x] `dotnet format --verify-no-changes` clean
- [ ] Update `granit-showcase-dotnet` / `granit-microservice-template` configuration where defaults changed
