### PR TITLE
test(security): multi-side auth regression suite

### DIFF
--- a/tests/Granit.ArchitectureTests/CookieOnlyAuthSchemeTests.cs
+++ b/tests/Granit.ArchitectureTests/CookieOnlyAuthSchemeTests.cs
@@ -1,0 +1,168 @@
+using System.Text.RegularExpressions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.ArchitectureTests;
+
+/// <summary>
+/// Prevents regressions where an endpoint in an <c>*.Endpoints</c> module explicitly
+/// binds its authorization to the Identity cookie scheme, thereby bypassing the
+/// <c>ForwardDefaultSelector</c> registered by <c>GranitOpenIddictModule</c> that
+/// forwards cookie-auth to OpenIddict Bearer validation when an <c>Authorization</c>
+/// header is present.
+/// </summary>
+/// <remarks>
+/// <para>
+/// In BFF-integrated deployments, the same backend serves multiple SPAs (e.g. a host
+/// admin and a tenant app) whose session cookies may collide on <c>localhost</c> (RFC
+/// 6265 — the port is not part of the cookie scope) or on a shared parent domain in
+/// production. The Identity cookie is therefore effectively shared across SPAs, and
+/// the last-logged-in principal wins whenever the request is authenticated via the
+/// cookie scheme. The module-level forward selector mitigates this by routing API
+/// requests that carry a BFF-injected <c>Authorization</c> header to OpenIddict
+/// Bearer validation instead.
+/// </para>
+/// <para>
+/// Any endpoint that declares <c>AuthenticationSchemes = IdentityConstants.ApplicationScheme</c>
+/// (or the literal <c>"Identity.Application"</c>, or the default
+/// <c>CookieAuthenticationDefaults.AuthenticationScheme</c>) via an
+/// <c>[Authorize]</c> attribute or an inline <c>AuthorizeAttribute</c> passed to
+/// <c>RequireAuthorization</c> opts out of that forwarding, so the cookie always
+/// wins. That is a security regression.
+/// </para>
+/// <para>
+/// The rule: endpoint files in <c>*.Endpoints</c> modules MUST NOT specify a
+/// cookie-only <c>AuthenticationSchemes</c> value. Use bare
+/// <c>.RequireAuthorization(...)</c> (inherits the default, which forwards when
+/// needed) or specify the Bearer/OpenIddict validation scheme explicitly.
+/// </para>
+/// </remarks>
+public sealed partial class CookieOnlyAuthSchemeTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    /// <summary>
+    /// Cookie-scheme names that, when used as the sole <c>AuthenticationSchemes</c>
+    /// value on an endpoint, bypass the OpenIddict Bearer forwarder and re-introduce
+    /// cross-frontend session leakage.
+    /// </summary>
+    private static readonly string[] CookieOnlySchemeTokens =
+    [
+        "IdentityConstants.ApplicationScheme",
+        "\"Identity.Application\"",
+        "CookieAuthenticationDefaults.AuthenticationScheme",
+        "\"Cookies\"",
+    ];
+
+    [Fact]
+    public void Endpoints_must_not_bind_authorization_to_the_Identity_cookie_scheme()
+    {
+        string srcDir = Path.Join(RepoRoot, "src");
+        List<string> violations = [];
+
+        foreach (string csFile in GetEndpointSourceFiles(srcDir))
+        {
+            string content = File.ReadAllText(csFile);
+            CheckFile(csFile, content, violations);
+        }
+
+        violations.ShouldBeEmpty(
+            "Endpoints MUST NOT bind their authorization to the Identity cookie scheme. " +
+            "Doing so bypasses the module-level ForwardDefaultSelector that routes " +
+            "BFF-injected Bearer requests to OpenIddict validation, which re-introduces " +
+            "the cross-frontend session leak fixed in PR #1190. Remove the explicit " +
+            "AuthenticationSchemes (falls back to the safe default) or replace it with " +
+            "the OpenIddict validation scheme." +
+            Environment.NewLine + string.Join(Environment.NewLine, violations));
+    }
+
+    private static void CheckFile(string csFile, string content, List<string> violations)
+    {
+        foreach (Match match in AuthenticationSchemesAssignment().Matches(content))
+        {
+            string rhs = match.Groups["value"].Value;
+
+            if (!CookieOnlySchemeTokens.Any(token => rhs.Contains(token, StringComparison.Ordinal)))
+            {
+                continue;
+            }
+
+            // Accept mixed schemes that also mention Bearer/OpenIddict — those opt
+            // into BOTH cookie and Bearer paths, which is harmless (the Bearer path
+            // still takes precedence when the header is present).
+            if (rhs.Contains("Bearer", StringComparison.OrdinalIgnoreCase)
+                || rhs.Contains("OpenIddictValidationAspNetCoreDefaults", StringComparison.Ordinal)
+                || rhs.Contains("OpenIddict.Validation.AspNetCore", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            int lineNumber = GetLineNumber(content, match.Index);
+            string relativePath = Path.GetRelativePath(RepoRoot, csFile);
+            violations.Add($"  {relativePath}:{lineNumber} — cookie-only scheme: {rhs.Trim()}");
+        }
+    }
+
+    private static int GetLineNumber(string content, int index)
+    {
+        int line = 1;
+        for (int i = 0; i < index; i++)
+        {
+            if (content[i] == '\n')
+            {
+                line++;
+            }
+        }
+
+        return line;
+    }
+
+    /// <summary>
+    /// Matches an <c>AuthenticationSchemes</c> assignment in an <c>[Authorize]</c>
+    /// attribute or an inline <c>new AuthorizeAttribute { AuthenticationSchemes = ... }</c>
+    /// initializer. Captures the right-hand side up to the next <c>,</c>, <c>}</c>,
+    /// or <c>)</c> at brace depth 0.
+    /// </summary>
+    [GeneratedRegex(@"AuthenticationSchemes\s*=\s*(?<value>[^,}\)\r\n]+)")]
+    private static partial Regex AuthenticationSchemesAssignment();
+
+    private static IEnumerable<string> GetEndpointSourceFiles(string srcDir)
+    {
+        foreach (string csFile in Directory.GetFiles(srcDir, "*.cs", SearchOption.AllDirectories))
+        {
+            if (csFile.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar)
+                || csFile.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar))
+            {
+                continue;
+            }
+
+            // Scope the scan to *.Endpoints/ modules so we don't false-positive on
+            // authentication plumbing in Granit.OpenIddict (which legitimately reads
+            // the cookie scheme to configure the forwarder itself).
+            string[] segments = csFile.Split(Path.DirectorySeparatorChar);
+            if (!segments.Any(s => s.EndsWith(".Endpoints", StringComparison.Ordinal)))
+            {
+                continue;
+            }
+
+            yield return csFile;
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        string? dir = Path.GetDirectoryName(typeof(CookieOnlyAuthSchemeTests).Assembly.Location);
+        while (dir is not null)
+        {
+            string gitPath = Path.Join(dir, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return dir;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new InvalidOperationException("Could not find repository root (.git directory)");
+    }
+}

--- a/tests/Granit.Bff.Endpoints.Tests/Extensions/BffTokenInjectionMiddlewareTests.cs
+++ b/tests/Granit.Bff.Endpoints.Tests/Extensions/BffTokenInjectionMiddlewareTests.cs
@@ -340,4 +340,83 @@ public sealed class BffTokenInjectionMiddlewareTests
         frontend.ShouldBe(app);
         sessionId.ShouldBe("session-app-bbb");
     }
+
+    // ──── Exhaustive 3 × 3 matrix (cookie setup × request origin) ────
+    //
+    // Security-critical regression surface: with a shared-origin BFF on localhost
+    // (ports are not part of the cookie scope — RFC 6265) every combination of
+    // held session(s) and caller origin must resolve to either the caller's own
+    // session or (null, null). A match that crosses the caller's origin would
+    // let a SPA on :5174 operate under the session bound to :5173 — and every
+    // subsequent mutating request would be CSRF-validated against the wrong
+    // HMAC secret (observed as the "403 on /account/login" symptom when logging
+    // in on the second frontend after logging in on the first).
+
+    public static IEnumerable<object?[]> MatrixCases()
+    {
+        const string HostUrl = "http://localhost:5173";
+        const string AppUrl = "http://localhost:5174";
+        const string UnknownUrl = "http://attacker.example:8080";
+        const string HostSession = "session-host-aaa";
+        const string AppSession = "session-app-bbb";
+
+        // Setup, origin, expectedFrontendName (null = must reject), expectedSession
+        // HOST-ONLY cookie
+        yield return ["host-only", HostUrl, "host", HostSession];
+        yield return ["host-only", AppUrl, null, null];         // cross-side → drop
+        yield return ["host-only", UnknownUrl, null, null];     // stranger origin → drop
+
+        // APP-ONLY cookie
+        yield return ["app-only", HostUrl, null, null];         // cross-side → drop
+        yield return ["app-only", AppUrl, "app", AppSession];
+        yield return ["app-only", UnknownUrl, null, null];      // stranger origin → drop
+
+        // BOTH cookies (the bug scenario after user logs in on both sides)
+        yield return ["both", HostUrl, "host", HostSession];
+        yield return ["both", AppUrl, "app", AppSession];
+        yield return ["both", UnknownUrl, null, null];          // stranger origin → drop
+    }
+
+    [Theory]
+    [MemberData(nameof(MatrixCases))]
+    public void ResolveFrontendFromCookies_Matrix(
+        string setup, string origin, string? expectedFrontend, string? expectedSession)
+    {
+        BffFrontendOptions host = Frontend("host", "http://localhost:5173");
+        BffFrontendOptions app = Frontend("app", "http://localhost:5174");
+        GranitBffOptions options = new()
+        {
+            Authority = new Uri("https://auth.example.com"),
+            Frontends = [host, app],
+        };
+
+        Dictionary<string, string> cookies = setup switch
+        {
+            "host-only" => new() { [".bff-host"] = "session-host-aaa" },
+            "app-only" => new() { [".bff-app"] = "session-app-bbb" },
+            "both" => new()
+            {
+                [".bff-host"] = "session-host-aaa",
+                [".bff-app"] = "session-app-bbb",
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(setup)),
+        };
+
+        HttpContext context = CreateContext(cookies, origin: origin);
+
+        (BffFrontendOptions? frontend, string? sessionId) =
+            BffTokenInjectionMiddleware.ResolveFrontendFromCookies(context, options);
+
+        if (expectedFrontend is null)
+        {
+            frontend.ShouldBeNull();
+            sessionId.ShouldBeNull();
+        }
+        else
+        {
+            frontend.ShouldNotBeNull();
+            frontend!.Name.ShouldBe(expectedFrontend);
+            sessionId.ShouldBe(expectedSession);
+        }
+    }
 }

