### PR TITLE
feat(metering)!: dual-layer idempotency on POST /events + RFC 6648 header rename (#1156)

### DIFF
--- a/.github/shard-filters/saas.slnf
+++ b/.github/shard-filters/saas.slnf
@@ -22,6 +22,7 @@
       "src/Granit.Http.ApiDocumentation/Granit.Http.ApiDocumentation.csproj",
       "src/Granit.Http.ApiVersioning/Granit.Http.ApiVersioning.csproj",
       "src/Granit.Http.ExceptionHandling/Granit.Http.ExceptionHandling.csproj",
+      "src/Granit.Http.Idempotency/Granit.Http.Idempotency.csproj",
       "src/Granit.Http.Resilience/Granit.Http.Resilience.csproj",
       "src/Granit.Invoicing.Abstractions/Granit.Invoicing.Abstractions.csproj",
       "src/Granit.Invoicing.BackgroundJobs/Granit.Invoicing.BackgroundJobs.csproj",

--- a/docs-site/src/content/docs/dotnet/api/idempotency.mdx
+++ b/docs-site/src/content/docs/dotnet/api/idempotency.mdx
@@ -61,7 +61,7 @@ flowchart TD
     START([Request arrives]) --> ABSENT{Key absent?}
     ABSENT -- Yes --> ACQUIRE[TryAcquire\nSET NX PX → InProgress]
     ABSENT -- No: InProgress --> CONFLICT[409 Request In Progress]
-    ABSENT -- No: Completed --> REPLAY[Replay cached response\nX-Idempotency-Replayed: true]
+    ABSENT -- No: Completed --> REPLAY[Replay cached response\nIdempotent-Replayed: true]
     ACQUIRE --> EXECUTE[Execute handler]
     EXECUTE -- 2xx / cacheable 4xx --> COMPLETE[SetCompleted\nSET XX PX → Completed]
     EXECUTE -- 5xx / timeout --> RELEASE[DELETE key → Absent]
@@ -108,7 +108,7 @@ different body.
 | Payload hash mismatch | 422 | Idempotency Key Conflict |
 | Execution timeout | 503 | Execution Timeout |
 
-Replayed responses include an `X-Idempotency-Replayed: true` header.
+Replayed responses include an `Idempotent-Replayed: true` header.
 
 ## Configuration reference
 

--- a/docs-site/src/content/docs/dotnet/architecture/http-conventions.md
+++ b/docs-site/src/content/docs/dotnet/architecture/http-conventions.md
@@ -478,7 +478,7 @@ The `Granit.Http.Idempotency` package provides Stripe-style idempotency via the
 | Scenario | Response |
 |----------|----------|
 | First request | Executes handler, caches response for 24h |
-| Duplicate with same body | Replays cached response + `X-Idempotency-Replayed: true` |
+| Duplicate with same body | Replays cached response + `Idempotent-Replayed: true` |
 | Duplicate with different body | `422` with detail "payload does not match" |
 | Concurrent duplicate | `409` with `Retry-After` header |
 | Missing required key | `422` with detail about missing header |

--- a/docs-site/src/content/docs/dotnet/guides/configure-idempotency.mdx
+++ b/docs-site/src/content/docs/dotnet/guides/configure-idempotency.mdx
@@ -136,7 +136,7 @@ Content-Type: application/json
 | Scenario | Response | Header |
 |----------|----------|--------|
 | First request (lock acquired) | Normal business response | -- |
-| Retry with same body (response cached) | Original response replayed | `X-Idempotency-Replayed: true` |
+| Retry with same body (response cached) | Original response replayed | `Idempotent-Replayed: true` |
 | Concurrent request (execution in progress) | `409 Conflict` | `Retry-After: 30` |
 | Retry with different body | `422 Unprocessable Entity` | -- |
 | Execution timeout | `503 Service Unavailable` | -- |

--- a/docs-site/src/content/docs/dotnet/saas/metering.mdx
+++ b/docs-site/src/content/docs/dotnet/saas/metering.mdx
@@ -277,6 +277,44 @@ paginate, export to CSV/XLSX, and save per-user views. When called without a
 tenant context (host admin), the multi-tenant query filter is bypassed so the
 host can review usage cross-tenant.
 
+## Idempotency model
+
+`POST /api/granit/metering/events` enforces idempotency at **two complementary
+layers** — neither replaces the other.
+
+### HTTP layer — request envelope dedup
+
+- **Mechanism**: `Idempotency-Key` header (RFC 8700, Stripe-style), required
+- **Scope**: the whole request envelope (the batch as a unit)
+- **Failure modes**:
+  - Missing header → 422
+  - Same key + different body → 422
+  - Replay returns the cached response with `Idempotent-Replayed: true`
+
+### Database layer — per-event dedup
+
+- **Mechanism**: `UNIQUE (TenantId, IdempotencyKey)` on `meter_events`
+- **Scope**: each event in the batch
+- **Failure mode**: duplicate event silently ignored (insert-first pattern)
+
+**Why both?** They protect against different threats:
+
+- **HTTP layer** prevents network-level replay of the entire batch (proxy retry,
+  client SDK retry without state). Without it, a flaky network could cause two
+  separate ingestions of the same batch under different HTTP keys.
+- **Database layer** allows safe partial-overlap retries: a client that resends
+  `[A, B, C, D]` after a previous successful `[A, B, C]` will only insert `D`
+  (the others are deduplicated against the per-event `IdempotencyKey`).
+
+**Client guidance**:
+
+- Generate a fresh UUID for the `Idempotency-Key` HTTP header on every new
+  logical send. Reuse it across retries of *the same* batch.
+- Generate a stable per-event `IdempotencyKey` payload value (e.g.,
+  `"{external_request_id}:{event_index}"`) so partial retries deduplicate
+  correctly at the DB layer.
+- Never put PII in either key (audit logs and Redis store retain them).
+
 ## See also
 
 - [SaaS Overview](/dotnet/saas/) — ecosystem architecture and choreography

--- a/src/Granit.Http.Idempotency/Internal/IdempotencyMiddleware.cs
+++ b/src/Granit.Http.Idempotency/Internal/IdempotencyMiddleware.cs
@@ -357,7 +357,7 @@ internal sealed partial class IdempotencyMiddleware(
             }
         }
 
