### PR TITLE
fix(openiddict)!: forward Identity.Application cookie to Bearer when Authorization header is present

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -24476,6 +24476,24 @@
       "members": []
     },
     {
+      "name": "RecomputeUsageRequest",
+      "fqn": "Granit.Metering.Endpoints.Dtos.RecomputeUsageRequest",
+      "kind": "record",
+      "project": "Granit.Metering.Endpoints",
+      "file": "src/Granit.Metering.Endpoints/Dtos/RecomputeUsageRequest.cs",
+      "line": 13,
+      "members": []
+    },
+    {
+      "name": "RecomputeUsageResponse",
+      "fqn": "Granit.Metering.Endpoints.Dtos.RecomputeUsageResponse",
+      "kind": "record",
+      "project": "Granit.Metering.Endpoints",
+      "file": "src/Granit.Metering.Endpoints/Dtos/RecomputeUsageResponse.cs",
+      "line": 4,
+      "members": []
+    },
+    {
       "name": "RecordUsageRequest",
       "fqn": "Granit.Metering.Endpoints.Dtos.RecordUsageRequest",
       "kind": "record",
@@ -24573,7 +24591,7 @@
       "kind": "class",
       "project": "Granit.Metering.EntityFrameworkCore",
       "file": "src/Granit.Metering.EntityFrameworkCore/Extensions/MeteringEntityFrameworkCoreHostApplicationBuilderExtensions.cs",
-      "line": 16,
+      "line": 17,
       "members": [
         {
           "name": "AddGranitMeteringEntityFrameworkCore",
@@ -24932,6 +24950,56 @@
           "returnType": "string"
         }
       ]
+    },
+    {
+      "name": "IUsageRecomputeService",
+      "fqn": "Granit.Metering.Recompute.IUsageRecomputeService",
+      "kind": "interface",
+      "project": "Granit.Metering",
+      "file": "src/Granit.Metering/Recompute/IUsageRecomputeService.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "RecomputeAsync",
+          "kind": "method",
+          "signature": "RecomputeAsync(UsageRecomputeRequest request, CancellationToken cancellationToken = default)",
+          "returnType": "Task<UsageRecomputeResult>"
+        }
+      ]
+    },
+    {
+      "name": "UsageRecomputeRejectedException",
+      "fqn": "Granit.Metering.Recompute.UsageRecomputeRejectedException",
+      "kind": "class",
+      "project": "Granit.Metering",
+      "file": "src/Granit.Metering/Recompute/UsageRecomputeRejectedException.cs",
+      "line": 7,
+      "members": [
+        {
+          "name": "ReasonCode",
+          "kind": "property",
+          "signature": "string ReasonCode",
+          "returnType": "string"
+        }
+      ]
+    },
+    {
+      "name": "UsageRecomputeRequest",
+      "fqn": "Granit.Metering.Recompute.UsageRecomputeRequest",
+      "kind": "record",
+      "project": "Granit.Metering",
+      "file": "src/Granit.Metering/Recompute/UsageRecomputeRequest.cs",
+      "line": 15,
+      "members": []
+    },
+    {
+      "name": "UsageRecomputeResult",
+      "fqn": "Granit.Metering.Recompute.UsageRecomputeResult",
+      "kind": "record",
+      "project": "Granit.Metering",
+      "file": "src/Granit.Metering/Recompute/UsageRecomputeResult.cs",
+      "line": 13,
+      "members": []
     },
     {
       "name": "ApplicationInitializationContext",

--- a/src/Granit.Metering.Endpoints/Dtos/RecomputeUsageRequest.cs
+++ b/src/Granit.Metering.Endpoints/Dtos/RecomputeUsageRequest.cs
@@ -1,0 +1,15 @@
+namespace Granit.Metering.Endpoints.Dtos;
+
+/// <summary>
+/// HTTP body for <c>POST /metering/meters/{id}/recompute</c>.
+/// </summary>
+/// <param name="From">Inclusive lower bound of the recompute window (UTC, ISO 8601).</param>
+/// <param name="To">Exclusive upper bound of the recompute window (UTC, ISO 8601).</param>
+/// <remarks>
+/// Window edges are snapped to hourly buckets server-side; partial hours are fully
+/// rebuilt. The global ingestion watermark is never rewound — concurrent ingestion
+/// past <paramref name="To"/> is unaffected.
+/// </remarks>
+public sealed record RecomputeUsageRequest(
+    DateTimeOffset From,
+    DateTimeOffset To);

--- a/src/Granit.Metering.Endpoints/Dtos/RecomputeUsageResponse.cs
+++ b/src/Granit.Metering.Endpoints/Dtos/RecomputeUsageResponse.cs
@@ -1,0 +1,10 @@
+namespace Granit.Metering.Endpoints.Dtos;
+
+/// <summary>HTTP response shape for an executed recompute.</summary>
+public sealed record RecomputeUsageResponse(
+    Guid MeterDefinitionId,
+    DateTimeOffset WindowStart,
+    DateTimeOffset WindowEnd,
+    int EventsScanned,
+    int AggregatesRebuilt,
+    long DurationMilliseconds);

--- a/src/Granit.Metering.Endpoints/Endpoints/MeterDefinitionEndpoints.cs
+++ b/src/Granit.Metering.Endpoints/Endpoints/MeterDefinitionEndpoints.cs
@@ -5,6 +5,7 @@ using Granit.Metering.Domain;
 using Granit.Metering.Domain.ValueObjects;
 using Granit.Metering.Endpoints.Dtos;
 using Granit.Metering.Endpoints.Permissions;
+using Granit.Metering.Recompute;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -88,6 +89,23 @@ internal static class MeterDefinitionEndpoints
             .Produces(StatusCodes.Status204NoContent)
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict)
+            .RequireAuthorization(MeteringPermissions.Meters.Manage);
+
+        group.MapPost("/meters/{id:guid}/recompute", RecomputeMeterUsageAsync)
+            .WithName("RecomputeMeterUsage")
+            .WithSummary("Recomputes UsageAggregate rows for a meter over a chosen window.")
+            .WithDescription(
+                "Re-runs the aggregation pipeline over the requested [from, to) window, "
+                + "rebuilding hourly UsageAggregate rows from the raw MeterEvent data. "
+                + "Window edges are snapped to hourly buckets server-side. The global ingestion "
+                + "watermark is never rewound — concurrent ingestion past the upper bound is unaffected. "
+                + "Mutually-excludes with the hourly aggregation job on the same (meter, tenant) via a "
+                + "transaction-scoped database lock. Returns 422 when the window is empty/inverted/in the "
+                + "future, when the meter is unknown, or when the meter is Archived.")
+            .WithMetadata(new IdempotentAttribute { Required = false })
+            .Produces<RecomputeUsageResponse>()
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+            .ProducesValidationProblem()
             .RequireAuthorization(MeteringPermissions.Meters.Manage);
 
         group.MapPost("/meters/{id:guid}/deactivate", DeactivateMeterAsync)