--- a/tests/Granit.OpenIddict.Tests/CrossSideAuthIntegrationTests.cs
+++ b/tests/Granit.OpenIddict.Tests/CrossSideAuthIntegrationTests.cs
@@ -1,0 +1,253 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Granit.Modularity;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.Tests;
+
+/// <summary>
+/// End-to-end integration tests for the Identity cookie → Bearer forward registered
+/// by <see cref="GranitOpenIddictModule"/>. These tests exercise the full ASP.NET
+/// Core authentication pipeline (not just the selector delegate) to verify that
+/// when a request carries both an Identity cookie AND an <c>Authorization</c>
+/// header, the Bearer-principal wins — preventing the cross-frontend session
+/// takeover scenario that motivated PR #1190.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The test host registers two authentication schemes:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// <description>
+/// The real cookie handler on <see cref="IdentityConstants.ApplicationScheme"/>,
+/// with the module's <c>ForwardDefaultSelector</c> applied via PostConfigure.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// A stub OpenIddict validation handler registered under the well-known scheme
+/// name <c>"OpenIddict.Validation.AspNetCore"</c> that materializes a distinct
+/// principal whenever an <c>Authorization</c> header is present.
+/// </description>
+/// </item>
+/// </list>
+/// <para>
+/// The stub lets us distinguish "cookie won" from "Bearer won" by comparing the
+/// resulting principal's name — if the forwarder is regressed and the cookie
+/// principal leaks through, the bearer-principal test fails loudly.
+/// </para>
+/// </remarks>
+public sealed class CrossSideAuthIntegrationTests : IAsyncDisposable
+{
+    private const string BearerScheme = "OpenIddict.Validation.AspNetCore";
+    private const string CookieUserName = "host-admin@example.test";
+    private const string BearerUserName = "tenant-user@example.test";
+
+    private readonly WebApplication _app;
+    private readonly HttpClient _client;
+    private string? _cookieValue;
+
+    public CrossSideAuthIntegrationTests()
+    {
+        // Development environment — the module's PostConfigureIdentityCookie uses the
+        // dev cookie name ".id" (no __Host- prefix, no HTTPS requirement). We need
+        // this because TestServer runs on HTTP and Secure/__Host- cookies would be
+        // suppressed by the browser-equivalent pipeline.
+        WebApplicationBuilder builder = WebApplication.CreateBuilder(
+            new WebApplicationOptions { EnvironmentName = "Development" });
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+
+        // The module registers services like IExternalLoginService that depend on
+        // UserManager<GranitUser> and IClock, which we don't wire in this focused
+        // fixture. Disable DI validation on build — these services are never
+        // resolved by the pipeline under test (we only exercise authentication).
+        builder.Host.UseDefaultServiceProvider(options =>
+        {
+            options.ValidateOnBuild = false;
+            options.ValidateScopes = false;
+        });
+
+        // Apply the module — this wires the ForwardDefaultSelector onto Identity.Application.
+        ServiceConfigurationContext context = new(
+            builder.Services, builder.Configuration, builder);
+        new GranitOpenIddictModule().ConfigureServices(context);
+
+        builder.Services
+            .AddAuthentication(IdentityConstants.ApplicationScheme)
+            .AddCookie(IdentityConstants.ApplicationScheme, options =>
+            {
+                options.Events = new CookieAuthenticationEvents
+                {
+                    OnRedirectToLogin = ctx =>
+                    {
+                        // Headless mode: never redirect; fail fast so the test sees 401.
+                        ctx.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                        return Task.CompletedTask;
+                    },
+                };
+            })
+            .AddScheme<AuthenticationSchemeOptions, StubBearerHandler>(BearerScheme, _ => { });
+
+        builder.Services.AddAuthorization();
+
+        _app = builder.Build();
+        _app.UseAuthentication();
+        _app.UseAuthorization();
+
+        _app.MapGet("/whoami", (HttpContext ctx) =>
+        {
+            string? name = ctx.User.Identity?.Name;
+            string? authType = ctx.User.Identity?.AuthenticationType;
+            return TypedResults.Ok(new { name, authType });
+        }).RequireAuthorization();
+
+        _app.MapPost("/signin-cookie", async (HttpContext ctx) =>
+        {
+            ClaimsPrincipal principal = new(new ClaimsIdentity(
+                [new Claim(ClaimTypes.Name, CookieUserName)],
+                IdentityConstants.ApplicationScheme));
+            await ctx.SignInAsync(IdentityConstants.ApplicationScheme, principal)
+                .ConfigureAwait(false);
+            return TypedResults.Ok();
+        });
+
+        _app.StartAsync().GetAwaiter().GetResult();
+        _client = _app.GetTestClient();
+    }
+
+    [Fact]
+    public async Task CookieOnly_NoAuthHeader_ResolvesToCookiePrincipal()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        await AuthenticateCookieAsync(cancellationToken);
+
+        HttpRequestMessage request = new(HttpMethod.Get, "/whoami");
+        AttachCookie(request);
+
+        HttpResponseMessage response = await _client.SendAsync(request, cancellationToken);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync(cancellationToken)).ShouldContain(CookieUserName);
+    }
+
+    [Fact]
+    public async Task CookieAndBearer_BearerHeaderWins()
+    {
+        // This is the regression case: a logged-in user on the "other" SPA left an
+        // Identity cookie on the browser; the BFF then injects its OWN Authorization
+        // header when proxying to /api. The forwarder must route to OpenIddict
+        // validation so the server sees the BFF-injected principal, not the cookie.
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        await AuthenticateCookieAsync(cancellationToken);
+
+        HttpRequestMessage request = new(HttpMethod.Get, "/whoami");
+        AttachCookie(request);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "stub-bearer-token");
+
+        HttpResponseMessage response = await _client.SendAsync(request, cancellationToken);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        string body = await response.Content.ReadAsStringAsync(cancellationToken);
+        body.ShouldContain(BearerUserName);
+        body.ShouldNotContain(CookieUserName);
+    }
+
+    [Fact]
+    public async Task BearerOnly_ResolvesToBearerPrincipal()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        HttpRequestMessage request = new(HttpMethod.Get, "/whoami");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "stub-bearer-token");
+
+        HttpResponseMessage response = await _client.SendAsync(request, cancellationToken);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync(cancellationToken)).ShouldContain(BearerUserName);
+    }
+
+    [Fact]
+    public async Task NoCookieNoBearer_Returns401()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        HttpRequestMessage request = new(HttpMethod.Get, "/whoami");
+        HttpResponseMessage response = await _client.SendAsync(request, cancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    private async Task AuthenticateCookieAsync(CancellationToken cancellationToken)
+    {
+        HttpResponseMessage response = await _client.PostAsync("/signin-cookie", content: null, cancellationToken);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        // TestServer returns Set-Cookie headers on the response; capture the value for later reuse.
+        // Module's PostConfigureIdentityCookie sets the dev cookie name to ".id".
+        if (response.Headers.TryGetValues("Set-Cookie", out IEnumerable<string>? cookies))
+        {
+            _cookieValue = cookies.FirstOrDefault(c => c.StartsWith(".id=", StringComparison.Ordinal))
+                ?.Split(';')[0];
+        }
+
+        _cookieValue.ShouldNotBeNull("expected Set-Cookie header after /signin-cookie");
+    }
+
+    private void AttachCookie(HttpRequestMessage request)
+    {
+        if (_cookieValue is not null)
+        {
+            request.Headers.Add("Cookie", _cookieValue);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client.Dispose();
+        await _app.StopAsync().ConfigureAwait(false);
+        await _app.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Stub handler masquerading as OpenIddict Bearer validation. Authenticates any
+    /// request that carries an <c>Authorization</c> header by materializing a principal
+    /// whose name differs from the cookie principal, so tests can tell which scheme
+    /// produced the authenticated user.
+    /// </summary>
+    private sealed class StubBearerHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.ContainsKey("Authorization"))
+            {
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+
+            ClaimsIdentity identity = new(
+                [new Claim(ClaimTypes.Name, BearerUserName)],
+                BearerScheme);
+            AuthenticationTicket ticket = new(
+                new ClaimsPrincipal(identity),
+                BearerScheme);
+
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+}

--- a/tests/Granit.OpenIddict.Tests/Granit.OpenIddict.Tests.csproj
+++ b/tests/Granit.OpenIddict.Tests/Granit.OpenIddict.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="NSubstitute" />

--- a/tests/Granit.OpenIddict.Tests/IdentityCookieForwardTests.cs
+++ b/tests/Granit.OpenIddict.Tests/IdentityCookieForwardTests.cs
@@ -1,0 +1,124 @@
+using Granit.Modularity;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.Tests;
+
+/// <summary>
+/// Regression tests for the <see cref="CookieAuthenticationOptions.ForwardDefaultSelector"/>
+/// wired onto the <see cref="IdentityConstants.ApplicationScheme"/> cookie by
+/// <see cref="GranitOpenIddictModule"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Without this forward, a BFF-integrated deployment that serves multiple SPAs from
+/// the same backend (host admin + tenant app) routes requests through the cookie
+/// scheme whenever the Identity cookie is present — even when a BFF Bearer token
+/// has been injected on the request. On localhost the cookie scope ignores the
+/// port (RFC 6265) so the Identity cookie is effectively shared across SPAs, and
+/// the last-logged-in principal silently overrides the BFF-injected one. The
+/// symptom: 403 on host-admin endpoints after a tenant user logs in on the
+/// other SPA (and vice-versa).
+/// </para>
+/// <para>
+/// These tests are intentionally end-to-end at the DI level: they boot
+/// <see cref="GranitOpenIddictModule"/> against a real <see cref="IServiceCollection"/>,
+/// resolve the PostConfigured <see cref="CookieAuthenticationOptions"/> from the
+/// container, and invoke the selector. Removing or weakening the registration
+/// in the module causes these tests to fail.
+/// </para>
+/// </remarks>
+public sealed class IdentityCookieForwardTests
+{
+    private const string OpenIddictValidationScheme = "OpenIddict.Validation.AspNetCore";
+
+    [Fact]
+    public void ApplicationScheme_ForwardsToBearer_WhenAuthorizationHeaderPresent()
+    {
+        CookieAuthenticationOptions options = BootstrapAndGetCookieOptions(
+            IdentityConstants.ApplicationScheme);
+
+        options.ForwardDefaultSelector.ShouldNotBeNull();
+
+        DefaultHttpContext httpContext = new();
+        httpContext.Request.Headers.Authorization = "Bearer injected-by-bff";
+
+        string? forwarded = options.ForwardDefaultSelector!(httpContext);
+
+        forwarded.ShouldBe(OpenIddictValidationScheme);
+    }
+
+    [Fact]
+    public void ApplicationScheme_DoesNotForward_WhenAuthorizationHeaderAbsent()
+    {
+        // Sessionless requests (anonymous GET, OIDC /connect/* endpoints) must
+        // keep using the Identity cookie — this is what lets /connect/authorize
+        // read the logged-in principal to build the authorization code.
+        CookieAuthenticationOptions options = BootstrapAndGetCookieOptions(
+            IdentityConstants.ApplicationScheme);
+
+        DefaultHttpContext httpContext = new();
+
+        string? forwarded = options.ForwardDefaultSelector!(httpContext);
+
+        forwarded.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ApplicationScheme_ForwardsToBearer_ForAnyAuthorizationValue()
+    {
+        // The selector keys on the PRESENCE of the Authorization header, not its
+        // value — a malformed or empty header still triggers the forward, and
+        // OpenIddict validation rejects it cleanly as an unauthenticated request.
+        // This matters because a selector that parsed the value would risk
+        // falling back to cookie-auth on malformed Bearer headers and reviving
+        // the cross-frontend leak this forward was added to prevent.
+        CookieAuthenticationOptions options = BootstrapAndGetCookieOptions(
+            IdentityConstants.ApplicationScheme);
+
+        DefaultHttpContext httpContext = new();
+        httpContext.Request.Headers.Authorization = string.Empty;
+
+        string? forwarded = options.ForwardDefaultSelector!(httpContext);
+
+        forwarded.ShouldBe(OpenIddictValidationScheme);
+    }
+
+    [Theory]
+    // IdentityConstants.* are static readonly strings, not consts — inline
+    // the literal values. Cross-checked against the fields in IdentityConstants.
+    [InlineData("Identity.TwoFactorUserId")]
+    [InlineData("Identity.External")]
+    public void NonApplicationIdentityCookies_DoNotForward(string scheme)
+    {
+        // The forward contract is scoped to the long-lived Application cookie.
+        // The 2FA and External cookies are short-lived transport for a specific
+        // sub-flow (second-factor challenge / external login callback) and are
+        // consumed by handlers that expect a cookie-shaped principal. Forwarding
+        // them to Bearer validation would break those flows.
+        CookieAuthenticationOptions options = BootstrapAndGetCookieOptions(scheme);
+
+        options.ForwardDefaultSelector.ShouldBeNull();
+    }
+
+    private static CookieAuthenticationOptions BootstrapAndGetCookieOptions(string scheme)
+    {
+        HostApplicationBuilder builder = new();
+        ServiceConfigurationContext context = new(
+            builder.Services, builder.Configuration, builder);
+
+        new GranitOpenIddictModule().ConfigureServices(context);
+
+        using ServiceProvider sp = builder.Services.BuildServiceProvider();
+        IOptionsMonitor<CookieAuthenticationOptions> monitor =
+            sp.GetRequiredService<IOptionsMonitor<CookieAuthenticationOptions>>();
+
+        return monitor.Get(scheme);
+    }
+}

--- a/tests/Granit.OpenIddict.Tests/packages.lock.json
+++ b/tests/Granit.OpenIddict.Tests/packages.lock.json
@@ -14,6 +14,16 @@
         "resolved": "7.1.0",
         "contentHash": "Iu3dSnhJ+gzjlOtpIPZgHvJbmvmPbIGjxT7h5pNxxMiNTXKfxgi0O0eehnZ29qlC5bElAM0o9dSrjzjydCaGiA=="
       },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "Direct",
+        "requested": "[10.*, )",
+        "resolved": "10.0.7",
+        "contentHash": "lWyzApi1g8/r0eXqZBbl5bA8zewS8koxOir83/+OvJcyn2HazdUzPFd4MWc9uMdVzCRX6Z5aY4tNK+N0pWXMLg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7"
+        }
+      },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
         "type": "Direct",
         "requested": "[3.*, )",