-        context.Response.Headers["X-Idempotency-Replayed"] = "true";
+        context.Response.Headers["Idempotent-Replayed"] = "true";
 
         if (entry.ResponseBody is { Length: > 0 })
         {

--- a/src/Granit.Metering.Endpoints/Endpoints/UsageEndpoints.cs
+++ b/src/Granit.Metering.Endpoints/Endpoints/UsageEndpoints.cs
@@ -46,7 +46,13 @@ internal static class UsageEndpoints
             .WithSummary("Records one or more usage events.")
             .WithDescription(
                 "Accepts a batch of usage events and records them against their respective meter definitions. "
-                + "Duplicate events (same idempotency key within a tenant) are silently ignored. "
+                + "Idempotency is enforced at two complementary layers: "
+                + "(1) the HTTP `Idempotency-Key` header (required, RFC 8700) protects against network-level replay of the entire batch — "
+                + "duplicate sends with the same header value return the cached response with `Idempotent-Replayed: true`, "
+                + "and reuse with a different payload returns 422; "
+                + "(2) per-event `IdempotencyKey` payload field is unique within a tenant — duplicate events across different batches are silently ignored "
+                + "(allows partial-overlap retries to safely add only new events). "
+                + "Requests without the `Idempotency-Key` header are rejected 422. "
                 + "All events must have a positive quantity and a non-empty idempotency key.")
             .WithMetadata(new IdempotentAttribute())
             .Produces(StatusCodes.Status204NoContent)
@@ -54,6 +60,7 @@ internal static class UsageEndpoints
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .RequireAuthorization(MeteringPermissions.Usage.Record);
 
         return group;

--- a/tests/Granit.Http.Idempotency.Tests/IdempotencyMiddlewareTests.cs
+++ b/tests/Granit.Http.Idempotency.Tests/IdempotencyMiddlewareTests.cs
@@ -5,7 +5,7 @@
 //   1. Double-click (InProgress) → HTTP 409 + Retry-After header
 //   2. Payload mutation (Completed, wrong hash) → HTTP 422
 //   3. Execution timeout → HTTP 503 + DeleteAsync called
-//   4. Successful replay → X-Idempotency-Replayed: true (no business logic re-executed)
+//   4. Successful replay → Idempotent-Replayed: true (no business logic re-executed)
 // =============================================================================
 
 using System.Net;
@@ -713,7 +713,7 @@ public sealed class IdempotencyMiddlewareTests
             HttpResponseMessage second = await client.SendAsync(BuildRequest(), TestContext.Current.CancellationToken);
 
             second.StatusCode.ShouldBe(HttpStatusCode.Created);
-            second.Headers.Contains("X-Idempotency-Replayed").ShouldBeTrue();
+            second.Headers.Contains("Idempotent-Replayed").ShouldBeTrue();
             string replayBody = await second.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             replayBody.ShouldContain("42");
         }
