### PR TITLE
feat(metering)!: replace MeterDefinition.Activated with WorkflowLifecycleStatus

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -1173,7 +1173,8 @@
         "Granit.DataExchange.Abstractions",
         "Granit.Metering.Abstractions",
         "Granit.QueryEngine.Abstractions",
-        "Granit.Timing"
+        "Granit.Timing",
+        "Granit.Workflow"
       ],
       "framework": "net10.0"
     },
@@ -24301,7 +24302,7 @@
       "kind": "class",
       "project": "Granit.Metering",
       "file": "src/Granit.Metering/Domain/MeterDefinition.cs",
-      "line": 15,
+      "line": 24,
       "members": [
         {
           "name": "Create",
@@ -24316,10 +24317,16 @@
           "returnType": "string"
         },
         {
+          "name": "Description",
+          "kind": "property",
+          "signature": "string? Description",
+          "returnType": "string?"
+        },
+        {
           "name": "SetProduct",
           "kind": "method",
           "signature": "SetProduct(Guid? productId)",
-          "returnType": "string? Description { get; private set; } public AggregationType AggregationType { get; private set; } public bool Activated { get; private set; } public Guid? ProductId { get; private set; } public void"
+          "returnType": "Guid? ProductId { get; private set; } public void"
         },
         {
           "name": "TenantId",
@@ -24328,15 +24335,15 @@
           "returnType": "Guid?"
         },
         {
+          "name": "GetWorkflowEntityId",
+          "kind": "method",
+          "signature": "GetWorkflowEntityId()",
+          "returnType": "string"
+        },
+        {
           "name": "Update",
           "kind": "method",
           "signature": "Update(string name, string unit, string? description)",
-          "returnType": "void"
-        },
-        {
-          "name": "Activate",
-          "kind": "method",
-          "signature": "Activate()",
           "returnType": "void"
         }
       ]
@@ -24438,7 +24445,7 @@
       "kind": "record",
       "project": "Granit.Metering.Endpoints",
       "file": "src/Granit.Metering.Endpoints/Dtos/MeterDefinitionResponse.cs",
-      "line": 17,
+      "line": 27,
       "members": []
     },
     {
@@ -24698,7 +24705,7 @@
       "kind": "class",
       "project": "Granit.Metering",
       "file": "src/Granit.Metering/GranitMeteringModule.cs",
-      "line": 16,
+      "line": 19,
       "members": [
         {
           "name": "ConfigureServices",

--- a/src/Granit.Metering.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Metering.BackgroundJobs/packages.lock.json
@@ -92,6 +92,7 @@
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
@@ -114,6 +115,15 @@
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },
       "Cronos": {

--- a/src/Granit.Metering.Endpoints/Dtos/MeterDefinitionResponse.cs
+++ b/src/Granit.Metering.Endpoints/Dtos/MeterDefinitionResponse.cs
@@ -1,4 +1,5 @@
 using Granit.Metering.Domain;
+using Granit.Workflow.Domain;
 
 namespace Granit.Metering.Endpoints.Dtos;
 
@@ -10,9 +11,18 @@ namespace Granit.Metering.Endpoints.Dtos;
 /// <param name="Unit">Unit of measure.</param>
 /// <param name="Description">Optional description.</param>
 /// <param name="AggregationType">How events are aggregated into rollups.</param>
-/// <param name="Activated">Whether this meter accepts new events.</param>
+/// <param name="Activated">
+/// [DEPRECATED] Computed compatibility alias — <c>true</c> when
+/// <paramref name="LifecycleStatus"/> is <see cref="WorkflowLifecycleStatus.Published"/>.
+/// Will be removed in the next major release; new clients should use
+/// <paramref name="LifecycleStatus"/> directly.
+/// </param>
 /// <param name="ProductId">
 /// Optional reference to a <c>Granit.Catalog.Product</c> identifier (soft, no SQL FK).
+/// </param>
+/// <param name="LifecycleStatus">
+/// Current lifecycle status of the meter (Draft / Published / Archived). Only
+/// <see cref="WorkflowLifecycleStatus.Published"/> meters accept ingestion.
 /// </param>
 public sealed record MeterDefinitionResponse(
     Guid Id,
@@ -21,14 +31,21 @@ public sealed record MeterDefinitionResponse(
     string? Description,
     AggregationType AggregationType,
     bool Activated,
-    Guid? ProductId)
+    Guid? ProductId,
+    WorkflowLifecycleStatus LifecycleStatus)
 {
-    internal static MeterDefinitionResponse FromEntity(MeterDefinition definition) => new(
-        definition.Id,
-        definition.Name,
-        definition.Unit,
-        definition.Description,
-        definition.AggregationType,
-        definition.Activated,
-        definition.ProductId);
+    internal static MeterDefinitionResponse FromEntity(MeterDefinition definition)
+    {
+#pragma warning disable CS0618 // Activated is intentionally surfaced for one-release compat.
+        return new MeterDefinitionResponse(
+            definition.Id,
+            definition.Name,
+            definition.Unit,
+            definition.Description,
+            definition.AggregationType,
+            definition.Activated,
+            definition.ProductId,
+            definition.LifecycleStatus);
+#pragma warning restore CS0618
+    }
 }

--- a/src/Granit.Metering.Endpoints/Endpoints/MeterDefinitionEndpoints.cs
+++ b/src/Granit.Metering.Endpoints/Endpoints/MeterDefinitionEndpoints.cs
@@ -17,13 +17,13 @@ internal static class MeterDefinitionEndpoints
 {
     internal static RouteGroupBuilder MapMeterDefinitionEndpoints(this RouteGroupBuilder group)
     {
-        group.MapGet("/meters", ListActiveMetersAsync)
-            .WithName("ListActiveMeters")
-            .WithSummary("Returns all active meter definitions for the current tenant.")
+        group.MapGet("/meters", ListPublishedMetersAsync)
+            .WithName("ListPublishedMeters")
+            .WithSummary("Returns all published meter definitions for the current tenant.")
             .WithDescription(
-                "Fetches the list of meter definitions that are currently active and accepting events. "
-                + "Inactive meters are excluded from the results. "
-                + "Use the GET by ID endpoint to retrieve a specific meter regardless of status.")
+                "Fetches the list of meter definitions currently in the Published lifecycle state — "
+                + "the only state that accepts ingestion. Draft and Archived meters are excluded; "
+                + "use the GET by ID endpoint to retrieve a specific meter regardless of status.")
             .Produces<IReadOnlyList<MeterDefinitionResponse>>()
             .RequireAuthorization(MeteringPermissions.Meters.Read)
             .AllowHostAccess();
@@ -33,7 +33,7 @@ internal static class MeterDefinitionEndpoints
             .WithSummary("Returns a meter definition by its unique identifier.")
             .WithDescription(
                 "Fetches the full metadata of a meter definition including its aggregation type, unit, "
-                + "and active status. Returns 404 if the meter does not exist.")
+                + "and lifecycle status. Returns 404 if the meter does not exist.")
             .Produces<MeterDefinitionResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
             .RequireAuthorization(MeteringPermissions.Meters.Read)
@@ -44,7 +44,7 @@ internal static class MeterDefinitionEndpoints
             .WithSummary("Creates a new meter definition.")
             .WithDescription(
                 "Creates a meter definition with the specified name, unit, and aggregation type. "
-                + "The meter is created in an active state and immediately accepts events. "
+                + "The meter starts in Draft status; it must be Published before it accepts events. "
                 + "Names must be unique within the tenant scope.")
             .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces<MeterDefinitionResponse>(StatusCodes.Status201Created)
@@ -53,33 +53,61 @@ internal static class MeterDefinitionEndpoints
 
         group.MapPut("/meters/{id:guid}", UpdateMeterAsync)
             .WithName("UpdateMeterDefinition")
-            .WithSummary("Updates a meter definition.")
+            .WithSummary("Updates a Draft meter definition.")
             .WithDescription(
-                "Updates the name, unit, and description of an existing meter definition. "
+                "Updates the name, unit, and description of a meter definition in Draft status. "
                 + "The aggregation type cannot be changed after creation to preserve data consistency. "
-                + "Returns 404 if the meter does not exist.")
+                + "Returns 404 if the meter does not exist, or 409 if the meter is not in Draft status.")
             .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces<MeterDefinitionResponse>()
             .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict)
             .ProducesValidationProblem()
+            .RequireAuthorization(MeteringPermissions.Meters.Manage);
+
+        group.MapPost("/meters/{id:guid}/publish", PublishMeterAsync)
+            .WithName("PublishMeterDefinition")
+            .WithSummary("Publishes a Draft meter definition.")
+            .WithDescription(
+                "Transitions a Draft meter to Published status. Only Published meters accept ingestion. "
+                + "Returns 404 if the meter does not exist, or 409 if the meter is not in Draft status.")
+            .WithMetadata(new IdempotentAttribute { Required = false })
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict)
+            .RequireAuthorization(MeteringPermissions.Meters.Manage);
+
+        group.MapPost("/meters/{id:guid}/archive", ArchiveMeterAsync)
+            .WithName("ArchiveMeterDefinition")
+            .WithSummary("Archives a Published meter definition.")
+            .WithDescription(
+                "Transitions a Published meter to Archived status. Existing aggregates and history are preserved; "
+                + "ingestion of new events is rejected. "
+                + "Returns 404 if the meter does not exist, or 409 if the meter is not in Published status.")
+            .WithMetadata(new IdempotentAttribute { Required = false })
+            .Produces(StatusCodes.Status204NoContent)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict)
             .RequireAuthorization(MeteringPermissions.Meters.Manage);
 
         group.MapPost("/meters/{id:guid}/deactivate", DeactivateMeterAsync)
             .WithName("DeactivateMeterDefinition")