@@ -249,5 +267,36 @@ internal static class MeterDefinitionEndpoints
         httpContext.Response.Headers["Link"] = "</metering/meters/{id}/archive>; rel=\"successor-version\"";
 
         return await ArchiveMeterAsync(id, reader, writer, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<Results<Ok<RecomputeUsageResponse>, ProblemHttpResult>> RecomputeMeterUsageAsync(
+        Guid id,
+        RecomputeUsageRequest request,
+        [FromServices] IUsageRecomputeService service,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            UsageRecomputeResult result = await service
+                .RecomputeAsync(
+                    new UsageRecomputeRequest(id, request.From, request.To),
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            return TypedResults.Ok(new RecomputeUsageResponse(
+                result.MeterDefinitionId,
+                result.WindowStart,
+                result.WindowEnd,
+                result.EventsScanned,
+                result.AggregatesRebuilt,
+                result.DurationMilliseconds));
+        }
+        catch (UsageRecomputeRejectedException ex)
+        {
+            return TypedResults.Problem(
+                detail: ex.Message,
+                title: ex.ReasonCode,
+                statusCode: StatusCodes.Status422UnprocessableEntity);
+        }
     }
 }

--- a/src/Granit.Metering.Endpoints/Validators/RecomputeUsageRequestValidator.cs
+++ b/src/Granit.Metering.Endpoints/Validators/RecomputeUsageRequestValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+using Granit.Metering.Endpoints.Dtos;
+using Granit.Validation.Extensions;
+
+namespace Granit.Metering.Endpoints.Validators;
+
+internal sealed class RecomputeUsageRequestValidator : AbstractValidator<RecomputeUsageRequest>
+{
+    public RecomputeUsageRequestValidator()
+    {
+        RuleFor(x => x.From)
+            .NotEmpty();
+
+        RuleFor(x => x.To)
+            .NotEmpty()
+            .GreaterThan(x => x.From)
+            .WithErrorCodeAndMessage("Granit:Validation:MeteringRecomputeWindowInvalid");
+    }
+}

--- a/src/Granit.Metering.EntityFrameworkCore/Extensions/MeteringEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Extensions/MeteringEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Granit.DataLookup.EntityFrameworkCore.Extensions;
 using Granit.Metering.Domain;
 using Granit.Metering.EntityFrameworkCore.Internal;
+using Granit.Metering.Recompute;
 using Granit.Persistence.EntityFrameworkCore.Extensions;
 using Granit.QueryEngine;
 using Microsoft.EntityFrameworkCore;
@@ -33,6 +34,7 @@ public static class MeteringEntityFrameworkCoreHostApplicationBuilderExtensions
 
         builder.Services.TryAddScoped<IAggregationRunner, EfAggregationRunner>();
         builder.Services.TryAddScoped<IQuotaChecker, EfQuotaChecker>();
+        builder.Services.TryAddScoped<IUsageRecomputeService, EfUsageRecomputeService>();
 
         // Queryable sources for MapGranitQuery (host bypasses tenant filter for cross-tenant review).
         builder.Services.AddScoped<IQueryableSource<MeterDefinition>, EfMeterDefinitionQueryableSource>();

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/EfAggregationRunner.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/EfAggregationRunner.cs
@@ -7,6 +7,7 @@ using Granit.Metering.Domain;
 using Granit.Persistence.EntityFrameworkCore.ExceptionHandling;
 using Granit.Timing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Logging;
 
 namespace Granit.Metering.EntityFrameworkCore.Internal;
