### PR TITLE
feat(metering): add CountDistinct aggregation + DistinctProperty

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -24307,7 +24307,7 @@
         {
           "name": "Create",
           "kind": "method",
-          "signature": "Create(Guid id, string name, string unit, AggregationType aggregationType, string? description = null, Guid? productId = null)",
+          "signature": "Create(Guid id, string name, string unit, AggregationType aggregationType, string? description = null, Guid? productId = null, string? distinctProperty = null)",
           "returnType": "MeterDefinition"
         },
         {
@@ -24436,7 +24436,7 @@
       "kind": "record",
       "project": "Granit.Metering.Endpoints",
       "file": "src/Granit.Metering.Endpoints/Dtos/MeterDefinitionCreateRequest.cs",
-      "line": 14,
+      "line": 19,
       "members": []
     },
     {
@@ -24445,7 +24445,7 @@
       "kind": "record",
       "project": "Granit.Metering.Endpoints",
       "file": "src/Granit.Metering.Endpoints/Dtos/MeterDefinitionResponse.cs",
-      "line": 27,
+      "line": 32,
       "members": []
     },
     {

--- a/src/Granit.Metering.Endpoints/Dtos/MeterDefinitionCreateRequest.cs
+++ b/src/Granit.Metering.Endpoints/Dtos/MeterDefinitionCreateRequest.cs
@@ -11,9 +11,15 @@ namespace Granit.Metering.Endpoints.Dtos;
 /// Optional reference to a <c>Granit.Catalog.Product</c> identifier — the catalog
 /// item this meter measures. Soft reference (no SQL FK across modules).
 /// </param>
+/// <param name="DistinctProperty">
+/// JSON property name inside <c>MeterEvent.Metadata</c> whose distinct values are
+/// counted. <strong>Required</strong> when <see cref="AggregationType"/> is
+/// <see cref="AggregationType.CountDistinct"/>; must be <c>null</c> for all others.
+/// </param>
 public sealed record MeterDefinitionCreateRequest(
     string Name,
     string Unit,
     AggregationType AggregationType,
     string? Description = null,
-    Guid? ProductId = null);
+    Guid? ProductId = null,
+    string? DistinctProperty = null);

--- a/src/Granit.Metering.Endpoints/Dtos/MeterDefinitionResponse.cs
+++ b/src/Granit.Metering.Endpoints/Dtos/MeterDefinitionResponse.cs
@@ -24,6 +24,11 @@ namespace Granit.Metering.Endpoints.Dtos;
 /// Current lifecycle status of the meter (Draft / Published / Archived). Only
 /// <see cref="WorkflowLifecycleStatus.Published"/> meters accept ingestion.
 /// </param>
+/// <param name="DistinctProperty">
+/// JSON property name inside <c>MeterEvent.Metadata</c> whose distinct values are
+/// counted. Set when <see cref="AggregationType"/> is
+/// <see cref="AggregationType.CountDistinct"/>; <c>null</c> for all others.
+/// </param>
 public sealed record MeterDefinitionResponse(
     Guid Id,
     string Name,
@@ -32,7 +37,8 @@ public sealed record MeterDefinitionResponse(
     AggregationType AggregationType,
     bool Activated,
     Guid? ProductId,
-    WorkflowLifecycleStatus LifecycleStatus)
+    WorkflowLifecycleStatus LifecycleStatus,
+    string? DistinctProperty)
 {
     internal static MeterDefinitionResponse FromEntity(MeterDefinition definition)
     {
@@ -45,7 +51,8 @@ public sealed record MeterDefinitionResponse(
             definition.AggregationType,
             definition.Activated,
             definition.ProductId,
-            definition.LifecycleStatus);
+            definition.LifecycleStatus,
+            definition.DistinctProperty);
 #pragma warning restore CS0618
     }
 }

--- a/src/Granit.Metering.Endpoints/Endpoints/MeterDefinitionEndpoints.cs
+++ b/src/Granit.Metering.Endpoints/Endpoints/MeterDefinitionEndpoints.cs
@@ -143,7 +143,8 @@ internal static class MeterDefinitionEndpoints
             request.Unit,
             request.AggregationType,
             request.Description,
-            request.ProductId);
+            request.ProductId,
+            request.DistinctProperty);
 
         await writer.AddAsync(definition, cancellationToken).ConfigureAwait(false);
 

--- a/src/Granit.Metering.Endpoints/Validators/MeterDefinitionCreateRequestValidator.cs
+++ b/src/Granit.Metering.Endpoints/Validators/MeterDefinitionCreateRequestValidator.cs
@@ -1,5 +1,7 @@
 using FluentValidation;
+using Granit.Metering.Domain;
 using Granit.Metering.Endpoints.Dtos;
+using Granit.Validation.Extensions;
 
 namespace Granit.Metering.Endpoints.Validators;
 
@@ -20,5 +22,16 @@ internal sealed class MeterDefinitionCreateRequestValidator : AbstractValidator<
 
         RuleFor(x => x.Description)
             .MaximumLength(1024);
+
+        RuleFor(x => x.DistinctProperty)
+            .NotEmpty()
+            .MaximumLength(200)
+            .WithErrorCodeAndMessage("Granit:Validation:MeteringDistinctPropertyRequired")
+            .When(x => x.AggregationType == AggregationType.CountDistinct);
+
+        RuleFor(x => x.DistinctProperty)
+            .Empty()
+            .WithErrorCodeAndMessage("Granit:Validation:MeteringDistinctPropertyNotAllowed")
+            .When(x => x.AggregationType != AggregationType.CountDistinct);
     }
 }

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/EfAggregationRunner.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/EfAggregationRunner.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Granit.DataFiltering;
 using Granit.Domain;
 using Granit.Guids;
