### PR TITLE
feat(openiddict): enforce ClientSide policy on OIDC applications

### DIFF
--- a/.mcp-code-index.json
+++ b/.mcp-code-index.json
@@ -30080,6 +30080,22 @@
       ]
     },
     {
+      "name": "OpenIddictApplicationClientSideExtensions",
+      "fqn": "Granit.OpenIddict.Extensions.OpenIddictApplicationClientSideExtensions",
+      "kind": "class",
+      "project": "Granit.OpenIddict",
+      "file": "src/Granit.OpenIddict/Extensions/OpenIddictApplicationClientSideExtensions.cs",
+      "line": 29,
+      "members": [
+        {
+          "name": "SetClientSide",
+          "kind": "method",
+          "signature": "SetClientSide(this OpenIddictApplicationDescriptor descriptor, MultiTenancySide? clientSide)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
       "name": "GranitOpenIddictModule",
       "fqn": "Granit.OpenIddict.GranitOpenIddictModule",
       "kind": "class",
@@ -30240,7 +30256,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs",
-      "line": 6,
+      "line": 8,
       "members": [
         {
           "name": "Applications",
@@ -30262,7 +30278,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs",
-      "line": 33,
+      "line": 36,
       "members": []
     },
     {
@@ -30271,7 +30287,7 @@
       "kind": "record",
       "project": "Granit.OpenIddict",
       "file": "src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs",
-      "line": 49,
+      "line": 53,
       "members": []
     },
     {
@@ -30348,7 +30364,7 @@
       "kind": "class",
       "project": "Granit.OpenIddict.Server",
       "file": "src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs",
-      "line": 16,
+      "line": 17,
       "members": [
         {
           "name": "AddGranitOpenIddictServer",
@@ -30364,8 +30380,37 @@
       "kind": "class",
       "project": "Granit.OpenIddict.Server",
       "file": "src/Granit.OpenIddict.Server/GranitOpenIddictServerModule.cs",
-      "line": 10,
-      "members": []
+      "line": 13,
+      "members": [
+        {
+          "name": "ConfigureServices",
+          "kind": "method",
+          "signature": "ConfigureServices(ServiceConfigurationContext context)",
+          "returnType": "void"
+        }
+      ]
+    },
+    {
+      "name": "ClientSideAuthorizationHandler",
+      "fqn": "Granit.OpenIddict.Server.Handlers.ClientSideAuthorizationHandler",
+      "kind": "class",
+      "project": "Granit.OpenIddict.Server",
+      "file": "src/Granit.OpenIddict.Server/Handlers/ClientSideAuthorizationHandler.cs",
+      "line": 38,
+      "members": [
+        {
+          "name": "Descriptor",
+          "kind": "property",
+          "signature": "OpenIddictServerHandlerDescriptor Descriptor",
+          "returnType": "OpenIddictServerHandlerDescriptor"
+        },
+        {
+          "name": "HandleAsync",
+          "kind": "method",
+          "signature": "HandleAsync(ProcessSignInContext context)",
+          "returnType": "ValueTask"
+        }
+      ]
     },
     {
       "name": "ClaimsDestinations",

--- a/src/Granit.Bff/Options/GranitBffOptions.cs
+++ b/src/Granit.Bff/Options/GranitBffOptions.cs
@@ -114,16 +114,23 @@ public sealed class BffFrontendOptions
     public string[] Scopes { get; set; } = ["openid", "profile", "email", "roles", "offline_access"];
 
     /// <summary>
-    /// Declared scope of this frontend relative to the host/tenant boundary. When set,
-    /// downstream components (e.g. a custom OIDC server handler) may enforce that the
-    /// authenticating user's context matches: <see cref="MultiTenancySide.Host"/> rejects
-    /// users with a tenant context, <see cref="MultiTenancySide.Tenant"/> rejects users
-    /// without one. <see cref="MultiTenancySide.Both"/> or <see langword="null"/> leaves
-    /// the frontend unrestricted.
+    /// Declared scope of this frontend relative to the host/tenant boundary, kept
+    /// here as documentation and for host-application configuration convenience.
     /// </summary>
     /// <remarks>
-    /// Granit.Bff does not act on this value itself — it is purely declarative metadata
-    /// for consumers (typically the host application's OpenIddict server handler) to read.
+    /// <para>
+    /// Granit.Bff does not enforce this value. Enforcement lives in
+    /// <c>Granit.OpenIddict.Server</c> via <c>ClientSideAuthorizationHandler</c>,
+    /// which reads the policy from the OIDC application record — not from the BFF
+    /// frontend options — so deployments without <c>Granit.Bff</c> can still
+    /// restrict access to host-only or tenant-only clients.
+    /// </para>
+    /// <para>
+    /// The host application is expected to mirror this value onto the matching
+    /// <c>OidcApplicationSeedDescriptor.ClientSide</c> (or apply it directly to
+    /// the OIDC application's <c>Properties</c> bag via
+    /// <c>OpenIddictApplicationDescriptor.SetClientSide(...)</c>).
+    /// </para>
     /// </remarks>
     public MultiTenancySide? ClientSide { get; set; }
 

--- a/src/Granit.OpenIddict.EntityFrameworkCore/Seeding/OpenIddictSeedContributor.cs
+++ b/src/Granit.OpenIddict.EntityFrameworkCore/Seeding/OpenIddictSeedContributor.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Granit.OpenIddict.Extensions;
 using Granit.OpenIddict.Options;
 using Granit.Persistence.EntityFrameworkCore.DataSeeding;
 using Microsoft.Extensions.Logging;
@@ -129,7 +130,12 @@ internal sealed partial class OpenIddictSeedContributor(
             ? BuildJsonWebKeySet(desired.SigningKeyJwk)
             : null;
 
-        return !JwksEqual(current.JsonWebKeySet, desiredJwks);
+        if (!JwksEqual(current.JsonWebKeySet, desiredJwks))
+        {
+            return true;
+        }
+
+        return current.GetClientSide() != desired.ClientSide;
     }
 
     /// <summary>
@@ -197,6 +203,10 @@ internal sealed partial class OpenIddictSeedContributor(
 
         // Consent type (default: implicit — auto-grant for first-party apps)
         appDescriptor.ConsentType = source.ConsentType ?? OpenIddictConstants.ConsentTypes.Implicit;
+
+        // Host/tenant policy — persisted in Properties so the OIDC server can enforce
+        // host-only / tenant-only client access without depending on Granit.Bff.
+        appDescriptor.SetClientSide(source.ClientSide);
     }
 
     private async Task SeedScopeAsync(

--- a/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
+++ b/src/Granit.OpenIddict.Server/Extensions/OpenIddictServerHostApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Granit.OpenIddict.Options;
+using Granit.OpenIddict.Server.Handlers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -149,6 +150,12 @@ public static class OpenIddictServerHostApplicationBuilderExtensions
                 OpenIddictConstants.Scopes.Profile,
                 OpenIddictConstants.Scopes.Roles,
                 "offline_access");
+
+            // ──── Custom event handlers ────
+            // Enforces the MultiTenancySide policy declared on each OIDC application
+            // at sign-in: host-only clients reject tenant users, tenant-only clients
+            // reject host users. See ClientSideAuthorizationHandler for semantics.
+            options.AddEventHandler(ClientSideAuthorizationHandler.Descriptor);
         });
 
         // ──── Validation — token validation for resource servers ────

--- a/src/Granit.OpenIddict.Server/GranitOpenIddictServerModule.cs
+++ b/src/Granit.OpenIddict.Server/GranitOpenIddictServerModule.cs
@@ -1,4 +1,7 @@
 using Granit.Modularity;
+using Granit.OpenIddict.Server.Handlers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Granit.OpenIddict.Server;
 
@@ -7,4 +10,14 @@ namespace Granit.OpenIddict.Server;
 /// endpoint URIs, flows, signing keys, custom grant types, and ASP.NET Core integration.
 /// </summary>
 [DependsOn(typeof(GranitOpenIddictModule))]
-public sealed class GranitOpenIddictServerModule : GranitModule;
+public sealed class GranitOpenIddictServerModule : GranitModule
+{
+    /// <inheritdoc/>
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        // Scoped handlers must be registered in DI for OpenIddict to resolve them
+        // via UseScopedHandler<T>(). The descriptor itself is attached to the
+        // OpenIddict server options in AddGranitOpenIddictServer().
+        context.Services.TryAddScoped<ClientSideAuthorizationHandler>();
+    }
+}

--- a/src/Granit.OpenIddict.Server/Handlers/ClientSideAuthorizationHandler.cs
+++ b/src/Granit.OpenIddict.Server/Handlers/ClientSideAuthorizationHandler.cs
@@ -1,0 +1,128 @@
+using Granit.MultiTenancy;
+using Granit.OpenIddict.Extensions;
+using Microsoft.Extensions.Logging;
+using OpenIddict.Abstractions;
+using OpenIddict.Server;
+using static OpenIddict.Server.OpenIddictServerEvents;
+
+namespace Granit.OpenIddict.Server.Handlers;
+
+/// <summary>
+/// OpenIddict server handler that enforces the <see cref="MultiTenancySide"/> policy
+/// declared on an OIDC application. Rejects sign-in when the authenticated user's
+/// tenancy (host or tenant, as carried by the <c>tenant_id</c> claim) does not
+/// match the application's declared side.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The rule is deliberately scoped to user sign-ins: <c>client_credentials</c>
+/// requests carry no user principal and are left untouched, preserving
+/// service-to-service flows regardless of the application's declared side.
+/// </para>
+/// <para>
+/// Policy semantics:
+/// </para>
+/// <list type="bullet">
+/// <item><description><see cref="MultiTenancySide.Host"/> — only users with
+/// <c>TenantId = null</c> (no <c>tenant_id</c> claim) may obtain tokens.</description></item>
+/// <item><description><see cref="MultiTenancySide.Tenant"/> — only users with a
+/// non-empty <c>tenant_id</c> claim may obtain tokens.</description></item>
+/// <item><description><see cref="MultiTenancySide.Both"/> or <see langword="null"/> —
+/// no restriction (backward-compatible default).</description></item>
+/// </list>
+/// <para>
+/// On mismatch the handler rejects the sign-in with <c>access_denied</c>, which
+/// OpenIddict surfaces to the caller as a standard OIDC error response.
+/// </para>
+/// </remarks>
+public sealed partial class ClientSideAuthorizationHandler(
+    IOpenIddictApplicationManager applicationManager,
+    ILogger<ClientSideAuthorizationHandler> logger)
+    : IOpenIddictServerHandler<ProcessSignInContext>
+{
+    /// <summary>
+    /// Well-known claim type for the tenant identifier carried on the principal,
+    /// as populated by <c>GranitUserClaimsPrincipalFactory</c> for tenant users.
+    /// </summary>
+    private const string TenantIdClaimType = "tenant_id";
+
+    /// <summary>
+    /// Descriptor registered with OpenIddict's server pipeline. Runs as a scoped
+    /// handler (because it resolves <see cref="IOpenIddictApplicationManager"/>)
+    /// and is ordered late enough to see the resolved <c>ClientId</c> on
+    /// <see cref="BaseContext"/>.
+    /// </summary>
+    public static OpenIddictServerHandlerDescriptor Descriptor { get; }
+        = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
+            .UseScopedHandler<ClientSideAuthorizationHandler>()
+            .SetOrder(100_000)
+            .SetType(OpenIddictServerHandlerType.Custom)
+            .Build();
+
+    /// <inheritdoc/>
+    public async ValueTask HandleAsync(ProcessSignInContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        // Service-to-service flows carry no user — let them through unchanged.
+        if (context.Request is not null && context.Request.IsClientCredentialsGrantType())
+        {
+            return;
+        }
+
+        string? clientId = context.ClientId;
+        if (string.IsNullOrEmpty(clientId))
+        {
+            return;
+        }
+
+        object? application = await applicationManager
+            .FindByClientIdAsync(clientId, context.CancellationToken)
+            .ConfigureAwait(false);
+
+        if (application is null)
+        {
+            // Built-in handlers reject unknown clients before we run — defensive skip.
+            return;
+        }
+
+        MultiTenancySide? clientSide = await applicationManager
+            .GetClientSideAsync(application, context.CancellationToken)
+            .ConfigureAwait(false);
+
+        if (clientSide is null || clientSide == MultiTenancySide.Both)
+        {
+            return;
+        }
+
+        bool userIsTenant = HasTenantIdClaim(context);
+
+        bool policyViolated = clientSide == MultiTenancySide.Host
+            ? userIsTenant
+            : !userIsTenant;
+
+        if (!policyViolated)
+        {
+            return;
+        }
+
+        LogClientSideViolation(logger, clientId, clientSide.Value.ToString(),
+            userIsTenant ? "tenant" : "host");
+
+        context.Reject(
+            error: OpenIddictConstants.Errors.AccessDenied,
+            description: "The authenticated user is not authorised for this client's side.");
+    }
+
+    private static bool HasTenantIdClaim(ProcessSignInContext context)
+    {
+        System.Security.Claims.Claim? claim = context.Principal?.FindFirst(TenantIdClaimType);
+        return claim is not null && !string.IsNullOrEmpty(claim.Value);
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "OpenIddict client-side policy violation: client '{ClientId}' declared ClientSide={ClientSide}, user is {UserSide} — rejecting sign-in.")]
+    private static partial void LogClientSideViolation(
+        ILogger logger, string clientId, string clientSide, string userSide);
+}

--- a/src/Granit.OpenIddict/Extensions/OpenIddictApplicationClientSideExtensions.cs
+++ b/src/Granit.OpenIddict/Extensions/OpenIddictApplicationClientSideExtensions.cs
@@ -1,0 +1,113 @@
+using System.Text.Json;
+using Granit.MultiTenancy;
+using OpenIddict.Abstractions;
+
+namespace Granit.OpenIddict.Extensions;
+
+/// <summary>
+/// Read/write helpers for the <see cref="MultiTenancySide"/> policy persisted on an
+/// OpenIddict application via its <c>Properties</c> dictionary. Used by seeding and
+/// by the OIDC server pipeline to enforce host/tenant isolation at sign-in.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The policy rides alongside the application record in the OpenIddict
+/// <c>Properties</c> bag (an <see cref="IDictionary{TKey,TValue}"/> of
+/// <see cref="JsonElement"/>). Storing it on the app record — rather than querying
+/// the BFF frontend configuration at authentication time — keeps the OIDC server
+/// self-sufficient: a deployment without <c>Granit.Bff</c> can still declare
+/// host-only or tenant-only clients, and the host-application author controls the
+/// policy through normal seeding configuration.
+/// </para>
+/// <para>
+/// The property value is the invariant enum name (<c>"Host"</c>, <c>"Tenant"</c>,
+/// <c>"Both"</c>). Unknown values are treated as <see langword="null"/> (no policy)
+/// to avoid locking out every user when a property written by a newer version is
+/// read by an older binary.
+/// </para>
+/// </remarks>
+public static class OpenIddictApplicationClientSideExtensions
+{
+    /// <summary>
+    /// Fully-qualified <c>Properties</c> key under which the client-side policy
+    /// is stored. The <c>urn:granit:</c> prefix avoids collisions with OpenIddict's
+    /// own keys and any other extension.
+    /// </summary>
+    public const string ClientSidePropertyKey = "urn:granit:openiddict:client_side";
+
+    /// <summary>
+    /// Writes the <paramref name="clientSide"/> policy onto the descriptor's
+    /// <see cref="OpenIddictApplicationDescriptor.Properties"/>. Passing
+    /// <see langword="null"/> removes the key, returning the application to the
+    /// "no restriction" default.
+    /// </summary>
+    public static void SetClientSide(
+        this OpenIddictApplicationDescriptor descriptor,
+        MultiTenancySide? clientSide)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        if (clientSide is null)
+        {
+            descriptor.Properties.Remove(ClientSidePropertyKey);
+            return;
+        }
+
+        descriptor.Properties[ClientSidePropertyKey] = JsonSerializer.SerializeToElement(
+            clientSide.Value.ToString());
+    }
+
+    /// <summary>
+    /// Reads the client-side policy from the descriptor's
+    /// <see cref="OpenIddictApplicationDescriptor.Properties"/>, or
+    /// <see langword="null"/> when the key is absent or its value is not a recognised
+    /// <see cref="MultiTenancySide"/> member.
+    /// </summary>
+    public static MultiTenancySide? GetClientSide(this OpenIddictApplicationDescriptor descriptor)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        if (!descriptor.Properties.TryGetValue(ClientSidePropertyKey, out JsonElement element))
+        {
+            return null;
+        }
+
+        return ParseClientSide(element);
+    }
+
+    /// <summary>
+    /// Reads the client-side policy from an application record via the OpenIddict
+    /// application manager. Returns <see langword="null"/> when the key is absent
+    /// or its value is not a recognised <see cref="MultiTenancySide"/> member.
+    /// </summary>
+    public static async ValueTask<MultiTenancySide?> GetClientSideAsync(
+        this IOpenIddictApplicationManager applicationManager,
+        object application,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(applicationManager);
+        ArgumentNullException.ThrowIfNull(application);
+
+        System.Collections.Immutable.ImmutableDictionary<string, JsonElement> properties =
+            await applicationManager.GetPropertiesAsync(application, cancellationToken)
+                .ConfigureAwait(false);
+
+        return properties.TryGetValue(ClientSidePropertyKey, out JsonElement element)
+            ? ParseClientSide(element)
+            : null;
+    }
+
+    private static MultiTenancySide? ParseClientSide(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        string? raw = element.GetString();
+        return Enum.TryParse(raw, ignoreCase: false, out MultiTenancySide value)
+            && Enum.IsDefined(value)
+            ? value
+            : null;
+    }
+}

--- a/src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs
+++ b/src/Granit.OpenIddict/Options/GranitOpenIddictSeedingOptions.cs
@@ -1,3 +1,5 @@
+using Granit.MultiTenancy;
+
 namespace Granit.OpenIddict.Options;
 
 /// <summary>
@@ -30,6 +32,7 @@ public sealed class GranitOpenIddictSeedingOptions
 /// <param name="PostLogoutRedirectUris">Allowed post-logout redirect URIs.</param>
 /// <param name="SigningKeyJwk">Optional public signing key as JWK JSON for <c>private_key_jwt</c> client authentication (RFC 7523). When set, the client authenticates with a signed JWT assertion instead of a shared secret.</param>
 /// <param name="ConsentType">The consent type for the application (<c>"implicit"</c>, <c>"explicit"</c>, or <c>"systematic"</c>). Default: <c>"implicit"</c> (auto-grant for first-party apps).</param>
+/// <param name="ClientSide">Optional host/tenant policy enforced at sign-in. <see cref="MultiTenancySide.Host"/> = only users with <c>TenantId = null</c> may obtain tokens for this client; <see cref="MultiTenancySide.Tenant"/> = only users with a non-null <c>TenantId</c>; <see cref="MultiTenancySide.Both"/> or <see langword="null"/> = no restriction. Stored on the OIDC application's <c>Properties</c> bag and enforced by <c>ClientSideAuthorizationHandler</c>.</param>
 public sealed record OidcApplicationSeedDescriptor(
     string ClientId,
     string? ClientSecret,
@@ -38,7 +41,8 @@ public sealed record OidcApplicationSeedDescriptor(
     string[] RedirectUris,
     string[] PostLogoutRedirectUris,
     string? SigningKeyJwk = null,
-    string? ConsentType = null);
+    string? ConsentType = null,
+    MultiTenancySide? ClientSide = null);
 
 /// <summary>
 /// Describes an OIDC scope to seed.

--- a/tests/Granit.OpenIddict.Server.Tests/Handlers/ClientSideAuthorizationHandlerTests.cs
+++ b/tests/Granit.OpenIddict.Server.Tests/Handlers/ClientSideAuthorizationHandlerTests.cs
@@ -1,0 +1,195 @@
+using System.Collections.Immutable;
+using System.Security.Claims;
+using System.Text.Json;
+using Granit.MultiTenancy;
+using Granit.OpenIddict.Extensions;
+using Granit.OpenIddict.Server.Handlers;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using OpenIddict.Abstractions;
+using OpenIddict.Server;
+using Shouldly;
+using Xunit;
+using static OpenIddict.Server.OpenIddictServerEvents;
+
+namespace Granit.OpenIddict.Server.Tests.Handlers;
+
+/// <summary>
+/// Unit tests for <see cref="ClientSideAuthorizationHandler"/> — the OIDC server
+/// handler that enforces the <see cref="MultiTenancySide"/> policy declared on
+/// each application. Verifies the full policy matrix (Host/Tenant/Both/null ×
+/// host-user/tenant-user) and the carve-outs for service-to-service flows.
+/// </summary>
+public sealed class ClientSideAuthorizationHandlerTests
+{
+    private const string ClientId = "test-client";
+    private const string TenantId = "11111111-2222-3333-4444-555555555555";
+
+    [Fact]
+    public async Task HostOnly_HostUser_Allowed()
+    {
+        ProcessSignInContext context = await RunAsync(
+            clientSide: MultiTenancySide.Host,
+            userTenantId: null);
+
+        context.IsRejected.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task HostOnly_TenantUser_Rejected()
+    {
+        ProcessSignInContext context = await RunAsync(
+            clientSide: MultiTenancySide.Host,
+            userTenantId: TenantId);
+
+        context.IsRejected.ShouldBeTrue();
+        context.Error.ShouldBe(OpenIddictConstants.Errors.AccessDenied);
+    }
+
+    [Fact]
+    public async Task TenantOnly_HostUser_Rejected()
+    {
+        ProcessSignInContext context = await RunAsync(
+            clientSide: MultiTenancySide.Tenant,
+            userTenantId: null);
+
+        context.IsRejected.ShouldBeTrue();
+        context.Error.ShouldBe(OpenIddictConstants.Errors.AccessDenied);
+    }
+
+    [Fact]
+    public async Task TenantOnly_TenantUser_Allowed()
+    {
+        ProcessSignInContext context = await RunAsync(
+            clientSide: MultiTenancySide.Tenant,
+            userTenantId: TenantId);
+
+        context.IsRejected.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(TenantId)]
+    public async Task Both_AnyUser_Allowed(string? userTenantId)
+    {
+        ProcessSignInContext context = await RunAsync(
+            clientSide: MultiTenancySide.Both,
+            userTenantId: userTenantId);
+
+        context.IsRejected.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(TenantId)]
+    public async Task NullPolicy_IsBackwardCompatible_AllowsAnyUser(string? userTenantId)
+    {
+        ProcessSignInContext context = await RunAsync(
+            clientSide: null,
+            userTenantId: userTenantId);
+
+        context.IsRejected.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ClientCredentialsGrant_IsNotRestricted_EvenWhenHostOnly()
+    {
+        // Service-to-service flows carry no user principal. Applying the side
+        // policy would lock out any host-only API client that uses client_credentials —
+        // the policy is about USERS, not clients.
+        ProcessSignInContext context = await RunAsync(
+            clientSide: MultiTenancySide.Host,
+            userTenantId: TenantId,
+            grantType: OpenIddictConstants.GrantTypes.ClientCredentials);
+
+        context.IsRejected.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task NullClientId_IsSkipped()
+    {
+        // Defensive: the built-in OpenIddict validation handlers reject missing
+        // client_id long before we run, but we must never throw if we see a null.
+        ProcessSignInContext context = await RunAsync(
+            clientSide: MultiTenancySide.Host,
+            userTenantId: TenantId,
+            clientId: null);
+
+        context.IsRejected.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task UnknownClient_IsSkipped()
+    {
+        IOpenIddictApplicationManager manager = Substitute.For<IOpenIddictApplicationManager>();
+        manager.FindByClientIdAsync(ClientId, Arg.Any<CancellationToken>())
+            .Returns((object?)null);
+
+        ClientSideAuthorizationHandler handler = new(manager, NullLogger<ClientSideAuthorizationHandler>.Instance);
+        ProcessSignInContext context = BuildContext(clientId: ClientId, userTenantId: null, grantType: null);
+
+        await handler.HandleAsync(context);
+
+        context.IsRejected.ShouldBeFalse();
+    }
+
+    private static async Task<ProcessSignInContext> RunAsync(
+        MultiTenancySide? clientSide,
+        string? userTenantId,
+        string? grantType = null,
+        string? clientId = ClientId)
+    {
+        IOpenIddictApplicationManager manager = Substitute.For<IOpenIddictApplicationManager>();
+        object app = new();
+
+        manager.FindByClientIdAsync(
+                Arg.Is<string>(id => id == clientId),
+                Arg.Any<CancellationToken>())
+            .Returns(app);
+
+        ImmutableDictionary<string, JsonElement> properties =
+            clientSide is null
+                ? ImmutableDictionary<string, JsonElement>.Empty
+                : ImmutableDictionary<string, JsonElement>.Empty.Add(
+                    OpenIddictApplicationClientSideExtensions.ClientSidePropertyKey,
+                    JsonSerializer.SerializeToElement(clientSide.Value.ToString()));
+
+        manager.GetPropertiesAsync(app, Arg.Any<CancellationToken>())
+            .Returns(properties);
+
+        ClientSideAuthorizationHandler handler = new(manager, NullLogger<ClientSideAuthorizationHandler>.Instance);
+        ProcessSignInContext context = BuildContext(clientId, userTenantId, grantType);
+
+        await handler.HandleAsync(context);
+        return context;
+    }
+
+    private static ProcessSignInContext BuildContext(
+        string? clientId, string? userTenantId, string? grantType)
+    {
+        OpenIddictRequest request = new()
+        {
+            ClientId = clientId,
+            GrantType = grantType,
+        };
+
+        OpenIddictServerTransaction transaction = new()
+        {
+            Request = request,
+            Response = new OpenIddictResponse(),
+        };
+
+        List<Claim> claims = [new Claim(ClaimTypes.NameIdentifier, "user-id")];
+        if (userTenantId is not null)
+        {
+            claims.Add(new Claim("tenant_id", userTenantId));
+        }
+
+        ClaimsPrincipal principal = new(new ClaimsIdentity(claims, "Test"));
+
+        return new ProcessSignInContext(transaction)
+        {
+            Principal = principal,
+        };
+    }
+}

--- a/tests/Granit.OpenIddict.Tests/Extensions/OpenIddictApplicationClientSideExtensionsTests.cs
+++ b/tests/Granit.OpenIddict.Tests/Extensions/OpenIddictApplicationClientSideExtensionsTests.cs
@@ -1,0 +1,143 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using Granit.MultiTenancy;
+using Granit.OpenIddict.Extensions;
+using NSubstitute;
+using OpenIddict.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace Granit.OpenIddict.Tests.Extensions;
+
+/// <summary>
+/// Tests for <see cref="OpenIddictApplicationClientSideExtensions"/> — the read/write
+/// helpers that persist a <see cref="MultiTenancySide"/> policy on an OIDC
+/// application's <see cref="OpenIddictApplicationDescriptor.Properties"/> bag.
+/// </summary>
+public sealed class OpenIddictApplicationClientSideExtensionsTests
+{
+    [Theory]
+    [InlineData(MultiTenancySide.Host)]
+    [InlineData(MultiTenancySide.Tenant)]
+    [InlineData(MultiTenancySide.Both)]
+    public void SetClientSide_Then_GetClientSide_Roundtrip(MultiTenancySide side)
+    {
+        OpenIddictApplicationDescriptor descriptor = new();
+
+        descriptor.SetClientSide(side);
+
+        descriptor.GetClientSide().ShouldBe(side);
+    }
+
+    [Fact]
+    public void SetClientSide_Writes_String_To_WellKnown_Key()
+    {
+        OpenIddictApplicationDescriptor descriptor = new();
+
+        descriptor.SetClientSide(MultiTenancySide.Tenant);
+
+        descriptor.Properties.ShouldContainKey(
+            OpenIddictApplicationClientSideExtensions.ClientSidePropertyKey);
+        JsonElement element = descriptor.Properties[
+            OpenIddictApplicationClientSideExtensions.ClientSidePropertyKey];
+        element.ValueKind.ShouldBe(JsonValueKind.String);
+        element.GetString().ShouldBe("Tenant");
+    }
+
+    [Fact]
+    public void SetClientSide_Null_Removes_Property()
+    {
+        OpenIddictApplicationDescriptor descriptor = new();
+        descriptor.SetClientSide(MultiTenancySide.Host);
+
+        descriptor.SetClientSide(null);
+
+        descriptor.Properties.ShouldNotContainKey(
+            OpenIddictApplicationClientSideExtensions.ClientSidePropertyKey);
+        descriptor.GetClientSide().ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetClientSide_ReturnsNull_WhenPropertyAbsent()
+    {
+        OpenIddictApplicationDescriptor descriptor = new();
+
+        descriptor.GetClientSide().ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetClientSide_ReturnsNull_WhenValueIsNotAString()
+    {
+        // Forward-compatibility: a future schema could write a number or object
+        // under the same key. Rather than throw (which would brick sign-in on
+        // every request), treat unknown shapes as "no policy".
+        OpenIddictApplicationDescriptor descriptor = new();
+        descriptor.Properties[OpenIddictApplicationClientSideExtensions.ClientSidePropertyKey] =
+            JsonSerializer.SerializeToElement(42);
+
+        descriptor.GetClientSide().ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetClientSide_ReturnsNull_WhenStringIsNotAnEnumMember()
+    {
+        OpenIddictApplicationDescriptor descriptor = new();
+        descriptor.Properties[OpenIddictApplicationClientSideExtensions.ClientSidePropertyKey] =
+            JsonSerializer.SerializeToElement("Martian");
+
+        descriptor.GetClientSide().ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetClientSide_IsCaseSensitive_OnEnumName()
+    {
+        // Persisted values are produced by our own SetClientSide which uses the
+        // invariant enum name ("Host" / "Tenant" / "Both"). A lowercase "host"
+        // would indicate either a hand-edited record or another writer — don't
+        // interpret it, treat as no policy. Matches the forward-compat stance
+        // of GetClientSide_ReturnsNull_WhenStringIsNotAnEnumMember.
+        OpenIddictApplicationDescriptor descriptor = new();
+        descriptor.Properties[OpenIddictApplicationClientSideExtensions.ClientSidePropertyKey] =
+            JsonSerializer.SerializeToElement("host");
+
+        descriptor.GetClientSide().ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(MultiTenancySide.Host)]
+    [InlineData(MultiTenancySide.Tenant)]
+    [InlineData(MultiTenancySide.Both)]
+    public async Task GetClientSideAsync_Reads_FromApplicationManager(MultiTenancySide side)
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        IOpenIddictApplicationManager manager = Substitute.For<IOpenIddictApplicationManager>();
+        object application = new();
+
+        ImmutableDictionary<string, JsonElement> properties =
+            ImmutableDictionary<string, JsonElement>.Empty.Add(
+                OpenIddictApplicationClientSideExtensions.ClientSidePropertyKey,
+                JsonSerializer.SerializeToElement(side.ToString()));
+
+        manager.GetPropertiesAsync(application, Arg.Any<CancellationToken>())
+            .Returns(properties);
+
+        MultiTenancySide? resolved = await manager.GetClientSideAsync(application, cancellationToken);
+
+        resolved.ShouldBe(side);
+    }
+
+    [Fact]
+    public async Task GetClientSideAsync_ReturnsNull_WhenKeyAbsent()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        IOpenIddictApplicationManager manager = Substitute.For<IOpenIddictApplicationManager>();
+        object application = new();
+
+        manager.GetPropertiesAsync(application, Arg.Any<CancellationToken>())
+            .Returns(ImmutableDictionary<string, JsonElement>.Empty);
+
+        MultiTenancySide? resolved = await manager.GetClientSideAsync(application, cancellationToken);
+
+        resolved.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Adds an OIDC server-side enforcement of the host/tenant boundary per application. A Host-only client now rejects sign-in from tenant users; a Tenant-only client rejects host users. The policy is persisted on the OIDC application record itself (not on a BFF option), so deployments without `Granit.Bff` can still restrict access.

## Shape

- `MultiTenancySide? ClientSide` → stored in `OpenIddictApplicationDescriptor.Properties` under `urn:granit:openiddict:client_side` as an invariant enum name.
- `SetClientSide` / `GetClientSide` on the descriptor; `GetClientSideAsync` on `IOpenIddictApplicationManager`.
- `OidcApplicationSeedDescriptor` gains a `ClientSide` parameter; seeding writes it via `SetClientSide` and change detection picks up edits.
- `ClientSideAuthorizationHandler` registered as scoped `IOpenIddictServerHandler<ProcessSignInContext>` at order `100_000`. Reads the app's `ClientSide`, compares against the `tenant_id` claim on the principal, rejects with `access_denied` on mismatch.
- `client_credentials` grants carved out — they carry no user principal and this policy is about users.
- `BffFrontendOptions.ClientSide` remains as a convenience mirror; docs now point at the real enforcement site.
- Backward-compatible: applications with no declared `ClientSide` behave exactly as before.

## Why at seed time, not BFF config

Enforcement needs to read the side at every sign-in. Putting the truth on the OIDC app record (queried via `IOpenIddictApplicationManager`) keeps the server self-sufficient and leaves `Granit.Bff` optional. Host authors who drive both from the same `appsettings.json` just pass the same `MultiTenancySide` into both spots.

## Forward-compat stance

`GetClientSide` treats non-string values, unknown enum names, and wrong casing as "no policy" rather than throwing. A future schema rev can write new shapes under the same key without bricking sign-in on older binaries.

## Test plan

- [x] `dotnet test tests/Granit.OpenIddict.Server.Tests` — 12/12 (new `ClientSideAuthorizationHandlerTests`: full 4×2 policy matrix, client_credentials carve-out, unknown-client and null-client_id skip paths).
- [x] `dotnet test tests/Granit.OpenIddict.Tests` — 251/251 (new `OpenIddictApplicationClientSideExtensionsTests`: roundtrip, null removes property, malformed value returns null, async-on-manager read).
- [x] `dotnet test tests/Granit.OpenIddict.EntityFrameworkCore.Tests` — 8/8 (seeding change detector still green with new ClientSide comparison).
- [x] `dotnet test tests/Granit.Bff.Tests` — 165/165 (doc-only change on `BffFrontendOptions.ClientSide`).
- [x] `dotnet format --verify-no-changes` clean on all touched projects.
