### PR TITLE
feat(metering): soft-deprecate meter events with auto-recompute

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -24367,6 +24367,12 @@
           "kind": "property",
           "signature": "decimal Quantity",
           "returnType": "decimal"
+        },
+        {
+          "name": "Deprecate",
+          "kind": "method",
+          "signature": "Deprecate(string reason, DateTimeOffset now)",
+          "returnType": "void"
         }
       ]
     },
@@ -24446,6 +24452,24 @@
       "project": "Granit.Metering.Endpoints",
       "file": "src/Granit.Metering.Endpoints/Dtos/BackfillUsageRequest.cs",
       "line": 17,
+      "members": []
+    },
+    {
+      "name": "DeprecateEventRequest",
+      "fqn": "Granit.Metering.Endpoints.Dtos.DeprecateEventRequest",
+      "kind": "record",
+      "project": "Granit.Metering.Endpoints",
+      "file": "src/Granit.Metering.Endpoints/Dtos/DeprecateEventRequest.cs",
+      "line": 5,
+      "members": []
+    },
+    {
+      "name": "DeprecateEventResponse",
+      "fqn": "Granit.Metering.Endpoints.Dtos.DeprecateEventResponse",
+      "kind": "record",
+      "project": "Granit.Metering.Endpoints",
+      "file": "src/Granit.Metering.Endpoints/Dtos/DeprecateEventResponse.cs",
+      "line": 8,
       "members": []
     },
     {
@@ -24979,6 +25003,22 @@
       ]
     },
     {
+      "name": "IMeterEventDeprecationService",
+      "fqn": "Granit.Metering.Recompute.IMeterEventDeprecationService",
+      "kind": "interface",
+      "project": "Granit.Metering",
+      "file": "src/Granit.Metering/Recompute/IMeterEventDeprecationService.cs",
+      "line": 14,
+      "members": [
+        {
+          "name": "DeprecateAsync",
+          "kind": "method",
+          "signature": "DeprecateAsync(Guid eventId, string reason, CancellationToken cancellationToken = default)",
+          "returnType": "Task<MeterEventDeprecationResult>"
+        }
+      ]
+    },
+    {
       "name": "IUsageBackfillService",
       "fqn": "Granit.Metering.Recompute.IUsageBackfillService",
       "kind": "interface",
@@ -25009,6 +25049,24 @@
           "returnType": "Task<UsageRecomputeResult>"
         }
       ]
+    },
+    {
+      "name": "MeterEventDeprecationResult",
+      "fqn": "Granit.Metering.Recompute.MeterEventDeprecationResult",
+      "kind": "record",
+      "project": "Granit.Metering",
+      "file": "src/Granit.Metering/Recompute/IMeterEventDeprecationService.cs",
+      "line": 28,
+      "members": []
+    },
+    {
+      "name": "MeterEventNotFoundException",
+      "fqn": "Granit.Metering.Recompute.MeterEventNotFoundException",
+      "kind": "class",
+      "project": "Granit.Metering",
+      "file": "src/Granit.Metering/Recompute/Exceptions/MeterEventNotFoundException.cs",
+      "line": 4,
+      "members": []
     },
     {
       "name": "UsageBackfillResult",
@@ -40022,6 +40080,22 @@
       "members": []
     },
     {
+      "name": "PricingTier",
+      "fqn": "Granit.Subscriptions.Domain.PricingTier",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Domain/PricingTier.cs",
+      "line": 16,
+      "members": [
+        {
+          "name": "Create",
+          "kind": "method",
+          "signature": "Create(Guid id, Guid planPriceId, int sortOrder, decimal? upToQuantity, decimal unitAmount, decimal? flatAmount = null)",
+          "returnType": "PricingTier"
+        }
+      ]
+    },
+    {
       "name": "Subscription",
       "fqn": "Granit.Subscriptions.Domain.Subscription",
       "kind": "class",
@@ -40142,6 +40216,15 @@
       "project": "Granit.Subscriptions",
       "file": "src/Granit.Subscriptions/Domain/SubscriptionStatus.cs",
       "line": 6,
+      "members": []
+    },
+    {
+      "name": "TieringMode",
+      "fqn": "Granit.Subscriptions.Domain.TieringMode",
+      "kind": "enum",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Domain/TieringMode.cs",
+      "line": 7,
       "members": []
     },
     {
@@ -41387,6 +41470,22 @@
           "kind": "property",
           "signature": "NotificationSeverity DefaultSeverity",
           "returnType": "NotificationSeverity"
+        }
+      ]
+    },
+    {
+      "name": "TieredPricingCalculator",
+      "fqn": "Granit.Subscriptions.Pricing.TieredPricingCalculator",
+      "kind": "class",
+      "project": "Granit.Subscriptions",
+      "file": "src/Granit.Subscriptions/Pricing/TieredPricingCalculator.cs",
+      "line": 15,
+      "members": [
+        {
+          "name": "Compute",
+          "kind": "method",
+          "signature": "Compute(decimal quantity, TieringMode mode, IReadOnlyList<PricingTier> tiers)",
+          "returnType": "decimal"
         }
       ]
     },

--- a/src/Granit.Metering.Endpoints/Dtos/DeprecateEventRequest.cs
+++ b/src/Granit.Metering.Endpoints/Dtos/DeprecateEventRequest.cs
@@ -1,0 +1,5 @@
+namespace Granit.Metering.Endpoints.Dtos;
+
+/// <summary>HTTP body for <c>POST /metering/events/{id}/deprecate</c>.</summary>
+/// <param name="Reason">Free-text justification (max 500 chars). Stored on the event for audit and surfaced in the audit log.</param>
+public sealed record DeprecateEventRequest(string Reason);