@@ -83,7 +84,7 @@ internal sealed partial class EfAggregationRunner(
         DateTimeOffset periodStart = new(now.Year, now.Month, now.Day, now.Hour, 0, 0, now.Offset);
         DateTimeOffset periodEnd = periodStart.AddHours(1);
 
-        decimal aggregatedValue = Aggregate(definition.AggregationType, events);
+        decimal aggregatedValue = Aggregate(definition, events);
 
         UsageAggregate? existing = await db.UsageAggregates
             .FirstOrDefaultAsync(
@@ -131,15 +132,79 @@ internal sealed partial class EfAggregationRunner(
         Log.AggregationBatchCompleted(logger, definition.Name, events.Count);
     }
 
-    private static decimal Aggregate(AggregationType type, List<MeterEvent> events) =>
-        type switch
+    internal static decimal Aggregate(MeterDefinition definition, List<MeterEvent> events) =>
+        definition.AggregationType switch
         {
             AggregationType.Sum => events.Sum(e => e.Quantity),
             AggregationType.Max => events.Max(e => e.Quantity),
             AggregationType.Count => events.Count,
             AggregationType.Last => events[^1].Quantity,
+            AggregationType.CountDistinct => CountDistinctValues(events, definition.DistinctProperty),
             _ => events.Sum(e => e.Quantity),
         };
+
+    /// <summary>
+    /// Counts distinct, non-null string values of <paramref name="property"/> extracted
+    /// from each event's <c>Metadata</c> JSON. Events with null/empty/invalid metadata,
+    /// or missing the property, are excluded entirely (never bucketed as a synthetic
+    /// <c>null</c>). Numbers and booleans are stringified ordinally so
+    /// <c>{"id": 1}</c> and <c>{"id": "1"}</c> hash to the same bucket.
+    /// </summary>
+    private static decimal CountDistinctValues(List<MeterEvent> events, string? property)
+    {
+        if (string.IsNullOrWhiteSpace(property))
+        {
+            return 0m;
+        }
+
+        HashSet<string> distinct = new(StringComparer.Ordinal);
+
+        foreach (MeterEvent ev in events)
+        {
+            if (string.IsNullOrWhiteSpace(ev.Metadata))
+            {
+                continue;
+            }
+
+            string? value = TryExtractStringValue(ev.Metadata, property);
+            if (value is not null)
+            {
+                distinct.Add(value);
+            }
+        }
+
+        return distinct.Count;
+    }
+
+    private static string? TryExtractStringValue(string metadataJson, string property)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(metadataJson);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            if (!doc.RootElement.TryGetProperty(property, out JsonElement value))
+            {
+                return null;
+            }
+
+            return value.ValueKind switch
+            {
+                JsonValueKind.String => value.GetString(),
+                JsonValueKind.Number => value.GetRawText(),
+                JsonValueKind.True => "true",
+                JsonValueKind.False => "false",
+                _ => null,
+            };
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
 
     private static partial class Log
     {

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/MeterDefinitionConfiguration.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/MeterDefinitionConfiguration.cs
@@ -18,6 +18,7 @@ internal sealed class MeterDefinitionConfiguration : IEntityTypeConfiguration<Me
         builder.Property(e => e.Unit).HasMaxLength(50).IsRequired();
         builder.Property(e => e.Description).HasMaxLength(2000);
         builder.Property(e => e.AggregationType).IsRequired();
+        builder.Property(e => e.DistinctProperty).HasMaxLength(200);
         builder.Property(e => e.LifecycleStatus).IsRequired();
         builder.HasIndex(e => e.LifecycleStatus)
             .HasDatabaseName($"ix_{GranitMeteringDbProperties.DbTablePrefix}meter_definitions_lifecycle");

--- a/src/Granit.Metering/Domain/AggregationType.cs
+++ b/src/Granit.Metering/Domain/AggregationType.cs
@@ -16,4 +16,12 @@ public enum AggregationType
 
     /// <summary>Last recorded event quantity in the period (gauge-style).</summary>
     Last = 3,
+
+    /// <summary>
+    /// Distinct count of values extracted from a JSON path in <c>MeterEvent.Metadata</c>
+    /// (e.g. <c>"user_id"</c> for monthly active users). Requires
+    /// <see cref="MeterDefinition.DistinctProperty"/> to be set; events whose metadata
+    /// does not contain the property are excluded from the count.
+    /// </summary>
+    CountDistinct = 4,
 }

--- a/src/Granit.Metering/Domain/MeterDefinition.cs
+++ b/src/Granit.Metering/Domain/MeterDefinition.cs
@@ -30,6 +30,10 @@ public sealed class MeterDefinition : AuditedAggregateRoot, IMultiTenant, IWorkf
     /// <paramref name="productId"/> is an optional soft reference (no SQL FK across
     /// modules) to a <c>Granit.Catalog.Product</c> — the catalog item this meter
     /// measures. The application layer is responsible for catalog deletion safety.
+    /// <paramref name="distinctProperty"/> is required when
+    /// <paramref name="aggregationType"/> is <see cref="AggregationType.CountDistinct"/>
+    /// — the JSON path inside <c>MeterEvent.Metadata</c> whose distinct values are
+    /// counted (e.g. <c>"user_id"</c>).
     /// </summary>
     public static MeterDefinition Create(
         Guid id,
@@ -37,10 +41,26 @@ public sealed class MeterDefinition : AuditedAggregateRoot, IMultiTenant, IWorkf
         string unit,
         AggregationType aggregationType,
         string? description = null,
-        Guid? productId = null)
+        Guid? productId = null,
+        string? distinctProperty = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         ArgumentException.ThrowIfNullOrWhiteSpace(unit);
+
+        if (aggregationType == AggregationType.CountDistinct
+            && string.IsNullOrWhiteSpace(distinctProperty))
+        {
+            throw new ArgumentException(
+                "DistinctProperty is required when AggregationType is CountDistinct.",
+                nameof(distinctProperty));
+        }
+
+        if (aggregationType != AggregationType.CountDistinct && distinctProperty is not null)
+        {
+            throw new ArgumentException(
+                "DistinctProperty must be null unless AggregationType is CountDistinct.",
+                nameof(distinctProperty));
+        }
 
         return new MeterDefinition
         {
@@ -51,6 +71,7 @@ public sealed class MeterDefinition : AuditedAggregateRoot, IMultiTenant, IWorkf
             Description = description,
             LifecycleStatus = WorkflowLifecycleStatus.Draft,
             ProductId = productId,
+            DistinctProperty = distinctProperty,
         };
     }
 
@@ -65,6 +86,15 @@ public sealed class MeterDefinition : AuditedAggregateRoot, IMultiTenant, IWorkf
 
     /// <summary>How events are aggregated into rollups.</summary>
     public AggregationType AggregationType { get; private set; }
+
+    /// <summary>
+    /// JSON path inside <c>MeterEvent.Metadata</c> whose distinct values are counted
+    /// when <see cref="AggregationType"/> is <see cref="AggregationType.CountDistinct"/>.
+    /// Required for that type, must be <c>null</c> for all others. Events whose
+    /// metadata does not contain the property are excluded from the count
+    /// (treated as missing — never counted as a synthetic <c>null</c> bucket).
+    /// </summary>
+    public string? DistinctProperty { get; private set; }
 
     /// <summary>Current lifecycle status (Draft, Published, Archived).</summary>
     public WorkflowLifecycleStatus LifecycleStatus { get; private set; }

--- a/src/Granit.Metering/Exports/MeterDefinitionExportDefinition.cs
+++ b/src/Granit.Metering/Exports/MeterDefinitionExportDefinition.cs
@@ -15,6 +15,7 @@ public sealed class MeterDefinitionExportDefinition : ExportDefinition<MeterDefi
             .Field(m => m.Unit)
             .Field(m => m.Description)
             .Field(m => m.AggregationType)
+            .Field(m => m.DistinctProperty)
             .Field(m => m.LifecycleStatus)
             .Field(m => m.TenantId)
             .Field(m => m.CreatedAt, f => f.Format("O"))

--- a/src/Granit.Validation/Localization/Validation/cs.json
+++ b/src/Granit.Validation/Localization/Validation/cs.json
@@ -61,17 +61,19 @@
     "Granit:Validation:MaxPresetEntries": "Je povoleno maximálně 20 předvoleb.",
     "Granit:Validation:MaxQuickFilterEntries": "Je povoleno maximálně 20 rychlých filtrů.",
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' nesmí mít více než {MaxLength} znaků. Zadali jste {TotalLength} znaků.",
+    "Granit:Validation:MeteringDistinctPropertyNotAllowed": "DistinctProperty musí být null, pokud AggregationType není CountDistinct.",
+    "Granit:Validation:MeteringDistinctPropertyRequired": "DistinctProperty je vyžadováno, pokud je AggregationType CountDistinct.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' musí mít alespoň {MinLength} znaků. Zadali jste {TotalLength} znaků.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' nesmí být prázdné.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' se nesmí rovnat '{ComparisonValue}'.",
     "Granit:Validation:NotNullValidator": "'{PropertyName}' nesmí být prázdné.",
     "Granit:Validation:NullValidator": "'{PropertyName}' musí být prázdné.",
+    "Granit:Validation:PaymentAmountOutOfRange": "Částka platby je mimo povolený rozsah.",
     "Granit:Validation:PredicateValidator": "Zadaná podmínka nebyla splněna pro '{PropertyName}'.",
     "Granit:Validation:RegularExpressionValidator": "'{PropertyName}' nemá správný formát.",
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' nesmí mít celkem více než {ExpectedPrecision} číslic, z toho {ExpectedScale} desetinných míst.",
     "Granit:Validation:ScheduledAction:FutureDate": "Plánované datum musí být v budoucnosti.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Platné do' musí být pozdější než 'Platné od'.",
-    "Granit:Validation:PaymentAmountOutOfRange": "Částka platby je mimo povolený rozsah.",
-    "Granit:Validation:UrlMustBeHttps": "Adresa URL musí používat HTTPS."
+    "Granit:Validation:UrlMustBeHttps": "Adresa URL musí používat HTTPS.",
+    "Granit:Validation:ValidToAfterValidFrom": "'Platné do' musí být pozdější než 'Platné od'."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/de.json
+++ b/src/Granit.Validation/Localization/Validation/de.json
@@ -61,17 +61,19 @@
     "Granit:Validation:MaxPresetEntries": "Maximal 20 Voreinstellungen sind zulässig.",
     "Granit:Validation:MaxQuickFilterEntries": "Maximal 20 Schnellfilter sind zulässig.",
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' darf maximal {MaxLength} Zeichen lang sein. Sie haben {TotalLength} Zeichen eingegeben.",
+    "Granit:Validation:MeteringDistinctPropertyNotAllowed": "DistinctProperty muss null sein, außer wenn AggregationType CountDistinct ist.",
+    "Granit:Validation:MeteringDistinctPropertyRequired": "DistinctProperty ist erforderlich, wenn AggregationType CountDistinct ist.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' muss mindestens {MinLength} Zeichen lang sein. Sie haben {TotalLength} Zeichen eingegeben.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' darf nicht leer sein.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' darf nicht gleich '{ComparisonValue}' sein.",
     "Granit:Validation:NotNullValidator": "'{PropertyName}' darf nicht leer sein.",
     "Granit:Validation:NullValidator": "'{PropertyName}' muss leer sein.",
+    "Granit:Validation:PaymentAmountOutOfRange": "Der Zahlungsbetrag liegt außerhalb des zulässigen Bereichs.",
     "Granit:Validation:PredicateValidator": "Die angegebene Bedingung für '{PropertyName}' wurde nicht erfüllt.",
     "Granit:Validation:RegularExpressionValidator": "'{PropertyName}' hat nicht das richtige Format.",
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' darf insgesamt nicht mehr als {ExpectedPrecision} Ziffern haben, davon {ExpectedScale} Dezimalstellen.",
     "Granit:Validation:ScheduledAction:FutureDate": "Das geplante Datum muss in der Zukunft liegen.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Gültig bis' muss nach 'Gültig ab' liegen.",
-    "Granit:Validation:PaymentAmountOutOfRange": "Der Zahlungsbetrag liegt außerhalb des zulässigen Bereichs.",
-    "Granit:Validation:UrlMustBeHttps": "Die URL muss HTTPS verwenden."
+    "Granit:Validation:UrlMustBeHttps": "Die URL muss HTTPS verwenden.",
+    "Granit:Validation:ValidToAfterValidFrom": "'Gültig bis' muss nach 'Gültig ab' liegen."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/en.json
+++ b/src/Granit.Validation/Localization/Validation/en.json
@@ -61,17 +61,19 @@
     "Granit:Validation:MaxPresetEntries": "At most 20 preset entries are allowed.",
     "Granit:Validation:MaxQuickFilterEntries": "At most 20 quick filters are allowed.",
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' must be {MaxLength} characters or fewer. You entered {TotalLength} characters.",
+    "Granit:Validation:MeteringDistinctPropertyNotAllowed": "DistinctProperty must be null unless AggregationType is CountDistinct.",
+    "Granit:Validation:MeteringDistinctPropertyRequired": "DistinctProperty is required when AggregationType is CountDistinct.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' must be at least {MinLength} characters. You entered {TotalLength} characters.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' must not be empty.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' must not be equal to '{ComparisonValue}'.",
     "Granit:Validation:NotNullValidator": "'{PropertyName}' must not be empty.",
     "Granit:Validation:NullValidator": "'{PropertyName}' must be empty.",
+    "Granit:Validation:PaymentAmountOutOfRange": "The payment amount is out of the allowed range.",
     "Granit:Validation:PredicateValidator": "The specified condition was not met for '{PropertyName}'.",
     "Granit:Validation:RegularExpressionValidator": "'{PropertyName}' is not in the correct format.",
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' must not be more than {ExpectedPrecision} digits in total, with allowance for {ExpectedScale} decimals.",
     "Granit:Validation:ScheduledAction:FutureDate": "Scheduled date must be in the future.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Valid to' must be after 'Valid from'.",
-    "Granit:Validation:PaymentAmountOutOfRange": "The payment amount is out of the allowed range.",
-    "Granit:Validation:UrlMustBeHttps": "The URL must use HTTPS."
+    "Granit:Validation:UrlMustBeHttps": "The URL must use HTTPS.",
+    "Granit:Validation:ValidToAfterValidFrom": "'Valid to' must be after 'Valid from'."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/es.json
+++ b/src/Granit.Validation/Localization/Validation/es.json
@@ -61,17 +61,19 @@
     "Granit:Validation:MaxPresetEntries": "Se permiten un máximo de 20 preajustes.",
     "Granit:Validation:MaxQuickFilterEntries": "Se permiten un máximo de 20 filtros rápidos.",
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' debe tener como máximo {MaxLength} caracteres. Ha introducido {TotalLength} caracteres.",
+    "Granit:Validation:MeteringDistinctPropertyNotAllowed": "DistinctProperty debe ser nulo a menos que AggregationType sea CountDistinct.",
+    "Granit:Validation:MeteringDistinctPropertyRequired": "DistinctProperty es obligatorio cuando AggregationType es CountDistinct.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' debe tener como mínimo {MinLength} caracteres. Ha introducido {TotalLength} caracteres.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' no puede estar vacío.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' no debe ser igual a '{ComparisonValue}'.",
     "Granit:Validation:NotNullValidator": "'{PropertyName}' no puede estar vacío.",
     "Granit:Validation:NullValidator": "'{PropertyName}' debe estar vacío.",
+    "Granit:Validation:PaymentAmountOutOfRange": "El importe del pago está fuera del rango permitido.",
     "Granit:Validation:PredicateValidator": "La condición especificada para '{PropertyName}' no se ha cumplido.",
     "Granit:Validation:RegularExpressionValidator": "'{PropertyName}' no tiene el formato correcto.",
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' no debe tener más de {ExpectedPrecision} dígitos en total, de los cuales {ExpectedScale} decimales.",
     "Granit:Validation:ScheduledAction:FutureDate": "La fecha programada debe ser en el futuro.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Válido hasta' debe ser posterior a 'Válido desde'.",
-    "Granit:Validation:PaymentAmountOutOfRange": "El importe del pago está fuera del rango permitido.",
-    "Granit:Validation:UrlMustBeHttps": "La URL debe usar HTTPS."
+    "Granit:Validation:UrlMustBeHttps": "La URL debe usar HTTPS.",
+    "Granit:Validation:ValidToAfterValidFrom": "'Válido hasta' debe ser posterior a 'Válido desde'."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/fr.json
+++ b/src/Granit.Validation/Localization/Validation/fr.json
@@ -61,17 +61,19 @@
     "Granit:Validation:MaxPresetEntries": "20 entrées de préréglage maximum sont autorisées.",
     "Granit:Validation:MaxQuickFilterEntries": "20 filtres rapides maximum sont autorisés.",
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' doit contenir au maximum {MaxLength} caractères. Vous avez saisi {TotalLength} caractères.",
+    "Granit:Validation:MeteringDistinctPropertyNotAllowed": "DistinctProperty doit être nul sauf si AggregationType est CountDistinct.",
+    "Granit:Validation:MeteringDistinctPropertyRequired": "La propriété DistinctProperty est requise lorsque AggregationType est CountDistinct.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' doit contenir au minimum {MinLength} caractères. Vous avez saisi {TotalLength} caractères.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' ne peut pas être vide.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' ne peut pas être égal à '{ComparisonValue}'.",
     "Granit:Validation:NotNullValidator": "'{PropertyName}' ne peut pas être vide.",
     "Granit:Validation:NullValidator": "'{PropertyName}' doit être vide.",
+    "Granit:Validation:PaymentAmountOutOfRange": "Le montant du paiement est hors de la plage autorisée.",
     "Granit:Validation:PredicateValidator": "La condition spécifiée n'a pas été remplie pour '{PropertyName}'.",
     "Granit:Validation:RegularExpressionValidator": "'{PropertyName}' n'est pas dans le format attendu.",
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' ne doit pas avoir plus de {ExpectedPrecision} chiffres au total, dont {ExpectedScale} décimaux.",
     "Granit:Validation:ScheduledAction:FutureDate": "La date planifiée doit être dans le futur.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Valide jusqu'au' doit être postérieur à 'Valide à partir du'.",
-    "Granit:Validation:PaymentAmountOutOfRange": "Le montant du paiement est hors de la plage autorisée.",
-    "Granit:Validation:UrlMustBeHttps": "L'URL doit utiliser HTTPS."
+    "Granit:Validation:UrlMustBeHttps": "L'URL doit utiliser HTTPS.",
+    "Granit:Validation:ValidToAfterValidFrom": "'Valide jusqu'au' doit être postérieur à 'Valide à partir du'."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/hi.json
+++ b/src/Granit.Validation/Localization/Validation/hi.json
@@ -61,17 +61,19 @@
     "Granit:Validation:MaxPresetEntries": "अधिकतम 20 प्रीसेट प्रविष्टियाँ अनुमत हैं।",
     "Granit:Validation:MaxQuickFilterEntries": "अधिकतम 20 त्वरित फ़िल्टर अनुमत हैं।",
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' {MaxLength} अक्षर या उससे कम होना चाहिए। आपने {TotalLength} अक्षर दर्ज किए।",
+    "Granit:Validation:MeteringDistinctPropertyNotAllowed": "जब तक AggregationType CountDistinct न हो, DistinctProperty शून्य होना चाहिए।",
+    "Granit:Validation:MeteringDistinctPropertyRequired": "जब AggregationType CountDistinct हो तो DistinctProperty आवश्यक है।",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' कम से कम {MinLength} अक्षरों का होना चाहिए। आपने {TotalLength} अक्षर दर्ज किए।",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' खाली नहीं होना चाहिए।",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' '{ComparisonValue}' के बराबर नहीं होना चाहिए।",
     "Granit:Validation:NotNullValidator": "'{PropertyName}' खाली नहीं होना चाहिए।",
     "Granit:Validation:NullValidator": "'{PropertyName}' खाली होना चाहिए।",
+    "Granit:Validation:PaymentAmountOutOfRange": "भुगतान राशि अनुमत सीमा से बाहर है।",
     "Granit:Validation:PredicateValidator": "'{PropertyName}' के लिए निर्दिष्ट शर्त पूरी नहीं हुई।",
     "Granit:Validation:RegularExpressionValidator": "'{PropertyName}' सही प्रारूप में नहीं है।",
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' कुल {ExpectedPrecision} अंकों से अधिक नहीं होना चाहिए, {ExpectedScale} दशमलव की अनुमति के साथ।",
     "Granit:Validation:ScheduledAction:FutureDate": "निर्धारित तिथि भविष्य में होनी चाहिए।",
-    "Granit:Validation:ValidToAfterValidFrom": "'मान्य तक' 'मान्य से' के बाद होना चाहिए।",
-    "Granit:Validation:PaymentAmountOutOfRange": "भुगतान राशि अनुमत सीमा से बाहर है।",
-    "Granit:Validation:UrlMustBeHttps": "URL को HTTPS का उपयोग करना चाहिए।"
+    "Granit:Validation:UrlMustBeHttps": "URL को HTTPS का उपयोग करना चाहिए।",
+    "Granit:Validation:ValidToAfterValidFrom": "'मान्य तक' 'मान्य से' के बाद होना चाहिए।"
   }
 }