@@ -806,7 +806,7 @@ public sealed class IdempotencyMiddlewareTests
     }
 
     // =========================================================================
-    // Scenario 15: Successful replay → X-Idempotency-Replayed (no re-execution)
+    // Scenario 15: Successful replay → Idempotent-Replayed (no re-execution)
     // =========================================================================
 
     [Fact]
@@ -857,8 +857,8 @@ public sealed class IdempotencyMiddlewareTests
 
             // Assert
             second.StatusCode.ShouldBe(HttpStatusCode.Created);
-            second.Headers.Contains("X-Idempotency-Replayed").ShouldBeTrue();
-            second.Headers.GetValues("X-Idempotency-Replayed").ShouldContain("true");
+            second.Headers.Contains("Idempotent-Replayed").ShouldBeTrue();
+            second.Headers.GetValues("Idempotent-Replayed").ShouldContain("true");
 
             handlerCallCount.ShouldBe(1, "business logic must not be re-executed on replay");
         }
@@ -925,7 +925,7 @@ public sealed class IdempotencyMiddlewareTests
             // be re-emitted to this new request.
             HttpResponseMessage second = await client.SendAsync(BuildRequest(), TestContext.Current.CancellationToken);
             second.StatusCode.ShouldBe(HttpStatusCode.OK);
-            second.Headers.Contains("X-Idempotency-Replayed").ShouldBeTrue();
+            second.Headers.Contains("Idempotent-Replayed").ShouldBeTrue();
             second.Headers.Contains("Set-Cookie").ShouldBeFalse(
                 "replay must not leak the original caller's cookie to a subsequent retry");
         }