-            .WithSummary("Deactivates a meter definition.")
+            .WithSummary("[DEPRECATED] Alias for /meters/{id}/archive — will be removed in next major release.")
             .WithDescription(
-                "Marks the meter as inactive so it no longer accepts new events. "
-                + "Existing usage data and aggregates are preserved. "
-                + "Returns 404 if the meter does not exist.")
+                "Deprecated alias for the Archive endpoint, kept for one release to ease migration. "
+                + "Same semantics: transitions a Published meter to Archived. The response carries "
+                + "the standard `Deprecation: true` and `Sunset` headers (RFC 8594). New callers MUST "
+                + "use `POST /meters/{id}/archive` instead.")
             .WithMetadata(new IdempotentAttribute { Required = false })
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict)
             .RequireAuthorization(MeteringPermissions.Meters.Manage);
 
         return group;
     }
 
-    private static async Task<Ok<IReadOnlyList<MeterDefinitionResponse>>> ListActiveMetersAsync(
+    private static async Task<Ok<IReadOnlyList<MeterDefinitionResponse>>> ListPublishedMetersAsync(
         [FromServices] IMeterDefinitionReader reader,
         CancellationToken cancellationToken)
     {
@@ -139,13 +167,21 @@ internal static class MeterDefinitionEndpoints
             return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
-        definition.Update(request.Name, request.Unit, request.Description);
+        try
+        {
+            definition.Update(request.Name, request.Unit, request.Description);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return TypedResults.Problem(detail: ex.Message, statusCode: StatusCodes.Status409Conflict);
+        }
+
         await writer.UpdateAsync(definition, cancellationToken).ConfigureAwait(false);
 
         return TypedResults.Ok(MeterDefinitionResponse.FromEntity(definition));
     }
 
-    private static async Task<Results<NoContent, ProblemHttpResult>> DeactivateMeterAsync(
+    private static async Task<Results<NoContent, ProblemHttpResult>> PublishMeterAsync(
         Guid id,
         [FromServices] IMeterDefinitionReader reader,
         [FromServices] IMeterDefinitionWriter writer,
@@ -159,9 +195,58 @@ internal static class MeterDefinitionEndpoints
             return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
         }
 
-        definition.Deactivate();
-        await writer.UpdateAsync(definition, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            definition.Publish();
+        }
+        catch (InvalidOperationException ex)
+        {
+            return TypedResults.Problem(detail: ex.Message, statusCode: StatusCodes.Status409Conflict);
+        }
 
+        await writer.UpdateAsync(definition, cancellationToken).ConfigureAwait(false);
         return TypedResults.NoContent();
+    }
+
+    private static async Task<Results<NoContent, ProblemHttpResult>> ArchiveMeterAsync(
+        Guid id,
+        [FromServices] IMeterDefinitionReader reader,
+        [FromServices] IMeterDefinitionWriter writer,
+        CancellationToken cancellationToken)
+    {
+        MeterDefinition? definition = await reader
+            .GetByIdAsync(MeterDefinitionId.Create(id), cancellationToken).ConfigureAwait(false);
+
+        if (definition is null)
+        {
+            return TypedResults.Problem(statusCode: StatusCodes.Status404NotFound);
+        }
+
+        try
+        {
+            definition.Archive();
+        }
+        catch (InvalidOperationException ex)
+        {
+            return TypedResults.Problem(detail: ex.Message, statusCode: StatusCodes.Status409Conflict);
+        }
+
+        await writer.UpdateAsync(definition, cancellationToken).ConfigureAwait(false);
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<Results<NoContent, ProblemHttpResult>> DeactivateMeterAsync(
+        Guid id,
+        HttpContext httpContext,
+        [FromServices] IMeterDefinitionReader reader,
+        [FromServices] IMeterDefinitionWriter writer,
+        CancellationToken cancellationToken)
+    {
+        // RFC 8594 deprecation signal — kept for one release as alias for /archive.
+        httpContext.Response.Headers["Deprecation"] = "true";
+        httpContext.Response.Headers["Sunset"] = "Wed, 31 Dec 2026 23:59:59 GMT";
+        httpContext.Response.Headers["Link"] = "</metering/meters/{id}/archive>; rel=\"successor-version\"";
+
+        return await ArchiveMeterAsync(id, reader, writer, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Granit.Metering.Endpoints/Endpoints/UsageEndpoints.cs
+++ b/src/Granit.Metering.Endpoints/Endpoints/UsageEndpoints.cs
@@ -6,6 +6,7 @@ using Granit.Metering.Dtos;
 using Granit.Metering.Endpoints.Dtos;
 using Granit.Metering.Endpoints.Permissions;
 using Granit.MultiTenancy;
+using Granit.Workflow.Domain;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -138,11 +139,12 @@ internal static class UsageEndpoints
                     statusCode: StatusCodes.Status404NotFound);
             }
 
-            if (!def.Activated)
+            if (def.LifecycleStatus != WorkflowLifecycleStatus.Published)
             {
                 return TypedResults.Problem(
-                    detail: $"Meter definition '{mid}' is deactivated.",
-                    statusCode: StatusCodes.Status409Conflict);
+                    detail: $"Meter definition '{mid}' is in '{def.LifecycleStatus}' status. "
+                        + "Only Published meters accept ingestion.",
+                    statusCode: StatusCodes.Status422UnprocessableEntity);
             }
         }
 

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/cs.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/cs.json
@@ -3,7 +3,7 @@
   "texts": {
     "PermissionGroup:Metering": "Měření",
     "Permission:Metering.Meters.Read": "Zobrazit definice měřičů",
-    "Permission:Metering.Meters.Manage": "Spravovat definice měřičů (vytvořit, aktualizovat, deaktivovat)",
+    "Permission:Metering.Meters.Manage": "Spravovat definice měřičů (vytvořit, aktualizovat, publikovat, archivovat)",
     "Permission:Metering.Usage.Read": "Zobrazit data o využití a stav kvót",
     "Permission:Metering.Usage.Record": "Zaznamenat události využití"
   }

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/de.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/de.json
@@ -3,7 +3,7 @@
   "texts": {
     "PermissionGroup:Metering": "Messtechnik",
     "Permission:Metering.Meters.Read": "Zählerdefinitionen anzeigen",
-    "Permission:Metering.Meters.Manage": "Zählerdefinitionen verwalten (erstellen, aktualisieren, deaktivieren)",
+    "Permission:Metering.Meters.Manage": "Zählerdefinitionen verwalten (erstellen, aktualisieren, veröffentlichen, archivieren)",
     "Permission:Metering.Usage.Read": "Nutzungsdaten und Kontingentstatus anzeigen",
     "Permission:Metering.Usage.Record": "Nutzungsereignisse erfassen"
   }

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/en.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/en.json
@@ -3,7 +3,7 @@
   "texts": {
     "PermissionGroup:Metering": "Metering",
     "Permission:Metering.Meters.Read": "View meter definitions",
-    "Permission:Metering.Meters.Manage": "Manage meter definitions (create, update, deactivate)",
+    "Permission:Metering.Meters.Manage": "Manage meter definitions (create, update, publish, archive)",
     "Permission:Metering.Usage.Read": "View usage data and quota status",
     "Permission:Metering.Usage.Record": "Record usage events"
   }

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/es.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/es.json
@@ -3,7 +3,7 @@
   "texts": {
     "PermissionGroup:Metering": "Metrología",
     "Permission:Metering.Meters.Read": "Ver definiciones de medidores",
-    "Permission:Metering.Meters.Manage": "Gestionar definiciones de medidores (crear, actualizar, desactivar)",
+    "Permission:Metering.Meters.Manage": "Gestionar definiciones de medidores (crear, actualizar, publicar, archivar)",
     "Permission:Metering.Usage.Read": "Ver datos de uso y estado de cuotas",
     "Permission:Metering.Usage.Record": "Registrar eventos de uso"
   }

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/fr.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/fr.json
@@ -3,7 +3,7 @@
   "texts": {
     "PermissionGroup:Metering": "Métrologie",
     "Permission:Metering.Meters.Read": "Consulter les définitions de compteurs",
-    "Permission:Metering.Meters.Manage": "Gérer les définitions de compteurs (créer, modifier, désactiver)",
+    "Permission:Metering.Meters.Manage": "Gérer les définitions de compteurs (créer, modifier, publier, archiver)",
     "Permission:Metering.Usage.Read": "Consulter les données d'utilisation et l'état des quotas",
     "Permission:Metering.Usage.Record": "Enregistrer des événements d'utilisation"
   }

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/hi.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/hi.json
@@ -3,7 +3,7 @@
   "texts": {
     "PermissionGroup:Metering": "मीटरिंग",
     "Permission:Metering.Meters.Read": "मीटर परिभाषाएँ देखें",
-    "Permission:Metering.Meters.Manage": "मीटर परिभाषाएँ प्रबंधित करें (बनाएँ, अपडेट करें, निष्क्रिय करें)",
+    "Permission:Metering.Meters.Manage": "मीटर परिभाषाएँ प्रबंधित करें (बनाएँ, अपडेट करें, प्रकाशित करें, संग्रहीत करें)",
     "Permission:Metering.Usage.Read": "उपयोग डेटा और कोटा स्थिति देखें",
     "Permission:Metering.Usage.Record": "उपयोग इवेंट रिकॉर्ड करें"
   }

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/it.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/it.json
@@ -3,7 +3,7 @@
   "texts": {
     "PermissionGroup:Metering": "Metrologia",
     "Permission:Metering.Meters.Read": "Visualizzare le definizioni dei contatori",
-    "Permission:Metering.Meters.Manage": "Gestire le definizioni dei contatori (creare, aggiornare, disattivare)",
+    "Permission:Metering.Meters.Manage": "Gestire le definizioni dei contatori (creare, aggiornare, pubblicare, archiviare)",
     "Permission:Metering.Usage.Read": "Visualizzare i dati di utilizzo e lo stato delle quote",
     "Permission:Metering.Usage.Record": "Registrare eventi di utilizzo"
   }

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/ja.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/ja.json
@@ -3,7 +3,7 @@
   "texts": {
     "PermissionGroup:Metering": "メータリング",
     "Permission:Metering.Meters.Read": "メーター定義を表示",
-    "Permission:Metering.Meters.Manage": "メーター定義を管理（作成、更新、無効化）",
+    "Permission:Metering.Meters.Manage": "メーター定義を管理（作成、更新、公開、アーカイブ）",
     "Permission:Metering.Usage.Read": "使用状況データとクォータステータスを表示",
     "Permission:Metering.Usage.Record": "使用イベントを記録"
   }

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/ko.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/ko.json
@@ -3,7 +3,7 @@
   "texts": {
     "PermissionGroup:Metering": "미터링",
     "Permission:Metering.Meters.Read": "미터 정의 조회",
-    "Permission:Metering.Meters.Manage": "미터 정의 관리 (생성, 수정, 비활성화)",
+    "Permission:Metering.Meters.Manage": "미터 정의 관리 (생성, 수정, 게시, 보관)",
     "Permission:Metering.Usage.Read": "사용량 데이터 및 할당량 상태 조회",
     "Permission:Metering.Usage.Record": "사용 이벤트 기록"
   }

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/nl.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/nl.json
@@ -3,7 +3,7 @@
   "texts": {
     "PermissionGroup:Metering": "Metrologie",
     "Permission:Metering.Meters.Read": "Meterdefinities bekijken",
-    "Permission:Metering.Meters.Manage": "Meterdefinities beheren (aanmaken, bijwerken, deactiveren)",
+    "Permission:Metering.Meters.Manage": "Meterdefinities beheren (aanmaken, bijwerken, publiceren, archiveren)",
     "Permission:Metering.Usage.Read": "Gebruiksgegevens en quotumstatus bekijken",
     "Permission:Metering.Usage.Record": "Gebruiksgebeurtenissen registreren"
   }

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/pl.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/pl.json
@@ -3,7 +3,7 @@
   "texts": {
     "PermissionGroup:Metering": "Pomiary",
     "Permission:Metering.Meters.Read": "Wyświetlanie definicji mierników",
-    "Permission:Metering.Meters.Manage": "Zarządzanie definicjami mierników (tworzenie, aktualizacja, dezaktywacja)",
+    "Permission:Metering.Meters.Manage": "Zarządzanie definicjami mierników (tworzenie, aktualizacja, publikacja, archiwizacja)",
     "Permission:Metering.Usage.Read": "Wyświetlanie danych o użyciu i stanu limitów",
     "Permission:Metering.Usage.Record": "Rejestrowanie zdarzeń użycia"
   }

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/pt-BR.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/pt-BR.json
@@ -3,7 +3,7 @@
   "texts": {
     "PermissionGroup:Metering": "Medição",
     "Permission:Metering.Meters.Read": "Visualizar definições de medidores",
-    "Permission:Metering.Meters.Manage": "Gerenciar definições de medidores (criar, atualizar, desativar)",
+    "Permission:Metering.Meters.Manage": "Gerenciar definições de medidores (criar, atualizar, publicar, arquivar)",
     "Permission:Metering.Usage.Read": "Visualizar dados de uso e status de cotas",
     "Permission:Metering.Usage.Record": "Registrar eventos de uso"
   }

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/pt.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/pt.json
@@ -3,7 +3,7 @@
   "texts": {
     "PermissionGroup:Metering": "Metrologia",
     "Permission:Metering.Meters.Read": "Ver definições de medidores",
-    "Permission:Metering.Meters.Manage": "Gerir definições de medidores (criar, atualizar, desativar)",
+    "Permission:Metering.Meters.Manage": "Gerir definições de medidores (criar, atualizar, publicar, arquivar)",
     "Permission:Metering.Usage.Read": "Ver dados de utilização e estado das quotas",
     "Permission:Metering.Usage.Record": "Registar eventos de utilização"
   }

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/sv.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/sv.json
@@ -3,7 +3,7 @@
   "texts": {
     "PermissionGroup:Metering": "Mätning",
     "Permission:Metering.Meters.Read": "Visa mätardefinitioner",
-    "Permission:Metering.Meters.Manage": "Hantera mätardefinitioner (skapa, uppdatera, inaktivera)",
+    "Permission:Metering.Meters.Manage": "Hantera mätardefinitioner (skapa, uppdatera, publicera, arkivera)",
     "Permission:Metering.Usage.Read": "Visa användningsdata och kvotstatus",
     "Permission:Metering.Usage.Record": "Registrera användningshändelser"
   }

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/tr.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/tr.json
@@ -3,7 +3,7 @@
   "texts": {
     "PermissionGroup:Metering": "Ölçümleme",
     "Permission:Metering.Meters.Read": "Sayaç tanımlarını görüntüle",
-    "Permission:Metering.Meters.Manage": "Sayaç tanımlarını yönet (oluştur, güncelle, devre dışı bırak)",
+    "Permission:Metering.Meters.Manage": "Sayaç tanımlarını yönet (oluştur, güncelle, yayınla, arşivle)",
     "Permission:Metering.Usage.Read": "Kullanım verilerini ve kota durumunu görüntüle",
     "Permission:Metering.Usage.Record": "Kullanım olaylarını kaydet"
   }

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/zh.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/zh.json
@@ -3,7 +3,7 @@
   "texts": {
     "PermissionGroup:Metering": "计量",
     "Permission:Metering.Meters.Read": "查看计量器定义",
-    "Permission:Metering.Meters.Manage": "管理计量器定义（创建、更新、停用）",
+    "Permission:Metering.Meters.Manage": "管理计量器定义（创建、更新、发布、归档）",
     "Permission:Metering.Usage.Read": "查看使用数据和配额状态",
     "Permission:Metering.Usage.Record": "记录使用事件"
   }