--- a/src/Granit.Validation/Localization/Validation/it.json
+++ b/src/Granit.Validation/Localization/Validation/it.json
@@ -61,17 +61,19 @@
     "Granit:Validation:MaxPresetEntries": "Sono consentite al massimo 20 preimpostazioni.",
     "Granit:Validation:MaxQuickFilterEntries": "Sono consentiti al massimo 20 filtri rapidi.",
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' deve contenere al massimo {MaxLength} caratteri. Sono stati inseriti {TotalLength} caratteri.",
+    "Granit:Validation:MeteringDistinctPropertyNotAllowed": "DistinctProperty deve essere null a meno che AggregationType non sia CountDistinct.",
+    "Granit:Validation:MeteringDistinctPropertyRequired": "DistinctProperty è richiesto quando AggregationType è CountDistinct.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' deve contenere almeno {MinLength} caratteri. Sono stati inseriti {TotalLength} caratteri.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' non può essere vuoto.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' non deve essere uguale a '{ComparisonValue}'.",
     "Granit:Validation:NotNullValidator": "'{PropertyName}' non può essere vuoto.",
     "Granit:Validation:NullValidator": "'{PropertyName}' deve essere vuoto.",
+    "Granit:Validation:PaymentAmountOutOfRange": "L'importo del pagamento è fuori dall'intervallo consentito.",
     "Granit:Validation:PredicateValidator": "La condizione specificata per '{PropertyName}' non è stata soddisfatta.",
     "Granit:Validation:RegularExpressionValidator": "'{PropertyName}' non è nel formato corretto.",
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' non deve avere più di {ExpectedPrecision} cifre in totale, di cui {ExpectedScale} decimali.",
     "Granit:Validation:ScheduledAction:FutureDate": "La data programmata deve essere nel futuro.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Valido fino a' deve essere successivo a 'Valido da'.",