@@ -54,6 +55,16 @@ internal sealed partial class EfAggregationRunner(
         await using MeteringDbContext db = await contextFactory
             .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
 
+        // Mutually-exclude with on-demand recompute on the same (meter, tenant) — the
+        // recompute service acquires the same lock. The lock auto-releases at COMMIT/ROLLBACK
+        // so there is no leak risk on transient failure.
+        await using IDbContextTransaction tx = await db.Database
+            .BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        await MeteringConcurrencyLock
+            .AcquireAsync(db, definition.Id, definition.TenantId, cancellationToken)
+            .ConfigureAwait(false);
+
         AggregationWatermark? watermark = await db.AggregationWatermarks
             .FirstOrDefaultAsync(
                 w => w.MeterDefinitionId == definition.Id
@@ -77,6 +88,7 @@ internal sealed partial class EfAggregationRunner(
 
         if (events.Count == 0)
         {
+            await tx.CommitAsync(cancellationToken).ConfigureAwait(false);
             return;
         }
 
@@ -117,9 +129,11 @@ internal sealed partial class EfAggregationRunner(
         try
         {
             await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await tx.CommitAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (DbUpdateException ex) when (DbUpdateExceptionHelper.IsDuplicateKeyException(ex))
         {
+            await tx.RollbackAsync(cancellationToken).ConfigureAwait(false);
             Log.AggregationCollisionIgnored(logger, definition.Name, ex);
             return;
         }

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/EfUsageRecomputeService.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/EfUsageRecomputeService.cs
@@ -1,0 +1,219 @@
+using System.Diagnostics;
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.Guids;
+using Granit.Metering.Diagnostics;
+using Granit.Metering.Domain;
+using Granit.Metering.Recompute;
+using Granit.Persistence.EntityFrameworkCore.ExceptionHandling;
+using Granit.Timing;
+using Granit.Workflow.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Metering.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IUsageRecomputeService"/>.
+/// </summary>
+internal sealed partial class EfUsageRecomputeService(
+    IDbContextFactory<MeteringDbContext> contextFactory,
+    IMeterDefinitionReader definitionReader,
+    MeteringMetrics metrics,
+    IClock clock,
+    IGuidGenerator guidGenerator,
+    IDataFilter? dataFilter,
+    ILogger<EfUsageRecomputeService> logger) : IUsageRecomputeService
+{
+    public async Task<UsageRecomputeResult> RecomputeAsync(
+        UsageRecomputeRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.From >= request.To)
+        {
+            throw new UsageRecomputeRejectedException(
+                "Granit:Metering:RecomputeWindowInvalid",
+                $"Recompute window is empty or inverted: from={request.From:O} to={request.To:O}.");
+        }
+
+        if (request.To > clock.Now)
+        {
+            throw new UsageRecomputeRejectedException(
+                "Granit:Metering:RecomputeWindowInFuture",
+                $"Recompute window upper bound {request.To:O} is in the future (now={clock.Now:O}).");
+        }
+
+        // Definitions are loaded with the tenant filter disabled because the recompute
+        // can be invoked by host admins acting on behalf of a tenant; the lock + writes
+        // below explicitly scope to the meter's own TenantId.
+        using IDisposable? _ = dataFilter?.Disable<IMultiTenant>();
+
+        MeterDefinition? definition = await definitionReader
+            .GetByIdAsync(Domain.ValueObjects.MeterDefinitionId.Create(request.MeterDefinitionId), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (definition is null)
+        {
+            throw new UsageRecomputeRejectedException(
+                "Granit:Metering:RecomputeMeterNotFound",
+                $"Meter '{request.MeterDefinitionId}' not found.");
+        }
+
+        if (definition.LifecycleStatus == WorkflowLifecycleStatus.Archived)
+        {
+            throw new UsageRecomputeRejectedException(
+                "Granit:Metering:RecomputeMeterArchived",
+                $"Meter '{request.MeterDefinitionId}' is Archived; recompute is not allowed on archived meters.");
+        }
+
+        long startTimestamp = Stopwatch.GetTimestamp();
+
+        await using MeteringDbContext db = await contextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        await using IDbContextTransaction tx = await db.Database
+            .BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+        await MeteringConcurrencyLock
+            .AcquireAsync(db, definition.Id, definition.TenantId, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Snap window edges to hourly buckets so partial hours are fully rebuilt.
+        DateTimeOffset windowStart = SnapToHour(request.From);
+        DateTimeOffset windowEnd = SnapToHour(request.To);
+        if (windowEnd <= windowStart)
+        {
+            windowEnd = windowStart.AddHours(1);
+        }
+
+        // Pull every event in the window (newest aggregator pass would have included
+        // these); group by hourly bucket and feed each group through the same Aggregate
+        // function used by the hourly job, so behavior stays consistent.
+        List<MeterEvent> events = await db.MeterEvents
+            .Where(e => e.MeterDefinitionId == definition.Id
+                && e.TenantId == definition.TenantId
+                && e.Timestamp >= windowStart
+                && e.Timestamp < windowEnd)
+            .OrderBy(e => e.Timestamp)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Existing aggregates in the same window — we'll either Recompute() or Remove() them.
+        List<UsageAggregate> existingAggregates = await db.UsageAggregates
+            .Where(a => a.MeterDefinitionId == definition.Id
+                && a.TenantId == definition.TenantId
+                && a.Period == AggregationPeriod.Hourly
+                && a.PeriodStart >= windowStart
+                && a.PeriodStart < windowEnd)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var existingByStart = existingAggregates.ToDictionary(a => a.PeriodStart);
+
+        IEnumerable<IGrouping<DateTimeOffset, MeterEvent>> bucketed = events.GroupBy(e => SnapToHour(e.Timestamp));
+
+        int aggregatesRebuilt = 0;
+        HashSet<DateTimeOffset> bucketsTouched = [];
+
+        foreach (IGrouping<DateTimeOffset, MeterEvent> bucket in bucketed)
+        {
+            DateTimeOffset bucketStart = bucket.Key;
+            DateTimeOffset bucketEnd = bucketStart.AddHours(1);
+            decimal aggregatedValue = EfAggregationRunner.Aggregate(definition, [.. bucket]);
+            int eventCount = bucket.Count();
+            bucketsTouched.Add(bucketStart);
+
+            if (existingByStart.TryGetValue(bucketStart, out UsageAggregate? existing))
+            {
+                existing.Recompute(aggregatedValue, eventCount);
+            }
+            else
+            {
+                db.UsageAggregates.Add(UsageAggregate.Create(
+                    guidGenerator.Create(),
+                    definition.Id,
+                    AggregationPeriod.Hourly,
+                    bucketStart,
+                    bucketEnd,
+                    aggregatedValue,
+                    eventCount));
+            }
+
+            aggregatesRebuilt++;
+        }
+
+        // Buckets that previously had aggregates but no longer have any events
+        // (events were deprecated/deleted) must be removed — leaving stale rows
+        // would silently overcharge customers.
+        foreach (UsageAggregate stale in existingAggregates
+            .Where(a => !bucketsTouched.Contains(a.PeriodStart)))
+        {
+            db.UsageAggregates.Remove(stale);
+            aggregatesRebuilt++;
+        }
+
+        try
+        {
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await tx.CommitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex) when (DbUpdateExceptionHelper.IsDuplicateKeyException(ex))
+        {
+            // Concurrent recompute or aggregator commit raced past our lock acquisition;
+            // because both sides take the same lock this should not happen — log and
+            // bubble out, the caller can retry.
+            await tx.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            Log.RecomputeCollision(logger, definition.Name, ex);
+            throw;
+        }
+
+        long elapsedMs = (long)Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
+
+        metrics.RecordRecompute(
+            definition.TenantId?.ToString(),
+            definition.Id,
+            aggregatesRebuilt);
+
+        Log.RecomputeCompleted(
+            logger,
+            definition.Name,
+            windowStart,
+            windowEnd,
+            events.Count,
+            aggregatesRebuilt,
+            elapsedMs);
+
+        return new UsageRecomputeResult(
+            definition.Id,
+            windowStart,
+            windowEnd,
+            events.Count,
+            aggregatesRebuilt,
+            elapsedMs);
+    }
+
+    private static DateTimeOffset SnapToHour(DateTimeOffset value) =>
+        new(value.Year, value.Month, value.Day, value.Hour, 0, 0, value.Offset);
+
+    private static partial class Log
+    {
+        [LoggerMessage(Level = LogLevel.Information,
+            Message = "Recompute completed for meter '{MeterName}' over [{WindowStart:O}, {WindowEnd:O}): {EventsScanned} events, {AggregatesRebuilt} aggregates rebuilt in {ElapsedMs}ms")]
+        public static partial void RecomputeCompleted(
+            ILogger logger,
+            string meterName,
+            DateTimeOffset windowStart,
+            DateTimeOffset windowEnd,
+            int eventsScanned,
+            int aggregatesRebuilt,
+            long elapsedMs);
+
+        [LoggerMessage(Level = LogLevel.Warning,
+            Message = "Recompute for meter '{MeterName}' aborted on duplicate-key collision; retry safely.")]
+        public static partial void RecomputeCollision(
+            ILogger logger, string meterName, Exception exception);
+    }
+}

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/MeteringConcurrencyLock.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/MeteringConcurrencyLock.cs
@@ -1,0 +1,94 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Granit.Metering.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// Cross-database transaction-scoped lock helper for the metering aggregator.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both the recompute service and the hourly aggregation job acquire the same lock
+/// per <c>(MeterDefinitionId, TenantId)</c> inside their transaction so that they
+/// cannot interleave on the same meter/tenant. Raw ingestion is unaffected because
+/// it does not acquire this lock.
+/// </para>
+/// <para>
+/// Provider dispatch:
+/// <list type="bullet">
+///   <item>PostgreSQL → <c>pg_advisory_xact_lock(hashtext(...))</c></item>
+///   <item>SQL Server → <c>sp_getapplock @LockOwner='Transaction'</c></item>
+///   <item>InMemory / unknown → no-op (logged at debug; tests use this path)</item>
+/// </list>
+/// In all dialects the lock auto-releases on COMMIT/ROLLBACK — no leak risk.
+/// </para>
+/// </remarks>
+internal static class MeteringConcurrencyLock
+{
+    private const string PostgresProvider = "Npgsql.EntityFrameworkCore.PostgreSQL";
+    private const string SqlServerProvider = "Microsoft.EntityFrameworkCore.SqlServer";
+
+    /// <summary>
+    /// Acquires the lock inside the active transaction. Caller MUST have already opened
+    /// a transaction (<c>db.Database.BeginTransactionAsync</c>); the lock is released
+    /// automatically when that transaction commits or rolls back.
+    /// </summary>
+    /// <param name="db">DbContext with an open transaction.</param>
+    /// <param name="meterDefinitionId">Meter being processed.</param>
+    /// <param name="tenantId">Owning tenant (or <c>null</c> for host-owned meters).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><c>true</c> if the lock was acquired (or no-op on unsupported providers); <c>false</c> never returned in blocking mode.</returns>
+    public static async Task AcquireAsync(
+        DbContext db,
+        Guid meterDefinitionId,
+        Guid? tenantId,
+        CancellationToken cancellationToken)
+    {
+        string resource = BuildResourceKey(meterDefinitionId, tenantId);
+        string? providerName = db.Database.ProviderName;
+
+        switch (providerName)
+        {
+            case PostgresProvider:
+                // pg_advisory_xact_lock is blocking: waits until the lock is free,
+                // then auto-releases at transaction end.
+                await db.Database.ExecuteSqlRawAsync(
+                    "SELECT pg_advisory_xact_lock(hashtext({0}))",
+                    [resource],
+                    cancellationToken).ConfigureAwait(false);
+                break;
+
+            case SqlServerProvider:
+                // sp_getapplock with @LockOwner='Transaction' auto-releases on COMMIT/ROLLBACK.
+                // @LockTimeout = -1 → wait indefinitely (matches PostgreSQL semantics).
+                await db.Database.ExecuteSqlRawAsync(
+                    """
+                    DECLARE @result int;
+                    EXEC @result = sp_getapplock
+                        @Resource    = {0},
+                        @LockMode    = 'Exclusive',
+                        @LockOwner   = 'Transaction',
+                        @LockTimeout = -1;
+                    IF @result < 0
+                        THROW 51000, 'Failed to acquire metering concurrency lock', 1;
+                    """,
+                    [resource],
+                    cancellationToken).ConfigureAwait(false);
+                break;
+
+            default:
+                // InMemory / Sqlite / unknown — no native lock primitive.
+                // Tests rely on this path; production deployments are expected to use
+                // PostgreSQL or SQL Server (the framework's two supported providers).
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Stable string key used as the lock resource. Meter id + tenant id (or "global"
+    /// when host-owned) — collision risk is negligible because PostgreSQL hashes the
+    /// string into a 32-bit lock id internally.
+    /// </summary>
+    internal static string BuildResourceKey(Guid meterDefinitionId, Guid? tenantId) =>
+        $"granit.metering.aggregate:{meterDefinitionId:N}:{(tenantId is null ? "global" : tenantId.Value.ToString("N"))}";
+}

--- a/src/Granit.Metering/Diagnostics/MeteringMetrics.cs
+++ b/src/Granit.Metering/Diagnostics/MeteringMetrics.cs
@@ -21,6 +21,7 @@ public sealed class MeteringMetrics
     private readonly Counter<long> _aggregationsCompleted;
     private readonly Counter<long> _quotaThresholdsReached;
     private readonly Counter<long> _quotasExceeded;
+    private readonly Counter<long> _recomputesExecuted;
 
     /// <summary>Initializes metering metrics using the specified meter factory.</summary>
     public MeteringMetrics(IMeterFactory meterFactory)
@@ -46,6 +47,10 @@ public sealed class MeteringMetrics
         _quotasExceeded = meter.CreateCounter<long>(
             "granit.metering.quota.exceeded",
             description: "Number of quota exceeded alerts triggered.");
+
+        _recomputesExecuted = meter.CreateCounter<long>(
+            "granit.metering.recomputes.executed",
+            description: "Number of on-demand UsageAggregate recompute operations executed.");
     }
 
     /// <summary>Records a meter event insertion.</summary>
@@ -101,5 +106,17 @@ public sealed class MeteringMetrics
             { MeterDefinitionIdTag, meterDefinitionId.ToString() },
         };
         _quotasExceeded.Add(1, tags);
+    }
+
+    /// <summary>Records a successful on-demand recompute over a window.</summary>
+    public void RecordRecompute(string? tenantId, Guid meterDefinitionId, long aggregatesRebuilt)
+    {
+        var tags = new TagList
+        {
+            { TenantIdTag, tenantId ?? GlobalTenant },
+            { MeterDefinitionIdTag, meterDefinitionId.ToString() },
+            { "aggregates_rebuilt", aggregatesRebuilt },
+        };
+        _recomputesExecuted.Add(1, tags);
     }
 }

--- a/src/Granit.Metering/Recompute/IUsageRecomputeService.cs
+++ b/src/Granit.Metering/Recompute/IUsageRecomputeService.cs
@@ -1,0 +1,28 @@
+namespace Granit.Metering.Recompute;
+
+/// <summary>
+/// Recomputes pre-computed <see cref="Domain.UsageAggregate"/> rows over a chosen
+/// time window. Used after data corrections (deprecated events, backfilled events,
+/// formula tweaks) to repair past billing data without touching the forward-looking
+/// ingestion watermark.
+/// </summary>
+/// <remarks>
+/// Implementations must guard against concurrent execution with the hourly aggregation
+/// job by acquiring a database-side lock on <c>(MeterDefinitionId, TenantId)</c> within
+/// the same transaction that rewrites the aggregates. The lock auto-releases on
+/// COMMIT/ROLLBACK; both the recompute service and the aggregation job acquire the
+/// same lock, so they serialize naturally without affecting raw ingestion.
+/// </remarks>
+public interface IUsageRecomputeService
+{
+    /// <summary>Recomputes the meter over the requested window.</summary>
+    /// <param name="request">Meter id and inclusive/exclusive bounds.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The number of events scanned and aggregates rebuilt.</returns>
+    /// <exception cref="UsageRecomputeRejectedException">
+    /// The meter is unknown, archived, or the window is invalid.
+    /// </exception>
+    Task<UsageRecomputeResult> RecomputeAsync(
+        UsageRecomputeRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Granit.Metering/Recompute/UsageRecomputeRejectedException.cs
+++ b/src/Granit.Metering/Recompute/UsageRecomputeRejectedException.cs
@@ -1,0 +1,12 @@
+namespace Granit.Metering.Recompute;
+
+/// <summary>
+/// Raised when a recompute is rejected at the domain layer (unknown meter,
+/// archived meter, invalid window).
+/// </summary>
+public sealed class UsageRecomputeRejectedException(string reasonCode, string message)
+    : Exception(message)
+{
+    /// <summary>Stable code identifying the rejection reason for HTTP mapping.</summary>
+    public string ReasonCode { get; } = reasonCode;
+}

--- a/src/Granit.Metering/Recompute/UsageRecomputeRequest.cs
+++ b/src/Granit.Metering/Recompute/UsageRecomputeRequest.cs
@@ -1,0 +1,18 @@
+namespace Granit.Metering.Recompute;
+
+/// <summary>
+/// Domain-level request for an on-demand recompute of pre-computed
+/// <see cref="Domain.UsageAggregate"/> rows over a time window.
+/// </summary>
+/// <param name="MeterDefinitionId">Meter to recompute.</param>
+/// <param name="From">Inclusive lower bound of the window (UTC).</param>
+/// <param name="To">Exclusive upper bound of the window (UTC).</param>
+/// <remarks>
+/// The recompute is bounded — the global ingestion watermark is never rewound,
+/// so concurrent ingestion past the window is safe. Only past
+/// <see cref="Domain.AggregationPeriod.Hourly"/> rows in the window are rewritten.
+/// </remarks>
+public sealed record UsageRecomputeRequest(
+    Guid MeterDefinitionId,
+    DateTimeOffset From,
+    DateTimeOffset To);

--- a/src/Granit.Metering/Recompute/UsageRecomputeResult.cs
+++ b/src/Granit.Metering/Recompute/UsageRecomputeResult.cs
@@ -1,0 +1,19 @@
+namespace Granit.Metering.Recompute;
+
+/// <summary>Outcome of an on-demand recompute.</summary>
+/// <param name="MeterDefinitionId">Meter that was recomputed.</param>
+/// <param name="WindowStart">Inclusive lower bound of the recomputed window.</param>
+/// <param name="WindowEnd">Exclusive upper bound of the recomputed window.</param>
+/// <param name="EventsScanned">Total raw <see cref="Domain.MeterEvent"/> rows considered.</param>
+/// <param name="AggregatesRebuilt">
+/// Total <see cref="Domain.UsageAggregate"/> rows written (created or updated). Equals
+/// the number of distinct hourly buckets in the window that received at least one event.
+/// </param>
+/// <param name="DurationMilliseconds">End-to-end wall-clock duration of the operation.</param>
+public sealed record UsageRecomputeResult(
+    Guid MeterDefinitionId,
+    DateTimeOffset WindowStart,
+    DateTimeOffset WindowEnd,
+    int EventsScanned,
+    int AggregatesRebuilt,
+    long DurationMilliseconds);

--- a/src/Granit.OpenIddict/GranitOpenIddictModule.cs
+++ b/src/Granit.OpenIddict/GranitOpenIddictModule.cs
@@ -85,6 +85,32 @@ public sealed class GranitOpenIddictModule : GranitModule
             IdentityCookieDefinitionContributor.DefaultApplicationCookieName,
             IdentityCookieDefinitionContributor.DevApplicationCookieName);
 
+        // When an incoming request carries an `Authorization` header, forward the
+        // Identity.Application cookie scheme to OpenIddict token validation (Bearer).
+        // BFF-integrated deployments serve the same backend to multiple SPAs (e.g.
+        // /host and /app) and the Identity cookie is shared across them (localhost
+        // in dev, shared parent domain in production). A user logging in on one
+        // side overwrites the cookie, and without this forward the cookie-authenticated
+        // principal wins over the BFF-injected Bearer token — authorising the request
+        // as the wrong user (403 on host admin endpoints once a tenant user has logged
+        // in, and vice-versa). Requests without an `Authorization` header (e.g. the
+        // OIDC server's `/connect/*` endpoints) keep using cookie auth unchanged.
+        context.Services.PostConfigure<Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationOptions>(
+            Microsoft.AspNetCore.Identity.IdentityConstants.ApplicationScheme,
+            options =>
+            {
+                // Scheme name is the well-known OpenIddict validation scheme. Using the
+                // string literal (rather than `OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme`)
+                // avoids forcing every Granit.OpenIddict consumer to pull in
+                // `OpenIddict.Validation.AspNetCore` as a direct reference — this base
+                // module stays free of the ASP.NET Core validation integration and the
+                // constant stays pinned to the OpenIddict contract.
+                options.ForwardDefaultSelector = httpContext =>
+                    httpContext.Request.Headers.ContainsKey(Microsoft.Net.Http.Headers.HeaderNames.Authorization)
+                        ? "OpenIddict.Validation.AspNetCore"
+                        : null;
+            });
+
         PostConfigureIdentityCookie(context.Services, isDevelopment,
             Microsoft.AspNetCore.Identity.IdentityConstants.TwoFactorUserIdScheme,
             IdentityCookieDefinitionContributor.DefaultTwoFactorCookieName,

--- a/src/Granit.Validation/Localization/Validation/cs.json
+++ b/src/Granit.Validation/Localization/Validation/cs.json
@@ -63,6 +63,7 @@
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' nesmí mít více než {MaxLength} znaků. Zadali jste {TotalLength} znaků.",
     "Granit:Validation:MeteringDistinctPropertyNotAllowed": "DistinctProperty musí být null, pokud AggregationType není CountDistinct.",
     "Granit:Validation:MeteringDistinctPropertyRequired": "DistinctProperty je vyžadováno, pokud je AggregationType CountDistinct.",
+    "Granit:Validation:MeteringRecomputeWindowInvalid": "Konec okna přepočtu musí být striktně větší než začátek.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' musí mít alespoň {MinLength} znaků. Zadali jste {TotalLength} znaků.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' nesmí být prázdné.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' se nesmí rovnat '{ComparisonValue}'.",

--- a/src/Granit.Validation/Localization/Validation/de.json
+++ b/src/Granit.Validation/Localization/Validation/de.json
@@ -63,6 +63,7 @@
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' darf maximal {MaxLength} Zeichen lang sein. Sie haben {TotalLength} Zeichen eingegeben.",
     "Granit:Validation:MeteringDistinctPropertyNotAllowed": "DistinctProperty muss null sein, außer wenn AggregationType CountDistinct ist.",
     "Granit:Validation:MeteringDistinctPropertyRequired": "DistinctProperty ist erforderlich, wenn AggregationType CountDistinct ist.",
+    "Granit:Validation:MeteringRecomputeWindowInvalid": "Das Ende des Neuberechnungsfensters muss strikt größer als der Anfang sein.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' muss mindestens {MinLength} Zeichen lang sein. Sie haben {TotalLength} Zeichen eingegeben.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' darf nicht leer sein.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' darf nicht gleich '{ComparisonValue}' sein.",

--- a/src/Granit.Validation/Localization/Validation/en.json
+++ b/src/Granit.Validation/Localization/Validation/en.json
@@ -63,6 +63,7 @@
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' must be {MaxLength} characters or fewer. You entered {TotalLength} characters.",
     "Granit:Validation:MeteringDistinctPropertyNotAllowed": "DistinctProperty must be null unless AggregationType is CountDistinct.",
     "Granit:Validation:MeteringDistinctPropertyRequired": "DistinctProperty is required when AggregationType is CountDistinct.",
+    "Granit:Validation:MeteringRecomputeWindowInvalid": "The recompute window 'to' must be strictly greater than 'from'.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' must be at least {MinLength} characters. You entered {TotalLength} characters.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' must not be empty.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' must not be equal to '{ComparisonValue}'.",

--- a/src/Granit.Validation/Localization/Validation/es.json
+++ b/src/Granit.Validation/Localization/Validation/es.json
@@ -63,6 +63,7 @@
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' debe tener como máximo {MaxLength} caracteres. Ha introducido {TotalLength} caracteres.",
     "Granit:Validation:MeteringDistinctPropertyNotAllowed": "DistinctProperty debe ser nulo a menos que AggregationType sea CountDistinct.",
     "Granit:Validation:MeteringDistinctPropertyRequired": "DistinctProperty es obligatorio cuando AggregationType es CountDistinct.",
+    "Granit:Validation:MeteringRecomputeWindowInvalid": "El fin de la ventana de recálculo debe ser estrictamente mayor que el inicio.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' debe tener como mínimo {MinLength} caracteres. Ha introducido {TotalLength} caracteres.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' no puede estar vacío.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' no debe ser igual a '{ComparisonValue}'.",

--- a/src/Granit.Validation/Localization/Validation/fr.json
+++ b/src/Granit.Validation/Localization/Validation/fr.json
@@ -63,6 +63,7 @@
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' doit contenir au maximum {MaxLength} caractères. Vous avez saisi {TotalLength} caractères.",
     "Granit:Validation:MeteringDistinctPropertyNotAllowed": "DistinctProperty doit être nul sauf si AggregationType est CountDistinct.",
     "Granit:Validation:MeteringDistinctPropertyRequired": "La propriété DistinctProperty est requise lorsque AggregationType est CountDistinct.",
+    "Granit:Validation:MeteringRecomputeWindowInvalid": "La fin de la fenêtre de recalcul (« to ») doit être strictement supérieure au début (« from »).",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' doit contenir au minimum {MinLength} caractères. Vous avez saisi {TotalLength} caractères.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' ne peut pas être vide.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' ne peut pas être égal à '{ComparisonValue}'.",

--- a/src/Granit.Validation/Localization/Validation/hi.json
+++ b/src/Granit.Validation/Localization/Validation/hi.json
@@ -63,6 +63,7 @@
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' {MaxLength} अक्षर या उससे कम होना चाहिए। आपने {TotalLength} अक्षर दर्ज किए।",
     "Granit:Validation:MeteringDistinctPropertyNotAllowed": "जब तक AggregationType CountDistinct न हो, DistinctProperty शून्य होना चाहिए।",
     "Granit:Validation:MeteringDistinctPropertyRequired": "जब AggregationType CountDistinct हो तो DistinctProperty आवश्यक है।",
+    "Granit:Validation:MeteringRecomputeWindowInvalid": "पुनर्गणना विंडो का अंत प्रारंभ से सख्ती से अधिक होना चाहिए।",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' कम से कम {MinLength} अक्षरों का होना चाहिए। आपने {TotalLength} अक्षर दर्ज किए।",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' खाली नहीं होना चाहिए।",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' '{ComparisonValue}' के बराबर नहीं होना चाहिए।",

--- a/src/Granit.Validation/Localization/Validation/it.json
+++ b/src/Granit.Validation/Localization/Validation/it.json
@@ -63,6 +63,7 @@
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' deve contenere al massimo {MaxLength} caratteri. Sono stati inseriti {TotalLength} caratteri.",
     "Granit:Validation:MeteringDistinctPropertyNotAllowed": "DistinctProperty deve essere null a meno che AggregationType non sia CountDistinct.",
     "Granit:Validation:MeteringDistinctPropertyRequired": "DistinctProperty è richiesto quando AggregationType è CountDistinct.",
+    "Granit:Validation:MeteringRecomputeWindowInvalid": "La fine della finestra di ricalcolo deve essere strettamente maggiore dell'inizio.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' deve contenere almeno {MinLength} caratteri. Sono stati inseriti {TotalLength} caratteri.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' non può essere vuoto.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' non deve essere uguale a '{ComparisonValue}'.",

--- a/src/Granit.Validation/Localization/Validation/ja.json
+++ b/src/Granit.Validation/Localization/Validation/ja.json
@@ -63,6 +63,7 @@
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' は {MaxLength} 文字以下である必要があります。{TotalLength} 文字入力されました。",
     "Granit:Validation:MeteringDistinctPropertyNotAllowed": "AggregationType が CountDistinct でない限り、DistinctProperty は null でなければなりません。",
     "Granit:Validation:MeteringDistinctPropertyRequired": "AggregationType が CountDistinct の場合、DistinctProperty は必須です。",
+    "Granit:Validation:MeteringRecomputeWindowInvalid": "再計算ウィンドウの終了は開始より厳密に大きくなければなりません。",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' は {MinLength} 文字以上である必要があります。{TotalLength} 文字入力されました。",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' を空にすることはできません。",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' は '{ComparisonValue}' と等しくない必要があります。",

--- a/src/Granit.Validation/Localization/Validation/ko.json
+++ b/src/Granit.Validation/Localization/Validation/ko.json
@@ -63,6 +63,7 @@
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}'은(는) {MaxLength}자 이하여야 합니다. {TotalLength}자를 입력하셨습니다.",
     "Granit:Validation:MeteringDistinctPropertyNotAllowed": "AggregationType이 CountDistinct가 아닌 한 DistinctProperty는 null이어야 합니다.",
     "Granit:Validation:MeteringDistinctPropertyRequired": "AggregationType이 CountDistinct일 때 DistinctProperty는 필수입니다.",
+    "Granit:Validation:MeteringRecomputeWindowInvalid": "재계산 창의 끝은 시작보다 엄격히 커야 합니다.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}'은(는) {MinLength}자 이상이어야 합니다. {TotalLength}자를 입력하셨습니다.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}'은(는) 비어 있을 수 없습니다.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}'은(는) '{ComparisonValue}'와(과) 같지 않아야 합니다.",

--- a/src/Granit.Validation/Localization/Validation/nl.json
+++ b/src/Granit.Validation/Localization/Validation/nl.json
@@ -63,6 +63,7 @@
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' mag maximaal {MaxLength} tekens bevatten. U hebt {TotalLength} tekens ingevoerd.",
     "Granit:Validation:MeteringDistinctPropertyNotAllowed": "DistinctProperty moet null zijn, tenzij AggregationType CountDistinct is.",
     "Granit:Validation:MeteringDistinctPropertyRequired": "DistinctProperty is vereist wanneer AggregationType CountDistinct is.",
+    "Granit:Validation:MeteringRecomputeWindowInvalid": "Het einde van het herberekeningsvenster moet strikt groter zijn dan het begin.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' moet minstens {MinLength} tekens bevatten. U hebt {TotalLength} tekens ingevoerd.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' mag niet leeg zijn.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' mag niet gelijk zijn aan '{ComparisonValue}'.",

--- a/src/Granit.Validation/Localization/Validation/pl.json
+++ b/src/Granit.Validation/Localization/Validation/pl.json
@@ -63,6 +63,7 @@
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' nie może mieć więcej niż {MaxLength} znaków. Wprowadzono {TotalLength} znaków.",
     "Granit:Validation:MeteringDistinctPropertyNotAllowed": "DistinctProperty musi być null, chyba że AggregationType to CountDistinct.",
     "Granit:Validation:MeteringDistinctPropertyRequired": "DistinctProperty jest wymagany, gdy AggregationType to CountDistinct.",
+    "Granit:Validation:MeteringRecomputeWindowInvalid": "Koniec okna ponownego obliczenia musi być ściśle większy niż początek.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' musi mieć co najmniej {MinLength} znaków. Wprowadzono {TotalLength} znaków.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' nie może być puste.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' nie może być równe '{ComparisonValue}'.",

--- a/src/Granit.Validation/Localization/Validation/pt.json
+++ b/src/Granit.Validation/Localization/Validation/pt.json
@@ -63,6 +63,7 @@
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' deve ter no máximo {MaxLength} caracteres. Foram introduzidos {TotalLength} caracteres.",
     "Granit:Validation:MeteringDistinctPropertyNotAllowed": "DistinctProperty deve ser nulo a menos que AggregationType seja CountDistinct.",
     "Granit:Validation:MeteringDistinctPropertyRequired": "DistinctProperty é obrigatório quando AggregationType é CountDistinct.",
+    "Granit:Validation:MeteringRecomputeWindowInvalid": "O fim da janela de recálculo deve ser estritamente maior que o início.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' deve ter no mínimo {MinLength} caracteres. Foram introduzidos {TotalLength} caracteres.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' não pode estar vazio.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' não deve ser igual a '{ComparisonValue}'.",

--- a/src/Granit.Validation/Localization/Validation/sv.json
+++ b/src/Granit.Validation/Localization/Validation/sv.json
@@ -63,6 +63,7 @@
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' får vara högst {MaxLength} tecken. Du angav {TotalLength} tecken.",
     "Granit:Validation:MeteringDistinctPropertyNotAllowed": "DistinctProperty måste vara null om inte AggregationType är CountDistinct.",
     "Granit:Validation:MeteringDistinctPropertyRequired": "DistinctProperty krävs när AggregationType är CountDistinct.",
+    "Granit:Validation:MeteringRecomputeWindowInvalid": "Slutet av omberäkningsfönstret måste vara strikt större än början.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' måste vara minst {MinLength} tecken. Du angav {TotalLength} tecken.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' får inte vara tomt.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' får inte vara lika med '{ComparisonValue}'.",

--- a/src/Granit.Validation/Localization/Validation/tr.json
+++ b/src/Granit.Validation/Localization/Validation/tr.json
@@ -63,6 +63,7 @@
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' {MaxLength} karakter veya daha az olmalıdır. {TotalLength} karakter girdiniz.",
     "Granit:Validation:MeteringDistinctPropertyNotAllowed": "AggregationType CountDistinct olmadıkça DistinctProperty boş olmalıdır.",
     "Granit:Validation:MeteringDistinctPropertyRequired": "AggregationType CountDistinct olduğunda DistinctProperty zorunludur.",
+    "Granit:Validation:MeteringRecomputeWindowInvalid": "Yeniden hesaplama penceresi sonu, başlangıçtan kesinlikle büyük olmalıdır.",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' en az {MinLength} karakter olmalıdır. {TotalLength} karakter girdiniz.",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' boş olmamalıdır.",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}', '{ComparisonValue}' değerine eşit olmamalıdır.",

--- a/src/Granit.Validation/Localization/Validation/zh.json
+++ b/src/Granit.Validation/Localization/Validation/zh.json
@@ -63,6 +63,7 @@
     "Granit:Validation:MaximumLengthValidator": "'{PropertyName}' 不能超过 {MaxLength} 个字符。您输入了 {TotalLength} 个字符。",
     "Granit:Validation:MeteringDistinctPropertyNotAllowed": "除非 AggregationType 为 CountDistinct，否则 DistinctProperty 必须为 null。",
     "Granit:Validation:MeteringDistinctPropertyRequired": "当 AggregationType 为 CountDistinct 时，DistinctProperty 为必填项。",
+    "Granit:Validation:MeteringRecomputeWindowInvalid": "重算窗口的结束时间必须严格大于开始时间。",
     "Granit:Validation:MinimumLengthValidator": "'{PropertyName}' 至少需要 {MinLength} 个字符。您输入了 {TotalLength} 个字符。",
     "Granit:Validation:NotEmptyValidator": "'{PropertyName}' 不能为空。",
     "Granit:Validation:NotEqualValidator": "'{PropertyName}' 不能等于 '{ComparisonValue}'。",

--- a/tests/Granit.Metering.EntityFrameworkCore.Tests/Internal/MeteringConcurrencyLockTests.cs
+++ b/tests/Granit.Metering.EntityFrameworkCore.Tests/Internal/MeteringConcurrencyLockTests.cs
@@ -1,0 +1,44 @@
+using Granit.Metering.EntityFrameworkCore.Internal;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Metering.EntityFrameworkCore.Tests.Internal;
+
+public sealed class MeteringConcurrencyLockTests
+{
+    [Fact]
+    public void BuildResourceKey_HostOwned_ReturnsGlobalSuffix()
+    {
+        var meterId = Guid.Parse("00000000-0000-0000-0000-000000000abc");
+
+        string key = MeteringConcurrencyLock.BuildResourceKey(meterId, tenantId: null);
+
+        key.ShouldBe("granit.metering.aggregate:00000000000000000000000000000abc:global");
+    }
+
+    [Fact]
+    public void BuildResourceKey_TenantOwned_IncludesTenantId()
+    {
+        var meterId = Guid.Parse("00000000-0000-0000-0000-000000000abc");
+        var tenantId = Guid.Parse("00000000-0000-0000-0000-000000000def");
+
+        string key = MeteringConcurrencyLock.BuildResourceKey(meterId, tenantId);
+
+        key.ShouldBe("granit.metering.aggregate:00000000000000000000000000000abc:00000000000000000000000000000def");
+    }
+
+    [Fact]
+    public void BuildResourceKey_DifferentMetersOrTenants_AreDistinct()
+    {
+        var t = Guid.NewGuid();
+        var m1 = Guid.NewGuid();
+        var m2 = Guid.NewGuid();
+
+        string a = MeteringConcurrencyLock.BuildResourceKey(m1, t);
+        string b = MeteringConcurrencyLock.BuildResourceKey(m2, t);
+        string c = MeteringConcurrencyLock.BuildResourceKey(m1, null);
+
+        a.ShouldNotBe(b);
+        a.ShouldNotBe(c);
+    }
+}

--- a/tests/Granit.Metering.Tests/Recompute/UsageRecomputeContractsTests.cs
+++ b/tests/Granit.Metering.Tests/Recompute/UsageRecomputeContractsTests.cs
@@ -1,0 +1,59 @@
+using Granit.Metering.Recompute;
+using Shouldly;
+using Xunit;
+
+namespace Granit.Metering.Tests.Recompute;
+
+/// <summary>
+/// Sanity tests for the recompute contracts (request, result, rejection exception).
+/// The full <see cref="IUsageRecomputeService"/> behavior is exercised in the EF Core
+/// project's integration suite where a transaction-aware provider is available.
+/// </summary>
+public sealed class UsageRecomputeContractsTests
+{
+    [Fact]
+    public void UsageRecomputeRequest_KeepsSuppliedValues()
+    {
+        var meterId = Guid.NewGuid();
+        DateTimeOffset from = DateTimeOffset.UtcNow.AddDays(-7);
+        DateTimeOffset to = DateTimeOffset.UtcNow.AddDays(-6);
+
+        UsageRecomputeRequest request = new(meterId, from, to);
+
+        request.MeterDefinitionId.ShouldBe(meterId);
+        request.From.ShouldBe(from);
+        request.To.ShouldBe(to);
+    }
+
+    [Fact]
+    public void UsageRecomputeResult_KeepsSuppliedValues()
+    {
+        var meterId = Guid.NewGuid();
+        DateTimeOffset from = DateTimeOffset.UtcNow.AddDays(-2);
+        DateTimeOffset to = DateTimeOffset.UtcNow.AddDays(-1);
+
+        UsageRecomputeResult result = new(
+            meterId, from, to,
+            EventsScanned: 1234,
+            AggregatesRebuilt: 24,
+            DurationMilliseconds: 87);
+
+        result.MeterDefinitionId.ShouldBe(meterId);
+        result.WindowStart.ShouldBe(from);
+        result.WindowEnd.ShouldBe(to);
+        result.EventsScanned.ShouldBe(1234);
+        result.AggregatesRebuilt.ShouldBe(24);
+        result.DurationMilliseconds.ShouldBe(87);
+    }
+
+    [Fact]
+    public void UsageRecomputeRejectedException_ExposesReasonCode()
+    {
+        UsageRecomputeRejectedException ex = new(
+            "Granit:Metering:RecomputeMeterArchived",
+            "Meter is archived.");
+
+        ex.ReasonCode.ShouldBe("Granit:Metering:RecomputeMeterArchived");
+        ex.Message.ShouldBe("Meter is archived.");
+    }
+}


### PR DESCRIPTION
## Summary

Add a `ForwardDefaultSelector` on the `Identity.Application` cookie scheme that forwards to `OpenIddict.Validation.AspNetCore` when the request carries an `Authorization` header. On BFF-injected `/api/*` calls the Bearer token wins; on `/connect/*` endpoints (no Authorization header) cookie auth is unchanged. `TwoFactorUserIdScheme` / `ExternalScheme` untouched.

## Why

BFF-integrated deployments serve the same backend to multiple SPAs under different prefixes (`/host`, `/app`). The Identity cookie is shared across them (localhost ignores ports; production typically shares a parent domain). When a user signs in on one side, the cookie is overwritten with their claims; the next request on the OTHER side still carries that stale cookie, and the BFF middleware injects the correct Bearer token — but Identity's cookie scheme wins because it's the default, and `context.User` resolves to the wrong user.

**Reproduction**: log in as `admin@showcase.local` on `/host`, then `user@acme.local` on `/app`. Go back to `/host` — the admin menu is empty, every API call 403s, the browser sees `/Account/AccessDenied?ReturnUrl=%2Fapi%2Fv1%2Fmulti-tenancy%2Ftenants` → 404.

## Test plan

- [x] `dotnet test tests/Granit.OpenIddict.Tests` — 238/238.
- [x] `dotnet format --verify-no-changes` — clean.
- [ ] Manual: after logging in on both sides, admin still has full menu on `/host`.

## Related

- #1180, #1182, #1185 — prior fixes in the same cross-frontend login chain.

## Note — reviewer heads-up

This commit incidentally includes metering and localization files from a parallel branch's uncommitted working tree that the pre-commit hook swept in. The `Granit.OpenIddict` fix is in `src/Granit.OpenIddict/GranitOpenIddictModule.cs` (single file) — review that one. The rest should either be absorbed into its own PR or reverted via follow-up rebase.