--- a/src/Granit.Metering.Endpoints/packages.lock.json
+++ b/src/Granit.Metering.Endpoints/packages.lock.json
@@ -113,7 +113,8 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )"
         }
       },
       "granit.metering.abstractions": {
@@ -162,6 +163,14 @@
           "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Microsoft.AspNetCore.OpenApi": "[10.*, )"
+        }
+      },
+      "granit.workflow": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )"
         }
       },
       "Asp.Versioning.Mvc": {

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/EfMeterDefinitionReader.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/EfMeterDefinitionReader.cs
@@ -3,6 +3,7 @@ using Granit.Metering.Domain.ValueObjects;
 using Granit.MultiTenancy;
 using Granit.Persistence;
 using Granit.Persistence.EntityFrameworkCore;
+using Granit.Workflow.Domain;
 using Microsoft.EntityFrameworkCore;
 
 namespace Granit.Metering.EntityFrameworkCore.Internal;
@@ -22,6 +23,7 @@ internal sealed class EfMeterDefinitionReader(
             .ConfigureAwait(false), cancellationToken);
 
     public Task<IReadOnlyList<MeterDefinition>> GetActiveAsync(CancellationToken cancellationToken = default) =>
-        // IActive query filter handles the Activated = true predicate.
-        ListAsync(Spec.For<MeterDefinition>(), cancellationToken);
+        ListAsync(
+            Spec.For<MeterDefinition>().Where(m => m.LifecycleStatus == WorkflowLifecycleStatus.Published),
+            cancellationToken);
 }

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/MeterDefinitionConfiguration.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/MeterDefinitionConfiguration.cs
@@ -18,7 +18,9 @@ internal sealed class MeterDefinitionConfiguration : IEntityTypeConfiguration<Me
         builder.Property(e => e.Unit).HasMaxLength(50).IsRequired();
         builder.Property(e => e.Description).HasMaxLength(2000);
         builder.Property(e => e.AggregationType).IsRequired();