-    "Granit:Validation:PaymentAmountOutOfRange": "L'importo del pagamento è fuori dall'intervallo consentito.",
-    "Granit:Validation:UrlMustBeHttps": "L'URL deve utilizzare HTTPS."
+    "Granit:Validation:UrlMustBeHttps": "L'URL deve utilizzare HTTPS.",
+    "Granit:Validation:ValidToAfterValidFrom": "'Valido fino a' deve essere successivo a 'Valido da'."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/ja.json
+++ b/src/Granit.Validation/Localization/Validation/ja.json
@@ -61,17 +61,19 @@
     "Granit:Validation:MaxPresetEntries": "プリセット項目は最大20件までです。",
     "Granit:Validation:MaxQuickFilterEntries": "クイックフィルターは最大20件までです。",
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' は {MaxLength} 文字以下である必要があります。{TotalLength} 文字入力されました。",
+    "Granit:Validation:MeteringDistinctPropertyNotAllowed": "AggregationType が CountDistinct でない限り、DistinctProperty は null でなければなりません。",
+    "Granit:Validation:MeteringDistinctPropertyRequired": "AggregationType が CountDistinct の場合、DistinctProperty は必須です。",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' は {MinLength} 文字以上である必要があります。{TotalLength} 文字入力されました。",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' を空にすることはできません。",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' は '{ComparisonValue}' と等しくない必要があります。",
     "Granit:Validation:NotNullValidator": "'{PropertyName}' を空にすることはできません。",
     "Granit:Validation:NullValidator": "'{PropertyName}' は空である必要があります。",
