### PR TITLE
fix(openiddict-endpoints): bypass multi-tenant filter on /connect/authorize user lookup

### DIFF
--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
 using System.Security.Claims;
+using Granit.DataFiltering;
+using Granit.Domain;
 using Granit.Identity.Local.Domain;
 using Granit.MultiTenancy;
 using Granit.OpenIddict.Diagnostics;
@@ -99,12 +101,28 @@ internal static partial class ConnectAuthorizationEndpoints
                 authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
         }
 
-        // Resolve the user.
+        // Resolve the user by primary key.
+        // Bypass the multi-tenant filter: the authenticated user ID is globally unique
+        // and the cookie signature already guarantees the principal's authenticity.
+        // Leaving the filter active makes the lookup depend on whatever tenant context
+        // has been resolved for this request (or leaked from prior state), which will
+        // hide the user whenever their TenantId does not match the active scope —
+        // host admins (TenantId = null) in particular become invisible on every
+        // request that has inherited a tenant context from another source.
         UserManager<GranitUser> userManager = context.RequestServices
             .GetRequiredService<UserManager<GranitUser>>();
-        GranitUser? user = await userManager
-            .GetUserAsync(authenticateResult.Principal)
-            .ConfigureAwait(false);
+        IDataFilter? dataFilter = context.RequestServices.GetService<IDataFilter>();
+
+        GranitUser? user;
+        IDisposable? filterScope = dataFilter?.Disable<IMultiTenant>();
+        try
+        {
+            user = await userManager.GetUserAsync(authenticateResult.Principal).ConfigureAwait(false);
+        }
+        finally
+        {
+            filterScope?.Dispose();
+        }
 
         if (user is null)
         {
@@ -112,6 +130,14 @@ internal static partial class ConnectAuthorizationEndpoints
             return Results.Forbid(
                 authenticationSchemes: [OpenIddictServerAspNetCoreDefaults.AuthenticationScheme]);
         }
+
+        // Align the tenant context with the resolved user for the rest of the flow
+        // (authorization record lookup, principal build, metrics). When the user is
+        // a host admin (TenantId = null) this clears any stale tenant leaked from
+        // a prior request; when the user is a tenant user this switches the scope
+        // to their own tenant regardless of what the resolver pipeline produced.
+        ICurrentTenant? requestTenant = context.RequestServices.GetService<ICurrentTenant>();
+        using IDisposable? tenantScope = requestTenant?.Change(user.TenantId);
 
         // Build the principal with requested scopes.
         ImmutableArray<string> scopes = request.GetScopes();
@@ -165,8 +191,7 @@ internal static partial class ConnectAuthorizationEndpoints
 
         LogAuthorizationGranted(logger, user.Id.ToString(), request.ClientId!);
 
-        ICurrentTenant? currentTenant = context.RequestServices.GetService<ICurrentTenant>();
-        string? tenantId = currentTenant is { IsAvailable: true } ? currentTenant.Id?.ToString() : null;
+        string? tenantId = requestTenant is { IsAvailable: true } ? requestTenant.Id?.ToString() : null;
         OpenIddictMetrics metrics = context.RequestServices.GetRequiredService<OpenIddictMetrics>();
         metrics.RecordAuthenticationSuccess(tenantId, "authorization_code");
 


### PR DESCRIPTION
## Summary

- Wrap `UserManager.GetUserAsync(principal)` in `IDataFilter.Disable<IMultiTenant>()` on `/connect/authorize` so the user lookup runs as a pure primary-key query, independent of `ICurrentTenant` state.
- Align `ICurrentTenant` with the resolved user's `TenantId` for the rest of the handler (authorization record lookup, principal build, metrics).
- Same pattern as #1182 (`/account/login`) — third layer of the same cross-frontend login bug chain.

## Why

Paired with #1180 (BFF origin check) and #1182 (login lookup). Those fixes unblock `POST /account/login`, but the next request — `GET /connect/authorize` — still returned `access_denied` in the reported reproduction.

Observed SQL on the failing request:

```sql
SELECT ... FROM host.openiddict_users AS o
WHERE NOT o."IsDeleted" AND o."TenantId" IS NULL AND o."Id" = @p
LIMIT 1
-- 0 rows
```

`admin@showcase.local` has `TenantId = NULL` in the DB (confirmed by direct SQL). The filter `TenantId IS NULL AND Id = @p` should match, yet the lookup returns 0 rows. The mismatch is a symptom of `ICurrentTenant._current` (static `AsyncLocal`) carrying a leaked tenant context across requests:

- The leak reproduces on fresh cookies and across **different browsers**, so it is a server-side singleton state issue, not a per-client one.
- `TenantResolutionMiddleware` should call `Change()` only when a resolver returns a tenant; when none match, the AsyncLocal should stay at whatever value it already held. That value is observed as a stale `Acme` on some requests even though no resolver ran.
- Pinpointing the exact leak source (a handler, an unawaited continuation, ExecutionContext capture inside OpenIddict's dispatcher) is out of scope for this fix.

What IS in scope: the user lookup by primary key has no legitimate reason to depend on the tenant filter. The authenticity of the principal is already guaranteed by the Identity cookie signature, and user IDs are globally unique. Disabling the filter around `GetUserAsync` removes the dependency entirely — regardless of what leaked, the authenticated user is always found.

After the lookup, `ICurrentTenant.Change(user.TenantId)` realigns the scope (null for host admins clears a leaked tenant; tenant users switch to their own tenant) so the subsequent authorization record operations and metrics run in the correct scope.

## Test plan

- [x] `dotnet test tests/Granit.OpenIddict.Endpoints.Tests` — 66/66 pass (existing).
- [x] `dotnet format --verify-no-changes` — clean.
- [ ] Manual reproduction: log in on Host as `admin@showcase.local` first, then in a second browser log in to Tenant. `/connect/authorize` should complete without `access_denied` on either side.

## Follow-up

A separate investigation is warranted to find the root-cause leak of `ICurrentTenant._current`. Likely candidates:

- `TenantResolutionMiddleware` — `using IDisposable _ = ...` interacting oddly with OpenIddict's async dispatcher.
- A Wolverine handler or hosted service that calls `Change(tenant)` and retains the captured ExecutionContext.
- `DataSeeder.SeedTenantContributorsAsync` finally-block dispose that doesn't flow back to the parent EC under some edge case.

That investigation would eliminate similar failures elsewhere. This PR fixes the immediate user-facing bug in a defensive, narrowly-scoped way.

## Related

- #1180 — BFF origin check.
- #1182 — `/account/login` tenant filter bypass.
- Together these unblock cross-frontend login on the Showcase (host admin / tenant user on both `/host` and `/app` BFFs).