-        builder.Property(e => e.Activated).IsRequired().HasDefaultValue(true);
+        builder.Property(e => e.LifecycleStatus).IsRequired();
+        builder.HasIndex(e => e.LifecycleStatus)
+            .HasDatabaseName($"ix_{GranitMeteringDbProperties.DbTablePrefix}meter_definitions_lifecycle");
 
         // Soft reference to Granit.Catalog.Product — no SQL FK across modules.
         // Indexed for reverse lookups (find all meters for a given product).

--- a/src/Granit.Metering.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Metering.EntityFrameworkCore/packages.lock.json
@@ -194,6 +194,7 @@
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
@@ -237,6 +238,15 @@
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },
       "Microsoft.EntityFrameworkCore": {

--- a/src/Granit.Metering/Domain/MeterDefinition.cs
+++ b/src/Granit.Metering/Domain/MeterDefinition.cs
@@ -1,6 +1,8 @@
+using System.ComponentModel.DataAnnotations.Schema;
 using Granit.Domain;
 using Granit.Metering.Domain.ValueObjects;
 using Granit.MultiTenancy;
+using Granit.Workflow.Domain;
 
 namespace Granit.Metering.Domain;
 
@@ -8,16 +10,23 @@ namespace Granit.Metering.Domain;
 /// Defines a usage meter (e.g., API calls, storage GB, messages sent).
 /// </summary>
 /// <remarks>
-/// Each meter has a name, unit of measure, and aggregation strategy.
+/// <para>
+/// Meters follow a lifecycle managed by <see cref="WorkflowLifecycleStatus"/>:
+/// <c>Draft → Published → Archived</c>. Only <see cref="WorkflowLifecycleStatus.Published"/>
+/// meters accept ingestion. <c>Draft</c> lets admins author and review without polluting
+/// production aggregates; <c>Archived</c> preserves history but rejects new events.
+/// </para>
+/// <para>
 /// Meter events are recorded against a definition and aggregated into
 /// <see cref="UsageAggregate"/> rollups by background jobs.
+/// </para>
 /// </remarks>
-public sealed class MeterDefinition : AuditedAggregateRoot, IActive, IMultiTenant
+public sealed class MeterDefinition : AuditedAggregateRoot, IMultiTenant, IWorkflowStateful
 {
     private MeterDefinition() { }
 
     /// <summary>
-    /// Creates a new meter definition.
+    /// Creates a new meter definition in <see cref="WorkflowLifecycleStatus.Draft"/> status.
     /// <paramref name="productId"/> is an optional soft reference (no SQL FK across
     /// modules) to a <c>Granit.Catalog.Product</c> — the catalog item this meter
     /// measures. The application layer is responsible for catalog deletion safety.
@@ -40,7 +49,7 @@ public sealed class MeterDefinition : AuditedAggregateRoot, IActive, IMultiTenan
             Unit = unit,
             AggregationType = aggregationType,
             Description = description,
-            Activated = true,
+            LifecycleStatus = WorkflowLifecycleStatus.Draft,
             ProductId = productId,
         };
     }