+    "Granit:Validation:PaymentAmountOutOfRange": "支払い金額が許容範囲外です。",
     "Granit:Validation:PredicateValidator": "'{PropertyName}' に対する指定された条件が満たされていません。",
     "Granit:Validation:RegularExpressionValidator": "'{PropertyName}' の形式が正しくありません。",
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' は合計 {ExpectedPrecision} 桁以内で、うち小数部は {ExpectedScale} 桁以内である必要があります。",
     "Granit:Validation:ScheduledAction:FutureDate": "スケジュール日は将来の日付である必要があります。",
-    "Granit:Validation:ValidToAfterValidFrom": "'有効終了日' は '有効開始日' より後でなければなりません。",
-    "Granit:Validation:PaymentAmountOutOfRange": "支払い金額が許容範囲外です。",
-    "Granit:Validation:UrlMustBeHttps": "URL は HTTPS を使用する必要があります。"
+    "Granit:Validation:UrlMustBeHttps": "URL は HTTPS を使用する必要があります。",
+    "Granit:Validation:ValidToAfterValidFrom": "'有効終了日' は '有効開始日' より後でなければなりません。"
   }
 }

--- a/src/Granit.Validation/Localization/Validation/ko.json
+++ b/src/Granit.Validation/Localization/Validation/ko.json
@@ -61,17 +61,19 @@
     "Granit:Validation:MaxPresetEntries": "프리셋 항목은 최대 20개까지 허용됩니다.",
     "Granit:Validation:MaxQuickFilterEntries": "빠른 필터는 최대 20개까지 허용됩니다.",
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}'은(는) {MaxLength}자 이하여야 합니다. {TotalLength}자를 입력하셨습니다.",
+    "Granit:Validation:MeteringDistinctPropertyNotAllowed": "AggregationType이 CountDistinct가 아닌 한 DistinctProperty는 null이어야 합니다.",
+    "Granit:Validation:MeteringDistinctPropertyRequired": "AggregationType이 CountDistinct일 때 DistinctProperty는 필수입니다.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}'은(는) {MinLength}자 이상이어야 합니다. {TotalLength}자를 입력하셨습니다.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}'은(는) 비어 있을 수 없습니다.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}'은(는) '{ComparisonValue}'와(과) 같지 않아야 합니다.",
     "Granit:Validation:NotNullValidator": "'{PropertyName}'은(는) 비어 있을 수 없습니다.",
     "Granit:Validation:NullValidator": "'{PropertyName}'은(는) 비어 있어야 합니다.",
+    "Granit:Validation:PaymentAmountOutOfRange": "결제 금액이 허용 범위를 벗어났습니다.",
     "Granit:Validation:PredicateValidator": "'{PropertyName}'에 대해 지정된 조건이 충족되지 않았습니다.",
     "Granit:Validation:RegularExpressionValidator": "'{PropertyName}'의 형식이 올바르지 않습니다.",
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}'은(는) 총 {ExpectedPrecision}자리를 초과할 수 없으며 소수점 이하 {ExpectedScale}자리까지 허용됩니다.",
     "Granit:Validation:ScheduledAction:FutureDate": "예약 날짜는 미래여야 합니다.",
-    "Granit:Validation:ValidToAfterValidFrom": "'유효 종료일'은 '유효 시작일' 이후여야 합니다.",
-    "Granit:Validation:PaymentAmountOutOfRange": "결제 금액이 허용 범위를 벗어났습니다.",
-    "Granit:Validation:UrlMustBeHttps": "URL은 HTTPS를 사용해야 합니다."
+    "Granit:Validation:UrlMustBeHttps": "URL은 HTTPS를 사용해야 합니다.",
+    "Granit:Validation:ValidToAfterValidFrom": "'유효 종료일'은 '유효 시작일' 이후여야 합니다."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/nl.json
+++ b/src/Granit.Validation/Localization/Validation/nl.json
@@ -61,17 +61,19 @@
     "Granit:Validation:MaxPresetEntries": "Maximaal 20 voorinstellingen zijn toegestaan.",
     "Granit:Validation:MaxQuickFilterEntries": "Maximaal 20 snelfilters zijn toegestaan.",
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' mag maximaal {MaxLength} tekens bevatten. U hebt {TotalLength} tekens ingevoerd.",
+    "Granit:Validation:MeteringDistinctPropertyNotAllowed": "DistinctProperty moet null zijn, tenzij AggregationType CountDistinct is.",
+    "Granit:Validation:MeteringDistinctPropertyRequired": "DistinctProperty is vereist wanneer AggregationType CountDistinct is.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' moet minstens {MinLength} tekens bevatten. U hebt {TotalLength} tekens ingevoerd.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' mag niet leeg zijn.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' mag niet gelijk zijn aan '{ComparisonValue}'.",
     "Granit:Validation:NotNullValidator": "'{PropertyName}' mag niet leeg zijn.",
     "Granit:Validation:NullValidator": "'{PropertyName}' moet leeg zijn.",
+    "Granit:Validation:PaymentAmountOutOfRange": "Het betalingsbedrag valt buiten het toegestane bereik.",
     "Granit:Validation:PredicateValidator": "Aan de opgegeven voorwaarde voor '{PropertyName}' is niet voldaan.",
     "Granit:Validation:RegularExpressionValidator": "'{PropertyName}' heeft niet het juiste formaat.",
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' mag niet meer dan {ExpectedPrecision} cijfers bevatten, waarvan {ExpectedScale} decimalen.",
     "Granit:Validation:ScheduledAction:FutureDate": "De geplande datum moet in de toekomst liggen.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Geldig tot' moet na 'Geldig vanaf' liggen.",
-    "Granit:Validation:PaymentAmountOutOfRange": "Het betalingsbedrag valt buiten het toegestane bereik.",
-    "Granit:Validation:UrlMustBeHttps": "De URL moet HTTPS gebruiken."
+    "Granit:Validation:UrlMustBeHttps": "De URL moet HTTPS gebruiken.",
+    "Granit:Validation:ValidToAfterValidFrom": "'Geldig tot' moet na 'Geldig vanaf' liggen."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/pl.json
+++ b/src/Granit.Validation/Localization/Validation/pl.json
@@ -61,17 +61,19 @@
     "Granit:Validation:MaxPresetEntries": "Dozwolonych jest maksymalnie 20 ustawień wstępnych.",
     "Granit:Validation:MaxQuickFilterEntries": "Dozwolonych jest maksymalnie 20 szybkich filtrów.",
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' nie może mieć więcej niż {MaxLength} znaków. Wprowadzono {TotalLength} znaków.",
+    "Granit:Validation:MeteringDistinctPropertyNotAllowed": "DistinctProperty musi być null, chyba że AggregationType to CountDistinct.",
+    "Granit:Validation:MeteringDistinctPropertyRequired": "DistinctProperty jest wymagany, gdy AggregationType to CountDistinct.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' musi mieć co najmniej {MinLength} znaków. Wprowadzono {TotalLength} znaków.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' nie może być puste.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' nie może być równe '{ComparisonValue}'.",
     "Granit:Validation:NotNullValidator": "'{PropertyName}' nie może być puste.",
     "Granit:Validation:NullValidator": "'{PropertyName}' musi być puste.",
