### PR TITLE
fix(identity-local-endpoints): disable multi-tenant filter unconditionally during login user lookup

### DIFF
--- a/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
+++ b/src/Granit.Identity.Local.Endpoints/Endpoints/AccountLoginEndpoints.cs
@@ -104,13 +104,15 @@ internal static partial class AccountLoginEndpoints
         IDataFilter? dataFilter = httpContext.RequestServices.GetService<IDataFilter>();
 
         // Resolve user by email or username.
-        // When no tenant context is active (single-URL app, login happens before authentication),
-        // disable the multi-tenant query filter so the user can be found across all tenants.
-        // RequireUniqueEmail=true guarantees no ambiguity.
+        // Always disable the multi-tenant filter for lookup: when the caller already
+        // has an Identity cookie from a prior login on another side (common on
+        // localhost where cookies ignore the port), ICurrentTenant resolves to the
+        // stale claim and a tenant-scoped query would hide any user whose TenantId
+        // does not match — making it impossible to log in as a host admin from a
+        // browser that previously authenticated a tenant user, and vice-versa.
+        // RequireUniqueEmail=true guarantees no ambiguity across tenants.
         GranitUser? user;
-        IDisposable? tenantFilterScope = currentTenant is { IsAvailable: false }
-            ? dataFilter?.Disable<IMultiTenant>()
-            : null;
+        IDisposable? tenantFilterScope = dataFilter?.Disable<IMultiTenant>();
         try
         {
             user = await userManager.FindByEmailAsync(request.Login).ConfigureAwait(false)
@@ -135,12 +137,12 @@ internal static partial class AccountLoginEndpoints
                 statusCode: StatusCodes.Status401Unauthorized);
         }
 
-        // Establish the tenant context from the resolved user so that
-        // PasswordSignInAsync and downstream Identity operations run within
-        // the correct tenant scope. Change(null) for host admins is a no-op.
-        using IDisposable? tenantScope = currentTenant is not null && user.TenantId is not null
-            ? currentTenant.Change(user.TenantId)
-            : null;
+        // Re-align the tenant context with the resolved user so PasswordSignInAsync
+        // and downstream Identity operations run within the correct scope. Passing
+        // `user.TenantId` handles both cases: a host admin (null) clears any stale
+        // tenant inherited from a prior login, and a tenant user switches the
+        // context to their own tenant even if it differs from the stale claim.
+        using IDisposable? tenantScope = currentTenant?.Change(user.TenantId);
 
         Microsoft.AspNetCore.Identity.SignInResult result = await signInManager
             .PasswordSignInAsync(user, request.Password, isPersistent: request.RememberMe, lockoutOnFailure: true)
@@ -296,16 +298,26 @@ internal static partial class AccountLoginEndpoints
     }
 
     /// <summary>
-    /// Resolves the tenant context from the 2FA session cookie when no tenant is active.
-    /// Returns an <see cref="IDisposable"/> that restores the previous tenant on dispose,
-    /// or <c>null</c> if no tenant switch was needed.
+    /// Resolves the tenant context from the 2FA session cookie and aligns
+    /// <see cref="ICurrentTenant"/> with the user identified by the challenge.
+    /// Returns an <see cref="IDisposable"/> that restores the previous tenant on
+    /// dispose, or <c>null</c> when the 2FA user cannot be resolved (the handler
+    /// lets the subsequent sign-in call surface the failure).
     /// </summary>
+    /// <remarks>
+    /// The filter is disabled unconditionally during lookup: a stale tenant claim
+    /// inherited from a prior login on another side would otherwise scope the
+    /// query to the wrong tenant and hide the 2FA user, mirroring the password
+    /// login issue. The scope returned by <see cref="ICurrentTenant.Change"/> is
+    /// entered with the user's actual <c>TenantId</c> (null for host admins) so
+    /// the rest of the 2FA ceremony runs in the correct context.
+    /// </remarks>
     private static async Task<IDisposable?> ResolveTenantFromTwoFactorSessionAsync(
         SignInManager<GranitUser> signInManager,
         ICurrentTenant? currentTenant,
         IDataFilter? dataFilter)
     {
-        if (currentTenant is not { IsAvailable: false })
+        if (currentTenant is null)
         {
             return null;
         }
@@ -315,9 +327,7 @@ internal static partial class AccountLoginEndpoints
         GranitUser? twoFactorUser = await signInManager.GetTwoFactorAuthenticationUserAsync()
             .ConfigureAwait(false);
 
-        return twoFactorUser?.TenantId is not null
-            ? currentTenant.Change(twoFactorUser.TenantId)
-            : null;
+        return twoFactorUser is null ? null : currentTenant.Change(twoFactorUser.TenantId);
     }
 
     // ──── Timing attack mitigation ────