@@ -88,6 +98,11 @@
         "resolved": "2.23.0",
         "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
       },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "2UM9EtTmX6yF6Efa6WOO7wmHz2kPksmnzPmMwveuOGJQwbtNg5wKGj7usGLr8Ve3AMhIAc2yqyRXt1xNsed3hg=="
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -122,6 +137,11 @@
         "type": "Transitive",
         "resolved": "10.3.0",
         "contentHash": "g6/S5rhP1XNBqeDa9zKXri/uDKe6gjzSqGsocuySb1OdVm8fz/M9YcWTJsCw5RHF8xIb/B3NgsfBPQF9Emjk3Q=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "gCglFg/9Chu3lyJNytRuQAYM3mXQKNs1i01Cz2bc545QaHQ+LbBb4O5UCfu968Gro3ZVSOZ/ktilmPcaUSGSZA=="
       },
       "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
         "type": "Transitive",


### PR DESCRIPTION
## Summary

Regression test suite covering the 4-bug cross-frontend login chain fixed in #1180, #1182, #1185, #1190. Six new tests across three layers (unit + integration + architecture).

## What this guards

- **BFF matrix** (`BffTokenInjectionMiddlewareTests.ResolveFrontendFromCookies_Matrix`)  
  Exhaustive 3×3 theory: cookie setup (`host-only` / `app-only` / `both`) × caller origin (host / tenant / unknown). Every cross-origin combination must resolve to `(null, null)` — no session bound to the wrong frontend can slip through.