+    "Granit:Validation:PaymentAmountOutOfRange": "Kwota płatności jest poza dozwolonym zakresem.",
     "Granit:Validation:PredicateValidator": "Określony warunek nie został spełniony dla '{PropertyName}'.",
     "Granit:Validation:RegularExpressionValidator": "'{PropertyName}' ma nieprawidłowy format.",
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' nie może mieć więcej niż {ExpectedPrecision} cyfr łącznie, w tym {ExpectedScale} miejsc po przecinku.",
     "Granit:Validation:ScheduledAction:FutureDate": "Zaplanowana data musi być w przyszłości.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Ważne do' musi być późniejsze niż 'Ważne od'.",
-    "Granit:Validation:PaymentAmountOutOfRange": "Kwota płatności jest poza dozwolonym zakresem.",
-    "Granit:Validation:UrlMustBeHttps": "Adres URL musi używać protokołu HTTPS."
+    "Granit:Validation:UrlMustBeHttps": "Adres URL musi używać protokołu HTTPS.",
+    "Granit:Validation:ValidToAfterValidFrom": "'Ważne do' musi być późniejsze niż 'Ważne od'."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/pt.json
+++ b/src/Granit.Validation/Localization/Validation/pt.json
@@ -61,17 +61,19 @@
     "Granit:Validation:MaxPresetEntries": "São permitidas no máximo 20 predefinições.",
     "Granit:Validation:MaxQuickFilterEntries": "São permitidos no máximo 20 filtros rápidos.",
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' deve ter no máximo {MaxLength} caracteres. Foram introduzidos {TotalLength} caracteres.",
+    "Granit:Validation:MeteringDistinctPropertyNotAllowed": "DistinctProperty deve ser nulo a menos que AggregationType seja CountDistinct.",
+    "Granit:Validation:MeteringDistinctPropertyRequired": "DistinctProperty é obrigatório quando AggregationType é CountDistinct.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' deve ter no mínimo {MinLength} caracteres. Foram introduzidos {TotalLength} caracteres.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' não pode estar vazio.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' não deve ser igual a '{ComparisonValue}'.",
     "Granit:Validation:NotNullValidator": "'{PropertyName}' não pode estar vazio.",
     "Granit:Validation:NullValidator": "'{PropertyName}' deve estar vazio.",
+    "Granit:Validation:PaymentAmountOutOfRange": "O valor do pagamento está fora do intervalo permitido.",
     "Granit:Validation:PredicateValidator": "A condição especificada para '{PropertyName}' não foi cumprida.",
     "Granit:Validation:RegularExpressionValidator": "'{PropertyName}' não está no formato correto.",
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' não deve ter mais de {ExpectedPrecision} dígitos no total, dos quais {ExpectedScale} decimais.",
     "Granit:Validation:ScheduledAction:FutureDate": "A data agendada deve ser no futuro.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Válido até' deve ser posterior a 'Válido desde'.",
-    "Granit:Validation:PaymentAmountOutOfRange": "O valor do pagamento está fora do intervalo permitido.",
-    "Granit:Validation:UrlMustBeHttps": "A URL deve usar HTTPS."
+    "Granit:Validation:UrlMustBeHttps": "A URL deve usar HTTPS.",
+    "Granit:Validation:ValidToAfterValidFrom": "'Válido até' deve ser posterior a 'Válido desde'."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/sv.json
+++ b/src/Granit.Validation/Localization/Validation/sv.json
@@ -61,17 +61,19 @@
     "Granit:Validation:MaxPresetEntries": "Högst 20 förinställningar är tillåtna.",
     "Granit:Validation:MaxQuickFilterEntries": "Högst 20 snabbfilter är tillåtna.",
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' får vara högst {MaxLength} tecken. Du angav {TotalLength} tecken.",
+    "Granit:Validation:MeteringDistinctPropertyNotAllowed": "DistinctProperty måste vara null om inte AggregationType är CountDistinct.",
+    "Granit:Validation:MeteringDistinctPropertyRequired": "DistinctProperty krävs när AggregationType är CountDistinct.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' måste vara minst {MinLength} tecken. Du angav {TotalLength} tecken.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' får inte vara tomt.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' får inte vara lika med '{ComparisonValue}'.",
     "Granit:Validation:NotNullValidator": "'{PropertyName}' får inte vara tomt.",
     "Granit:Validation:NullValidator": "'{PropertyName}' måste vara tomt.",
+    "Granit:Validation:PaymentAmountOutOfRange": "Betalningsbeloppet ligger utanför det tillåtna intervallet.",
     "Granit:Validation:PredicateValidator": "Det angivna villkoret uppfylldes inte för '{PropertyName}'.",
     "Granit:Validation:RegularExpressionValidator": "'{PropertyName}' har inte korrekt format.",
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' får inte ha fler än {ExpectedPrecision} siffror totalt, varav {ExpectedScale} decimaler.",
     "Granit:Validation:ScheduledAction:FutureDate": "Schemalagt datum måste vara i framtiden.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Giltig till' måste vara efter 'Giltig från'.",
-    "Granit:Validation:PaymentAmountOutOfRange": "Betalningsbeloppet ligger utanför det tillåtna intervallet.",
-    "Granit:Validation:UrlMustBeHttps": "URL:en måste använda HTTPS."
+    "Granit:Validation:UrlMustBeHttps": "URL:en måste använda HTTPS.",
+    "Granit:Validation:ValidToAfterValidFrom": "'Giltig till' måste vara efter 'Giltig från'."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/tr.json
+++ b/src/Granit.Validation/Localization/Validation/tr.json
@@ -61,17 +61,19 @@
     "Granit:Validation:MaxPresetEntries": "En fazla 20 ön ayara izin verilir.",
     "Granit:Validation:MaxQuickFilterEntries": "En fazla 20 hızlı filtreye izin verilir.",
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' {MaxLength} karakter veya daha az olmalıdır. {TotalLength} karakter girdiniz.",
+    "Granit:Validation:MeteringDistinctPropertyNotAllowed": "AggregationType CountDistinct olmadıkça DistinctProperty boş olmalıdır.",
+    "Granit:Validation:MeteringDistinctPropertyRequired": "AggregationType CountDistinct olduğunda DistinctProperty zorunludur.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' en az {MinLength} karakter olmalıdır. {TotalLength} karakter girdiniz.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' boş olmamalıdır.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}', '{ComparisonValue}' değerine eşit olmamalıdır.",
     "Granit:Validation:NotNullValidator": "'{PropertyName}' boş olmamalıdır.",
     "Granit:Validation:NullValidator": "'{PropertyName}' boş olmalıdır.",
+    "Granit:Validation:PaymentAmountOutOfRange": "Ödeme tutarı izin verilen aralığın dışında.",
     "Granit:Validation:PredicateValidator": "'{PropertyName}' için belirtilen koşul karşılanmadı.",
     "Granit:Validation:RegularExpressionValidator": "'{PropertyName}' doğru biçimde değil.",
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' toplamda {ExpectedPrecision} basamaktan fazla olmamalı ve {ExpectedScale} ondalık basamağa izin verilmelidir.",
     "Granit:Validation:ScheduledAction:FutureDate": "Planlanan tarih gelecekte olmalıdır.",