--- a/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsIntegrationTests.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsIntegrationTests.cs
@@ -1,5 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
+using Granit.DataFiltering;
+using Granit.Domain;
 using Granit.Events;
 using Granit.Identity;
 using Granit.Identity.Local;
@@ -7,6 +9,7 @@ using Granit.Identity.Local.Domain;
 using Granit.Identity.Local.Endpoints.Dtos;
 using Granit.Identity.Local.Events;
 using Granit.Identity.Local.Services;
+using Granit.MultiTenancy;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Shouldly;
@@ -1172,6 +1175,53 @@ public sealed class AccountEndpointsIntegrationTests : IAsyncLifetime
 
         result.ShouldNotBeNull();
         result.Succeeded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Login_WithStaleTenantContext_DisablesFilterAndRealignsTenantToUser()
+    {
+        // Regression: when the browser carries a live Identity cookie from a prior
+        // login on another "side" (e.g. logged in on tenant SPA, now signing in on
+        // host SPA), TenantResolutionMiddleware resolves ICurrentTenant from the
+        // stale tenant_id claim. Before the fix, the handler only disabled the
+        // multi-tenant filter when ICurrentTenant was unavailable — so the lookup
+        // ran scoped to the wrong tenant and returned null, producing a 401 for
+        // credentials that were in fact valid.
+        var staleTenantId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        _server.CurrentTenant.IsAvailable.Returns(true);
+        _server.CurrentTenant.Id.Returns(staleTenantId);
+
+        var hostAdmin = new GranitUser
+        {
+            Id = AccountEndpointsTestServer.TestUserId,
+            Email = "host-admin@example.com",
+            TenantId = null,
+        };
+
+        _server.UserManager
+            .FindByEmailAsync("host-admin@example.com")
+            .Returns(hostAdmin);
+
+        _server.SignInManager
+            .PasswordSignInAsync(hostAdmin, "GoodP@ss1!", false, true)
+            .Returns(Microsoft.AspNetCore.Identity.SignInResult.Success);
+
+        HttpResponseMessage response = await _server.AnonymousClient.PostAsJsonAsync(
+            "/account/login",
+            new AccountLoginRequest("host-admin@example.com", "GoodP@ss1!"),
+            TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // The filter must have been disabled for the lookup — otherwise the host
+        // admin (TenantId == null) would be invisible while the stale tenant is
+        // active and the request would have returned 401.
+        _server.DataFilter.Received().Disable<IMultiTenant>();
+
+        // And the tenant context must be re-aligned with the resolved user's
+        // TenantId (null here) so PasswordSignInAsync and downstream operations
+        // no longer run within the stale tenant scope.
+        _server.CurrentTenant.Received().Change(null, Arg.Any<string?>());
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsTestServer.cs
+++ b/tests/Granit.Identity.Local.Endpoints.Tests/Integration/AccountEndpointsTestServer.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using FluentValidation;
+using Granit.DataFiltering;
 using Granit.Events;
 using Granit.Identity;
 using Granit.Identity.Local.Diagnostics;
@@ -10,6 +11,7 @@ using Granit.Identity.Local.Endpoints.Extensions;
 using Granit.Identity.Local.Endpoints.Options;
 using Granit.Identity.Local.Endpoints.Permissions;
 using Granit.Identity.Local.Services;
+using Granit.MultiTenancy;
 using Granit.Settings.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
@@ -69,6 +71,8 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
     public TimeProvider TimeProvider { get; }
     public SignInManager<GranitUser> SignInManager { get; }
     public UserManager<GranitUser> UserManager { get; }
+    public ICurrentTenant CurrentTenant { get; }
+    public IDataFilter DataFilter { get; }
 
     private AccountEndpointsTestServer(
         WebApplication app,
@@ -93,7 +97,9 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
         ISettingProvider settingProvider,
         TimeProvider timeProvider,
         SignInManager<GranitUser> signInManager,
-        UserManager<GranitUser> userManager)
+        UserManager<GranitUser> userManager,
+        ICurrentTenant currentTenant,
+        IDataFilter dataFilter)
     {
         _app = app;
         AuthenticatedClient = authenticatedClient;
@@ -118,6 +124,8 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
         TimeProvider = timeProvider;
         SignInManager = signInManager;
         UserManager = userManager;
+        CurrentTenant = currentTenant;
+        DataFilter = dataFilter;
     }
 
     public static async Task<AccountEndpointsTestServer> CreateAsync()
@@ -138,6 +146,13 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
         IAccountDeletionService deletionService = Substitute.For<IAccountDeletionService>();
         IDistributedEventBus eventBus = Substitute.For<IDistributedEventBus>();
         IFusionCache fusionCache = Substitute.For<IFusionCache>();
+
+        // Multi-tenancy stand-ins — default to "no tenant, no filter" so all existing
+        // tests keep the pre-existing behaviour (filter untouched, no tenant switch).
+        // Tests that exercise tenant-switching wire up their own return values via
+        // the exposed CurrentTenant / DataFilter properties.
+        ICurrentTenant currentTenant = Substitute.For<ICurrentTenant>();
+        IDataFilter dataFilter = Substitute.For<IDataFilter>();
 
         ISettingProvider settingProvider = Substitute.For<ISettingProvider>();
 
@@ -205,6 +220,8 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
         builder.Services.AddSingleton(timeProvider);
         builder.Services.AddSingleton(signInManager);
         builder.Services.AddSingleton(userManager);
+        builder.Services.AddSingleton(currentTenant);
+        builder.Services.AddSingleton(dataFilter);
         builder.Services.AddSingleton<IPasswordHasher<GranitUser>, PasswordHasher<GranitUser>>();
 
         // Options
@@ -242,7 +259,7 @@ internal sealed class AccountEndpointsTestServer : IAsyncDisposable
             externalLoginService, externalProviderRegistry,
             passkeyService, impersonationService, deletionService,
             eventBus, fusionCache, settingProvider, timeProvider,
-            signInManager, userManager);
+            signInManager, userManager, currentTenant, dataFilter);
     }
 
     public async ValueTask DisposeAsync()