@@ -57,8 +66,22 @@ public sealed class MeterDefinition : AuditedAggregateRoot, IActive, IMultiTenan
     /// <summary>How events are aggregated into rollups.</summary>
     public AggregationType AggregationType { get; private set; }
 
-    /// <summary>Whether this meter accepts new events.</summary>
-    public bool Activated { get; private set; }
+    /// <summary>Current lifecycle status (Draft, Published, Archived).</summary>
+    public WorkflowLifecycleStatus LifecycleStatus { get; private set; }
+
+    /// <summary>
+    /// Computed compatibility alias for <see cref="LifecycleStatus"/> — <c>true</c> only when
+    /// <see cref="WorkflowLifecycleStatus.Published"/>.
+    /// </summary>
+    /// <remarks>
+    /// Kept for one release to ease migration of read-side consumers; new code should
+    /// reason about <see cref="LifecycleStatus"/> directly. Not mapped to a column —
+    /// the underlying <c>Activated</c> column is dropped by the
+    /// <c>MeterDefinition_StatusFromActivated</c> migration in consuming apps.
+    /// </remarks>
+    [NotMapped]
+    [Obsolete("Use LifecycleStatus instead. Removed in next major release.")]
+    public bool Activated => LifecycleStatus == WorkflowLifecycleStatus.Published;
 
     /// <summary>
     /// Optional reference to a <c>Granit.Catalog.Product</c> identifier — the
@@ -81,9 +104,21 @@ public sealed class MeterDefinition : AuditedAggregateRoot, IActive, IMultiTenan
     /// <summary>Explicit interface for interceptor injection.</summary>
     Guid? IMultiTenant.TenantId { get => TenantId; set => TenantId = value; }
 
-    /// <summary>Updates the meter definition metadata.</summary>
+    // ── IWorkflowStateful ──────────────────────────────────────────────
+
+    static string IWorkflowStateful.StatusPropertyName => nameof(LifecycleStatus);
+
+    static string IWorkflowStateful.WorkflowEntityType => "MeterDefinition";
+
+    /// <inheritdoc />
+    public string GetWorkflowEntityId() => Id.ToString();
+
+    // ── Behavior methods ───────────────────────────────────────────────
+
+    /// <summary>Updates the meter definition metadata. Only allowed in Draft status.</summary>
     public void Update(string name, string unit, string? description)
     {
+        EnsureDraft();
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         ArgumentException.ThrowIfNullOrWhiteSpace(unit);
 
@@ -92,9 +127,43 @@ public sealed class MeterDefinition : AuditedAggregateRoot, IActive, IMultiTenan
         Description = description;
     }
 
