### PR TITLE
feat(metering)!: migrate GET /metering/meters to QueryEngine pagination

### DIFF
--- a/src/Granit.Metering.Endpoints/Endpoints/MeterDefinitionEndpoints.cs
+++ b/src/Granit.Metering.Endpoints/Endpoints/MeterDefinitionEndpoints.cs
@@ -17,17 +17,6 @@ internal static class MeterDefinitionEndpoints
 {
     internal static RouteGroupBuilder MapMeterDefinitionEndpoints(this RouteGroupBuilder group)
     {
-        group.MapGet("/meters", ListPublishedMetersAsync)
-            .WithName("ListPublishedMeters")
-            .WithSummary("Returns all published meter definitions for the current tenant.")
-            .WithDescription(
-                "Fetches the list of meter definitions currently in the Published lifecycle state — "
-                + "the only state that accepts ingestion. Draft and Archived meters are excluded; "
-                + "use the GET by ID endpoint to retrieve a specific meter regardless of status.")
-            .Produces<IReadOnlyList<MeterDefinitionResponse>>()
-            .RequireAuthorization(MeteringPermissions.Meters.Read)
-            .AllowHostAccess();
-
         group.MapGet("/meters/{id:guid}", GetMeterByIdAsync)
             .WithName("GetMeterDefinition")
             .WithSummary("Returns a meter definition by its unique identifier.")
@@ -105,17 +94,6 @@ internal static class MeterDefinitionEndpoints
             .RequireAuthorization(MeteringPermissions.Meters.Manage);
 
         return group;
-    }
-
-    private static async Task<Ok<IReadOnlyList<MeterDefinitionResponse>>> ListPublishedMetersAsync(
-        [FromServices] IMeterDefinitionReader reader,
-        CancellationToken cancellationToken)
-    {
-        IReadOnlyList<MeterDefinition> meters = await reader
-            .GetActiveAsync(cancellationToken).ConfigureAwait(false);
-
-        return TypedResults.Ok<IReadOnlyList<MeterDefinitionResponse>>(
-            meters.Select(MeterDefinitionResponse.FromEntity).ToList());
     }
 
     private static async Task<Results<Ok<MeterDefinitionResponse>, ProblemHttpResult>> GetMeterByIdAsync(

--- a/src/Granit.Metering.Endpoints/Extensions/MeteringEndpointRouteBuilderExtensions.cs
+++ b/src/Granit.Metering.Endpoints/Extensions/MeteringEndpointRouteBuilderExtensions.cs
@@ -34,9 +34,13 @@ public static class MeteringEndpointRouteBuilderExtensions
         group.MapUsageEndpoints();
 
         // Admin query endpoints — list / filter / sort / paginate / export via the QueryEngine.
-        // Mounted on dedicated sub-paths to avoid colliding with the business endpoints above
-        // (/meters returns only active meters; /usage returns a single aggregate by period).
-        group.MapGranitGroup("meter-definitions")
+        // GET /meters is now QueryEngine-backed: it returns a paged envelope (replacing the
+        // previous flat array of Published meters) and supports filtering on every column
+        // declared by MeterDefinitionQueryDefinition, including LifecycleStatus. URL-level
+        // collisions are avoided because the QueryEngine routes (`/`, `/meta`, `/saved-views`)
+        // do not overlap with the GUID-constrained CRUD routes (`/{id:guid}`, `/{id:guid}/...`)
+        // mapped above.
+        group.MapGranitGroup("meters")
             .MapGranitQuery<MeterDefinition>()
             .RequireAuthorization(MeteringPermissions.Meters.Read);
 


### PR DESCRIPTION
Closes #1170 (Phase 2 Story 3 of [EPIC #1155](https://github.com/granit-fx/granit-dotnet/issues/1155) ORB alignment, [Feature #1158](https://github.com/granit-fx/granit-dotnet/issues/1158) Metering hybrid).

Replaces the legacy flat-list `GET /metering/meters` endpoint with the QueryEngine-backed paginated, filterable, sortable list — same path, new envelope.

## What changes

**Before**
- `GET /metering/meters` → `IReadOnlyList<MeterDefinitionResponse>` (flat array, only Published meters, no filters, no pagination).

**After**
- `GET /metering/meters` → QueryEngine paged envelope `{ items, totalCount, pageSize, pageNumber }`, with all columns declared in `MeterDefinitionQueryDefinition` (`Tenant`, `Name`, `Unit`, `AggregationType`, `LifecycleStatus`, `CreatedAt`, `ModifiedAt`).
- Status filter: `?filter[lifecycleStatus.eq]=Published` (also `Draft`, `Archived`)
- Sort: `?sort=name asc`
- Pagination: `?pageNumber=1&pageSize=25`
- Bonus QueryEngine routes: `GET /meters/meta`, `GET /meters/saved-views`, `POST /meters/saved-views`, etc.

**Unchanged**
- `GET /meters/{id}` — single get
- `POST /meters` — create
- `PUT /meters/{id}` — update
- `POST /meters/{id}/{publish|archive|deactivate}` — lifecycle transitions

## Why the path stays /meters

The resource noun is "meters". The previous duplicate `/metering/meter-definitions` sub-path is removed (unused, internal) — no consumer relied on it. QueryEngine routes (`/`, `/meta`, `/saved-views`) do not collide with the GUID-constrained CRUD routes (`/{id:guid}`).

## Breaking changes

| Surface | Change | Mitigation |
|---|---|---|
| `GET /metering/meters` response shape | Was `MeterDefinitionResponse[]`, now `{ items, totalCount, pageSize, pageNumber }` | Auto-generated SDK clients (granit-showcase-admin-react, granit-front packages) regenerate from OpenAPI on next build. Hand-written consumers update to read `.items`. |
| Default scope changed | Was "only Published"; now returns all statuses by default | Add explicit `?filter[lifecycleStatus.eq]=Published` to restore previous behavior |
| `/metering/meter-definitions` path removed | Internal sub-path that mirrored QueryEngine | None — no documented consumer |

## Test plan

- [x] `dotnet build src/Granit.Metering.Endpoints` — 0 errors, 0 warnings
- [x] `dotnet test tests/Granit.Metering.Endpoints.Tests` — 9 / 9 (idempotency suite — covers the orthogonal behavior; no test referenced the removed legacy list endpoint)
- [ ] CI green on all 6 shards (TBD post-push — depends on #1186 architecture-test fix)