### PR DESCRIPTION
## Summary

- Unconditionally disable `IDataFilter.Disable<IMultiTenant>()` during `FindByEmailAsync` / `FindByNameAsync` in `AccountLoginEndpoints`.
- Align `ICurrentTenant` with the resolved user's `TenantId` via `Change(user.TenantId)` (nullable — clears stale context for host admins, switches it for tenant users).
- Apply the same pattern to the 2FA user resolver, which had the identical guard.
- Extend the integration test server to expose `ICurrentTenant` + `IDataFilter` substitutes and add a regression test.

## Why

Paired with #1180 (BFF origin check). With the BFF fix in place, `POST /account/login` actually reaches the handler in the cross-side scenario. It then surfaces a second layer of the same bug: when the browser carries an `.AspNetCore.Identity.Application` cookie from a prior login elsewhere, `TenantResolutionMiddleware` reads the `tenant_id` claim and populates `ICurrentTenant`. The previous guard only disabled the multi-tenant filter when the tenant was *unavailable*:

```csharp
IDisposable? tenantFilterScope = currentTenant is { IsAvailable: false }
    ? dataFilter?.Disable<IMultiTenant>()
    : null;
```

So with a stale tenant claim active, `FindByEmailAsync` ran tenant-scoped and returned `null` for any user on a different side — a host admin (`TenantId == null`) logging in from a browser that previously authenticated a tenant user got 401 with perfectly valid credentials, and vice-versa. On `localhost` the port is not part of cookie scope (RFC 6265), so the Identity cookie is always sent cross-port in development.

`RequireUniqueEmail=true` is validated at startup (`RequireUniqueEmailValidator`), so cross-tenant lookup cannot return an ambiguous match — it's safe to always bypass the filter for credential resolution.

## Behaviour matrix

| Active tenant | User `TenantId` | Before | After |
|---------------|-----------------|--------|-------|
| none          | null            | OK (filter already disabled) | unchanged |
| none          | some tenant     | OK (filter disabled, Change applied) | unchanged |
| **stale tenant A** | **null (host admin)** | **user invisible → 401** | **user found, Change(null) clears stale tenant → 200** |
| **stale tenant A** | **tenant B**    | **user invisible → 401** | **user found, Change(B) realigns → 200** |
| matching tenant | same tenant    | OK (filter on, no change needed) | filter disabled + Change(same) — no behavioural diff |

## Test plan

- [x] `dotnet test tests/Granit.Identity.Local.Endpoints.Tests` — 70/70 (69 existing + `Login_WithStaleTenantContext_DisablesFilterAndRealignsTenantToUser`).
- [x] `dotnet format --verify-no-changes` on src + tests — clean.
- [ ] Manual: log in on tenant SPA, switch to host SPA, log in as host admin — no 401. And the reverse.

## Related

- #1180 (BFF origin check) — paired fix. Both layers needed to fully unblock cross-frontend login on shared origins.