### PR TITLE
fix(bff): reject session cookies whose frontend does not match caller origin

### DIFF
--- a/src/Granit.Bff.Endpoints/Extensions/BffTokenInjectionMiddleware.cs
+++ b/src/Granit.Bff.Endpoints/Extensions/BffTokenInjectionMiddleware.cs
@@ -157,11 +157,17 @@ public sealed partial class BffTokenInjectionMiddleware
     /// Resolves the BFF frontend for the current request based on session cookies.
     /// When multiple frontends are configured on a single backend origin, the browser
     /// sends every <c>.bff-{name}</c> cookie it holds for that origin (they share
-    /// <c>Path=/</c>). Picking the first cookie found would mismatch the CSRF token
-    /// that the SPA obtained for its own frontend, which produces 403 responses on
-    /// mutating calls. Disambiguate by matching the request's <c>Origin</c> (or
-    /// <c>Referer</c> when <c>Origin</c> is absent) against each candidate's
-    /// <see cref="BffFrontendOptions.ClientUrl"/>.
+    /// <c>Path=/</c>). Even with a single cookie the choice can be wrong: on
+    /// <c>localhost</c> the port is not part of the cookie scope (RFC 6265), so a
+    /// cookie set by the SPA on <c>localhost:5173</c> is also sent by the browser
+    /// on requests to <c>localhost:5174</c>. Picking that cookie blindly would
+    /// mismatch the CSRF token the tenant SPA obtained for its own frontend and
+    /// produce a 403 on every mutating call (including <c>/api/v1/account/login</c>).
+    /// Disambiguate by matching the request's <c>Origin</c> (or <c>Referer</c> when
+    /// <c>Origin</c> is absent) against each candidate's
+    /// <see cref="BffFrontendOptions.ClientUrl"/>; when the caller origin is known
+    /// but matches no candidate, treat the request as sessionless so anonymous
+    /// endpoints proceed and authenticated endpoints challenge normally.
     /// </summary>
     internal static (BffFrontendOptions? Frontend, string? SessionId) ResolveFrontendFromCookies(
         HttpContext context, GranitBffOptions options)
@@ -182,24 +188,25 @@ public sealed partial class BffTokenInjectionMiddleware
             return (null, null);
         }
 
-        if (candidates.Count == 1)
+        string? callerOrigin = GetCallerOrigin(context.Request);
+
+        if (callerOrigin is null)
         {
+            // No Origin/Referer (same-origin GET navigation, server-to-server) —
+            // fall back to the first candidate to preserve single-frontend and
+            // monolithic setups.
             return candidates[0];
         }
 
-        string? callerOrigin = GetCallerOrigin(context.Request);
-        if (callerOrigin is not null)
+        foreach ((BffFrontendOptions frontend, string sessionId) in candidates)
         {
-            foreach ((BffFrontendOptions frontend, string sessionId) in candidates)
+            if (OriginMatchesClientUrl(callerOrigin, frontend.ClientUrl))
             {
-                if (OriginMatchesClientUrl(callerOrigin, frontend.ClientUrl))
-                {
-                    return (frontend, sessionId);
-                }
+                return (frontend, sessionId);
             }
         }
 
-        return candidates[0];
+        return (null, null);
     }
 
     private static string? GetCallerOrigin(HttpRequest request)

--- a/tests/Granit.Bff.Endpoints.Tests/Extensions/BffTokenInjectionMiddlewareTests.cs
+++ b/tests/Granit.Bff.Endpoints.Tests/Extensions/BffTokenInjectionMiddlewareTests.cs
@@ -204,7 +204,7 @@ public sealed class BffTokenInjectionMiddlewareTests
     }
 
     [Fact]