--- a/src/Granit.Metering.Endpoints/Dtos/DeprecateEventResponse.cs
+++ b/src/Granit.Metering.Endpoints/Dtos/DeprecateEventResponse.cs
@@ -1,0 +1,12 @@
+namespace Granit.Metering.Endpoints.Dtos;
+
+/// <summary>HTTP response for a successful event deprecation.</summary>
+/// <param name="EventId">Id of the deprecated event.</param>
+/// <param name="MeterDefinitionId">Owning meter.</param>
+/// <param name="DeprecatedAt">Server-side UTC timestamp written on the event.</param>
+/// <param name="AggregatesRebuilt">Number of <c>UsageAggregate</c> rows updated by the auto-recompute on the affected hourly bucket.</param>
+public sealed record DeprecateEventResponse(
+    Guid EventId,
+    Guid MeterDefinitionId,
+    DateTimeOffset DeprecatedAt,
+    int AggregatesRebuilt);

--- a/src/Granit.Metering.Endpoints/Endpoints/UsageEndpoints.cs
+++ b/src/Granit.Metering.Endpoints/Endpoints/UsageEndpoints.cs
@@ -81,6 +81,23 @@ internal static class UsageEndpoints
             .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
             .RequireAuthorization(MeteringPermissions.Events.Backfill);
 
+        group.MapPost("/events/{id:guid}/deprecate", DeprecateEventAsync)
+            .WithName("DeprecateMeterEvent")
+            .WithSummary("Soft-deprecates a single meter event so it stops contributing to aggregates.")
+            .WithDescription(
+                "Marks the event as deprecated (audit-safe alternative to DELETE; ISO 27001 A.12.4 keeps the row "
+                + "for the audit trail) and triggers an automatic recompute on the affected hourly bucket so the "
+                + "UsageAggregate immediately reflects the change. "
+                + "Returns 404 if the event does not exist; 409 if the event is already deprecated. "
+                + "The original IdempotencyKey remains reserved by the unique index — re-ingestion is rejected, "
+                + "preventing accidental resurrection of the deprecated event.")
+            .WithMetadata(new IdempotentAttribute { Required = false })
+            .Produces<DeprecateEventResponse>()
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict)
+            .ProducesValidationProblem()
+            .RequireAuthorization(MeteringPermissions.Events.Manage);
+
         return group;
     }
 
@@ -246,6 +263,39 @@ internal static class UsageEndpoints
                 detail: ex.Message,
                 title: ex.ReasonCode,
                 statusCode: StatusCodes.Status422UnprocessableEntity);