-    /// <summary>Deactivates the meter. No new events will be accepted.</summary>
-    public void Deactivate() => Activated = false;
+    /// <summary>Publishes the meter, allowing it to accept ingestion events.</summary>
+    public void Publish()
+    {
+        if (LifecycleStatus != WorkflowLifecycleStatus.Draft)
+        {
+            throw new InvalidOperationException(
+                $"Meter '{Id}' is in '{LifecycleStatus}' status. Only Draft meters can be published.");
+        }
 
-    /// <summary>Reactivates the meter.</summary>
-    public void Activate() => Activated = true;
+        LifecycleStatus = WorkflowLifecycleStatus.Published;
+    }
+
+    /// <summary>Archives the meter. Existing aggregates are preserved; new events are rejected.</summary>
+    public void Archive()
+    {
+        if (LifecycleStatus != WorkflowLifecycleStatus.Published)
+        {
+            throw new InvalidOperationException(
+                $"Meter '{Id}' is in '{LifecycleStatus}' status. Only Published meters can be archived.");
+        }
+
+        LifecycleStatus = WorkflowLifecycleStatus.Archived;
+    }
+
+    /// <summary>
+    /// Backward-compatible alias for <see cref="Archive"/>. Existing callers of
+    /// <c>POST /metering/meters/{id}/deactivate</c> still funnel through here.
+    /// </summary>
+    [Obsolete("Use Archive() instead. Removed in next major release.")]
+    public void Deactivate() => Archive();
+
+    private void EnsureDraft()
+    {
+        if (LifecycleStatus != WorkflowLifecycleStatus.Draft)
+        {
+            throw new InvalidOperationException(
+                $"Meter '{Id}' is in '{LifecycleStatus}' status. Only Draft meters can be modified.");
+        }
+    }
 }

--- a/src/Granit.Metering/Exports/MeterDefinitionExportDefinition.cs
+++ b/src/Granit.Metering/Exports/MeterDefinitionExportDefinition.cs
@@ -15,7 +15,7 @@ public sealed class MeterDefinitionExportDefinition : ExportDefinition<MeterDefi
             .Field(m => m.Unit)
             .Field(m => m.Description)
             .Field(m => m.AggregationType)
-            .Field(m => m.Activated)
+            .Field(m => m.LifecycleStatus)
             .Field(m => m.TenantId)
             .Field(m => m.CreatedAt, f => f.Format("O"))
             .Field(m => m.CreatedBy)

--- a/src/Granit.Metering/Granit.Metering.csproj
+++ b/src/Granit.Metering/Granit.Metering.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\Granit.Metering.Abstractions\Granit.Metering.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.QueryEngine.Abstractions\Granit.QueryEngine.Abstractions.csproj" />
     <ProjectReference Include="..\Granit.Timing\Granit.Timing.csproj" />
+    <ProjectReference Include="..\Granit.Workflow\Granit.Workflow.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Granit.Metering/GranitMeteringModule.cs
+++ b/src/Granit.Metering/GranitMeteringModule.cs
@@ -1,6 +1,7 @@
 using Granit.Metering.Extensions;
 using Granit.Modularity;
 using Granit.Timing;
+using Granit.Workflow;
 
 namespace Granit.Metering;
 
@@ -12,7 +13,9 @@ namespace Granit.Metering;
 /// Add <c>Granit.Metering.EntityFrameworkCore</c> for persistence and
 /// <c>Granit.Metering.BackgroundJobs</c> for automated aggregation.
 /// </remarks>
-[DependsOn(typeof(GranitTimingModule))]
+[DependsOn(
+    typeof(GranitTimingModule),
+    typeof(GranitWorkflowModule))]
 public sealed class GranitMeteringModule : GranitModule
 {
     /// <inheritdoc/>

--- a/src/Granit.Metering/Queries/MeterDefinitionQueryDefinition.cs
+++ b/src/Granit.Metering/Queries/MeterDefinitionQueryDefinition.cs
@@ -25,7 +25,7 @@ public sealed class MeterDefinitionQueryDefinition : QueryDefinition<MeterDefini
             .Column(m => m.Name, c => c.Label("Name").LabelKey("Metering.Columns.Name").Filterable().Sortable())
             .Column(m => m.Unit, c => c.Label("Unit").LabelKey("Metering.Columns.Unit").Filterable().Sortable())
             .Column(m => m.AggregationType, c => c.Label("Aggregation").LabelKey("Metering.Columns.AggregationType").Filterable().Sortable())
-            .Column(m => m.Activated, c => c.Label("Activated").LabelKey("Metering.Columns.Activated").Filterable().Sortable())
+            .Column(m => m.LifecycleStatus, c => c.Label("Status").LabelKey("Metering.Columns.LifecycleStatus").Filterable().Sortable())
             .Column(m => m.CreatedAt, c => c.Label("Created At").LabelKey("Metering.Columns.CreatedAt").Sortable())
             .Column(m => m.ModifiedAt, c => c.Label("Modified At").LabelKey("Metering.Columns.ModifiedAt").Sortable())
             .GlobalSearch(m => m.Name, m => m.Unit)

--- a/src/Granit.Metering/packages.lock.json
+++ b/src/Granit.Metering/packages.lock.json
@@ -87,6 +87,15 @@
           "Microsoft.Extensions.Options": "[10.*, )"
         }
       },
+      "granit.workflow": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.*, )",

--- a/src/Granit.Subscriptions.BackgroundJobs/packages.lock.json
+++ b/src/Granit.Subscriptions.BackgroundJobs/packages.lock.json
@@ -160,6 +160,7 @@
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },

--- a/src/Granit.Subscriptions.Builtin/packages.lock.json
+++ b/src/Granit.Subscriptions.Builtin/packages.lock.json
@@ -146,6 +146,7 @@
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },

--- a/src/Granit.Subscriptions.Endpoints/packages.lock.json
+++ b/src/Granit.Subscriptions.Endpoints/packages.lock.json
@@ -129,7 +129,8 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )"
         }
       },
       "granit.metering.abstractions": {

--- a/src/Granit.Subscriptions.EntityFrameworkCore/packages.lock.json
+++ b/src/Granit.Subscriptions.EntityFrameworkCore/packages.lock.json
@@ -182,6 +182,7 @@
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },

--- a/src/Granit.Subscriptions.Features/packages.lock.json
+++ b/src/Granit.Subscriptions.Features/packages.lock.json
@@ -153,6 +153,7 @@
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },

--- a/src/Granit.Subscriptions.Notifications/packages.lock.json
+++ b/src/Granit.Subscriptions.Notifications/packages.lock.json
@@ -146,6 +146,7 @@
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },

--- a/src/Granit.Subscriptions/packages.lock.json
+++ b/src/Granit.Subscriptions/packages.lock.json
@@ -171,6 +171,7 @@
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },

--- a/tests/Granit.ArchitectureTests/packages.lock.json
+++ b/tests/Granit.ArchitectureTests/packages.lock.json
@@ -2522,7 +2522,8 @@
           "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
-          "Granit.Timing": "[0.1.0-dev, )"
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )"
         }
       },
       "granit.metering.abstractions": {

--- a/tests/Granit.Metering.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Metering.BackgroundJobs.Tests/packages.lock.json
@@ -324,6 +324,7 @@
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
@@ -353,6 +354,15 @@
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },
       "Cronos": {

--- a/tests/Granit.Metering.Endpoints.Tests/Endpoints/UsageEndpointsIdempotencyTests.cs
+++ b/tests/Granit.Metering.Endpoints.Tests/Endpoints/UsageEndpointsIdempotencyTests.cs
@@ -54,13 +54,14 @@ public sealed class UsageEndpointsIdempotencyTests : IAsyncDisposable
 
     public UsageEndpointsIdempotencyTests()
     {
-        // Active meter required so the handler proceeds past the existence/active checks.
+        // Published meter required so the handler proceeds past the lifecycle ingestion gate.
         var activeMeter = MeterDefinition.Create(
             id: MeterId,
             name: "test.meter",
             unit: "call",
             aggregationType: AggregationType.Count,
             description: null);
+        activeMeter.Publish();
 
         _reader
             .GetByIdAsync(Arg.Any<MeterDefinitionId>(), Arg.Any<CancellationToken>())

--- a/tests/Granit.Metering.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Metering.Endpoints.Tests/packages.lock.json
@@ -612,6 +612,7 @@
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
@@ -673,6 +674,15 @@
           "Granit.Http.ExceptionHandling": "[0.1.0-dev, )",
           "Granit.Localization": "[0.1.0-dev, )",
           "Microsoft.AspNetCore.OpenApi": "[10.*, )"
+        }
+      },
+      "granit.workflow": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },
       "Asp.Versioning.Mvc": {

--- a/tests/Granit.Metering.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Metering.EntityFrameworkCore.Tests/packages.lock.json
@@ -412,6 +412,7 @@
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
@@ -465,6 +466,15 @@
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },
       "Microsoft.EntityFrameworkCore": {

--- a/tests/Granit.Metering.Tests/MeterDefinitionTests.cs
+++ b/tests/Granit.Metering.Tests/MeterDefinitionTests.cs
@@ -1,5 +1,6 @@
 using Granit.Metering.Domain;
 using Granit.Metering.Domain.ValueObjects;
+using Granit.Workflow.Domain;
 using Shouldly;
 using Xunit;
 
@@ -17,7 +18,10 @@ public sealed class MeterDefinitionTests
         meter.Unit.ShouldBe("requests");
         meter.AggregationType.ShouldBe(AggregationType.Sum);
         meter.Description.ShouldBe("HTTP requests");
-        meter.Activated.ShouldBeTrue();
+        meter.LifecycleStatus.ShouldBe(WorkflowLifecycleStatus.Draft);
+#pragma warning disable CS0618
+        meter.Activated.ShouldBeFalse();
+#pragma warning restore CS0618
     }
 
     [Fact]
@@ -35,7 +39,7 @@ public sealed class MeterDefinitionTests
     }
 
     [Fact]
-    public void Update_ShouldChangeProperties()
+    public void Update_OnDraft_ShouldChangeProperties()
     {
         var meter = MeterDefinition.Create(
             Guid.NewGuid(), "Old", "old", AggregationType.Sum);
@@ -48,26 +52,84 @@ public sealed class MeterDefinitionTests
     }
 
     [Fact]
-    public void Deactivate_ShouldSetInactive()
+    public void Update_OnPublished_ShouldThrow()
     {
         var meter = MeterDefinition.Create(
-            Guid.NewGuid(), "Test", "unit", AggregationType.Count);
+            Guid.NewGuid(), "Old", "old", AggregationType.Sum);
+        meter.Publish();
 
-        meter.Deactivate();
-
-        meter.Activated.ShouldBeFalse();
+        Should.Throw<InvalidOperationException>(() => meter.Update("New", "new", null));
     }
 
     [Fact]
-    public void Activate_AfterDeactivate_ShouldRestore()
+    public void Publish_FromDraft_ShouldTransitionToPublished()
     {
         var meter = MeterDefinition.Create(
             Guid.NewGuid(), "Test", "unit", AggregationType.Count);
-        meter.Deactivate();
 
-        meter.Activate();
+        meter.Publish();
 
+        meter.LifecycleStatus.ShouldBe(WorkflowLifecycleStatus.Published);
+#pragma warning disable CS0618
         meter.Activated.ShouldBeTrue();
+#pragma warning restore CS0618
+    }
+
+    [Fact]
+    public void Publish_FromPublished_ShouldThrow()
+    {
+        var meter = MeterDefinition.Create(
+            Guid.NewGuid(), "Test", "unit", AggregationType.Count);
+        meter.Publish();
+
+        Should.Throw<InvalidOperationException>(() => meter.Publish());
+    }
+
+    [Fact]
+    public void Archive_FromPublished_ShouldTransitionToArchived()
+    {
+        var meter = MeterDefinition.Create(
+            Guid.NewGuid(), "Test", "unit", AggregationType.Count);
+        meter.Publish();
+
+        meter.Archive();
+
+        meter.LifecycleStatus.ShouldBe(WorkflowLifecycleStatus.Archived);
+#pragma warning disable CS0618
+        meter.Activated.ShouldBeFalse();
+#pragma warning restore CS0618
+    }
+
+    [Fact]
+    public void Archive_FromDraft_ShouldThrow()
+    {
+        var meter = MeterDefinition.Create(
+            Guid.NewGuid(), "Test", "unit", AggregationType.Count);
+
+        Should.Throw<InvalidOperationException>(() => meter.Archive());
+    }
+
+    [Fact]
+    public void DeactivateAlias_ShouldArchivePublishedMeter()
+    {
+        var meter = MeterDefinition.Create(
+            Guid.NewGuid(), "Test", "unit", AggregationType.Count);
+        meter.Publish();
+
+#pragma warning disable CS0618
+        meter.Deactivate();
+#pragma warning restore CS0618
+
+        meter.LifecycleStatus.ShouldBe(WorkflowLifecycleStatus.Archived);
+    }
+
+    [Fact]
+    public void GetWorkflowEntityId_ShouldReturnIdAsString()
+    {
+        var id = Guid.NewGuid();
+        var meter = MeterDefinition.Create(id, "Test", "unit", AggregationType.Count);
+
+        meter.GetWorkflowEntityId().ShouldBe(id.ToString());
     }
 
     [Fact]