- **Identity cookie → Bearer forwarder** (`IdentityCookieForwardTests`)  
  Boots `GranitOpenIddictModule` on a real service collection and verifies the PostConfigure selector on `IdentityConstants.ApplicationScheme`: forwards to `OpenIddict.Validation.AspNetCore` when an `Authorization` header is present, returns `null` otherwise, and does NOT leak onto the 2FA/External cookie schemes.
- **Cross-side integration** (`CrossSideAuthIntegrationTests`)  
  Full TestServer pipeline with a real cookie handler + stub OpenIddict Bearer handler. The regression case (cookie + Authorization header) must resolve to the Bearer principal, not the stale cookie principal.
- **Architecture guard** (`CookieOnlyAuthSchemeTests`)  
  Source-scans `*.Endpoints/` modules for `AuthenticationSchemes = IdentityConstants.ApplicationScheme` (or equivalents) assignments. Any endpoint pinning itself to the cookie scheme bypasses the module-level Bearer forwarder and re-introduces the cross-frontend leak. Zero violations today; test fails if someone adds one tomorrow.

## Out of scope

The Tier 1 `ClientSideAuthorizationHandlerTests` originally proposed — the handler doesn't exist in the tree yet (`ClientSide` is only declared on `BffFrontendOptions` and never consumed). That's a feature PR, not a test PR.

The Tier 3 property-based/concurrent-leak tests — disproportionate cost for the current state; revisit once we have a reproducible leak case (see the open `ICurrentTenant._current` AsyncLocal investigation).

## Test plan

- [x] `dotnet test tests/Granit.OpenIddict.Tests` — 247/247 pass (includes 9 new tests across 2 files)
- [x] `dotnet test tests/Granit.Bff.Endpoints.Tests` — 109/109 pass (includes 9 new matrix theory cases)
- [x] `dotnet test tests/Granit.ArchitectureTests` — 119/120 pass including the new `CookieOnlyAuthSchemeTests`. The single failure is pre-existing and unrelated: `src/Granit.Metering/Recompute/Exceptions/UsageRecomputeRejectedException.cs` has a stale namespace after the move in #1193.
- [x] `dotnet format --verify-no-changes` clean on all touched files