-    "Granit:Validation:ValidToAfterValidFrom": "'Geçerlilik bitiş tarihi', 'Geçerlilik başlangıç tarihi'nden sonra olmalıdır.",
-    "Granit:Validation:PaymentAmountOutOfRange": "Ödeme tutarı izin verilen aralığın dışında.",
-    "Granit:Validation:UrlMustBeHttps": "URL, HTTPS kullanmalıdır."
+    "Granit:Validation:UrlMustBeHttps": "URL, HTTPS kullanmalıdır.",
+    "Granit:Validation:ValidToAfterValidFrom": "'Geçerlilik bitiş tarihi', 'Geçerlilik başlangıç tarihi'nden sonra olmalıdır."
   }
 }

--- a/src/Granit.Validation/Localization/Validation/zh.json
+++ b/src/Granit.Validation/Localization/Validation/zh.json
@@ -61,17 +61,19 @@
     "Granit:Validation:MaxPresetEntries": "最多允许 20 个预设条目。",
     "Granit:Validation:MaxQuickFilterEntries": "最多允许 20 个快速筛选。",
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' 不能超过 {MaxLength} 个字符。您输入了 {TotalLength} 个字符。",
+    "Granit:Validation:MeteringDistinctPropertyNotAllowed": "除非 AggregationType 为 CountDistinct，否则 DistinctProperty 必须为 null。",
+    "Granit:Validation:MeteringDistinctPropertyRequired": "当 AggregationType 为 CountDistinct 时，DistinctProperty 为必填项。",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' 至少需要 {MinLength} 个字符。您输入了 {TotalLength} 个字符。",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' 不能为空。",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' 不能等于 '{ComparisonValue}'。",
     "Granit:Validation:NotNullValidator": "'{PropertyName}' 不能为空。",
     "Granit:Validation:NullValidator": "'{PropertyName}' 必须为空。",
+    "Granit:Validation:PaymentAmountOutOfRange": "付款金额超出允许范围。",
     "Granit:Validation:PredicateValidator": "'{PropertyName}' 的指定条件未满足。",
     "Granit:Validation:RegularExpressionValidator": "'{PropertyName}' 的格式不正确。",
     "Granit:Validation:ScalePrecisionValidator": "'{PropertyName}' 总共不能超过 {ExpectedPrecision} 位数字，其中允许 {ExpectedScale} 位小数。",
     "Granit:Validation:ScheduledAction:FutureDate": "计划日期必须是将来的日期。",
-    "Granit:Validation:ValidToAfterValidFrom": "'有效截止日期' 必须晚于 '有效起始日期'。",
-    "Granit:Validation:PaymentAmountOutOfRange": "付款金额超出允许范围。",
-    "Granit:Validation:UrlMustBeHttps": "URL 必须使用 HTTPS。"
+    "Granit:Validation:UrlMustBeHttps": "URL 必须使用 HTTPS。",
+    "Granit:Validation:ValidToAfterValidFrom": "'有效截止日期' 必须晚于 '有效起始日期'。"
   }
 }

--- a/tests/Granit.Metering.EntityFrameworkCore.Tests/Internal/AggregateCountDistinctTests.cs
+++ b/tests/Granit.Metering.EntityFrameworkCore.Tests/Internal/AggregateCountDistinctTests.cs
@@ -1,0 +1,174 @@
+using Granit.Metering.Domain;
+using Granit.Metering.EntityFrameworkCore.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Metering.EntityFrameworkCore.Tests.Internal;
+
+/// <summary>
+/// Pure-function tests for the CountDistinct aggregation path on
+/// <see cref="EfAggregationRunner.Aggregate"/>. The aggregator extracts a JSON
+/// property from each event's <c>Metadata</c>, dedupes the values, and returns
+/// the distinct count. Events with null/empty/invalid metadata or missing
+/// property are excluded entirely.
+/// </summary>
+public sealed class AggregateCountDistinctTests
+{
+    private static MeterDefinition NewCountDistinctMeter(string distinctProperty) =>
+        MeterDefinition.Create(
+            Guid.NewGuid(),
+            "Active Users",
+            "users",
+            AggregationType.CountDistinct,
+            description: null,
+            productId: null,
+            distinctProperty: distinctProperty);
+
+    private static MeterEvent NewEvent(string? metadataJson, decimal quantity = 1m) =>
+        MeterEvent.Create(
+            Guid.NewGuid(),
+            meterDefinitionId: Guid.NewGuid(),
+            idempotencyKey: Guid.NewGuid().ToString("N"),
+            quantity: quantity,
+            timestamp: DateTimeOffset.UtcNow,
+            metadata: metadataJson);
+
+    [Fact]
+    public void Aggregate_AllDistinct_ShouldReturnEventCount()
+    {
+        MeterDefinition meter = NewCountDistinctMeter("user_id");
+        var events = new List<MeterEvent>
+        {
+            NewEvent("""{"user_id":"alice"}"""),
+            NewEvent("""{"user_id":"bob"}"""),
+            NewEvent("""{"user_id":"carol"}"""),
+        };
+
+        EfAggregationRunner.Aggregate(meter, events).ShouldBe(3m);
+    }
+
+    [Fact]
+    public void Aggregate_AllSame_ShouldReturnOne()
+    {
+        MeterDefinition meter = NewCountDistinctMeter("user_id");
+        var events = Enumerable.Range(0, 5)
+            .Select(_ => NewEvent("""{"user_id":"alice"}"""))
+            .ToList();
+
+        EfAggregationRunner.Aggregate(meter, events).ShouldBe(1m);
+    }
+
+    [Fact]
+    public void Aggregate_MixedDuplicates_ShouldReturnDistinctCount()
+    {
+        MeterDefinition meter = NewCountDistinctMeter("user_id");
+        var events = new List<MeterEvent>
+        {
+            NewEvent("""{"user_id":"A"}"""),
+            NewEvent("""{"user_id":"A"}"""),
+            NewEvent("""{"user_id":"A"}"""),
+            NewEvent("""{"user_id":"A"}"""),
+            NewEvent("""{"user_id":"A"}"""),
+            NewEvent("""{"user_id":"B"}"""),
+            NewEvent("""{"user_id":"B"}"""),
+            NewEvent("""{"user_id":"B"}"""),
+        };
+
+        EfAggregationRunner.Aggregate(meter, events).ShouldBe(2m);
+    }
+
+    [Fact]
+    public void Aggregate_MissingProperty_ShouldExcludeEvent()
+    {
+        MeterDefinition meter = NewCountDistinctMeter("user_id");
+        var events = new List<MeterEvent>
+        {
+            NewEvent("""{"user_id":"alice"}"""),
+            NewEvent("""{"unrelated":"value"}"""),
+            NewEvent("""{"user_id":"bob"}"""),
+        };
+
+        EfAggregationRunner.Aggregate(meter, events).ShouldBe(2m);
+    }
+
+    [Fact]
+    public void Aggregate_NullOrEmptyMetadata_ShouldExcludeEvent()
+    {
+        MeterDefinition meter = NewCountDistinctMeter("user_id");
+        var events = new List<MeterEvent>
+        {
+            NewEvent("""{"user_id":"alice"}"""),
+            NewEvent(metadataJson: null),
+            NewEvent(""),
+            NewEvent("   "),
+        };
+
+        EfAggregationRunner.Aggregate(meter, events).ShouldBe(1m);
+    }
+
+    [Fact]
+    public void Aggregate_InvalidJson_ShouldExcludeEvent()
+    {
+        MeterDefinition meter = NewCountDistinctMeter("user_id");
+        var events = new List<MeterEvent>
+        {
+            NewEvent("""{"user_id":"alice"}"""),
+            NewEvent("not-json-at-all"),
+            NewEvent("{ malformed"),
+            NewEvent("""{"user_id":"bob"}"""),
+        };
+
+        EfAggregationRunner.Aggregate(meter, events).ShouldBe(2m);
+    }
+
+    [Fact]
+    public void Aggregate_NumericValues_ShouldBeStringified()
+    {
+        MeterDefinition meter = NewCountDistinctMeter("user_id");
+        var events = new List<MeterEvent>
+        {
+            NewEvent("""{"user_id":1}"""),
+            NewEvent("""{"user_id":"1"}"""), // distinct from numeric 1 — raw text "1" vs JSON string "1"
+            NewEvent("""{"user_id":2}"""),
+        };
+
+        // JsonValueKind.Number GetRawText() = "1"; String GetString() = "1" — collide ordinally.
+        EfAggregationRunner.Aggregate(meter, events).ShouldBe(2m);
+    }
+
+    [Fact]
+    public void Aggregate_NestedOrArrayValues_ShouldBeExcluded()
+    {
+        MeterDefinition meter = NewCountDistinctMeter("user_id");
+        var events = new List<MeterEvent>
+        {
+            NewEvent("""{"user_id":{"nested":"obj"}}"""),
+            NewEvent("""{"user_id":["array"]}"""),
+            NewEvent("""{"user_id":"alice"}"""),
+        };
+
+        EfAggregationRunner.Aggregate(meter, events).ShouldBe(1m);
+    }
+
+    [Fact]
+    public void Aggregate_BooleanValues_ShouldBeStringified()
+    {
+        MeterDefinition meter = NewCountDistinctMeter("flag");
+        var events = new List<MeterEvent>
+        {
+            NewEvent("""{"flag":true}"""),
+            NewEvent("""{"flag":false}"""),
+            NewEvent("""{"flag":true}"""),
+        };
+
+        EfAggregationRunner.Aggregate(meter, events).ShouldBe(2m);
+    }
+
+    [Fact]
+    public void Aggregate_NoEvents_ShouldReturnZero()
+    {
+        MeterDefinition meter = NewCountDistinctMeter("user_id");
+
+        EfAggregationRunner.Aggregate(meter, []).ShouldBe(0m);
+    }
+}