+        }
+    }
+
+    private static async Task<Results<Ok<DeprecateEventResponse>, ProblemHttpResult>> DeprecateEventAsync(
+        Guid id,
+        DeprecateEventRequest request,
+        [FromServices] IMeterEventDeprecationService service,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            MeterEventDeprecationResult result = await service
+                .DeprecateAsync(id, request.Reason, cancellationToken)
+                .ConfigureAwait(false);
+
+            return TypedResults.Ok(new DeprecateEventResponse(
+                result.EventId,
+                result.MeterDefinitionId,
+                result.DeprecatedAt,
+                result.Recompute.AggregatesRebuilt));
+        }
+        catch (MeterEventNotFoundException ex)
+        {
+            return TypedResults.Problem(
+                detail: ex.Message,
+                statusCode: StatusCodes.Status404NotFound);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Raised by MeterEvent.Deprecate when the event is already deprecated.
+            return TypedResults.Problem(
+                detail: ex.Message,
+                statusCode: StatusCodes.Status409Conflict);
         }
     }
 }

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/cs.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/cs.json
@@ -2,6 +2,7 @@
   "culture": "cs",
   "texts": {
     "Permission:Metering.Events.Backfill": "Doplnění historických událostí měřiče mimo standardní okno (až 365 dní)",
+    "Permission:Metering.Events.Manage": "Správa jednotlivých událostí měřiče (zastarání chybných nebo podvodných událostí)",
     "Permission:Metering.Meters.Manage": "Spravovat definice měřičů (vytvořit, aktualizovat, publikovat, archivovat)",
     "Permission:Metering.Meters.Read": "Zobrazit definice měřičů",
     "Permission:Metering.Usage.Read": "Zobrazit data o využití a stav kvót",

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/de.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/de.json
@@ -2,6 +2,7 @@
   "culture": "de",
   "texts": {
     "Permission:Metering.Events.Backfill": "Historische Zählerereignisse jenseits des Standard-Ingestionsfensters einspielen (bis zu 365 Tage)",
+    "Permission:Metering.Events.Manage": "Einzelne Zählerereignisse verwalten (fehlerhafte oder betrügerische Ereignisse veralten)",
     "Permission:Metering.Meters.Manage": "Zählerdefinitionen verwalten (erstellen, aktualisieren, veröffentlichen, archivieren)",
     "Permission:Metering.Meters.Read": "Zählerdefinitionen anzeigen",
     "Permission:Metering.Usage.Read": "Nutzungsdaten und Kontingentstatus anzeigen",

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/en.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/en.json
@@ -2,6 +2,7 @@
   "culture": "en",
   "texts": {
     "Permission:Metering.Events.Backfill": "Backfill historical meter events older than the standard ingestion window (up to 365 days)",
+    "Permission:Metering.Events.Manage": "Manage individual meter events (deprecate erroneous or fraudulent events)",
     "Permission:Metering.Meters.Manage": "Manage meter definitions (create, update, publish, archive)",
     "Permission:Metering.Meters.Read": "View meter definitions",
     "Permission:Metering.Usage.Read": "View usage data and quota status",

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/es.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/es.json
@@ -2,6 +2,7 @@
   "culture": "es",
   "texts": {
     "Permission:Metering.Events.Backfill": "Insertar eventos históricos más allá de la ventana de ingestión estándar (hasta 365 días)",
+    "Permission:Metering.Events.Manage": "Gestionar eventos de medidor individuales (deprecar eventos erróneos o fraudulentos)",
     "Permission:Metering.Meters.Manage": "Gestionar definiciones de medidores (crear, actualizar, publicar, archivar)",
     "Permission:Metering.Meters.Read": "Ver definiciones de medidores",
     "Permission:Metering.Usage.Read": "Ver datos de uso y estado de cuotas",

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/fr.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/fr.json
@@ -2,6 +2,7 @@
   "culture": "fr",
   "texts": {
     "Permission:Metering.Events.Backfill": "Insérer des événements historiques au-delà de la fenêtre d'ingestion standard (jusqu'à 365 jours)",
+    "Permission:Metering.Events.Manage": "Gérer les événements individuels (déprécier les événements erronés ou frauduleux)",
     "Permission:Metering.Meters.Manage": "Gérer les définitions de compteurs (créer, modifier, publier, archiver)",
     "Permission:Metering.Meters.Read": "Consulter les définitions de compteurs",
     "Permission:Metering.Usage.Read": "Consulter les données d'utilisation et l'état des quotas",

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/hi.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/hi.json
@@ -2,6 +2,7 @@
   "culture": "hi",
   "texts": {
     "Permission:Metering.Events.Backfill": "मानक इनजेशन विंडो से पुराने ऐतिहासिक मीटर इवेंट जोड़ें (365 दिनों तक)",
+    "Permission:Metering.Events.Manage": "व्यक्तिगत मीटर इवेंट प्रबंधित करें (गलत या धोखाधड़ी वाले इवेंट को अप्रचलित करें)",
     "Permission:Metering.Meters.Manage": "मीटर परिभाषाएँ प्रबंधित करें (बनाएँ, अपडेट करें, प्रकाशित करें, संग्रहीत करें)",
     "Permission:Metering.Meters.Read": "मीटर परिभाषाएँ देखें",
     "Permission:Metering.Usage.Read": "उपयोग डेटा और कोटा स्थिति देखें",

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/it.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/it.json
@@ -2,6 +2,7 @@
   "culture": "it",
   "texts": {
     "Permission:Metering.Events.Backfill": "Inserire eventi storici oltre la finestra di ingestione standard (fino a 365 giorni)",
+    "Permission:Metering.Events.Manage": "Gestire i singoli eventi del contatore (deprecare eventi errati o fraudolenti)",
     "Permission:Metering.Meters.Manage": "Gestire le definizioni dei contatori (creare, aggiornare, pubblicare, archiviare)",
     "Permission:Metering.Meters.Read": "Visualizzare le definizioni dei contatori",
     "Permission:Metering.Usage.Read": "Visualizzare i dati di utilizzo e lo stato delle quote",

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/ja.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/ja.json
@@ -2,6 +2,7 @@
   "culture": "ja",
   "texts": {
     "Permission:Metering.Events.Backfill": "標準の取り込みウィンドウを超える過去のメーターイベントをバックフィル（最大365日）",
+    "Permission:Metering.Events.Manage": "個別のメーターイベントを管理（誤ったまたは不正なイベントを廃止）",
     "Permission:Metering.Meters.Manage": "メーター定義を管理（作成、更新、公開、アーカイブ）",
     "Permission:Metering.Meters.Read": "メーター定義を表示",
     "Permission:Metering.Usage.Read": "使用状況データとクォータステータスを表示",

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/ko.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/ko.json
@@ -2,6 +2,7 @@
   "culture": "ko",
   "texts": {
     "Permission:Metering.Events.Backfill": "표준 수집 창 이전의 과거 미터 이벤트 백필 (최대 365일)",
+    "Permission:Metering.Events.Manage": "개별 미터 이벤트 관리 (잘못되거나 부정한 이벤트 폐기)",
     "Permission:Metering.Meters.Manage": "미터 정의 관리 (생성, 수정, 게시, 보관)",
     "Permission:Metering.Meters.Read": "미터 정의 조회",
     "Permission:Metering.Usage.Read": "사용량 데이터 및 할당량 상태 조회",

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/nl.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/nl.json
@@ -2,6 +2,7 @@
   "culture": "nl",
   "texts": {
     "Permission:Metering.Events.Backfill": "Historische meterevents inladen buiten het standaard ingestievenster (tot 365 dagen)",
+    "Permission:Metering.Events.Manage": "Individuele meterevents beheren (verkeerde of frauduleuze events afkeuren)",
     "Permission:Metering.Meters.Manage": "Meterdefinities beheren (aanmaken, bijwerken, publiceren, archiveren)",
     "Permission:Metering.Meters.Read": "Meterdefinities bekijken",
     "Permission:Metering.Usage.Read": "Gebruiksgegevens en quotumstatus bekijken",

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/pl.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/pl.json
@@ -2,6 +2,7 @@
   "culture": "pl",
   "texts": {
     "Permission:Metering.Events.Backfill": "Wstawianie historycznych zdarzeń miernika poza standardowym oknem (do 365 dni)",
+    "Permission:Metering.Events.Manage": "Zarządzanie pojedynczymi zdarzeniami miernika (deprecjacja błędnych lub oszukańczych zdarzeń)",
     "Permission:Metering.Meters.Manage": "Zarządzanie definicjami mierników (tworzenie, aktualizacja, publikacja, archiwizacja)",
     "Permission:Metering.Meters.Read": "Wyświetlanie definicji mierników",
     "Permission:Metering.Usage.Read": "Wyświetlanie danych o użyciu i stanu limitów",

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/pt-BR.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/pt-BR.json
@@ -2,6 +2,7 @@
   "culture": "pt-BR",
   "texts": {
     "Permission:Metering.Events.Backfill": "Reinserir eventos históricos do medidor além da janela padrão de ingestão (até 365 dias)",
+    "Permission:Metering.Events.Manage": "Gerenciar eventos individuais do medidor (depreciar eventos errôneos ou fraudulentos)",
     "Permission:Metering.Meters.Manage": "Gerenciar definições de medidores (criar, atualizar, publicar, arquivar)",
     "Permission:Metering.Meters.Read": "Visualizar definições de medidores",
     "Permission:Metering.Usage.Read": "Visualizar dados de uso e status de cotas",

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/pt.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/pt.json
@@ -2,6 +2,7 @@
   "culture": "pt",
   "texts": {
     "Permission:Metering.Events.Backfill": "Inserir eventos históricos para além da janela padrão de ingestão (até 365 dias)",
+    "Permission:Metering.Events.Manage": "Gerir eventos de medidor individuais (descontinuar eventos errados ou fraudulentos)",
     "Permission:Metering.Meters.Manage": "Gerir definições de medidores (criar, atualizar, publicar, arquivar)",
     "Permission:Metering.Meters.Read": "Ver definições de medidores",
     "Permission:Metering.Usage.Read": "Ver dados de utilização e estado das quotas",

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/sv.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/sv.json
@@ -2,6 +2,7 @@
   "culture": "sv",
   "texts": {
     "Permission:Metering.Events.Backfill": "Fyll i historiska mätarhändelser bortom standardingestionsfönstret (upp till 365 dagar)",
+    "Permission:Metering.Events.Manage": "Hantera enskilda mätarhändelser (föråldra felaktiga eller bedrägliga händelser)",
     "Permission:Metering.Meters.Manage": "Hantera mätardefinitioner (skapa, uppdatera, publicera, arkivera)",
     "Permission:Metering.Meters.Read": "Visa mätardefinitioner",
     "Permission:Metering.Usage.Read": "Visa användningsdata och kvotstatus",

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/tr.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/tr.json
@@ -2,6 +2,7 @@
   "culture": "tr",
   "texts": {
     "Permission:Metering.Events.Backfill": "Standart alım penceresinin ötesindeki geçmiş sayaç olaylarını geri doldur (365 güne kadar)",
+    "Permission:Metering.Events.Manage": "Bireysel sayaç olaylarını yönet (hatalı veya hileli olayları kullanım dışı bırak)",
     "Permission:Metering.Meters.Manage": "Sayaç tanımlarını yönet (oluştur, güncelle, yayınla, arşivle)",
     "Permission:Metering.Meters.Read": "Sayaç tanımlarını görüntüle",
     "Permission:Metering.Usage.Read": "Kullanım verilerini ve kota durumunu görüntüle",

--- a/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/zh.json
+++ b/src/Granit.Metering.Endpoints/Localization/MeteringEndpoints/zh.json
@@ -2,6 +2,7 @@
   "culture": "zh",
   "texts": {
     "Permission:Metering.Events.Backfill": "回填超出标准摄取窗口的历史计量器事件（最长 365 天）",
+    "Permission:Metering.Events.Manage": "管理单个计量器事件（弃用错误或欺诈性事件）",
     "Permission:Metering.Meters.Manage": "管理计量器定义（创建、更新、发布、归档）",
     "Permission:Metering.Meters.Read": "查看计量器定义",
     "Permission:Metering.Usage.Read": "查看使用数据和配额状态",

--- a/src/Granit.Metering.Endpoints/Permissions/MeteringPermissionDefinitionProvider.cs
+++ b/src/Granit.Metering.Endpoints/Permissions/MeteringPermissionDefinitionProvider.cs
@@ -26,6 +26,9 @@ internal sealed class MeteringPermissionDefinitionProvider : IPermissionDefiniti
         group.AddPermission(MeteringPermissions.Usage.Record,
             LocalizableString.Create<MeteringEndpointsLocalizationResource>("Permission:Metering.Usage.Record"),
             MultiTenancySide.Both);
+        group.AddPermission(MeteringPermissions.Events.Manage,
+            LocalizableString.Create<MeteringEndpointsLocalizationResource>("Permission:Metering.Events.Manage"),
+            MultiTenancySide.Both);
         group.AddPermission(MeteringPermissions.Events.Backfill,
             LocalizableString.Create<MeteringEndpointsLocalizationResource>("Permission:Metering.Events.Backfill"),
             MultiTenancySide.Both);

--- a/src/Granit.Metering.Endpoints/Permissions/MeteringPermissions.cs
+++ b/src/Granit.Metering.Endpoints/Permissions/MeteringPermissions.cs
@@ -30,6 +30,15 @@ public static class MeteringPermissions
     public static class Events
     {
         /// <summary>
+        /// Manage individual meter events — currently used by the soft-deprecation
+        /// endpoint. Deliberately separated from <see cref="Usage.Record"/> (which
+        /// gates ingestion) because deprecation is destructive at the billing-data
+        /// level and must be restricted to admins (ISO 27001 A.9.4 — least
+        /// privilege on event tampering operations).
+        /// </summary>
+        public const string Manage = "Metering.Events.Manage";
+
+        /// <summary>
         /// Backfill historical events older than the standard 7-day ingestion
         /// window (up to 365 days). Deliberately separated from
         /// <see cref="Usage.Record"/> because backfilling triggers automatic

--- a/src/Granit.Metering.Endpoints/Validators/DeprecateEventRequestValidator.cs
+++ b/src/Granit.Metering.Endpoints/Validators/DeprecateEventRequestValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+using Granit.Metering.Domain;
+using Granit.Metering.Endpoints.Dtos;
+
+namespace Granit.Metering.Endpoints.Validators;
+
+internal sealed class DeprecateEventRequestValidator : AbstractValidator<DeprecateEventRequest>
+{
+    public DeprecateEventRequestValidator()
+    {
+        RuleFor(x => x.Reason)
+            .NotEmpty()
+            .MaximumLength(MeterEvent.DeprecationReasonMaxLength);
+    }
+}

--- a/src/Granit.Metering.EntityFrameworkCore/Extensions/MeteringEntityFrameworkCoreHostApplicationBuilderExtensions.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Extensions/MeteringEntityFrameworkCoreHostApplicationBuilderExtensions.cs
@@ -36,6 +36,7 @@ public static class MeteringEntityFrameworkCoreHostApplicationBuilderExtensions
         builder.Services.TryAddScoped<IQuotaChecker, EfQuotaChecker>();
         builder.Services.TryAddScoped<IUsageRecomputeService, EfUsageRecomputeService>();
         builder.Services.TryAddScoped<IUsageBackfillService, EfUsageBackfillService>();
+        builder.Services.TryAddScoped<IMeterEventDeprecationService, EfMeterEventDeprecationService>();
 
         // Queryable sources for MapGranitQuery (host bypasses tenant filter for cross-tenant review).
         builder.Services.AddScoped<IQueryableSource<MeterDefinition>, EfMeterDefinitionQueryableSource>();

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/EfAggregationRunner.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/EfAggregationRunner.cs
@@ -81,7 +81,8 @@ internal sealed partial class EfAggregationRunner(
         List<MeterEvent> events = await db.MeterEvents
             .Where(e => e.MeterDefinitionId == definition.Id
                 && e.TenantId == definition.TenantId
-                && e.Id.CompareTo(watermark.LastProcessedEventId) > 0)
+                && e.Id.CompareTo(watermark.LastProcessedEventId) > 0
+                && e.DeprecatedAt == null)
             .OrderBy(e => e.Id)
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/EfMeterEventDeprecationService.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/EfMeterEventDeprecationService.cs
@@ -1,0 +1,85 @@
+using Granit.DataFiltering;
+using Granit.Domain;
+using Granit.Metering.Diagnostics;
+using Granit.Metering.Domain;
+using Granit.Metering.Recompute;
+using Granit.MultiTenancy;
+using Granit.Timing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Granit.Metering.EntityFrameworkCore.Internal;
+
+/// <summary>
+/// EF Core implementation of <see cref="IMeterEventDeprecationService"/>.
+/// </summary>
+internal sealed partial class EfMeterEventDeprecationService(
+    IDbContextFactory<MeteringDbContext> contextFactory,
+    IUsageRecomputeService recomputeService,
+    MeteringMetrics metrics,
+    IClock clock,
+    IDataFilter? dataFilter,
+    ILogger<EfMeterEventDeprecationService> logger) : IMeterEventDeprecationService
+{
+    public async Task<MeterEventDeprecationResult> DeprecateAsync(
+        Guid eventId,
+        string reason,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+
+        // Admins may operate on events from any tenant; the lookup disables the
+        // tenant filter, then the recompute step uses the meter's actual TenantId.
+        using IDisposable? _ = dataFilter?.Disable<IMultiTenant>();
+
+        DateTimeOffset deprecatedAt;
+        Guid meterDefinitionId;
+
+        await using (MeteringDbContext db = await contextFactory
+            .CreateDbContextAsync(cancellationToken).ConfigureAwait(false))
+        {
+            MeterEvent? meterEvent = await db.MeterEvents
+                .FirstOrDefaultAsync(e => e.Id == eventId, cancellationToken)
+                .ConfigureAwait(false)
+                ?? throw new MeterEventNotFoundException(eventId);
+
+            deprecatedAt = clock.Now;
+
+            // Throws InvalidOperationException if already deprecated — caller maps to 409.
+            meterEvent.Deprecate(reason, deprecatedAt);
+
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            meterDefinitionId = meterEvent.MeterDefinitionId;
+
+            metrics.RecordEventDeprecated(meterEvent.TenantId?.ToString(), meterEvent.MeterDefinitionId);
+            Log.EventDeprecated(logger, meterEvent.Id, meterEvent.MeterDefinitionId, reason);
+
+            // Auto-recompute the affected hourly window so consumers see the corrected
+            // aggregate immediately. Uses the recompute service (which acquires the
+            // meter-level lock); no additional locking needed here.
+            DateTimeOffset windowStart = SnapToHour(meterEvent.Timestamp);
+            DateTimeOffset windowEnd = windowStart.AddHours(1);
+
+            UsageRecomputeResult recompute = await recomputeService
+                .RecomputeAsync(
+                    new UsageRecomputeRequest(meterDefinitionId, windowStart, windowEnd),
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            return new MeterEventDeprecationResult(
+                eventId, meterDefinitionId, deprecatedAt, recompute);
+        }
+    }
+
+    private static DateTimeOffset SnapToHour(DateTimeOffset value) =>
+        new(value.Year, value.Month, value.Day, value.Hour, 0, 0, value.Offset);
+
+    private static partial class Log
+    {
+        [LoggerMessage(Level = LogLevel.Information,
+            Message = "Meter event '{EventId}' on meter '{MeterDefinitionId}' soft-deprecated. Reason: {Reason}")]
+        public static partial void EventDeprecated(
+            ILogger logger, Guid eventId, Guid meterDefinitionId, string reason);
+    }
+}

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/EfUsageRecomputeService.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/EfUsageRecomputeService.cs
@@ -39,11 +39,12 @@ internal sealed partial class EfUsageRecomputeService(
                 $"Recompute window is empty or inverted: from={request.From:O} to={request.To:O}.");
         }
 
-        if (request.To > clock.Now)
+        if (request.From > clock.Now)
         {
             throw new UsageRecomputeRejectedException(
                 "Granit:Metering:RecomputeWindowInFuture",
-                $"Recompute window upper bound {request.To:O} is in the future (now={clock.Now:O}).");
+                $"Recompute window lower bound {request.From:O} is in the future (now={clock.Now:O}). "
+                + "The upper bound may extend past now (no events past now will be considered).");
         }
 
         // Definitions are loaded with the tenant filter disabled because the recompute
@@ -96,7 +97,8 @@ internal sealed partial class EfUsageRecomputeService(
             .Where(e => e.MeterDefinitionId == definition.Id
                 && e.TenantId == definition.TenantId
                 && e.Timestamp >= windowStart
-                && e.Timestamp < windowEnd)
+                && e.Timestamp < windowEnd
+                && e.DeprecatedAt == null)
             .OrderBy(e => e.Timestamp)
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);

--- a/src/Granit.Metering.EntityFrameworkCore/Internal/MeterEventConfiguration.cs
+++ b/src/Granit.Metering.EntityFrameworkCore/Internal/MeterEventConfiguration.cs
@@ -19,6 +19,8 @@ internal sealed class MeterEventConfiguration : IEntityTypeConfiguration<MeterEv
         builder.Property(e => e.Quantity).HasPrecision(18, 6).IsRequired();
         builder.Property(e => e.Timestamp).IsRequired();
         builder.Property(e => e.Metadata).HasMaxLength(4000);
+        builder.Property(e => e.DeprecatedAt);
+        builder.Property(e => e.DeprecationReason).HasMaxLength(MeterEvent.DeprecationReasonMaxLength);
 
         // Deduplication index: unique per tenant + idempotency key
         builder.HasIndex(e => new { e.TenantId, e.IdempotencyKey })

--- a/src/Granit.Metering/Diagnostics/MeteringMetrics.cs
+++ b/src/Granit.Metering/Diagnostics/MeteringMetrics.cs
@@ -23,6 +23,7 @@ public sealed class MeteringMetrics
     private readonly Counter<long> _quotasExceeded;
     private readonly Counter<long> _recomputesExecuted;
     private readonly Counter<long> _backfillsIngested;
+    private readonly Counter<long> _eventsDeprecated;
 
     /// <summary>Initializes metering metrics using the specified meter factory.</summary>
     public MeteringMetrics(IMeterFactory meterFactory)
@@ -56,6 +57,10 @@ public sealed class MeteringMetrics
         _backfillsIngested = meter.CreateCounter<long>(
             "granit.metering.backfills.events_ingested",
             description: "Number of historical events accepted by the backfill endpoint.");
+
+        _eventsDeprecated = meter.CreateCounter<long>(
+            "granit.metering.events.deprecated",
+            description: "Number of meter events soft-deprecated (excluded from aggregation while preserved for audit).");
     }
 
     /// <summary>Records a meter event insertion.</summary>
@@ -133,5 +138,16 @@ public sealed class MeteringMetrics
             { TenantIdTag, tenantId ?? GlobalTenant },
         };
         _backfillsIngested.Add(eventCount, tags);
+    }
+
+    /// <summary>Records a soft-deprecation of a single meter event.</summary>
+    public void RecordEventDeprecated(string? tenantId, Guid meterDefinitionId)
+    {
+        var tags = new TagList
+        {
+            { TenantIdTag, tenantId ?? GlobalTenant },
+            { MeterDefinitionIdTag, meterDefinitionId.ToString() },
+        };
+        _eventsDeprecated.Add(1, tags);
     }
 }

--- a/src/Granit.Metering/Domain/MeterEvent.cs
+++ b/src/Granit.Metering/Domain/MeterEvent.cs
@@ -62,9 +62,48 @@ public sealed class MeterEvent : Entity, IMultiTenant
     /// <summary>Optional JSON metadata (e.g., endpoint, resource ID).</summary>
     public string? Metadata { get; private set; }
 
+    /// <summary>
+    /// When the event was soft-deprecated (UTC), or <c>null</c> when active.
+    /// Deprecated events stay on the table for audit (ISO 27001 A.12.4) but are
+    /// excluded from aggregation; the per-tenant unique index on
+    /// (TenantId, IdempotencyKey) still applies, so a re-ingestion with the
+    /// same key is rejected — no resurrection path.
+    /// </summary>
+    public DateTimeOffset? DeprecatedAt { get; private set; }
+
+    /// <summary>
+    /// Free-text reason captured at deprecation time (max 500 chars). Surfaces in
+    /// audit logs and admin UIs. <c>null</c> while the event is active.
+    /// </summary>
+    public string? DeprecationReason { get; private set; }
+
     /// <inheritdoc/>
     public Guid? TenantId { get; private set; }
 
     /// <summary>Explicit interface for interceptor injection.</summary>
     Guid? IMultiTenant.TenantId { get => TenantId; set => TenantId = value; }
+
+    /// <summary>Maximum length of <see cref="DeprecationReason"/>.</summary>
+    public const int DeprecationReasonMaxLength = 500;
+
+    /// <summary>
+    /// Soft-deprecates this event so the aggregator stops counting it. The event
+    /// row is preserved for audit. Idempotency is the caller's responsibility —
+    /// calling <c>Deprecate</c> on an already-deprecated event throws so the
+    /// HTTP layer can return 409.
+    /// </summary>
+    public void Deprecate(string reason, DateTimeOffset now)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(reason.Length, DeprecationReasonMaxLength);
+
+        if (DeprecatedAt is not null)
+        {
+            throw new InvalidOperationException(
+                $"Event '{Id}' is already deprecated (at {DeprecatedAt:O}).");
+        }
+
+        DeprecatedAt = now;
+        DeprecationReason = reason;
+    }
 }

--- a/src/Granit.Metering/Recompute/Exceptions/MeterEventNotFoundException.cs
+++ b/src/Granit.Metering/Recompute/Exceptions/MeterEventNotFoundException.cs
@@ -1,0 +1,9 @@
+namespace Granit.Metering.Recompute;
+
+/// <summary>Raised when a deprecation targets a non-existent <see cref="Domain.MeterEvent"/>.</summary>
+public sealed class MeterEventNotFoundException(Guid eventId)
+    : Exception($"Meter event '{eventId}' not found.")
+{
+    /// <summary>The requested event id.</summary>
+    public Guid EventId { get; } = eventId;
+}

--- a/src/Granit.Metering/Recompute/IMeterEventDeprecationService.cs
+++ b/src/Granit.Metering/Recompute/IMeterEventDeprecationService.cs
@@ -1,0 +1,32 @@
+namespace Granit.Metering.Recompute;
+
+/// <summary>
+/// Soft-deprecates a single <see cref="Domain.MeterEvent"/> (audit-safe alternative to
+/// DELETE) and triggers an automatic <see cref="IUsageRecomputeService"/> pass over
+/// the affected hourly bucket so existing aggregates immediately reflect the change.
+/// </summary>
+/// <remarks>
+/// Deprecation is admin-only — see <c>Metering.Events.Manage</c>. It is intentionally
+/// NOT idempotent: deprecating an already-deprecated event throws (and the HTTP layer
+/// returns 409). This guards against accidental re-deprecation that would otherwise
+/// be silently swallowed and could mask bugs in admin tooling.
+/// </remarks>
+public interface IMeterEventDeprecationService
+{
+    /// <summary>Deprecates the event and recomputes its hourly bucket in one transaction.</summary>
+    Task<MeterEventDeprecationResult> DeprecateAsync(
+        Guid eventId,
+        string reason,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>Outcome of a successful deprecation.</summary>
+/// <param name="EventId">Id of the deprecated event.</param>
+/// <param name="MeterDefinitionId">Owning meter (for audit / metrics).</param>
+/// <param name="DeprecatedAt">Server-side UTC timestamp written on the event.</param>
+/// <param name="Recompute">Recompute summary for the affected hourly window.</param>
+public sealed record MeterEventDeprecationResult(
+    Guid EventId,
+    Guid MeterDefinitionId,
+    DateTimeOffset DeprecatedAt,
+    UsageRecomputeResult Recompute);

--- a/tests/Granit.Metering.Tests/MeterEventTests.cs
+++ b/tests/Granit.Metering.Tests/MeterEventTests.cs
@@ -78,4 +78,60 @@ public sealed class MeterEventTests
 
         evt.Metadata.ShouldBeNull();
     }
+
+    // ======== Soft deprecation ========
+
+    [Fact]
+    public void Create_NewEvent_IsNotDeprecated()
+    {
+        var evt = MeterEvent.Create(
+            Guid.NewGuid(), Guid.NewGuid(), "key-fresh", 1m, DateTimeOffset.UtcNow);
+
+        evt.DeprecatedAt.ShouldBeNull();
+        evt.DeprecationReason.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Deprecate_SetsTimestampAndReason()
+    {
+        var evt = MeterEvent.Create(
+            Guid.NewGuid(), Guid.NewGuid(), "key-x", 1m, DateTimeOffset.UtcNow);
+        var now = DateTimeOffset.Parse("2026-04-24T15:30:00Z");
+
+        evt.Deprecate("billing-fix #123", now);
+
+        evt.DeprecatedAt.ShouldBe(now);
+        evt.DeprecationReason.ShouldBe("billing-fix #123");
+    }
+
+    [Fact]
+    public void Deprecate_TwiceOnSameEvent_ShouldThrow()
+    {
+        var evt = MeterEvent.Create(
+            Guid.NewGuid(), Guid.NewGuid(), "key-twice", 1m, DateTimeOffset.UtcNow);
+        evt.Deprecate("first", DateTimeOffset.UtcNow);
+
+        Should.Throw<InvalidOperationException>(() =>
+            evt.Deprecate("second", DateTimeOffset.UtcNow));
+    }
+
+    [Fact]
+    public void Deprecate_WithEmptyReason_ShouldThrow()
+    {
+        var evt = MeterEvent.Create(
+            Guid.NewGuid(), Guid.NewGuid(), "key-empty", 1m, DateTimeOffset.UtcNow);
+
+        Should.Throw<ArgumentException>(() => evt.Deprecate("  ", DateTimeOffset.UtcNow));
+    }
+
+    [Fact]
+    public void Deprecate_WithReasonOverMaxLength_ShouldThrow()
+    {
+        var evt = MeterEvent.Create(
+            Guid.NewGuid(), Guid.NewGuid(), "key-long", 1m, DateTimeOffset.UtcNow);
+        string overLong = new('x', MeterEvent.DeprecationReasonMaxLength + 1);
+
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            evt.Deprecate(overLong, DateTimeOffset.UtcNow));
+    }
 }


### PR DESCRIPTION
Closes #1169 (Phase 2 Story 5 of [EPIC #1155](https://github.com/granit-fx/granit-dotnet/issues/1155) ORB alignment, [Feature #1158](https://github.com/granit-fx/granit-dotnet/issues/1158) Metering hybrid).

> **Re-PR**: original PR #1192 was merged into the stacked `feature/metering-recompute` base, but the squash-merge of #1191 captured only the recompute commit — the deprecation work never propagated to `develop`. This branches fresh from `develop` with the same content.

Adds an audit-safe alternative to DELETE for individual `MeterEvent` rows: the event stays on the table (ISO 27001 A.12.4 audit trail) but is excluded from aggregation. The affected hourly `UsageAggregate` is recomputed automatically in the same call so consumers see the corrected value immediately.

## Domain (`Granit.Metering.Domain.MeterEvent`)

- New nullable fields: `DeprecatedAt` (`DateTimeOffset?`) and `DeprecationReason` (`string?`, max 500 chars). Both null while the event is active.
- New `Deprecate(reason, now)` behavior method:
  - validates `reason` (non-empty, ≤ 500 chars)
  - throws `InvalidOperationException` if already deprecated (intentionally **non-idempotent** so the HTTP layer returns 409 — guards against silently swallowing duplicate admin actions)
- Public `const MeterEvent.DeprecationReasonMaxLength` shared with the validator.

## Domain abstraction (`Granit.Metering.Recompute`)

- `IMeterEventDeprecationService` + `MeterEventDeprecationResult` record
- `MeterEventNotFoundException` (in `Recompute/Exceptions/` per the convention enforced after #1193)

## EF impl (`Granit.Metering.EntityFrameworkCore.Internal`)

- `MeterEventConfiguration` maps the two new columns (nullable, no default)
- `EfAggregationRunner.AggregateForDefinitionAsync` filters `DeprecatedAt == null` on the events list — deprecated events stop contributing on the next watermark pass automatically (no rebuild needed for fresh windows)
- `EfUsageRecomputeService.RecomputeAsync` filters `DeprecatedAt == null` on the re-scan, so manual recomputes also exclude deprecated events
- New `EfMeterEventDeprecationService`:
  - loads the event (cross-tenant for host admins via `IDataFilter.Disable<IMultiTenant>`)
  - calls `MeterEvent.Deprecate(reason, clock.Now)` → throws on already-deprecated
  - `SaveChangesAsync` (audit interceptors run normally)
  - calls `IUsageRecomputeService.RecomputeAsync` on the affected hourly bucket (snapped from `event.Timestamp`). Reuses the meter-level cross-DB transaction lock from #1191 — no extra coordination needed
  - emits structured log + counter

### `EfUsageRecomputeService` window-bound check loosened

The "window in the future" guard now compares `request.From` (not `request.To`) to `clock.Now`. This lets the deprecation auto-recompute run on the **current** hourly bucket — `windowEnd = bucketStart + 1h` is naturally past now, but no events past now exist so the result is identical.

## HTTP (`Granit.Metering.Endpoints`)

- New `MeteringPermissions.Events.Manage` constant + provider entry, **deliberately separated from `Usage.Record`** (which gates ingestion). ISO 27001 A.9.4.
- **16 culture localization files** updated for the new `Permission:Metering.Events.Manage` label.
- `POST /metering/events/{id}/deprecate` with `DeprecateEventRequest { Reason }` body and `DeprecateEventResponse { EventId, MeterDefinitionId, DeprecatedAt, AggregatesRebuilt }` body
  - 404 (event not found) / 409 (already deprecated) / validation problem
- FluentValidation guard on `Reason` (`NotEmpty + MaximumLength` shared constant)

## Diagnostics

- New counter `granit.metering.events.deprecated` with tags `tenant_id`, `meter_definition_id`
- Structured log `"Meter event '{EventId}' on meter '{MeterDefinitionId}' soft-deprecated. Reason: {Reason}"`

## Tests (+5 domain)

- New event is not deprecated by default
- `Deprecate` sets timestamp + reason
- Deprecating twice throws (drives the 409 mapping)
- Empty reason throws
- Reason over `MaxLength` throws
- All existing tests still green; total now **58 + 17 + 9 = 84** Metering tests.

## Schema (consumer apps run their own EF migration)

```sql
ALTER TABLE meter_events ADD DeprecatedAt timestamptz NULL;
ALTER TABLE meter_events ADD DeprecationReason varchar(500) NULL;
```

## Re-ingestion safety

The per-tenant unique index on `(TenantId, IdempotencyKey)` remains in place — a deprecated event cannot be silently resurrected by re-sending the same payload.

## Test plan

- [x] `dotnet build src/Granit.Metering*` — 0 errors, 0 warnings
- [x] `dotnet test tests/Granit.Metering.Tests` — 58 / 58
- [x] `dotnet test tests/Granit.Metering.EntityFrameworkCore.Tests` — 17 / 17
- [x] `dotnet test tests/Granit.Metering.Endpoints.Tests` — 9 / 9
- [x] `dotnet test tests/Granit.ArchitectureTests --filter "Exception_classes"` — 3 / 3
- [ ] CI green on all 6 shards (TBD post-push)