--- a/tests/Granit.Metering.Endpoints.Tests/Endpoints/UsageEndpointsIdempotencyTests.cs
+++ b/tests/Granit.Metering.Endpoints.Tests/Endpoints/UsageEndpointsIdempotencyTests.cs
@@ -1,0 +1,288 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Granit.Guids;
+using Granit.Http.Idempotency.Abstractions;
+using Granit.Http.Idempotency.Extensions;
+using Granit.Http.Idempotency.Models;
+using Granit.Metering;
+using Granit.Metering.Domain;
+using Granit.Metering.Domain.ValueObjects;
+using Granit.Metering.Endpoints.Dtos;
+using Granit.Metering.Endpoints.Extensions;
+using Granit.Metering.Endpoints.Permissions;
+using Granit.MultiTenancy;
+using Granit.Users;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Metering.Endpoints.Tests.Endpoints;
+
+/// <summary>
+/// Tests proving the dual-layer idempotency wiring on <c>POST /metering/events</c>:
+/// (1) HTTP layer enforced via <see cref="Granit.Http.Idempotency.Attributes.IdempotentAttribute"/> +
+/// <c>UseGranitIdempotency</c> middleware (rejects missing header, replays on duplicate);
+/// (2) DB layer enforced via the unique constraint on
+/// <c>(TenantId, IdempotencyKey)</c> in <c>MeterEvent</c> (silent dedup at the recorder layer).
+///
+/// The DB layer behavior itself is exercised by the EF integration tests; here we
+/// verify the HTTP-side wiring stays in place and the renamed RFC 6648 replay header
+/// (<c>Idempotent-Replayed</c>) is emitted.
+/// </summary>
+public sealed class UsageEndpointsIdempotencyTests : IAsyncDisposable
+{
+    private const string AdminRole = "metering-recorder";
+    private const string EventsRoute = "/metering/events";
+    private static readonly Guid TenantId = Guid.Parse("00000000-0000-0000-0000-000000000aaa");
+    private static readonly Guid MeterId = Guid.Parse("00000000-0000-0000-0000-000000000bbb");
+
+    private readonly IMeterEventRecorder _recorder = Substitute.For<IMeterEventRecorder>();
+    private readonly IMeterDefinitionReader _reader = Substitute.For<IMeterDefinitionReader>();
+    private readonly IIdempotencyStore _idempotencyStore = new InMemoryIdempotencyStore();
+    private readonly WebApplication _app;
+    private readonly HttpClient _client;
+
+    public UsageEndpointsIdempotencyTests()
+    {
+        // Active meter required so the handler proceeds past the existence/active checks.
+        var activeMeter = MeterDefinition.Create(
+            id: MeterId,
+            name: "test.meter",
+            unit: "call",
+            aggregationType: AggregationType.Count,
+            description: null);
+
+        _reader
+            .GetByIdAsync(Arg.Any<MeterDefinitionId>(), Arg.Any<CancellationToken>())
+            .Returns(activeMeter);
+
+        // Stable GUID for predictable assertions in test output.
+        IGuidGenerator guidGen = Substitute.For<IGuidGenerator>();
+        guidGen.Create().Returns(_ => Guid.NewGuid());
+
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        currentTenant.IsAvailable.Returns(true);
+        currentTenant.Id.Returns(TenantId);
+
+        ICurrentUserService currentUser = Substitute.For<ICurrentUserService>();
+        currentUser.UserId.Returns("test-user");
+
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+
+        builder.Services
+            .AddAuthentication(TestAuthHandler.SchemeName)
+            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                TestAuthHandler.SchemeName, _ => { });
+
+        builder.Services
+            .AddAuthorizationBuilder()
+            .AddPolicy(MeteringPermissions.Usage.Record, p => p.RequireRole(AdminRole))
+            .AddPolicy(MeteringPermissions.Usage.Read, p => p.RequireRole(AdminRole))
+            .AddPolicy(MeteringPermissions.Meters.Read, p => p.RequireRole(AdminRole))
+            .AddPolicy(MeteringPermissions.Meters.Manage, p => p.RequireRole(AdminRole));
+
+        // Idempotency middleware + override the store with our in-memory implementation.
+        builder.Services.AddGranitIdempotency(opts =>
+        {
+            opts.ExecutionTimeout = TimeSpan.FromSeconds(10);
+            opts.InProgressTtl = TimeSpan.FromSeconds(15);
+        });
+        builder.Services.AddSingleton(_idempotencyStore);
+
+        // Application services consumed by the endpoint handler.
+        builder.Services.AddSingleton(_recorder);
+        builder.Services.AddSingleton(_reader);
+        builder.Services.AddSingleton(guidGen);
+        builder.Services.AddScoped(_ => currentTenant);
+        builder.Services.AddScoped(_ => currentUser);
+
+        _app = builder.Build();
+        _app.UseAuthentication();
+        _app.UseAuthorization();
+        _app.UseGranitIdempotency();
+        _app.MapUsageOnly();
+        _app.StartAsync().GetAwaiter().GetResult();
+
+        _client = _app.GetTestClient();
+        _client.DefaultRequestHeaders.Add(TestAuthHandler.RolesHeader, AdminRole);
+    }
+
+    public async ValueTask DisposeAsync() => await _app.DisposeAsync();
+
+    [Fact]
+    public async Task PostEvents_WithoutIdempotencyKey_Returns422()
+    {
+        HttpResponseMessage response = await _client.PostAsJsonAsync(
+            EventsRoute,
+            BuildBatch("evt-1"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity);
+        await _recorder.DidNotReceiveWithAnyArgs().RecordBatchAsync(default!, TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task PostEvents_SecondRequestWithSameKey_ReplaysWith_IdempotentReplayedHeader()
+    {
+        HttpResponseMessage first = await SendWithKey("idem-key-replay", BuildBatch("evt-replay"));
+        first.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        HttpResponseMessage second = await SendWithKey("idem-key-replay", BuildBatch("evt-replay"));
+
+        second.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+        second.Headers.Contains("Idempotent-Replayed").ShouldBeTrue(
+            "RFC 6648 (no X- prefix) — replay marker MUST be 'Idempotent-Replayed', aligned with ORB / Stripe");
+        second.Headers.GetValues("Idempotent-Replayed").ShouldContain("true");
+
+        // The handler must execute exactly ONCE — the second response is a replay.
+        await _recorder.Received(1).RecordBatchAsync(
+            Arg.Any<IReadOnlyList<MeterEvent>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PostEvents_SameKey_DifferentBody_Returns422()
+    {
+        HttpResponseMessage first = await SendWithKey("idem-key-mismatch", BuildBatch("evt-A"));
+        first.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        HttpResponseMessage second = await SendWithKey("idem-key-mismatch", BuildBatch("evt-B"));
+
+        second.StatusCode.ShouldBe(HttpStatusCode.UnprocessableEntity,
+            "Reusing an idempotency key with a different payload MUST be rejected (HTTP-layer payload hash mismatch)");
+    }
+
+    private async Task<HttpResponseMessage> SendWithKey(string key, RecordUsageRequest body)
+    {
+        HttpRequestMessage req = new(HttpMethod.Post, EventsRoute)
+        {
+            Content = JsonContent.Create(body),
+        };
+        req.Headers.Add("Idempotency-Key", key);
+        return await _client.SendAsync(req, TestContext.Current.CancellationToken);
+    }
+
+    private static readonly DateTimeOffset FixedTimestamp =
+        new(2026, 4, 24, 12, 0, 0, TimeSpan.Zero);
+
+    private static RecordUsageRequest BuildBatch(string payloadKey) =>
+        new([
+            new MeterEventRequest(
+                MeterDefinitionId: MeterId,
+                IdempotencyKey: payloadKey,
+                Quantity: 1m,
+                Timestamp: FixedTimestamp,
+                Metadata: null),
+        ]);
+
+    // ── In-memory idempotency store ───────────────────────────────────────────
+    // The middleware exercises full state transitions (Absent → InProgress → Completed).
+    // We reuse the same store across requests so replays observe the cached entry.
+
+    private sealed class InMemoryIdempotencyStore : IIdempotencyStore
+    {
+        private readonly Lock _lock = new();
+        private readonly Dictionary<string, IdempotencyEntry> _entries = new(StringComparer.Ordinal);
+
+        public Task<bool> TryAcquireAsync(string key, IdempotencyEntry entry, TimeSpan ttl, CancellationToken cancellationToken)
+        {
+            lock (_lock)
+            {
+                if (_entries.ContainsKey(key))
+                {
+                    return Task.FromResult(false);
+                }
+
+                _entries[key] = entry;
+                return Task.FromResult(true);
+            }
+        }
+
+        public Task<IdempotencyEntry?> GetAsync(string key, CancellationToken cancellationToken)
+        {
+            lock (_lock)
+            {
+                return Task.FromResult(_entries.TryGetValue(key, out IdempotencyEntry? e) ? e : null);
+            }
+        }
+
+        public Task SetCompletedAsync(string key, IdempotencyEntry entry, TimeSpan ttl, CancellationToken cancellationToken)
+        {
+            lock (_lock)
+            {
+                if (_entries.ContainsKey(key))
+                {
+                    _entries[key] = entry;
+                }
+
+                return Task.CompletedTask;
+            }
+        }
+
+        public Task DeleteAsync(string key, CancellationToken cancellationToken)
+        {
+            lock (_lock)
+            {
+                _entries.Remove(key);
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    // ── Fake authentication handler ───────────────────────────────────────────
+
+    private sealed class TestAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        public const string SchemeName = "Test";
+        public const string RolesHeader = "X-Test-Roles";
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.TryGetValue(RolesHeader, out Microsoft.Extensions.Primitives.StringValues rolesHeader))
+            {
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+
+            string[] roles = rolesHeader.ToString().Split(',', StringSplitOptions.RemoveEmptyEntries);
+            Claim[] claims =
+            [
+                new(ClaimTypes.Name, "test-user"),
+                .. roles.Select(r => new Claim(ClaimTypes.Role, r.Trim())),
+            ];
+
+            ClaimsIdentity identity = new(claims, SchemeName);
+            ClaimsPrincipal principal = new(identity);
+            AuthenticationTicket ticket = new(principal, SchemeName);
+
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+}
+
+// ── Endpoint mapping helper ──────────────────────────────────────────────────
+// MapGranitMetering also wires QueryEngine endpoints which require a richer DI setup.
+// To stay focused on the /events endpoint, we re-mount only the usage routes via
+// the same internal extension used by the production module.
+
+internal static class TestRouteHelpers
+{
+    public static IEndpointRouteBuilder MapUsageOnly(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGranitMetering(opts => opts.RoutePrefix = "metering");
+        return endpoints;
+    }
+}

--- a/tests/Granit.Metering.Endpoints.Tests/Granit.Metering.Endpoints.Tests.csproj
+++ b/tests/Granit.Metering.Endpoints.Tests/Granit.Metering.Endpoints.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Granit.Metering.Endpoints\Granit.Metering.Endpoints.csproj" />
+    <ProjectReference Include="..\..\src\Granit.Http.Idempotency\Granit.Http.Idempotency.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Granit.Metering.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Metering.Endpoints.Tests/packages.lock.json
@@ -583,6 +583,14 @@
           "Granit": "[0.1.0-dev, )"
         }
       },
+      "granit.http.idempotency": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.Caching": "[0.1.0-dev, )",
+          "Granit.Http.Abstractions": "[0.1.0-dev, )",
+          "Microsoft.IO.RecyclableMemoryStream": "[3.*, )"
+        }
+      },
       "granit.localization": {
         "type": "Project",
         "dependencies": {
@@ -810,6 +818,12 @@
           "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
+      "Microsoft.IO.RecyclableMemoryStream": {
+        "type": "CentralTransitive",
+        "requested": "[3.*, )",
+        "resolved": "3.0.1",
+        "contentHash": "s/s20YTVY9r9TPfTrN5g8zPF1YhwxyqO6PxUkrYTGI2B+OGPe9AdajWZrLhFqXIvqIW23fnUE4+ztrUWNU1+9g=="
+      },
       "OpenTelemetry.Api": {
         "type": "CentralTransitive",
         "requested": "[1.15.*, )",
@@ -819,8 +833,8 @@
       "Scalar.AspNetCore": {
         "type": "CentralTransitive",
         "requested": "[2.*, )",
-        "resolved": "2.14.3",
-        "contentHash": "RUy9LiqIl8AY6j2veG2h5gLv31L/REoMMIYm2/7V73nEI/N0EnMpUjuz6FDNDrwhFi2hjqZGXYXA6Li8bZcilA=="
+        "resolved": "2.14.4",
+        "contentHash": "PyuqLRi7JXyTJm/rh+IWCA4Fct1SlZuWrdYiui5hiaBuSY88+roc4eWKfYaE6zrupBIwnEP8pJLe4ifvU7HtZA=="
       },
       "SmartFormat": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Summary

Phase 0 of the **ORB alignment EPIC** (#1155). Closes #1156.

Discovery during Phase 0 scoping: `[Idempotent]` was *already* applied on `POST /metering/events` and the DB unique constraint *already* in place — but neither the description, the documentation, nor any test pinned this dual-layer wiring. This PR closes those gaps and aligns the replay-marker header on RFC 6648.

### Two commits, two concerns

1. `feat(http-idempotency)!: rename replay header to Idempotent-Replayed (RFC 6648)`
   - Replaces `X-Idempotency-Replayed` with `Idempotent-Replayed` framework-wide (1 source line + 4 tests + 4 doc references)
   - **Breaking** for clients reading the previous header name
   - Aligns with ORB and Stripe conventions

2. `feat(metering): document and test dual-layer idempotency on POST /events`
   - Rewrites the OpenAPI summary/description for `POST /metering/events` to state both layers explicitly
   - Adds a new "Idempotency model" section in the Metering module documentation page
   - Adds 3 integration tests in `Granit.Metering.Endpoints.Tests` pinning the wiring

### Out of scope (deliberately deferred)

- Full DB-layer integration test (would require testcontainer infra reused across modules — slated for the eventual `Granit.*.Tests.Integration` consolidation, not Phase 0)
- Rename of `[Idempotent]` attribute or `Idempotency-Key` request header — only the response header is renamed (RFC 8700 names the request header `Idempotency-Key`)

## Test plan

- [x] `dotnet build tests/Granit.Metering.Endpoints.Tests` succeeds
- [x] `dotnet test tests/Granit.Http.Idempotency.Tests` — 110/110 green (4 assertions updated to new header name)
- [x] `dotnet test tests/Granit.Metering.Endpoints.Tests` — 9/9 green including 3 new tests
- [x] `dotnet format Granit.slnx --include … --verify-no-changes` — clean
- [x] Manual verification — no remaining occurrences of `X-Idempotency-Replayed` anywhere
- [ ] CI green
- [ ] Markdownlint on touched .md files green (the lint errors at metering.mdx:251,261 are pre-existing on develop — unrelated to this PR)

## Migration note

Apps that read `Response.Headers["X-Idempotency-Replayed"]` must be updated to read `Response.Headers["Idempotent-Replayed"]`. Server behavior is unchanged.