--- a/tests/Granit.Metering.Tests/MeterDefinitionTests.cs
+++ b/tests/Granit.Metering.Tests/MeterDefinitionTests.cs
@@ -224,4 +224,43 @@ public sealed class MeterDefinitionTests
 
         meter.ProductId.ShouldBeNull();
     }
+
+    // ======== CountDistinct + DistinctProperty pairing ========
+
+    [Fact]
+    public void Create_CountDistinct_WithoutDistinctProperty_ShouldThrow()
+    {
+        Should.Throw<ArgumentException>(() =>
+            MeterDefinition.Create(
+                Guid.NewGuid(), "MAU", "users", AggregationType.CountDistinct));
+    }
+
+    [Fact]
+    public void Create_CountDistinct_WithEmptyDistinctProperty_ShouldThrow()
+    {
+        Should.Throw<ArgumentException>(() =>
+            MeterDefinition.Create(
+                Guid.NewGuid(), "MAU", "users", AggregationType.CountDistinct,
+                description: null, productId: null, distinctProperty: "  "));
+    }
+
+    [Fact]
+    public void Create_CountDistinct_WithDistinctProperty_ShouldStoreIt()
+    {
+        var meter = MeterDefinition.Create(
+            Guid.NewGuid(), "MAU", "users", AggregationType.CountDistinct,
+            description: null, productId: null, distinctProperty: "user_id");
+
+        meter.AggregationType.ShouldBe(AggregationType.CountDistinct);
+        meter.DistinctProperty.ShouldBe("user_id");
+    }
+
+    [Fact]
+    public void Create_NonCountDistinct_WithDistinctProperty_ShouldThrow()
+    {
+        Should.Throw<ArgumentException>(() =>
+            MeterDefinition.Create(
+                Guid.NewGuid(), "Sum", "calls", AggregationType.Sum,
+                description: null, productId: null, distinctProperty: "user_id"));
+    }
 }


### PR DESCRIPTION
Closes #1166 (Phase 2 Story 2 of [EPIC #1155](https://github.com/granit-fx/granit-dotnet/issues/1155) ORB alignment, [Feature #1158](https://github.com/granit-fx/granit-dotnet/issues/1158) Metering hybrid).

Adds the missing fifth `AggregationType` for ORB-style **active-users billing** — counting unique values of a JSON property (e.g. `user_id`) over the period instead of raw events. Closes the gap that prevented MAU-style metric pricing.

## What ships

**Domain**
- `AggregationType.CountDistinct = 4`
- `MeterDefinition.DistinctProperty` (string?, max 200) — JSON property name extracted from each event's metadata
- Pairing rule on `MeterDefinition.Create()`: `DistinctProperty` is **required** when `AggregationType == CountDistinct`, and **must be `null`** for all other types. Both rules throw `ArgumentException` with explicit messages.

**HTTP validation** (mirrors the domain rule)
- `MeterDefinitionCreateRequestValidator` enforces the same pairing using `When(...)` clauses
- New error codes `Granit:Validation:MeteringDistinctPropertyRequired` / `MeteringDistinctPropertyNotAllowed`, localized in **15 base culture files** (regional `en-GB` / `fr-CA` / `pt-BR` inherit from base)

**Aggregator** (`EfAggregationRunner.Aggregate`)
- New `CountDistinct` branch: parses each event's `Metadata` JSON in C# (`System.Text.Json` — already a framework dep, provider-agnostic, bounded by the watermark window), extracts the property at the JSON root, dedupes ordinally with `HashSet<string>`
- **Stringification rules**: numbers and booleans are converted to their raw text representation, so `{\"id\":1}` and `{\"id\":\"1\"}` collide on the value `\"1\"`. Nested objects, arrays, and JSON `null` are excluded
- **Exclusion rules**: events with null/empty/whitespace metadata, malformed JSON, non-object root, or missing property are excluded entirely — never bucketed as a synthetic null

**HTTP DTOs**
- `MeterDefinitionCreateRequest` and `MeterDefinitionResponse` add trailing `DistinctProperty` (additive — record-positional consumers update one ctor call; JSON consumers see only an extra nullable field, non-breaking on the wire)

**Aggregator method visibility**
- `EfAggregationRunner.Aggregate` flipped to `internal static` so the new unit tests call it directly via the existing `InternalsVisibleTo` to `Granit.Metering.EntityFrameworkCore.Tests`. No public surface change.

## Schema (consumer apps run their own EF migration)

```sql
ALTER TABLE meter_definitions ADD DistinctProperty varchar(200) NULL;
```

No data migration required — the column is nullable and only populated for new `CountDistinct` meters.

## Test plan

- [x] `dotnet test tests/Granit.Metering.Tests` — 50 / 50 (4 new pairing tests on Create())
- [x] `dotnet test tests/Granit.Metering.EntityFrameworkCore.Tests` — 14 / 14 (10 new aggregator tests covering: all-distinct, all-same, mixed duplicates, missing property, null/empty/whitespace metadata, invalid JSON, numeric vs string collision, nested/array exclusion, boolean stringification, no events)
- [x] `dotnet build src/Granit.Metering*` — 0 errors, 0 warnings
- [ ] CI green on all 6 shards (TBD post-push — depends on #1186 architecture-test fix being merged)

## Stacking

This branch is logically stacked on the (now-merged) `feature/metering-lifecycle-status` (#1187 — Story #1165). The MeterDefinition domain refactor here builds on the lifecycle additions; the cherry-pick is clean because #1187 already merged.