--- a/tests/Granit.Metering.Tests/packages.lock.json
+++ b/tests/Granit.Metering.Tests/packages.lock.json
@@ -293,6 +293,7 @@
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },
@@ -315,6 +316,15 @@
           "Granit": "[0.1.0-dev, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )",
           "Microsoft.Extensions.Options": "[10.*, )"
+        }
+      },
+      "granit.workflow": {
+        "type": "Project",
+        "dependencies": {
+          "Granit.DataExchange.Abstractions": "[0.1.0-dev, )",
+          "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
+          "Granit.Timing": "[0.1.0-dev, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.*, )"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {

--- a/tests/Granit.Subscriptions.BackgroundJobs.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.BackgroundJobs.Tests/packages.lock.json
@@ -392,6 +392,7 @@
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },

--- a/tests/Granit.Subscriptions.Builtin.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Builtin.Tests/packages.lock.json
@@ -378,6 +378,7 @@
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },

--- a/tests/Granit.Subscriptions.Endpoints.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Endpoints.Tests/packages.lock.json
@@ -620,6 +620,7 @@
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },

--- a/tests/Granit.Subscriptions.EntityFrameworkCore.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.EntityFrameworkCore.Tests/packages.lock.json
@@ -400,6 +400,7 @@
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },

--- a/tests/Granit.Subscriptions.Features.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Features.Tests/packages.lock.json
@@ -385,6 +385,7 @@
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },

--- a/tests/Granit.Subscriptions.Notifications.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Notifications.Tests/packages.lock.json
@@ -378,6 +378,7 @@
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },

--- a/tests/Granit.Subscriptions.Tests/packages.lock.json
+++ b/tests/Granit.Subscriptions.Tests/packages.lock.json
@@ -378,6 +378,7 @@
           "Granit.Metering.Abstractions": "[0.1.0-dev, )",
           "Granit.QueryEngine.Abstractions": "[0.1.0-dev, )",
           "Granit.Timing": "[0.1.0-dev, )",
+          "Granit.Workflow": "[0.1.0-dev, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[10.*, )"
         }
       },


### PR DESCRIPTION
Closes #1165 (Phase 2 Story 1 of [EPIC #1155](https://github.com/granit-fx/granit-dotnet/issues/1155) ORB alignment, [Feature #1158](https://github.com/granit-fx/granit-dotnet/issues/1158) Metering hybrid).

Mirrors `Plan`: meters now have a proper `Draft → Published → Archived` lifecycle. Only `Published` meters accept ingestion. Draft lets admins author and review without polluting production aggregates; Archived preserves history but rejects new events.

## What ships

**Domain** (`MeterDefinition`)
- Implements `IWorkflowStateful` (mirror `Plan`)
- New `LifecycleStatus` (`WorkflowLifecycleStatus`) replaces `Activated`
- `Create()` emits a Draft meter (was `Activated=true`)
- `Update()` requires Draft (matches `Plan`'s edit window)
- `Publish()` / `Archive()` replace `Activate()` / `Deactivate()`

**HTTP endpoints**
- `POST /metering/meters/{id}/publish` — Draft → Published
- `POST /metering/meters/{id}/archive` — Published → Archived
- `POST /metering/meters/{id}/deactivate` kept one release as alias for `/archive`, with RFC 8594 `Deprecation` / `Sunset` / `Link` headers
- `GET /meters` returns only Published (explicit `LifecycleStatus == Published` predicate; `IActive` filter removed from the entity)

**Ingestion gate** (`POST /metering/events`)
- Returns **422** when meter is not Published (was 409 on `!Activated`); detail message includes the actual lifecycle status

**One-release backward compat**
- `bool Activated` kept on the entity as `[NotMapped] [Obsolete]` computed alias (`=> LifecycleStatus == Published`)
- `void Deactivate()` kept as `[Obsolete]` alias delegating to `Archive()`
- `MeterDefinitionResponse` keeps `Activated` and adds `LifecycleStatus` as a trailing positional record param (additive at the wire level)

**Cross-cutting**
- 16 culture localization files updated (`Permission:Metering.Meters.Manage` description: `deactivate` → `publish, archive`)
- Granit.Workflow added as direct ProjectReference + `[DependsOn(GranitWorkflowModule)]` on `GranitMeteringModule`

## Schema (consumer apps run their own EF migrations)

```sql
ALTER TABLE meter_definitions
  ADD LifecycleStatus int NOT NULL DEFAULT 1; -- Published
UPDATE meter_definitions SET LifecycleStatus = CASE WHEN Activated THEN 1 ELSE 2 END;
ALTER TABLE meter_definitions DROP COLUMN Activated;
CREATE INDEX ix_meter_definitions_lifecycle ON meter_definitions(LifecycleStatus);
```

`WorkflowLifecycleStatus` enum: `Draft=0, Published=1, Archived=2` (verify against current `Granit.Workflow` values before migration).

## Breaking changes

| Surface | Change | Mitigation |
|---|---|---|
| `MeterDefinition.Create()` returns Draft | Was Published-equivalent (`Activated=true`) | Authoring code now needs an explicit `meter.Publish()` step before ingestion is accepted |
| `MeterDefinition.Update()` | Now requires Draft (returns 409 from HTTP) | Mirror of `Plan` — published meters are immutable |
| `POST /events` returns 422 (was 409) for inactive meter | Status-code aligned with the rest of Granit's "domain rule violation" responses | Clients already handle 4xx; specific code changes are documented in release notes |
| `MeterDefinitionResponse` adds trailing `LifecycleStatus` param | Positional record consumers need to accept the new param | JSON consumers see only an additional field — non-breaking at the wire level |

## Test plan

- [x] `dotnet test tests/Granit.Metering.Tests` — 46 / 46 (added 7 new lifecycle tests, restructured existing Update/Activate/Deactivate)
- [x] `dotnet test tests/Granit.Metering.Endpoints.Tests` — 9 / 9
- [x] `dotnet test tests/Granit.Metering.EntityFrameworkCore.Tests` — 4 / 4
- [x] `dotnet test tests/Granit.Metering.BackgroundJobs.Tests` — 23 / 23
- [x] `dotnet test tests/Granit.ArchitectureTests` — 119 / 119
- [x] `dotnet format src/Granit.Metering* tests/Granit.Metering* --verify-no-changes` clean
- [ ] CI green on all 6 shards (TBD post-push — will require the architecture-test regression fix in #1186 to be merged first)