### PR TITLE
fix: anchor PII test ClassDeclaration regex to avoid false matches in comments

### DIFF
--- a/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs
+++ b/src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs
@@ -132,7 +132,7 @@ internal static partial class ConnectAuthorizationEndpoints
         }
 
         // Align the tenant context with the resolved user for the rest of the flow
-        // (authorization record lookup, principal build, metrics). When the user is
+        // (authorization-record lookup, principal build, metrics). When the user is
         // a host admin (TenantId = null) this clears any stale tenant leaked from
         // a prior request; when the user is a tenant user this switches the scope
         // to their own tenant regardless of what the resolver pipeline produced.

--- a/tests/Granit.ArchitectureTests/LoggerMessagePiiConventionTests.cs
+++ b/tests/Granit.ArchitectureTests/LoggerMessagePiiConventionTests.cs
@@ -206,7 +206,15 @@ public sealed partial class LoggerMessagePiiConventionTests
     /// <summary>
     /// Matches class/record/struct declarations. Group 1: type name.
     /// </summary>
-    [GeneratedRegex(@"(?:class|record|struct)\s+(\w+)", RegexOptions.None)]
+    /// <remarks>
+    /// Anchored to start-of-line and accepts only word-character modifier tokens before
+    /// the keyword, so the keywords are not matched inside comments — comment lines
+    /// start with <c>//</c> or contain <c>*</c>, neither of which is a <c>\w</c>
+    /// character followed by whitespace. Without this guard, a comment like
+    /// <c>// (authorization record lookup, ...)</c> would set <c>currentClass</c> to
+    /// <c>"lookup"</c> and break the per-class exemption matching downstream.
+    /// </remarks>
+    [GeneratedRegex(@"^\s*(?:\w+\s+)*?(?:class|record|struct)\s+(\w+)", RegexOptions.None)]
     private static partial Regex ClassDeclaration();
 
     /// <summary>


### PR DESCRIPTION
## Context

PR #1185 (merged earlier today) introduced a comment containing `record lookup` inside `ConnectAuthorizationEndpoints.cs`. The architecture test [`LoggerMessagePiiConventionTests`](tests/Granit.ArchitectureTests/LoggerMessagePiiConventionTests.cs) tracks the current class via the regex `(?:class\|record\|struct)\s+(\w+)` line by line. Without a start-of-line anchor, the regex matched `record lookup` inside the comment and set `currentClass = "lookup"` — causing the per-class exemption `ConnectAuthorizationEndpoints.Subject` (line 50 of the test) to be silently bypassed and the legitimate `LogAuthorizationGranted({Subject}, …)` log to be flagged as a PII violation.

CI on PR #1184 (Catalog Phase 1) failed on the `architecture` shard with:

> `["src/Granit.OpenIddict.Endpoints/Endpoints/ConnectAuthorizationEndpoints.cs:216 lookup.Subject in \"Authorization granted for subject '{Subject}' to client '{ClientId}'\""]`

## Fix

**Primary** (the actual fix): anchor the `ClassDeclaration` regex to start-of-line and only allow `\w+\s+` modifier tokens before the keyword. Comment lines start with `//` or contain `*` — neither is a `\w` character — so comments can no longer poison `currentClass`.

```diff
-[GeneratedRegex(@"(?:class|record|struct)\s+(\w+)", RegexOptions.None)]
+[GeneratedRegex(@"^\s*(?:\w+\s+)*?(?:class|record|struct)\s+(\w+)", RegexOptions.None)]
```

**Defensive** (belt-and-suspenders): rephrase the offending comment from `authorization record lookup` to `authorization-record lookup` so the same shape of regression is harder to reintroduce by accident. The regex fix alone is sufficient — verified by stash-revert of the comment change.

## Test plan

- [x] `dotnet test tests/Granit.ArchitectureTests --filter "LoggerMessagePiiConvention"` — passes
- [ ] CI architecture shard — green (post-merge will also unblock all open PRs that hit this regression)