-    public void ResolveFrontendFromCookies_BothCookiesPresent_UnknownOrigin_FallsBackToFirst()
+    public void ResolveFrontendFromCookies_BothCookiesPresent_UnknownOrigin_ReturnsNull()
     {
         BffFrontendOptions host = Frontend("host", "http://localhost:5173");
         BffFrontendOptions app = Frontend("app", "http://localhost:5174");
@@ -225,8 +225,42 @@ public sealed class BffTokenInjectionMiddlewareTests
         (BffFrontendOptions? frontend, string? sessionId) =
             BffTokenInjectionMiddleware.ResolveFrontendFromCookies(context, options);
 
-        frontend.ShouldBe(host);
-        sessionId.ShouldBe("session-host-aaa");
+        // Caller origin does not match any frontend's ClientUrl — granting one
+        // arbitrary session to a stranger would hand it CSRF-protected state it
+        // has no claim to. Drop both candidates instead.
+        frontend.ShouldBeNull();
+        sessionId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ResolveFrontendFromCookies_SingleCookie_OriginMismatch_ReturnsNull()
+    {
+        // Regression: on localhost the cookie scope ignores the port (RFC 6265),
+        // so a `.bff-host` cookie set by the host SPA on :5173 is also sent by
+        // the browser to :5174. With only one cookie the old fast path returned
+        // it unconditionally — the tenant SPA's mutating request (e.g. login)
+        // was then CSRF-validated against the host session's HMAC secret and
+        // rejected with 403.
+        BffFrontendOptions host = Frontend("host", "http://localhost:5173");
+        BffFrontendOptions app = Frontend("app", "http://localhost:5174");
+        GranitBffOptions options = new()
+        {
+            Authority = new Uri("https://auth.example.com"),
+            Frontends = [host, app],
+        };
+
+        HttpContext context = CreateContext(
+            new Dictionary<string, string>
+            {
+                [".bff-host"] = "session-host-aaa",
+            },
+            origin: "http://localhost:5174");
+
+        (BffFrontendOptions? frontend, string? sessionId) =
+            BffTokenInjectionMiddleware.ResolveFrontendFromCookies(context, options);
+
+        frontend.ShouldBeNull();
+        sessionId.ShouldBeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Tightens `BffTokenInjectionMiddleware.ResolveFrontendFromCookies`: when the caller Origin/Referer is known, require a `ClientUrl` match. If no candidate matches, return `(null, null)` so the request falls through to the next middleware.
- Drops the single-cookie fast path that blindly returned the lone candidate — the exact hole that made the user-visible bug survive #1142.

## Why

The multi-frontend disambiguation added in #1142 only triggered when **two or more** BFF session cookies were present. The single-cookie path still returned the lone candidate unchecked, so a `.bff-host` cookie surfacing on a `localhost:5174` request (tenant SPA) produced a 403 on every mutating call — including `POST /api/v1/account/login` — making a fresh login on the second frontend impossible once the first was authenticated.

On `localhost` the port is not part of the cookie scope (RFC 6265), so a cookie set by the host SPA on `:5173` is sent by the browser to every request on `:5174` too. The tenant SPA's mutating login request was then CSRF-validated against the host session's HMAC secret and rejected.

With the fix, the tenant POST reaches the anonymous `/account/login` endpoint cleanly; authenticated endpoints on the tenant still challenge normally because no session is injected.

## Behaviour matrix

| Candidates | Origin known | Match? | Before | After |
|-----------:|:-------------|:------:|:-------|:------|
| 0 | — | — | `(null,null)` | unchanged |
| 1 | no | — | return it | unchanged |
| 1 | yes | yes | return it | unchanged |
| 1 | yes | **no** | **return it (bug)** | **`(null,null)`** |
| 2+ | no | — | first candidate | unchanged |
| 2+ | yes | yes | matched candidate | unchanged |
| 2+ | yes | no | first candidate | `(null,null)` |

## Test plan

- [x] `dotnet test tests/Granit.Bff.Endpoints.Tests --filter FullyQualifiedName~BffTokenInjectionMiddlewareTests` — 11/11 pass (10 existing + 1 new `SingleCookie_OriginMismatch_ReturnsNull` reproducing the reported scenario).
- [x] `dotnet format --verify-no-changes` on Bff.Endpoints + Bff.Endpoints.Tests — clean.
- [x] Existing test `BothCookiesPresent_UnknownOrigin_FallsBackToFirst` renamed to `…_ReturnsNull` and expectation updated — an origin matching no ClientUrl must not receive an arbitrary session.
- [ ] Manual: log in on `localhost:5173` (host), open `localhost:5174` (tenant), log in — no 403 on `POST /app/api/v1/account/login`.